### PR TITLE
Allow more flexible assistant and system response

### DIFF
--- a/python/sglang/srt/conversation.py
+++ b/python/sglang/srt/conversation.py
@@ -391,11 +391,11 @@ def generate_chat_conv(
             elif isinstance(message.content, list):
                 if (
                     len(message.content) != 1
-                    or message.content.get("type", None) != "text"
+                    or getattr(message.content[0], "type", None) != "text"
                 ):
                     raise ValueError("The system message should be a single text.")
                 else:
-                    conv.system_message = message.content[0].get("text", "")
+                    conv.system_message = getattr(message.content[0], "text", "")
         elif msg_role == "user":
             # Handle the various types of Chat Request content types here.
             role = conv.roles[0]
@@ -429,13 +429,13 @@ def generate_chat_conv(
             elif isinstance(message.content, list):
                 if (
                     len(message.content) != 1
-                    or message.content.get("type", None) != "text"
+                    or getattr(message.content[0], "type", None) != "text"
                 ):
                     raise ValueError(
                         "The assistant's response should be a single text."
                     )
                 else:
-                    parsed_content = message.content[0].get("text", "")
+                    parsed_content = getattr(message.content[0], "text", "")
             conv.append_message(conv.roles[1], parsed_content)
         else:
             raise ValueError(f"Unknown role: {msg_role}")

--- a/python/sglang/srt/conversation.py
+++ b/python/sglang/srt/conversation.py
@@ -389,7 +389,10 @@ def generate_chat_conv(
             if isinstance(message.content, str):
                 conv.system_message = message.content
             elif isinstance(message.content, list):
-                if len(message.content) != 1 or message.content.get("type", None) != "text":
+                if (
+                    len(message.content) != 1
+                    or message.content.get("type", None) != "text"
+                ):
                     raise ValueError("The system message should be a single text.")
                 else:
                     conv.system_message = message.content[0].get("text", "")
@@ -424,8 +427,13 @@ def generate_chat_conv(
             if isinstance(message.content, str):
                 parsed_content = message.content
             elif isinstance(message.content, list):
-                if len(message.content) != 1 or message.content.get("type", None) != "text":
-                    raise ValueError("The assistant's response should be a single text.")
+                if (
+                    len(message.content) != 1
+                    or message.content.get("type", None) != "text"
+                ):
+                    raise ValueError(
+                        "The assistant's response should be a single text."
+                    )
                 else:
                     parsed_content = message.content[0].get("text", "")
             conv.append_message(conv.roles[1], parsed_content)

--- a/python/sglang/srt/conversation.py
+++ b/python/sglang/srt/conversation.py
@@ -386,7 +386,13 @@ def generate_chat_conv(
     for message in request.messages:
         msg_role = message.role
         if msg_role == "system":
-            conv.system_message = message.content
+            if isinstance(message.content, str):
+                conv.system_message = message.content
+            elif isinstance(message.content, list):
+                if len(message.content) != 1 or message.content.get("type", None) != "text":
+                    raise ValueError("The system message should be a single text.")
+                else:
+                    conv.system_message = message.content[0].get("text", "")
         elif msg_role == "user":
             # Handle the various types of Chat Request content types here.
             role = conv.roles[0]
@@ -414,7 +420,15 @@ def generate_chat_conv(
                         conv.append_image(content.image_url.url)
                 conv.append_message(conv.roles[0], real_content)
         elif msg_role == "assistant":
-            conv.append_message(conv.roles[1], message.content)
+            parsed_content = ""
+            if isinstance(message.content, str):
+                parsed_content = message.content
+            elif isinstance(message.content, list):
+                if len(message.content) != 1 or message.content.get("type", None) != "text":
+                    raise ValueError("The assistant's response should be a single text.")
+                else:
+                    parsed_content = message.content[0].get("text", "")
+            conv.append_message(conv.roles[1], parsed_content)
         else:
             raise ValueError(f"Unknown role: {msg_role}")
 

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -847,20 +847,20 @@ def v1_chat_generate_request(
                 openai_compatible_messages = []
                 for message in request.messages:
                     if isinstance(message.content, str):
-                        openai_compatible_messages.append({
-                            "role": message.role,
-                            "content": message.content
-                        })
+                        openai_compatible_messages.append(
+                            {"role": message.role, "content": message.content}
+                        )
                     else:
-                        content_list = message.dict()['content']
+                        content_list = message.dict()["content"]
                         for content in content_list:
-                            if content['type'] == 'text':
-                                openai_compatible_messages.append({
-                                    "role": message.role,
-                                    "content": content['text']
-                                })
+                            if content["type"] == "text":
+                                openai_compatible_messages.append(
+                                    {"role": message.role, "content": content["text"]}
+                                )
                 prompt_ids = tokenizer_manager.tokenizer.apply_chat_template(
-                    openai_compatible_messages, tokenize=True, add_generation_prompt=True
+                    openai_compatible_messages,
+                    tokenize=True,
+                    add_generation_prompt=True,
                 )
                 stop = request.stop
                 image_data = None

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -844,8 +844,23 @@ def v1_chat_generate_request(
         if not isinstance(request.messages, str):
             # Apply chat template and its stop strings.
             if chat_template_name is None:
+                openai_compatible_messages = []
+                for message in request.messages:
+                    if isinstance(message.content, str):
+                        openai_compatible_messages.append({
+                            "role": message.role,
+                            "content": message.content
+                        })
+                    else:
+                        content_list = message.dict()['content']
+                        for content in content_list:
+                            if content['type'] == 'text':
+                                openai_compatible_messages.append({
+                                    "role": message.role,
+                                    "content": content['text']
+                                })
                 prompt_ids = tokenizer_manager.tokenizer.apply_chat_template(
-                    request.messages, tokenize=True, add_generation_prompt=True
+                    openai_compatible_messages, tokenize=True, add_generation_prompt=True
                 )
                 stop = request.stop
                 image_data = None

--- a/python/sglang/srt/openai_api/protocol.py
+++ b/python/sglang/srt/openai_api/protocol.py
@@ -199,12 +199,6 @@ class CompletionStreamResponse(BaseModel):
     choices: List[CompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
 
-
-class ChatCompletionMessageGenericParam(BaseModel):
-    role: Literal["system", "assistant"]
-    content: str
-
-
 class ChatCompletionMessageContentTextPart(BaseModel):
     type: Literal["text"]
     text: str
@@ -224,6 +218,10 @@ ChatCompletionMessageContentPart = Union[
     ChatCompletionMessageContentTextPart, ChatCompletionMessageContentImagePart
 ]
 
+
+class ChatCompletionMessageGenericParam(BaseModel):
+    role: Literal["system", "assistant"]
+    content: Union[str, List[ChatCompletionMessageContentTextPart]]
 
 class ChatCompletionMessageUserParam(BaseModel):
     role: Literal["user"]

--- a/python/sglang/srt/openai_api/protocol.py
+++ b/python/sglang/srt/openai_api/protocol.py
@@ -199,6 +199,7 @@ class CompletionStreamResponse(BaseModel):
     choices: List[CompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
 
+
 class ChatCompletionMessageContentTextPart(BaseModel):
     type: Literal["text"]
     text: str
@@ -222,6 +223,7 @@ ChatCompletionMessageContentPart = Union[
 class ChatCompletionMessageGenericParam(BaseModel):
     role: Literal["system", "assistant"]
     content: Union[str, List[ChatCompletionMessageContentTextPart]]
+
 
 class ChatCompletionMessageUserParam(BaseModel):
     role: Literal["user"]

--- a/test/srt/test_vision_openai_server.py
+++ b/test/srt/test_vision_openai_server.py
@@ -102,18 +102,15 @@ class TestOpenAIVisionServer(unittest.TestCase):
                     "content": [
                         {
                             "type": "text",
-                            "text": "There is a man at the back of a yellow cab ironing his clothes."
+                            "text": "There is a man at the back of a yellow cab ironing his clothes.",
                         }
-                    ]
+                    ],
                 },
-                 {
+                {
                     "role": "user",
                     "content": [
-                        {
-                            "type": "text",
-                            "text": "Repeat your previous answer."
-                        }
-                    ]
+                        {"type": "text", "text": "Repeat your previous answer."}
+                    ],
                 },
             ],
             temperature=0,

--- a/test/srt/test_vision_openai_server.py
+++ b/test/srt/test_vision_openai_server.py
@@ -76,6 +76,59 @@ class TestOpenAIVisionServer(unittest.TestCase):
         assert response.usage.completion_tokens > 0
         assert response.usage.total_tokens > 0
 
+    def test_multi_turn_chat_completion(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+
+        response = client.chat.completions.create(
+            model="default",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://github.com/sgl-project/sglang/blob/main/test/lang/example_image.png?raw=true"
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": "Describe this image in a very short sentence.",
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "There is a man at the back of a yellow cab ironing his clothes."
+                        }
+                    ]
+                },
+                 {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Repeat your previous answer."
+                        }
+                    ]
+                },
+            ],
+            temperature=0,
+        )
+
+        assert response.choices[0].message.role == "assistant"
+        text = response.choices[0].message.content
+        assert isinstance(text, str)
+        assert "man" in text or "cab" in text, text
+        assert response.id
+        assert response.created
+        assert response.usage.prompt_tokens > 0
+        assert response.usage.completion_tokens > 0
+        assert response.usage.total_tokens > 0
+
     def test_mult_images_chat_completion(self):
         client = openai.Client(api_key=self.api_key, base_url=self.base_url)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Right now system and assistant response are required to be in this format:
```
{'role': 'assistant', 'content': text}
```
where `text` is an instance of a string. We seek to add the additional flexibility of this format: 
```
{'role': 'assistant', 'content':  ['type': 'text', 'text': text]}
```
Additionally, this PR also closes #1265. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->