### PR TITLE
[FIX] Catch syntax error of Regex Guide to avoid crash

### DIFF
--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -12,8 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from interegular import parse_pattern, InvalidSyntax
 
 """Cache for the compressed finite state machine."""
+import logging
 
 from outlines.fsm.json_schema import build_regex_from_schema
 from transformers import AutoTokenizer
@@ -21,6 +23,7 @@ from transformers import AutoTokenizer
 from sglang.srt.constrained import RegexGuide, TransformerTokenizer
 from sglang.srt.constrained.base_tool_cache import BaseToolCache
 
+logger = logging.getLogger(__name__)
 
 class FSMCache(BaseToolCache):
     def __init__(
@@ -76,5 +79,9 @@ class FSMCache(BaseToolCache):
             regex = key_string
         else:
             raise ValueError(f"Invalid key_type: {key_type}")
-
+        try:
+            parse_pattern(regex)
+        except InvalidSyntax as e:
+            logger.warning(f"skip invalid regex guide: {regex}, error: {e}")
+            return None, regex
         return RegexGuide(regex, self.outlines_tokenizer), regex

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -13,11 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from interegular import InvalidSyntax, parse_pattern
-
 """Cache for the compressed finite state machine."""
 import logging
 
+from interegular import InvalidSyntax, parse_pattern
 from outlines.fsm.json_schema import build_regex_from_schema
 from transformers import AutoTokenizer
 

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -84,6 +84,6 @@ class FSMCache(BaseToolCache):
         try:
             parse_pattern(regex)
         except InvalidSyntax as e:
-            logger.warning(f"skip invalid regex guide: {regex}, error: {e}")
+            logger.warning(f"skip invalid regex guide: {regex}")
             return None, regex
         return RegexGuide(regex, self.outlines_tokenizer), regex

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -12,7 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from interegular import parse_pattern, InvalidSyntax
+
+from interegular import InvalidSyntax, parse_pattern
 
 """Cache for the compressed finite state machine."""
 import logging
@@ -24,6 +25,7 @@ from sglang.srt.constrained import RegexGuide, TransformerTokenizer
 from sglang.srt.constrained.base_tool_cache import BaseToolCache
 
 logger = logging.getLogger(__name__)
+
 
 class FSMCache(BaseToolCache):
     def __init__(

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -83,6 +83,6 @@ class FSMCache(BaseToolCache):
         try:
             parse_pattern(regex)
         except InvalidSyntax as e:
-            logger.warning(f"skip invalid regex guide: {regex}")
+            logger.warning(f"skip invalid regex guide: {regex=}, {e=}")
             return None, regex
         return RegexGuide(regex, self.outlines_tokenizer), regex

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -56,6 +56,7 @@ class JumpForwardMap:
             except InvalidSyntax as e:
                 logger.warning(f"skip invalid regex: {regex_string}, error: {e}")
                 self.state_to_jump_forward = None
+                return
 
             byte_fsm = make_byte_level_fsm(
                 regex_pattern.to_fsm().reduce(), keep_utf8=True

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -20,9 +20,12 @@ Reference: https://lmsys.org/blog/2024-02-05-compressed-fsm/
 
 import dataclasses
 from collections import defaultdict
+from interegular import InvalidSyntax
 
 import interegular
 import outlines.caching
+
+import logging
 
 from sglang.srt.constrained import (
     FSMInfo,
@@ -34,6 +37,7 @@ from sglang.srt.constrained.base_tool_cache import BaseToolCache
 
 IP_REGEX = r"((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)"
 
+logger = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class JumpEdge:
@@ -47,7 +51,11 @@ class JumpForwardMap:
     def __init__(self, regex_string):
         @disk_cache()
         def _init_state_to_jump_forward(regex_string):
-            regex_pattern = interegular.parse_pattern(regex_string)
+            try:
+                regex_pattern = interegular.parse_pattern(regex_string)
+            except InvalidSyntax as e:
+                logger.warning(f"skip invalid regex: {regex_string}, error: {e}")
+                self.state_to_jump_forward = None
 
             byte_fsm = make_byte_level_fsm(
                 regex_pattern.to_fsm().reduce(), keep_utf8=True
@@ -165,7 +173,11 @@ class JumpForwardCache(BaseToolCache):
         super().__init__()
 
     def init_value(self, regex):
-        return JumpForwardMap(regex)
+        forward_map = JumpForwardMap(regex)
+        if forward_map.state_to_jump_forward:
+            return forward_map
+        else:
+            return None
 
 
 def test_main(regex_string):

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -54,7 +54,7 @@ class JumpForwardMap:
             try:
                 regex_pattern = interegular.parse_pattern(regex_string)
             except InvalidSyntax as e:
-                logger.warning(f"skip invalid regex: {regex_string}")
+                logger.warning(f"skip invalid regex: {regex_string}, {e=}")
                 self.state_to_jump_forward = None
                 return
 

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -19,13 +19,12 @@ Reference: https://lmsys.org/blog/2024-02-05-compressed-fsm/
 """
 
 import dataclasses
+import logging
 from collections import defaultdict
-from interegular import InvalidSyntax
 
 import interegular
 import outlines.caching
-
-import logging
+from interegular import InvalidSyntax
 
 from sglang.srt.constrained import (
     FSMInfo,
@@ -38,6 +37,7 @@ from sglang.srt.constrained.base_tool_cache import BaseToolCache
 IP_REGEX = r"((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)"
 
 logger = logging.getLogger(__name__)
+
 
 @dataclasses.dataclass
 class JumpEdge:

--- a/python/sglang/srt/constrained/jump_forward.py
+++ b/python/sglang/srt/constrained/jump_forward.py
@@ -54,7 +54,7 @@ class JumpForwardMap:
             try:
                 regex_pattern = interegular.parse_pattern(regex_string)
             except InvalidSyntax as e:
-                logger.warning(f"skip invalid regex: {regex_string}, error: {e}")
+                logger.warning(f"skip invalid regex: {regex_string}")
                 self.state_to_jump_forward = None
                 return
 


### PR DESCRIPTION
## Motivation

Invalid regex will lead to an immediate server exit now.
![image](https://github.com/user-attachments/assets/ba101efa-3bf4-4be2-979a-589e28161bcb)

(please ignore the first error catch)

## Modifications

Catch `InvalidSyntax` error of interegular, and set the regex guide and jump forward to `None`.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.