### PR TITLE
Nit about the decorator of `PortArgs.init_new`

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -621,8 +621,8 @@ class PortArgs:
     # The port for nccl initialization for multiple TP groups (torch.dist)
     nccl_ports: List[int]
 
-    @classmethod
-    def init_new(self, server_args):
+    @staticmethod
+    def init_new(server_args) -> "PortArgs":
         port = server_args.port + 1
         while True:
             if is_port_available(port):


### PR DESCRIPTION
Trivial issues:
1) From both the definition and the usage of `PortArgs.init_new()`, it may be better to be decorated with `staticmethod` rather than `classmethod`.
2) Even for a `classmethod`, the convention is typically using `cls` instead of `self`.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.