### PR TITLE
[Submodule] Change FlashInfer to import

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/flashinfer"]
-	path = 3rdparty/flashinfer
-	url = https://github.com/flashinfer-ai/flashinfer.git

--- a/docs/flashinfer.md
+++ b/docs/flashinfer.md
@@ -5,12 +5,14 @@ It can be used in SGLang runtime to accelerate attention computation.
 
 ### Install flashinfer
 
-Note: The compilation can take a very long time.
+You can install flashinfer via pip as follows for CUDA 12.1.
 
 ```bash
-git submodule update --init --recursive
-pip install 3rdparty/flashinfer/python
+pip install flashinfer -i https://flashinfer.ai/whl/cu121/
 ```
+
+You can look for other CUDA versions in https://github.com/flashinfer-ai/flashinfer?tab=readme-ov-file#installation. If there is no desire version for your environment,
+please build it from source (the compilation takes a long time).
 
 ### Run a Server With Flashinfer Mode
 

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -98,12 +98,7 @@ class RadixAttention(nn.Module):
 
         o = input_metadata.prefill_wrapper.forward(
             q.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
-            input_metadata.qo_indptr,
             input_metadata.token_to_kv_pool.kv_data[self.layer_id],
-            input_metadata.kv_indptr,
-            input_metadata.kv_indices,
-            input_metadata.kv_last_page_len,
-            allow_fp16_qk_reduction=True,
         )
 
         return o.view(-1, self.tp_q_head_num * self.head_dim)
@@ -114,9 +109,6 @@ class RadixAttention(nn.Module):
         o = input_metadata.decode_wrapper.forward(
             q.contiguous().view(-1, self.tp_q_head_num, self.head_dim),
             input_metadata.token_to_kv_pool.kv_data[self.layer_id],
-            input_metadata.kv_indptr,
-            input_metadata.kv_indices,
-            input_metadata.kv_last_page_len,
         )
 
         return o.view(-1, self.tp_q_head_num * self.head_dim)


### PR DESCRIPTION
This PR removes submodule flashinfer from this repo. As flashinfer is now officially released, we can directly install it via pip. However, I didn't add it to pyproject.toml but just updated the README due to two reasons:
1. flashinfer is not available on PYPI yet.
2. It supports limited CUDA version and requires to manually select the wheel path.

Meanwhile, the latest version of flashinfer has some interface changes. I modified them according to this comparison:
https://github.com/flashinfer-ai/flashinfer/compare/88b9496...3fc62cb

I verified two things with this PR:
1. My test prompt gets the same output tokens before and after this PR.
2. benchmark/multi_chain_reasoning generates different results even `temperature=0`. There might be due to the misuse  of the new interface or the randomness in the kernel. I'll do more investigation.

cc @Ying1123 