### PR TITLE
misc: create slim srt image tag

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -43,10 +43,16 @@ jobs:
           
           tag=v${version}-${cuda_tag}
           
-          docker build . -f docker/Dockerfile --build-arg CUDA_VERSION=${{ matrix.cuda_version }} -t lmsysorg/sglang:${tag} --no-cache
+          docker build . -f docker/Dockerfile --build-arg CUDA_VERSION=${{ matrix.cuda_version }} -t lmsysorg/sglang:${tag} --no-cache --target base
+          docker build . -f docker/Dockerfile --build-arg CUDA_VERSION=${{ matrix.cuda_version }} -t lmsysorg/sglang:${tag}-srt --target srt
+
           docker push lmsysorg/sglang:${tag}
+          docker push lmsysorg/sglang:${tag}-srt
           
           if [ "${{ matrix.cuda_version }}" = "12.1.1" ]; then
             docker tag lmsysorg/sglang:${tag} lmsysorg/sglang:latest
+            docker tag lmsysorg/sglang:${tag}-srt lmsysorg/sglang:latest-srt
+
             docker push lmsysorg/sglang:latest
+            docker push lmsysorg/sglang:latest-srt
           fi

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run --gpus all \
     python3 -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --host 0.0.0.0 --port 30000
 ```
 
-or, if you only want to run the srt server, you can try out the new slim srt-only images:
+or, if you only want to run the SRT server, you can try out the new slim SRT-only images:
 
 ```bash
 docker run --gpus all \

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ docker run --gpus all \
     python3 -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct --host 0.0.0.0 --port 30000
 ```
 
+or, if you only want to run the srt server, you can try out the new slim srt-only images:
+
+```bash
+docker run --gpus all \
+    -p 30000:30000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --env "HF_TOKEN=<secret>" \
+    --ipc=host \
+    lmsysorg/sglang:latest-srt \
+    --model-path meta-llama/Meta-Llama-3-8B-Instruct --host 0.0.0.0 --port 30000
+```
+
 ### Common Notes
 - If you cannot install FlashInfer, check out its [installation](https://docs.flashinfer.ai/installation.html#) page. If you still cannot install it, you can use the slower Triton kernels by adding `--disable-flashinfer` when launching the server.
 - If you only need to use the OpenAI backend, you can avoid installing other dependencies by using `pip install "sglang[openai]"`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG CUDA_VERSION=12.1.1
 
-FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04 AS base
 
 ARG PYTHON_VERSION=3
 
@@ -32,3 +32,22 @@ RUN pip3 --no-cache-dir install --upgrade pip \
     && pip3 --no-cache-dir install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.4/
 
 ENV DEBIAN_FRONTEND=interactive
+
+# build the wheel
+FROM base AS build
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install build
+
+WORKDIR /sgl-workspace/sglang/python
+RUN python3 -m build
+
+# minimal sglang srt image
+FROM python:3.10-slim AS srt
+
+RUN --mount=type=bind,from=build,src=/sgl-workspace/sglang/python/dist,target=/sgl-workspace/dist \
+    --mount=type=cache,target=/root/.cache/pip \
+    pip install --verbose $(find /sgl-workspace/dist -name "*.whl" -printf "%p[srt] ") && \
+    pip install --index https://flashinfer.ai/whl/cu121/torch2.4/ flashinfer
+
+ENTRYPOINT [ "python3", "-m", "sglang.launch_server" ]


### PR DESCRIPTION
Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help.

## Motivation

The current `lmsysorg/sglang` image is somewhat painful to download in some shared cloud environment, where they don't cache images locally, due to it's size (compressed size of 8.19 GB). Uncompressed image size:
```bash
$ docker inspect -f "{{ .Size }}" lmsysorg/sglang:latest | numfmt --to=si
16G
```

## Modification

- This PR defines standalone docker build stage `srt` which only installs `sglang[srt]` on top of `python:slim` image. If anyone think we need to use `nvidia/cuda:*-base-*` image, I can change this PR to use that image instead. The result is whopping -46% in size (compressed size of 4.44 GB). Uncompressed image size:
  ```bash
  $ docker inspect -f "{{ .Size }}" tmfi/sglang:latest-srt | numfmt --to=si
  8.6G
  ```
  - Turned out that we don't need full `nvidia/cuda:*-devel-*` image to run `srt` (seems like all the needed CUDA stuffs are already being installed by pip and/or mounted by the host machine).
  - So the `srt` build stage is basically simply gonna build the wheel from the base stage, and installing it.
  - I have rolled out this `srt`-only image to some of our production instances and are working fine. 
- In order to not affect any other environments and/or use cases, I've created a new tag by appending `-srt` to the existing tags, so that the existing tags can still be used as-is.
- The new `-srt` tagged images will have `python -m sglang.launch_server` as an `ENTRYPOINT`.

## Discussions

- The current base image is installing Python 3.8. However 3.8's [EOL is approaching](https://devguide.python.org/versions/) (it's just 2 months away from now), so we might want to upgrade it? (cc: @Ying1123)
- I can see that the base Dockerfile [clones from Github](https://github.com/sgl-project/sglang/blob/main/docker/Dockerfile#L29), while it the Github workflow is [already checking out the full repo](https://github.com/sgl-project/sglang/blob/main/.github/workflows/release-docker.yml#L22-L23). This can lead into race-condition and potentially mismatching version (Git tag != Docker image tag). We can change this to use `COPY` instruction instead? (cc: @zhyncs)

## Checklist

- [x] 1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
- [x] 2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
- [x] 3. Modify documentation as needed, such as docstrings or example tutorials.
