### PR TITLE
Revert "[Minor] Raise exception for wrong import (#1409)"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,0 @@
-raise Exception(
-    "You imported 'sglang' from the git repo root directory 'sglang', which is incorrect. You should import it from 'sglang/python/sglang'. Please do not run your scripts adjacent to the git repo root directory."
-)


### PR DESCRIPTION
This reverts commit 9a903a878413dd6ef894ff481f28294e9293a9a4.

It prevents Python programs that use SGL to be adjacent to the SGL root dir.
But it also raises an exception for `python -m slang.launch_server` when run adjacent to SGL root dir, which previously looked into lib instead.

I'm not sure if we still want the exception or not, or if there is a better way.