### PR TITLE
Allow `input_ids` in the input of the `/generate` endpoint 

### DIFF
--- a/benchmark/latency_throughput/test_latency.py
+++ b/benchmark/latency_throughput/test_latency.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         response = requests.post(
             url + "/generate",
             json={
-                "text": f"{a}, ",
+                "input_ids": [[1,2,3], [1,2,3]],
                 "sampling_params": {
                     "temperature": 0,
                     "max_new_tokens": max_new_tokens,

--- a/docs/sampling_params.md
+++ b/docs/sampling_params.md
@@ -8,6 +8,8 @@ The `/generate` endpoint accepts the following arguments in the JSON format.
 class GenerateReqInput:
     # The input prompt
     text: Union[List[str], str]
+    # The token ids for text; one can either specify text or input_ids
+    input_ids: Optional[Union[List[List[int]], List[int]]] = None
     # The image input
     image_data: Optional[Union[List[str], str]] = None
     # The sampling_params

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -9,7 +9,7 @@ from sglang.srt.sampling_params import SamplingParams
 class GenerateReqInput:
     # The input prompt
     text: Optional[Union[List[str], str]] = None
-    # The tokens for text; one can either specify text or input_ids
+    # The token ids for text; one can either specify text or input_ids
     input_ids: Optional[Union[List[List[int]], List[int]]] = None
     # The image input
     image_data: Optional[Union[List[str], str]] = None
@@ -35,13 +35,12 @@ class GenerateReqInput:
             assert self.input_ids is not None, "Either text or input_ids should be provided"
         else:
             assert self.input_ids is None, "Either text or input_ids should be provided"
-        
+
         if self.text is not None:
             is_single = isinstance(self.text, str)
         else:
             is_single = isinstance(self.input_ids[0], int)
-        
-        self._is_single = is_single
+        self.is_single = is_single
 
         if is_single:
             if self.sampling_params is None:
@@ -87,8 +86,6 @@ class GenerateReqInput:
             elif not isinstance(self.top_logprobs_num, list):
                 self.top_logprobs_num = [self.top_logprobs_num] * num
 
-    def is_single(self):
-        return self._is_single
 
 @dataclass
 class TokenizedGenerateReqInput:

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -85,6 +85,9 @@ class Req:
         )
         if first_token.startswith("▁"):
             old_output_str = " " + old_output_str
+        if self.input_text is None:
+            # TODO(lmzheng): This can be wrong. Check with Liangsheng.
+            self.input_text = self.tokenizer.decode(self.input_ids)
         new_input_string = (
             self.input_text
             + self.output_and_jump_forward_str

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -147,11 +147,16 @@ class TokenizerManager:
         if self.to_create_loop:
             await self.create_handle_loop()
 
-        is_single = isinstance(obj.text, str)
-
+        is_single = obj.is_single()
         if is_single:
             rid = obj.rid
-            input_ids = self.tokenizer.encode(obj.text)
+            
+            if obj.input_ids is None:
+                input_ids = obj.input_ids = self.tokenizer.encode(obj.text)
+            else:
+                input_ids = obj.input_ids
+                obj.text = self.tokenizer.decode(input_ids, skip_special_tokens=True)
+
             sampling_params = SamplingParams(**obj.sampling_params)
             if sampling_params.max_new_tokens != 0:
                 sampling_params.normalize(self.tokenizer)
@@ -204,10 +209,22 @@ class TokenizerManager:
                 event.clear()
         else:
             assert obj.stream is False
-            bs = len(obj.text)
+            
+            if obj.text is not None:
+                bs = len(obj.text)
+                _input_ids = []
+            else:
+                bs = len(obj.input_ids)
+                _text = []
+
             for i in range(bs):
                 rid = obj.rid[i]
-                input_ids = self.tokenizer.encode(obj.text[i])
+                if obj.input_ids is None:
+                    input_ids = self.tokenizer.encode(obj.text[i])
+                    _input_ids.append(input_ids)
+                else:
+                    input_ids = obj.input_ids[i]
+                    _text.append(self.tokenizer.decode(input_ids, skip_special_tokens=True))
                 sampling_params = SamplingParams(**obj.sampling_params[i])
                 if sampling_params.max_new_tokens != 0:
                     sampling_params.normalize(self.tokenizer)
@@ -236,6 +253,13 @@ class TokenizerManager:
                 event = asyncio.Event()
                 state = ReqState([], False, event)
                 self.rid_to_state[rid] = state
+
+            if obj.input_ids is None:
+                obj.input_ids = _input_ids
+            elif obj.text is None:
+                obj.text = _text
+            else:
+                raise ValueError("Either text or input_ids should be None, not both; possibly a corrupted object.")
 
             output_list = []
             for i in range(bs):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -209,7 +209,7 @@ class TokenizerManager:
         else:
             assert obj.stream is False
 
-            if obj.text is not None:
+            if obj.input_ids is None:
                 bs = len(obj.text)
             else:
                 bs = len(obj.input_ids)


### PR DESCRIPTION
As of now, `GenerateReqInput` only allows `text` in the input; this PR enables specifying either `text` or `input_ids` as the request input. Supplementing `input_ids` allows more precise token operations in the input; and hopefully this simple patch won't affect other functionality.