### PR TITLE
[Easy] use .text() instead of .text

### DIFF
--- a/python/sglang/test/test_programs.py
+++ b/python/sglang/test/test_programs.py
@@ -72,7 +72,7 @@ def test_select(check_answer):
         statement="The capital of Germany is Berlin.",
     )
     if check_answer:
-        assert ret["answer"] == "True", ret.text
+        assert ret["answer"] == "True", ret.text()
     else:
         assert ret["answer"] in ["True", "False", "Unknown"]
 
@@ -80,7 +80,7 @@ def test_select(check_answer):
         statement="The capital of Canada is Tokyo.",
     )
     if check_answer:
-        assert ret["answer"] == "False", ret.text
+        assert ret["answer"] == "False", ret.text()
     else:
         assert ret["answer"] in ["True", "False", "Unknown"]
 
@@ -88,7 +88,7 @@ def test_select(check_answer):
         statement="Purple is a better color than green.",
     )
     if check_answer:
-        assert ret["answer"] == "Unknown", ret.text
+        assert ret["answer"] == "Unknown", ret.text()
     else:
         assert ret["answer"] in ["True", "False", "Unknown"]
 
@@ -100,8 +100,8 @@ def test_decode_int():
         s += "The number of days in a year is " + sgl.gen_int("days") + "\n"
 
     ret = decode_int.run(temperature=0.1)
-    assert int(ret["hours"]) == 24, ret.text
-    assert int(ret["days"]) == 365, ret.text
+    assert int(ret["hours"]) == 24, ret.text()
+    assert int(ret["days"]) == 365, ret.text()
 
 
 def test_decode_json_regex():


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`.text` returns a method object. We should use `.text()` to retrieve the string

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.