### PR TITLE
Pr fix max workers

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -123,7 +123,7 @@ class TokenizerManager:
                     initializer=init_global_processor,
                     mp_context=mp.get_context("fork"),
                     initargs=(server_args,),
-                    max_workers=server_args.image_processor_max_workers,
+                    max_workers=os.environ.get("SGLANG_CPU_COUNT", os.cpu_count()),
                 )
             else:
                 self.tokenizer = get_tokenizer(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -123,6 +123,7 @@ class TokenizerManager:
                     initializer=init_global_processor,
                     mp_context=mp.get_context("fork"),
                     initargs=(server_args,),
+                    max_workers=server_args.image_processor_max_workers
                 )
             else:
                 self.tokenizer = get_tokenizer(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -123,7 +123,7 @@ class TokenizerManager:
                     initializer=init_global_processor,
                     mp_context=mp.get_context("fork"),
                     initargs=(server_args,),
-                    max_workers=server_args.image_processor_max_workers
+                    max_workers=server_args.image_processor_max_workers,
                 )
             else:
                 self.tokenizer = get_tokenizer(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -110,6 +110,7 @@ class ServerArgs:
     max_loras_per_batch: int = 8
     # Multi-Modal
     image_processor_max_workers: int = 4
+
     def __post_init__(self):
         # Set missing default values
         if self.tokenizer_path is None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -108,8 +108,6 @@ class ServerArgs:
     # LoRA
     lora_paths: Optional[List[str]] = None
     max_loras_per_batch: int = 8
-    # Multi-Modal
-    image_processor_max_workers: int = 4
 
     def __post_init__(self):
         # Set missing default values

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -108,7 +108,8 @@ class ServerArgs:
     # LoRA
     lora_paths: Optional[List[str]] = None
     max_loras_per_batch: int = 8
-
+    # Multi-Modal
+    image_processor_max_workers: int = 4
     def __post_init__(self):
         # Set missing default values
         if self.tokenizer_path is None:


### PR DESCRIPTION
## Motivation
the default value for max_workers is the num of cpu on the physical server, this may cause problems when running on a docker with much less cpu cores than its physical server.

https://github.com/sgl-project/sglang/issues/1424

## Modifications
add param image_processor_max_workers to ServerArgs as the max_workers for ProcessPoolExecutor
## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.