### PR TITLE
Lazy-import third-party backends

### DIFF
--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -1,3 +1,27 @@
+import importlib
+
+
+class LazyImport:
+    def __init__(self, module_name, class_name):
+        self.module_name = module_name
+        self.class_name = class_name
+        self._module = None
+
+    def _load(self):
+        if self._module is None:
+            module = importlib.import_module(self.module_name)
+            self._module = getattr(module, self.class_name)
+        return self._module
+
+    def __getattr__(self, name):
+        module = self._load()
+        return getattr(module, name)
+
+    def __call__(self, *args, **kwargs):
+        module = self._load()
+        return module(*args, **kwargs)
+
+
 # SGL API Components
 from sglang.api import (
     Runtime,
@@ -24,11 +48,12 @@ from sglang.api import (
 from sglang.global_config import global_config
 
 # SGL Backends
-from sglang.lang.backend.anthropic import Anthropic
-from sglang.lang.backend.litellm import LiteLLM
-from sglang.lang.backend.openai import OpenAI
 from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-from sglang.lang.backend.vertexai import VertexAI
+
+Anthropic = LazyImport("sglang.lang.backend.anthropic", "Anthropic")
+LiteLLM = LazyImport("sglang.lang.backend.litellm", "LiteLLM")
+OpenAI = LazyImport("sglang.lang.backend.openai", "OpenAI")
+VertexAI = LazyImport("sglang.lang.backend.vertexai", "VertexAI")
 
 from .version import __version__
 


### PR DESCRIPTION
## Motivation

`import sglang` imports all backends(e.g., LiteLLM, OpenAI)

Especially importing litellm takes about 1.5 sec to import(#606) and has issues with proxy environment variables.(#521)

I presume most users of sglang probably use first-party backend, which is `RuntimeEndpoint`. Importing all third-party backends when importing sglang seems to be inefficient.

## Modification

In order to have third-party backends available by `sgl.OpenAI` rather than by `sgl.lang.backend.OpenAI`, `python/__init__.py` needs to import them which slows down `import sglang`.

Apparently lazy import is what you do for this(e.g., https://pypi.org/project/lazy-imports/) but using library for tens of lines can do seem unnecessary. So I added code directly to `__init__.py`.

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
