### PR TITLE
Fix RAG nb, parea setup (parea -> parea-ai)

### DIFF
--- a/examples/usage/rag_using_parea/trace_and_evaluate_rag_using_parea.ipynb
+++ b/examples/usage/rag_using_parea/trace_and_evaluate_rag_using_parea.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "## Setting up the environment\n",
     "\n",
-    "We will first install the necessary packages: `sglang`, `parea` and `chromadb`."
+    "We will first install the necessary packages: `sglang`, `parea-ai` and `chromadb`."
    ],
    "metadata": {
     "collapsed": false
@@ -38,7 +38,7 @@
     "# note, if you use a Mac M1 chip, you might need to install grpcio 1.59.0 first such that installing chromadb works\n",
     "# !pip install grpcio==1.59.0\n",
     "\n",
-    "!pip install sglang[openai] parea chromadb"
+    "!pip install sglang[openai] parea-ai chromadb"
    ],
    "metadata": {
     "collapsed": false


### PR DESCRIPTION
The current notebook installs the wrong library for parea.

`pip install parea` points to https://pypi.org/project/parea/

The intended library (https://github.com/parea-ai/parea-sdk-py) should probably be installed with:

`pip install parea-ai`