### PR TITLE
Add torchao quant for mixtral and qwen_moe

### DIFF
--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -48,7 +48,7 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
     return dummy_linear.weight
 
 
-def quantize_params_with_suffixes_(
+def apply_torchao_config_(
     self: torch.nn.Module,
     params_dict: Dict[str, torch.Tensor],
     param_suffixes: Set[str],

--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -3,9 +3,18 @@ Common utilities for torchao.
 """
 
 import torch
+from typing import Dict, Set
 
 
-def torchao_quantize_param_data(param, torchao_config):
+def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
+    """Quantize a Tensor with torchao quantization specified by torchao_config
+
+    Args:
+       `param`: weight parameter of the linear module
+       `torchao_config`: type of quantization and their arguments we want to use to
+        quantize the Tensor, e.g. int4wo-128 means int4 weight only quantization with group_size
+        128
+    """
     # Lazy import to suppress some warnings
     from torchao.quantization import (
         int4_weight_only,
@@ -36,3 +45,22 @@ def torchao_quantize_param_data(param, torchao_config):
         # [rank0]: AssertionError: fp8e4nv data type is not supported on CUDA arch < 89
         quantize_(dummy_linear, float8_weight_only())
     return dummy_linear.weight
+
+
+def quantize_params_with_suffixes_(params_dict: Dict[str, torch.Tensor], param_suffixes: Set[str], torchao_config: str) -> None:
+    """A util function used for quantizing the weight parameters after they are loaded
+
+    Args:
+      `params_dict`: dictionary mapping from param_name to the parameter Tensor
+      `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching these suffixes
+
+    Returns:
+       None, the `params_dict` is modified inplace
+    """
+    for param_suffix in param_suffixes:
+        for name in params_dict:
+            param = params_dict[name]
+            if param_suffix in name and param.ndim == 2:
+                params_dict[name] = torchao_quantize_param_data(
+                    param, torchao_config
+                )

--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -49,19 +49,27 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
 
 
 def quantize_params_with_suffixes_(
-    params_dict: Dict[str, torch.Tensor], param_suffixes: Set[str], torchao_config: str
+    self: torch.nn.Module,
+    params_dict: Dict[str, torch.Tensor],
+    param_suffixes: Set[str],
 ) -> None:
-    """A util function used for quantizing the weight parameters after they are loaded
+    """A util function used for quantizing the weight parameters after they are loaded if
+       self.torchao_config is specified
 
     Args:
+      `self`: the model we want to quantize
       `params_dict`: dictionary mapping from param_name to the parameter Tensor
       `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching these suffixes
 
     Returns:
-       None, the `params_dict` is modified inplace
+       None, the `params_dict` is modified inplace and the weights of `self` model are quantized
     """
-    for param_suffix in param_suffixes:
-        for name in params_dict:
-            param = params_dict[name]
-            if param_suffix in name and param.ndim == 2:
-                params_dict[name] = torchao_quantize_param_data(param, torchao_config)
+    if self.torchao_config:
+        for param_suffix in param_suffixes:
+            for name in params_dict:
+                param = params_dict[name]
+                if param_suffix in name and param.ndim == 2:
+                    params_dict[name] = torchao_quantize_param_data(
+                        param, self.torchao_config
+                    )
+        self.load_state_dict(params_dict, assign=True)

--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -2,8 +2,9 @@
 Common utilities for torchao.
 """
 
-import torch
 from typing import Dict, Set
+
+import torch
 
 
 def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
@@ -47,7 +48,9 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
     return dummy_linear.weight
 
 
-def quantize_params_with_suffixes_(params_dict: Dict[str, torch.Tensor], param_suffixes: Set[str], torchao_config: str) -> None:
+def quantize_params_with_suffixes_(
+    params_dict: Dict[str, torch.Tensor], param_suffixes: Set[str], torchao_config: str
+) -> None:
     """A util function used for quantizing the weight parameters after they are loaded
 
     Args:
@@ -61,6 +64,4 @@ def quantize_params_with_suffixes_(params_dict: Dict[str, torch.Tensor], param_s
         for name in params_dict:
             param = params_dict[name]
             if param_suffix in name and param.ndim == 2:
-                params_dict[name] = torchao_quantize_param_data(
-                    param, torchao_config
-                )
+                params_dict[name] = torchao_quantize_param_data(param, torchao_config)

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -406,10 +406,8 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight)
 
         if self.torchao_config:
-            param_suffixes = set(["proj.weight"])
-            param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
             quantize_params_with_suffixes_(
-                params_dict, param_suffixes, self.torchao_config
+                params_dict, set(["proj.weight"]), self.torchao_config
             )
             self.load_state_dict(params_dict, assign=True)
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -408,7 +408,9 @@ class LlamaForCausalLM(nn.Module):
         if self.torchao_config:
             param_suffixes = set(["proj.weight"])
             param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
-            quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)
+            quantize_params_with_suffixes_(
+                params_dict, param_suffixes, self.torchao_config
+            )
             self.load_state_dict(params_dict, assign=True)
 
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -41,7 +41,7 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.torchao_utils import quantize_params_with_suffixes_
+from sglang.srt.layers.torchao_utils import apply_torchao_config_
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import InputMetadata
 
@@ -405,7 +405,7 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 
-        quantize_params_with_suffixes_(self, params_dict, set(["proj.weight"]))
+        apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 
 class Phi3ForCausalLM(LlamaForCausalLM):

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -416,8 +416,8 @@ class LlamaForCausalLM(nn.Module):
             stacked_params = set(entry[0] for entry in stacked_params_mapping)
             for param_suffix in stacked_params:
                 for name in params_dict:
-                    if param_suffix in name:
-                        param = params_dict[name]
+                    param = params_dict[name]
+                    if param_suffix in name and name.endswith("proj.weight") and param.ndim == 2:
                         params_dict[name] = torchao_quantize_param_data(
                             param, self.torchao_config
                         )

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -406,7 +406,6 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight)
 
         if self.torchao_config:
-            # quantizing the loaded, stacked params, e.g. "...qkv_proj"
             param_suffixes = set(["proj.weight"])
             param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
             quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -41,7 +41,7 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.torchao_utils import torchao_quantize_param_data
+from sglang.srt.layers.torchao_utils import quantize_params_with_suffixes_
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import InputMetadata
 
@@ -405,27 +405,11 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 
-                if self.torchao_config:
-                    if name.endswith("proj.weight") and param.ndim == 2:
-                        params_dict[name] = torchao_quantize_param_data(
-                            param, self.torchao_config
-                        )
-
         if self.torchao_config:
             # quantizing the loaded, stacked params, e.g. "...qkv_proj"
-            stacked_params = set(entry[0] for entry in stacked_params_mapping)
-            for param_suffix in stacked_params:
-                for name in params_dict:
-                    param = params_dict[name]
-                    if (
-                        param_suffix in name
-                        and name.endswith("proj.weight")
-                        and param.ndim == 2
-                    ):
-                        params_dict[name] = torchao_quantize_param_data(
-                            param, self.torchao_config
-                        )
-
+            param_suffixes = set(["proj.weight"])
+            param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
+            quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)
             self.load_state_dict(params_dict, assign=True)
 
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -417,7 +417,11 @@ class LlamaForCausalLM(nn.Module):
             for param_suffix in stacked_params:
                 for name in params_dict:
                     param = params_dict[name]
-                    if param_suffix in name and name.endswith("proj.weight") and param.ndim == 2:
+                    if (
+                        param_suffix in name
+                        and name.endswith("proj.weight")
+                        and param.ndim == 2
+                    ):
                         params_dict[name] = torchao_quantize_param_data(
                             param, self.torchao_config
                         )

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -405,11 +405,7 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 
-        if self.torchao_config:
-            quantize_params_with_suffixes_(
-                params_dict, set(["proj.weight"]), self.torchao_config
-            )
-            self.load_state_dict(params_dict, assign=True)
+        quantize_params_with_suffixes_(self, params_dict, set(["proj.weight"]))
 
 
 class Phi3ForCausalLM(LlamaForCausalLM):

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -380,7 +380,6 @@ class MixtralForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
 
         if self.torchao_config:
-            # quantizing the loaded, stacked params, e.g. "...qkv_proj"
             param_suffixes = set(["proj.weight"])
             param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
             quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -382,7 +382,9 @@ class MixtralForCausalLM(nn.Module):
         if self.torchao_config:
             param_suffixes = set(["proj.weight"])
             param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
-            quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)
+            quantize_params_with_suffixes_(
+                params_dict, param_suffixes, self.torchao_config
+            )
             self.load_state_dict(params_dict, assign=True)
 
 

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -390,13 +390,16 @@ class MixtralForCausalLM(nn.Module):
             for param_suffix in stacked_params:
                 for name in params_dict:
                     param = params_dict[name]
-                    if param_suffix in name and name.endswith("proj.weight") and param.ndim == 2:
+                    if (
+                        param_suffix in name
+                        and name.endswith("proj.weight")
+                        and param.ndim == 2
+                    ):
                         params_dict[name] = torchao_quantize_param_data(
                             param, self.torchao_config
                         )
 
             self.load_state_dict(params_dict, assign=True)
-
 
 
 EntryClass = MixtralForCausalLM

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -379,11 +379,7 @@ class MixtralForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
 
-        if self.torchao_config:
-            quantize_params_with_suffixes_(
-                params_dict, set(["proj.weight"]), self.torchao_config
-            )
-            self.load_state_dict(params_dict, assign=True)
+        quantize_params_with_suffixes_(self, params_dict, set(["proj.weight"]))
 
 
 EntryClass = MixtralForCausalLM

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -41,7 +41,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.torchao_utils import quantize_params_with_suffixes_
+from sglang.srt.layers.torchao_utils import apply_torchao_config_
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import InputMetadata
 
@@ -379,7 +379,7 @@ class MixtralForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
 
-        quantize_params_with_suffixes_(self, params_dict, set(["proj.weight"]))
+        apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 
 EntryClass = MixtralForCausalLM

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -380,10 +380,8 @@ class MixtralForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
 
         if self.torchao_config:
-            param_suffixes = set(["proj.weight"])
-            param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
             quantize_params_with_suffixes_(
-                params_dict, param_suffixes, self.torchao_config
+                params_dict, set(["proj.weight"]), self.torchao_config
             )
             self.load_state_dict(params_dict, assign=True)
 

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -41,7 +41,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.torchao_utils import torchao_quantize_param_data
+from sglang.srt.layers.torchao_utils import quantize_params_with_suffixes_
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import InputMetadata
 
@@ -378,27 +378,12 @@ class MixtralForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
-                    if self.torchao_config:
-                        if name.endswith("proj.weight") and param.ndim == 2:
-                            params_dict[name] = torchao_quantize_param_data(
-                                param, self.torchao_config
-                            )
 
         if self.torchao_config:
             # quantizing the loaded, stacked params, e.g. "...qkv_proj"
-            stacked_params = set(entry[0] for entry in stacked_params_mapping)
-            for param_suffix in stacked_params:
-                for name in params_dict:
-                    param = params_dict[name]
-                    if (
-                        param_suffix in name
-                        and name.endswith("proj.weight")
-                        and param.ndim == 2
-                    ):
-                        params_dict[name] = torchao_quantize_param_data(
-                            param, self.torchao_config
-                        )
-
+            param_suffixes = set(["proj.weight"])
+            param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
+            quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)
             self.load_state_dict(params_dict, assign=True)
 
 

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -47,7 +47,7 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.layers.torchao_utils import quantize_params_with_suffixes_
+from sglang.srt.layers.torchao_utils import apply_torchao_config_
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import InputMetadata
 
@@ -454,7 +454,7 @@ class Qwen2MoeForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
 
-        quantize_params_with_suffixes_(self, params_dict, set(["proj.weight"]))
+        apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 
 EntryClass = Qwen2MoeForCausalLM

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -455,7 +455,6 @@ class Qwen2MoeForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
 
         if self.torchao_config:
-            # quantizing the loaded, stacked params, e.g. "...qkv_proj"
             param_suffixes = set(["proj.weight"])
             param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
             param_suffixes.union(set(entry[0] for entry in expert_params_mapping))

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -47,6 +47,8 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.torchao_utils import torchao_quantize_param_data
+from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import InputMetadata
 
 
@@ -359,6 +361,7 @@ class Qwen2MoeForCausalLM(nn.Module):
         super().__init__()
         self.config = config
         self.quant_config = quant_config
+        self.torchao_config = global_server_args_dict["torchao_config"]
         self.model = Qwen2MoeModel(config, cache_config, quant_config)
         self.lm_head = ParallelLMHead(
             config.vocab_size, config.hidden_size, quant_config=quant_config
@@ -450,6 +453,24 @@ class Qwen2MoeForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+                    if self.torchao_config:
+                        if name.endswith("proj.weight") and param.ndim == 2:
+                            params_dict[name] = torchao_quantize_param_data(
+                                param, self.torchao_config
+                            )
+        if self.torchao_config:
+            # quantizing the loaded, stacked params, e.g. "...qkv_proj"
+            stacked_params = set(entry[0] for entry in stacked_params_mapping)
+            stacked_params.union(set(entry[0] for entry in expert_params_mapping))
+            for param_suffix in stacked_params:
+                for name in params_dict:
+                    param = params_dict[name]
+                    if param_suffix in name and param.ndim == 2:
+                        params_dict[name] = torchao_quantize_param_data(
+                            param, self.torchao_config
+                        )
+
+            self.load_state_dict(params_dict, assign=True)
 
 
 EntryClass = Qwen2MoeForCausalLM

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -454,11 +454,7 @@ class Qwen2MoeForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
 
-        if self.torchao_config:
-            quantize_params_with_suffixes_(
-                params_dict, set(["proj.weight"]), self.torchao_config
-            )
-            self.load_state_dict(params_dict, assign=True)
+        quantize_params_with_suffixes_(self, params_dict, set(["proj.weight"]))
 
 
 EntryClass = Qwen2MoeForCausalLM

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -455,11 +455,8 @@ class Qwen2MoeForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
 
         if self.torchao_config:
-            param_suffixes = set(["proj.weight"])
-            param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
-            param_suffixes.union(set(entry[0] for entry in expert_params_mapping))
             quantize_params_with_suffixes_(
-                params_dict, param_suffixes, self.torchao_config
+                params_dict, set(["proj.weight"]), self.torchao_config
             )
             self.load_state_dict(params_dict, assign=True)
 

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -458,7 +458,9 @@ class Qwen2MoeForCausalLM(nn.Module):
             param_suffixes = set(["proj.weight"])
             param_suffixes.union(set(entry[0] for entry in stacked_params_mapping))
             param_suffixes.union(set(entry[0] for entry in expert_params_mapping))
-            quantize_params_with_suffixes_(params_dict, param_suffixes, self.torchao_config)
+            quantize_params_with_suffixes_(
+                params_dict, param_suffixes, self.torchao_config
+            )
             self.load_state_dict(params_dict, assign=True)
 
 


### PR DESCRIPTION
Summary:
Similar to https://github.com/sgl-project/sglang/pull/1341 we add torchao quantization to mixtral model

Test Plan:
Note: compile is not working yet, and I can't install torchnightly locally and make it work either. I'll wait for pytorch 2.5 release which happens in mid Oct, or check that again later

python3 -m sglang.bench_latency --model Qwen/Qwen1.5-MoE-A2.7B --batch-size 1 --input 128 --output 8  Warmup ...
Prefill. latency: 0.05532 s, throughput:   2313.73 token/s
Decode.  latency: 0.00896 s, throughput:    111.65 token/s
Decode.  latency: 0.00833 s, throughput:    120.04 token/s
Decode.  latency: 0.00869 s, throughput:    115.06 token/s
Decode.  latency: 0.00842 s, throughput:    118.79 token/s
Decode.  median latency: 0.00855 s, median throughput:    116.89 token/s
Total. latency:  0.090 s, throughput:   1471.26 token/s
Benchmark ...
Prefill. latency: 0.04294 s, throughput:   2980.61 token/s
Decode.  latency: 0.00839 s, throughput:    119.12 token/s
Decode.  latency: 0.00828 s, throughput:    120.78 token/s
Decode.  latency: 0.00857 s, throughput:    116.64 token/s
Decode.  latency: 0.00853 s, throughput:    117.19 token/s
Decode.  latency: 0.00859 s, throughput:    116.39 token/s
Decode.  median latency: 0.00853 s, median throughput:    117.17 token/s
Total. latency:  0.111 s, throughput:   1226.84 token/s

python3 -m sglang.bench_latency --model Qwen/Qwen1.5-MoE-A2.7B --batch-size 1 --input 128 --output 8 --torchao-config int4wo-128

Warmup ...
Prefill. latency: 0.06413 s, throughput:   1996.05 token/s
Decode.  latency: 0.00764 s, throughput:    130.84 token/s
Decode.  latency: 0.00748 s, throughput:    133.73 token/s
Decode.  latency: 0.00725 s, throughput:    137.84 token/s
Decode.  latency: 0.00721 s, throughput:    138.74 token/s
Decode.  median latency: 0.00737 s, median throughput:    135.76 token/s
Total. latency:  0.094 s, throughput:   1408.61 token/s
Benchmark ...
Prefill. latency: 0.05239 s, throughput:   2443.43 token/s
Decode.  latency: 0.00739 s, throughput:    135.25 token/s
Decode.  latency: 0.00720 s, throughput:    138.90 token/s
Decode.  latency: 0.00718 s, throughput:    139.21 token/s
Decode.  latency: 0.00722 s, throughput:    138.42 token/s
Decode.  latency: 0.00745 s, throughput:    134.30 token/s
Decode.  median latency: 0.00731 s, median throughput:    136.82 token/s
Total. latency:  0.111 s, throughput:   1223.51 token/s

A100, no compile
python3 -m sglang.bench_latency --model Qwen/Qwen1.5-MoE-A2.7B --batch-size 1 --input 128 --output 8 --torchao-config fp8wo max_total_num_tokens=199454
Warmup ...
Prefill. latency: 0.06958 s, throughput:   1839.60 token/s
Decode.  latency: 0.02343 s, throughput:     42.68 token/s
Decode.  latency: 0.02342 s, throughput:     42.70 token/s
Decode.  latency: 0.02368 s, throughput:     42.23 token/s
Decode.  latency: 0.02337 s, throughput:     42.80 token/s
Decode.  median latency: 0.02342 s, median throughput:     42.69 token/s
Total. latency:  0.163 s, throughput:    807.48 token/s
Benchmark ...
Prefill. latency: 0.05767 s, throughput:   2219.36 token/s
Decode.  latency: 0.02293 s, throughput:     43.61 token/s
Decode.  latency: 0.02026 s, throughput:     49.36 token/s
Decode.  latency: 0.02029 s, throughput:     49.29 token/s
Decode.  latency: 0.02024 s, throughput:     49.41 token/s
Decode.  latency: 0.02026 s, throughput:     49.36 token/s
Decode.  median latency: 0.02025 s, median throughput:     49.39 token/s
Total. latency:  0.222 s, throughput:    611.87 token/s

Reviewers:

Subscribers:

Tasks:

Tags:
