### PR TITLE
correct mistake README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ states = text_qa.run(
     stream=True
 )
 
-for out in state.text_iter():
+for out in states.text_iter():
     print(out, end="", flush=True)
 ```
 


### PR DESCRIPTION
improve README by fixing a mistake: `states.text_iter()`instead of `state.text_iter()`, since the reference variable is `states` .