### PR TITLE
Improve performance when running with full parallel

### DIFF
--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -348,6 +348,7 @@ class ModelRpcServer:
                     # Undo the insertion
                     delta = self.tree_cache.dec_ref_counter(req.last_node)
                     available_size += delta
+                    break
                 else:
                     # Add this request to the running batch
                     self.token_to_kv_pool.add_refs(req.prefix_indices)
@@ -356,7 +357,8 @@ class ModelRpcServer:
                         req.extend_input_len + req.max_new_tokens()
                     )
                     new_batch_input_tokens += req.extend_input_len
-
+            else:
+                break
         if len(can_run_list) == 0:
             return None
 


### PR DESCRIPTION
### Why this PR?

- Before this PR, llm_judge benchmark with `parallel=64`, `latency=90.094`, `cache_hit_rate = 24%`
- After this PR, llm_judge benchmark with `parallel=64`, `latency=53.705s`, `cache_hit_rate = 74%`

### What does this PR do?

When the priority of the waiting queue is fixed, e.g. LPM (Longest Prefix Match), the SRT should only accept a prefix of the waiting queue.

This is because we don't want the requests with lower priority to come into the prefill phase which will lead to the eviction of the previously cached prefix.

