### PR TITLE
[WIP] [Formater] Replace black with ruff

### DIFF
--- a/python/sglang/api.py
+++ b/python/sglang/api.py
@@ -3,22 +3,10 @@
 import re
 from typing import Callable, List, Optional, Union
 
-from sglang.backend.anthropic import Anthropic
 from sglang.backend.base_backend import BaseBackend
-from sglang.backend.openai import OpenAI
-from sglang.backend.runtime_endpoint import RuntimeEndpoint
-from sglang.backend.vertexai import VertexAI
 from sglang.global_config import global_config
-from sglang.lang.ir import (
-    SglExpr,
-    SglExprList,
-    SglFunction,
-    SglGen,
-    SglImage,
-    SglRoleBegin,
-    SglRoleEnd,
-    SglSelect,
-)
+from sglang.lang.ir import (SglExpr, SglExprList, SglFunction, SglGen,
+                            SglImage, SglRoleBegin, SglRoleEnd, SglSelect)
 
 
 def function(

--- a/python/sglang/backend/anthropic.py
+++ b/python/sglang/backend/anthropic.py
@@ -1,6 +1,4 @@
-from typing import List, Optional, Union
 
-import numpy as np
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/base_backend.py
+++ b/python/sglang/backend/base_backend.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Optional, Union
+from typing import List, Optional, Union
 
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/openai.py
+++ b/python/sglang/backend/openai.py
@@ -1,17 +1,17 @@
 import logging
 import time
-from typing import Callable, List, Optional, Union
+from typing import List, Optional
 
 import numpy as np
 from sglang.backend.base_backend import BaseBackend
-from sglang.lang.chat_template import ChatTemplate, get_chat_template_by_model_path
+from sglang.lang.chat_template import (ChatTemplate,
+                                       get_chat_template_by_model_path)
 from sglang.lang.interpreter import StreamExecutor
 from sglang.lang.ir import SglSamplingParams
 
 try:
-    import tiktoken
-
     import openai
+    import tiktoken
 except ImportError as e:
     openai = tiktoken = e
 

--- a/python/sglang/backend/runtime_endpoint.py
+++ b/python/sglang/backend/runtime_endpoint.py
@@ -1,14 +1,13 @@
 import json
-from typing import Callable, List, Optional, Union
+from typing import List, Optional
 
 import numpy as np
-import requests
 from sglang.backend.base_backend import BaseBackend
 from sglang.global_config import global_config
 from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.lang.interpreter import StreamExecutor
-from sglang.lang.ir import SglArgument, SglSamplingParams
-from sglang.utils import encode_image_base64, find_printable_text, http_request
+from sglang.lang.ir import SglSamplingParams
+from sglang.utils import find_printable_text, http_request
 
 
 class RuntimeEndpoint(BaseBackend):

--- a/python/sglang/backend/vertexai.py
+++ b/python/sglang/backend/vertexai.py
@@ -1,8 +1,6 @@
 import os
 import warnings
-from typing import List, Optional, Union
 
-import numpy as np
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor
@@ -10,11 +8,8 @@ from sglang.lang.ir import SglSamplingParams
 
 try:
     import vertexai
-    from vertexai.preview.generative_models import (
-        GenerationConfig,
-        GenerativeModel,
-        Image,
-    )
+    from vertexai.preview.generative_models import (GenerationConfig,
+                                                    GenerativeModel, Image)
 except ImportError as e:
     GenerativeModel = e
 

--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Tuple
 
 
 class ChatTemplateStyle(Enum):

--- a/python/sglang/lang/compiler.py
+++ b/python/sglang/lang/compiler.py
@@ -5,13 +5,7 @@ from typing import List, Union
 
 from sglang.global_config import global_config
 from sglang.lang.interpreter import ProgramState, StreamExecutor, pin_program
-from sglang.lang.ir import (
-    SglArgument,
-    SglConstantText,
-    SglExpr,
-    SglSamplingParams,
-    SglVariable,
-)
+from sglang.lang.ir import SglArgument, SglExpr, SglSamplingParams, SglVariable
 
 
 def compile_func(function, backend):

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -7,26 +7,14 @@ import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 import tqdm
 from sglang.global_config import global_config
-from sglang.lang.ir import (
-    SglCommitLazy,
-    SglConcateAndAppend,
-    SglConstantText,
-    SglExpr,
-    SglExprList,
-    SglFunction,
-    SglGen,
-    SglImage,
-    SglRoleBegin,
-    SglRoleEnd,
-    SglSelect,
-    SglVariable,
-    SglVarScopeBegin,
-    SglVarScopeEnd,
-)
+from sglang.lang.ir import (SglCommitLazy, SglConcateAndAppend,
+                            SglConstantText, SglExpr, SglExprList, SglGen,
+                            SglImage, SglRoleBegin, SglRoleEnd, SglSelect,
+                            SglVariable, SglVarScopeBegin, SglVarScopeEnd)
 from sglang.utils import encode_image_base64
 
 

--- a/python/sglang/lang/ir.py
+++ b/python/sglang/lang/ir.py
@@ -472,4 +472,4 @@ class SglCommitLazy(SglExpr):
         super().__init__()
 
     def __repr__(self):
-        return f"CommitLazy()"
+        return "CommitLazy()"

--- a/python/sglang/lang/tracer.py
+++ b/python/sglang/lang/tracer.py
@@ -1,29 +1,14 @@
 """Tracing a program."""
 
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from sglang.backend.base_backend import BaseBackend
-from sglang.global_config import global_config
 from sglang.lang.interpreter import ProgramState, ProgramStateGroup
-from sglang.lang.ir import (
-    SglArgument,
-    SglCommitLazy,
-    SglConcateAndAppend,
-    SglConstantText,
-    SglExpr,
-    SglExprList,
-    SglFork,
-    SglFunction,
-    SglGen,
-    SglGetForkItem,
-    SglRoleBegin,
-    SglRoleEnd,
-    SglSelect,
-    SglVariable,
-    SglVarScopeBegin,
-    SglVarScopeEnd,
-)
+from sglang.lang.ir import (SglArgument, SglConstantText, SglExpr, SglExprList,
+                            SglFork, SglGen, SglGetForkItem, SglRoleBegin,
+                            SglRoleEnd, SglSelect, SglVariable,
+                            SglVarScopeBegin, SglVarScopeEnd)
 
 
 class StopTracing(Exception):

--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -3,17 +3,12 @@
 import json
 import os
 import warnings
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 from huggingface_hub import snapshot_download
 from sglang.srt.utils import is_multimodal_model
-from transformers import (
-    AutoConfig,
-    AutoProcessor,
-    AutoTokenizer,
-    PreTrainedTokenizer,
-    PreTrainedTokenizerFast,
-)
+from transformers import (AutoConfig, AutoProcessor, AutoTokenizer,
+                          PreTrainedTokenizer, PreTrainedTokenizerFast)
 
 
 def download_from_hf(model_path: str):

--- a/python/sglang/srt/layers/extend_attention.py
+++ b/python/sglang/srt/layers/extend_attention.py
@@ -1,7 +1,8 @@
 import torch
 import triton
 import triton.language as tl
-from sglang.srt.layers.context_flashattention_nopad import context_attention_fwd
+from sglang.srt.layers.context_flashattention_nopad import \
+    context_attention_fwd
 from sglang.srt.utils import wrap_kernel_launcher
 
 CUDA_CAPABILITY = torch.cuda.get_device_capability()

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -1,10 +1,8 @@
 import torch
-from sglang.srt.managers.router.model_runner import ForwardMode, InputMetadata
+from sglang.srt.managers.router.model_runner import ForwardMode
 from torch import nn
 from vllm.model_executor.parallel_utils.communication_op import (
-    get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_gather,
-)
+    get_tensor_model_parallel_world_size, tensor_model_parallel_all_gather)
 
 
 class LogitsProcessor(nn.Module):

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -1,5 +1,6 @@
 import torch
-from sglang.srt.layers.context_flashattention_nopad import context_attention_fwd
+from sglang.srt.layers.context_flashattention_nopad import \
+    context_attention_fwd
 from sglang.srt.layers.extend_attention import extend_attention_fwd
 from sglang.srt.layers.token_attention import token_attention_fwd
 from sglang.srt.managers.router.model_runner import ForwardMode, InputMetadata
@@ -15,7 +16,8 @@ class RadixAttention(nn.Module):
         self.head_dim = head_dim
         self.layer_id = layer_id
 
-        from sglang.srt.managers.router.model_runner import global_server_args_dict
+        from sglang.srt.managers.router.model_runner import \
+            global_server_args_dict
 
         if global_server_args_dict.get("enable_flashinfer", False):
             self.prefill_forward = self.prefill_forward_flashinfer

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -83,7 +83,7 @@ def start_detokenizer_process(
 ):
     try:
         manager = DetokenizerManager(server_args, port_args)
-    except Exception as e:
+    except Exception:
         pipe_writer.send(get_exception_traceback())
         raise
     pipe_writer.send("init ok")

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -13,23 +13,17 @@ from rpyc.utils.server import ThreadedServer
 from sglang.srt.constrained.fsm_cache import FSMCache
 from sglang.srt.constrained.jump_forward import JumpForwardCache
 from sglang.srt.hf_transformers_utils import get_processor, get_tokenizer
-from sglang.srt.managers.io_struct import (
-    BatchTokenIDOut,
-    FlushCacheReq,
-    TokenizedGenerateReqInput,
-)
+from sglang.srt.managers.io_struct import (BatchTokenIDOut, FlushCacheReq,
+                                           TokenizedGenerateReqInput)
 from sglang.srt.managers.router.infer_batch import Batch, ForwardMode, Req
 from sglang.srt.managers.router.model_runner import ModelRunner
 from sglang.srt.managers.router.radix_cache import RadixCache
 from sglang.srt.managers.router.scheduler import Scheduler
 from sglang.srt.model_config import ModelConfig
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import (
-    get_exception_traceback,
-    get_int_token_logit_bias,
-    is_multimodal_model,
-    set_random_seed,
-)
+from sglang.srt.utils import (get_exception_traceback,
+                              get_int_token_logit_bias, is_multimodal_model,
+                              set_random_seed)
 from vllm.logger import _default_handler as vllm_default_handler
 
 logger = logging.getLogger("model_rpc")

--- a/python/sglang/srt/managers/router/model_runner.py
+++ b/python/sglang/srt/managers/router/model_runner.py
@@ -16,7 +16,8 @@ from vllm.model_executor.layers.quantization.awq import AWQConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.model_loader import _set_default_torch_dtype
-from vllm.model_executor.parallel_utils.parallel_state import initialize_model_parallel
+from vllm.model_executor.parallel_utils.parallel_state import \
+    initialize_model_parallel
 
 QUANTIONCONFIG_MAPPING = {"awq": AWQConfig, "gptq": GPTQConfig, "marlin": MarlinConfig}
 
@@ -92,10 +93,8 @@ class InputMetadata:
     decode_wrapper = None
 
     def init_flashinfer_args(self, tp_size):
-        from flashinfer import (
-            BatchDecodeWithPagedKVCacheWrapper,
-            BatchPrefillWithPagedKVCacheWrapper,
-        )
+        from flashinfer import (BatchDecodeWithPagedKVCacheWrapper,
+                                BatchPrefillWithPagedKVCacheWrapper)
 
         self.kv_indptr = torch.zeros(
             (self.batch_size + 1,), dtype=torch.int32, device="cuda"

--- a/python/sglang/srt/managers/router/radix_cache.py
+++ b/python/sglang/srt/managers/router/radix_cache.py
@@ -1,8 +1,6 @@
 import heapq
 import time
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import Tuple
 
 import torch
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -10,23 +10,16 @@ import transformers
 import uvloop
 import zmq
 import zmq.asyncio
-from sglang.srt.hf_transformers_utils import (
-    get_config,
-    get_context_length,
-    get_processor,
-    get_tokenizer,
-)
-from sglang.srt.managers.io_struct import (
-    BatchStrOut,
-    DetokenizeReqInput,
-    FlushCacheReq,
-    GenerateReqInput,
-    TokenizedGenerateReqInput,
-)
+from sglang.srt.hf_transformers_utils import (get_config, get_context_length,
+                                              get_processor, get_tokenizer)
+from sglang.srt.managers.io_struct import (BatchStrOut, DetokenizeReqInput,
+                                           FlushCacheReq, GenerateReqInput,
+                                           TokenizedGenerateReqInput)
 from sglang.srt.mm_utils import expand2square, process_anyres_image
 from sglang.srt.sampling_params import SamplingParams
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import get_exception_traceback, is_multimodal_model, load_image
+from sglang.srt.utils import (get_exception_traceback, is_multimodal_model,
+                              load_image)
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 

--- a/python/sglang/srt/models/gemma.py
+++ b/python/sglang/srt/models/gemma.py
@@ -12,21 +12,17 @@ from vllm.config import LoRAConfig
 from vllm.model_executor.input_metadata import InputMetadata
 from vllm.model_executor.layers.activation import GeluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import (
-    LinearMethodBase,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.rotary_embedding import get_rope
-from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
-from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size,
-)
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+from vllm.model_executor.layers.vocab_parallel_embedding import \
+    VocabParallelEmbedding
+from vllm.model_executor.parallel_utils.parallel_state import \
+    get_tensor_model_parallel_world_size
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class GemmaMLP(nn.Module):

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -1,7 +1,7 @@
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/671af2b1c0b3ed6d856d37c21a561cc429a10701/vllm/model_executor/models/llama.py#L1
 """Inference-only LLaMA model compatible with HuggingFace weights."""
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -11,24 +11,17 @@ from torch import nn
 from transformers import LlamaConfig
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import (
-    LinearMethodBase,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
-from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size,
-)
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.parallel_utils.parallel_state import \
+    get_tensor_model_parallel_world_size
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class LlamaMLP(nn.Module):

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -6,20 +6,15 @@ import numpy as np
 import torch
 from sglang.srt.managers.router.infer_batch import ForwardMode
 from sglang.srt.managers.router.model_runner import InputMetadata
-from sglang.srt.mm_utils import (
-    get_anyres_image_grid_shape,
-    unpad_image,
-    unpad_image_shape,
-)
+from sglang.srt.mm_utils import (get_anyres_image_grid_shape, unpad_image,
+                                 unpad_image_shape)
 from sglang.srt.models.llama2 import LlamaForCausalLM
 from torch import nn
-from transformers import CLIPVisionModel, LlamaConfig, LlavaConfig
+from transformers import CLIPVisionModel, LlavaConfig
 from transformers.models.llava.modeling_llava import LlavaMultiModalProjector
 from vllm.model_executor.layers.linear import LinearMethodBase
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class LlavaLlamaForCausalLM(nn.Module):

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -1,7 +1,7 @@
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/d0215a58e78572d91dadafe9d832a2db89b09a13/vllm/model_executor/models/mixtral.py#L1
 """Inference-only Mixtral model."""
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import torch
@@ -12,28 +12,19 @@ from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from transformers import MixtralConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import (
-    LinearMethodBase,
-    QKVParallelLinear,
-    ReplicatedLinear,
-    RowParallelLinear,
-)
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               QKVParallelLinear,
+                                               ReplicatedLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
-from vllm.model_executor.parallel_utils.communication_op import (
-    tensor_model_parallel_all_reduce,
-)
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.parallel_utils.communication_op import \
+    tensor_model_parallel_all_reduce
 from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
-)
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+    get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class MixtralMLP(nn.Module):

--- a/python/sglang/srt/models/qwen.py
+++ b/python/sglang/srt/models/qwen.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -8,24 +8,17 @@ from torch import nn
 from transformers import PretrainedConfig
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import (
-    LinearMethodBase,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
-from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size,
-)
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.parallel_utils.parallel_state import \
+    get_tensor_model_parallel_world_size
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class QWenMLP(nn.Module):

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -1,7 +1,7 @@
 # Adapted from llama2.py
 # Modify details for the adaptation of Qwen2 model.
 """Inference-only Qwen2 model compatible with HuggingFace weights."""
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -10,24 +10,17 @@ from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import (
-    LinearMethodBase,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    ParallelLMHead,
-    VocabParallelEmbedding,
-)
-from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size,
-)
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.parallel_utils.parallel_state import \
+    get_tensor_model_parallel_world_size
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 Qwen2Config = None
 

--- a/python/sglang/srt/models/stablelm.py
+++ b/python/sglang/srt/models/stablelm.py
@@ -5,31 +5,23 @@ model compatible with HuggingFace weights."""
 from typing import Optional, Tuple
 
 import torch
-from torch import nn
-from transformers import PretrainedConfig
-
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.managers.router.model_runner import InputMetadata
+from torch import nn
+from transformers import PretrainedConfig
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.linear import (
-    LinearMethodBase,
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    VocabParallelEmbedding,
-    ParallelLMHead,
-)
-from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size,
-)
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.parallel_utils.parallel_state import \
+    get_tensor_model_parallel_world_size
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class StablelmMLP(nn.Module):

--- a/python/sglang/srt/models/yivl.py
+++ b/python/sglang/srt/models/yivl.py
@@ -1,20 +1,14 @@
 """Inference-only Yi-VL model."""
 
-import os
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
-from sglang.srt.models.llava import (
-    LlavaLlamaForCausalLM,
-    clip_vision_embed_forward,
-    monkey_path_clip_vision_embed_forward,
-)
+from sglang.srt.models.llava import (LlavaLlamaForCausalLM,
+                                     monkey_path_clip_vision_embed_forward)
 from transformers import CLIPVisionModel, LlavaConfig
-from vllm.model_executor.weight_utils import (
-    default_weight_loader,
-    hf_model_weights_iterator,
-)
+from vllm.model_executor.weight_utils import (default_weight_loader,
+                                              hf_model_weights_iterator)
 
 
 class YiVLForCausalLM(LlavaLlamaForCausalLM):

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -24,32 +24,19 @@ from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 from sglang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.srt.constrained import disable_cache
-from sglang.srt.conversation import (
-    Conversation,
-    SeparatorStyle,
-    chat_template_exists,
-    generate_chat_conv,
-    register_conv_template,
-)
+from sglang.srt.conversation import (Conversation, SeparatorStyle,
+                                     chat_template_exists, generate_chat_conv,
+                                     register_conv_template)
 from sglang.srt.hf_transformers_utils import get_tokenizer
 from sglang.srt.managers.detokenizer_manager import start_detokenizer_process
 from sglang.srt.managers.io_struct import DetokenizeReqInput, GenerateReqInput
 from sglang.srt.managers.openai_protocol import (
-    ChatCompletionRequest,
-    ChatCompletionResponse,
-    ChatCompletionResponseChoice,
-    ChatCompletionResponseStreamChoice,
-    ChatCompletionStreamResponse,
-    ChatMessage,
-    CompletionRequest,
-    CompletionResponse,
-    CompletionResponseChoice,
-    CompletionResponseStreamChoice,
-    CompletionStreamResponse,
-    DeltaMessage,
-    LogProbs,
-    UsageInfo,
-)
+    ChatCompletionRequest, ChatCompletionResponse,
+    ChatCompletionResponseChoice, ChatCompletionResponseStreamChoice,
+    ChatCompletionStreamResponse, ChatMessage, CompletionRequest,
+    CompletionResponse, CompletionResponseChoice,
+    CompletionResponseStreamChoice, CompletionStreamResponse, DeltaMessage,
+    LogProbs, UsageInfo)
 from sglang.srt.managers.router.manager import start_router_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.server_args import PortArgs, ServerArgs
@@ -527,7 +514,7 @@ def launch_server(server_args, pipe_finish_writer):
             try:
                 requests.get(url + "/get_model_info", timeout=5, headers=headers)
                 break
-            except requests.exceptions.RequestException as e:
+            except requests.exceptions.RequestException:
                 pass
         else:
             if pipe_finish_writer is not None:

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -149,7 +149,6 @@ def get_exception_traceback():
 
 
 def get_int_token_logit_bias(tokenizer, vocab_size):
-    from transformers import LlamaTokenizer, LlamaTokenizerFast
 
     # a bug when model's vocab size > tokenizer.vocab_size
     vocab_size = tokenizer.vocab_size

--- a/python/sglang/test/test_conversation.py
+++ b/python/sglang/test/test_conversation.py
@@ -1,12 +1,9 @@
 from sglang.srt.conversation import generate_chat_conv
 from sglang.srt.managers.openai_protocol import (
     ChatCompletionMessageContentImagePart,
-    ChatCompletionMessageContentImageURL,
-    ChatCompletionMessageContentTextPart,
-    ChatCompletionMessageGenericParam,
-    ChatCompletionMessageUserParam,
-    ChatCompletionRequest,
-)
+    ChatCompletionMessageContentImageURL, ChatCompletionMessageContentTextPart,
+    ChatCompletionMessageGenericParam, ChatCompletionMessageUserParam,
+    ChatCompletionRequest)
 
 
 def test_chat_completion_to_conv_image():

--- a/python/sglang/test/test_openai_protocol.py
+++ b/python/sglang/test/test_openai_protocol.py
@@ -1,11 +1,8 @@
 from sglang.srt.managers.openai_protocol import (
     ChatCompletionMessageContentImagePart,
-    ChatCompletionMessageContentImageURL,
-    ChatCompletionMessageContentTextPart,
-    ChatCompletionMessageGenericParam,
-    ChatCompletionMessageUserParam,
-    ChatCompletionRequest,
-)
+    ChatCompletionMessageContentImageURL, ChatCompletionMessageContentTextPart,
+    ChatCompletionMessageGenericParam, ChatCompletionMessageUserParam,
+    ChatCompletionRequest)
 
 
 def test_chat_completion_request_image():

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,5 +1,5 @@
 isort python
-black python
+ruff python
 
 isort test
-black test
+ruff test

--- a/test/lang/run_all.py
+++ b/test/lang/run_all.py
@@ -1,7 +1,6 @@
 import argparse
 import glob
 import multiprocessing
-import os
 import time
 import unittest
 

--- a/test/lang/test_anthropic_backend.py
+++ b/test/lang/test_anthropic_backend.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 
 from sglang.test.test_programs import test_mt_bench, test_stream

--- a/test/lang/test_openai_backend.py
+++ b/test/lang/test_openai_backend.py
@@ -1,19 +1,11 @@
 import unittest
 
-from sglang.test.test_programs import (
-    test_decode_int,
-    test_decode_json,
-    test_expert_answer,
-    test_few_shot_qa,
-    test_image_qa,
-    test_mt_bench,
-    test_parallel_decoding,
-    test_parallel_encoding,
-    test_react,
-    test_select,
-    test_stream,
-    test_tool_use,
-)
+from sglang.test.test_programs import (test_decode_int, test_decode_json,
+                                       test_expert_answer, test_few_shot_qa,
+                                       test_image_qa, test_mt_bench,
+                                       test_parallel_decoding,
+                                       test_parallel_encoding, test_react,
+                                       test_select, test_stream, test_tool_use)
 
 from sglang import OpenAI, set_default_backend
 

--- a/test/lang/test_srt_backend.py
+++ b/test/lang/test_srt_backend.py
@@ -2,23 +2,13 @@
 python3 -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --port 30000
 """
 
-import json
 import unittest
 
-from sglang.test.test_programs import (
-    test_decode_int,
-    test_decode_json_regex,
-    test_expert_answer,
-    test_few_shot_qa,
-    test_mt_bench,
-    test_parallel_decoding,
-    test_parallel_encoding,
-    test_react,
-    test_regex,
-    test_select,
-    test_stream,
-    test_tool_use,
-)
+from sglang.test.test_programs import (test_decode_int, test_decode_json_regex,
+                                       test_expert_answer, test_few_shot_qa,
+                                       test_mt_bench, test_parallel_decoding,
+                                       test_regex, test_select, test_stream,
+                                       test_tool_use)
 
 import sglang as sgl
 

--- a/test/lang/test_tracing.py
+++ b/test/lang/test_tracing.py
@@ -111,7 +111,7 @@ class TestTracing(unittest.TestCase):
             forks = s.fork(3)
             for i in range(3):
                 forks[i] += f"Now, expand tip {i+1} into a paragraph:\n"
-                forks[i] += sgl.gen(f"detailed_tip")
+                forks[i] += sgl.gen("detailed_tip")
 
             s += "Tip 1:" + forks[0]["detailed_tip"] + "\n"
             s += "Tip 2:" + forks[1]["detailed_tip"] + "\n"

--- a/test/lang/test_vertexai_backend.py
+++ b/test/lang/test_vertexai_backend.py
@@ -1,14 +1,9 @@
 import unittest
 
-from sglang.test.test_programs import (
-    test_expert_answer,
-    test_few_shot_qa,
-    test_image_qa,
-    test_mt_bench,
-    test_parallel_decoding,
-    test_parallel_encoding,
-    test_stream,
-)
+from sglang.test.test_programs import (test_expert_answer, test_few_shot_qa,
+                                       test_image_qa, test_mt_bench,
+                                       test_parallel_decoding,
+                                       test_parallel_encoding, test_stream)
 
 from sglang import VertexAI, set_default_backend
 

--- a/test/srt/model/reference_hf.py
+++ b/test/srt/model/reference_hf.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/test/srt/model/test_llama_extend.py
+++ b/test/srt/model/test_llama_extend.py
@@ -1,10 +1,6 @@
 import multiprocessing
 import os
-import time
 
-import numpy as np
-import torch
-import torch.distributed as dist
 import transformers
 from sglang.srt.managers.router.infer_batch import Batch, ForwardMode, Req
 from sglang.srt.managers.router.model_runner import ModelRunner

--- a/test/srt/model/test_llava_low_api.py
+++ b/test/srt/model/test_llava_low_api.py
@@ -1,12 +1,9 @@
 import multiprocessing
-import time
 
 import numpy as np
 import torch
-import torch.distributed as dist
 from sglang.srt.hf_transformers_utils import get_processor
-from sglang.srt.managers.router.infer_batch import ForwardMode
-from sglang.srt.managers.router.model_runner import InputMetadata, ModelRunner
+from sglang.srt.managers.router.model_runner import ModelRunner
 from sglang.srt.model_config import ModelConfig
 from sglang.srt.utils import load_image
 

--- a/test/srt/test_httpserver_concurrent.py
+++ b/test/srt/test_httpserver_concurrent.py
@@ -9,11 +9,8 @@ The capital of the United Kindom is London.\nThe capital of the United Kingdom i
 
 import argparse
 import asyncio
-import json
-import time
 
 import aiohttp
-import requests
 
 
 async def send_request(url, data, delay=0):

--- a/test/srt/test_httpserver_llava.py
+++ b/test/srt/test_httpserver_llava.py
@@ -10,7 +10,6 @@ The image features a man standing on the back of a yellow taxi cab, holding
 import argparse
 import asyncio
 import json
-import time
 
 import aiohttp
 import requests

--- a/test/srt/test_httpserver_reuse.py
+++ b/test/srt/test_httpserver_reuse.py
@@ -6,7 +6,6 @@ The capital of France is Paris.\nThe capital of the United States is Washington,
 """
 
 import argparse
-import time
 
 import requests
 

--- a/test/srt/test_jump_forward.py
+++ b/test/srt/test_jump_forward.py
@@ -3,10 +3,8 @@ from enum import Enum
 
 from pydantic import BaseModel, constr
 from sglang.srt.constrained import build_regex_from_object
-from sglang.test.test_utils import (
-    add_common_sglang_args_and_parse,
-    select_sglang_backend,
-)
+from sglang.test.test_utils import (add_common_sglang_args_and_parse,
+                                    select_sglang_backend)
 
 import sglang as sgl
 

--- a/test/srt/test_robust.py
+++ b/test/srt/test_robust.py
@@ -2,10 +2,8 @@ import argparse
 import random
 import string
 
-from sglang.test.test_utils import (
-    add_common_sglang_args_and_parse,
-    select_sglang_backend,
-)
+from sglang.test.test_utils import (add_common_sglang_args_and_parse,
+                                    select_sglang_backend)
 from vllm.transformers_utils.tokenizer import get_tokenizer
 
 import sglang as sgl


### PR DESCRIPTION
Reason for PR:

1. ruff is faster
2. ruff is PEP compliant
3. ruff is much saner than black: black sometimes like to create new lines or bloat code into multiple lines for no logical reason
4. ruff is compatible with black rules

The PR diff shows the improvements while staying both PEP compliant and retain/improve legibility. 

```
# ruff version 0.3.4
pip install ruff==0.3.4
```