### PR TITLE
fix issue: If request.stream is false, the code after "yield out" will not be executed

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -183,12 +183,17 @@ class TokenizerManager:
                 if self.server_args.log_requests and state.finished:
                     logger.info(f"in={obj.text}, out={out}")
 
-                yield out
                 state.out_list = []
                 if state.finished:
                     del self.rid_to_state[rid]
+
+                    yield out
+
                     break
+
                 event.clear()
+
+                yield out
         else:
             if obj.stream:
                 raise ValueError("Do not support stream for batch mode.")


### PR DESCRIPTION
If **request.stream** is **false**, the code after **"yield out"** will not be executed.


![Screenshot_20240605_093213](https://github.com/sgl-project/sglang/assets/165115237/924dd98e-11f1-428b-8d9c-53f25e565528)


 
Because **return** statement in **generate_request()** will interrupt the asynchronous **generator**.
![Uploading Screenshot_20240605_102103.png…]()


