### PR TITLE
Support stream=True in v1/completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,22 @@ curl http://localhost:30000/generate \
     }
   }'
 ```
-
 Learn more about the argument format [here](docs/sampling_params.md).
+
+### OpenAI Compatible API
+
+In addition, it also supports an OpenAI-compatible API.
+```
+import openai
+client = openai.Client(base_url="http://127.0.0.1:30000/v1")
+response = client.completions.create(
+	model="default",
+	prompt="The capital of France is",
+	temperature=0,
+	max_tokens=32,
+)
+print(response)
+```
 
 ### Additional Arguments
 - Add `--tp 2` to enable tensor parallelism.

--- a/README.md
+++ b/README.md
@@ -243,9 +243,10 @@ Learn more about the argument format [here](docs/sampling_params.md).
 ### OpenAI Compatible API
 
 In addition, it also supports an OpenAI-compatible API.
-```
+```python
 import openai
-client = openai.Client(base_url="http://127.0.0.1:30000/v1")
+client = openai.Client(
+    base_url="http://127.0.0.1:30000/v1", api_key="EMPTY")
 response = client.completions.create(
 	model="default",
 	prompt="The capital of France is",

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ Learn more about the argument format [here](docs/sampling_params.md).
 
 ### OpenAI Compatible API
 
-In addition, it also supports an OpenAI-compatible API.
+In addition, the server supports an experimental OpenAI-compatible API.
+
 ```python
 import openai
 client = openai.Client(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 srt = ["fastapi", "psutil", "rpyc", "torch", "uvloop", "uvicorn", "zmq", "vllm>=0.2.5",
-       "interegular", "lark", "numba", "pydantic]
+       "interegular", "lark", "numba", "pydantic"]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic"]
 all = ["sglang[srt]", "sglang[openai]", "sglang[anthropic]"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 srt = ["fastapi", "psutil", "rpyc", "torch", "uvloop", "uvicorn", "zmq", "vllm>=0.2.5",
-       "interegular", "lark", "numba"]
+       "interegular", "lark", "numba", "pydantic]
 openai = ["openai>=1.0"]
 anthropic = ["anthropic"]
 all = ["sglang[srt]", "sglang[openai]", "sglang[anthropic]"]

--- a/python/sglang/backend/runtime_endpoint.py
+++ b/python/sglang/backend/runtime_endpoint.py
@@ -116,9 +116,12 @@ class RuntimeEndpoint(BaseBackend):
         pos = 0
 
         incomplete_text = ""
-        for chunk in response.iter_lines(decode_unicode=False, delimiter=b"\0"):
-            if chunk:
-                data = json.loads(chunk.decode())
+        for chunk in response.iter_lines(decode_unicode=False):
+            chunk = chunk.decode("utf-8")
+            if chunk and chunk.startswith("data:"):
+                if chunk == "data: [DONE]":
+                    break
+                data = json.loads(chunk[5:].strip("\n"))
                 text = find_printable_text(data["text"][pos:])
                 meta_info = data["meta_info"]
                 pos += len(text)

--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -1,12 +1,65 @@
-from dataclasses import dataclass
-from typing import Any, List, Optional, Union
+import time
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
 
 
-@dataclass
-class CompletionRequest:
-    prompt: Union[str, List[Any]]
-    model: str = "default"
-    temperature: Optional[float] = 0.7
+class CompletionRequest(BaseModel):
+    model: str
+    prompt: Union[str, List[str]]
+    suffix: Optional[str] = None
     max_tokens: Optional[int] = 16
+    temperature: Optional[float] = 0.7
+    top_p: Optional[float] = 1.0
     n: Optional[int] = 1
-    stop: Optional[Union[str, List[str]]] = None
+    stream: Optional[bool] = False
+    logprobs: Optional[int] = None
+    echo: Optional[bool] = False
+    stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
+    presence_penalty: Optional[float] = 0.0
+    frequency_penalty: Optional[float] = 0.0
+    best_of: Optional[int] = None
+    logit_bias: Optional[Dict[str, float]] = None
+    user: Optional[str] = None
+
+
+class LogProbs(BaseModel):
+    text_offset: List[int] = Field(default_factory=list)
+    token_logprobs: List[Optional[float]] = Field(default_factory=list)
+    tokens: List[str] = Field(default_factory=list)
+    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
+
+class UsageInfo(BaseModel):
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    completion_tokens: Optional[int] = 0
+
+class CompletionResponseChoice(BaseModel):
+    index: int
+    text: str
+    logprobs: Optional[LogProbs] = None
+    finish_reason: Optional[str] = None
+
+
+class CompletionResponse(BaseModel):
+    id: str
+    object: str = "text_completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[CompletionResponseChoice]
+    usage: UsageInfo
+
+
+class CompletionResponseStreamChoice(BaseModel):
+    index: int
+    text: str
+    logprobs: Optional[LogProbs] = None
+    finish_reason: Optional[str] = None
+
+
+class CompletionStreamResponse(BaseModel):
+    id: str
+    object: str = "text_completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: List[CompletionResponseStreamChoice]

--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -4,6 +4,19 @@ from typing import Dict, List, Optional, Union
 from pydantic import BaseModel, Field
 
 
+class LogProbs(BaseModel):
+    text_offset: List[int] = Field(default_factory=list)
+    token_logprobs: List[Optional[float]] = Field(default_factory=list)
+    tokens: List[str] = Field(default_factory=list)
+    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
+
+
+class UsageInfo(BaseModel):
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    completion_tokens: Optional[int] = 0
+
+
 class CompletionRequest(BaseModel):
     model: str
     prompt: Union[str, List[str]]
@@ -22,17 +35,6 @@ class CompletionRequest(BaseModel):
     logit_bias: Optional[Dict[str, float]] = None
     user: Optional[str] = None
 
-
-class LogProbs(BaseModel):
-    text_offset: List[int] = Field(default_factory=list)
-    token_logprobs: List[Optional[float]] = Field(default_factory=list)
-    tokens: List[str] = Field(default_factory=list)
-    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
-
-class UsageInfo(BaseModel):
-    prompt_tokens: int = 0
-    total_tokens: int = 0
-    completion_tokens: Optional[int] = 0
 
 class CompletionResponseChoice(BaseModel):
     index: int

--- a/test/srt/test_httpserver_decode_stream.py
+++ b/test/srt/test_httpserver_decode_stream.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
             "text": "The capital of France is",
             "sampling_params": {
                 "temperature": 0,
-                "max_new_tokens": 1024,
+                "max_new_tokens": 512,
             },
             "stream": True,
         },
@@ -33,9 +33,12 @@ if __name__ == "__main__":
     )
 
     prev = 0
-    for chunk in response.iter_lines(decode_unicode=False, delimiter=b"\0"):
-        if chunk:
-            data = json.loads(chunk.decode())
+    for chunk in response.iter_lines(decode_unicode=False):
+        chunk = chunk.decode("utf-8")
+        if chunk and chunk.startswith("data:"):
+            if chunk == "data: [DONE]":
+                break
+            data = json.loads(chunk[5:].strip("\n"))
             output = data["text"].strip()
             print(output[prev:], end="", flush=True)
             prev = len(output)

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -1,0 +1,54 @@
+"""
+python3 -m sglang.launch_server --model-path TinyLlama/TinyLlama-1.1B-Chat-v0.4 --port 30000
+
+Output:
+The capital of France is Paris.\nThe capital of the United States is Washington, D.C.\nThe capital of Canada is Ottawa.\nThe capital of Japan is Tokyo
+"""
+
+import argparse
+
+import openai
+
+
+def test_completion(args):
+    client = openai.Client(api_key="EMPTY", base_url=args.base_url)
+    response = client.completions.create(
+        model="default",
+        prompt="The capital of France is",
+        temperature=0,
+        max_tokens=32,
+    )
+    print(response.choices[0].text)
+    assert response.id
+    assert response.created
+    assert response.usage.prompt_tokens > 0
+    assert response.usage.completion_tokens > 0
+    assert response.usage.total_tokens > 0
+
+
+def test_completion_stream(args):
+    client = openai.Client(api_key="EMPTY", base_url=args.base_url)
+    response = client.completions.create(
+        model="default",
+        prompt="The capital of France is",
+        temperature=0,
+        max_tokens=32,
+        stream=True,
+    )
+    for r in response:
+        print(r.choices[0].text, end="", flush=True)
+        assert r.id
+        assert r.created
+        assert r.usage.prompt_tokens > 0
+        assert r.usage.completion_tokens > 0
+        assert r.usage.total_tokens > 0
+    print()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", type=str, default="http://127.0.0.1:30000/v1")
+    args = parser.parse_args()
+
+    test_completion(args)
+    test_completion_stream(args)


### PR DESCRIPTION
- Make OpenAI API `v1/completions` protocol compatible with OpenAI API.
- Support stream=True in OpenAI API `v1/completions`.
- Change the delimiter to `\n\n`  so that it could be compatible with other frameworks.
- Add unit tests.

On my local, all tests in `tests/srt/test_httpserver_*` and `tests/srt/test_openai_server.py` are passed.