### PR TITLE
Minor bugfix on benchmark serving

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -195,7 +195,8 @@ async def async_request_openai_completions(
                                     output.ttft = ttft
 
                                 # Decoding phase
-                                output.itl.append(timestamp - most_recent_timestamp)
+                                else:
+                                    output.itl.append(timestamp - most_recent_timestamp)
 
                                 most_recent_timestamp = timestamp
                                 generated_text += data["choices"][0]["text"]


### PR DESCRIPTION
This PR fixes a minor bug in the benchmark serving where it incorrectly records TTFT as part of ITLs for a request. This issue was originally raised [here](https://github.com/vllm-project/vllm/issues/7242) but I figured to fix it here as well :)