### PR TITLE
fix decoding stats

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -41,8 +41,9 @@ class ServerArgs:
     additional_ports: Optional[Union[List[int], int]] = None
 
     # Memory and scheduling
+    # A default value "None" means a computed default value will be used.
     mem_fraction_static: Optional[float] = None
-    max_prefill_tokens: Optional[int] = None
+    max_prefill_tokens: int = 16384
     max_running_requests: Optional[int] = None
     max_num_reqs: Optional[int] = None
     max_total_tokens: Optional[int] = None


### PR DESCRIPTION
fixed the stats for decoding

Before:
<img width="991" alt="image" src="https://github.com/user-attachments/assets/e6b9e2a5-a9a0-4eb1-85b9-b695c954aa0c">

After:
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/eb975369-3e00-4410-a74c-0170ddbe654d">


## Modification

* use a time counter in seconds that keep track of decoding timing
* do not rely on when is the print function is called
* also simplified the init of the max prefill arg since it is not computed
* also fixed typo of "hit rate" to "hit ratio"

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
