### PR TITLE
Remove inf value for chunked prefill size

### DIFF
--- a/python/sglang/srt/managers/controller/tp_worker.py
+++ b/python/sglang/srt/managers/controller/tp_worker.py
@@ -442,8 +442,11 @@ class ModelTpServer:
                 else:
                     # Add this request to the running batch
                     if (
-                        new_batch_input_tokens + req.extend_input_len
-                        <= self.chunked_prefill_size
+                        self.chunked_prefill_size is None
+                        or (
+                            new_batch_input_tokens + req.extend_input_len
+                            <= self.chunked_prefill_size
+                        )
                         or (
                             req.return_logprob and req.normalized_prompt_logprob is None
                         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -87,8 +87,6 @@ class ServerArgs:
     node_rank: Optional[int] = None
 
     def __post_init__(self):
-        if self.chunked_prefill_size is None:
-            self.chunked_prefill_size = 1 << 30
         if self.tokenizer_path is None:
             self.tokenizer_path = self.model_path
         if self.mem_fraction_static is None:
@@ -414,7 +412,7 @@ class ServerArgs:
         ), "multi-node data parallel is not supported"
 
         assert not (
-            self.chunked_prefill_size < (1 << 30) and self.disable_radix_cache
+            self.chunked_prefill_size is not None and self.disable_radix_cache
         ), "chunked prefill is not supported with radix cache disabled currently"
 
 


### PR DESCRIPTION
Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help.

## Motivation

Some runtime implementation varies according to whether the chunked prefill feature is enabled or not. We do not have a global fixed INF value, using `1<<30` may cause judging mistakes.

## Modification

When chunked prefill is disabled, the `chunked_prefill_size` is set to `None`.

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
