### PR TITLE
correct reference dtype openai.py

### DIFF
--- a/python/sglang/backend/openai.py
+++ b/python/sglang/backend/openai.py
@@ -137,7 +137,7 @@ class OpenAI(BaseBackend):
             )
             return generator
         else:
-            raise ValueError(f"Unknown dtype: {dtype}")
+            raise ValueError(f"Unknown dtype: {sampling_params.dtype}")
 
     def select(
         self,


### PR DESCRIPTION
The actual version raises a `dtype` error instead of `sampling_params.dtype`. This pull request correct this.