### PR TITLE
Add Auth Token to RuntimeEndpoint

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -95,7 +95,7 @@ def http_request(url, json=None, stream=False, auth_token=None):
             "Content-Type": "application/json",
             "Authentication": f"Bearer {auth_token}"
         }
-        return requests.post(url, json=json, stream=True, headers={})
+        return requests.post(url, json=json, stream=True, headers=headers)
     else:
         req = urllib.request.Request(url)
         req.add_header("Content-Type", "application/json; charset=utf-8")

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -88,13 +88,18 @@ class HttpResponse:
         return self.resp.status
 
 
-def http_request(url, json=None, stream=False):
+def http_request(url, json=None, stream=False, auth_token=None):
     """A faster version of requests.post with low-level urllib API."""
     if stream:
-        return requests.post(url, json=json, stream=True)
+        headers = {
+            "Content-Type": "application/json",
+            "Authentication": f"Bearer {auth_token}"
+        }
+        return requests.post(url, json=json, stream=True, headers={})
     else:
         req = urllib.request.Request(url)
         req.add_header("Content-Type", "application/json; charset=utf-8")
+        req.add_header("Authentication", f"Bearer {auth_token}")
         if json is None:
             data = None
         else:


### PR DESCRIPTION
Hi,

So I had an interesting use case. I was deploying this model for testing on a databricks notebook. And I was trying to use the sglang library locally. To do this the databricks_access_token must be passed as the auth token in the header.

If im calling the endpoint via CURL its fine since I can manually add it.

But I wasn't able to do this via the `RuntimeEnpoint` class. Hence I added this functionality into the class itself as an optional variable which defaults to None.