### PR TITLE
Fix #857

### DIFF
--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -553,7 +553,8 @@ class StreamExecutor:
                 "output_token_logprobs": output_token_logprobs,
             }
             self.variable_event[name].set()
-            self.stream_var_event[name].set()
+            if self.stream_var_event:
+                self.stream_var_event[name].set()
         self.text_ += decision
 
     def _execute_variable(self, expr: SglVariable):


### PR DESCRIPTION
## Motivation

Fix #857

## Modification

Error gets thrown when using select without stream mode.

Added check in `_execute_select` in `lang/interpreter.py`
```python
if self.stream_var_event:
    self.stream_var_event[name].set()
```

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
