### PR TITLE
fix ipv6 url when warm up model

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -21,7 +21,7 @@ import logging
 import random
 from typing import List, Optional, Union
 
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import is_hip, is_ipv6
 
 logger = logging.getLogger(__name__)
 
@@ -570,7 +570,10 @@ class ServerArgs:
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
     def url(self):
-        return f"http://{self.host}:{self.port}"
+        if is_ipv6(self.host):
+            return f"http://[{self.host}]:{self.port}"
+        else:
+            return f"http://{self.host}:{self.port}"
 
     def check_server_args(self):
         assert (

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -16,6 +16,7 @@ limitations under the License.
 """Common utilities."""
 
 import base64
+import ipaddress
 import logging
 import os
 import pickle
@@ -52,6 +53,14 @@ time_infos = {}
 # torch flag AMD GPU
 def is_hip() -> bool:
     return torch.version.hip is not None
+
+
+def is_ipv6(address):
+    try:
+        ipaddress.IPv6Address(address)
+        return True
+    except ipaddress.AddressValueError:
+        return False
 
 
 def enable_show_time_cost():


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

BUG i encountered:

  File "/home/tiger/.local/lib/python3.11/site-packages/requests/models.py", line 435, in prepare_url
    raise InvalidURL(*e.args)
requests.exceptions.InvalidURL: Failed to parse: http://fdbd:dc05:8:8::24:10052/get_model_info

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ x ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ x ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ x ] Update documentation as needed, including docstrings or example tutorials.