### PR TITLE
Fix token usage with jump forward

### DIFF
--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -27,6 +27,9 @@ class Req:
         self.input_ids = input_ids
         self.output_ids = []
 
+        # for accumulated prompt tokens from jump forward
+        self.orig_prompt_tokens = len(input_ids)
+
         # For vision input
         self.pixel_values = None
         self.image_size = None
@@ -52,7 +55,6 @@ class Req:
         self.normalized_logprob = None
 
         # For constrained decoding
-        self.orig_prompt_tokens = None
         self.regex_fsm = None
         self.regex_fsm_state = 0
         self.jump_forward_map = None
@@ -342,10 +344,6 @@ class Batch:
                     jump_forward_str, next_state = res
                     if len(jump_forward_str) <= 1:
                         continue
-
-                    # in the first jump forward, record the real prompt token length
-                    if req.orig_prompt_tokens is None:
-                        req.orig_prompt_tokens = len(req.input_ids)
 
                     # insert the old request into tree_cache
                     token_ids_in_memory = tuple(req.input_ids + req.output_ids)[:-1]

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -52,6 +52,7 @@ class Req:
         self.normalized_logprob = None
 
         # For constrained decoding
+        self.orig_prompt_tokens = None
         self.regex_fsm = None
         self.regex_fsm_state = 0
         self.jump_forward_map = None
@@ -341,6 +342,10 @@ class Batch:
                     jump_forward_str, next_state = res
                     if len(jump_forward_str) <= 1:
                         continue
+
+                    # in the first jump forward, record the real prompt token length
+                    if req.orig_prompt_tokens is None:
+                        req.orig_prompt_tokens = len(req.input_ids)
 
                     # insert the old request into tree_cache
                     token_ids_in_memory = tuple(req.input_ids + req.output_ids)[:-1]

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -535,22 +535,13 @@ class ModelRpcServer(rpyc.Service):
                     req.sampling_params.skip_special_tokens
                 )
 
-                if req.orig_prompt_tokens is not None:
-                    # When orig_prompt_tokens is set, this request was procssed with
-                    # jump forward, which results in accumnulated prompt tokens from
-                    # partial decoding tokens.
-                    prompt_tokens = req.orig_prompt_tokens
-                    completion_tokens = (
-                        len(req.input_ids) - prompt_tokens + len(req.output_ids)
-                    )
-                else:
-                    prompt_tokens = len(req.input_ids)
-                    completion_tokens = len(req.output_ids)
-
                 meta_info = {
-                    "prompt_tokens": prompt_tokens,
-                    "completion_tokens": completion_tokens,
+                    "prompt_tokens": req.orig_prompt_tokens,
+                    "completion_tokens": len(req.input_ids)
+                    + len(req.output_ids)
+                    - req.orig_prompt_tokens,
                 }
+
                 if req.return_logprob:
                     meta_info["prompt_logprob"] = req.logprob
                     meta_info["token_logprob"] = req.token_logprob

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -534,7 +534,9 @@ class ModelRpcServer(rpyc.Service):
                 output_skip_special_tokens.append(
                     req.sampling_params.skip_special_tokens
                 )
-
+                
+                # For the length of input_ids, which will be accumulated during jump-forward.
+                # Use the original length of input_ids to calculate the token usage info.
                 meta_info = {
                     "prompt_tokens": req.orig_prompt_tokens,
                     "completion_tokens": len(req.input_ids)

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -534,9 +534,22 @@ class ModelRpcServer(rpyc.Service):
                 output_skip_special_tokens.append(
                     req.sampling_params.skip_special_tokens
                 )
+
+                if req.orig_prompt_tokens is not None:
+                    # When orig_prompt_tokens is set, this request was procssed with
+                    # jump forward, which results in accumnulated prompt tokens from
+                    # partial decoding tokens.
+                    prompt_tokens = req.orig_prompt_tokens
+                    completion_tokens = (
+                        len(req.input_ids) - prompt_tokens + len(req.output_ids)
+                    )
+                else:
+                    prompt_tokens = len(req.input_ids)
+                    completion_tokens = len(req.output_ids)
+
                 meta_info = {
-                    "prompt_tokens": len(req.input_ids),
-                    "completion_tokens": len(req.output_ids),
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
                 }
                 if req.return_logprob:
                     meta_info["prompt_logprob"] = req.logprob


### PR DESCRIPTION
close #173 

This PR fixes the incorrect token usage when jump forward is enabled. Specifically, we introduce a new field `orig_prompt_tokens`, which will be set when the first jump forward happens so that we could know the original number of prompt tokens. When returning a response (a chunk in streaming or a complete response), we use the following equations to correct the token usage:

```
completion_tokens = curr_prompt_token - orig_prompt_tokens + completion_tokens
prompt_tokens = orig_prompt_tokens
```