### PR TITLE
[FP8 KV Cache] Avoid KeyError at loading pre-quantized FP8 model with kv_scale

### DIFF
--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -400,6 +400,9 @@ class LlamaForCausalLM(nn.Module):
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue
+                # Skip loading kv_scale from ckpts towards new design.
+                if name.endswith(".kv_scale") and name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Reuse some FP8 quantized models, just skip/ignore `kv_scale` for now.
E.g. `amd/Meta-Llama-3.1-405B-Instruct-FP8-KV` has `kv_scale` embedded, enable following command to ignore them for now.
`python -m sglang.bench_latency --model amd/Meta-Llama-3.1-405B-Instruct-FP8-KV --tp 8 --batch-size 32 --input 1024 --output 256 --quant fp8`

## Modifications

Skip loading named parameter ends with `.kv_scale`. 
None scaled kv cache still works with `--kv-cache-dtype fp8_e5m2`.
Later, we will revisit this as part of e4m3, etc. format kv scaling design. 

## Checklist

- [+] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [+] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [+] Update documentation as needed, including docstrings or example tutorials.