### PR TITLE
Fix marlin model loading compat with autogptq

### DIFF
--- a/python/sglang/srt/managers/router/model_runner.py
+++ b/python/sglang/srt/managers/router/model_runner.py
@@ -297,9 +297,15 @@ class ModelRunner:
                     self.model_config.hf_config, "quantization_config", None
                 )
                 if hf_quant_config is not None:
-                    quant_config_class = QUANTIONCONFIG_MAPPING.get(
-                        hf_quant_config["quant_method"]
-                    )
+                    hf_quant_method = hf_quant_config["quant_method"]
+
+                    # compat: autogptq uses is_marlin_format within quant config
+                    if (hf_quant_method == "gptq"
+                            and "is_marlin_format" in hf_quant_config
+                            and hf_quant_config["is_marlin_format"]):
+                        hf_quant_method = "marlin"
+                    quant_config_class = QUANTIONCONFIG_MAPPING.get(hf_quant_method)
+
                     if quant_config_class is None:
                         raise ValueError(
                             f"Unsupported quantization method: {hf_quant_config['quant_method']}"


### PR DESCRIPTION
Fix Issue #289 
Autogptq uses is_marlin_format for Marlin. So depending on how/tool used to quantize, it can be quant_method=="marlin" or quant_method=="gptq" and is_marlin_format==True. Technically, Marlin is a format, not new quant method so autogptq way is more correct. But regardless, this PR will allow both methods to work.