### PR TITLE
Fix CORS compatibility with OpenAI, vLLM, TGI, LMDeploy

### DIFF
--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -102,6 +102,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.get("/health")
 async def health() -> Response:
     """Check the health of the http server."""

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -39,7 +39,6 @@ import uvloop
 from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
-from fastapi.middleware.cors import CORSMiddleware
 
 from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.srt.constrained import disable_cache

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -37,6 +37,7 @@ import requests
 import uvicorn
 import uvloop
 from fastapi import FastAPI, File, Form, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -38,6 +38,7 @@ import uvicorn
 import uvloop
 from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
 
 from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.srt.constrained import disable_cache
@@ -93,6 +94,12 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 app = FastAPI()
 tokenizer_manager = None
 
+app.add_middleware(CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/health")
 async def health() -> Response:

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -94,7 +94,8 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 app = FastAPI()
 tokenizer_manager = None
 
-app.add_middleware(CORSMiddleware,
+app.add_middleware(
+    CORSMiddleware,
     allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],


### PR DESCRIPTION
## Motivation

Fixes #333

Fix CORS compatibility with OpenAI API, vLLM, TGI, LMDeploy, TabbyAPI, and others. Currently SGLang is the only one which does not use wildcard CORS headers. This makes it annoying to make requests directly from a web page to a SGLang server, since it requires adding an extra proxy server in between to add the CORS headers.

My particular use case is an in-browser eval framework. An intermediary server is not needed for this use case, except to solve this CORS issue.

Examples:

* https://github.com/vllm-project/vllm/blob/da1a844e61366b473cef6b3f7437ea5dc41876a1/vllm/entrypoints/openai/api_server.py#L389
* https://github.com/InternLM/lmdeploy/blob/e8a1a33aa826646420ed2e67250d8eb97cf5cea9/lmdeploy/serve/proxy/proxy.py#L306

## Modifications

Add CORS middleware.