### PR TITLE
Fix the Jump-Forward with Chinese

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 [project.optional-dependencies]
 srt = ["aiohttp", "fastapi", "psutil", "rpyc", "torch", "uvloop", "uvicorn",
-       "zmq", "vllm==0.5.0", "interegular", "pydantic", "pillow", "packaging", "huggingface_hub", "hf_transfer", "outlines>=0.0.41"]
+       "zmq", "vllm==0.5.0", "interegular", "pydantic", "pillow", "packaging", "huggingface_hub", "hf_transfer", "outlines>=0.0.44"]
 openai = ["openai>=1.0", "tiktoken"]
 anthropic = ["anthropic>=0.20.0"]
 litellm = ["litellm>=1.0.0"]

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -81,8 +81,10 @@ class JumpForwardMap:
                     if len(c) == 1 and ord(c) < 0x80:
                         # ASCII character
                         byte_ = ord(c)
-                    elif len(c) == 2:
-                        byte_ = int(symbols[0], 16)
+                    elif len(c) > 1:
+                        # FIXME: This logic is due to the leading \x00
+                        # https://github.com/outlines-dev/outlines/pull/930
+                        byte_ = int(symbols[0][1:], 16)
 
                     if byte_ is not None:
                         outgoings_ct[state] += 1


### PR DESCRIPTION
This PR fixes #549 and upgrades the Outlines version to 0.0.44.

- outlines=0.0.43 has the problem of a numba bug https://github.com/outlines-dev/outlines/pull/930
- It solves this using a leading \x00 at each byte.