### PR TITLE
remove assertion in triton attention and add an unit test

### DIFF
--- a/python/sglang/srt/layers/triton_attention/decode_attention.py
+++ b/python/sglang/srt/layers/triton_attention/decode_attention.py
@@ -199,8 +199,6 @@ def _decode_att_m_fwd(
     BLOCK = 32
     # shape constraints
     Lq, Lk = q.shape[-1], k_buffer.shape[-1]
-    assert Lq == Lk
-    assert Lk in {16, 32, 64, 96, 128, 256}
 
     batch, head_num = B_req_idx.shape[0], q.shape[1]
 
@@ -483,7 +481,7 @@ def _decode_grouped_att_m_fwd(
     # shape constraints
     Lq, Lk = q.shape[-1], k_buffer.shape[-1]
     assert Lq == Lk
-    assert Lk in {16, 32, 64, 96, 128, 256, 576, 288}
+    # assert Lk in {16, 32, 64, 96, 128, 256, 576, 288}
 
     if Lk == 576:
         BLOCK_DMODEL = 512

--- a/python/sglang/srt/layers/triton_attention/decode_attention.py
+++ b/python/sglang/srt/layers/triton_attention/decode_attention.py
@@ -480,8 +480,6 @@ def _decode_grouped_att_m_fwd(
     BLOCK = 32
     # shape constraints
     Lq, Lk = q.shape[-1], k_buffer.shape[-1]
-    assert Lq == Lk
-    # assert Lk in {16, 32, 64, 96, 128, 256, 576, 288}
 
     if Lk == 576:
         BLOCK_DMODEL = 512

--- a/python/sglang/srt/layers/triton_attention/extend_attention.py
+++ b/python/sglang/srt/layers/triton_attention/extend_attention.py
@@ -277,10 +277,6 @@ def extend_attention_fwd(
         o_extend.shape[-1],
     )
 
-    # TODO: is the assertion necessary?
-    # assert Lq in {16, 32, 64, 96, 128, 256, 576, 288}
-    # assert Lv in {16, 32, 64, 96, 128, 256, 512}
-
     if Lq == 576:
         BLOCK_DMODEL = 512
         BLOCK_DPE = 64

--- a/python/sglang/srt/layers/triton_attention/prefill_attention.py
+++ b/python/sglang/srt/layers/triton_attention/prefill_attention.py
@@ -151,8 +151,6 @@ def context_attention_fwd(q, k, v, o, b_start_loc, b_seq_len, max_input_len):
         BLOCK = 64
 
     Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
-    assert Lq == Lk and Lk == Lv
-    assert Lk in {16, 32, 64, 96, 128, 256}
 
     sm_scale = 1.0 / (Lq**0.5)
     batch, head = b_seq_len.shape[0], q.shape[1]

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -193,11 +193,6 @@ class TestExtendAttention(unittest.TestCase):
             sm_scale,
         )
 
-        # Basic checks
-        self.assertFalse(torch.isnan(o).any(), "Output contains NaN values")
-        self.assertFalse(torch.isinf(o).any(), "Output contains infinite values")
-        self.assertFalse(torch.all(o == 0), "Output is all zeros")
-
     def test_decode_attention(self):
         # Here we just to ensure there is no error
         # TODO: correctnesss test
@@ -211,8 +206,7 @@ class TestExtendAttention(unittest.TestCase):
         ]
 
         for B, H_Q, H_KV, D in configs:
-            with self.subTest(f"B={B}, H_Q={H_Q}, H_KV={H_KV}, D={D}"):
-                self._test_decode_attention_once(B, H_Q, H_KV, D)
+            self._test_decode_attention_once(B, H_Q, H_KV, D)
 
 
 if __name__ == "__main__":

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -1,0 +1,219 @@
+import random
+import unittest
+
+import torch
+
+from sglang.srt.layers.triton_attention.decode_attention import decode_attention_fwd
+from sglang.srt.layers.triton_attention.extend_attention import (
+    extend_attention_fwd,
+    redundant_attention,
+)
+from sglang.srt.layers.triton_attention.prefill_attention import context_attention_fwd
+
+
+class TestExtendAttention(unittest.TestCase):
+
+    def _set_all_seeds(self, seed):
+        """Set all random seeds for reproducibility."""
+        random.seed(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    def setUp(self):
+        # Set seeds before each test method
+        self._set_all_seeds(42)
+
+    def _test_extend_attention_once(self, B, N_CTX, H_Q, H_KV, D):
+        dtype = torch.bfloat16
+
+        b_seq_len_prefix = torch.randint(
+            1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
+        )
+        b_seq_len_extend = torch.randint(
+            1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
+        )
+        b_seq_len = b_seq_len_prefix + b_seq_len_extend
+        max_len_in_batch = torch.max(b_seq_len, 0)[0].item()
+
+        b_req_idx = torch.arange(B, dtype=torch.int32, device="cuda")
+        req_to_tokens = torch.empty(
+            (B, max_len_in_batch), dtype=torch.int32, device="cuda"
+        )
+        b_start_loc = torch.zeros((B,), dtype=torch.int32, device="cuda")
+        b_start_loc[1:] = torch.cumsum(b_seq_len[:-1], 0)
+        b_start_loc_extend = torch.zeros((B,), dtype=torch.int32, device="cuda")
+        b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+        for i in range(B):
+            req_to_tokens[i, : b_seq_len[i]] = torch.arange(
+                b_start_loc[i], b_start_loc[i] + b_seq_len[i]
+            )
+
+        total_token_num = torch.sum(b_seq_len).item()
+        extend_token_num = torch.sum(b_seq_len_extend).item()
+        k_buffer = torch.empty(
+            (total_token_num, H_KV, D), dtype=dtype, device="cuda"
+        ).normal_(mean=0.1, std=0.2)
+        v_buffer = torch.empty(
+            (total_token_num, H_KV, D), dtype=dtype, device="cuda"
+        ).normal_(mean=0.1, std=0.2)
+
+        k_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype, device="cuda")
+        v_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype, device="cuda")
+        q_extend = torch.empty((extend_token_num, H_Q, D), dtype=dtype, device="cuda")
+        for i in range(B):
+            extend_start_in_buffer = b_start_loc[i] + b_seq_len_prefix[i]
+            extend_end_in_buffer = b_start_loc[i] + b_seq_len[i]
+            extend_start = b_start_loc_extend[i]
+            extend_end = b_start_loc_extend[i] + b_seq_len_extend[i]
+            k_extend[extend_start:extend_end] = k_buffer[
+                extend_start_in_buffer:extend_end_in_buffer
+            ]
+            v_extend[extend_start:extend_end] = v_buffer[
+                extend_start_in_buffer:extend_end_in_buffer
+            ]
+            q_extend[extend_start:extend_end] = torch.empty(
+                (b_seq_len_extend[i], H_Q, D), dtype=dtype, device="cuda"
+            ).normal_(mean=0.1, std=0.2)
+
+        o_extend = torch.empty((extend_token_num, H_Q, D), dtype=dtype, device="cuda")
+        o_redundant = torch.empty(
+            (extend_token_num, H_Q, D), dtype=dtype, device="cuda"
+        )
+
+        b_seq_len_extend = b_seq_len - b_seq_len_prefix
+        b_start_loc_extend = torch.zeros_like(b_seq_len)
+        b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+        max_len_extend = torch.max(b_seq_len_extend, 0)[0].item()
+        extend_attention_fwd(
+            q_extend,
+            k_extend,
+            v_extend,
+            o_extend,
+            k_buffer,
+            v_buffer,
+            req_to_tokens,
+            b_req_idx,
+            b_start_loc,
+            b_seq_len,
+            b_seq_len_prefix,
+            b_start_loc_extend,
+            b_seq_len_extend,
+            max_len_in_batch,
+            max_len_extend,
+        )
+
+        redundant_attention(
+            q_extend,
+            k_extend,
+            v_extend,
+            o_redundant,
+            k_buffer,
+            v_buffer,
+            req_to_tokens,
+            b_req_idx,
+            b_start_loc,
+            b_seq_len,
+            b_seq_len_prefix,
+            max_len_in_batch,
+        )
+
+        self.assertTrue(torch.allclose(o_extend, o_redundant, rtol=1e-2))
+
+    def test_extend_attention(self):
+
+        # Define the varying parameter values
+        attention_values = [128, 96, 80, 13]
+
+        # Loop through the values and call the method
+        for value in attention_values:
+            self._test_extend_attention_once(19, 12331, 12, 4, value)
+
+    def _test_context_attention_once(self, head_dim):
+        # Set up a simple test case
+        batch_size = 2
+        num_heads = 4
+        seq_lens = [8, 12]
+        max_seq_len = max(seq_lens)
+
+        # Create random input tensors
+        q = torch.randn(sum(seq_lens), num_heads, head_dim, device="cuda")
+        k = torch.randn(sum(seq_lens), num_heads, head_dim, device="cuda")
+        v = torch.randn(sum(seq_lens), num_heads, head_dim, device="cuda")
+        o = torch.zeros(sum(seq_lens), num_heads, head_dim, device="cuda")
+
+        # Create b_start_loc and b_seq_len tensors
+        b_start_loc = torch.tensor([0, seq_lens[0]], device="cuda")
+        b_seq_len = torch.tensor(seq_lens, device="cuda")
+
+        context_attention_fwd(q, k, v, o, b_start_loc, b_seq_len, max_seq_len)
+
+    def test_context_attention(self):
+        # Here we just to ensure there is no error
+        # TODO: correctnesss test
+        head_dim = [128, 96, 80, 13]
+
+        for dim in head_dim:
+            self._test_context_attention_once(dim)
+
+    def _test_decode_attention_once(self, B, H_Q, H_KV, D):
+        dtype = torch.bfloat16
+        seq_len = 10  # This represents the number of tokens already in the sequence
+        total_tokens = B * seq_len
+        sm_scale = 1.0 / (D**0.5)
+
+        # q represents the new token being generated, one per batch
+        q = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")
+
+        # k_buffer and v_buffer represent all previous tokens
+        k_buffer = torch.randn(total_tokens, H_KV, D, dtype=dtype, device="cuda")
+        v_buffer = torch.randn(total_tokens, H_KV, D, dtype=dtype, device="cuda")
+
+        # o will have the same shape as q
+        o = torch.zeros(B, H_Q, D, dtype=dtype, device="cuda")
+
+        req_to_token = torch.arange(total_tokens, device="cuda").reshape(B, seq_len)
+        b_req_idx = torch.arange(B, device="cuda")
+        b_start_loc = torch.arange(0, total_tokens, seq_len, device="cuda")
+        b_seq_len = torch.full((B,), seq_len, device="cuda")
+
+        decode_attention_fwd(
+            q,
+            k_buffer,
+            v_buffer,
+            o,
+            req_to_token,
+            b_req_idx,
+            b_start_loc,
+            b_seq_len,
+            seq_len,
+            total_tokens,
+            sm_scale,
+        )
+
+        # Basic checks
+        self.assertFalse(torch.isnan(o).any(), "Output contains NaN values")
+        self.assertFalse(torch.isinf(o).any(), "Output contains infinite values")
+        self.assertFalse(torch.all(o == 0), "Output is all zeros")
+
+    def test_decode_attention(self):
+        # Here we just to ensure there is no error
+        # TODO: correctnesss test
+
+        # Test configurations
+        configs = [
+            (2, 4, 4, 64),  # MHA
+            (2, 4, 2, 64),  # GQA
+            (2, 4, 4, 80),  # Non-standard head dim
+            (2, 4, 4, 13),  # Prime number head dim
+        ]
+
+        for B, H_Q, H_KV, D in configs:
+            with self.subTest(f"B={B}, H_Q={H_Q}, H_KV={H_KV}, D={D}"):
+                self._test_decode_attention_once(B, H_Q, H_KV, D)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Resolve https://github.com/sgl-project/sglang/issues/1359 in order to support all non 2^n attention use cases. 

## Modifications

<!-- Describe the changes made in this PR. -->
1. Remove assertion in attention
2. Add unit tests for decode, extend and prefill attention. Note that decode and extend are only tested for not erroring out instead of correctness. We need a follow up for correctness compared with torch implementation. 

## Test

Successfully run on 3 models regarding 3 issues

1. https://github.com/sgl-project/sglang/pull/1299

```
$ python3 -m sglang.bench_latency --model microsoft/Phi-3-medium-4k-instruct --output-len 128 --trust-remote-code --attention-backend triton

Init nccl begin.
Load weight begin. avail mem=78.66 GB
INFO 09-11 04:04:30 weight_utils.py:236] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/6 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  17% Completed | 1/6 [00:00<00:04,  1.10it/s]
Loading safetensors checkpoint shards:  33% Completed | 2/6 [00:01<00:03,  1.24it/s]
Loading safetensors checkpoint shards:  50% Completed | 3/6 [00:02<00:02,  1.18it/s]
Loading safetensors checkpoint shards:  67% Completed | 4/6 [00:03<00:01,  1.13it/s]
Loading safetensors checkpoint shards:  83% Completed | 5/6 [00:04<00:00,  1.08it/s]
Loading safetensors checkpoint shards: 100% Completed | 6/6 [00:05<00:00,  1.06it/s]
Loading safetensors checkpoint shards: 100% Completed | 6/6 [00:05<00:00,  1.10it/s]

Load weight end. type=Phi3ForCausalLM, dtype=torch.bfloat16, avail mem=52.50 GB
Memory pool end. avail mem=9.31 GB
max_total_num_tokens=225766
Warmup ...
Prefill. latency: 1.24759 s, throughput:    820.78 token/s
Decode.  latency: 0.03711 s, throughput:     26.95 token/s
Decode.  latency: 0.02068 s, throughput:     48.36 token/s
Decode.  latency: 0.02067 s, throughput:     48.37 token/s
Decode.  latency: 0.02060 s, throughput:     48.55 token/s
Decode.  median latency: 0.02068 s, median throughput:     48.37 token/s
Total. latency:  1.347 s, throughput:    763.38 token/s
Benchmark ...
Prefill. latency: 0.08270 s, throughput:  12382.60 token/s
Decode.  latency: 0.02173 s, throughput:     46.02 token/s
Decode.  latency: 0.02061 s, throughput:     48.52 token/s
Decode.  latency: 0.02070 s, throughput:     48.30 token/s
Decode.  latency: 0.02064 s, throughput:     48.45 token/s
Decode.  latency: 0.02097 s, throughput:     47.69 token/s
Decode.  median latency: 0.02027 s, median throughput:     49.33 token/s
Total. latency:  2.615 s, throughput:    440.60 token/s
```

2. https://github.com/sgl-project/sglang/issues/1159

```

$ python3 -m sglang.bench_latency --model vonjack/Phi-3-mini-4k-instruct-LLaMAfied  --output-len 128 --trust-remote-code --attention-backend triton

max_total_num_tokens=169367
Warmup ...
Prefill. latency: 2.15460 s, throughput:    475.26 token/s
Decode.  latency: 1.52448 s, throughput:      0.66 token/s
Decode.  latency: 0.02624 s, throughput:     38.11 token/s
Decode.  latency: 0.01949 s, throughput:     51.31 token/s
Decode.  latency: 0.01732 s, throughput:     57.73 token/s
Decode.  median latency: 0.02286 s, median throughput:     43.74 token/s
Total. latency:  3.742 s, throughput:    274.71 token/s
Benchmark ...
Prefill. latency: 0.02857 s, throughput:  35840.08 token/s
Decode.  latency: 0.02151 s, throughput:     46.48 token/s
Decode.  latency: 0.01859 s, throughput:     53.78 token/s
Decode.  latency: 0.01494 s, throughput:     66.94 token/s
Decode.  latency: 0.01057 s, throughput:     94.58 token/s
Decode.  latency: 0.01036 s, throughput:     96.55 token/s
Decode.  median latency: 0.01625 s, median throughput:     61.55 token/s
Total. latency:  2.835 s, throughput:    406.32 token/s
```

3. https://github.com/sgl-project/sglang/issues/1109


```
$ python3 -m sglang.bench_latency --model stabilityai/stablelm-3b-4e1t --output-len 128 --trust-remote-code --attention-backend triton

Init nccl begin.
Load weight begin. avail mem=78.66 GB
INFO 09-11 04:03:41 weight_utils.py:236] Using model weights format ['*.safetensors']
INFO 09-11 04:03:42 weight_utils.py:280] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.02it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.02it/s]

Load weight end. type=StableLmForCausalLM, dtype=torch.bfloat16, avail mem=73.29 GB
Memory pool end. avail mem=9.35 GB
max_total_num_tokens=209225
Warmup ...
Prefill. latency: 0.96427 s, throughput:   1061.94 token/s
Decode.  latency: 0.08962 s, throughput:     11.16 token/s
Decode.  latency: 0.01486 s, throughput:     67.29 token/s
Decode.  latency: 0.01477 s, throughput:     67.69 token/s
Decode.  latency: 0.01456 s, throughput:     68.69 token/s
Decode.  median latency: 0.01482 s, median throughput:     67.49 token/s
Total. latency:  1.098 s, throughput:    936.17 token/s
Benchmark ...
Prefill. latency: 0.02249 s, throughput:  45525.51 token/s
Decode.  latency: 0.01480 s, throughput:     67.55 token/s
Decode.  latency: 0.01457 s, throughput:     68.64 token/s
Decode.  latency: 0.01479 s, throughput:     67.63 token/s
Decode.  latency: 0.01463 s, throughput:     68.37 token/s
Decode.  latency: 0.01452 s, throughput:     68.87 token/s
Decode.  median latency: 0.01438 s, median throughput:     69.53 token/s
Total. latency:  1.874 s, throughput:    614.77 token/s
```
## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.