### PR TITLE
Detokenize incrementally when streaming

### DIFF
--- a/python/sglang/srt/managers/controller/tp_worker.py
+++ b/python/sglang/srt/managers/controller/tp_worker.py
@@ -590,8 +590,8 @@ class ModelTpServer:
     def handle_finished_requests(self, batch: Batch):
         output_rids = []
         decoded_texts = []
-        surr_output_ids = []
-        read_output_ids = []
+        output_read_ids = []
+        output_read_offsets = []
         output_skip_special_tokens = []
         output_spaces_between_special_tokens = []
         output_meta_info = []
@@ -615,9 +615,9 @@ class ModelTpServer:
             ):
                 output_rids.append(req.rid)
                 decoded_texts.append(req.decoded_text)
-                surr_ids, read_ids, _ = req.init_detokenize_incrementally()
-                surr_output_ids.append(surr_ids)
-                read_output_ids.append(read_ids)
+                read_ids, read_offset = req.init_incremental_detokenize()
+                output_read_ids.append(read_ids)
+                output_read_offsets.append(read_offset)
                 output_skip_special_tokens.append(
                     req.sampling_params.skip_special_tokens
                 )
@@ -654,8 +654,8 @@ class ModelTpServer:
                 BatchTokenIDOut(
                     output_rids,
                     decoded_texts,
-                    surr_output_ids,
-                    read_output_ids,
+                    output_read_ids,
+                    output_read_offsets,
                     output_skip_special_tokens,
                     output_spaces_between_special_tokens,
                     output_meta_info,

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -61,14 +61,14 @@ class DetokenizerManager:
                 if rid not in self.decode_status:
                     s = DecodeStatus(
                         decoded_text=recv_obj.decoded_texts[i],
-                        decode_ids=recv_obj.read_ids[i],
+                        decode_ids=recv_obj.decode_ids[i],
                         surr_offset=0,
                         read_offset=recv_obj.read_offsets[i],
                     )
                     self.decode_status[rid] = s
                 else:
                     s = self.decode_status[rid]
-                    s.decode_ids = recv_obj.read_ids[i]
+                    s.decode_ids = recv_obj.decode_ids[i]
 
                 read_ids.append(s.decode_ids[s.surr_offset :])
                 surr_ids.append(s.decode_ids[s.surr_offset : s.read_offset])

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -111,7 +111,7 @@ class TokenizedGenerateReqInput:
 class BatchTokenIDOut:
     rids: List[str]
     decoded_texts: List[str]
-    read_ids: List[int]
+    decode_ids: List[int]
     read_offsets: List[int]
     skip_special_tokens: List[bool]
     spaces_between_special_tokens: List[bool]

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -111,8 +111,8 @@ class TokenizedGenerateReqInput:
 class BatchTokenIDOut:
     rids: List[str]
     decoded_texts: List[str]
-    surr_output_ids: List[List[int]]
-    read_output_ids: List[List[int]]
+    read_ids: List[int]
+    read_offsets: List[int]
     skip_special_tokens: List[bool]
     spaces_between_special_tokens: List[bool]
     meta_info: List[Dict]


### PR DESCRIPTION
The `detokenizer_manager` achieves very low performance when 1) streaming is enabled, 2) model forward is very swift.

Changed the decoding process into incremental detokenization in detokenizer_manager, and it is not compatible with mutable output_ids (when jump forward).
