### PR TITLE
[Fix] Move ScheduleBatch out of SamplingInfo

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -797,7 +797,7 @@ class ScheduleBatch:
 
         lora_paths = [req.lora_path for req in self.reqs]
         if self.has_regex:
-            self.sampling_info.regex_fsm = [req.regex_fsm for req in self.reqs]
+            self.sampling_info.regex_fsms = [req.regex_fsm for req in self.reqs]
             self.sampling_info.regex_fsm_states = [
                 req.regex_fsm_state for req in self.reqs
             ]

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -109,7 +109,7 @@ class SamplingBatchInfo:
                     self.linear_penalties = penalizer.apply(self.linear_penalties)
 
     def update_regex_vocab_mask(self):
-        has_regex = any(regex_fsm for regex_fsm in self.regex_fsms)
+        has_regex = self.regex_fsms and any(regex_fsm for regex_fsm in self.regex_fsms)
 
         # Reset the vocab mask
         self.vocab_mask = None


### PR DESCRIPTION
We can get regex info during `get_model_worker_batch`, so we do not need to keep a reference of `ScheduleBatch` in `SamplingInfo`