### PR TITLE
Fix outlines-0.0.35 incompatibility

### DIFF
--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -5,9 +5,20 @@ from sglang.srt.constrained.base_cache import BaseCache
 class FSMCache(BaseCache):
     def __init__(self, tokenizer_path, tokenizer_args_dict, enable=True):
         super().__init__(enable=enable)
-        self.outlines_tokenizer = TransformerTokenizer(
-            tokenizer_path, **tokenizer_args_dict
-        )
+
+        from importlib.metadata import version
+        if version("outlines") >= "0.0.35":
+            from transformers import AutoTokenizer
+
+            tokenizer_args_dict.setdefault("padding_side", "left")
+            tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer_path, **tokenizer_args_dict
+            )
+            self.outlines_tokenizer = TransformerTokenizer(tokenizer)
+        else:
+            self.outlines_tokenizer = TransformerTokenizer(
+                tokenizer_path, **tokenizer_args_dict
+            )
 
     def init_value(self, regex):
         return RegexFSM(regex, self.outlines_tokenizer)


### PR DESCRIPTION
 [Changes in outlines 0.0.35 TransformerTokenizer](https://github.com/outlines-dev/outlines/commit/a62ff007299a1634ff2ff0ecd1f6aa250d9a6b55#diff-f1e3ec9b1d7a259bbe9691a9f3d4918404d8a1c3a8ffb6e71c5de7542e4c3af7R58) broke compatibility.
 
 
![Screenshot_20240314_092536](https://github.com/sgl-project/sglang/assets/18276248/74e371d1-39a6-4846-b8d4-27667d72d660)
