### PR TITLE
Fix torch compile for deepseek-v2

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -41,7 +41,8 @@ if TYPE_CHECKING:
 def _to_torch(model: torch.nn.Module, reverse: bool = False):
     for sub in model._modules.values():
         if isinstance(sub, CustomOp):
-            if reverse:
+            # NOTE: FusedMoE torch native implementaiton is not efficient
+            if reverse or "FusedMoE" in sub.__class__.__name__:
                 sub._forward_method = sub.forward_cuda
                 setattr(sub, "is_torch_compile", False)
             else:

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -106,7 +106,15 @@ class CudaGraphRunner:
             self.capture_bs = list(range(1, 32)) + [64, 128]
         else:
             self.capture_bs = [1, 2, 4] + [i * 8 for i in range(1, 21)]
-        self.compile_bs = [1, 2, 4, 8, 16, 24, 32] if self.use_torch_compile else []
+        self.compile_bs = (
+            [
+                bs
+                for bs in self.capture_bs
+                if bs <= self.model_runner.server_args.max_torch_compile_bs
+            ]
+            if self.use_torch_compile
+            else []
+        )
 
         # Common inputs
         self.max_bs = max(self.capture_bs)

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -42,7 +42,9 @@ def _to_torch(model: torch.nn.Module, reverse: bool = False):
     for sub in model._modules.values():
         if isinstance(sub, CustomOp):
             # NOTE: FusedMoE torch native implementaiton is not efficient
-            if reverse or "FusedMoE" in sub.__class__.__name__:
+            if "FusedMoE" in sub.__class__.__name__:
+                continue
+            if reverse:
                 sub._forward_method = sub.forward_cuda
                 setattr(sub, "is_torch_compile", False)
             else:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -649,6 +649,7 @@ class DeepseekV2ForCausalLM(nn.Module):
         )
         self.logits_processor = LogitsProcessor(config)
 
+    @torch.no_grad()
     def forward(
         self,
         input_ids: torch.Tensor,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -520,7 +520,6 @@ class ServerArgs:
         parser.add_argument(
             "--max-torch-compile-bs",
             type=int,
-            choices=[1, 2, 4, 8, 16, 24, 32],
             default=ServerArgs.max_torch_compile_bs,
             help="Set the maximum batch size when using torch compile.",
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -108,6 +108,7 @@ class ServerArgs:
     disable_custom_all_reduce: bool = False
     enable_mixed_chunk: bool = False
     enable_torch_compile: bool = False
+    max_torch_compile_bs: int = 32
     torchao_config: str = ""
     enable_p2p_check: bool = False
     enable_mla: bool = False
@@ -515,6 +516,13 @@ class ServerArgs:
             "--enable-torch-compile",
             action="store_true",
             help="Optimize the model with torch.compile. Experimental feature.",
+        )
+        parser.add_argument(
+            "--max-torch-compile-bs",
+            type=int,
+            choices=[1, 2, 4, 8, 16, 24, 32],
+            default=ServerArgs.max_torch_compile_bs,
+            help="Set the maximum batch size when using torch compile.",
         )
         parser.add_argument(
             "--torchao-config",


### PR DESCRIPTION
## Motivation
Fix issue https://github.com/sgl-project/sglang/issues/1372.

## Bench Latency
### w/ torch compile
```
python3 -m sglang.bench_latency --model /workdir/llm_models/DeepSeek-V2-Lite/ --disable-radix --trust-remote-code --input-len 128 --output-len 8 --batch 1 --enable-mla --enable-torch-compile

Decode.  median latency: 0.00742 s, median throughput:    134.82 token/s
Total. latency:  0.095 s, throughput:   1428.89 token/s
```

### w/o torch compile
```
python3 -m sglang.bench_latency --model /workdir/llm_models/DeepSeek-V2-Lite/ --disable-radix --trust-remote-code --input-len 128 --output-len 8 --batch 1 --enable-mla

Decode.  median latency: 0.00938 s, median throughput:    106.64 token/s
Total. latency:  0.118 s, throughput:   1147.73 token/s
```