### PR TITLE
fix missing ignore_eos in v1/chat/completions

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -910,6 +910,7 @@ def v1_chat_generate_request(
             "repetition_penalty": request.repetition_penalty,
             "regex": request.regex,
             "n": request.n,
+            "ignore_eos": request.ignore_eos,
         }
         if request.response_format and request.response_format.type == "json_schema":
             sampling_params["json_schema"] = convert_json_schema_to_str(


### PR DESCRIPTION
Fix the missing ignore_eos parameter in the /v1/chat/completions API.

In some certain performance benchmark scenarios, we need the model to generate a fixed number of tokens. To prevent the process from ending prematurely due to encountering the eos/stop token, the ignore_eos=True parameter needs to be passed.