### PR TITLE
Add cache metrics

### DIFF
--- a/python/sglang/srt/constrained/base_cache.py
+++ b/python/sglang/srt/constrained/base_cache.py
@@ -3,7 +3,7 @@
 import time
 
 
-class Cache:
+class BaseCache:
     def __init__(self, enable=True):
         self.enable = enable
         self.reset()

--- a/python/sglang/srt/constrained/base_cache.py
+++ b/python/sglang/srt/constrained/base_cache.py
@@ -1,0 +1,50 @@
+"""Base cache class."""
+
+import time
+
+
+class Cache:
+    def __init__(self, enable=True):
+        self.enable = enable
+        self.reset()
+
+    def reset(self):
+        self.cache = {}
+        self.metrics = {"total": 0, "hit": 0, "avg_init_time": 0}
+
+    def query(self, key):
+        def _init_with_timer(key):
+            start = time.monotonic()
+            val = self.init_value(key)
+            init_time = time.monotonic() - start
+            curr_total = self.metrics["total"]
+            new_total = curr_total + 1
+
+            # Update average init time without old_avg * old_total to avoid overflow.
+            self.metrics["avg_init_time"] = (init_time / new_total) + (
+                curr_total / new_total
+            ) * self.metrics["avg_init_time"]
+            self.metrics["total"] += 1
+            return val
+
+        if key in self.cache:
+            self.metrics["hit"] += 1
+            val = self.cache[key]
+        else:
+            # Cache miss or disabled.
+            val = _init_with_timer(key)
+
+        if self.enable:
+            self.cache[key] = val
+        return val
+
+    def init_value(self, key):
+        raise NotImplementedError
+
+    def get_cache_hit_rate(self):
+        if self.metrics["total"] == 0:
+            return 0
+        return self.metrics["hit"] / self.metrics["total"]
+
+    def get_avg_init_time(self):
+        return self.metrics["avg_init_time"]

--- a/python/sglang/srt/constrained/fast_forward.py
+++ b/python/sglang/srt/constrained/fast_forward.py
@@ -1,5 +1,5 @@
 import interegular
-from sglang.srt.constrained.base_cache import Cache
+from sglang.srt.constrained.base_cache import BaseCache
 from sglang.srt.constrained.disk_cache import disk_cache
 from sglang.srt.constrained.regex import FSMInfo, make_deterministic_fsm
 
@@ -57,7 +57,7 @@ class FastForwardMap:
         return fast_forward_str, next_state
 
 
-class FastForwardCache(Cache):
+class FastForwardCache(BaseCache):
     def __init__(self):
         super().__init__()
 

--- a/python/sglang/srt/constrained/fast_forward.py
+++ b/python/sglang/srt/constrained/fast_forward.py
@@ -1,4 +1,5 @@
 import interegular
+from sglang.srt.constrained.base_cache import Cache
 from sglang.srt.constrained.disk_cache import disk_cache
 from sglang.srt.constrained.regex import FSMInfo, make_deterministic_fsm
 
@@ -56,15 +57,12 @@ class FastForwardMap:
         return fast_forward_str, next_state
 
 
-class FastForwardCache:
+class FastForwardCache(Cache):
     def __init__(self):
-        self.cache = {}
+        super().__init__()
 
-    def init_fast_forward_map(self, regex_string):
-        if regex_string not in self.cache:
-            fast_forward_map = FastForwardMap(regex_string)
-            self.cache[regex_string] = fast_forward_map
-        return self.cache[regex_string]
+    def init_value(self, regex):
+        return FastForwardMap(regex)
 
 
 def test_main():

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -1,51 +1,14 @@
-import time
-
+from sglang.srt.constrained.base_cache import Cache
 from sglang.srt.constrained.fsm import RegexFSM
 from sglang.srt.constrained.tokenizer import TransformerTokenizer
 
-_enable_memory_cache = True
 
-
-class FSMCache:
-    def __init__(self, tokenizer_path, tokenizer_args_dict):
-        self.reset()
+class FSMCache(Cache):
+    def __init__(self, tokenizer_path, tokenizer_args_dict, enable=True):
+        super().__init__(enable=enable)
         self.outlines_tokenizer = TransformerTokenizer(
             tokenizer_path, **tokenizer_args_dict
         )
 
-    def reset(self):
-        self.cache = {}
-        self.metrics = {"total": 0, "hit": 0, "avg_init_time": 0}
-
-    def init_fsm(self, regex):
-        def _init_fsm_helper(regex):
-            start = time.monotonic()
-            fsm = RegexFSM(regex, self.outlines_tokenizer)
-            init_time = time.monotonic() - start
-            curr_total = self.metrics["total"]
-            new_total = curr_total + 1
-
-            # Update average init time without old_avg * old_total to avoid overflow.
-            self.metrics["avg_init_time"] = (init_time / new_total) + (
-                curr_total / new_total
-            ) * self.metrics["avg_init_time"]
-            self.metrics["total"] += 1
-            return fsm
-
-        if _enable_memory_cache:
-            if regex not in self.cache:
-                self.cache[regex] = _init_fsm_helper(regex)
-            else:
-                self.metrics["hit"] += 1
-            fsm = self.cache[regex]
-        else:
-            fsm = _init_fsm_helper(regex)
-        return fsm
-
-    def get_cache_hit_rate(self):
-        if self.metrics["total"] == 0:
-            return 0
-        return self.metrics["hit"] / self.metrics["total"]
-
-    def get_avg_init_time(self):
-        return self.metrics["avg_init_time"]
+    def init_value(self, regex):
+        return RegexFSM(regex, self.outlines_tokenizer)

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -1,3 +1,5 @@
+import time
+
 from sglang.srt.constrained.fsm import RegexFSM
 from sglang.srt.constrained.tokenizer import TransformerTokenizer
 
@@ -6,16 +8,44 @@ _enable_memory_cache = True
 
 class FSMCache:
     def __init__(self, tokenizer_path, tokenizer_args_dict):
-        self.cache = {}
+        self.reset()
         self.outlines_tokenizer = TransformerTokenizer(
             tokenizer_path, **tokenizer_args_dict
         )
 
+    def reset(self):
+        self.cache = {}
+        self.metrics = {"total": 0, "hit": 0, "avg_init_time": 0}
+
     def init_fsm(self, regex):
+        def _init_fsm_helper(regex):
+            start = time.monotonic()
+            fsm = RegexFSM(regex, self.outlines_tokenizer)
+            init_time = time.monotonic() - start
+            curr_total = self.metrics["total"]
+            new_total = curr_total + 1
+
+            # Update average init time without old_avg * old_total to avoid overflow.
+            self.metrics["avg_init_time"] = (init_time / new_total) + (
+                curr_total / new_total
+            ) * self.metrics["avg_init_time"]
+            self.metrics["total"] += 1
+            return fsm
+
         if _enable_memory_cache:
             if regex not in self.cache:
-                fsm = RegexFSM(regex, self.outlines_tokenizer)
-                self.cache[regex] = fsm
-            return self.cache[regex]
+                self.cache[regex] = _init_fsm_helper(regex)
+            else:
+                self.metrics["hit"] += 1
+            fsm = self.cache[regex]
+        else:
+            fsm = _init_fsm_helper(regex)
+        return fsm
 
-        return RegexFSM(regex, self.outlines_tokenizer)
+    def get_cache_hit_rate(self):
+        if self.metrics["total"] == 0:
+            return 0
+        return self.metrics["hit"] / self.metrics["total"]
+
+    def get_avg_init_time(self):
+        return self.metrics["avg_init_time"]

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -1,9 +1,9 @@
-from sglang.srt.constrained.base_cache import Cache
+from sglang.srt.constrained.base_cache import BaseCache
 from sglang.srt.constrained.fsm import RegexFSM
 from sglang.srt.constrained.tokenizer import TransformerTokenizer
 
 
-class FSMCache(Cache):
+class FSMCache(BaseCache):
     def __init__(self, tokenizer_path, tokenizer_args_dict, enable=True):
         super().__init__(enable=enable)
         self.outlines_tokenizer = TransformerTokenizer(

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -60,7 +60,11 @@ class Req:
 
     def tokenize_fast_forward(self, fast_forward_str, next_state):
         old_output_str = self.tokenizer.decode(self.output_ids)
-        if self.tokenizer.convert_ids_to_tokens(self.output_ids[0]).startswith("▁"):
+        # FIXME: This logic does not really solve the problem of determining whether
+        # there should be a leading space.
+        first_token = self.tokenizer.convert_ids_to_tokens(self.output_ids[0])
+        first_token = first_token.decode() if isinstance(first_token, bytes) else first_token
+        if first_token.startswith("▁"):
             old_output_str = " " + old_output_str
         new_input_string = (
             self.input_text

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -4,8 +4,7 @@ import multiprocessing
 import time
 import warnings
 from concurrent.futures import ThreadPoolExecutor
-from enum import Enum, auto
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List
 
 import numpy as np
 import rpyc
@@ -251,9 +250,9 @@ class ModelRpcServer(rpyc.Service):
 
         # Init regex fsm
         if req.sampling_params.regex is not None:
-            req.regex_fsm = self.regex_fsm_cache.init_fsm(req.sampling_params.regex)
+            req.regex_fsm = self.regex_fsm_cache.query(req.sampling_params.regex)
             if not self.no_regex_fast_forward:
-                req.fast_forward_map = self.fast_forward_cache.init_fast_forward_map(
+                req.fast_forward_map = self.fast_forward_cache.query(
                     req.sampling_params.regex
                 )
 
@@ -358,9 +357,13 @@ class ModelRpcServer(rpyc.Service):
                 f"#new_token: {new_batch_input_tokens}. "
                 f"#remaining_req: {len(self.forward_queue) - len(can_run_list)}. "
                 f"#running_req: {running_req}. "
-                f"tree_cache_hit_rate: {100.0 * tree_cache_hit_rate:.2f}%. "
+                f"tree_cache_hit_rate: {100.0 * tree_cache_hit_rate:.2f}%."
+            )
+            logger.debug(
                 f"fsm_cache_hit_rate: {100.0 * self.regex_fsm_cache.get_cache_hit_rate():.2f}%. "
                 f"fsm_cache_avg_init_time: {self.regex_fsm_cache.get_avg_init_time():.2f}s. "
+                f"ff_cache_hit_rate: {100.0 * self.fast_forward_cache.get_cache_hit_rate():.2f}%. "
+                f"ff_cache_avg_init_time: {self.fast_forward_cache.get_avg_init_time():.2f}s. "
             )
 
         new_batch = Batch.init_new(


### PR DESCRIPTION
This PR introduces several cache metrics for better benchmarking and analysis.
- Tree cache hit rate: The accumulated `cached_token / total_token` ratio.
- FSM cache hit rate: The accumulated `init_fsm_cache / total_query` ratio.
- FSM cache average initialization time: The average RegexFSM initialization time.

The log now becomes (a bit long...)

```
new fill batch. #seq: 1. #cached_token: 2510. #new_token: 18. tree_cache_hit_rate: 62.18%. fsm_cache_hit_rate: 33.33%. fsm_cache_avg_init_time: 15.73s. #remaining_req: 0. #running_req: 0
```