### PR TITLE
Fix hang when doing s += None.

### DIFF
--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -855,6 +855,8 @@ class ProgramState:
         return self.stream_executor.get_meta_info(name)
 
     def __iadd__(self, other):
+        if other is None:
+            raise ValueError("Tried to append None to state.")
         self.stream_executor.submit(other)
         return self
 


### PR DESCRIPTION
## Motivation

SGLang will terminate the worker thread if you append a `None` to a `ProgramState` because `None` is used as a sentinel to signal the executor to terminate. This results in the program silently hanging when anything that waits on the worker is read from the state.

Repro script:
```
@sglang.function
def f(s):
    s += sglang.user('What is the capital of Iceland?')
    s += sglang.assistant(sglang.gen('result', max_tokens=256))
    s += None

state = f.run()
for m in state.messages():
    print(m["role"], ":", m["content"])
```

## Modifications

Adding `None` to a `ProgramState` will now raise a `ValueError`.

## Checklist

- [✅] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [N/A] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [N/A] Update documentation as needed, including docstrings or example tutorials.