### PR TITLE
Revert "fix: update flashinfer to 0.1.2 to fix sampling for cu118"

### DIFF
--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -226,7 +226,7 @@ def launch_server(
     if not server_args.disable_flashinfer:
         assert_pkg_version(
             "flashinfer",
-            "0.1.2",
+            "0.1.1",
             "Please uninstall the old version and "
             "reinstall the latest version by following the instructions "
             "at https://docs.flashinfer.ai/installation.html.",


### PR DESCRIPTION
Reverts sgl-project/sglang#803

The wheel of 0.1.2 has not been uploaded.