### PR TITLE
Support extra field regex in OpenAI API

### DIFF
--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -36,6 +36,9 @@ class CompletionRequest(BaseModel):
     logit_bias: Optional[Dict[str, float]] = None
     user: Optional[str] = None
 
+    # Extra parameters for SRT backend only and will be ignored by OpenAI models.
+    regex: Optional[str] = None
+
 
 class CompletionResponseChoice(BaseModel):
     index: int
@@ -118,6 +121,9 @@ class ChatCompletionRequest(BaseModel):
     logit_bias: Optional[Dict[str, float]] = None
     user: Optional[str] = None
     best_of: Optional[int] = None
+
+    # Extra parameters for SRT backend only and will be ignored by OpenAI models.
+    regex: Optional[str] = None
 
 
 class ChatMessage(BaseModel):

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -151,6 +151,7 @@ async def v1_completions(raw_request: Request):
             "top_p": request.top_p,
             "presence_penalty": request.presence_penalty,
             "frequency_penalty": request.frequency_penalty,
+            "regex": request.regex,
         },
         return_logprob=request.logprobs is not None,
         stream=request.stream,
@@ -304,6 +305,7 @@ async def v1_chat_completions(raw_request: Request):
             "top_p": request.top_p,
             "presence_penalty": request.presence_penalty,
             "frequency_penalty": request.frequency_penalty,
+            "regex": request.regex,
         },
         stream=request.stream,
     )

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -193,5 +193,6 @@ if __name__ == "__main__":
     test_completion_stream(args, echo=True, logprobs=True)
     test_chat_completion(args)
     test_chat_completion_stream(args)
+    test_regex(args)
     if args.test_image:
         test_chat_completion_image(args)

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -14,6 +14,7 @@ The capital of Japan is Tokyo
 """
 
 import argparse
+import json
 
 import openai
 
@@ -149,6 +150,29 @@ def test_chat_completion_stream(args):
             continue
         print(data.content, end="", flush=True)
     print()
+
+
+def test_regex(args):
+    client = openai.Client(api_key="EMPTY", base_url=args.base_url)
+
+    regex = (r"""\{\n"""
+        + r"""   "name": "[\w]+",\n"""
+        + r"""   "population": "[\w\d\s]+"\n"""
+        + r"""\}"""
+    )
+
+    response = client.chat.completions.create(
+        model="default",
+        messages=[
+            {"role": "system", "content": "You are a helpful AI assistant"},
+            {"role": "user", "content": "Introduce the capital of France."},
+        ],
+        temperature=0,
+        max_tokens=128,
+        extra_body={"regex": regex},
+    )
+    text = response.choices[0].message.content
+    print(json.loads(text))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
close #171 

This PR adds an extra field `regex` in OpenAI protocols. Since OpenAI SDK 2.0, it allows arbitrary fields to be specified in the following approaches:

1. OpenAI SDK:

```python
response = client.chat.completions.create(
    ...
    extra_body={"more_param": more_param_value},
)
```

2. CURL:

```
curl http://localhost:5000/v1/chat/completions?more_param=more_param_value ...
```

The extra parameter (i.e., `regex`) will be ignored by OpenAI models (e.g., gpt-3.5-turbo, gpt4, etc), but our SRT OpenAI API server will forward it correctly.

cc @remixer-dec