### PR TITLE
Add float8 dynamic quant to torchao_utils

### DIFF
--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -21,8 +21,10 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
         int4_weight_only,
         int8_dynamic_activation_int8_weight,
         int8_weight_only,
+        float8_dynamic_activation_float8_weight,
         quantize_,
     )
+    from torchao.quantization.observer import PerTensor, PerRow
 
     dummy_linear = torch.nn.Linear(param.shape[1], param.shape[0], bias=False)
     dummy_linear.weight = param
@@ -45,6 +47,15 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
         # this requires newer hardware
         # [rank0]: AssertionError: fp8e4nv data type is not supported on CUDA arch < 89
         quantize_(dummy_linear, float8_weight_only())
+    elif "fp8dq" in torchao_config:
+        granularity = torchao_config.split("-")[-1]
+        GRANULARITY_MAP = {
+            "per_row": PerRow(),
+            "per_tensor": PerTensor(),
+        }
+        assert granularity in GRANULARITY_MAP, f"Supported granularity are: {GRANULARITY_MAP.keys()}, got {granularity}"
+        quantize_(dummy_linear, float8_dynamic_activation_float8_weight(granularity=GRANULARITY_MAP[granularity]))
+
     return dummy_linear.weight
 
 

--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -18,13 +18,13 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
     """
     # Lazy import to suppress some warnings
     from torchao.quantization import (
+        float8_dynamic_activation_float8_weight,
         int4_weight_only,
         int8_dynamic_activation_int8_weight,
         int8_weight_only,
-        float8_dynamic_activation_float8_weight,
         quantize_,
     )
-    from torchao.quantization.observer import PerTensor, PerRow
+    from torchao.quantization.observer import PerRow, PerTensor
 
     dummy_linear = torch.nn.Linear(param.shape[1], param.shape[0], bias=False)
     dummy_linear.weight = param
@@ -53,8 +53,15 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
             "per_row": PerRow(),
             "per_tensor": PerTensor(),
         }
-        assert granularity in GRANULARITY_MAP, f"Supported granularity are: {GRANULARITY_MAP.keys()}, got {granularity}"
-        quantize_(dummy_linear, float8_dynamic_activation_float8_weight(granularity=GRANULARITY_MAP[granularity]))
+        assert (
+            granularity in GRANULARITY_MAP
+        ), f"Supported granularity are: {GRANULARITY_MAP.keys()}, got {granularity}"
+        quantize_(
+            dummy_linear,
+            float8_dynamic_activation_float8_weight(
+                granularity=GRANULARITY_MAP[granularity]
+            ),
+        )
 
     return dummy_linear.weight
 


### PR DESCRIPTION
Summary:
Adding float8 dynamic quant with per row and per tensor granularity for benchmarking

Note: this needs torch.compile to show speedup, and torchao needs torch 2.5+ to work with torch.compile, we are waiting for sglang to remove dep on vllm 0.5.5 (which depends on torch 2.4), and allow for dep on torch 2.5

torch 2.5 is going to be released some time in Oct.

Test Plan:
```
baseline bs = 1
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8

[13:25:21 TP0] Capture cuda graph begin. This can take up to several minutes.
max_total_num_tokens=557684
Warmup ...
Prefill. latency: 0.03888 s, throughput:   3292.05 token/s
Decode.  latency: 0.00980 s, throughput:    102.03 token/s
Decode.  latency: 0.00906 s, throughput:    110.36 token/s
Decode.  latency: 0.00908 s, throughput:    110.08 token/s
Decode.  median latency: 0.00908 s, median throughput:    110.08 token/s
Total. latency:  0.067 s, throughput:   1975.22 token/s
Benchmark ...
Prefill. latency: 0.01192 s, throughput:  10741.29 token/s
Decode.  latency: 0.00913 s, throughput:    109.49 token/s
Decode.  latency: 0.00903 s, throughput:    110.70 token/s
Decode.  latency: 0.00905 s, throughput:    110.50 token/s
Decode.  latency: 0.00896 s, throughput:    111.60 token/s
Decode.  latency: 0.00900 s, throughput:    111.17 token/s
Decode.  median latency: 0.00903 s, median throughput:    110.70 token/s
Total. latency:  0.075 s, throughput:   1810.36 token/s

baseline bs = 32
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 32 --input 128 --output 8
[13:24:37 TP0] Capture cuda graph begin. This can take up to several minutes.
max_total_num_tokens=557684
Warmup ...
Prefill. latency: 0.13418 s, throughput:  30525.17 token/s
Decode.  latency: 0.01107 s, throughput:   2891.81 token/s
Decode.  latency: 0.01017 s, throughput:   3145.56 token/s
Decode.  latency: 0.01014 s, throughput:   3156.36 token/s
Decode.  median latency: 0.01017 s, median throughput:   3145.56 token/s
Total. latency:  0.166 s, throughput:  25513.19 token/s
Benchmark ...
Prefill. latency: 0.10745 s, throughput:  38120.98 token/s
Decode.  latency: 0.01084 s, throughput:   2952.70 token/s
Decode.  latency: 0.01032 s, throughput:   3101.36 token/s
Decode.  latency: 0.01005 s, throughput:   3183.68 token/s
Decode.  latency: 0.00998 s, throughput:   3205.43 token/s
Decode.  latency: 0.00997 s, throughput:   3209.57 token/s
Decode.  median latency: 0.00998 s, median throughput:   3205.43 token/s
Total. latency:  0.178 s, throughput:  24383.34 token/s

fp8-per_row bs = 1

python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --torchao-config fp8wo-per_row

[13:22:04 TP0] Capture cuda graph begin. This can take up to several minutes.
max_total_num_tokens=607588
Warmup ...
Prefill. latency: 0.08340 s, throughput:   1534.79 token/s
Decode.  latency: 0.05161 s, throughput:     19.38 token/s
Decode.  latency: 0.05054 s, throughput:     19.79 token/s
Decode.  latency: 0.05053 s, throughput:     19.79 token/s
Decode.  median latency: 0.05054 s, median throughput:     19.79 token/s
Total. latency:  0.236 s, throughput:    559.15 token/s
Benchmark ...
Prefill. latency: 0.05395 s, throughput:   2372.57 token/s
Decode.  latency: 0.05052 s, throughput:     19.79 token/s
Decode.  latency: 0.05067 s, throughput:     19.73 token/s
Decode.  latency: 0.05048 s, throughput:     19.81 token/s
Decode.  latency: 0.05056 s, throughput:     19.78 token/s
Decode.  latency: 0.05055 s, throughput:     19.78 token/s
Decode.  median latency: 0.05052 s, median throughput:     19.79 token/s
Total. latency:  0.408 s, throughput:    333.56 token/s

python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 32 --input 128 --output 8 --torchao-config fp8wo-per_row

fp8-per_row bs = 32
max_total_num_tokens=607588
Warmup ...
Prefill. latency: 0.17669 s, throughput:  23181.77 token/s
Decode.  latency: 0.05362 s, throughput:    596.75 token/s
Decode.  latency: 0.05158 s, throughput:    620.42 token/s
Decode.  latency: 0.05139 s, throughput:    622.68 token/s
Decode.  median latency: 0.05158 s, median throughput:    620.42 token/s
Total. latency:  0.333 s, throughput:  12673.92 token/s
Benchmark ...
Prefill. latency: 0.14910 s, throughput:  27470.87 token/s
Decode.  latency: 0.05265 s, throughput:    607.77 token/s
Decode.  latency: 0.05161 s, throughput:    619.98 token/s
Decode.  latency: 0.05149 s, throughput:    621.44 token/s
Decode.  latency: 0.05144 s, throughput:    622.13 token/s
Decode.  latency: 0.05130 s, throughput:    623.72 token/s
Decode.  median latency: 0.05144 s, median throughput:    622.13 token/s
Total. latency:  0.510 s, throughput:   8531.40 token/s
```

Reviewers:

Subscribers:

Tasks: