### PR TITLE
kernel: use tensor cores for flashinfer gqa kernels

### DIFF
--- a/python/sglang/srt/layers/attention_backend.py
+++ b/python/sglang/srt/layers/attention_backend.py
@@ -52,9 +52,17 @@ class FlashInferAttnBackend(AttentionBackend):
         super().__init__()
         self.model_runner = model_runner
 
-        if not _grouped_size_compiled_for_decode_kernels(
-            model_runner.model_config.num_attention_heads // model_runner.tp_size,
-            model_runner.model_config.get_num_kv_heads(model_runner.tp_size),
+        local_num_qo_heads = (
+            model_runner.model_config.num_attention_heads // model_runner.tp_size
+        )
+        local_num_kv_heads = model_runner.model_config.get_num_kv_heads(
+            model_runner.tp_size
+        )
+        if (
+            not _grouped_size_compiled_for_decode_kernels(
+                local_num_qo_heads, local_num_kv_heads
+            )
+            or local_num_qo_heads // local_num_kv_heads > 4
         ):
             self.decode_use_tensor_cores = True
         else:


### PR DESCRIPTION
This pr fixes the kernel dispatch rule for flashinfer backend.

## Motivation
When group size > 4, using tensor cores is faster.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.