### PR TITLE
Move filter_batch out of stream_output

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -659,7 +659,7 @@ class ScheduleBatch:
 
     def check_for_jump_forward(self, pad_input_ids_func):
         jump_forward_reqs = []
-        filter_indices = [i for i in range(len(self.reqs))]
+        keep_indices = set(i for i in range(len(self.reqs)))
 
         for i, req in enumerate(self.reqs):
             if req.jump_forward_map is not None:
@@ -719,9 +719,9 @@ class ScheduleBatch:
                         )
 
                     jump_forward_reqs.append(req)
-                    filter_indices.remove(i)
+                    keep_indices.remove(i)
 
-        self.filter_batch(filter_indices)
+        self.filter_batch(keep_indices=list(keep_indices))
 
         return jump_forward_reqs
 
@@ -740,27 +740,33 @@ class ScheduleBatch:
             self.req_pool_indices, self.seq_lens - 1
         ] = self.out_cache_loc
 
-    def filter_batch(self, current_inflight_req: Req):
-        unfinished_indices = [
-            i
-            for i in range(len(self.reqs))
-            if not self.reqs[i].finished() and self.reqs[i] is not current_inflight_req
-        ]
+    def filter_batch(
+        self,
+        current_inflight_req: Optional[Req] = None,
+        keep_indices: Optional[List[int]] = None,
+    ):
+        if keep_indices is None:
+            keep_indices = [
+                i
+                for i in range(len(self.reqs))
+                if not self.reqs[i].finished()
+                and self.reqs[i] is not current_inflight_req
+            ]
 
-        has_filtered = len(unfinished_indices) == len(self.reqs)
+        has_filtered = len(keep_indices) == len(self.reqs)
 
-        if unfinished_indices is None or len(unfinished_indices) == 0:
+        if keep_indices is None or len(keep_indices) == 0:
             # Filter out all requests
             self.reqs = []
             return has_filtered
 
-        if len(unfinished_indices) == len(self.reqs):
+        if len(keep_indices) == len(self.reqs):
             # No need to filter
             return has_filtered
 
-        self.reqs = [self.reqs[i] for i in unfinished_indices]
+        self.reqs = [self.reqs[i] for i in keep_indices]
         new_indices = torch.tensor(
-            unfinished_indices, dtype=torch.int32, device=self.seq_lens.device
+            keep_indices, dtype=torch.int32, device=self.seq_lens.device
         )
         self.req_pool_indices = self.req_pool_indices[new_indices]
         self.seq_lens = self.seq_lens[new_indices]
@@ -768,16 +774,14 @@ class ScheduleBatch:
         self.output_ids = self.output_ids[new_indices]
         self.return_logprob = any(req.return_logprob for req in self.reqs)
         if self.return_logprob:
-            self.top_logprobs_nums = [
-                self.top_logprobs_nums[i] for i in unfinished_indices
-            ]
+            self.top_logprobs_nums = [self.top_logprobs_nums[i] for i in keep_indices]
         else:
             self.top_logprobs_nums = None
 
         self.has_stream = any(req.stream for req in self.reqs)
         self.has_regex = any(req.regex_fsm for req in self.reqs)
 
-        self.sampling_info.filter_batch(unfinished_indices, new_indices)
+        self.sampling_info.filter_batch(keep_indices, new_indices)
 
         return has_filtered
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -747,14 +747,16 @@ class ScheduleBatch:
             if not self.reqs[i].finished() and self.reqs[i] is not current_inflight_req
         ]
 
+        has_filtered = len(unfinished_indices) == len(self.reqs)
+
         if unfinished_indices is None or len(unfinished_indices) == 0:
             # Filter out all requests
             self.reqs = []
-            return
+            return has_filtered
 
         if len(unfinished_indices) == len(self.reqs):
             # No need to filter
-            return
+            return has_filtered
 
         self.reqs = [self.reqs[i] for i in unfinished_indices]
         new_indices = torch.tensor(
@@ -776,6 +778,8 @@ class ScheduleBatch:
         self.has_regex = any(req.regex_fsm for req in self.reqs)
 
         self.sampling_info.filter_batch(unfinished_indices, new_indices)
+
+        return has_filtered
 
     def merge_batch(self, other: "ScheduleBatch"):
         # Penalizer orchestrator must be merged before Batch.reqs is merged. This is because

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -740,7 +740,13 @@ class ScheduleBatch:
             self.req_pool_indices, self.seq_lens - 1
         ] = self.out_cache_loc
 
-    def filter_batch(self, unfinished_indices: List[int]):
+    def filter_batch(self, current_inflight_req: Req):
+        unfinished_indices = [
+            i
+            for i in range(len(self.reqs))
+            if not self.reqs[i].finished() and self.reqs[i] is not current_inflight_req
+        ]
+
         if unfinished_indices is None or len(unfinished_indices) == 0:
             # Filter out all requests
             self.reqs = []

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -753,16 +753,14 @@ class ScheduleBatch:
                 and self.reqs[i] is not current_inflight_req
             ]
 
-        has_filtered = len(keep_indices) == len(self.reqs)
-
         if keep_indices is None or len(keep_indices) == 0:
             # Filter out all requests
             self.reqs = []
-            return has_filtered
+            return
 
         if len(keep_indices) == len(self.reqs):
             # No need to filter
-            return has_filtered
+            return
 
         self.reqs = [self.reqs[i] for i in keep_indices]
         new_indices = torch.tensor(
@@ -782,8 +780,6 @@ class ScheduleBatch:
         self.has_regex = any(req.regex_fsm for req in self.reqs)
 
         self.sampling_info.filter_batch(keep_indices, new_indices)
-
-        return has_filtered
 
     def merge_batch(self, other: "ScheduleBatch"):
         # Penalizer orchestrator must be merged before Batch.reqs is merged. This is because

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -622,7 +622,10 @@ class Scheduler:
         global test_retract
         batch = self.running_batch
 
-        batch.filter_batch(None)
+        has_filtered = batch.filter_batch(None)
+        if has_filtered:
+            self.batch_is_full = False
+
         if batch.is_empty():
             self.running_batch = None
             return

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -622,7 +622,7 @@ class Scheduler:
         global test_retract
         batch = self.running_batch
 
-        has_filtered = batch.filter_batch(None)
+        has_filtered = batch.filter_batch()
         if has_filtered:
             self.batch_is_full = False
 

--- a/test/srt/test_json_constrained.py
+++ b/test/srt/test_json_constrained.py
@@ -1,3 +1,7 @@
+"""
+python3 -m unittest test_json_constrained.TestJSONConstrained.test_json_generate
+"""
+
 import json
 import unittest
 from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
We want to consolidate the batch operations all into `get_next_batch_to_run`, so we move filter_batch from `stream_output`  to `get_next_batch_to_run`