### PR TITLE
Fixed n>1 causing list index out of range with VLM

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -133,6 +133,9 @@ class GenerateReqInput:
                 self.image_data = [None] * num
             elif not isinstance(self.image_data, list):
                 self.image_data = [self.image_data] * num
+            elif isinstance(self.image_data, list):
+                # multi-image with n > 1
+                self.image_data = self.image_data * num
 
             if self.sampling_params is None:
                 self.sampling_params = [{}] * num

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -346,7 +346,7 @@ class TokenizerManager:
 
                 if self.is_generation:
                     pixel_values, image_hashes, image_sizes = (
-                        await self._get_pixel_values(obj.image_data[index])
+                        await self._get_pixel_values(obj.image_data)
                     )
                     modalities = obj.modalities
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -346,7 +346,7 @@ class TokenizerManager:
 
                 if self.is_generation:
                     pixel_values, image_hashes, image_sizes = (
-                        await self._get_pixel_values(obj.image_data)
+                        await self._get_pixel_values(obj.image_data[index])
                     )
                     modalities = obj.modalities
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When using VLM inference (e.g., the ones in `test/srt/test_vision_openai_server.py`), changing `n=1` to `n>1` will cause the following error:

```bash
(other error message omitted)
  File "/home/docker/.local/lib/python3.10/site-packages/sglang/srt/managers/tokenizer_manager.py", line 351, in _handle_batch_request
    await self._get_pixel_values(obj.image_data[index])
IndexError: list index out of range
```

## Modifications

<!-- Describe the changes made in this PR. -->
After printing out a few things, I find that this is because `obj.image_data` is not cloned into batches, unlike `obj.sampling_params`. So simply changing to `obj.image_data` worked.

---

Edit 1: the above will cause errors when facing batch requests. So instead of removing indexing, just clone the `obj.image_data` in a similar way as how other fields are cloned (e.g., `obj.sampling_params`)

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.