### PR TITLE
add `.isort.cfg`

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=black
+known_first_party=sglang

--- a/python/sglang/api.py
+++ b/python/sglang/api.py
@@ -3,11 +3,7 @@
 import re
 from typing import Callable, List, Optional, Union
 
-from sglang.backend.anthropic import Anthropic
 from sglang.backend.base_backend import BaseBackend
-from sglang.backend.openai import OpenAI
-from sglang.backend.runtime_endpoint import RuntimeEndpoint
-from sglang.backend.vertexai import VertexAI
 from sglang.global_config import global_config
 from sglang.lang.ir import (
     SglExpr,

--- a/python/sglang/backend/anthropic.py
+++ b/python/sglang/backend/anthropic.py
@@ -1,7 +1,3 @@
-from typing import List, Optional, Union
-
-import numpy as np
-
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/anthropic.py
+++ b/python/sglang/backend/anthropic.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Union
 
 import numpy as np
+
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/base_backend.py
+++ b/python/sglang/backend/base_backend.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Optional, Union
+from typing import List, Optional, Union
 
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/openai.py
+++ b/python/sglang/backend/openai.py
@@ -3,6 +3,7 @@ import time
 from typing import Callable, List, Optional, Union
 
 import numpy as np
+
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import ChatTemplate, get_chat_template_by_model_path
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/openai.py
+++ b/python/sglang/backend/openai.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Callable, List, Optional, Union
+from typing import List, Optional
 
 import numpy as np
 

--- a/python/sglang/backend/runtime_endpoint.py
+++ b/python/sglang/backend/runtime_endpoint.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional, Union
 
 import numpy as np
 import requests
+
 from sglang.backend.base_backend import BaseBackend
 from sglang.global_config import global_config
 from sglang.lang.chat_template import get_chat_template_by_model_path

--- a/python/sglang/backend/runtime_endpoint.py
+++ b/python/sglang/backend/runtime_endpoint.py
@@ -1,15 +1,14 @@
 import json
-from typing import Callable, List, Optional, Union
+from typing import List, Optional
 
 import numpy as np
-import requests
 
 from sglang.backend.base_backend import BaseBackend
 from sglang.global_config import global_config
 from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.lang.interpreter import StreamExecutor
-from sglang.lang.ir import SglArgument, SglSamplingParams
-from sglang.utils import encode_image_base64, find_printable_text, http_request
+from sglang.lang.ir import SglSamplingParams
+from sglang.utils import find_printable_text, http_request
 
 
 class RuntimeEndpoint(BaseBackend):

--- a/python/sglang/backend/vertexai.py
+++ b/python/sglang/backend/vertexai.py
@@ -3,6 +3,7 @@ import warnings
 from typing import List, Optional, Union
 
 import numpy as np
+
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/vertexai.py
+++ b/python/sglang/backend/vertexai.py
@@ -1,7 +1,6 @@
 import os
 import warnings
 
-
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
 from sglang.lang.interpreter import StreamExecutor

--- a/python/sglang/backend/vertexai.py
+++ b/python/sglang/backend/vertexai.py
@@ -1,8 +1,6 @@
 import os
 import warnings
-from typing import List, Optional, Union
 
-import numpy as np
 
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template

--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Tuple
 
 
 class ChatTemplateStyle(Enum):

--- a/python/sglang/lang/compiler.py
+++ b/python/sglang/lang/compiler.py
@@ -7,7 +7,6 @@ from sglang.global_config import global_config
 from sglang.lang.interpreter import ProgramState, StreamExecutor, pin_program
 from sglang.lang.ir import (
     SglArgument,
-    SglConstantText,
     SglExpr,
     SglSamplingParams,
     SglVariable,

--- a/python/sglang/lang/compiler.py
+++ b/python/sglang/lang/compiler.py
@@ -5,12 +5,7 @@ from typing import List, Union
 
 from sglang.global_config import global_config
 from sglang.lang.interpreter import ProgramState, StreamExecutor, pin_program
-from sglang.lang.ir import (
-    SglArgument,
-    SglExpr,
-    SglSamplingParams,
-    SglVariable,
-)
+from sglang.lang.ir import SglArgument, SglExpr, SglSamplingParams, SglVariable
 
 
 def compile_func(function, backend):

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import tqdm
+
 from sglang.global_config import global_config
 from sglang.lang.ir import (
     SglCommitLazy,

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -7,7 +7,7 @@ import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 import tqdm
 
@@ -18,7 +18,6 @@ from sglang.lang.ir import (
     SglConstantText,
     SglExpr,
     SglExprList,
-    SglFunction,
     SglGen,
     SglImage,
     SglRoleBegin,

--- a/python/sglang/lang/ir.py
+++ b/python/sglang/lang/ir.py
@@ -472,4 +472,4 @@ class SglCommitLazy(SglExpr):
         super().__init__()
 
     def __repr__(self):
-        return f"CommitLazy()"
+        return "CommitLazy()"

--- a/python/sglang/lang/tracer.py
+++ b/python/sglang/lang/tracer.py
@@ -1,20 +1,16 @@
 """Tracing a program."""
 
 import uuid
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from sglang.backend.base_backend import BaseBackend
-from sglang.global_config import global_config
 from sglang.lang.interpreter import ProgramState, ProgramStateGroup
 from sglang.lang.ir import (
     SglArgument,
-    SglCommitLazy,
-    SglConcateAndAppend,
     SglConstantText,
     SglExpr,
     SglExprList,
     SglFork,
-    SglFunction,
     SglGen,
     SglGetForkItem,
     SglRoleBegin,

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -1,4 +1,5 @@
 import interegular
+
 from sglang.srt.constrained import FSMInfo, disk_cache, make_deterministic_fsm
 from sglang.srt.constrained.base_cache import BaseCache
 

--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -6,7 +6,6 @@ import warnings
 from typing import List, Optional, Tuple, Union
 
 from huggingface_hub import snapshot_download
-from sglang.srt.utils import is_multimodal_model
 from transformers import (
     AutoConfig,
     AutoProcessor,
@@ -14,6 +13,8 @@ from transformers import (
     PreTrainedTokenizer,
     PreTrainedTokenizerFast,
 )
+
+from sglang.srt.utils import is_multimodal_model
 
 
 def download_from_hf(model_path: str):

--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -3,7 +3,7 @@
 import json
 import os
 import warnings
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 from huggingface_hub import snapshot_download
 from transformers import (

--- a/python/sglang/srt/layers/context_flashattention_nopad.py
+++ b/python/sglang/srt/layers/context_flashattention_nopad.py
@@ -3,6 +3,7 @@
 import torch
 import triton
 import triton.language as tl
+
 from sglang.srt.utils import wrap_kernel_launcher
 
 CUDA_CAPABILITY = torch.cuda.get_device_capability()

--- a/python/sglang/srt/layers/extend_attention.py
+++ b/python/sglang/srt/layers/extend_attention.py
@@ -1,6 +1,7 @@
 import torch
 import triton
 import triton.language as tl
+
 from sglang.srt.layers.context_flashattention_nopad import context_attention_fwd
 from sglang.srt.utils import wrap_kernel_launcher
 

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -1,10 +1,11 @@
 import torch
-from sglang.srt.managers.router.model_runner import ForwardMode, InputMetadata
 from torch import nn
 from vllm.model_executor.parallel_utils.communication_op import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
 )
+
+from sglang.srt.managers.router.model_runner import ForwardMode, InputMetadata
 
 
 class LogitsProcessor(nn.Module):

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -1,9 +1,10 @@
 import torch
+from torch import nn
+
 from sglang.srt.layers.context_flashattention_nopad import context_attention_fwd
 from sglang.srt.layers.extend_attention import extend_attention_fwd
 from sglang.srt.layers.token_attention import token_attention_fwd
 from sglang.srt.managers.router.model_runner import ForwardMode, InputMetadata
-from torch import nn
 
 
 class RadixAttention(nn.Module):

--- a/python/sglang/srt/layers/token_attention.py
+++ b/python/sglang/srt/layers/token_attention.py
@@ -4,6 +4,7 @@
 import torch
 import triton
 import triton.language as tl
+
 from sglang.srt.managers.router.model_runner import global_server_args_dict
 from sglang.srt.utils import wrap_kernel_launcher
 

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -3,6 +3,7 @@ import asyncio
 import uvloop
 import zmq
 import zmq.asyncio
+
 from sglang.srt.hf_transformers_utils import get_tokenizer
 from sglang.srt.managers.io_struct import BatchStrOut, BatchTokenIDOut
 from sglang.srt.server_args import PortArgs, ServerArgs

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -84,7 +84,7 @@ def start_detokenizer_process(
 ):
     try:
         manager = DetokenizerManager(server_args, port_args)
-    except Exception as e:
+    except Exception:
         pipe_writer.send(get_exception_traceback())
         raise
     pipe_writer.send("init ok")

--- a/python/sglang/srt/managers/router/infer_batch.py
+++ b/python/sglang/srt/managers/router/infer_batch.py
@@ -4,6 +4,7 @@ from typing import List
 
 import numpy as np
 import torch
+
 from sglang.srt.managers.router.radix_cache import RadixCache
 from sglang.srt.memory_pool import ReqToTokenPool, TokenToKVPool
 

--- a/python/sglang/srt/managers/router/manager.py
+++ b/python/sglang/srt/managers/router/manager.py
@@ -4,6 +4,7 @@ import logging
 import uvloop
 import zmq
 import zmq.asyncio
+
 from sglang.srt.backend_config import GLOBAL_BACKEND_CONFIG
 from sglang.srt.managers.router.model_rpc import ModelRpcClient
 from sglang.srt.server_args import PortArgs, ServerArgs

--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -10,6 +10,8 @@ import rpyc
 import torch
 from rpyc.utils.classic import obtain
 from rpyc.utils.server import ThreadedServer
+from vllm.logger import _default_handler as vllm_default_handler
+
 from sglang.srt.constrained.fsm_cache import FSMCache
 from sglang.srt.constrained.jump_forward import JumpForwardCache
 from sglang.srt.hf_transformers_utils import get_processor, get_tokenizer
@@ -30,7 +32,6 @@ from sglang.srt.utils import (
     is_multimodal_model,
     set_random_seed,
 )
-from vllm.logger import _default_handler as vllm_default_handler
 
 logger = logging.getLogger("model_rpc")
 

--- a/python/sglang/srt/managers/router/model_runner.py
+++ b/python/sglang/srt/managers/router/model_runner.py
@@ -9,15 +9,16 @@ from typing import List
 
 import numpy as np
 import torch
-from sglang.srt.managers.router.infer_batch import Batch, ForwardMode
-from sglang.srt.memory_pool import ReqToTokenPool, TokenToKVPool
-from sglang.srt.utils import is_multimodal_model
-from sglang.utils import get_available_gpu_memory
 from vllm.model_executor.layers.quantization.awq import AWQConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.model_loader import _set_default_torch_dtype
 from vllm.model_executor.parallel_utils.parallel_state import initialize_model_parallel
+
+from sglang.srt.managers.router.infer_batch import Batch, ForwardMode
+from sglang.srt.memory_pool import ReqToTokenPool, TokenToKVPool
+from sglang.srt.utils import is_multimodal_model
+from sglang.utils import get_available_gpu_memory
 
 QUANTIZATION_CONFIG_MAPPING = {
     "awq": AWQConfig,

--- a/python/sglang/srt/managers/router/radix_cache.py
+++ b/python/sglang/srt/managers/router/radix_cache.py
@@ -1,8 +1,6 @@
 import heapq
 import time
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import Tuple
 
 import torch
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -10,6 +10,7 @@ import transformers
 import uvloop
 import zmq
 import zmq.asyncio
+
 from sglang.srt.hf_transformers_utils import (
     get_config,
     get_context_length,

--- a/python/sglang/srt/models/commandr.py
+++ b/python/sglang/srt/models/commandr.py
@@ -20,7 +20,7 @@
 
 # This file is based on the LLama model definition file in transformers
 """PyTorch Cohere model."""
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 import torch.utils.checkpoint

--- a/python/sglang/srt/models/commandr.py
+++ b/python/sglang/srt/models/commandr.py
@@ -24,9 +24,6 @@ from typing import List, Optional, Tuple
 
 import torch
 import torch.utils.checkpoint
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from torch.nn.parameter import Parameter
 from transformers import PretrainedConfig
@@ -48,6 +45,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 
 @torch.compile

--- a/python/sglang/srt/models/dbrx.py
+++ b/python/sglang/srt/models/dbrx.py
@@ -5,10 +5,6 @@ from typing import Optional
 
 import torch
 import torch.nn as nn
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
-from sglang.srt.models.dbrx_config import DbrxConfig
 from vllm.model_executor.layers.fused_moe import fused_moe
 from vllm.model_executor.layers.linear import (
     LinearMethodBase,
@@ -34,6 +30,11 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
+from sglang.srt.models.dbrx_config import DbrxConfig
 
 
 class DbrxRouter(nn.Module):

--- a/python/sglang/srt/models/gemma.py
+++ b/python/sglang/srt/models/gemma.py
@@ -4,9 +4,6 @@
 from typing import Optional, Tuple
 
 import torch
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from transformers import PretrainedConfig
 from vllm.config import LoRAConfig
@@ -27,6 +24,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 
 class GemmaMLP(nn.Module):

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -4,9 +4,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from transformers import LlamaConfig
 from vllm.model_executor.layers.activation import SiluAndMul
@@ -29,6 +26,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 
 class LlamaMLP(nn.Module):

--- a/python/sglang/srt/models/llama2.py
+++ b/python/sglang/srt/models/llama2.py
@@ -1,7 +1,7 @@
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/671af2b1c0b3ed6d856d37c21a561cc429a10701/vllm/model_executor/models/llama.py#L1
 """Inference-only LLaMA model compatible with HuggingFace weights."""
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from torch import nn

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -4,14 +4,6 @@ from typing import List, Optional
 
 import numpy as np
 import torch
-from sglang.srt.managers.router.infer_batch import ForwardMode
-from sglang.srt.managers.router.model_runner import InputMetadata
-from sglang.srt.mm_utils import (
-    get_anyres_image_grid_shape,
-    unpad_image,
-    unpad_image_shape,
-)
-from sglang.srt.models.llama2 import LlamaForCausalLM
 from torch import nn
 from transformers import CLIPVisionModel, LlamaConfig, LlavaConfig
 from transformers.models.llava.modeling_llava import LlavaMultiModalProjector
@@ -20,6 +12,15 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.managers.router.infer_batch import ForwardMode
+from sglang.srt.managers.router.model_runner import InputMetadata
+from sglang.srt.mm_utils import (
+    get_anyres_image_grid_shape,
+    unpad_image,
+    unpad_image_shape,
+)
+from sglang.srt.models.llama2 import LlamaForCausalLM
 
 
 class LlavaLlamaForCausalLM(nn.Module):

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import numpy as np
 import torch
 from torch import nn
-from transformers import CLIPVisionModel, LlamaConfig, LlavaConfig
+from transformers import CLIPVisionModel, LlavaConfig
 from transformers.models.llava.modeling_llava import LlavaMultiModalProjector
 from vllm.model_executor.layers.linear import LinearMethodBase
 from vllm.model_executor.weight_utils import (

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -1,7 +1,7 @@
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/d0215a58e78572d91dadafe9d832a2db89b09a13/vllm/model_executor/models/mixtral.py#L1
 """Inference-only Mixtral model."""
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import torch

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -6,9 +6,6 @@ from typing import List, Optional, Tuple
 import numpy as np
 import torch
 import torch.nn.functional as F
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from transformers import MixtralConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -34,6 +31,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 
 class MixtralMLP(nn.Module):

--- a/python/sglang/srt/models/qwen.py
+++ b/python/sglang/srt/models/qwen.py
@@ -1,9 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from transformers import PretrainedConfig
 from vllm.model_executor.layers.activation import SiluAndMul
@@ -26,6 +23,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 
 class QWenMLP(nn.Module):

--- a/python/sglang/srt/models/qwen.py
+++ b/python/sglang/srt/models/qwen.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional
 
 import torch
 from torch import nn

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -4,9 +4,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -28,6 +25,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 Qwen2Config = None
 

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -1,7 +1,7 @@
 # Adapted from llama2.py
 # Modify details for the adaptation of Qwen2 model.
 """Inference-only Qwen2 model compatible with HuggingFace weights."""
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from torch import nn

--- a/python/sglang/srt/models/stablelm.py
+++ b/python/sglang/srt/models/stablelm.py
@@ -5,9 +5,6 @@ model compatible with HuggingFace weights."""
 from typing import Optional, Tuple
 
 import torch
-from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.managers.router.model_runner import InputMetadata
 from torch import nn
 from transformers import PretrainedConfig
 from vllm.model_executor.layers.activation import SiluAndMul
@@ -29,6 +26,10 @@ from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
 )
+
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.managers.router.model_runner import InputMetadata
 
 
 class StablelmMLP(nn.Module):

--- a/python/sglang/srt/models/yivl.py
+++ b/python/sglang/srt/models/yivl.py
@@ -1,7 +1,6 @@
 """Inference-only Yi-VL model."""
 
-import os
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -13,7 +12,6 @@ from vllm.model_executor.weight_utils import (
 
 from sglang.srt.models.llava import (
     LlavaLlamaForCausalLM,
-    clip_vision_embed_forward,
     monkey_path_clip_vision_embed_forward,
 )
 

--- a/python/sglang/srt/models/yivl.py
+++ b/python/sglang/srt/models/yivl.py
@@ -5,15 +5,16 @@ from typing import List, Optional
 
 import torch
 import torch.nn as nn
-from sglang.srt.models.llava import (
-    LlavaLlamaForCausalLM,
-    clip_vision_embed_forward,
-    monkey_path_clip_vision_embed_forward,
-)
 from transformers import CLIPVisionModel, LlavaConfig
 from vllm.model_executor.weight_utils import (
     default_weight_loader,
     hf_model_weights_iterator,
+)
+
+from sglang.srt.models.llava import (
+    LlavaLlamaForCausalLM,
+    clip_vision_embed_forward,
+    monkey_path_clip_vision_embed_forward,
 )
 
 

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -10,9 +10,6 @@ import threading
 import time
 from typing import List, Optional, Union
 
-# Fix a Python bug
-setattr(threading, "_register_atexit", lambda *args, **kwargs: None)
-
 import aiohttp
 import psutil
 import pydantic
@@ -57,6 +54,9 @@ from sglang.srt.managers.router.manager import start_router_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import enable_show_time_cost, handle_port_init
+
+# Fix a Python bug
+setattr(threading, "_register_atexit", lambda *args, **kwargs: None)
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
@@ -619,7 +619,7 @@ def launch_server(server_args, pipe_finish_writer):
             try:
                 requests.get(url + "/get_model_info", timeout=5, headers=headers)
                 break
-            except requests.exceptions.RequestException as e:
+            except requests.exceptions.RequestException:
                 pass
         else:
             if pipe_finish_writer is not None:

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -22,6 +22,9 @@ import uvloop
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
 from sglang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.srt.constrained import disable_cache
 from sglang.srt.conversation import (
@@ -54,8 +57,6 @@ from sglang.srt.managers.router.manager import start_router_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import enable_show_time_cost, handle_port_init
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -157,7 +157,6 @@ def get_exception_traceback():
 
 
 def get_int_token_logit_bias(tokenizer, vocab_size):
-    from transformers import LlamaTokenizer, LlamaTokenizerFast
 
     # a bug when model's vocab size > tokenizer.vocab_size
     vocab_size = tokenizer.vocab_size

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import requests
+
 from sglang.backend.openai import OpenAI
 from sglang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.global_config import global_config

--- a/test/lang/run_all.py
+++ b/test/lang/run_all.py
@@ -1,7 +1,6 @@
 import argparse
 import glob
 import multiprocessing
-import os
 import time
 import unittest
 

--- a/test/lang/test_anthropic_backend.py
+++ b/test/lang/test_anthropic_backend.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 
 from sglang import Anthropic, set_default_backend

--- a/test/lang/test_anthropic_backend.py
+++ b/test/lang/test_anthropic_backend.py
@@ -1,9 +1,8 @@
 import json
 import unittest
 
-from sglang.test.test_programs import test_mt_bench, test_stream
-
 from sglang import Anthropic, set_default_backend
+from sglang.test.test_programs import test_mt_bench, test_stream
 
 
 class TestAnthropicBackend(unittest.TestCase):

--- a/test/lang/test_bind_pin.py
+++ b/test/lang/test_bind_pin.py
@@ -1,8 +1,7 @@
 import unittest
 
-from sglang.backend.runtime_endpoint import RuntimeEndpoint
-
 import sglang as sgl
+from sglang.backend.runtime_endpoint import RuntimeEndpoint
 
 
 class TestBind(unittest.TestCase):

--- a/test/lang/test_openai_backend.py
+++ b/test/lang/test_openai_backend.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang import OpenAI, set_default_backend
 from sglang.test.test_programs import (
     test_decode_int,
     test_decode_json,
@@ -14,8 +15,6 @@ from sglang.test.test_programs import (
     test_stream,
     test_tool_use,
 )
-
-from sglang import OpenAI, set_default_backend
 
 
 class TestOpenAIBackend(unittest.TestCase):

--- a/test/lang/test_srt_backend.py
+++ b/test/lang/test_srt_backend.py
@@ -5,6 +5,7 @@ python3 -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --por
 import json
 import unittest
 
+import sglang as sgl
 from sglang.test.test_programs import (
     test_decode_int,
     test_decode_json_regex,
@@ -19,8 +20,6 @@ from sglang.test.test_programs import (
     test_stream,
     test_tool_use,
 )
-
-import sglang as sgl
 
 
 class TestSRTBackend(unittest.TestCase):

--- a/test/lang/test_srt_backend.py
+++ b/test/lang/test_srt_backend.py
@@ -2,7 +2,6 @@
 python3 -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --port 30000
 """
 
-import json
 import unittest
 
 import sglang as sgl
@@ -13,8 +12,6 @@ from sglang.test.test_programs import (
     test_few_shot_qa,
     test_mt_bench,
     test_parallel_decoding,
-    test_parallel_encoding,
-    test_react,
     test_regex,
     test_select,
     test_stream,

--- a/test/lang/test_tracing.py
+++ b/test/lang/test_tracing.py
@@ -1,9 +1,8 @@
 import unittest
 
+import sglang as sgl
 from sglang.backend.base_backend import BaseBackend
 from sglang.lang.chat_template import get_chat_template
-
-import sglang as sgl
 
 
 class TestTracing(unittest.TestCase):

--- a/test/lang/test_tracing.py
+++ b/test/lang/test_tracing.py
@@ -110,7 +110,7 @@ class TestTracing(unittest.TestCase):
             forks = s.fork(3)
             for i in range(3):
                 forks[i] += f"Now, expand tip {i+1} into a paragraph:\n"
-                forks[i] += sgl.gen(f"detailed_tip")
+                forks[i] += sgl.gen("detailed_tip")
 
             s += "Tip 1:" + forks[0]["detailed_tip"] + "\n"
             s += "Tip 2:" + forks[1]["detailed_tip"] + "\n"

--- a/test/lang/test_vertexai_backend.py
+++ b/test/lang/test_vertexai_backend.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang import VertexAI, set_default_backend
 from sglang.test.test_programs import (
     test_expert_answer,
     test_few_shot_qa,
@@ -9,8 +10,6 @@ from sglang.test.test_programs import (
     test_parallel_encoding,
     test_stream,
 )
-
-from sglang import VertexAI, set_default_backend
 
 
 class TestVertexAIBackend(unittest.TestCase):

--- a/test/srt/model/bench_llama_low_api.py
+++ b/test/srt/model/bench_llama_low_api.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import torch
 import torch.distributed as dist
+
 from sglang.srt.managers.router.model_runner import ModelRunner
 from sglang.srt.model_config import ModelConfig
 
@@ -66,9 +67,9 @@ class BenchBatch:
             p_idx = prefix_req_idx[i // fork_num].item()
             n_idx = self.req_pool_indices[i].item()
             req_to_token[n_idx, :prefix_len] = req_to_token[p_idx, :prefix_len]
-            req_to_token[
-                n_idx, prefix_len : prefix_len + extend_len
-            ] = self.out_cache_loc[i * extend_len : (i + 1) * extend_len]
+            req_to_token[n_idx, prefix_len : prefix_len + extend_len] = (
+                self.out_cache_loc[i * extend_len : (i + 1) * extend_len]
+            )
 
     def update_decode(self, predict_ids, batch_size):
         assert predict_ids.shape[0] == batch_size
@@ -81,9 +82,9 @@ class BenchBatch:
             self.out_cache_cont_start,
             self.out_cache_cont_end,
         ) = self.token_to_kv_pool.alloc_contiguous(batch_size)
-        self.req_to_token_pool.req_to_token[
-            self.req_pool_indices, self.seq_lens
-        ] = self.out_cache_loc
+        self.req_to_token_pool.req_to_token[self.req_pool_indices, self.seq_lens] = (
+            self.out_cache_loc
+        )
         self.seq_lens.add_(1)
 
 

--- a/test/srt/model/reference_hf.py
+++ b/test/srt/model/reference_hf.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/test/srt/model/test_llama_extend.py
+++ b/test/srt/model/test_llama_extend.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import transformers
+
 from sglang.srt.managers.router.infer_batch import Batch, ForwardMode, Req
 from sglang.srt.managers.router.model_runner import ModelRunner
 from sglang.srt.model_config import ModelConfig

--- a/test/srt/model/test_llama_extend.py
+++ b/test/srt/model/test_llama_extend.py
@@ -1,10 +1,6 @@
 import multiprocessing
 import os
-import time
 
-import numpy as np
-import torch
-import torch.distributed as dist
 import transformers
 
 from sglang.srt.managers.router.infer_batch import Batch, ForwardMode, Req

--- a/test/srt/model/test_llama_low_api.py
+++ b/test/srt/model/test_llama_low_api.py
@@ -4,6 +4,7 @@ import time
 import numpy as np
 import torch
 import torch.distributed as dist
+
 from sglang.srt.managers.router.model_runner import ModelRunner
 from sglang.srt.model_config import ModelConfig
 

--- a/test/srt/model/test_llava_low_api.py
+++ b/test/srt/model/test_llava_low_api.py
@@ -4,6 +4,7 @@ import time
 import numpy as np
 import torch
 import torch.distributed as dist
+
 from sglang.srt.hf_transformers_utils import get_processor
 from sglang.srt.managers.router.infer_batch import ForwardMode
 from sglang.srt.managers.router.model_runner import InputMetadata, ModelRunner

--- a/test/srt/model/test_llava_low_api.py
+++ b/test/srt/model/test_llava_low_api.py
@@ -1,13 +1,10 @@
 import multiprocessing
-import time
 
 import numpy as np
 import torch
-import torch.distributed as dist
 
 from sglang.srt.hf_transformers_utils import get_processor
-from sglang.srt.managers.router.infer_batch import ForwardMode
-from sglang.srt.managers.router.model_runner import InputMetadata, ModelRunner
+from sglang.srt.managers.router.model_runner import ModelRunner
 from sglang.srt.model_config import ModelConfig
 from sglang.srt.utils import load_image
 

--- a/test/srt/test_flashinfer.py
+++ b/test/srt/test_flashinfer.py
@@ -1,6 +1,7 @@
 import flashinfer
 import pytest
 import torch
+
 from sglang.srt.layers.extend_attention import extend_attention_fwd
 from sglang.srt.layers.token_attention import token_attention_fwd
 

--- a/test/srt/test_httpserver_concurrent.py
+++ b/test/srt/test_httpserver_concurrent.py
@@ -9,11 +9,8 @@ The capital of the United Kindom is London.\nThe capital of the United Kingdom i
 
 import argparse
 import asyncio
-import json
-import time
 
 import aiohttp
-import requests
 
 
 async def send_request(url, data, delay=0):

--- a/test/srt/test_httpserver_llava.py
+++ b/test/srt/test_httpserver_llava.py
@@ -10,7 +10,6 @@ The image features a man standing on the back of a yellow taxi cab, holding
 import argparse
 import asyncio
 import json
-import time
 
 import aiohttp
 import requests

--- a/test/srt/test_httpserver_reuse.py
+++ b/test/srt/test_httpserver_reuse.py
@@ -6,7 +6,6 @@ The capital of France is Paris.\nThe capital of the United States is Washington,
 """
 
 import argparse
-import time
 
 import requests
 

--- a/test/srt/test_jump_forward.py
+++ b/test/srt/test_jump_forward.py
@@ -2,13 +2,13 @@ import argparse
 from enum import Enum
 
 from pydantic import BaseModel, constr
+
+import sglang as sgl
 from sglang.srt.constrained import build_regex_from_object
 from sglang.test.test_utils import (
     add_common_sglang_args_and_parse,
     select_sglang_backend,
 )
-
-import sglang as sgl
 
 IP_REGEX = r"((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)"
 

--- a/test/srt/test_robust.py
+++ b/test/srt/test_robust.py
@@ -2,13 +2,13 @@ import argparse
 import random
 import string
 
+from vllm.transformers_utils.tokenizer import get_tokenizer
+
+import sglang as sgl
 from sglang.test.test_utils import (
     add_common_sglang_args_and_parse,
     select_sglang_backend,
 )
-from vllm.transformers_utils.tokenizer import get_tokenizer
-
-import sglang as sgl
 
 TOKENIZER = None
 RANDOM_PREFILL_LEN = None


### PR DESCRIPTION
This is due to `isort` does not recognize `sglang` as a first-party module, adding a `.isort.cfg` to fix it.

This PR does:
1. Reformatted all files under `/python` and `/test` to follow the new config.
2. Safely removed some unused imports/variables.