### PR TITLE
[bugfix]Add modelscope package to avoid docker image without modelscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,17 @@ Launch [Qwen2-7B-Instruct](https://www.modelscope.cn/models/qwen/qwen2-7b-instru
 ```
 SGLANG_USE_MODELSCOPE=true python -m sglang.launch_server --model-path qwen/Qwen2-7B-Instruct --port 30000
 ```
+
+Or start it by docker.
+```bash
+docker run --gpus all \
+    -p 30000:30000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --env "SGLANG_USE_MODELSCOPE=true" \
+    --ipc=host \
+    lmsysorg/sglang:latest \
+    python3 -m sglang.launch_server --model-path Qwen/Qwen2.5-7B-Instruct --host 0.0.0.0 --port 30000
+```
   
 </details>
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Or start it by docker.
 ```bash
 docker run --gpus all \
     -p 30000:30000 \
-    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -v ~/.cache/modelscope:/root/.cache/modelscope \
     --env "SGLANG_USE_MODELSCOPE=true" \
     --ipc=host \
     lmsysorg/sglang:latest \

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ${HOME}/.cache/huggingface:/root/.cache/huggingface
       # If you use modelscope, you need mount this directory
-      # - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+      # - ${HOME}/.cache/modelscope:/root/.cache/modelscope
     restart: always
     network_mode: host
     # Or you can only publish port 30000

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -4,6 +4,8 @@ services:
     container_name: sglang
     volumes:
       - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+      # If you use modelscope, you need mount this directory
+      # - ${HOME}/.cache/huggingface:/root/.cache/huggingface
     restart: always
     network_mode: host
     # Or you can only publish port 30000
@@ -11,6 +13,8 @@ services:
     #   - 30000:30000
     environment:
       HF_TOKEN: <secret>
+      # if you use modelscope to download model, you need set this environment
+      # - SGLANG_USE_MODELSCOPE: true
     entrypoint: python3 -m sglang.launch_server
     command:
       --model-path meta-llama/Meta-Llama-3.1-8B-Instruct

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 srt = ["aiohttp", "decord", "fastapi", "hf_transfer", "huggingface_hub", "interegular",
        "packaging", "pillow", "psutil", "pydantic", "python-multipart",
        "torch", "torchao", "uvicorn", "uvloop", "zmq",
-       "vllm==0.5.5", "outlines>=0.0.44"]
+       "vllm==0.5.5", "outlines>=0.0.44", "modelscope"]
 openai = ["openai>=1.0", "tiktoken"]
 anthropic = ["anthropic>=0.20.0"]
 litellm = ["litellm>=1.0.0"]


### PR DESCRIPTION
## Motivation

When deploy sglang with docker or docker-compose and config env `SGLANG_USE_MODELSCOPE=true`, it will report No module modelscope found.

Here is the related compose file, you can reproduce it.
```
services:
  sglang:
    image: lmsysorg/sglang:latest
    container_name: sglang
    volumes:
      - ~/.cache/modelscope:/root/.cache/modelscope
      - ~/.cache/huggingface:/root/.cache/huggingface
    restart: always
    network_mode: host
    # Or you can only publish port 30000
    # ports:
    #   - 30000:30000
    environment:
      - 'SGLANG_USE_MODELSCOPE=true'
    entrypoint: python3 -m sglang.launch_server
    command:
      --model-path qwen/Qwen2.5-72B-Instruct-GPTQ-Int8
      --tp 4
      --mem-fraction-static 0.7
      --chunked-prefill-size 2048
      --host 0.0.0.0
      --port 30000
    ulimits:
      memlock: -1
      stack: 67108864
    ipc: host
    healthcheck:
      test: ["CMD-SHELL", "curl -f http://localhost:30000/health || exit 1"]
    logging:
      driver: "json-file"
      options:
        max-size: "10m"
        max-file: "3"
    deploy:
      resources:
        reservations:
          devices:
            - driver: nvidia
              capabilities: [gpu]
```

## Modifications

Add modelscope to the default sgl pyproject.tom config.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.