### PR TITLE
ORJson. Faster Json serialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.9
+    python: python3.11
 
 repos:
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.11
+    python: python3.9
 
 repos:
   - repo: https://github.com/PyCQA/isort

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -435,6 +435,14 @@ def launch_server(
 
     try:
         # Listen for HTTP requests
+        LOGGING_CONFIG["formatters"]["default"][
+            "fmt"
+        ] = "[%(asctime)s] %(levelprefix)s %(message)s"
+        LOGGING_CONFIG["formatters"]["default"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
+        LOGGING_CONFIG["formatters"]["access"][
+            "fmt"
+        ] = '[%(asctime)s] %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+        LOGGING_CONFIG["formatters"]["access"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
         uvicorn.run(
             app,
             host=server_args.host,

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -198,12 +198,12 @@ async def generate_request(obj: GenerateReqInput, request: Request):
             try:
                 async for out in tokenizer_manager.generate_request(obj, request):
                     yield b"data: " + orjson.dumps(
-                        out, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
+                        out, option=orjson.OPT_NON_STR_KEYS
                     ) + b"\n\n"
             except ValueError as e:
                 out = {"error": {"message": str(e)}}
                 yield b"data: " + orjson.dumps(
-                    out, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
+                    out, option=orjson.OPT_NON_STR_KEYS
                 ) + b"\n\n"
             yield b"data: [DONE]\n\n"
 


### PR DESCRIPTION
## Motivation

Remove overhead in python from encoding the responses. Follow up to: https://github.com/sgl-project/sglang/pull/1688

## Modifications
Uses ORJson more wideley
```
/v1/embedding from JsonRepsponse to ORJsonResponse
```

Replaces UTF-8 encoding and f-string generation in streaming with simple byte concatenation.
```python
import orjson
import json

sample = {
    "some": "data",
    "number": 123,
    "boolean": True,
    "null": None,
    "array": [1, 2, 3],
    "object": {"key": "value"},
    "non_unicode_key": "中文",
    1: "int key",
}
# orjson returns utf-8 bytes
ex1 = b"data: " + orjson.dumps(sample, option=orjson.OPT_NON_STR_KEYS) + b"\n\n"
ex2 = f"data: {json.dumps(sample, ensure_ascii=False)}\n\n".encode("utf-8")
assert json.loads(ex1.decode("utf-8")[6:-2]) == json.loads(ex2.decode("utf-8")[6:-2])

>>> ex1
b'data: {"some":"data","number":123,"boolean":true,"null":null,"array":[1,2,3],"object":{"key":"value"},"non_unicode_key":"\xe4\xb8\xad\xe6\x96\x87","1":"int key"}\n\n'
>>> ex2
b'data: {"some": "data", "number": 123, "boolean": true, "null": null, "array": [1, 2, 3], "object": {"key": "value"}, "non_unicode_key": "\xe4\xb8\xad\xe6\x96\x87", "1": "int key"}\n\n'
```

Returning bytes (utf-8) in the generator is the same as the default StreamingResponse. https://github.com/encode/starlette/blob/46131a1af875a5be2190d91713a43ee80c8311c6/starlette/responses.py#L246

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ x] Update documentation as needed, including docstrings or example tutorials.