### PR TITLE
Support load fine-tuned LLaVA model

### DIFF
--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -303,6 +303,8 @@ class LlamaForCausalLM(nn.Module):
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue
+                if name.startswith("model.vision_tower") and name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -310,6 +312,8 @@ class LlamaForCausalLM(nn.Module):
             else:
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name.startswith("model.vision_tower") and name not in params_dict:
                     continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)


### PR DESCRIPTION
When loading a fine-tuned LLaVA model, ignore the vision tower keys in the `params_dict` to workaround the following error:

```console
~$ python3 -m sglang.launch_server --model-path org/llava_1.5_13b_finetune --tokenizer-path llava-hf/llava-1.5-13b-hf --port 30000
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Process Process-1:
router init state: Traceback (most recent call last):
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/managers/router/manager.py", line 68, in start_router_process
    model_client = ModelRpcClient(server_args, port_args)
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/managers/router/model_rpc.py", line 448, in __init__
    self.model_server.exposed_init_model(0, server_args, port_args)
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/managers/router/model_rpc.py", line 54, in exposed_init_model
    self.model_runner = ModelRunner(
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/managers/router/model_runner.py", line 229, in __init__
    self.load_model()
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/managers/router/model_runner.py", line 275, in load_model
    model.load_weights(
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/models/llava.py", line 177, in load_weights
    self.language_model.load_weights(
  File "/opt/conda/envs/llava_sglang/lib/python3.10/site-packages/sglang/srt/models/llama2.py", line 306, in load_weights
    param = params_dict[name]
KeyError: 'model.vision_tower.vision_tower.vision_model.encoder.layers.0.self_attn.qkv_proj.weight'
```

Fixing https://github.com/sgl-project/sglang/issues/79