### PR TITLE
Fix `is_multimodal_model` judge

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -233,12 +233,12 @@ def wrap_kernel_launcher(kernel):
 
 def is_multimodal_model(model):
     if isinstance(model, str):
-        return "llava" or "yi-vl" in model
+        return "llava" in model or "yi-vl" in model
     from sglang.srt.model_config import ModelConfig
 
     if isinstance(model, ModelConfig):
         model_path = model.path.lower()
-        return "llava" in model_path  or "yi-vl" in model_path
+        return "llava" in model_path or "yi-vl" in model_path
     raise Exception("unrecognized type")
 
 


### PR DESCRIPTION
```python
if isinstance(model, str):
    return "llava" or "yi-vl" in model
```
The above logic is wrong, when model is llama-7b, it returns `"llava"` but not `True` or `False`.

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ubuntu/sglang/python/sglang/launch_server.py", line 11, in <module>
    launch_server(server_args, None)
  File "/home/ubuntu/sglang/python/sglang/srt/server.py", line 356, in launch_server
    tokenizer_manager = TokenizerManager(server_args, port_args)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/sglang/python/sglang/srt/managers/tokenizer_manager.py", line 106, in __init__
    self.tokenizer = self.processor.tokenizer
                     ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LlamaTokenizerFast' object has no attribute 'tokenizer'. Did you mean: '_tokenizer'?
```