### PR TITLE
Implement served_model_name to customize model id when use local mode…

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -79,6 +79,7 @@ class TokenizerManager:
         self.send_to_router.connect(f"tcp://127.0.0.1:{port_args.controller_port}")
 
         self.model_path = server_args.model_path
+        self.served_model_name = server_args.served_model_name
         self.hf_config = get_config(
             self.model_path,
             trust_remote_code=server_args.trust_remote_code,

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -190,10 +190,10 @@ async def retrieve_file_content(file_id: str):
 @app.get("/v1/models")
 def available_models():
     """Show available models."""
-    model_names = [tokenizer_manager.model_path]
+    served_model_names = [tokenizer_manager.served_model_name]
     model_cards = []
-    for model_name in model_names:
-        model_cards.append(ModelCard(id=model_name, root=model_name))
+    for served_model_name in served_model_names:
+        model_cards.append(ModelCard(id=served_model_name, root=served_model_name))
     return ModelList(data=model_cards)
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -32,8 +32,8 @@ class ServerArgs:
     trust_remote_code: bool = True
     context_length: Optional[int] = None
     quantization: Optional[str] = None
+    served_model_name: Optional[str] = None
     chat_template: Optional[str] = None
-    served_model_name: Optional[Union[str, List[str]]] = None
 
     # Port
     host: str = "127.0.0.1"
@@ -91,12 +91,10 @@ class ServerArgs:
     def __post_init__(self):
         if self.tokenizer_path is None:
             self.tokenizer_path = self.model_path
-        if isinstance(self.served_model_name, str):
-            pass
-        elif isinstance(self.served_model_name, list) and self.served_model_name:
-            self.served_model_name = self.served_model_name[0]
-        else:
+
+        if self.served_model_name is None:
             self.served_model_name = self.model_path
+
         if self.mem_fraction_static is None:
             if self.tp_size >= 16:
                 self.mem_fraction_static = 0.79
@@ -208,6 +206,12 @@ class ServerArgs:
                 "bitsandbytes",
             ],
             help="The quantization method.",
+        )
+        parser.add_argument(
+            "--served-model-name",
+            type=str,
+            default=ServerArgs.served_model_name,
+            help="Override the model name returned by the v1/models endpoint in OpenAI API server.",
         )
         parser.add_argument(
             "--chat-template",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -33,6 +33,7 @@ class ServerArgs:
     context_length: Optional[int] = None
     quantization: Optional[str] = None
     chat_template: Optional[str] = None
+    served_model_name: Optional[Union[str, List[str]]] = None
 
     # Port
     host: str = "127.0.0.1"
@@ -90,6 +91,10 @@ class ServerArgs:
     def __post_init__(self):
         if self.tokenizer_path is None:
             self.tokenizer_path = self.model_path
+        if not self.served_model_name:
+            self.served_model_name = self.model_path
+        elif isinstance(self.served_model_name, list):
+            self.served_model_name = self.served_model_name[0]
         if self.mem_fraction_static is None:
             if self.tp_size >= 16:
                 self.mem_fraction_static = 0.79

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -91,10 +91,12 @@ class ServerArgs:
     def __post_init__(self):
         if self.tokenizer_path is None:
             self.tokenizer_path = self.model_path
-        if not self.served_model_name:
-            self.served_model_name = self.model_path
-        elif isinstance(self.served_model_name, list):
+        if isinstance(self.served_model_name, str):
+            pass
+        elif isinstance(self.served_model_name, list) and self.served_model_name:
             self.served_model_name = self.served_model_name[0]
+        else:
+            self.served_model_name = self.model_path
         if self.mem_fraction_static is None:
             if self.tp_size >= 16:
                 self.mem_fraction_static = 0.79


### PR DESCRIPTION
## Motivation

Like vllm, user can load local model with model's id same as huggingface like: mistralai/Mistral-Large-Instruct-2407

## Modification

Add an optional arg: served_model_name, change API: /v1/models

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
