### PR TITLE
bugfix: penalizers to be merged before reqs

### DIFF
--- a/python/sglang/srt/sampling/penaltylib/orchestrator.py
+++ b/python/sglang/srt/sampling/penaltylib/orchestrator.py
@@ -133,6 +133,10 @@ class BatchedPenalizerOrchestrator:
         """
         Merge the penalizers of another orchestrator into this one.
 
+        Note that this function **must** be called _before_ self.batch.reqs is updated (filtered).
+        Each unprepared penalizers would have to be prepared (creating tensors, etc.) first before merging.
+        This step requires the original batch.reqs, before it gets merged with other batch.reqs.
+
         Args:
             their (BatchedPenalizerOrchestrator): The orchestrator to merge into this one.
         """


### PR DESCRIPTION
Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help.

## Motivation

I've running the latest `sglang` with #973 merged in our production environment. After serving several request, critical bug has been just found around 1 hr ago. The bug is raised during `penalizer_orchestrator.merge()` and only when the `batch.reqs` gets extended _before_ the penalizers getting merged.

<details>
<summary>Show exception logs</summary>

```
2024-08-09T09:20:41.072998301Z Exception in ModelTpServer:
2024-08-09T09:20:41.073078821Z Traceback (most recent call last):
2024-08-09T09:20:41.073083661Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 222, in exposed_step
2024-08-09T09:20:41.073087291Z     self.forward_step()
2024-08-09T09:20:41.073091221Z   File "/usr/local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
2024-08-09T09:20:41.073094361Z     return func(*args, **kwargs)
2024-08-09T09:20:41.073097261Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 251, in forward_step
2024-08-09T09:20:41.073100071Z     self.forward_decode_batch(self.running_batch)
2024-08-09T09:20:41.073103931Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 597, in forward_decode_batch
2024-08-09T09:20:41.073107581Z     next_token_ids = batch.sample(output.next_token_logits)
2024-08-09T09:20:41.073110821Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/schedule_batch.py", line 742, in sample
2024-08-09T09:20:41.073113451Z     logits = self.penalizer_orchestrator.apply(logits)
2024-08-09T09:20:41.073115941Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/sampling/penaltylib/orchestrator.py", line 99, in apply
2024-08-09T09:20:41.073118741Z     logits = penalizer.apply(logits)
2024-08-09T09:20:41.073121161Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/sampling/penaltylib/orchestrator.py", line 271, in apply
2024-08-09T09:20:41.073127541Z     return self._apply(logits=logits)
2024-08-09T09:20:41.073130361Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/sampling/penaltylib/penalizers/frequency_penalty.py", line 62, in _apply
2024-08-09T09:20:41.073134191Z     logits -= self.cumulated_frequency_penalties
2024-08-09T09:20:41.073136891Z RuntimeError: The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 0
2024-08-09T09:20:41.073139491Z 
2024-08-09T09:20:41.073188501Z Exception in ControllerSingle:
2024-08-09T09:20:41.073213241Z Traceback (most recent call last):
2024-08-09T09:20:41.073218912Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/controller_single.py", line 166, in start_controller_process
2024-08-09T09:20:41.073223121Z     controller.loop_for_forward()
2024-08-09T09:20:41.073226661Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/controller_single.py", line 103, in loop_for_forward
2024-08-09T09:20:41.073230581Z     out_pyobjs = self.tp_server.exposed_step(recv_reqs)
2024-08-09T09:20:41.073235462Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 222, in exposed_step
2024-08-09T09:20:41.073239082Z     self.forward_step()
2024-08-09T09:20:41.073243042Z   File "/usr/local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
2024-08-09T09:20:41.073246682Z     return func(*args, **kwargs)
2024-08-09T09:20:41.073249262Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 251, in forward_step
2024-08-09T09:20:41.073252592Z     self.forward_decode_batch(self.running_batch)
2024-08-09T09:20:41.073255712Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 597, in forward_decode_batch
2024-08-09T09:20:41.073258892Z     next_token_ids = batch.sample(output.next_token_logits)
2024-08-09T09:20:41.073261982Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/managers/schedule_batch.py", line 742, in sample
2024-08-09T09:20:41.073264542Z     logits = self.penalizer_orchestrator.apply(logits)
2024-08-09T09:20:41.073267202Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/sampling/penaltylib/orchestrator.py", line 99, in apply
2024-08-09T09:20:41.073269632Z     logits = penalizer.apply(logits)
2024-08-09T09:20:41.073272092Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/sampling/penaltylib/orchestrator.py", line 271, in apply
2024-08-09T09:20:41.073274772Z     return self._apply(logits=logits)
2024-08-09T09:20:41.073277212Z   File "/usr/local/lib/python3.10/site-packages/sglang/srt/sampling/penaltylib/penalizers/frequency_penalty.py", line 62, in _apply
2024-08-09T09:20:41.073292912Z     logits -= self.cumulated_frequency_penalties
2024-08-09T09:20:41.073296432Z RuntimeError: The size of tensor a (2) must match the size of tensor b (3) at non-singleton dimension 0
```

</details>

## Modification

- Updated `ScheduleBatch` to merge `penalizer_orchestrator` first, before `self.reqs.extend()`.
- Added test cases that will fail before this patch, and passing after this patch.
- Added thorough comments regarding why `penalizer_orchestrator.merge()` should happen before.

## Checklist

- [x] 1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
- [x] 2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
- [x] 3. Modify documentation as needed, such as docstrings or example tutorials.
