### PR TITLE
[LoRA, Performance] Add gemm expand triton kernel for multi-LoRA

### DIFF
--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -44,13 +44,14 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 
 
 class BaseLayerWithLoRA(nn.Module):
-    def __init__(self, base_layer, segment_gemm, lora_rank, scaling):
+    def __init__(self, base_layer, segment_gemm, lora_rank, scaling, gemm_expand=None):
         super().__init__()
         self.base_layer = base_layer
         self.segment_gemm = segment_gemm
         self.lora_rank = lora_rank
         self.scaling = scaling
         self.set_lora = False
+        self.gemm_expand = gemm_expand
 
     def forward(self, x: torch.Tensor):
         return self.base_layer.forward(x)
@@ -61,17 +62,27 @@ class BaseLayerWithLoRA(nn.Module):
 
 class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
     def __init__(
-        self, base_layer: VocabParallelEmbedding, segment_gemm, lora_rank, scaling
+        self,
+        base_layer: VocabParallelEmbedding,
+        segment_gemm,
+        lora_rank,
+        scaling,
+        gemm_expand=None,
     ) -> None:
-        super().__init__(base_layer, segment_gemm, lora_rank, scaling)
+        super().__init__(base_layer, segment_gemm, lora_rank, scaling, gemm_expand)
         self.weight = base_layer.weight
 
 
 class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
     def __init__(
-        self, base_layer: ColumnParallelLinear, segment_gemm, lora_rank, scaling
+        self,
+        base_layer: ColumnParallelLinear,
+        segment_gemm,
+        lora_rank,
+        scaling,
+        gemm_expand=None,
     ) -> None:
-        super().__init__(base_layer, segment_gemm, lora_rank, scaling)
+        super().__init__(base_layer, segment_gemm, lora_rank, scaling, gemm_expand)
 
     def apply_lora(self, output: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
         # TODO
@@ -97,16 +108,32 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
 
 class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
     def __init__(
-        self, base_layer: MergedColumnParallelLinear, segment_gemm, lora_rank, scaling
+        self,
+        base_layer: MergedColumnParallelLinear,
+        segment_gemm,
+        lora_rank,
+        scaling,
+        gemm_expand=None,
     ) -> None:
-        super().__init__(base_layer, segment_gemm, lora_rank, scaling)
+        super().__init__(base_layer, segment_gemm, lora_rank, scaling, gemm_expand)
 
-    def set_lora_info(self, A_buffer, B_buffer, bs, seg_indptr, weight_indices):
+    def set_lora_info(
+        self,
+        A_buffer,
+        B_buffer,
+        bs,
+        seg_indptr,
+        weight_indices,
+        seg_lens=None,
+        max_len=None,
+    ):
         self.set_lora = True
         self.A_buffer = A_buffer
         self.B_buffer = B_buffer
         self.bs = bs
         self.seg_indptr = seg_indptr
+        self.seg_lens = seg_lens
+        self.max_len = max_len
         self.weight_indices = weight_indices
 
     def apply_lora(self, base_output: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
@@ -118,33 +145,64 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
             seg_indptr=self.seg_indptr,
             weight_indices=self.weight_indices,
         )
-        # FIXME
-        lora_output = torch.empty_like(base_output)
-        output_dim = lora_output.shape[-1] // 2
-        for i in range(2):
-            left = output_dim * i
-            right = left + output_dim
-            lora_output[:, left:right] = self.segment_gemm.run(
-                x=lora_a_output[
-                    :, self.lora_rank * i : self.lora_rank * (i + 1)
-                ].contiguous(),
-                weights=self.B_buffer[:, left:right, :].contiguous(),
-                batch_size=self.bs,
-                weight_column_major=True,
-                seg_indptr=self.seg_indptr,
-                weight_indices=self.weight_indices,
-            )
-        return base_output + lora_output * self.scaling
+        output_dim = lora_output.shape[-1]
+        if self.gemm_expand is not None:
+            for i in range(2):
+                self.gemm_expand(
+                    base_output,
+                    lora_a_output,
+                    self.B_buffer[i],
+                    batch_size=self.bs,
+                    seg_lens=self.seg_lens,
+                    seg_start=self.seg_indptr,
+                    weight_indices=self.weight_indices,
+                    max_len=self.max_len,
+                    input_slice_offset=self.lora_rank * i,
+                    output_slice_offset=output_dim * i,
+                    output_add=True,
+                    scaling=self.scaling,
+                )
+            return base_output
+        else:
+            # FIXME wait for flashinfer segment gemm update
+            lora_output = torch.empty_like(base_output)
+            for i in range(2):
+                left = output_dim * i
+                right = left + output_dim
+                lora_output[:, left:right] = self.segment_gemm.run(
+                    x=lora_a_output[
+                        :, self.lora_rank * i : self.lora_rank * (i + 1)
+                    ].contiguous(),
+                    weights=self.B_buffer[i],
+                    batch_size=self.bs,
+                    weight_column_major=True,
+                    seg_indptr=self.seg_indptr,
+                    weight_indices=self.weight_indices,
+                )
+            return base_output + lora_output * self.scaling
 
 
 class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
-    def __init__(
-        self, base_layer: QKVParallelLinear, segment_gemm, lora_rank, scaling
+    def init__(
+        self,
+        base_layer: QKVParallelLinear,
+        segment_gemm,
+        lora_rank,
+        scaling,
+        gemm_expand=None,
     ) -> None:
-        super().__init__(base_layer, segment_gemm, lora_rank, scaling)
+        super().__init__(base_layer, segment_gemm, lora_rank, scaling, gemm_expand)
 
     def set_lora_info(
-        self, A_buffer_qkv, B_buffer_q, B_buffer_kv, bs, seg_indptr, weight_indices
+        self,
+        A_buffer_qkv,
+        B_buffer_q,
+        B_buffer_kv,
+        bs,
+        seg_indptr,
+        weight_indices,
+        seg_lens=None,
+        max_len=None,
     ):
         self.set_lora = True
         self.A_buffer_qkv = A_buffer_qkv
@@ -152,6 +210,8 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         self.B_buffer_kv = B_buffer_kv
         self.bs = bs
         self.seg_indptr = seg_indptr
+        self.seg_lens = seg_lens
+        self.max_len = max_len
         self.weight_indices = weight_indices
 
     def apply_lora(self, base_output: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
@@ -169,37 +229,60 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
         output_dim_q = self.B_buffer_q.shape[-2]
         lora_output[:, :output_dim_q] = self.segment_gemm.run(
             x=lora_a_output[:, : self.lora_rank].contiguous(),
-            weights=self.B_buffer_q,
+            weights=self.B_buffer_q[0],
             batch_size=self.bs,
             weight_column_major=True,
             seg_indptr=self.seg_indptr,
             weight_indices=self.weight_indices,
         )
         # kv
-        output_dim_kv = self.B_buffer_kv.shape[-2] // 2
-        for i in range(2):
-            left = output_dim_kv * i
-            right = left + output_dim_kv
-            lora_output[:, output_dim_q + left : output_dim_q + right] = (
-                self.segment_gemm.run(
-                    x=lora_a_output[
-                        :, self.lora_rank * (i + 1) : self.lora_rank * (i + 2)
-                    ].contiguous(),
-                    weights=self.B_buffer_kv[:, left:right, :].contiguous(),
+        output_dim_kv = self.B_buffer_kv.shape[-2]
+        if self.gemm_expand is not None:
+            for i in range(2):
+                self.gemm_expand(
+                    base_output,
+                    lora_a_output,
+                    self.B_buffer_kv[i],
                     batch_size=self.bs,
-                    weight_column_major=True,
-                    seg_indptr=self.seg_indptr,
+                    seg_lens=self.seg_lens,
+                    seg_start=self.seg_indptr,
                     weight_indices=self.weight_indices,
+                    max_len=self.max_len,
+                    input_slice_offset=self.lora_rank * (i + 1),
+                    output_slice_offset=output_dim_q + output_dim_kv * i,
+                    output_add=True,
+                    scaling=self.scaling,
                 )
-            )
-        return base_output + lora_output * self.scaling
+            return base_output
+        else:
+            for i in range(2):
+                left = output_dim_kv * i
+                right = left + output_dim_kv
+                lora_output[:, output_dim_q + left : output_dim_q + right] = (
+                    self.segment_gemm.run(
+                        x=lora_a_output[
+                            :, self.lora_rank * (i + 1) : self.lora_rank * (i + 2)
+                        ].contiguous(),
+                        weights=self.B_buffer_kv[i],
+                        batch_size=self.bs,
+                        weight_column_major=True,
+                        seg_indptr=self.seg_indptr,
+                        weight_indices=self.weight_indices,
+                    )
+                )
+            return base_output + lora_output * self.scaling
 
 
 class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
     def __init__(
-        self, base_layer: RowParallelLinear, segment_gemm, lora_rank, scaling
+        self,
+        base_layer: RowParallelLinear,
+        segment_gemm,
+        lora_rank,
+        scaling,
+        gemm_expand=None,
     ) -> None:
-        super().__init__(base_layer, segment_gemm, lora_rank, scaling)
+        super().__init__(base_layer, segment_gemm, lora_rank, scaling, gemm_expand)
 
     def set_lora_info(self, A_buffer, B_buffer, bs, seg_indptr, weight_indices):
         self.set_lora = True
@@ -220,7 +303,7 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
         )
         lora_output = self.segment_gemm.run(
             x=lora_output,
-            weights=self.B_buffer,
+            weights=self.B_buffer[0],
             batch_size=self.bs,
             weight_column_major=True,
             seg_indptr=self.seg_indptr,
@@ -264,7 +347,11 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
 
 
 def get_lora_layer(
-    layer: nn.Module, segment_gemm, lora_rank, scaling
+    layer: nn.Module,
+    segment_gemm,
+    lora_rank,
+    scaling,
+    gemm_expand,
 ) -> BaseLayerWithLoRA:
     supported_layer_types = {
         # the order matters
@@ -276,7 +363,9 @@ def get_lora_layer(
     }
     for src_layer_type, lora_layer_type in supported_layer_types.items():
         if isinstance(layer, src_layer_type):  # pylint: disable=unidiomatic-typecheck
-            ret = lora_layer_type(layer, segment_gemm, lora_rank, scaling)
+            ret = lora_layer_type(
+                layer, segment_gemm, lora_rank, scaling, gemm_expand=gemm_expand
+            )
             return ret
     raise Exception(f"No corresponding LoRA layer supported for {type(layer)}.")
 
@@ -306,13 +395,14 @@ class LoRALayer(nn.Module):
 
 
 class LoRAAdapter(nn.Module):
-    def __init__(self, uid, config, base_hf_config, load_config):
+    def __init__(self, uid, config, base_hf_config, load_config, lora_backend):
         super().__init__()
         self.uid = uid
         self.config = config
         assert self.config.hf_config["peft_type"].lower() == "lora"
         self.base_hf_config = base_hf_config
         self.load_config = load_config
+        self.lora_backend = lora_backend
         self.scaling = self.config.lora_alpha / self.config.r
 
         self.layers = nn.ModuleList(
@@ -383,20 +473,25 @@ class LoRAAdapter(nn.Module):
                         layer.weights.pop(weight_name)
                         layer.weights.pop(v_name)
                     else:
-                        layer.weights[kv_name] = torch.cat(
-                            (
+                        layer.weights[kv_name] = torch.stack(
+                            [
                                 layer.weights[weight_name],
                                 layer.weights[v_name],
-                            ),
-                            0,
+                            ],
+                            dim=0,
                         )
                         layer.weights.pop(weight_name)
                         layer.weights.pop(v_name)
                 elif "gate_proj" in weight_name:
                     up_name = weight_name.replace("gate_proj", "up_proj")
                     gate_up_name = weight_name.replace("gate_proj", "gate_up_proj")
-                    layer.weights[gate_up_name] = torch.cat(
-                        (layer.weights[weight_name], layer.weights[up_name]), 0
-                    )
+                    if "lora_A" in weight_name:
+                        layer.weights[gate_up_name] = torch.cat(
+                            (layer.weights[weight_name], layer.weights[up_name]), 0
+                        )
+                    else:
+                        layer.weights[gate_up_name] = torch.stack(
+                            [layer.weights[weight_name], layer.weights[up_name]], dim=0
+                        )
                     layer.weights.pop(weight_name)
                     layer.weights.pop(up_name)

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 if is_flashinfer_available():
     from flashinfer import SegmentGEMMWrapper
+from sglang.srt.lora.triton_ops.lora_expand import segment_gemm_expand
 
 
 def get_module_name(name):
@@ -95,6 +96,7 @@ class LoRAManager:
         max_loras_per_batch,
         load_config,
         dtype,
+        lora_backend,
     ):
         self.base_model = base_model
         self.lora_paths = lora_paths
@@ -102,9 +104,13 @@ class LoRAManager:
         self.max_loras_per_batch = max_loras_per_batch
         self.load_config = load_config
         self.dtype = dtype
+        self.lora_backend = lora_backend
 
         workspace_buffer = torch.empty(1 * 1024 * 1024, dtype=torch.int8, device="cuda")
+        # waiting for flashinfer's updates on grouped gemm
         self.segment_gemm = SegmentGEMMWrapper(workspace_buffer)
+
+        self.gemm_expand = segment_gemm_expand if lora_backend == "triton" else None
 
         self.init_loras()
         self.init_lora_memory_pool()
@@ -125,7 +131,11 @@ class LoRAManager:
 
     def set_lora_module(self, module_name, module):
         lora_module = get_lora_layer(
-            module, self.segment_gemm, self.max_lora_dim, self.scaling
+            module,
+            self.segment_gemm,
+            self.max_lora_dim,
+            self.scaling,
+            gemm_expand=self.gemm_expand,
         )
         replace_submodule(self.base_model, module_name, lora_module)
         return lora_module
@@ -164,7 +174,11 @@ class LoRAManager:
             self.lora_id[name] = len(self.loras)
             self.loras.append(
                 LoRAAdapter(
-                    name, self.configs[name], self.base_hf_config, self.load_config
+                    name,
+                    self.configs[name],
+                    self.base_hf_config,
+                    self.load_config,
+                    self.lora_backend,
                 )
             )
             self.loras[-1].initialize_weights()
@@ -225,18 +239,34 @@ class LoRAManager:
                 _, hidden_dim_B = get_hidden_dim(module_B, self.base_hf_config)
             c = self.loras[-1].get_stacked_multiply(module_B)
             if module_B not in self.B_buffer:
-                self.B_buffer[module_B] = [
-                    torch.empty(
-                        (
-                            self.max_loras_per_batch,
-                            hidden_dim_B * c,
-                            self.max_lora_dim,
-                        ),
-                        dtype=self.dtype,
-                        device="cuda",
-                    )
-                    for i in range(num_layer)
-                ]
+                if self.lora_backend == "triton":
+                    self.B_buffer[module_B] = [
+                        torch.empty(
+                            (
+                                c,
+                                self.max_loras_per_batch,
+                                hidden_dim_B,
+                                self.max_lora_dim,
+                            ),
+                            dtype=self.dtype,
+                            device="cuda",
+                        )
+                        for i in range(num_layer)
+                    ]
+                else:
+                    self.B_buffer[module_B] = [
+                        torch.empty(
+                            (
+                                c,
+                                self.max_loras_per_batch,
+                                hidden_dim_B,
+                                self.max_lora_dim,
+                            ),
+                            dtype=self.dtype,
+                            device="cuda",
+                        )
+                        for i in range(num_layer)
+                    ]
 
     def init_lora_batch(self):
         self.active_uids = set()  # set of active loras
@@ -265,7 +295,16 @@ class LoRAManager:
                 else:
                     lora_weight_name = self.get_weight_name(name, 1)
                     if lora_weight_name:
-                        self.B_buffer[lora_weight_name][i][buffer_id].copy_(weights)
+                        c = self.loras[-1].get_stacked_multiply(lora_weight_name)
+                        if c > 1:
+                            for j in range(c):
+                                self.B_buffer[lora_weight_name][i][j][buffer_id].copy_(
+                                    weights[j]
+                                )
+                        else:
+                            self.B_buffer[lora_weight_name][i][0][buffer_id].copy_(
+                                weights
+                            )
 
     def prepare_lora_batch(self, forward_batch: ForwardBatch):
         # load active loras into lora memory pool
@@ -304,6 +343,7 @@ class LoRAManager:
         # FIXME: reuse the data rather than recompute
         seg_indptr = torch.zeros((bs + 1,), dtype=torch.int32, device="cuda")
         seg_indptr[1:] = torch.cumsum(seg_lens, dim=0)
+        max_len = int(torch.max(seg_lens))
         weight_indices = torch.empty((bs,), dtype=torch.int64, device="cuda")
         for i, lora_path in enumerate(forward_batch.lora_paths):
             weight_indices[i] = self.buffer_id[lora_path]
@@ -328,4 +368,6 @@ class LoRAManager:
                     bs,
                     seg_indptr,
                     weight_indices,
+                    seg_lens=seg_lens,
+                    max_len=max_len,
                 )

--- a/python/sglang/srt/lora/triton_ops/lora_expand.py
+++ b/python/sglang/srt/lora/triton_ops/lora_expand.py
@@ -1,0 +1,148 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _segment_gemm_expand_kernel(
+    output,  # (s, h) = (m, k)
+    x,  # (s, r) = (m, n)
+    weights,  # (num_lora, h, r) = (..., k, n)
+    x_stride_0,
+    w_stride_0,
+    w_stride_1,
+    output_stride_0,
+    seg_lens,
+    seg_start,
+    weight_indices,
+    K,
+    N,
+    BLOCK_S: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    divisible,
+    output_add,
+    input_slice_offset,
+    output_slice_offset,
+    scaling,
+):
+    batch_id = tl.program_id(axis=1)
+    pid = tl.program_id(axis=0)
+
+    width = tl.cdiv(K, BLOCK_K)
+    pid_s = pid // width
+    pid_h = pid % width
+
+    seg_len = tl.load(seg_lens + batch_id)
+    w_index = tl.load(weight_indices + batch_id)
+    seg_start = tl.load(seg_start + batch_id)
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    h_offset = tl.arange(0, BLOCK_K) + pid_h * BLOCK_K
+    r_offset = tl.arange(0, BLOCK_N)
+
+    # (BLOCK_S, BLOCK_N)
+    x_ptrs = (
+        x
+        + seg_start * x_stride_0
+        + s_offset[:, None] * x_stride_0
+        + r_offset[None, :]
+        + input_slice_offset
+    )
+    # (BLOCK_N, BLOCK_K)
+    w_ptrs = (
+        weights
+        + w_index * w_stride_0
+        + r_offset[:, None]
+        + h_offset[None, :] * w_stride_1
+    )
+
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_K), dtype=tl.float32)
+    for rid in range(tl.cdiv(N, BLOCK_N)):
+        if divisible:
+            tiled_x = tl.load(x_ptrs)
+            tiled_w = tl.load(w_ptrs)
+        else:
+            tiled_x = tl.load(
+                x_ptrs, mask=r_offset[None, :] < N - rid * BLOCK_N, other=0
+            )
+            tiled_w = tl.load(
+                w_ptrs, mask=r_offset[:, None] < N - rid * BLOCK_N, other=0
+            )
+        partial_sum += tl.dot(tiled_x, tiled_w) * scaling
+        x_ptrs += BLOCK_N
+        w_ptrs += BLOCK_N
+
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    seg_start_offset = seg_start * output_stride_0
+    out_ptr = (
+        output
+        + seg_start_offset
+        + s_offset[:, None] * output_stride_0
+        + h_offset[None, :]
+        + output_slice_offset
+    )
+    s_mask = s_offset[:, None] < seg_len
+    if output_add:
+        partial_sum += tl.load(out_ptr, mask=s_mask)
+    tl.store(out_ptr, partial_sum, mask=s_mask)
+
+
+def segment_gemm_expand(
+    output,  # (s, h)
+    x,  # (s, r)
+    weights,  # (num_lora, h, r)
+    batch_size,
+    # weight_column_major,
+    seg_lens,
+    seg_start,
+    weight_indices,
+    max_len,
+    input_slice_offset=0,
+    output_slice_offset=0,
+    output_add=False,
+    scaling=1,
+):
+    assert weights.ndim == 3
+    assert batch_size == seg_lens.shape[0] == weight_indices.shape[0]
+    # assert weight_column_major
+    # assert x.shape[-1] == weights.shape[-1]
+    assert x.is_contiguous()
+    assert weights.is_contiguous()
+
+    H = weights.shape[-2]
+    R = weights.shape[-1]
+
+    BLOCK_S = 16
+    BLOCK_H = 32
+    BLOCK_R = 16
+    divisible = R % BLOCK_R == 0
+    assert H % BLOCK_H == 0
+
+    grid = (
+        triton.cdiv(max_len, BLOCK_S) * triton.cdiv(H, BLOCK_H),
+        batch_size,
+    )
+
+    _segment_gemm_expand_kernel[grid](
+        output,  # (s, h)
+        x,  # (s, r)
+        weights,  # (num_lora, h, r)
+        x.stride(0),
+        weights.stride(0),
+        weights.stride(1),
+        output.stride(0),
+        seg_lens,
+        seg_start,
+        weight_indices,
+        H,
+        R,
+        BLOCK_S,
+        BLOCK_H,
+        BLOCK_R,
+        divisible,
+        output_add=output_add,
+        input_slice_offset=input_slice_offset,
+        output_slice_offset=output_slice_offset,
+        scaling=scaling,
+    )
+    return output

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -338,6 +338,7 @@ class ModelRunner:
             max_loras_per_batch=self.server_args.max_loras_per_batch,
             load_config=self.load_config,
             dtype=self.dtype,
+            lora_backend=self.server_args.lora_backend,
         )
         logger.info("LoRA manager ready.")
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -108,6 +108,7 @@ class ServerArgs:
     # LoRA
     lora_paths: Optional[List[str]] = None
     max_loras_per_batch: int = 8
+    lora_backend: str = "triton"
 
     def __post_init__(self):
         # Set missing default values
@@ -539,13 +540,19 @@ class ServerArgs:
             nargs="*",
             default=None,
             action=LoRAPathAction,
-            help="The list of LoRA adapters. You can provide a list of either path in str or renamed path in the format {name}={path}",
+            help="The list of LoRA adapters. You can provide a list of either path in str or renamed path in the format {name}={path}.",
         )
         parser.add_argument(
             "--max-loras-per-batch",
             type=int,
             default=8,
-            help="Maximum number of adapters for a running batch, include base-only request",
+            help="Maximum number of adapters for a running batch, include base-only request.",
+        )
+        parser.add_argument(
+            "--lora-backend",
+            type=str,
+            default="triton",
+            help="Choose the kernel backend for multi-LoRA serving.",
         )
 
     @classmethod


### PR DESCRIPTION
This PR added the option `--lora-backend` to choose between triton and flashinfer backend.

Items before merging this PR.
- [ ] Accuracy test

The triton kernels for shrink and 2-D segmented gemm will come up in follow-up PRs.


See example below:
```
# launch server
python -m sglang.launch_server --model mistralai/Mistral-7B-Instruct-v0.3 --lora-paths /home/ying/test_lora lora1=/home/ying/test_lora_1 lora2=/home/ying/test_lora_2 --disable-radix --disable-cuda-graph --max-loras-per-batch 4 --lora-backend triton
```
```
# send requests
# lora_path[i] specifies the LoRA used for text[i], so make sure they have the same length
# use None to specify base-only prompt, e.x. "lora_path": [None, "/home/ying/test_lora"]
import json
import requests

url = "http://127.0.0.1:30000"
json_data = {
        "text": ["prompt 1", "prompt 2", "prompt 3", "prompt 4", "prompt 5", "prompt 6", "prompt7"],
        "sampling_params": {"max_new_tokens": 32},
        "lora_path": ["/home/ying/test_lora", "lora1", "lora2", "lora1", "lora2", None, None],
}
response = requests.post(
        url + "/generate",
        json=json_data,
)
print(json.dumps(response.json()))
```

For multi-LoRA serving, what has been done:
- [x] Initial LoRA support #1307
This PR gives initial multi-LoRA serving support. Currently, it supports LoRA on attention (`qkvo`) and mlp (`gate, up, down`) linear layers. It supports dynamic loading and offloading, but it does not support unified memory. The memory pool for LoRA adapters is pre-allocated. Please use a smaller `--mem-frac` to launch server with larger `--max-loras-per-batch`.
- [x] Misc: path renaming #1433 

What is in progress:
- [x] Add triton backend and performance optimizations
  - [x] expand kernel for segmented gemm (this PR)
  - [ ] shrink kernel for segmented gemm
  - [ ] 2-D segmented gemm

You can expect the items below in the follow-up PRs.
- [ ] OpenAI compatible API
- [ ] compatibility with cuda graph
- [ ] compatibility with radix attention
- [ ] fully sharded LoRAs with tensor parallelism
- [ ] performance optimization
- [ ] memory optimization
- [ ] support LoRAs with different ranks
- [ ] test cases enhancement

References:
[S-LoRA: Serving Thousands of Concurrent LoRA Adapters](https://arxiv.org/abs/2311.03285)
[Punica: Multi-Tenant LoRA Serving](https://arxiv.org/abs/2310.18547)