### PR TITLE
Fix `sync()` when `fork(1)`

### DIFF
--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -232,9 +232,15 @@ register_chat_template(
         name="c4ai-command-r",
         default_system_prompt=None,
         role_prefix_and_suffix={
-            "system": ("<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>", "<|END_OF_TURN_TOKEN|>"),
+            "system": (
+                "<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>",
+                "<|END_OF_TURN_TOKEN|>",
+            ),
             "user": ("<|START_OF_TURN_TOKEN|><|USER_TOKEN|>", "<|END_OF_TURN_TOKEN|>"),
-            "assistant": ("<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>", "<|END_OF_TURN_TOKEN|>"),
+            "assistant": (
+                "<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>",
+                "<|END_OF_TURN_TOKEN|>",
+            ),
         },
         style=ChatTemplateStyle.PLAIN,
     )

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -269,12 +269,10 @@ class StreamExecutor:
         number: int,
         position_ids_offset: Optional[List[int]] = None,
     ):
-        self.sync()
-
         if number > 1:
             self.submit(SglCommitLazy())
-            self.sync()
 
+        self.sync()
         number = int(number)
 
         exes = [

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -1,6 +1,7 @@
 """The interpreter that executes SGL programs"""
 
 import asyncio
+import contextvars
 import multiprocessing
 import queue
 import threading
@@ -9,7 +10,6 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import contextvars
 import tqdm
 
 from sglang.global_config import global_config

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -42,7 +42,9 @@ class DetokenizerManager:
                 output_strs = self.tokenizer.batch_decode(
                     output_tokens,
                     skip_special_tokens=recv_obj.skip_special_tokens[0],
-                    spaces_between_special_tokens=recv_obj.spaces_between_special_tokens[0],
+                    spaces_between_special_tokens=recv_obj.spaces_between_special_tokens[
+                        0
+                    ],
                 )
 
                 # Trim stop str


### PR DESCRIPTION
This pr fixes #410 due to missing `sync()` operation when `fork(1)`.

History review:

- This commit https://github.com/sgl-project/sglang/commit/67be11c790f600b0003ed36be94e748eb3341be6#  removes the `fork > 1` condition, which tries to resolve the racing condition. This can be done by only a sync(?)
- This PR #375 reverts the condition to reduce the overhead of caching in benchmark react, but it brings a racing condition back.

To solve these two problems, we always sync before forking and only commit lazily when fork num > 1.


