### PR TITLE
Fix union operator

### DIFF
--- a/python/sglang/lang/choices.py
+++ b/python/sglang/lang/choices.py
@@ -8,7 +8,7 @@ import numpy as np
 @dataclass
 class ChoicesDecision:
     decision: str
-    meta_info: Dict[str, Any] | None = None
+    meta_info: Optional[Dict[str, Any]] = None
 
 
 class ChoicesSamplingMethod(ABC):


### PR DESCRIPTION
## Motivation

Facing error:
```
TypeError: unsupported operand type(s) for |: '_GenericAlias' and 'NoneType'
```

The `|` operator is introduced in Python 3.10. ([PEP604](https://peps.python.org/pep-0604/))

## Modification

Replace `|` with `Optional` for compatibility with Python 3.8 and 3.9. 

cc: @AidanCooper 