### PR TITLE
Fix addr reuse in check_port

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -103,6 +103,7 @@ def alloc_usable_network_port(num, used_list=()):
 def check_port(port):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind(("", port))
             return True
         except socket.error:


### PR DESCRIPTION
### What does this PR do?

After a socket is closed, it comes into `TIME_WAIT` status and refuses other socket listeners to bind it. `TIME_WAIT` normally lasts 30s and causes troubles when we want to fix the HTTP server port between frequently shutdown/starting SRT.

Add a `SO_REUSEADDR` option when checking the port to fix this, which allows binding to a just-released port with the same address.
