### PR TITLE
Fix wrong assert

### DIFF
--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -39,9 +39,11 @@ class ChunkCache(BasePrefixCache):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(token_ids)
         ]
-        assert req.rid in self.entries
         self.req_to_token_pool.free(req.req_pool_idx)
         self.token_to_kv_pool.free(kv_indices)
+
+        if req.rid in self.entries:
+            del self.entries[req.rid]
 
     def cache_unfinished_req(self, req: "Req", token_ids=None):
         if token_ids is None:


### PR DESCRIPTION
Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help.

## Motivation

The assert `req.rid in self.entries` is wrong when the first token is eos after prefill.

## Modification

Remove the assert and delete the element if it is in.

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
