### PR TITLE
Add support for tie_word_embeddings when loading weights + support for SmolLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3-8B-Instruct 
 - BaiChuan2
 - MiniCPM / MiniCPM 3
 - XVERSE / XVERSE MoE
+- SmolLM
 
 
 **Embedding Models**

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -403,12 +403,14 @@ class LlamaForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 
-        if hasattr(self.config, "tie_word_embeddings") and self.config.tie_word_embeddings:
+        if (
+            hasattr(self.config, "tie_word_embeddings")
+            and self.config.tie_word_embeddings
+        ):
             # Tie output embedding layer to input embedding layer, to solve issues where lm_head.weight is missing
             param = self.lm_head.weight
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, self.model.embed_tokens.weight)
-
         apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -402,7 +402,13 @@ class LlamaForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
-
+        
+        if hasattr(self.config, "tie_word_embeddings") and self.config.tie_word_embeddings:
+            # Tie output embedding layer to input embedding layer, to solve issues where lm_head.weight is missing
+            param = self.lm_head.weight
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, self.model.embed_tokens.weight)
+        
         apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -402,13 +402,13 @@ class LlamaForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
-        
+
         if hasattr(self.config, "tie_word_embeddings") and self.config.tie_word_embeddings:
             # Tie output embedding layer to input embedding layer, to solve issues where lm_head.weight is missing
             param = self.lm_head.weight
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, self.model.embed_tokens.weight)
-        
+
         apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -411,6 +411,7 @@ class LlamaForCausalLM(nn.Module):
             param = self.lm_head.weight
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, self.model.embed_tokens.weight)
+            
         apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -411,7 +411,6 @@ class LlamaForCausalLM(nn.Module):
             param = self.lm_head.weight
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, self.model.embed_tokens.weight)
-            
         apply_torchao_config_(self, params_dict, set(["proj.weight"]))
 
 

--- a/test/srt/models/test_generation_models.py
+++ b/test/srt/models/test_generation_models.py
@@ -51,6 +51,7 @@ CI_MODELS = [
 # All other models
 ALL_OTHER_MODELS = [
     ModelCase("Qwen/Qwen2-1.5B"),
+    ModelCase("HuggingFaceTB/SmolLM-135M-Instruct"),
 ]
 
 TORCH_DTYPES = [torch.float16]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When trying to add support for SmolLM, I noticed that its config dict has `"tie_word_embeddings": true` which isn't supported by SGLang, and as a result, `lm_head.weight` is not loaded. This problem likely exists for some other models too (not just SmolLM).

## Modifications

Within `LlamaForCausalLM`, at the end of the weight loading stage, I added the following code:

```python3
if hasattr(self.config, "tie_word_embeddings") and self.config.tie_word_embeddings:
    # Tie output embedding layer to input embedding layer, to solve issues where lm_head.weight is missing
    param = self.lm_head.weight
    weight_loader = getattr(param, "weight_loader", default_weight_loader)
    weight_loader(param, self.model.embed_tokens.weight)
```

This can probably be copy-pasted to other LM classes other than `LlamaForCausalLM`, but I'm less familiar with those, and will defer to maintainers to decide whether to do the copying.

The effect can be tested by running `python3 -m sglang.bench_latency --correct --model HuggingFaceTB/SmolLM-135M-Instruct`. This would output gibberish before the change, but output coherent answers after it.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.