### PR TITLE
Support Phi3 mini and medium

### DIFF
--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -92,7 +92,7 @@ def get_context_length(config):
     """Get the context length of a model from a huggingface model configs."""
     rope_scaling = getattr(config, "rope_scaling", None)
     if rope_scaling:
-        rope_scaling_factor = config.rope_scaling["factor"]
+        rope_scaling_factor = config.rope_scaling.get("factor", 1)
         if "original_max_position_embeddings" in rope_scaling:
             rope_scaling_factor = 1
         if config.rope_scaling.get("rope_type", None) == "llama3":

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -362,5 +362,8 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight)
 
 
-EntryClass = LlamaForCausalLM
-EntryClassRemapping = [("Phi3ForCausalLM", LlamaForCausalLM)]
+class Phi3ForCausalLM(LlamaForCausalLM):
+    pass
+
+
+EntryClass = [LlamaForCausalLM, Phi3ForCausalLM]

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -324,11 +324,11 @@ class LlamaForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
         ]
         params_dict = self.param_dict
 
@@ -363,3 +363,4 @@ class LlamaForCausalLM(nn.Module):
 
 
 EntryClass = LlamaForCausalLM
+EntryClassRemapping = [("Phi3ForCausalLM", LlamaForCausalLM)]


### PR DESCRIPTION
Tested with all Phi-3 mini and medium variants and Phi-3.5 mini.

Fixes #1283 

It requires the recent #1281 fix for supporting non n^2 attention head sizes.

## Motivation

Support for Phi-3 and Phi-3.5 mini and medium models.

## Modifications

It is using the Llama 2 architecture so just like vllm have it handled by the llama2.py model with updates to the weight names copied from vllm.
Additionally for the 128k context variants handle a missing factor field in the config.

