### PR TITLE
Support cuda graph in the triton attention backend

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -112,12 +112,6 @@ jobs:
           cd test/srt
           python3 -m unittest test_serving_throughput.TestServingThroughput.test_default_without_chunked_prefill
 
-      - name: Benchmark Serving Throughput (triton attention backend)
-        timeout-minutes: 10
-        run: |
-          cd test/srt
-          python3 -m unittest test_serving_throughput.TestServingThroughput.test_default_with_triton_attention_backend
-
   performance-test-2-gpu:
     if: github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request'
     runs-on: 2-gpu-runner

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -112,6 +112,12 @@ jobs:
           cd test/srt
           python3 -m unittest test_serving_throughput.TestServingThroughput.test_default_without_chunked_prefill
 
+      - name: Benchmark Serving Throughput (triton attention backend)
+        timeout-minutes: 10
+        run: |
+          cd test/srt
+          python3 -m unittest test_serving_throughput.TestServingThroughput.test_default_with_triton_attention_backend
+
   performance-test-2-gpu:
     if: github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request'
     runs-on: 2-gpu-runner

--- a/python/sglang/srt/layers/attention_backend.py
+++ b/python/sglang/srt/layers/attention_backend.py
@@ -36,13 +36,37 @@ class AttentionBackend(ABC):
     def init_forward_metadata(
         self, batch: ScheduleBatch, input_metadata: InputMetadata
     ):
-        pass
+        """Init the metadata for a forward pass."""
+        raise NotImplementedError()
 
-    def forward(self, q, k, v, layer, input_metadata: InputMetadata):
+    def init_cuda_graph_state(self, max_bs: int):
+        """Init the global shared states for cuda graph."""
+        raise NotImplementedError()
+
+    def init_forward_metadata_capture_cuda_graph(
+        self, bs: int, req_pool_indices, seq_lens
+    ):
+        """Init the metadata for a forward pass for capturing a cuda graph."""
+        raise NotImplementedError()
+
+    def init_forward_metadata_replay_cuda_graph(
+        self, bs: int, req_pool_indices, seq_lens
+    ):
+        """Init the metadata for a forward pass for replying a cuda graph."""
+        raise NotImplementedError()
+
+    def forward(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
+        """Run forward on an attention layer."""
         if input_metadata.forward_mode.is_decode():
             return self.forward_decode(q, k, v, layer, input_metadata)
         else:
             return self.forward_extend(q, k, v, layer, input_metadata)
+
+    def forward_decode(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
+        raise NotImplementedError()
+
+    def forward_extend(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
+        raise NotImplementedError()
 
 
 class FlashInferAttnBackend(AttentionBackend):
@@ -153,7 +177,9 @@ class FlashInferAttnBackend(AttentionBackend):
                 self.cuda_graph_kv_indices.clone(),
             ]
 
-    def capture_cuda_graph_init(self, bs: int, req_pool_indices, seq_lens):
+    def init_forward_metadata_capture_cuda_graph(
+        self, bs: int, req_pool_indices, seq_lens
+    ):
         if self.model_runner.sliding_window_size is None:
             decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self.workspace_buffer,
@@ -194,7 +220,9 @@ class FlashInferAttnBackend(AttentionBackend):
 
         self.forward_metadata = (False, None, decode_wrapper)
 
-    def replay_cuda_graph_init(self, bs: int, req_pool_indices, seq_lens):
+    def init_forward_metadata_replay_cuda_graph(
+        self, bs: int, req_pool_indices, seq_lens
+    ):
         update_flashinfer_indices(
             ForwardMode.DECODE,
             self.model_runner,
@@ -290,6 +318,7 @@ class TritonAttnBackend(AttentionBackend):
     def __init__(self, model_runner: ModelRunner):
         # Lazy import to avoid the initialization of cuda context
         from sglang.srt.layers.triton_attention.decode_attention import (
+            REDUCE_TORCH_TYPE,
             decode_attention_fwd,
         )
         from sglang.srt.layers.triton_attention.extend_attention import (
@@ -300,8 +329,12 @@ class TritonAttnBackend(AttentionBackend):
 
         self.decode_attention_fwd = decode_attention_fwd
         self.extend_attention_fwd = extend_attention_fwd
+        self.REDUCE_TORCH_TYPE = REDUCE_TORCH_TYPE
+        self.num_head = model_runner.model_config.num_attention_heads
 
         self.forward_metadata = None
+
+        self.cuda_graph_max_seq_len = model_runner.model_config.context_len
 
     def init_forward_metadata(
         self, batch: ScheduleBatch, input_metadata: InputMetadata
@@ -309,20 +342,62 @@ class TritonAttnBackend(AttentionBackend):
         """Init auxiliary variables for triton attention backend."""
 
         if input_metadata.forward_mode.is_decode():
-            max_seq_len = torch.max(input_metadata.seq_lens).item()
             start_loc = torch.zeros_like(input_metadata.seq_lens, dtype=torch.int32)
             start_loc[1:] = torch.cumsum(input_metadata.seq_lens[:-1], dim=0)
 
             total_num_tokens = torch.sum(input_metadata.seq_lens).item()
+            attn_logits = torch.empty(
+                (self.num_head, total_num_tokens),
+                dtype=self.REDUCE_TORCH_TYPE,
+                device="cuda",
+            )
+
+            max_seq_len = torch.max(input_metadata.seq_lens).item()
             max_extend_len = None
         else:
-            start_loc = max_seq_len = total_num_tokens = None
+            start_loc = attn_logits = max_seq_len = None
             prefix_lens = torch.tensor(batch.prefix_lens_cpu, device="cuda")
             max_extend_len = torch.max(input_metadata.seq_lens - prefix_lens).item()
 
-        self.forward_metadata = start_loc, max_seq_len, max_extend_len, total_num_tokens
+        self.forward_metadata = start_loc, attn_logits, max_seq_len, max_extend_len
+
+    def init_cuda_graph_state(self, max_bs: int):
+        self.cuda_graph_max_total_num_tokens = max_bs * self.cuda_graph_max_seq_len
+
+        self.cuda_graph_start_loc = torch.zeros(
+            (max_bs,), dtype=torch.int32, device="cuda"
+        )
+        self.cuda_graph_attn_logits = torch.empty(
+            (self.num_head, self.cuda_graph_max_total_num_tokens),
+            dtype=self.REDUCE_TORCH_TYPE,
+            device="cuda",
+        )
+
+    def init_forward_metadata_capture_cuda_graph(
+        self, bs: int, req_pool_indices, seq_lens
+    ):
+        self.forward_metadata = (
+            self.cuda_graph_start_loc,
+            self.cuda_graph_attn_logits,
+            self.cuda_graph_max_seq_len,
+            None,
+        )
+
+    def init_forward_metadata_replay_cuda_graph(
+        self, bs: int, req_pool_indices, seq_lens
+    ):
+        self.cuda_graph_start_loc.zero_()
+        self.cuda_graph_start_loc[1:bs] = torch.cumsum(seq_lens[: bs - 1], dim=0)
+
+        self.forward_metadata = (
+            self.cuda_graph_start_loc,
+            self.cuda_graph_attn_logits,
+            self.cuda_graph_max_seq_len,
+            None,
+        )
 
     def forward_extend(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
+        # TODO: reuse the buffer across layers
         if layer.qk_head_dim != layer.v_head_dim:
             o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
         else:
@@ -332,8 +407,7 @@ class TritonAttnBackend(AttentionBackend):
             layer.layer_id, input_metadata.out_cache_loc, k, v
         )
 
-        start_loc, max_seq_len, max_extend_len, total_num_tokens = self.forward_metadata
-
+        start_loc, attn_logits, max_seq_len, max_extend_len = self.forward_metadata
         self.extend_attention_fwd(
             q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
             k.contiguous(),
@@ -350,16 +424,16 @@ class TritonAttnBackend(AttentionBackend):
             layer.scaling,
             layer.logit_cap,
         )
-
         return o
 
     def forward_decode(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
+        # TODO: reuse the buffer across layers
         if layer.qk_head_dim != layer.v_head_dim:
             o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
         else:
             o = torch.empty_like(q)
 
-        start_loc, max_seq_len, max_extend_len, total_num_tokens = self.forward_metadata
+        start_loc, attn_logits, max_seq_len, max_extend_len = self.forward_metadata
 
         input_metadata.token_to_kv_pool.set_kv_buffer(
             layer.layer_id, input_metadata.out_cache_loc, k, v
@@ -374,10 +448,9 @@ class TritonAttnBackend(AttentionBackend):
             input_metadata.req_pool_indices,
             start_loc,
             input_metadata.seq_lens,
+            attn_logits,
             max_seq_len,
-            total_num_tokens,
             layer.scaling,
             layer.logit_cap,
         )
-
         return o

--- a/python/sglang/srt/layers/attention_backend.py
+++ b/python/sglang/srt/layers/attention_backend.py
@@ -55,6 +55,9 @@ class AttentionBackend(ABC):
         """Init the metadata for a forward pass for replying a cuda graph."""
         raise NotImplementedError()
 
+    def get_cuda_graph_seq_len_fill_value(self):
+        raise NotImplementedError()
+
     def forward(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
         """Run forward on an attention layer."""
         if input_metadata.forward_mode.is_decode():
@@ -232,6 +235,9 @@ class FlashInferAttnBackend(AttentionBackend):
             self.cuda_graph_metadata[bs],
         )
 
+    def get_cuda_graph_seq_len_fill_value(self):
+        return 0
+
     def forward_extend(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
         if not isinstance(self.prefill_wrapper_paged, list):
             prefill_wrapper_paged = self.prefill_wrapper_paged
@@ -395,6 +401,9 @@ class TritonAttnBackend(AttentionBackend):
             self.cuda_graph_max_seq_len,
             None,
         )
+
+    def get_cuda_graph_seq_len_fill_value(self):
+        return 1
 
     def forward_extend(self, q, k, v, layer: nn.Module, input_metadata: InputMetadata):
         # TODO: reuse the buffer across layers

--- a/python/sglang/srt/layers/flashinfer_utils.py
+++ b/python/sglang/srt/layers/flashinfer_utils.py
@@ -66,18 +66,18 @@ class FlashinferUpdater:
         self.head_dim = model_runner.model_config.head_dim
         self.batch_size = len(req_pool_indices)
 
-        self.kv_last_page_len = torch.ones(
-            (self.batch_size,), dtype=torch.int32, device="cuda"
+        self.decode_wrapper = (
+            decode_wrapper or self.model_runner.attn_backend.decode_wrapper
+        )
+        self.prefill_wrapper_ragged = (
+            self.model_runner.attn_backend.prefill_wrapper_ragged
+        )
+        self.prefill_wrapper_paged = (
+            self.model_runner.attn_backend.prefill_wrapper_paged
         )
 
-        (
-            self.decode_wrapper,
-            self.prefill_wrapper_ragged,
-            self.prefill_wrapper_paged,
-        ) = (
-            decode_wrapper or self.model_runner.attn_backend.decode_wrapper,
-            self.model_runner.attn_backend.prefill_wrapper_ragged,
-            self.model_runner.attn_backend.prefill_wrapper_paged,
+        self.kv_last_page_len = torch.ones(
+            (self.batch_size,), dtype=torch.int32, device="cuda"
         )
 
     def _init_indices_no_sliding_window(self):

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -176,7 +176,7 @@ class CudaGraphRunner:
         out_cache_loc = self.out_cache_loc[:bs]
 
         # Attention backend
-        self.model_runner.attn_backend.capture_cuda_graph_init(
+        self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
             bs, req_pool_indices, seq_lens
         )
 
@@ -239,7 +239,7 @@ class CudaGraphRunner:
         self.out_cache_loc[:raw_bs] = batch.out_cache_loc
 
         # Attention backend
-        self.model_runner.attn_backend.replay_cuda_graph_init(
+        self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
             bs, self.req_pool_indices, self.seq_lens
         )
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -445,12 +445,6 @@ class ModelRunner:
         if self.server_args.disable_cuda_graph:
             return
 
-        if self.server_args.attention_backend != "flashinfer":
-            logger.warning(
-                f"Cuda graph is not supported for attention backend: {self.server_args.attention_backend}"
-            )
-            return
-
         logger.info("Capture cuda graph begin. This can take up to several minutes.")
         self.cuda_graph_runner = CudaGraphRunner(self)
 

--- a/test/srt/test_serving_throughput.py
+++ b/test/srt/test_serving_throughput.py
@@ -96,6 +96,16 @@ class TestServingThroughput(unittest.TestCase):
         if os.getenv("SGLANG_IS_IN_CI", "false") == "true":
             assert res["output_throughput"] > 2400
 
+    def test_default_with_triton_attention_backend(self):
+        res = self.run_test(
+            disable_radix_cache=ServerArgs.disable_radix_cache,
+            attention_backend="triton",
+            chunked_prefill_size=-1,
+        )
+
+        if os.getenv("SGLANG_IS_IN_CI", "false") == "true":
+            assert res["output_throughput"] > 2400
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Llama 3 8B (1.3x faster)

```
# triton w/ cuda graph
# Decode.  median latency: 0.00706 s, median throughput:    141.63 token/s
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --attention-backend triton

# triton w/o cuda graph
# Decode.  median latency: 0.00928 s, median throughput:    107.79 token/s
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --attention-backend triton --disable-cuda-graph


# flashinfer w/ cuda graph
# Decode.  median latency: 0.00735 s, median throughput:    135.98 token/s
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --attention-backend flashinfer

# flashinfer w/o cuda graph
# Decode.  median latency: 0.00823 s, median throughput:    121.46 token/s
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --attention-backend flashinfer --disable-cuda-graph
```

## DeepSeek-Coder-V2-Lite (4x faster)
```
# triton w/ cuda graph
# Decode.  median latency: 0.00622 s, median throughput:    160.82 token/s
python3 -m sglang.bench_latency --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --trust-remote --batch-size 1 --input 128 --output 8 --enable-mla

# triton w/o cuda graph
# Decode.  median latency: 0.02453 s, median throughput:     40.77 token/s
python3 -m sglang.bench_latency --model deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct --trust-remote --batch-size 1 --input 128 --output 8 --enable-mla --disable-cuda-graph
```