### PR TITLE
fix: creat new dict everytime for putting new frame

### DIFF
--- a/examples/runtime/llava_onevision/http_llava_onevision_test.py
+++ b/examples/runtime/llava_onevision/http_llava_onevision_test.py
@@ -217,17 +217,14 @@ def prepare_video_messages(video_path):
         base64_frames.append(base64_str)
 
     messages = [{"role": "user", "content": []}]
-    frame_format = {
-        "type": "image_url",
-        "image_url": {"url": "data:image/jpeg;base64,{}"},
-        "modalities": "video",
-    }
 
     for base64_frame in base64_frames:
-        frame_format["image_url"]["url"] = "data:image/jpeg;base64,{}".format(
-            base64_frame
-        )
-        messages[0]["content"].append(frame_format.copy())
+        frame_format = {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/jpeg;base64,{base64_frame}"},
+            "modalities": "video",
+        }
+        messages[0]["content"].append(frame_format)
 
     prompt = {"type": "text", "text": "Please describe the video in detail."}
     messages[0]["content"].append(prompt)


### PR DESCRIPTION
This change fixes a severe bug where all video frames were being encoded
as the last frame due to dictionary reuse. It will put last frame 32 times into the messages due to the python's object reference logic.

By creating the frame_format dictionary inside the loop, we ensure each frame is uniquely encoded.