### PR TITLE
Include finish reason in meta info response

### DIFF
--- a/python/sglang/srt/managers/router/model_rpc.py
+++ b/python/sglang/srt/managers/router/model_rpc.py
@@ -586,6 +586,8 @@ class ModelRpcServer:
                     + len(req.output_ids)
                     - req.prompt_tokens,
                     "completion_tokens_wo_jump_forward": req.completion_tokens_wo_jump_forward,
+                    "finish_reason": req.finish_reason,
+                    "hit_stop_str": req.hit_stop_str,
                 }
                 if req.return_logprob:
                     (


### PR DESCRIPTION
This would be very useful when doing looped generation.