### PR TITLE
[Bug] Fix the Image Input of Batch Generation

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -119,8 +119,7 @@ class GenerateReqInput:
             elif not isinstance(self.image_data, list):
                 self.image_data = [self.image_data] * num
             elif isinstance(self.image_data, list):
-                # FIXME incorrect order for duplication
-                self.image_data = self.image_data * num
+                pass
 
             if self.sampling_params is None:
                 self.sampling_params = [{}] * num

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -924,7 +924,7 @@ def v1_chat_generate_request(
         else:
             prompt_kwargs = {"input_ids": input_ids}
         sampling_params_list = sampling_params_list[0]
-        image_data = image_data_list[0]
+        image_data_list = image_data_list[0]
         return_logprobs = return_logprobs[0]
         logprob_start_lens = logprob_start_lens[0]
         top_logprobs_nums = top_logprobs_nums[0]
@@ -937,7 +937,7 @@ def v1_chat_generate_request(
 
     adapted_request = GenerateReqInput(
         **prompt_kwargs,
-        image_data=image_data,
+        image_data=image_data_list,
         sampling_params=sampling_params_list,
         return_logprob=return_logprobs,
         logprob_start_len=logprob_start_lens,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When using the OpenAI API for batch generation, all prompts receive the same image, specifically **the last image in the batch**. Upon investigation, I discovered a bug in `openai_api/adapter.py`:

- Issue in `v1_chat_generate_request` (line 824): The `image_data_list` gathers all images for the batch. However, on line 938, the variable `adapted_request = GenerateReqInput(...)` incorrectly uses `image_data` (a temporary variable inside the loop) as an argument, which leads to all prompts receiving **the last image in the batch.**

- Additionally, in `srt/managers/io_struct.py`, line 136, the `self.image_data` will duplicate `num` times, preventing any warning or indexing error but causing incorrect behavior.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

- Replaced image_data with `image_data_list` in `v1_chat_generate_request` to ensure each prompt receives the correct image from the batch.
- Removed the duplication of images.
- Tested the fix with [examples/runtime/openai_batch_chat.py](https://github.com/sgl-project/sglang/blob/main/examples/runtime/openai_batch_chat.py) and it now works as expected.


<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.