### PR TITLE
Fix evictable_size when deleting leaf

### DIFF
--- a/python/sglang/srt/managers/router/radix_cache.py
+++ b/python/sglang/srt/managers/router/radix_cache.py
@@ -176,8 +176,9 @@ class RadixCache:
         for k, v in node.parent.children.items():
             if v == node:
                 break
+        value = node.value
         del node.parent.children[k]
-        self.evictable_size_ -= len(k)
+        self.evictable_size_ -= len(value)
 
     def _total_size_helper(self, node):
         x = len(node.value)


### PR DESCRIPTION
I notice that the variable `evictable_size` is obtained by summing the values of all tree nodes, not the keys.