### PR TITLE
Handle grayscale images in expand2square

### DIFF
--- a/python/sglang/srt/mm_utils.py
+++ b/python/sglang/srt/mm_utils.py
@@ -163,15 +163,13 @@ def expand2square(pil_img, background_color):
     width, height = pil_img.size
     if width == height:
         return pil_img
-    elif width > height:
-        if pil_img.mode == "L":
-            pil_img = pil_img.convert("RGB")
+    if pil_img.mode == "L":
+        pil_img = pil_img.convert("RGB")
+    if width > height:
         result = Image.new(pil_img.mode, (width, width), background_color)
         result.paste(pil_img, (0, (width - height) // 2))
         return result
     else:
-        if pil_img.mode == "L":
-            pil_img = pil_img.convert("RGB")
         result = Image.new(pil_img.mode, (height, height), background_color)
         result.paste(pil_img, ((height - width) // 2, 0))
         return result

--- a/python/sglang/srt/mm_utils.py
+++ b/python/sglang/srt/mm_utils.py
@@ -164,10 +164,14 @@ def expand2square(pil_img, background_color):
     if width == height:
         return pil_img
     elif width > height:
+        if pil_img.mode == "L":
+            pil_img = pil_img.convert("RGB")
         result = Image.new(pil_img.mode, (width, width), background_color)
         result.paste(pil_img, (0, (width - height) // 2))
         return result
     else:
+        if pil_img.mode == "L":
+            pil_img = pil_img.convert("RGB")
         result = Image.new(pil_img.mode, (height, height), background_color)
         result.paste(pil_img, ((height - width) // 2, 0))
         return result


### PR DESCRIPTION
Fix error when handling grayscale images in expand2square:

```console
Exception in TokenizerManager:
Traceback (most recent call last):
  File "/home/gcpuser/sglang/python/sglang/srt/managers/tokenizer_manager.py", line 61, in get_pixel_values
    image = expand2square(
  File "/home/gcpuser/sglang/python/sglang/srt/mm_utils.py", line 167, in expand2square
    result = Image.new(pil_img.mode, (width, width), background_color)
  File "/opt/conda/envs/sglang_flashinfer/lib/python3.9/site-packages/PIL/Image.py", line 2941, in new
    return im._new(core.fill(mode, size, color))
TypeError: color must be int or single-element tuple
```