### PR TITLE
Fix missing numpy dependency in pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,13 +16,14 @@ classifiers = [
 dependencies = [
     "requests",
     "tqdm",
+    "numpy",
 ]
 
 [project.optional-dependencies]
 srt = ["aiohttp", "fastapi", "psutil", "rpyc", "torch", "uvloop", "uvicorn",
        "zmq", "vllm==0.4.3", "interegular", "pydantic", "pillow", "packaging", "huggingface_hub", "hf_transfer", "outlines>=0.0.34"]
-openai = ["openai>=1.0", "numpy", "tiktoken"]
-anthropic = ["anthropic>=0.20.0", "numpy"]
+openai = ["openai>=1.0", "tiktoken"]
+anthropic = ["anthropic>=0.20.0"]
 litellm = ["litellm>=1.0.0"]
 all = ["sglang[srt]", "sglang[openai]", "sglang[anthropic]", "sglang[litellm]"]
 


### PR DESCRIPTION
numpy is currently listed as an optional dependency. With the current version on pypi and on the master branch, sglang will fail to import without numpy installed. See the log output below:

```log
Python 3.11.9 (main, May 27 2024, 20:31:01) [GCC 14.1.1 20240507] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sglang
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/fpreiss/Downloads/github/sglang/python/sglang/__init__.py", line 4, in <module>
    from sglang.api import (
  File "/home/fpreiss/Downloads/github/sglang/python/sglang/api.py", line 7, in <module>
    from sglang.backend.base_backend import BaseBackend
  File "/home/fpreiss/Downloads/github/sglang/python/sglang/backend/base_backend.py", line 4, in <module>
    from sglang.lang.interpreter import StreamExecutor
  File "/home/fpreiss/Downloads/github/sglang/python/sglang/lang/interpreter.py", line 34, in <module>
    from sglang.utils import (
  File "/home/fpreiss/Downloads/github/sglang/python/sglang/utils.py", line 15, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

This commit proposes a simple fix by requiring numpy in the `pyproject.toml`.