### PR TITLE
fix data racing due to mutable reference using deepcopy

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -18,8 +18,9 @@ The definition of objects transfered between different
 processes (TokenizerManager, DetokenizerManager, Controller).
 """
 
+import copy
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
 from sglang.srt.managers.schedule_batch import BaseFinishReason
@@ -238,16 +239,21 @@ class TokenizedEmbeddingReqInput:
 @dataclass
 class BatchTokenIDOut:
     # The request id
-    rids: List[str]
+    rids: List[str] = field(default_factory=list)
     # The version id to sync decode status with in detokenizer_manager
-    vids: List[int]
-    decoded_texts: List[str]
-    decode_ids: List[int]
-    read_offsets: List[int]
-    skip_special_tokens: List[bool]
-    spaces_between_special_tokens: List[bool]
-    meta_info: List[Dict]
-    finished_reason: List[BaseFinishReason]
+    vids: List[int] = field(default_factory=list)
+    decoded_texts: List[str] = field(default_factory=list)
+    decode_ids: List[int] = field(default_factory=list)
+    read_offsets: List[int] = field(default_factory=list)
+    skip_special_tokens: List[bool] = field(default_factory=list)
+    spaces_between_special_tokens: List[bool] = field(default_factory=list)
+    meta_info: List[Dict] = field(default_factory=list)
+    finished_reason: List[BaseFinishReason] = field(default_factory=list)
+
+    def __post_init__(self):
+        # deepcopy the mutable references
+        self.meta_info = copy.deepcopy(self.meta_info)
+        self.finished_reason = copy.deepcopy(self.finished_reason)
 
 
 @dataclass
@@ -265,13 +271,19 @@ class BatchStrOut:
 @dataclass
 class BatchEmbeddingOut:
     # The request id
-    rids: List[str]
+    rids: List[str] = field(default_factory=list)
     # The output embedding
-    embeddings: List[List[float]]
+    embeddings: List[List[float]] = field(default_factory=list)
     # The meta info
-    meta_info: List[Dict]
+    meta_info: List[Dict] = field(default_factory=list)
     # The finish reason
-    finished_reason: List[BaseFinishReason]
+    finished_reason: List[BaseFinishReason] = field(default_factory=list)
+
+    def __post_init__(self):
+        # deepcopy the mutable references
+        self.embeddings = copy.deepcopy(self.embeddings)
+        self.meta_info = copy.deepcopy(self.meta_info)
+        self.finished_reason = copy.deepcopy(self.finished_reason)
 
 
 @dataclass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -239,21 +239,20 @@ class TokenizedEmbeddingReqInput:
 @dataclass
 class BatchTokenIDOut:
     # The request id
-    rids: List[str] = field(default_factory=list)
+    rids: List[str]
     # The version id to sync decode status with in detokenizer_manager
-    vids: List[int] = field(default_factory=list)
-    decoded_texts: List[str] = field(default_factory=list)
-    decode_ids: List[int] = field(default_factory=list)
-    read_offsets: List[int] = field(default_factory=list)
-    skip_special_tokens: List[bool] = field(default_factory=list)
-    spaces_between_special_tokens: List[bool] = field(default_factory=list)
-    meta_info: List[Dict] = field(default_factory=list)
-    finished_reason: List[BaseFinishReason] = field(default_factory=list)
+    vids: List[int]
+    decoded_texts: List[str]
+    decode_ids: List[int]
+    read_offsets: List[int]
+    skip_special_tokens: List[bool]
+    spaces_between_special_tokens: List[bool]
+    meta_info: List[Dict]
+    finished_reason: List[BaseFinishReason]
 
     def __post_init__(self):
-        # deepcopy the mutable references
+        # deepcopy meta_info to avoid modification in place
         self.meta_info = copy.deepcopy(self.meta_info)
-        self.finished_reason = copy.deepcopy(self.finished_reason)
 
 
 @dataclass
@@ -271,19 +270,13 @@ class BatchStrOut:
 @dataclass
 class BatchEmbeddingOut:
     # The request id
-    rids: List[str] = field(default_factory=list)
+    rids: List[str]
     # The output embedding
-    embeddings: List[List[float]] = field(default_factory=list)
+    embeddings: List[List[float]]
     # The meta info
-    meta_info: List[Dict] = field(default_factory=list)
+    meta_info: List[Dict]
     # The finish reason
-    finished_reason: List[BaseFinishReason] = field(default_factory=list)
-
-    def __post_init__(self):
-        # deepcopy the mutable references
-        self.embeddings = copy.deepcopy(self.embeddings)
-        self.meta_info = copy.deepcopy(self.meta_info)
-        self.finished_reason = copy.deepcopy(self.finished_reason)
+    finished_reason: List[BaseFinishReason]
 
 
 @dataclass


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Objects including `BatchTokenIDOut` and `BatchEmbeddingOut` hold mutable references to ongoing requests, which could cause data racing when the order of accesses are not strictly ordered.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
Using `field` to ensure list object is copied and `deepcopy` to remove all possible mutable references.

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.