### PR TITLE
Dynamic model class loading

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 srt = ["aiohttp", "fastapi", "psutil", "rpyc", "torch", "uvloop", "uvicorn",
        "zmq", "vllm>=0.2.5", "interegular", "lark", "numba",
-       "pydantic", "diskcache", "cloudpickle"]
+       "pydantic", "diskcache", "cloudpickle", "pillow"]
 openai = ["openai>=1.0", "numpy"]
 anthropic = ["anthropic", "numpy"]
 all = ["sglang[srt]", "sglang[openai]", "sglang[anthropic]"]

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -318,3 +318,5 @@ class LlamaForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+EntryClass = LlamaForCausalLM

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -330,3 +330,5 @@ def monkey_path_clip_vision_embed_forward():
         "forward",
         clip_vision_embed_forward,
     )
+
+EntryClass = LlavaLlamaForCausalLM

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -376,3 +376,5 @@ class MixtralForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+EntryClass = MixtralForCausalLM

--- a/python/sglang/srt/models/qwen.py
+++ b/python/sglang/srt/models/qwen.py
@@ -258,3 +258,5 @@ class QWenLMHeadModel(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+EntryClass = QWenLMHeadModel


### PR DESCRIPTION
This PR attempts to make the model loading process more systematic and self-contained. Currently when addinga new model, we have to explicitly import the model entry class in `model_runnter.load_model` function. This introduces two drawbacks:
1. `model_runner.py` cannot focus on the changes of "model runner".
2. Developers have to change 2 files when adding a new model. The change in`model_runner.py` is easy to be missed and may result in conflicts.

`sglang.srt` does not follow the standard Python package structure (i.e., leveraging `__init__.py` to construct module hierarchy), so it's not straightforward to use a model registry with decorator. In this PR, I tried to dynamically scan all model files under `models`, and load their entry classes. The major drawback of this approach is that every model file has to have `EntryClass` alias to be scanned. IMHO it should be relatively easy for developers to follow.

Please share your thoughts.