### PR TITLE
Fix stuck in `get_new_prefill_batch`

### DIFF
--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -364,12 +364,13 @@ class ModelTpServer:
         # Compute matched prefix length
         for req in self.waiting_queue:
             req.input_ids = req.origin_input_ids + req.output_ids
-            prefix_indices, last_node = self.tree_cache.match_prefix(
-                rid=req.rid,
-                key=req.input_ids,
-            )
+            try_match_ids = req.input_ids
             if req.return_logprob:
-                prefix_indices = prefix_indices[: req.logprob_start_len]
+                try_match_ids = req.input_ids[: req.logprob_start_len]
+            # NOTE: the prefix_indices must always be aligned with last_node
+            prefix_indices, last_node = self.tree_cache.match_prefix(
+                rid=req.rid, key=try_match_ids
+            )
             req.extend_input_len = len(req.input_ids) - len(prefix_indices)
             req.prefix_indices = prefix_indices
             req.last_node = last_node


### PR DESCRIPTION
This PR fixes the bug in which the server repeats `get_new_prefill_batch` forever but gets no one out.

This happens when:

1. The `max_new_tokens` is set to `None`.
2. The max total tokens are less than the context length, which is, the `max_req_input_len` is decided by `max_total_tokens`
3. `return_logprob` is `True`
4. There is some cached sharing prefix already in the server for the request.

Then:

The `max_new_tokens` is set to `max_total_tokens` - `len(input_ids)` - 1. The current implementation has unaligned `last_node` and `prefix_indices`, when we calculate the available space for a new prefill batch, the radix cache lock status gets wrong and never accepts new requests.
