### PR TITLE
Add matched_stop token or str to distinguish between eos or stop str finish_reason generation

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -625,7 +625,9 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 "text": text,
                 "logprobs": logprobs,
                 "finish_reason": (finish_reason["type"] if finish_reason else ""),
-                "stop_reason": (finish_reason["matched"] if finish_reason else ""),
+                "stop_reason": (
+                    finish_reason["matched"] if "matched" in finish_reason else ""
+                ),
             }
         else:
             choice_data = CompletionResponseChoice(
@@ -633,7 +635,9 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 text=text,
                 logprobs=logprobs,
                 finish_reason=(finish_reason["type"] if finish_reason else ""),
-                stop_reason=(finish_reason["matched"] if finish_reason else ""),
+                stop_reason=(
+                    finish_reason["matched"] if "matched" in finish_reason else ""
+                ),
             )
 
         choices.append(choice_data)
@@ -768,7 +772,11 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
                         text=delta,
                         logprobs=logprobs,
                         finish_reason=(finish_reason["type"] if finish_reason else ""),
-                        stop_reason=(finish_reason["matched"] if finish_reason else ""),
+                        stop_reason=(
+                            finish_reason["matched"]
+                            if "matched" in finish_reason
+                            else ""
+                        ),
                     )
                     chunk = CompletionStreamResponse(
                         id=content["meta_info"]["id"],
@@ -1014,7 +1022,9 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 "message": {"role": "assistant", "content": ret_item["text"]},
                 "logprobs": choice_logprobs,
                 "finish_reason": (finish_reason["type"] if finish_reason else ""),
-                "stop_reason": (finish_reason["matched"] if finish_reason else ""),
+                "stop_reason": (
+                    finish_reason["matched"] if "matched" in finish_reason else ""
+                ),
             }
         else:
             choice_data = ChatCompletionResponseChoice(
@@ -1022,7 +1032,9 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 message=ChatMessage(role="assistant", content=ret_item["text"]),
                 logprobs=choice_logprobs,
                 finish_reason=(finish_reason["type"] if finish_reason else ""),
-                stop_reason=(finish_reason["matched"] if finish_reason else ""),
+                stop_reason=(
+                    finish_reason["matched"] if "matched" in finish_reason else ""
+                ),
             )
 
         choices.append(choice_data)
@@ -1152,7 +1164,9 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                                 finish_reason["type"] if finish_reason else ""
                             ),
                             stop_reason=(
-                                finish_reason["matched"] if finish_reason else ""
+                                finish_reason["matched"]
+                                if "matched" in finish_reason
+                                else ""
                             ),
                             logprobs=choice_logprobs,
                         )
@@ -1170,7 +1184,11 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                         index=index,
                         delta=DeltaMessage(content=delta),
                         finish_reason=(finish_reason["type"] if finish_reason else ""),
-                        stop_reason=(finish_reason["matched"] if finish_reason else ""),
+                        stop_reason=(
+                            finish_reason["matched"]
+                            if "matched" in finish_reason
+                            else ""
+                        ),
                         logprobs=choice_logprobs,
                     )
                     chunk = ChatCompletionStreamResponse(

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -624,32 +624,16 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 "index": 0,
                 "text": text,
                 "logprobs": logprobs,
-                "finish_reason": (
-                    finish_reason["type"]
-                    if finish_reason
-                    else ""
-                ),
-                "stop_reason": (
-                    finish_reason["matched"]
-                    if finish_reason
-                    else ""
-                ),
+                "finish_reason": (finish_reason["type"] if finish_reason else ""),
+                "stop_reason": (finish_reason["matched"] if finish_reason else ""),
             }
         else:
             choice_data = CompletionResponseChoice(
                 index=idx,
                 text=text,
                 logprobs=logprobs,
-                finish_reason=(
-                    finish_reason["type"]
-                    if finish_reason
-                    else ""
-                ),
-                stop_reason=(
-                    finish_reason["matched"]
-                    if finish_reason
-                    else ""
-                ),
+                finish_reason=(finish_reason["type"] if finish_reason else ""),
+                stop_reason=(finish_reason["matched"] if finish_reason else ""),
             )
 
         choices.append(choice_data)
@@ -783,16 +767,8 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
                         index=index,
                         text=delta,
                         logprobs=logprobs,
-                        finish_reason=(
-                            finish_reason["type"]
-                            if finish_reason
-                            else ""
-                        ),
-                        stop_reason=(
-                            finish_reason["matched"]
-                            if finish_reason
-                            else ""
-                        )
+                        finish_reason=(finish_reason["type"] if finish_reason else ""),
+                        stop_reason=(finish_reason["matched"] if finish_reason else ""),
                     )
                     chunk = CompletionStreamResponse(
                         id=content["meta_info"]["id"],
@@ -1037,32 +1013,16 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 "index": 0,
                 "message": {"role": "assistant", "content": ret_item["text"]},
                 "logprobs": choice_logprobs,
-                "finish_reason": (
-                    finish_reason["type"]
-                    if finish_reason
-                    else ""
-                ),
-                "stop_reason": (
-                    finish_reason["matched"]
-                    if finish_reason
-                    else ""
-                ),
+                "finish_reason": (finish_reason["type"] if finish_reason else ""),
+                "stop_reason": (finish_reason["matched"] if finish_reason else ""),
             }
         else:
             choice_data = ChatCompletionResponseChoice(
                 index=idx,
                 message=ChatMessage(role="assistant", content=ret_item["text"]),
                 logprobs=choice_logprobs,
-                finish_reason=(
-                    finish_reason["type"]
-                    if finish_reason
-                    else ""
-                ),
-                stop_reason=(
-                    finish_reason["matched"]
-                    if finish_reason
-                    else ""
-                )
+                finish_reason=(finish_reason["type"] if finish_reason else ""),
+                stop_reason=(finish_reason["matched"] if finish_reason else ""),
             )
 
         choices.append(choice_data)
@@ -1189,14 +1149,10 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                             index=index,
                             delta=DeltaMessage(role="assistant"),
                             finish_reason=(
-                                finish_reason["type"]
-                                if finish_reason
-                                else ""
+                                finish_reason["type"] if finish_reason else ""
                             ),
                             stop_reason=(
-                                finish_reason["matched"]
-                                if finish_reason
-                                else ""
+                                finish_reason["matched"] if finish_reason else ""
                             ),
                             logprobs=choice_logprobs,
                         )
@@ -1213,16 +1169,8 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                     choice_data = ChatCompletionResponseStreamChoice(
                         index=index,
                         delta=DeltaMessage(content=delta),
-                        finish_reason=(
-                            finish_reason["type"]
-                            if finish_reason
-                            else ""
-                        ),
-                        stop_reason=(
-                            finish_reason["matched"]
-                            if finish_reason
-                            else ""
-                        ),
+                        finish_reason=(finish_reason["type"] if finish_reason else ""),
+                        stop_reason=(finish_reason["matched"] if finish_reason else ""),
                         logprobs=choice_logprobs,
                     )
                     chunk = ChatCompletionStreamResponse(

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -626,7 +626,7 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 "logprobs": logprobs,
                 "finish_reason": (finish_reason["type"] if finish_reason else ""),
                 "stop_reason": (
-                    finish_reason["matched"] if "matched" in finish_reason else ""
+                    finish_reason["matched"] if "matched" in finish_reason else None
                 ),
             }
         else:
@@ -636,7 +636,7 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 logprobs=logprobs,
                 finish_reason=(finish_reason["type"] if finish_reason else ""),
                 stop_reason=(
-                    finish_reason["matched"] if "matched" in finish_reason else ""
+                    finish_reason["matched"] if "matched" in finish_reason else None
                 ),
             )
 
@@ -775,7 +775,7 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
                         stop_reason=(
                             finish_reason["matched"]
                             if "matched" in finish_reason
-                            else ""
+                            else None
                         ),
                     )
                     chunk = CompletionStreamResponse(
@@ -1023,7 +1023,7 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 "logprobs": choice_logprobs,
                 "finish_reason": (finish_reason["type"] if finish_reason else ""),
                 "stop_reason": (
-                    finish_reason["matched"] if "matched" in finish_reason else ""
+                    finish_reason["matched"] if "matched" in finish_reason else None
                 ),
             }
         else:
@@ -1033,7 +1033,7 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 logprobs=choice_logprobs,
                 finish_reason=(finish_reason["type"] if finish_reason else ""),
                 stop_reason=(
-                    finish_reason["matched"] if "matched" in finish_reason else ""
+                    finish_reason["matched"] if "matched" in finish_reason else None
                 ),
             )
 
@@ -1166,7 +1166,7 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                             stop_reason=(
                                 finish_reason["matched"]
                                 if "matched" in finish_reason
-                                else ""
+                                else None
                             ),
                             logprobs=choice_logprobs,
                         )
@@ -1187,7 +1187,7 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                         stop_reason=(
                             finish_reason["matched"]
                             if "matched" in finish_reason
-                            else ""
+                            else None
                         ),
                         logprobs=choice_logprobs,
                     )

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -616,6 +616,8 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
         else:
             logprobs = None
 
+        finish_reason = ret_item["meta_info"]["finish_reason"]
+
         if to_file:
             # to make the choise data json serializable
             choice_data = {
@@ -623,8 +625,13 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 "text": text,
                 "logprobs": logprobs,
                 "finish_reason": (
-                    ret_item["meta_info"]["finish_reason"]["type"]
-                    if ret_item["meta_info"]["finish_reason"]
+                    finish_reason["type"]
+                    if finish_reason
+                    else ""
+                ),
+                "stop_reason": (
+                    finish_reason["matched"]
+                    if finish_reason
                     else ""
                 ),
             }
@@ -634,8 +641,13 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 text=text,
                 logprobs=logprobs,
                 finish_reason=(
-                    ret_item["meta_info"]["finish_reason"]["type"]
-                    if ret_item["meta_info"]["finish_reason"]
+                    finish_reason["type"]
+                    if finish_reason
+                    else ""
+                ),
+                stop_reason=(
+                    finish_reason["matched"]
+                    if finish_reason
                     else ""
                 ),
             )
@@ -766,15 +778,21 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
 
                     delta = text[len(stream_buffer) :]
                     stream_buffer = stream_buffer + delta
+                    finish_reason = content["meta_info"]["finish_reason"]
                     choice_data = CompletionResponseStreamChoice(
                         index=index,
                         text=delta,
                         logprobs=logprobs,
                         finish_reason=(
-                            content["meta_info"]["finish_reason"]["type"]
-                            if content["meta_info"]["finish_reason"]
+                            finish_reason["type"]
+                            if finish_reason
                             else ""
                         ),
+                        stop_reason=(
+                            finish_reason["matched"]
+                            if finish_reason
+                            else ""
+                        )
                     )
                     chunk = CompletionStreamResponse(
                         id=content["meta_info"]["id"],
@@ -1011,6 +1029,8 @@ def v1_chat_generate_response(request, ret, to_file=False):
         else:
             choice_logprobs = None
 
+        finish_reason = ret_item["meta_info"]["finish_reason"]
+
         if to_file:
             # to make the choice data json serializable
             choice_data = {
@@ -1018,8 +1038,13 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 "message": {"role": "assistant", "content": ret_item["text"]},
                 "logprobs": choice_logprobs,
                 "finish_reason": (
-                    ret_item["meta_info"]["finish_reason"]["type"]
-                    if ret_item["meta_info"]["finish_reason"]
+                    finish_reason["type"]
+                    if finish_reason
+                    else ""
+                ),
+                "stop_reason": (
+                    finish_reason["matched"]
+                    if finish_reason
                     else ""
                 ),
             }
@@ -1029,10 +1054,15 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 message=ChatMessage(role="assistant", content=ret_item["text"]),
                 logprobs=choice_logprobs,
                 finish_reason=(
-                    ret_item["meta_info"]["finish_reason"]["type"]
-                    if ret_item["meta_info"]["finish_reason"]
+                    finish_reason["type"]
+                    if finish_reason
                     else ""
                 ),
+                stop_reason=(
+                    finish_reason["matched"]
+                    if finish_reason
+                    else ""
+                )
             )
 
         choices.append(choice_data)
@@ -1150,6 +1180,8 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                     else:
                         choice_logprobs = None
 
+                    finish_reason = content["meta_info"]["finish_reason"]
+
                     if is_first:
                         # First chunk with role
                         is_first = False
@@ -1157,8 +1189,13 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                             index=index,
                             delta=DeltaMessage(role="assistant"),
                             finish_reason=(
-                                content["meta_info"]["finish_reason"]["type"]
-                                if content["meta_info"]["finish_reason"]
+                                finish_reason["type"]
+                                if finish_reason
+                                else ""
+                            ),
+                            stop_reason=(
+                                finish_reason["matched"]
+                                if finish_reason
                                 else ""
                             ),
                             logprobs=choice_logprobs,
@@ -1177,8 +1214,13 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                         index=index,
                         delta=DeltaMessage(content=delta),
                         finish_reason=(
-                            content["meta_info"]["finish_reason"]["type"]
-                            if content["meta_info"]["finish_reason"]
+                            finish_reason["type"]
+                            if finish_reason
+                            else ""
+                        ),
+                        stop_reason=(
+                            finish_reason["matched"]
+                            if finish_reason
                             else ""
                         ),
                         logprobs=choice_logprobs,

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -625,8 +625,10 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 "text": text,
                 "logprobs": logprobs,
                 "finish_reason": (finish_reason["type"] if finish_reason else ""),
-                "stop_reason": (
-                    finish_reason["matched"] if "matched" in finish_reason else None
+                "matched_stop": (
+                    finish_reason["matched"]
+                    if finish_reason and "matched" in finish_reason
+                    else None
                 ),
             }
         else:
@@ -635,8 +637,10 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 text=text,
                 logprobs=logprobs,
                 finish_reason=(finish_reason["type"] if finish_reason else ""),
-                stop_reason=(
-                    finish_reason["matched"] if "matched" in finish_reason else None
+                matched_stop=(
+                    finish_reason["matched"]
+                    if finish_reason and "matched" in finish_reason
+                    else None
                 ),
             )
 
@@ -772,9 +776,9 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
                         text=delta,
                         logprobs=logprobs,
                         finish_reason=(finish_reason["type"] if finish_reason else ""),
-                        stop_reason=(
+                        matched_stop=(
                             finish_reason["matched"]
-                            if "matched" in finish_reason
+                            if finish_reason and "matched" in finish_reason
                             else None
                         ),
                     )
@@ -1022,8 +1026,10 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 "message": {"role": "assistant", "content": ret_item["text"]},
                 "logprobs": choice_logprobs,
                 "finish_reason": (finish_reason["type"] if finish_reason else ""),
-                "stop_reason": (
-                    finish_reason["matched"] if "matched" in finish_reason else None
+                "matched_stop": (
+                    finish_reason["matched"]
+                    if finish_reason and "matched" in finish_reason
+                    else None
                 ),
             }
         else:
@@ -1032,8 +1038,10 @@ def v1_chat_generate_response(request, ret, to_file=False):
                 message=ChatMessage(role="assistant", content=ret_item["text"]),
                 logprobs=choice_logprobs,
                 finish_reason=(finish_reason["type"] if finish_reason else ""),
-                stop_reason=(
-                    finish_reason["matched"] if "matched" in finish_reason else None
+                matched_stop=(
+                    finish_reason["matched"]
+                    if finish_reason and "matched" in finish_reason
+                    else None
                 ),
             )
 
@@ -1163,9 +1171,9 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                             finish_reason=(
                                 finish_reason["type"] if finish_reason else ""
                             ),
-                            stop_reason=(
+                            matched_stop=(
                                 finish_reason["matched"]
-                                if "matched" in finish_reason
+                                if finish_reason and "matched" in finish_reason
                                 else None
                             ),
                             logprobs=choice_logprobs,
@@ -1184,9 +1192,9 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                         index=index,
                         delta=DeltaMessage(content=delta),
                         finish_reason=(finish_reason["type"] if finish_reason else ""),
-                        stop_reason=(
+                        matched_stop=(
                             finish_reason["matched"]
-                            if "matched" in finish_reason
+                            if finish_reason and "matched" in finish_reason
                             else None
                         ),
                         logprobs=choice_logprobs,

--- a/python/sglang/srt/openai_api/protocol.py
+++ b/python/sglang/srt/openai_api/protocol.py
@@ -182,6 +182,7 @@ class CompletionResponseChoice(BaseModel):
     text: str
     logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
+    stop_reason: Union[int, str] = None
 
 
 class CompletionResponse(BaseModel):
@@ -198,6 +199,7 @@ class CompletionResponseStreamChoice(BaseModel):
     text: str
     logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
+    stop_reason: Union[int, str] = None
 
 
 class CompletionStreamResponse(BaseModel):
@@ -289,6 +291,7 @@ class ChatCompletionResponseChoice(BaseModel):
     message: ChatMessage
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: str
+    stop_reason: Union[int, str] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -310,6 +313,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     delta: DeltaMessage
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: Optional[str] = None
+    stop_reason: Union[int, str] = None
 
 
 class ChatCompletionStreamResponse(BaseModel):

--- a/python/sglang/srt/openai_api/protocol.py
+++ b/python/sglang/srt/openai_api/protocol.py
@@ -182,7 +182,7 @@ class CompletionResponseChoice(BaseModel):
     text: str
     logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
-    stop_reason: Union[int, str] = None
+    stop_reason: Union[None, int, str] = None
 
 
 class CompletionResponse(BaseModel):
@@ -199,7 +199,7 @@ class CompletionResponseStreamChoice(BaseModel):
     text: str
     logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
-    stop_reason: Union[int, str] = None
+    stop_reason: Union[None, int, str] = None
 
 
 class CompletionStreamResponse(BaseModel):
@@ -291,7 +291,7 @@ class ChatCompletionResponseChoice(BaseModel):
     message: ChatMessage
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: str
-    stop_reason: Union[int, str] = None
+    stop_reason: Union[None, int, str] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -313,7 +313,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     delta: DeltaMessage
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: Optional[str] = None
-    stop_reason: Union[int, str] = None
+    stop_reason: Union[None, int, str] = None
 
 
 class ChatCompletionStreamResponse(BaseModel):

--- a/python/sglang/srt/openai_api/protocol.py
+++ b/python/sglang/srt/openai_api/protocol.py
@@ -182,7 +182,7 @@ class CompletionResponseChoice(BaseModel):
     text: str
     logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
-    stop_reason: Union[None, int, str] = None
+    matched_stop: Union[None, int, str] = None
 
 
 class CompletionResponse(BaseModel):
@@ -199,7 +199,7 @@ class CompletionResponseStreamChoice(BaseModel):
     text: str
     logprobs: Optional[LogProbs] = None
     finish_reason: Optional[str] = None
-    stop_reason: Union[None, int, str] = None
+    matched_stop: Union[None, int, str] = None
 
 
 class CompletionStreamResponse(BaseModel):
@@ -291,7 +291,7 @@ class ChatCompletionResponseChoice(BaseModel):
     message: ChatMessage
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: str
-    stop_reason: Union[None, int, str] = None
+    matched_stop: Union[None, int, str] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -313,7 +313,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     delta: DeltaMessage
     logprobs: Optional[Union[LogProbs, ChoiceLogprobs]] = None
     finish_reason: Optional[str] = None
-    stop_reason: Union[None, int, str] = None
+    matched_stop: Union[None, int, str] = None
 
 
 class ChatCompletionStreamResponse(BaseModel):

--- a/test/srt/test_matched_stop.py
+++ b/test/srt/test_matched_stop.py
@@ -18,7 +18,7 @@ The story should span multiple events, challenges, and character developments ov
 """
 
 
-class TestJSONConstrained(unittest.TestCase):
+class TestMatchedStop(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST

--- a/test/srt/test_stop_reason.py
+++ b/test/srt/test_stop_reason.py
@@ -128,10 +128,10 @@ class TestJSONConstrained(unittest.TestCase):
 
     def test_finish_length(self):
         self.run_completions_generation(
-            max_tokens=5, finish_reason="length", stop_reason=""
+            max_tokens=5, finish_reason="length", stop_reason=None
         )
         self.run_chat_completions_generation(
-            max_tokens=5, finish_reason="length", stop_reason=""
+            max_tokens=5, finish_reason="length", stop_reason=None
         )
 
 

--- a/test/srt/test_stop_reason.py
+++ b/test/srt/test_stop_reason.py
@@ -40,7 +40,7 @@ class TestJSONConstrained(unittest.TestCase):
         max_tokens=1,
         stop=None,
         finish_reason=None,
-        stop_reason=None,
+        matched_stop=None,
     ):
         payload = {
             "prompt": prompt,
@@ -63,7 +63,7 @@ class TestJSONConstrained(unittest.TestCase):
         assert (
             response_completions.json()["choices"][0]["finish_reason"] == finish_reason
         )
-        assert response_completions.json()["choices"][0]["stop_reason"] == stop_reason
+        assert response_completions.json()["choices"][0]["matched_stop"] == matched_stop
 
     def run_chat_completions_generation(
         self,
@@ -71,7 +71,7 @@ class TestJSONConstrained(unittest.TestCase):
         max_tokens=1,
         stop=None,
         finish_reason=None,
-        stop_reason=None,
+        matched_stop=None,
     ):
         chat_payload = {
             "model": self.model,
@@ -95,14 +95,14 @@ class TestJSONConstrained(unittest.TestCase):
         print("=" * 100)
 
         assert response_chat.json()["choices"][0]["finish_reason"] == finish_reason
-        assert response_chat.json()["choices"][0]["stop_reason"] == stop_reason
+        assert response_chat.json()["choices"][0]["matched_stop"] == matched_stop
 
     def test_finish_stop_str(self):
         self.run_completions_generation(
-            max_tokens=1000, stop="\n", finish_reason="stop", stop_reason="\n"
+            max_tokens=1000, stop="\n", finish_reason="stop", matched_stop="\n"
         )
         self.run_chat_completions_generation(
-            max_tokens=1000, stop="\n", finish_reason="stop", stop_reason="\n"
+            max_tokens=1000, stop="\n", finish_reason="stop", matched_stop="\n"
         )
 
     def test_finish_stop_eos(self):
@@ -117,21 +117,21 @@ class TestJSONConstrained(unittest.TestCase):
             prompt=llama_format_prompt,
             max_tokens=1000,
             finish_reason="stop",
-            stop_reason=eos_token_id,
+            matched_stop=eos_token_id,
         )
         self.run_chat_completions_generation(
             prompt="What is 2 + 2?",
             max_tokens=1000,
             finish_reason="stop",
-            stop_reason=eos_token_id,
+            matched_stop=eos_token_id,
         )
 
     def test_finish_length(self):
         self.run_completions_generation(
-            max_tokens=5, finish_reason="length", stop_reason=None
+            max_tokens=5, finish_reason="length", matched_stop=None
         )
         self.run_chat_completions_generation(
-            max_tokens=5, finish_reason="length", stop_reason=None
+            max_tokens=5, finish_reason="length", matched_stop=None
         )
 
 

--- a/test/srt/test_stop_reason.py
+++ b/test/srt/test_stop_reason.py
@@ -1,0 +1,139 @@
+import json
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_child_process
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_URL_FOR_TEST,
+    popen_launch_server,
+)
+
+MANY_NEW_TOKENS_PROMPT = """
+Please write an extremely detailed and vivid fantasy story, set in a world full of intricate magic systems, political intrigue, and complex characters. 
+Ensure that you thoroughly describe every scene, character's motivations, and the environment. Include long, engaging dialogues and elaborate on the inner thoughts of the characters. 
+Each section should be as comprehensive as possible to create a rich and immersive experience for the reader. 
+The story should span multiple events, challenges, and character developments over time. Aim to make the story at least 3,000 words long.
+"""
+
+
+class TestJSONConstrained(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=300,
+            other_args=["--max-running-requests", "10"],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_child_process(cls.process.pid)
+
+    def run_completions_generation(
+        self,
+        prompt=MANY_NEW_TOKENS_PROMPT,
+        max_tokens=1,
+        stop=None,
+        finish_reason=None,
+        stop_reason=None,
+    ):
+        payload = {
+            "prompt": prompt,
+            "model": self.model,
+            "temperature": 0,
+            "top_p": 1,
+            "max_tokens": max_tokens,
+        }
+
+        if stop is not None:
+            payload["stop"] = stop
+
+        response_completions = requests.post(
+            self.base_url + "/v1/completions",
+            json=payload,
+        )
+        print(json.dumps(response_completions.json()))
+        print("=" * 100)
+
+        assert (
+            response_completions.json()["choices"][0]["finish_reason"] == finish_reason
+        )
+        assert response_completions.json()["choices"][0]["stop_reason"] == stop_reason
+
+    def run_chat_completions_generation(
+        self,
+        prompt=MANY_NEW_TOKENS_PROMPT,
+        max_tokens=1,
+        stop=None,
+        finish_reason=None,
+        stop_reason=None,
+    ):
+        chat_payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": "You are a helpful AI assistant"},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": 0,
+            "top_p": 1,
+            "max_tokens": max_tokens,
+        }
+
+        if stop is not None:
+            chat_payload["stop"] = stop
+
+        response_chat = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json=chat_payload,
+        )
+        print(json.dumps(response_chat.json()))
+        print("=" * 100)
+
+        assert response_chat.json()["choices"][0]["finish_reason"] == finish_reason
+        assert response_chat.json()["choices"][0]["stop_reason"] == stop_reason
+
+    def test_finish_stop_str(self):
+        self.run_completions_generation(
+            max_tokens=1000, stop="\n", finish_reason="stop", stop_reason="\n"
+        )
+        self.run_chat_completions_generation(
+            max_tokens=1000, stop="\n", finish_reason="stop", stop_reason="\n"
+        )
+
+    def test_finish_stop_eos(self):
+        llama_format_prompt = """
+        <|begin_of_text|><|start_header_id|>system<|end_header_id|>
+        You are a helpful assistant.<|eot_id|><|start_header_id|>user<|end_header_id|>
+        
+        What is 2 + 2?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+        """
+        eos_token_id = 128009
+        self.run_completions_generation(
+            prompt=llama_format_prompt,
+            max_tokens=1000,
+            finish_reason="stop",
+            stop_reason=eos_token_id,
+        )
+        self.run_chat_completions_generation(
+            prompt="What is 2 + 2?",
+            max_tokens=1000,
+            finish_reason="stop",
+            stop_reason=eos_token_id,
+        )
+
+    def test_finish_length(self):
+        self.run_completions_generation(
+            max_tokens=5, finish_reason="length", stop_reason=""
+        )
+        self.run_chat_completions_generation(
+            max_tokens=5, finish_reason="length", stop_reason=""
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

It is impossible to distinguish whether the EOS token or the stop token caused the generation to stop. It can be useful to know specifically which of these caused the sequence generation to stop, especially since by default the stop tokens and eos are omitted from the output text.
Details are in this issue https://github.com/sgl-project/sglang/issues/1609

## Modifications

Add matched_stop parameter which stores matched token or matched str if finish_reason is "stop" type, otherwise matched_stop will be equal to None

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.