### PR TITLE
feat: add chat template for internlm2-chat

### DIFF
--- a/python/sglang/srt/conversation.py
+++ b/python/sglang/srt/conversation.py
@@ -436,3 +436,14 @@ register_conv_template(
         sep2="</s>",
     )
 )
+
+# Reference: https://github.com/InternLM/lmdeploy/blob/387bf54b4f124e72aab30ae9755f562e435d3d01/lmdeploy/model.py#L425-L442
+register_conv_template(
+    Conversation(
+        name="internlm2-chat",
+        system_template="<|im_start|>system\n{system_message}",
+        roles=("<|im_start|>user", "<|im_start|>assistant"),
+        sep="\n",
+        stop_str=["<|im_end|>", "<|action_end|>"],
+    )
+)


### PR DESCRIPTION
## Motivation

```bash
# before
python3 -m sglang.launch_server --model internlm/internlm2-chat-7b --trust-remote-code

# after
python3 -m sglang.launch_server --model internlm/internlm2-chat-7b --trust-remote-code --chat-template internlm2-chat

# client
  curl http://127.0.0.1:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer EMPTY" \
  -d '{
    "model": "internlm/internlm2-chat-7b",
    "messages": [{"role": "user", "content": "介绍广州"}],
    "stream": false
  }' \
  --no-buffer
```

cc @merrymercy @Ying1123 @hnyls2002 
Before this fix, users needed to explicitly pass in `stop_str` when making a request. Otherwise, the response would not stop.

Currently, users need to specify the `--chat-template` when starting the server, which is an improvement over before but still not good enough. We should automatically detect the chat or instruct models and determine whether there is a chat template in the tokenizer json, then automatically match and set it.

I plan to implement this feature in another PR, but the priority is not very high at the moment. Assign it to me first, and I will work on it later.

## Modification

as titled

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
