### PR TITLE
Improve Chinese character streaming when the last char is half Chinese word.

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -154,6 +154,9 @@ def find_printable_text(text):
     # If the last token is a CJK character, we print the characters.
     elif len(text) > 0 and _is_chinese_char(ord(text[-1])):
         return text
+    # Otherwise if the penultimate token is a CJK character, we print the characters except for the last one.
+    elif len(text) > 1 and _is_chinese_char(ord(text[-2])):
+        return text[:-1]
     # Otherwise, prints until the last space char (simple heuristic to avoid printing incomplete words,
     # which may change with the subsequent token -- there are probably smarter ways to do this!)
     else:


### PR DESCRIPTION
Currently when the last word is Chinese, but only the first-half, the streaming will be delayed until the next chunk containing a full word -- occasionally delayed by three chunks or more.

Add a check if the penultimate token is a full Chinese word and stream the full words in that case.