### PR TITLE
check user-specified model_max_len with hf derived max_model_len

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
 import logging
+import os
 from enum import IntEnum, auto
 from typing import Optional
 
@@ -23,6 +23,7 @@ from transformers import PretrainedConfig
 from sglang.srt.hf_transformers_utils import get_config, get_context_length
 
 logger = logging.getLogger(__name__)
+
 
 class AttentionArch(IntEnum):
     MLA = auto()
@@ -50,18 +51,24 @@ class ModelConfig:
         )
         self.hf_text_config = get_hf_text_config(self.hf_config)
         derived_context_len = get_context_length(self.hf_text_config)
-        allow_long_context = os.environ.get("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", None)
-        
+        allow_long_context = os.environ.get(
+            "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", None
+        )
+
         if context_length is not None:
             if context_length > derived_context_len:
                 if allow_long_context:
-                    logger.warning(f"Warning: User-specified context_length ({context_length}) is greater than the derived context_length ({derived_context_len}). "
-                          f"This may lead to incorrect model outputs or CUDA errors.")
+                    logger.warning(
+                        f"Warning: User-specified context_length ({context_length}) is greater than the derived context_length ({derived_context_len}). "
+                        f"This may lead to incorrect model outputs or CUDA errors."
+                    )
                     self.context_len = context_length
                 else:
-                    raise ValueError(f"User-specified context_length ({context_length}) is greater than the derived context_length ({derived_context_len}). "
-                                     f"This may lead to incorrect model outputs or CUDA errors. Note that the derived context_length may differ from max_position_embeddings in the model's config. "
-                                     f"To allow overriding this maximum, set the env var SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1")
+                    raise ValueError(
+                        f"User-specified context_length ({context_length}) is greater than the derived context_length ({derived_context_len}). "
+                        f"This may lead to incorrect model outputs or CUDA errors. Note that the derived context_length may differ from max_position_embeddings in the model's config. "
+                        f"To allow overriding this maximum, set the env var SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1"
+                    )
             else:
                 self.context_len = context_length
         else:


### PR DESCRIPTION
## Motivation

This PR aims to improve the handling of context length in the `ModelConfig` class. It addresses potential issues when users specify a context length exceeding the model's derived maximum, enhances error messaging, and introduces a controlled override mechanism. These changes will prevent **decoding nan errors**, which I have met recently.

## Modifications


The `ModelConfig` class in `model_config.py` has been updated to include a check comparing user-specified `context_length` against the model's `derived_context_len`. It now handles the `SGLANG_ALLOW_LONG_MAX_MODEL_LEN` environment variable, allowing controlled overrides of maximum context length. The changes include logic to raise a `ValueError` or print a warning based on the specified length and override settings, with improved error and warning messages for clear user guidance.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/en/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.