### PR TITLE
Fix StreamExecutor.fork() losing the current role start index.

### DIFF
--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -288,6 +288,7 @@ class StreamExecutor:
             exes[i].text_ = str(self.text_)
             exes[i].messages_ = list(self.messages_)
             exes[i].cur_role = self.cur_role
+            exes[i].cur_role_begin_pos = self.cur_role_begin_pos
             exes[i].fork_start_text_pos = len(self.text_)
             exes[i].images_ = list(self.images_)
 


### PR DESCRIPTION
## Motivation

If you call `fork()` while the state is within a role, the forked program states will return the full text for the in-progress role from `messages()`. Example:
```
s += sglang.user('Parent ')
s += sglang.assistant_begin()
c = s.fork()[0]
c += 'Child'
c += sglang.assistant_end()
print(c.messages())
```
Previous wrong output:
`[{'role': 'user', 'content': 'Parent '}, {'role': 'assistant', 'content': 'Parent Child'}]`

New correct output:
`[{'role': 'user', 'content': 'Parent '}, {'role': 'assistant', 'content': 'Child'}]`

## Modification

Copied `cur_role_begin_pos` from parent to forked executors when forking.

## Checklist

This seems simple enough to not be worth a separate test, but let me know if you want me to add one.