### PR TITLE
fix bug of `undefined is_single` in meth `create_abort_task`

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -53,6 +53,8 @@ class GenerateReqInput:
     # The modalities of the image data [image, multi-images, video]
     modalities: Optional[List[str]] = None
 
+    is_single: bool = True
+
     def post_init(self):
         if (self.text is None and self.input_ids is None) or (
             self.text is not None and self.input_ids is not None
@@ -193,6 +195,8 @@ class EmbeddingReqInput:
     rid: Optional[Union[List[str], str]] = None
     # Dummy sampling params for compatibility
     sampling_params: Union[List[Dict], Dict] = None
+
+    is_single: bool = True
 
     def post_init(self):
         if (self.text is None and self.input_ids is None) or (


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
According to the current logic in `GenerateReqInput.post_init`, when neither `text` nor `input_ids` are provided, the `is_single` field will not be dynamically set. This results in an `AttributeError` being triggered in `TokenizerManager.create_abort_task`.

Additionally, dynamically setting fields in a dataclass is not a good practice. The fields in a dataclass should all be predefined.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
I just add predefined field `is_single: bool = True` to class `GenerateReqInput` and `EmbeddingReqInput`
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.