### PR TITLE
fixed an error handling in bench_latency.py

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -380,13 +380,15 @@ class Batch:
         extend_num_tokens = seq_lens.sum() - prefix_lens.sum()
         out_cache_loc = self.token_to_kv_pool.alloc(extend_num_tokens)
         if out_cache_loc is None:
-            self.tree_cache.evict(extend_num_tokens, self.token_to_kv_pool.free)
-            out_cache_loc = self.token_to_kv_pool.alloc(extend_num_tokens)
+            if self.tree_cache is not None:
+                self.tree_cache.evict(extend_num_tokens, self.token_to_kv_pool.free)
+                out_cache_loc = self.token_to_kv_pool.alloc(extend_num_tokens)
 
             if out_cache_loc is None:
-                logger.error("Prefill out of memory. This should never happen.")
-                self.tree_cache.pretty_print()
-                exit()
+                logger.error("Prefill out of memory. Try to lower your batch size.")
+                if self.tree_cache is not None:
+                    self.tree_cache.pretty_print()
+                exit(1)
 
         pt = 0
         for i in range(bs):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -639,9 +639,10 @@ class Batch:
         self.out_cache_loc = self.token_to_kv_pool.alloc(bs)
 
         if self.out_cache_loc is None:
-            logger.error("Decode out of memory. This should never happen.")
-            self.tree_cache.pretty_print()
-            exit()
+            logger.error("Decode out of memory. Try to lower your batch size.")
+            if self.tree_cache is not None:
+                self.tree_cache.pretty_print()
+            exit(1)
 
         self.req_to_token_pool.req_to_token[
             self.req_pool_indices, self.seq_lens - 1


### PR DESCRIPTION
when running the latency benchmark on a L4 with 24GB of VRAM, the error was not well handled. See before and after below:

before:

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "/home/min/.cache/sglang/python/sglang/bench_latency.py", line 323, in <module>
[rank0]:     main(server_args, bench_args)
[rank0]:   File "/home/min/.cache/sglang/python/sglang/bench_latency.py", line 288, in main
[rank0]:     work_func(server_args, bench_args, 0)
[rank0]:   File "/home/min/.cache/sglang/python/sglang/bench_latency.py", line 272, in latency_test
[rank0]:     run_once(4)
[rank0]:   File "/home/min/miniconda3/envs/sgl/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/min/.cache/sglang/python/sglang/bench_latency.py", line 234, in run_once
[rank0]:     next_token_ids, _, batch = extend(reqs, model_runner)
[rank0]:                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/min/.cache/sglang/python/sglang/bench_latency.py", line 157, in extend
[rank0]:     batch.prepare_for_extend(model_runner.model_config.vocab_size, None)
[rank0]:   File "/home/min/.cache/sglang/python/sglang/srt/managers/schedule_batch.py", line 383, in prepare_for_extend
[rank0]:     self.tree_cache.evict(extend_num_tokens, self.token_to_kv_pool.free)
[rank0]:     ^^^^^^^^^^^^^^^^^^^^^
[rank0]: AttributeError: 'NoneType' object has no attribute 'evict'
```


after
```
[gpu=0] Load weight end. type=LlamaForCausalLM, dtype=torch.float16, avail mem=9.30 GB
[gpu=0] Memory pool end. avail mem=4.27 GB
[gpu=0] Capture cuda graph begin. This can take up to several minutes.
max_total_num_tokens=10085
max_batch_size=13
Prefill out of memory. Try to lower your batch size.
```