### PR TITLE
[Bug] Catch any errors caused by parsing json schema

### DIFF
--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -73,9 +73,13 @@ class FSMCache(BaseToolCache):
     def init_value(self, key):
         key_type, key_string = key
         if key_type == "json":
-            regex = build_regex_from_schema(
-                key_string, whitespace_pattern=self.constrained_json_whitespace_pattern
-            )
+            try:
+                regex = build_regex_from_schema(
+                    key_string, whitespace_pattern=self.constrained_json_whitespace_pattern
+                )
+            except NotImplementedError as e:
+                logger.warning(f"skip invalid json schema: json_schema={key_string}, {e=}")
+                return None, key_string
         elif key_type == "regex":
             regex = key_string
         else:

--- a/python/sglang/srt/constrained/fsm_cache.py
+++ b/python/sglang/srt/constrained/fsm_cache.py
@@ -75,10 +75,13 @@ class FSMCache(BaseToolCache):
         if key_type == "json":
             try:
                 regex = build_regex_from_schema(
-                    key_string, whitespace_pattern=self.constrained_json_whitespace_pattern
+                    key_string,
+                    whitespace_pattern=self.constrained_json_whitespace_pattern,
                 )
             except NotImplementedError as e:
-                logger.warning(f"skip invalid json schema: json_schema={key_string}, {e=}")
+                logger.warning(
+                    f"skip invalid json schema: json_schema={key_string}, {e=}"
+                )
                 return None, key_string
         elif key_type == "regex":
             regex = key_string


### PR DESCRIPTION
## Motivation

Passing `json_schema` with types unimplemented by Outlines to the `/generate` endpoint would crash the scheduler and take down the whole server.

Example:
skip invalid json schema: json_schema={"type":"object","properties":{"id":{"type":"string","format":"uuid"},"name":{"type":"string","minLength":2,"maxLength":50},"age":{"type":"integer","minimum":0,"maximum":120},"email":{"type":"string","format":"email"},"tags":{"type":"array","items":{"type":"string"},"minItems":1,"maxItems":5},"role":{"type":"string","enum":["admin","user","guest"]},"settings":{"type":"object","properties":{"theme":{"type":"string","enum":["light","dark"]},"notifications":{"type":"boolean"}},"required":["theme","notifications"],"additionalProperties":false},"joinedAt":{"type":"string","format":"date"}},"required":["id","name","age","email","tags","role","joinedAt"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}, e=NotImplementedError('Format email is not supported by Outlines')

"email" is a valid JSON schema format but is not implemented. Using that JSON schema would crash the sglang scheduler.

## Modifications

Catches `NotImplemented errors thrown by JSON schema creation

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.