### PR TITLE
Adjust max prefix len

### DIFF
--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -394,15 +394,11 @@ class ModelTpServer:
                     delta = 2 - req.extend_input_len
                     req.extend_input_len += delta
                     req.prefix_indices = req.prefix_indices[:-delta]
-                    if req.image_offset is not None:
-                        req.image_offset += delta
 
             if req.extend_input_len == 0 and req.sampling_params.max_new_tokens > 0:
                 # Need at least one token to compute logits
                 req.extend_input_len = 1
                 req.prefix_indices = req.prefix_indices[:-1]
-                if req.image_offset is not None:
-                    req.image_offset += 1
 
             res = adder.add_one_req(req)
             if (

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -387,19 +387,6 @@ class ModelTpServer:
 
         for req in self.waiting_queue:
 
-            # FIXME: Move this code into adjust_max_prefix_len
-            if req.return_logprob and req.normalized_prompt_logprob is None:
-                # Need at least two tokens to compute normalized logprob
-                if req.extend_input_len < 2:
-                    delta = 2 - req.extend_input_len
-                    req.extend_input_len += delta
-                    req.prefix_indices = req.prefix_indices[:-delta]
-
-            if req.extend_input_len == 0 and req.sampling_params.max_new_tokens > 0:
-                # Need at least one token to compute logits
-                req.extend_input_len = 1
-                req.prefix_indices = req.prefix_indices[:-1]
-
             res = adder.add_one_req(req)
             if (
                 not res


### PR DESCRIPTION
Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help.

## Motivation

There is no need to adjust the `image_offset`:
- The image offset is calculated by later batching operations, so the previous implementation is wrong.
- When `extend_input_len` < 2, there could not be an image input, so the adjust is also a dead code.

This PR also adjusts `extend_input_len` into a separate function. We do not adjust the prefix indices after the request matches the radix tree, as there is a bug mentioned in #948. Instead,   we adjust the token_ids to be matched.

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
