### PR TITLE
`TokenizerManager.context_len` should inherit from `server_args.conte…

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -69,7 +69,10 @@ class TokenizerManager:
             trust_remote_code=server_args.trust_remote_code,
             model_overide_args=model_overide_args,
         )
-        self.context_len = get_context_length(self.hf_config)
+        if server_args.context_length is not None:
+            self.context_len = server_args.context_length
+        else:
+            self.context_len = get_context_length(self.hf_config)
 
         if is_multimodal_model(self.model_path):
             self.processor = get_processor(


### PR DESCRIPTION
## Motivation

Overriding context length using the CLI flag `--context-length` and then using a large prompt still triggers an error from the tokenizer, which does not inherit from this CLI flag.

## Modification

This PR updates the tokenizer's initialisation to take into account this CI flag.

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
