### PR TITLE
Logprobs Refractor

### DIFF
--- a/docs/sampling_params.md
+++ b/docs/sampling_params.md
@@ -14,10 +14,14 @@ class GenerateReqInput:
     sampling_params: Union[List[Dict], Dict] = None
     # The request id
     rid: Optional[Union[List[str], str]] = None
-    # Whether return logprobs of the prompts
+    # Whether to return logprobs
     return_logprob: Optional[Union[List[bool], bool]] = None
     # The start location of the prompt for return_logprob
     logprob_start_len: Optional[Union[List[int], int]] = None
+    # The number of top logprobs to return
+    top_logprobs_num: Optional[Union[List[int], int]] = None
+    # Whether to detokenize tokens in logprobs
+    return_text_in_logprobs: bool = False
     # Whether to stream output
     stream: bool = False
 ```

--- a/examples/usage/choices_logprob.py
+++ b/examples/usage/choices_logprob.py
@@ -3,6 +3,7 @@ Usage:
 python -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --port 30000
 python choices_logprob.py
 """
+
 import sglang as sgl
 
 
@@ -19,9 +20,9 @@ def main():
     print("questions:", question)
     print("choice:", state["tool"])
     meta_info = state.get_meta_info("tool")
-    print("logprobs of choice 1", meta_info["prompt_logprob"][0])
-    print("logprobs of choice 2", meta_info["prompt_logprob"][1])
-    print('-' * 50)
+    print("logprobs of choice 1", meta_info["prefill_token_logprobs"][0])
+    print("logprobs of choice 2", meta_info["prefill_token_logprobs"][1])
+    print("-" * 50)
 
     # Run a batch
     questions = [
@@ -33,9 +34,9 @@ def main():
         print("questions:", question)
         print("choice:", state["tool"])
         meta_info = state.get_meta_info("tool")
-        print("logprobs of choice 1", meta_info["prompt_logprob"][0])
-        print("logprobs of choice 2", meta_info["prompt_logprob"][1])
-        print('-' * 50)
+        print("logprobs of choice 1", meta_info["prefill_token_logprobs"][0])
+        print("logprobs of choice 2", meta_info["prefill_token_logprobs"][1])
+        print("-" * 50)
 
 
 if __name__ == "__main__":

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -464,7 +464,7 @@ class StreamExecutor:
             name = expr.name
             self.variables[name] = decision
             self.meta_info[name] = {
-                "normalized_prompt_logprob": normalized_prompt_logprobs,
+                "normalized_prompt_logprobs": normalized_prompt_logprobs,
                 "prefill_token_logprobs": prefill_token_logprobs,
                 "decode_token_logprobs": decode_token_logprobs,
             }

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -454,15 +454,19 @@ class StreamExecutor:
             self.stream_var_event[name].set()
 
     def _execute_select(self, expr: SglSelect):
-        decision, normalized_prompt_logprob, prompt_logprob = self.backend.select(
-            self, expr.choices, expr.temperature
-        )
+        (
+            decision,
+            normalized_prompt_logprobs,
+            prefill_token_logprobs,
+            decode_token_logprobs,
+        ) = self.backend.select(self, expr.choices, expr.temperature)
         if expr.name is not None:
             name = expr.name
             self.variables[name] = decision
             self.meta_info[name] = {
-                "normalized_prompt_logprob": normalized_prompt_logprob,
-                "prompt_logprob": prompt_logprob,
+                "normalized_prompt_logprob": normalized_prompt_logprobs,
+                "prefill_token_logprobs": prefill_token_logprobs,
+                "decode_token_logprobs": decode_token_logprobs,
             }
             self.variable_event[name].set()
         self.text_ += decision

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -35,6 +35,34 @@ class LogitsProcessor(nn.Module):
 
         return normalized_prompt_logprobs
 
+    def _get_top_logprobs(self, all_logprobs, input_metadata: InputMetadata):
+        if input_metadata.forward_mode == ForwardMode.DECODE:
+            decode_top_logprobs = []
+            for i in range(all_logprobs.shape[0]):
+                k = input_metadata.top_logprobs_nums[i]
+                t = all_logprobs[i].topk(k)
+                v_cpu = t.values.cpu().tolist()
+                p_cpu = t.indices.cpu().tolist()
+                decode_top_logprobs.append(list(zip(v_cpu, p_cpu)))
+            return None, decode_top_logprobs
+        else:
+            prefill_top_logprobs, decode_top_logprobs = [], []
+            pt = 0
+            # NOTE: the GPU-CPU overhead can be reduced
+            extend_seq_lens_cpu = input_metadata.extend_seq_lens
+            for i in range(len(input_metadata.extend_seq_lens)):
+                if extend_seq_lens_cpu[i] == 0:
+                    continue
+                k = input_metadata.top_logprobs_nums[i]
+                t = all_logprobs[pt : pt + extend_seq_lens_cpu[i]].topk(k)
+                vs_cpu = t.values.cpu().tolist()
+                ps_cpu = t.indices.cpu().tolist()
+                prefill_top_logprobs.append(
+                    [list(zip(vs_cpu[j], ps_cpu[j])) for j in range(len(vs_cpu) - 1)]
+                )
+                decode_top_logprobs.append(list(zip(vs_cpu[-1], ps_cpu[-1])))
+            return prefill_top_logprobs, decode_top_logprobs
+
     def forward(self, input_ids, hidden_states, weight, input_metadata: InputMetadata):
         # Get last index for next token prediction, except for DECODE mode.
         last_index = None
@@ -58,7 +86,7 @@ class LogitsProcessor(nn.Module):
         # Return only last_logits if logprob is not requested
         if not input_metadata.return_logprob:
             hidden_states = None
-            return last_logits, (None, None, None)
+            return last_logits, (None, None, None, None, None)
         else:
             # When logprob is requested, compute the logits for all tokens.
             if input_metadata.forward_mode == ForwardMode.DECODE:
@@ -71,9 +99,19 @@ class LogitsProcessor(nn.Module):
 
             all_logprobs = torch.log(torch.softmax(all_logits.float(), dim=-1) + 1e-6)
 
+            prefill_top_logprobs, decode_top_logprobs = self._get_top_logprobs(
+                all_logprobs, input_metadata
+            )
+
             if input_metadata.forward_mode == ForwardMode.DECODE:
                 last_logprobs = all_logprobs
-                return last_logits, (None, None, last_logprobs)
+                return last_logits, (
+                    None,
+                    None,
+                    decode_top_logprobs,
+                    None,
+                    last_logprobs,
+                )
             else:
                 # Compute the logprobs for the last token of each request.
                 last_logprobs = all_logprobs[last_index]
@@ -90,6 +128,8 @@ class LogitsProcessor(nn.Module):
                 )
                 return last_logits, (
                     prefill_token_logprobs,
+                    prefill_top_logprobs,
+                    decode_top_logprobs,
                     normalized_prompt_logprobs,
                     last_logprobs,
                 )

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -19,10 +19,13 @@ class GenerateReqInput:
     return_logprob: Optional[Union[List[bool], bool]] = None
     # The start location of the prompt for return_logprob
     logprob_start_len: Optional[Union[List[int], int]] = None
+    # The number of top logprobs to return
+    top_logprobs_num: Optional[Union[List[int], int]] = None
     # Whether to detokenize tokens in logprobs
     return_text_in_logprobs: bool = False
     # Whether to stream output
     stream: bool = False
+    # TODO: make all parameters a Union[List[T], T] to allow for batched requests
 
     def post_init(self):
         is_single = isinstance(self.text, str)
@@ -36,6 +39,8 @@ class GenerateReqInput:
                 self.return_logprob = False
             if self.logprob_start_len is None:
                 self.logprob_start_len = 0
+            if self.top_logprobs_num is None:
+                self.top_logprobs_num = 0
         else:
             num = len(self.text)
 
@@ -64,6 +69,11 @@ class GenerateReqInput:
             elif not isinstance(self.logprob_start_len, list):
                 self.logprob_start_len = [self.logprob_start_len] * num
 
+            if self.top_logprobs_num is None:
+                self.top_logprobs_num = [0] * num
+            elif not isinstance(self.top_logprobs_num, list):
+                self.top_logprobs_num = [self.top_logprobs_num] * num
+
 
 @dataclass
 class TokenizedGenerateReqInput:
@@ -76,6 +86,7 @@ class TokenizedGenerateReqInput:
     sampling_params: SamplingParams
     return_logprob: bool
     logprob_start_len: int
+    top_logprobs_num: int
     stream: bool
 
 

--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -5,16 +5,17 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 
-class TopLogProbs(BaseModel):
-    # TODO: not supported yet
-    pass
+class LogProbs(BaseModel):
+    text_offset: List[int] = Field(default_factory=list)
+    token_logprobs: List[Optional[float]] = Field(default_factory=list)
+    tokens: List[str] = Field(default_factory=list)
+    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
 
-
-class TokenLogProb(BaseModel):
-    logprob: Optional[float] = None
-    token_id: int
-    token_text: Optional[str] = None
-    top_logprobs: Optional[TopLogProbs] = None
+    def extend(self, other: "LogProbs"):
+        self.text_offset.extend(other.text_offset)
+        self.token_logprobs.extend(other.token_logprobs)
+        self.tokens.extend(other.tokens)
+        self.top_logprobs.extend(other.top_logprobs)
 
 
 class UsageInfo(BaseModel):
@@ -48,7 +49,7 @@ class CompletionRequest(BaseModel):
 class CompletionResponseChoice(BaseModel):
     index: int
     text: str
-    logprobs: Optional[List[TokenLogProb]] = None
+    logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
 
 
@@ -64,7 +65,7 @@ class CompletionResponse(BaseModel):
 class CompletionResponseStreamChoice(BaseModel):
     index: int
     text: str
-    logprobs: Optional[List[TokenLogProb]] = None
+    logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
 
 

--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -5,11 +5,16 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 
-class LogProbs(BaseModel):
-    text_offset: List[int] = Field(default_factory=list)
-    token_logprobs: List[Optional[float]] = Field(default_factory=list)
-    tokens: List[str] = Field(default_factory=list)
-    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
+class TopLogProbs(BaseModel):
+    # TODO: not supported yet
+    pass
+
+
+class TokenLogProb(BaseModel):
+    logprob: Optional[float] = None
+    token_id: int
+    token_text: Optional[str] = None
+    top_logprobs: Optional[TopLogProbs] = None
 
 
 class UsageInfo(BaseModel):
@@ -27,7 +32,7 @@ class CompletionRequest(BaseModel):
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1
     stream: Optional[bool] = False
-    logprobs: Optional[int] = None
+    logprobs: Optional[bool] = None
     echo: Optional[bool] = False
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     presence_penalty: Optional[float] = 0.0
@@ -43,7 +48,7 @@ class CompletionRequest(BaseModel):
 class CompletionResponseChoice(BaseModel):
     index: int
     text: str
-    logprobs: Optional[LogProbs] = None
+    logprobs: Optional[List[TokenLogProb]] = None
     finish_reason: Optional[str] = None
 
 
@@ -59,7 +64,7 @@ class CompletionResponse(BaseModel):
 class CompletionResponseStreamChoice(BaseModel):
     index: int
     text: str
-    logprobs: Optional[LogProbs] = None
+    logprobs: Optional[List[TokenLogProb]] = None
     finish_reason: Optional[str] = None
 
 

--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -11,12 +11,6 @@ class LogProbs(BaseModel):
     tokens: List[str] = Field(default_factory=list)
     top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
 
-    def extend(self, other: "LogProbs"):
-        self.text_offset.extend(other.text_offset)
-        self.token_logprobs.extend(other.token_logprobs)
-        self.tokens.extend(other.tokens)
-        self.top_logprobs.extend(other.top_logprobs)
-
 
 class UsageInfo(BaseModel):
     prompt_tokens: int = 0
@@ -34,6 +28,7 @@ class CompletionRequest(BaseModel):
     n: Optional[int] = 1
     stream: Optional[bool] = False
     logprobs: Optional[bool] = None
+    top_logprobs: Optional[int] = None
     echo: Optional[bool] = False
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     presence_penalty: Optional[float] = 0.0

--- a/python/sglang/srt/managers/openai_protocol.py
+++ b/python/sglang/srt/managers/openai_protocol.py
@@ -27,8 +27,7 @@ class CompletionRequest(BaseModel):
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1
     stream: Optional[bool] = False
-    logprobs: Optional[bool] = None
-    top_logprobs: Optional[int] = None
+    logprobs: Optional[int] = None
     echo: Optional[bool] = False
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     presence_penalty: Optional[float] = 0.0

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -54,8 +54,8 @@ class Req:
         self.prefix_indices = []
         self.last_node = None
 
-        self.prefill_token_logprobs_with_ids = None
-        self.decode_token_logprobs_with_ids = None
+        self.prefill_token_logprobs = None
+        self.decode_token_logprobs = None
         self.normalized_prompt_logprob = None
 
         # For constrained decoding

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -54,9 +54,9 @@ class Req:
         self.prefix_indices = []
         self.last_node = None
 
-        self.logprob = None
-        self.token_logprob = None
-        self.normalized_logprob = None
+        self.prefill_token_logprobs_with_ids = None
+        self.decode_token_logprobs_with_ids = None
+        self.normalized_prompt_logprob = None
 
         # For constrained decoding
         self.regex_fsm = None

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -43,6 +43,7 @@ class Req:
         self.sampling_params = None
         self.return_logprob = False
         self.logprob_start_len = 0
+        self.top_logprobs_num = 0
         self.stream = False
 
         self.tokenizer = None
@@ -57,6 +58,8 @@ class Req:
         self.prefill_token_logprobs = None
         self.decode_token_logprobs = None
         self.normalized_prompt_logprob = None
+        self.prefill_top_logprobs = None
+        self.decode_top_logprobs = None
 
         # For constrained decoding
         self.regex_fsm = None
@@ -159,6 +162,9 @@ class Batch:
     out_cache_loc: torch.Tensor = None
     out_cache_cont_start: torch.Tensor = None
     out_cache_cont_end: torch.Tensor = None
+
+    # for processing logprobs
+    top_logprobs_nums: List[int] = None
     return_logprob: bool = False
 
     # for multimodal
@@ -266,6 +272,7 @@ class Batch:
         self.position_ids_offsets = position_ids_offsets
         self.extend_num_tokens = extend_num_tokens
         self.out_cache_loc = out_cache_loc
+        self.top_logprobs_nums = [r.top_logprobs_num for r in reqs]
 
         self.temperatures = torch.tensor(
             [r.sampling_params.temperature for r in reqs],
@@ -415,6 +422,7 @@ class Batch:
         self.prefix_lens = None
         self.position_ids_offsets = self.position_ids_offsets[new_indices]
         self.out_cache_loc = self.out_cache_cont_start = self.out_cache_cont_end = None
+        self.top_logprobs_nums = [self.top_logprobs_nums[i] for i in unfinished_indices]
         self.return_logprob = any(req.return_logprob for req in self.reqs)
 
         for item in [
@@ -439,6 +447,7 @@ class Batch:
             [self.position_ids_offsets, other.position_ids_offsets]
         )
         self.out_cache_loc = self.out_cache_cont_start = self.out_cache_cont_end = None
+        self.top_logprobs_nums.extend(other.top_logprobs_nums)
         self.return_logprob = any(req.return_logprob for req in self.reqs)
 
         for item in [

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -419,9 +419,12 @@ class ModelRpcServer:
             next_token_ids = next_token_ids.cpu().tolist()
         else:
             next_token_ids = [self.tokenizer.eos_token_id] * len(batch.reqs)
-            logits = prefill_token_logprobs = normalized_prompt_logprobs = (
-                last_logprobs
-            ) = None
+            (
+                logits,
+                prefill_token_logprobs,
+                normalized_prompt_logprobs,
+                last_logprobs,
+            ) = (None,) * 4
 
         # Only batch transfer the selected logprobs of the next token to CPU to reduce overhead.
         reqs = batch.reqs

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -437,17 +437,17 @@ class ModelRpcServer:
 
             if prefill_token_logprobs is not None:
                 # If logprob_start_len > 0, then first logprob_start_len prompt tokens will be ignored.
-                req.prefill_token_logprobs_with_ids = list(
+                req.prefill_token_logprobs = list(
                     zip(
                         prefill_token_logprobs[pt : pt + req.extend_input_len - 1],
                         req.input_ids[-req.extend_input_len + 1 :],
                     )
                 )
                 if req.logprob_start_len == 0:
-                    req.prefill_token_logprobs_with_ids = [
+                    req.prefill_token_logprobs = [
                         (None, req.input_ids[0])
-                    ] + req.prefill_token_logprobs_with_ids
-                req.decode_token_logprobs_with_ids = [
+                    ] + req.prefill_token_logprobs
+                req.decode_token_logprobs = [
                     (last_token_logprobs[i], next_token_ids[i])
                 ]
                 req.normalized_prompt_logprob = normalized_prompt_logprobs[i]
@@ -521,9 +521,7 @@ class ModelRpcServer:
             req.check_finished()
 
             if new_token_logprobs is not None:
-                req.decode_token_logprobs_with_ids.append(
-                    (new_token_logprobs[i], next_token_id)
-                )
+                req.decode_token_logprobs.append((new_token_logprobs[i], next_token_id))
 
         self.handle_finished_requests(batch)
 
@@ -569,12 +567,12 @@ class ModelRpcServer:
                 }
                 if req.return_logprob:
                     (
-                        meta_info["prefill_token_logprobs_with_ids"],
-                        meta_info["decode_token_logprobs_with_ids"],
+                        meta_info["prefill_token_logprobs"],
+                        meta_info["decode_token_logprobs"],
                         meta_info["normalized_prompt_logprob"],
                     ) = (
-                        req.prefill_token_logprobs_with_ids,
-                        req.decode_token_logprobs_with_ids,
+                        req.prefill_token_logprobs,
+                        req.decode_token_logprobs,
                         req.normalized_prompt_logprob,
                     )
                 output_meta_info.append(meta_info)

--- a/python/sglang/srt/managers/router/model_runner.py
+++ b/python/sglang/srt/managers/router/model_runner.py
@@ -5,6 +5,7 @@ import logging
 import pkgutil
 from dataclasses import dataclass
 from functools import lru_cache
+from typing import List
 
 import numpy as np
 import torch
@@ -81,6 +82,7 @@ class InputMetadata:
     out_cache_cont_end: torch.Tensor = None
 
     other_kv_index: torch.Tensor = None
+    top_logprobs_nums: List[int] = None
     return_logprob: bool = False
 
     # for flashinfer
@@ -181,6 +183,7 @@ class InputMetadata:
         out_cache_loc,
         out_cache_cont_start=None,
         out_cache_cont_end=None,
+        top_logprobs_nums=None,
         return_logprob=False,
     ):
         batch_size = len(req_pool_indices)
@@ -229,6 +232,7 @@ class InputMetadata:
             out_cache_loc=out_cache_loc,
             out_cache_cont_start=out_cache_cont_start,
             out_cache_cont_end=out_cache_cont_end,
+            top_logprobs_nums=top_logprobs_nums,
             return_logprob=return_logprob,
             other_kv_index=other_kv_index,
         )
@@ -377,6 +381,7 @@ class ModelRunner:
             prefix_lens=batch.prefix_lens,
             position_ids_offsets=batch.position_ids_offsets,
             out_cache_loc=batch.out_cache_loc,
+            top_logprobs_nums=batch.top_logprobs_nums,
             return_logprob=batch.return_logprob,
         )
         return self.model.forward(
@@ -394,6 +399,7 @@ class ModelRunner:
             prefix_lens=batch.prefix_lens,
             position_ids_offsets=batch.position_ids_offsets,
             out_cache_loc=batch.out_cache_loc,
+            top_logprobs_nums=batch.top_logprobs_nums,
             return_logprob=batch.return_logprob,
         )
         return self.model.forward(
@@ -413,6 +419,7 @@ class ModelRunner:
             out_cache_loc=batch.out_cache_loc,
             out_cache_cont_start=batch.out_cache_cont_start,
             out_cache_cont_end=batch.out_cache_cont_end,
+            top_logprobs_nums=batch.top_logprobs_nums,
             return_logprob=batch.return_logprob,
         )
         return self.model.forward(
@@ -430,6 +437,7 @@ class ModelRunner:
             prefix_lens=batch.prefix_lens,
             position_ids_offsets=batch.position_ids_offsets,
             out_cache_loc=batch.out_cache_loc,
+            top_logprobs_nums=batch.top_logprobs_nums,
             return_logprob=batch.return_logprob,
         )
         return self.model.forward(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -173,6 +173,7 @@ class TokenizerManager:
                 sampling_params=sampling_params,
                 return_logprob=obj.return_logprob,
                 logprob_start_len=obj.logprob_start_len,
+                top_logprobs_num=obj.top_logprobs_num,
                 stream=obj.stream,
             )
             self.send_to_router.send_pyobj(tokenized_obj)
@@ -215,6 +216,7 @@ class TokenizerManager:
                     sampling_params=sampling_params,
                     return_logprob=obj.return_logprob[i],
                     logprob_start_len=obj.logprob_start_len[i],
+                    top_logprobs_num=obj.top_logprobs_num[i],
                     stream=obj.stream,
                 )
                 self.send_to_router.send_pyobj(tokenized_obj)

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -47,7 +47,7 @@ from sglang.srt.managers.openai_protocol import (
     CompletionResponseStreamChoice,
     CompletionStreamResponse,
     DeltaMessage,
-    LogProbs,
+    TokenLogProb,
     UsageInfo,
 )
 from sglang.srt.managers.router.manager import start_router_process
@@ -123,31 +123,64 @@ async def flush_cache():
     )
 
 
-async def detokenize_logprob_tokens(token_logprobs):
-    token_ids = [tid for tid, _ in token_logprobs]
+async def detokenize_logprob_tokens(token_logprobs, decode_to_text):
+    if not decode_to_text:
+        return [(logprob, token_id, None) for logprob, token_id in token_logprobs]
+
+    token_ids = [tid for _, tid in token_logprobs]
     token_texts = await tokenizer_manager.detokenize(DetokenizeReqInput(token_ids))
-    return [(text, logprob) for text, (_, logprob) in zip(token_texts, token_logprobs)]
+    return [
+        (logprob, token_id, token_text)
+        for (logprob, token_id), token_text, in zip(token_logprobs, token_texts)
+    ]
+
+
+async def handle_token_logprobs_results(obj: GenerateReqInput, ret):
+    # NOTE: This is because the multiple requests in one http request.
+
+    if isinstance(obj.text, str):
+        if obj.return_logprob:
+            ret["meta_info"]["prefill_token_logprobs"] = (
+                await detokenize_logprob_tokens(
+                    ret["meta_info"]["prefill_token_logprobs_with_ids"],
+                    obj.return_text_in_logprobs,
+                )
+            )
+            ret["meta_info"]["decode_token_logprobs"] = await detokenize_logprob_tokens(
+                ret["meta_info"]["decode_token_logprobs_with_ids"],
+                obj.return_text_in_logprobs,
+            )
+    else:
+        for i, r in enumerate(ret):
+            if obj.return_logprob[i]:
+                r["meta_info"]["prefill_token_logprobs"] = (
+                    await detokenize_logprob_tokens(
+                        r["meta_info"]["prefill_token_logprobs_with_ids"],
+                        obj.return_text_in_logprobs,
+                    )
+                )
+                r["meta_info"]["decode_token_logprobs"] = (
+                    await detokenize_logprob_tokens(
+                        r["meta_info"]["decode_token_logprobs_with_ids"],
+                        obj.return_text_in_logprobs,
+                    )
+                )
 
 
 async def stream_generator(obj: GenerateReqInput):
     async for out in tokenizer_manager.generate_request(obj):
-        if obj.return_logprob and obj.return_text_in_logprobs:
-            out["meta_info"]["token_logprob"] = await detokenize_logprob_tokens(
-                out["meta_info"]["token_logprob"]
-            )
+        await handle_token_logprobs_results(obj, out)
         yield out
 
 
 async def make_openai_style_logprobs(token_logprobs):
-    ret_logprobs = LogProbs()
+    ret_logprobs = []
 
-    for token_text, token_logprob in token_logprobs:
-        ret_logprobs.tokens.append(token_text)
-        ret_logprobs.token_logprobs.append(token_logprob)
-
-        # Not supported yet.
-        ret_logprobs.top_logprobs.append({})
-        ret_logprobs.text_offset.append(-1)
+    for logprob, token_id, token_text in token_logprobs:
+        token_logprob = TokenLogProb(
+            logprob=logprob, token_id=token_id, token_text=token_text
+        )
+        ret_logprobs.append(token_logprob)
     return ret_logprobs
 
 
@@ -165,10 +198,7 @@ async def generate_request(obj: GenerateReqInput):
         return StreamingResponse(stream_results(), media_type="text/event-stream")
 
     ret = await tokenizer_manager.generate_request(obj).__anext__()
-    if obj.return_logprob and obj.return_text_in_logprobs:
-        ret["meta_info"]["token_logprob"] = await detokenize_logprob_tokens(
-            ret["meta_info"]["token_logprob"]
-        )
+    await handle_token_logprobs_results(obj, ret)
 
     return ret
 
@@ -192,7 +222,7 @@ async def v1_completions(raw_request: Request):
             "frequency_penalty": request.frequency_penalty,
             "regex": request.regex,
         },
-        return_logprob=request.logprobs is not None,
+        return_logprob=request.logprobs is not None and request.logprobs,
         return_text_in_logprobs=True,
         stream=request.stream,
     )
@@ -212,15 +242,21 @@ async def v1_completions(raw_request: Request):
                     if request.echo:
                         # Prepend prompt in response text.
                         text = request.prompt + text
-                    else:
-                        # Skip prompt tokens if echo is disabled.
-                        n_prev_token = prompt_tokens
 
-                if request.logprobs is not None:
-                    logprobs = await make_openai_style_logprobs(
-                        content["meta_info"]["token_logprob"][n_prev_token:]
+                if request.logprobs:
+                    logprobs = []
+                    # The first chunk and echo is enabled.
+                    if not stream_buffer and request.echo:
+                        prefill_token_logprobs = await make_openai_style_logprobs(
+                            content["meta_info"]["prefill_token_logprobs"]
+                        )
+                        logprobs.extend(prefill_token_logprobs)
+
+                    decode_token_logprobs = await make_openai_style_logprobs(
+                        content["meta_info"]["decode_token_logprobs"][n_prev_token:]
                     )
-                    n_prev_token = len(content["meta_info"]["token_logprob"])
+                    logprobs.extend(decode_token_logprobs)
+                    n_prev_token = len(content["meta_info"]["decode_token_logprobs"])
                 else:
                     logprobs = None
 
@@ -255,20 +291,23 @@ async def v1_completions(raw_request: Request):
     prompt_tokens = ret["meta_info"]["prompt_tokens"]
     completion_tokens = ret["meta_info"]["completion_tokens"]
     text = ret["text"]
-    token_logprob_pos = prompt_tokens
     if request.echo:
-        token_logprob_pos = 0
         text = request.prompt + text
-    else:
-        token_logprob_pos = prompt_tokens
 
-    logprobs = (
-        await make_openai_style_logprobs(
-            ret["meta_info"]["token_logprob"][token_logprob_pos:]
+    if request.logprobs:
+        logprobs = []
+        if request.echo:
+            prefill_token_logprobs = await make_openai_style_logprobs(
+                ret["meta_info"]["prefill_token_logprobs"]
+            )
+            logprobs.extend(prefill_token_logprobs)
+        decode_token_logprob_pos = await make_openai_style_logprobs(
+            ret["meta_info"]["decode_token_logprobs"]
         )
-        if request.logprobs is not None
-        else None
-    )
+        logprobs.extend(decode_token_logprob_pos)
+    else:
+        logprobs = None
+
     choice_data = CompletionResponseChoice(
         index=0,
         text=text,

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -249,8 +249,8 @@ async def v1_completions(raw_request: Request):
             "frequency_penalty": request.frequency_penalty,
             "regex": request.regex,
         },
-        return_logprob=request.logprobs is not None and request.logprobs,
-        top_logprobs_num=request.top_logprobs,
+        return_logprob=request.logprobs is not None and request.logprobs > 0,
+        top_logprobs_num=request.logprobs if request.logprobs is not None else 0,
         return_text_in_logprobs=True,
         stream=request.stream,
     )

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -136,18 +136,21 @@ async def detokenize_logprob_tokens(token_logprobs, decode_to_text):
 
 
 async def handle_token_logprobs_results(obj: GenerateReqInput, ret):
+    """
+    Convert the style `(logprobs, token_id)` into `(logprobs, token_id, token_text)`
+    """
     # NOTE: This is because the multiple requests in one http request.
 
     if isinstance(obj.text, str):
         if obj.return_logprob:
             ret["meta_info"]["prefill_token_logprobs"] = (
                 await detokenize_logprob_tokens(
-                    ret["meta_info"]["prefill_token_logprobs_with_ids"],
+                    ret["meta_info"]["prefill_token_logprobs"],
                     obj.return_text_in_logprobs,
                 )
             )
             ret["meta_info"]["decode_token_logprobs"] = await detokenize_logprob_tokens(
-                ret["meta_info"]["decode_token_logprobs_with_ids"],
+                ret["meta_info"]["decode_token_logprobs"],
                 obj.return_text_in_logprobs,
             )
     else:
@@ -155,13 +158,13 @@ async def handle_token_logprobs_results(obj: GenerateReqInput, ret):
             if obj.return_logprob[i]:
                 r["meta_info"]["prefill_token_logprobs"] = (
                     await detokenize_logprob_tokens(
-                        r["meta_info"]["prefill_token_logprobs_with_ids"],
+                        r["meta_info"]["prefill_token_logprobs"],
                         obj.return_text_in_logprobs,
                     )
                 )
                 r["meta_info"]["decode_token_logprobs"] = (
                     await detokenize_logprob_tokens(
-                        r["meta_info"]["decode_token_logprobs_with_ids"],
+                        r["meta_info"]["decode_token_logprobs"],
                         obj.return_text_in_logprobs,
                     )
                 )

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -143,8 +143,11 @@ async def detokenize_top_logprobs_tokens(top_logprobs, decode_to_text):
 
 
 async def handle_token_logprobs_results(obj: GenerateReqInput, ret):
-    """
-    Convert the style `(logprobs, token_id)` into `(logprobs, token_id, token_text)`
+    """Handle the token logprobs results, convert token ids to text if needed.
+
+    Args:
+        obj (GenerateReqInput): The request object.
+        ret (Union[Dict, List[Dict]]): The response object.
     """
     # NOTE: This is because the multiple requests in one http request.
 

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -166,9 +166,9 @@ async def handle_token_logprobs_results(obj: GenerateReqInput, ret):
         if obj.return_logprob:
             await convert_style(ret, obj.return_text_in_logprobs)
     else:
-        for i, r in enumerate(r):
+        for i, r in enumerate(ret):
             if obj.return_logprob[i]:
-                await convert_style(r, obj.return_text_in_logprobs[i])
+                await convert_style(r, obj.return_text_in_logprobs)
 
 
 async def stream_generator(obj: GenerateReqInput):

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -193,6 +193,9 @@ async def make_openai_style_logprobs(
             ret_logprobs.tokens.append(token_text)
             ret_logprobs.token_logprobs.append(logprob)
 
+            # Not Supported yet
+            ret_logprobs.text_offset.append(-1)
+
     def append_top_logprobs(top_logprobs):
         for tokens in top_logprobs:
             if tokens is not None:

--- a/test/srt/test_httpserver_decode.py
+++ b/test/srt/test_httpserver_decode.py
@@ -9,11 +9,12 @@ The capital of France is Paris.\nThe capital of the United States is Washington,
 """
 
 import argparse
+import json
 
 import requests
 
 
-def test_decode(url, return_logprob):
+def test_decode(url, return_logprob, top_logprobs_num, return_text):
     response = requests.post(
         url + "/generate",
         json={
@@ -23,10 +24,13 @@ def test_decode(url, return_logprob):
                 "max_new_tokens": 32,
             },
             "return_logprob": return_logprob,
+            "top_logprobs_num": top_logprobs_num,
+            "return_text_in_logprobs": return_text,
             "logprob_start_len": 0,
         },
     )
-    print(response.json())
+    print(json.dumps(response.json()))
+    print("=" * 100)
 
 
 if __name__ == "__main__":
@@ -37,5 +41,8 @@ if __name__ == "__main__":
 
     url = f"{args.host}:{args.port}"
 
-    test_decode(url, False)
-    test_decode(url, True)
+    test_decode(url, False, 0, False)
+    test_decode(url, True, 0, False)
+    test_decode(url, True, 0, True)
+    test_decode(url, True, 3, False)
+    test_decode(url, True, 3, True)

--- a/test/srt/test_httpserver_decode_stream.py
+++ b/test/srt/test_httpserver_decode_stream.py
@@ -24,6 +24,7 @@ def test_decode_stream(url, return_logprob):
             },
             "stream": True,
             "return_logprob": return_logprob,
+            "return_text_in_logprobs": True,
         },
         stream=True,
     )
@@ -37,14 +38,14 @@ def test_decode_stream(url, return_logprob):
             data = json.loads(chunk[5:].strip("\n"))
 
             if return_logprob:
-                assert data["meta_info"]["prompt_logprob"] is not None
-                assert data["meta_info"]["token_logprob"] is not None
+                assert data["meta_info"]["prefill_token_logprobs"] is not None
+                assert data["meta_info"]["decode_token_logprobs"] is not None
                 assert data["meta_info"]["normalized_prompt_logprob"] is not None
-                if prev == 0:  # Skip prompt logprobs
-                    prev = data["meta_info"]["prompt_tokens"]
-                for token_txt, _, logprob in data["meta_info"]["token_logprob"][prev:]:
-                    print(f"{token_txt}\t{logprob}", flush=True)
-                prev = len(data["meta_info"]["token_logprob"])
+                for logprob, token_id, token_text in data["meta_info"][
+                    "decode_token_logprobs"
+                ][prev:]:
+                    print(f"{token_text:12s}\t{logprob}\t{token_id}", flush=True)
+                prev = len(data["meta_info"]["decode_token_logprobs"])
             else:
                 output = data["text"].strip()
                 print(output[prev:], end="", flush=True)

--- a/test/srt/test_httpserver_decode_stream.py
+++ b/test/srt/test_httpserver_decode_stream.py
@@ -13,7 +13,7 @@ import json
 import requests
 
 
-def test_decode_stream(url, return_logprob):
+def test_decode_stream(url, return_logprob, top_logprobs_num):
     response = requests.post(
         url + "/generate",
         json={
@@ -24,6 +24,7 @@ def test_decode_stream(url, return_logprob):
             },
             "stream": True,
             "return_logprob": return_logprob,
+            "top_logprobs_num": top_logprobs_num,
             "return_text_in_logprobs": True,
         },
         stream=True,
@@ -50,7 +51,8 @@ def test_decode_stream(url, return_logprob):
                 output = data["text"].strip()
                 print(output[prev:], end="", flush=True)
                 prev = len(output)
-    print("")
+
+    print("=" * 100)
 
 
 if __name__ == "__main__":
@@ -61,5 +63,6 @@ if __name__ == "__main__":
 
     url = f"{args.host}:{args.port}"
 
-    test_decode_stream(url, False)
-    test_decode_stream(url, True)
+    test_decode_stream(url, False, 0)
+    test_decode_stream(url, True, 0)
+    test_decode_stream(url, True, 3)

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -34,6 +34,7 @@ def test_completion(args, echo, logprobs):
     if echo:
         assert text.startswith("The capital of France is")
     if logprobs:
+        print(response.choices[0].logprobs.top_logprobs)
         assert response.choices[0].logprobs
         if echo:
             assert response.choices[0].logprobs.token_logprobs[0] == None
@@ -44,6 +45,7 @@ def test_completion(args, echo, logprobs):
     assert response.usage.prompt_tokens > 0
     assert response.usage.completion_tokens > 0
     assert response.usage.total_tokens > 0
+    print("=" * 100)
 
 
 def test_completion_stream(args, echo, logprobs):
@@ -68,13 +70,14 @@ def test_completion_stream(args, echo, logprobs):
                 f"{r.choices[0].text:12s}\t" f"{r.choices[0].logprobs.token_logprobs}",
                 flush=True,
             )
+            print(r.choices[0].logprobs.top_logprobs)
         else:
             print(r.choices[0].text, end="", flush=True)
         assert r.id
         assert r.usage.prompt_tokens > 0
         assert r.usage.completion_tokens > 0
         assert r.usage.total_tokens > 0
-    print()
+    print("=" * 100)
 
 
 def test_chat_completion(args):
@@ -94,6 +97,7 @@ def test_chat_completion(args):
     assert response.usage.prompt_tokens > 0
     assert response.usage.completion_tokens > 0
     assert response.usage.total_tokens > 0
+    print("=" * 100)
 
 
 def test_chat_completion_image(args):
@@ -124,6 +128,7 @@ def test_chat_completion_image(args):
     assert response.usage.prompt_tokens > 0
     assert response.usage.completion_tokens > 0
     assert response.usage.total_tokens > 0
+    print("=" * 100)
 
 
 def test_chat_completion_stream(args):
@@ -149,7 +154,7 @@ def test_chat_completion_stream(args):
         if not data.content:
             continue
         print(data.content, end="", flush=True)
-    print()
+    print("=" * 100)
 
 
 def test_regex(args):
@@ -174,6 +179,7 @@ def test_regex(args):
     )
     text = response.choices[0].message.content
     print(json.loads(text))
+    print("=" * 100)
 
 
 if __name__ == "__main__":
@@ -188,10 +194,14 @@ if __name__ == "__main__":
     test_completion(args, echo=True, logprobs=False)
     test_completion(args, echo=False, logprobs=True)
     test_completion(args, echo=True, logprobs=True)
+    test_completion(args, echo=False, logprobs=3)
+    test_completion(args, echo=True, logprobs=3)
     test_completion_stream(args, echo=False, logprobs=False)
     test_completion_stream(args, echo=True, logprobs=False)
     test_completion_stream(args, echo=False, logprobs=True)
     test_completion_stream(args, echo=True, logprobs=True)
+    test_completion_stream(args, echo=False, logprobs=3)
+    test_completion_stream(args, echo=True, logprobs=3)
     test_chat_completion(args)
     test_chat_completion_stream(args)
     test_regex(args)


### PR DESCRIPTION
# What does this PR do?

- [x] Refractor all logits and logprobs handling logic, including:
  - Clarify the naming rules: `*_token_logprobs` stands for each token' logprobs, `*_prompt_logprob` stands for the sum of logprobs of a segment of prompt.
  - Split the `*_token_logprobs` into `prefill_token_logprobs` and `decode_token_logprobs`.
- [x] Refractor SRT API and OpenAI API logprobs response format: `List[(logprob, token_id, token_text)]`
  - OpenAI API responds with the prefilling and decoding logprobs in one list and always returns all the prefilling logprobs.
  - SRT API can specify the `logprob_start_len` and respond in `meta_data["prefill_token_logprobs"]` and `meta_data["decode_token_logprobs"]` respectively.
- [x] Support detokenized results in `sgl.select` response which is the only use case for multiple requests in a single HTTP request.
- [x] `top_logprobs` support.