### PR TITLE
Fix chunked prefill condition

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -249,7 +249,10 @@ class PrefillAdder:
                 return AddReqResult.NO_TOKEN
             tokens_freed += tokens_occupied
 
-        if req.extend_input_len <= self.rem_chunk_tokens:
+        if (
+            self.rem_chunk_tokens is None
+            or req.extend_input_len <= self.rem_chunk_tokens
+        ):
             self.can_run_list.append(req)
             self._prefill_one_req(
                 0,

--- a/test/srt/test_chunked_prefill.py
+++ b/test/srt/test_chunked_prefill.py
@@ -8,6 +8,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     popen_launch_server,
+    run_bench_serving,
 )
 
 
@@ -61,6 +62,16 @@ class TestChunkedPrefill(unittest.TestCase):
         self.run_mmlu(
             disable_radix_cache=False, enable_mixed_chunk=False, chunked_prefill_size=-1
         )
+
+    def test_no_chunked_prefill_without_radix_cache(self):
+        res = run_bench_serving(
+            model=DEFAULT_MODEL_NAME_FOR_TEST,
+            num_prompts=10,
+            request_rate=float("inf"),
+            other_server_args=["--disable-radix-cache", "--chunked-prefill-size", "-1"],
+        )
+
+        assert res["completed"] == 10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

`bench_serving` will fail when disabling chunked prefill (`--chunked-prefill-size -1`). 
```
if req.extend_input_len <= self.rem_chunk_tokens:
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```
Reproduce:
```
python3 -m sglang.launch_server  --model meta-llama/Meta-Llama-3.1-8B-Instruct --port 30000 --trust-remote-code --disable-radix --chunked-prefill-size -1

python3 -m sglang.bench_serving --backend sglang --num-prompts 1000
```
## Modification
Fix chunked prefill condition.