### PR TITLE
Fix issue #367 – System message not supported for Anthropic (anthropic.BadRequestError)

### DIFF
--- a/python/sglang/backend/anthropic.py
+++ b/python/sglang/backend/anthropic.py
@@ -60,8 +60,14 @@ class Anthropic(BaseBackend):
         else:
             messages = [{"role": "user", "content": s.text_}]
 
+        if messages and messages[0]["role"] == "system":
+            system = messages.pop(0)["content"]
+        else:
+            system = ""
+
         with anthropic.Anthropic().messages.stream(
             model=self.model_name,
+            system=system,
             messages=messages,
             **sampling_params.to_anthropic_kwargs(),
         ) as stream:

--- a/python/sglang/backend/anthropic.py
+++ b/python/sglang/backend/anthropic.py
@@ -35,8 +35,14 @@ class Anthropic(BaseBackend):
         else:
             messages = [{"role": "user", "content": s.text_}]
 
+        if messages and messages[0]["role"] == "system":
+            system = messages.pop(0)["content"]
+        else:
+            system = ""
+
         ret = anthropic.Anthropic().messages.create(
             model=self.model_name,
+            system=system,
             messages=messages,
             **sampling_params.to_anthropic_kwargs(),
         )

--- a/python/sglang/test/test_programs.py
+++ b/python/sglang/test/test_programs.py
@@ -313,6 +313,7 @@ def test_image_qa():
 def test_stream():
     @sgl.function
     def qa(s, question):
+        s += sgl.system("You are a helpful assistant.")
         s += sgl.user(question)
         s += sgl.assistant(sgl.gen("answer"))
 


### PR DESCRIPTION
This fixes #367 by converting a system prompt provided as a message to Anthropic's special `system` parameter.

It is assumed that a system prompt is only ever passed as the first message. After extracting it, the first message is removed from the message list.