### PR TITLE
Fix create_abort_task, GenerateReqInput does not have rids.

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -507,7 +507,7 @@ class TokenizerManager:
             if obj.is_single:
                 self.abort_request(obj.rid)
             else:
-                for rid in obj.rids:
+                for rid in obj.rid:
                     self.abort_request(rid)
 
         background_tasks = BackgroundTasks()


### PR DESCRIPTION
Thank you for your contribution, we really appreciate it. The following instructions will help improve your pull request and make it easier to receive feedback. If there are any items you don't understand, don't worry. Just submit the pull request and ask the maintainers for help.

## Motivation

  File "/usr/local/python/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/python/lib/python3.10/site-packages/starlette/routing.py", line 75, in app
    await response(scope, receive, send)
  File "/usr/local/python/lib/python3.10/site-packages/starlette/responses.py", line 268, in __call__
    await self.background()
  File "/usr/local/python/lib/python3.10/site-packages/starlette/background.py", line 45, in __call__
    await task()
  File "/usr/local/python/lib/python3.10/site-packages/starlette/background.py", line 28, in __call__
    await self.func(*self.args, **self.kwargs)
  File "/workspace/opensource/sglang/python/sglang/srt/managers/tokenizer_manager.py", line 511, in abort_request
    for rid in obj.rids:
AttributeError: 'GenerateReqInput' object has no attribute 'rids'. Did you mean: 'rid'

## Modification

fix typo.

## Checklist

1. Ensure pre-commit `pre-commit run --all-files` or other linting tools are used to fix potential lint issues.
2. Confirm that modifications are covered by complete unit tests. If not, please add more unit tests for correctness.
3. Modify documentation as needed, such as docstrings or example tutorials.
