### PR TITLE
Fix filter_batch function call

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -649,7 +649,7 @@ class ScheduleBatch:
             req.last_update_decode_tokens = 0
             req.logprob_start_len = 10**9
 
-        self.filter_batch(sorted_indices)
+        self.filter_batch(keep_indices=sorted_indices)
 
         # Reqs in batch are filtered
         total_decoded_tokens = sum(len(r.output_ids) for r in self.reqs)


### PR DESCRIPTION
The `filter_batch` function call in the code has been fixed to use the correct argument name `keep_indices` instead of `sorted_indices`. This ensures that the function is called correctly and the desired filtering behavior is achieved.