### PR TITLE
Fixes for running reward model inference using sglang

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -238,10 +238,13 @@ class TokenizedEmbeddingReqInput:
     sampling_params: SamplingParams
 
 
+RewardReqConv = Union[List[List[Dict]], List[Dict], str, List[str]]
+
+
 @dataclass
 class RewardReqInput:
-    # The input prompt in the chat format. It can be a single prompt or a batch of prompts.
-    conv: Union[List[List[Dict]], List[Dict]]
+    # The input prompt. It can be a single prompt or a batch of prompts. Can be either chat format or a string.
+    conv: RewardReqConv
     # The request id.
     rid: Optional[Union[List[str], str]] = None
     # Dummy sampling params for compatibility

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -559,17 +559,17 @@ class ModelRunner:
         )
 
     def forward_extend(self, forward_batch: ForwardBatch):
-        if self.is_embedding:
+        if not self.is_embedding:
+            return self.model.forward(
+                forward_batch.input_ids, forward_batch.positions, forward_batch
+            )
+        else:
             # Only embedding models have get_embedding parameter
             return self.model.forward(
                 forward_batch.input_ids,
                 forward_batch.positions,
                 forward_batch,
                 get_embedding=True,
-            )
-        else:
-            return self.model.forward(
-                forward_batch.input_ids, forward_batch.positions, forward_batch
             )
 
     def forward(self, forward_batch: ForwardBatch) -> LogitsProcessorOutput:

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -409,6 +409,7 @@ class LlamaForCausalLM(nn.Module):
         if (
             hasattr(self.config, "tie_word_embeddings")
             and self.config.tie_word_embeddings
+            and "lm_head.weight" in params_dict
         ):
             # Tie output embedding layer to input embedding layer, to solve issues where lm_head.weight is missing
             param = self.lm_head.weight

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -215,20 +215,29 @@ def is_multimodal_model(model_architectures):
         return False
 
 
+def is_embedding_model(model_architectures, is_embedding: bool = False):
+    if ("LlamaEmbeddingModel" in model_architectures) or is_embedding:
+        return True
+    else:
+        return False
+
+
 def is_generation_model(model_architectures, is_embedding: bool = False):
     # We have two ways to determine whether a model is a generative model.
-    # 1. Check the model architectue
-    # 2. check the `is_embedding` server args
+    # 1. Check if it is an embedding model
+    # 2. Check if it is a specific model architecture that is not a generative model
+
+    if is_embedding_model(model_architectures, is_embedding):
+        return False
 
     if (
-        "LlamaEmbeddingModel" in model_architectures
-        or "MistralModel" in model_architectures
+        "MistralModel" in model_architectures
         or "LlamaForSequenceClassification" in model_architectures
         or "LlamaForSequenceClassificationWithNormal_Weights" in model_architectures
     ):
         return False
     else:
-        return not is_embedding
+        return True
 
 
 def decode_video_base64(video_base64):
@@ -522,7 +531,6 @@ def maybe_set_triton_cache_manager() -> None:
 class CustomCacheManager(FileCacheManager):
     # Adapted from: https://github.com/tdoublep/vllm/blob/3307522289fdfefe323b6c00d0db696651989a2f/vllm/triton_utils/custom_cache_manager.py
     def __init__(self, key, override=False, dump=False):
-
         self.key = key
         self.lock_path = None
         if dump:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

I'm trying to run a reward model (specifically a `LlamaForSequenceClassification`) with sglang. I ran into several bugs while doing so that this PR addresses.

## Modifications

1. Previously when serving a reward model, sglang attempted to pass `get_embedding=True` to the model's `forward()` method. That keyword doesn't exist, which caused calls to the model to fail. This change distinguishes embedding models from other non-generation models, which fixes the bug. I do this by adding a new `is_embedding_model` function which works similarly to the `is_generation_model` function.
2. Previously it was required to pass conversational input to reward models, which would then be serialized using the `apply_chat_template` function. However, sometimes it is convenient to pass in pre-templated strings instead, for example when using a model that doesn't have a chat template applied. This change allows reward models to accept strings in addition to chat formatted inputs. It accomplishes this by defining a new `_apply_chat_template` method on `TokenizerManager`
3. Skip copying the `lm_head` weights for models that don't have them defined. This previously caused a crash on startup for my `LlamaForSequenceClassification` model.

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.