### PR TITLE
fix /generate without sampling_params

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -40,7 +40,7 @@ class GenerateReqInput:
             self.text is not None and self.input_ids is not None
         ):
             raise ValueError("Either text or input_ids should be provided.")
-        if self.sampling_params.get("n", 1) != 1:
+        if isinstance(self.sampling_params, dict) and self.sampling_params.get("n", 1) != 1:
             is_single = False
         else:
             if self.text is not None:


### PR DESCRIPTION
## Motivation

```
curl -X POST -H "Content-Type: application/json" http://localhost:8000/generate --data-raw '{"text": "hello,"}'
```
causes Internal Server Error. The server log says
```
    if self.sampling_params.get("n", 1) != 1:
       ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```
The expected behavior would be equivalent with
```
curl -X POST -H "Content-Type: application/json" http://localhost:8000/generate --data-raw '{"text": "hello,", "sampling_params": {}}'
```

## Modification

Fix `__post_init__` of 
```python
    sampling_params: Union[List[Dict], Dict] = None
```
to properly handle the `None` case.

## Checklist

- [ ] 1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
- [ ] 2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
- [ ] 3. Modify documentation as needed, such as docstrings or example tutorials.
