### PR TITLE
Make token mapping non-blocking in the overlapped mode

### DIFF
--- a/test/killall_sglang.sh
+++ b/test/killall_sglang.sh
@@ -1,1 +1,2 @@
 kill -9 $(ps aux | grep 'multiprocessing.spawn' | grep -v 'grep' | awk '{print $2}')
+kill -9 $(ps aux | grep 'sglang.launch_server' | grep -v 'grep' | awk '{print $2}')


### PR DESCRIPTION
`future_mask = resolved_input_ids < 0` is a blocking call so we should get rid of it