### PR TITLE
Eliminate 2 gpu ops during sampling when logit_bias is zero

### DIFF
--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -470,6 +470,10 @@ class Batch:
                 setattr(
                     self, item, torch.concat([self_val, other_val])
                 )
+            elif self_val is not None or other_val is not None:
+                setattr(
+                    self, item, self_val if self_val else other_val
+                )
 
     def sample(self, logits: torch.Tensor):
         # Post process logits

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -251,10 +251,12 @@ class Batch:
             ] = out_cache_loc[pt : pt + extend_lens[i]]
             pt += extend_lens[i]
 
-        # Handle logit bias
-        logit_bias = torch.zeros((bs, vocab_size), dtype=torch.float32, device=device)
+        # Handle logit bias but only allocate when needed
+        logit_bias = None
         for i in range(bs):
             if reqs[i].sampling_params.dtype == "int":
+                if logit_bias is None:
+                    logit_bias = torch.zeros((bs, vocab_size), dtype=torch.float32, device=device)
                 logit_bias[i] = int_token_logit_bias
 
         # Set fields
@@ -433,7 +435,10 @@ class Batch:
             "presence_penalties",
             "logit_bias",
         ]:
-            setattr(self, item, getattr(self, item)[new_indices])
+            self_val = getattr(self, item, None)
+            # logit_bias can be None
+            if self_val is not None:
+                setattr(self, item, self_val[new_indices])
 
     def merge(self, other):
         self.reqs.extend(other.reqs)
@@ -458,15 +463,20 @@ class Batch:
             "presence_penalties",
             "logit_bias",
         ]:
-            setattr(
-                self, item, torch.concat([getattr(self, item), getattr(other, item)])
-            )
+            self_val = getattr(self, item, None)
+            other_val = getattr(other, item, None)
+            # logit_bias can be None
+            if self_val is not None and other_val is not None:
+                setattr(
+                    self, item, torch.concat([self_val, other_val])
+                )
 
     def sample(self, logits: torch.Tensor):
         # Post process logits
         logits = logits.contiguous()
         logits.div_(self.temperatures)
-        logits.add_(self.logit_bias)
+        if self.logit_bias is not None:
+            logits.add_(self.logit_bias)
 
         has_regex = any(req.regex_fsm is not None for req in self.reqs)
         if has_regex:


### PR DESCRIPTION
Reason for PR: Eliminate 2 gpu ops during sampling when `logit_bias` is not used (all zeros)

1. skip allocation of `logit_bias`
2. skip applying `logits.add_(self.logit_bias)`

On our internal test of Yi-6B quantized using `marlin` on 4090 we see tangible improvement: up to 63% throughput improvement for small sized tokens output work loads when batch > 1.

Concurrency is 10 requests so it will cause sglang to use batch size between 1-10:


![IMG_20240328_204927.png](https://github.com/sgl-project/sglang/assets/417764/41619785-6092-4288-a38b-ff2f0d274e83)

