### PR TITLE
[Minor] Correct Optional type hints in api

### DIFF
--- a/python/sglang/api.py
+++ b/python/sglang/api.py
@@ -43,14 +43,14 @@ def set_default_backend(backend: BaseBackend):
     global_config.default_backend = backend
 
 
-def flush_cache(backend: BaseBackend = None):
+def flush_cache(backend: Optional[BaseBackend] = None):
     backend = backend or global_config.default_backend
     if backend is None:
         return False
     return backend.flush_cache()
 
 
-def get_server_args(backend: BaseBackend = None):
+def get_server_args(backend: Optional[BaseBackend] = None):
     backend = backend or global_config.default_backend
     if backend is None:
         return None
@@ -158,7 +158,7 @@ def video(path: str, num_frames: int):
 
 def select(
     name: Optional[str] = None,
-    choices: List[str] = None,
+    choices: Optional[List[str]] = None,
     temperature: float = 0.0,
 ):
     assert choices is not None


### PR DESCRIPTION
The given type annotations in python/sglang/api.py should probably be typed as `Optional`.

Bonus Question:
Generally the code base uses type annotations in most situations (which I personally enjoy working with). When reading through the examples however I find it a little bit harder to understand what kind of objects are passed around. Is there an interest in having type annotations added to the example code? I know that its not everybody's preference.