### PR TITLE
[Fix] Fix NaN issues by fixing the cuda graph padding values for flashinfer

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -211,7 +211,7 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
     def get_cuda_graph_seq_len_fill_value(self):
-        return 1
+        return 0
 
     def forward_extend(
         self, q, k, v, layer: RadixAttention, forward_batch: ForwardBatch

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -211,7 +211,7 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
     def get_cuda_graph_seq_len_fill_value(self):
-        return 0
+        return 1
 
     def forward_extend(
         self, q, k, v, layer: RadixAttention, forward_batch: ForwardBatch

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -290,7 +290,7 @@ class CudaGraphRunner:
         index = bisect.bisect_left(self.capture_bs, raw_bs)
         bs = self.capture_bs[index]
         if bs != raw_bs:
-            self.seq_lens.fill_(self.seq_len_fill_value)
+            self.seq_lens.fill_(1)
             self.out_cache_loc.zero_()
 
         # Common inputs


### PR DESCRIPTION
Previously, we set seq_len = 0 for padded requests. This can result in some NaN issues, as reported in https://github.com/sgl-project/sglang/issues/1571.
This PR fixes it by setting the seq_len = 1. This mostly only happens for models with dynamic fp8 quantization `--quantization fp8`, so I suspect it relates to the dynamic quantization and flash infer kernels.

cc @yzh119 