### PR TITLE
fix undfined variable

### DIFF
--- a/python/sglang/backend/openai.py
+++ b/python/sglang/backend/openai.py
@@ -106,7 +106,7 @@ class OpenAI(BaseBackend):
                 **kwargs,
             )
         else:
-            raise ValueError(f"Unknown dtype: {dtype}")
+            raise ValueError(f"Unknown dtype: {sampling_params.dtype}")
 
         return comp, {}
 


### PR DESCRIPTION
Line `109` in the python file `python/sglang/openai.py` raises a 'dtype' ValueError. However, this variable is not defined. This pull request fixes this issue by raising the ValueError of `sampling_params.dtype`.