### PR TITLE
Support jinja as chat template file

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -118,6 +118,14 @@ class TokenizerManager:
                     trust_remote_code=server_args.trust_remote_code,
                 )
 
+        if (
+            server_args.chat_template is not None
+            and server_args.chat_template.endswith(".jinja")
+        ):
+            with open(server_args.chat_template, "r") as f:
+                chat_template = "".join(f.readlines()).strip("\n")
+            self.tokenizer.chat_template = chat_template.replace("\\n", "\n")
+
         self.to_create_loop = True
         self.rid_to_state: Dict[str, ReqState] = {}
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -118,14 +118,6 @@ class TokenizerManager:
                     trust_remote_code=server_args.trust_remote_code,
                 )
 
-        if (
-            server_args.chat_template is not None
-            and server_args.chat_template.endswith(".jinja")
-        ):
-            with open(server_args.chat_template, "r") as f:
-                chat_template = "".join(f.readlines()).strip("\n")
-            self.tokenizer.chat_template = chat_template.replace("\\n", "\n")
-
         self.to_create_loop = True
         self.rid_to_state: Dict[str, ReqState] = {}
 

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -376,7 +376,7 @@ def _set_envs_and_config(server_args: ServerArgs):
         maybe_set_triton_cache_manager()
 
     # Set global chat template
-    if server_args.chat_template:
+    if server_args.chat_template and not server_args.chat_template.endswith(".jinja"):
         # TODO: replace this with huggingface transformers template
         load_chat_template_for_openai_api(server_args.chat_template)
 

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -288,6 +288,8 @@ def launch_server(
 
     # Launch processes
     tokenizer_manager = TokenizerManager(server_args, port_args, model_overide_args)
+    if server_args.chat_template:
+        load_chat_template_for_openai_api(tokenizer_manager, server_args.chat_template)
     pipe_controller_reader, pipe_controller_writer = mp.Pipe(duplex=False)
     pipe_detoken_reader, pipe_detoken_writer = mp.Pipe(duplex=False)
 
@@ -374,11 +376,6 @@ def _set_envs_and_config(server_args: ServerArgs):
     if server_args.tp_size * server_args.dp_size > 1:
         # FIXME: remove this after https://github.com/triton-lang/triton/pull/4295 is used as a dependency.
         maybe_set_triton_cache_manager()
-
-    # Set global chat template
-    if server_args.chat_template and not server_args.chat_template.endswith(".jinja"):
-        # TODO: replace this with huggingface transformers template
-        load_chat_template_for_openai_api(server_args.chat_template)
 
     # Check flashinfer version
     if not server_args.disable_flashinfer:


### PR DESCRIPTION
Example Usage:
```
python -m sglang.launch_server --model [model_path] --chat-template [jinja_file_path]
```