### PR TITLE
[Engine] Fix generate hanging issue after the first call

### DIFF
--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -691,8 +691,9 @@ class Engine:
             lora_path=lora_path,
         )
 
-        # make it synchronous
-        return asyncio.run(generate_request(obj, None))
+        # get the current event loop
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(generate_request(obj, None))
 
     def shutdown(self):
         kill_child_process(os.getpid(), including_parent=False)

--- a/test/srt/test_srt_engine.py
+++ b/test/srt/test_srt_engine.py
@@ -28,6 +28,18 @@ class TestSRTBackend(unittest.TestCase):
         print(out2)
         assert out1 == out2, f"{out1} != {out2}"
 
+    def test_engine_multiple_generate(self):
+        # just to ensure there is no issue running multiple generate calls
+        prompt = "Today is a sunny day and I like"
+        model_path = DEFAULT_MODEL_NAME_FOR_TEST
+
+        sampling_params = {"temperature": 0, "max_new_tokens": 8}
+
+        engine = sgl.Engine(model_path=model_path, random_seed=42)
+        engine.generate(prompt, sampling_params)
+        engine.generate(prompt, sampling_params)
+        engine.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, `engine.generate` after the first call hangs forever.

```python
engine = sgl.Engine(model_path=model_path, random_seed=42)
engine.generate(prompt, sampling_params)
engine.generate(prompt, sampling_params) # HANGS!!!
engine.shutdown()
```

The root cause is tricky:

1. At the first call, `asyncio.run` creates a new loop (`loop1`)
2. In tokenizer.manager (https://github.com/sgl-project/sglang/blob/c5325aba75b29cd6c893ba6bb67b31870f03692d/python/sglang/srt/managers/tokenizer_manager.py#L560), it uses the existing event loop to run the `while loop`, which keeps receiving messages  
3. At the end of the first call, `asyncio.run` closes `loop1` by nature
4. At the second call, `asyncio.run` creates another new loop (say `loop2`)
5. In tokenizer.manager, the while loop is still handled by `loop1` which is already cleaned up. Thus, it hangs forever.

In general, `asyncio.get_event_loop()` + `loop.run_until_complete()` is better than `asyncio.run` because get_event_loop creates a new loop if not exist, and use the existing loop if exist

## Modifications

<!-- Describe the changes made in this PR. -->
1. Change to `get_event_loop`
2. Add a test

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.