### PR TITLE
Fix the batch_is_full check for jump-forward decoding

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -633,6 +633,8 @@ class Scheduler:
         if not self.disable_regex_jump_forward:
             jump_forward_reqs = batch.check_for_jump_forward(self.pad_input_ids_func)
             self.waiting_queue.extend(jump_forward_reqs)
+            if jump_forward_reqs:
+                self.batch_is_full = False
             if batch.is_empty():
                 return None
 


### PR DESCRIPTION
We need to set `self.batch_is_full = False` if there are jump-forward decoding requests. Otherwise, it does not accept new requests.