### PR TITLE
[Fix] Fix abort in data parallelism

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -156,7 +156,7 @@ class DataParallelController:
                 else:
                     # Send other control messages to all workers
                     for worker in self.workers:
-                        worker.queue.put(recv_req)
+                        worker.send_pyobj(recv_req)
 
 
 def run_data_parallel_controller_process(


### PR DESCRIPTION
Fix the error `AttributeError: queue attribute is write-only`