### PR TITLE
Use HTTP link in 3rdparty module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/flashinfer"]
 	path = 3rdparty/flashinfer
-	url = git@github.com:flashinfer-ai/flashinfer.git
+	url = https://github.com/flashinfer-ai/flashinfer.git


### PR DESCRIPTION
Replace the SSH link of FlashInfer with HTTP link, so that users don't need to deploy the SSH key of their Github account for cloning, as deploying SSH key could be tedious in cloud instances or docker containers.