### PR TITLE
Fix flashinfer version

### DIFF
--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -152,7 +152,7 @@ def launch_server(server_args: ServerArgs, pipe_finish_writer, model_overide_arg
     if server_args.disable_disk_cache:
         disable_cache()
     if server_args.enable_flashinfer:
-        assert_pkg_version("flashinfer", "0.0.5")
+        assert_pkg_version("flashinfer", "0.0.7")
     if server_args.chat_template:
         # TODO: replace this with huggingface transformers template
         load_chat_template_for_openai_api(server_args.chat_template)


### PR DESCRIPTION
The interface of flashinfer has changed from version 0.0.6 to 0.0.7. Instead of taking the bool value `logits_cap`, it now takes a float `logits_soft_cap`, which replaces the `30` in the original calculation. See issue #575 

One thing I am not sure now is whether I need to add support for version 0.0.5 and 0.0.6 as well. If so, I can amend the PR.