### PR TITLE
Make `req_pool_indices` on CPU

### DIFF
--- a/python/sglang/global_config.py
+++ b/python/sglang/global_config.py
@@ -19,7 +19,6 @@ class GlobalConfig:
         self.init_new_token_ratio = 0.7
         self.base_min_new_token_ratio = 0.1
         self.new_token_ratio_decay = 0.001
-        self.new_token_ratio_recovery = 0.05
 
         # Runtime constants: The threshold (number of tokens) to trigger layer-wise cuda sync.
         # This can improve the speed for large batch sizes during prefill.

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -432,7 +432,7 @@ class ScheduleBatch:
         out_cache_loc = self.alloc_token_slots(extend_num_tokens)
 
         pt = 0
-        for i in range(bs):
+        for i, req in enumerate(reqs):
             self.req_to_token_pool.req_to_token[req.req_pool_idx][
                 prefix_lens[i] : prefix_lens[i] + extend_lens[i]
             ] = out_cache_loc[pt : pt + extend_lens[i]]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -331,6 +331,31 @@ class ScheduleBatch:
         # Return whether batch has at least 1 streaming request
         return any(r.stream for r in self.reqs)
 
+    def alloc_req_slots(self, num_reqs):
+        req_pool_indices = self.req_to_token_pool.alloc(num_reqs)
+        if req_pool_indices is None:
+            raise RuntimeError(
+                "Out of memory. "
+                "Please set a smaller number for `--max-running-requests`."
+            )
+        return req_pool_indices
+
+    def alloc_token_slots(self, num_tokens: int):
+        out_cache_loc = self.token_to_kv_pool.alloc(num_tokens)
+
+        if out_cache_loc is None:
+            if self.tree_cache is not None:
+                self.tree_cache.evict(num_tokens, self.token_to_kv_pool.free)
+                out_cache_loc = self.token_to_kv_pool.alloc(num_tokens)
+
+            if out_cache_loc is None:
+                logger.error("Prefill out of memory. Try to lower your batch size.")
+                if self.tree_cache is not None:
+                    self.tree_cache.pretty_print()
+                exit(1)
+
+        return out_cache_loc
+
     def batch_sampling_params(self, vocab_size, int_token_logit_bias):
         device = "cuda"
         bs, reqs = self.batch_size(), self.reqs
@@ -379,15 +404,9 @@ class ScheduleBatch:
         prefix_lens = []
         seq_lens = []
 
-        req_pool_indices = self.req_to_token_pool.alloc(bs)
+        req_pool_indices = self.alloc_req_slots(bs)
+        req_pool_indices_cpu = req_pool_indices
 
-        if req_pool_indices is None:
-            raise RuntimeError(
-                "Out of memory. "
-                "Please set a smaller number for `--max-running-requests`."
-            )
-
-        req_pool_indices_cpu = req_pool_indices.cpu().numpy()
         for i in range(bs):
             flatten_input_ids.extend(input_ids[i])
             extend_lens.append(len(input_ids[i]))
@@ -407,17 +426,7 @@ class ScheduleBatch:
         # Allocate memory
         seq_lens, prefix_lens = np.array(seq_lens), np.array(prefix_lens)
         extend_num_tokens = seq_lens.sum() - prefix_lens.sum()
-        out_cache_loc = self.token_to_kv_pool.alloc(extend_num_tokens)
-        if out_cache_loc is None:
-            if self.tree_cache is not None:
-                self.tree_cache.evict(extend_num_tokens, self.token_to_kv_pool.free)
-                out_cache_loc = self.token_to_kv_pool.alloc(extend_num_tokens)
-
-            if out_cache_loc is None:
-                logger.error("Prefill out of memory. Try to lower your batch size.")
-                if self.tree_cache is not None:
-                    self.tree_cache.pretty_print()
-                exit(1)
+        out_cache_loc = self.alloc_token_slots(extend_num_tokens)
 
         pt = 0
         for i in range(bs):
@@ -435,7 +444,7 @@ class ScheduleBatch:
         self.image_offsets = [
             r.image_offset - p_len for r, p_len in zip(reqs, prefix_lens)
         ]
-        self.req_pool_indices = req_pool_indices
+        self.req_pool_indices = torch.tensor(req_pool_indices_cpu, device=device)
         self.seq_lens = torch.tensor(seq_lens, dtype=torch.int32, device=device)
         self.prefix_lens = torch.tensor(prefix_lens, dtype=torch.int32, device=device)
         self.position_ids_offsets = position_ids_offsets
@@ -633,14 +642,8 @@ class ScheduleBatch:
         self.prefix_lens = None
 
         # Alloc mem
-        bs = len(self.reqs)
-        self.out_cache_loc = self.token_to_kv_pool.alloc(bs)
-
-        if self.out_cache_loc is None:
-            logger.error("Decode out of memory. Try to lower your batch size.")
-            if self.tree_cache is not None:
-                self.tree_cache.pretty_print()
-            exit(1)
+        bs = self.batch_size()
+        self.out_cache_loc = self.alloc_token_slots(bs)
 
         self.req_to_token_pool.req_to_token[
             self.req_pool_indices, self.seq_lens - 1

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -625,13 +625,12 @@ class ModelTpServer:
             req.output_top_logprobs.append(output.output_top_logprobs[i])
 
     def cache_filled_batch(self, batch: ScheduleBatch):
-        req_pool_indices_cpu = batch.req_pool_indices.cpu().numpy()
         for i, req in enumerate(batch.reqs):
             new_prefix_indices, new_last_node = self.tree_cache.cache_req(
                 rid=req.rid,
                 token_ids=tuple(req.input_ids),
                 last_uncached_pos=len(req.prefix_indices),
-                req_pool_idx=req_pool_indices_cpu[i],
+                req_pool_idx=req.req_pool_idx,
                 del_in_memory_pool=False,
                 old_last_node=req.last_node,
             )
@@ -639,7 +638,7 @@ class ModelTpServer:
 
             if req is self.current_inflight_req:
                 # inflight request would get a new req idx
-                self.req_to_token_pool.free(int(req_pool_indices_cpu[i]))
+                self.req_to_token_pool.free(req.req_pool_idx)
 
     def forward_decode_batch(self, batch: ScheduleBatch):
         # Check if decode out of memory
@@ -782,14 +781,13 @@ class ModelTpServer:
         # Remove finished reqs
         if finished_indices:
             # Update radix cache
-            req_pool_indices_cpu = batch.req_pool_indices.tolist()
             for i in finished_indices:
                 req = batch.reqs[i]
                 self.tree_cache.cache_req(
                     rid=req.rid,
                     token_ids=tuple(req.origin_input_ids + req.output_ids)[:-1],
                     last_uncached_pos=len(req.prefix_indices),
-                    req_pool_idx=req_pool_indices_cpu[i],
+                    req_pool_idx=req.req_pool_idx,
                 )
 
                 self.tree_cache.dec_lock_ref(req.last_node)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -200,7 +200,6 @@ class ModelTpServer:
         )
         self.new_token_ratio = self.min_new_token_ratio
         self.new_token_ratio_decay = global_config.new_token_ratio_decay
-        self.new_token_ratio_recovery = global_config.new_token_ratio_recovery
 
     def exposed_step(self, recv_reqs):
         try:


### PR DESCRIPTION
The allocation of `req_pool_indices` can be put on the CPU by just using python list. And we can reduce the GPU CPU sync overhead here.