### PR TITLE
[BugFix] gemma loading weights "lm_head.weight" key error

### DIFF
--- a/python/sglang/srt/models/gemma.py
+++ b/python/sglang/srt/models/gemma.py
@@ -310,6 +310,10 @@ class GemmaForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
+                # lm_head is not used in vllm as it is tied with embed_token.
+                # To prevent errors, skip loading lm_head.weight.
+                if "lm_head.weight" in name:
+                    continue
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue


### PR DESCRIPTION
Fix error when using quantization gemma models like https://huggingface.co/TechxGenus/gemma-7b-it-GPTQ or https://huggingface.co/TechxGenus/gemma-2b-it-AWQ

> Initialization failed. router_init_state: Traceback (most recent call last):
>   File "/root/.local/lib/python3.10/site-packages/sglang/srt/managers/router/manager.py", line 71, in start_router_process
>     model_client = ModelRpcClient(server_args, port_args, model_overide_args)
>   File "/root/.local/lib/python3.10/site-packages/sglang/srt/managers/router/model_rpc.py", line 686, in __init__
>     self.model_server = ModelRpcService().exposed_ModelRpcServer(
>   File "/root/.local/lib/python3.10/site-packages/sglang/srt/managers/router/model_rpc.py", line 76, in __init__
>     self.model_runner = ModelRunner(
>   File "/root/.local/lib/python3.10/site-packages/sglang/srt/managers/router/model_runner.py", line 285, in __init__
>     self.load_model()
>   File "/root/.local/lib/python3.10/site-packages/sglang/srt/managers/router/model_runner.py", line 326, in load_model
>     model.load_weights(
>   File "/root/.local/lib/python3.10/site-packages/sglang/srt/models/gemma.py", line 327, in load_weights
>     param = params_dict[name]
> KeyError: 'lm_head.weight'
> 
> Initialization failed. detoken_init_state: init ok


This error has been fixed in VLLM [pull request #3553](https://github.com/vllm-project/vllm/pull/3553).

I copied the same solution into sglang/srt/models/gemma.py  to skip lm_head if it exists