### PR TITLE
Add qwen2 tie word embedding

### DIFF
--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -313,6 +313,8 @@ class Qwen2ForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+                if self.config.tie_word_embeddings and name=="model.embed_tokens.weight":
+                    weight_loader(params_dict["lm_head.weight"], loaded_weight)
 
 
 EntryClass = Qwen2ForCausalLM


### PR DESCRIPTION
Qwen2 1.5B uses tie word embedding, which is different from other Qwen2 model. So we should add a step to load lm_head's weight from embed_tokens layer.