### PR TITLE
fix test bug in srt_llava_next_test.py

### DIFF
--- a/examples/usage/llava/srt_llava_next_test.py
+++ b/examples/usage/llava/srt_llava_next_test.py
@@ -17,14 +17,14 @@ def image_qa(s, image, question):
 
 def single():
     image_url = "https://farm4.staticflickr.com/3175/2653711032_804ff86d81_z.jpg"
-    pil_image = load_image(image_url)
+    pil_image, _ = load_image(image_url)
     state = image_qa.run(image=pil_image, question="What is this?", max_new_tokens=512)
     print(state["answer"], "\n")
 
 
 def stream():
     image_url = "https://farm4.staticflickr.com/3175/2653711032_804ff86d81_z.jpg"
-    pil_image = load_image(image_url)
+    pil_image, _ = load_image(image_url)
     state = image_qa.run(
         image=pil_image,
         question="Please generate short caption for this image.",
@@ -40,7 +40,7 @@ def stream():
 
 def batch():
     image_url = "https://farm4.staticflickr.com/3175/2653711032_804ff86d81_z.jpg"
-    pil_image = load_image(image_url)
+    pil_image, _ = load_image(image_url)
     states = image_qa.run_batch(
         [
             {"image": pil_image, "question": "What is this?"},


### PR DESCRIPTION
otherwise it will cause error like below:

========== single ==========

/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py:328: UserWarning: Error in stream_executor: Traceback (most recent call last):
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 326, in _thread_worker_func
self._execute(expr)
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 369, in _execute
self._execute(x)
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 369, in _execute
self._execute(x)
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 375, in _execute
self._execute_image(other)
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 419, in _execute_image
base64_data = encode_image_base64(path)
File "/home/ubuntu/wubing/sglang/python/sglang/utils.py", line 116, in encode_image_base64
image.save(buffered, format="PNG")
AttributeError: 'tuple' object has no attribute 'save'

warnings.warn(f"Error in stream_executor: {get_exception_traceback()}")
Traceback (most recent call last):
File "/home/ubuntu/wubing/sglang/examples/usage/llava/srt_llava_next_test.py", line 78, in
single()
File "/home/ubuntu/wubing/sglang/examples/usage/llava/srt_llava_next_test.py", line 22, in single
print(state["answer"], "\n")
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 844, in getitem
return self.get_var(name)
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 831, in get_var
return self.stream_executor.get_var(name)
File "/home/ubuntu/wubing/sglang/python/sglang/lang/interpreter.py", line 252, in get_var
return self.variables[name]
KeyError: 'answer'