### PR TITLE
Fix seq_lens_sum for cuda graph runner in padded cases

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -307,7 +307,7 @@ class CudaGraphRunner:
             bs,
             self.req_pool_indices,
             self.seq_lens,
-            forward_batch.seq_lens_sum,
+            forward_batch.seq_lens_sum + (bs - raw_bs),
             self.encoder_lens,
         )
 


### PR DESCRIPTION
When we compute `seq_lens_sum` for cuda graph, we need to consider padded requests.
This fixed the error for https://github.com/sgl-project/sglang/actions/runs/11510875908/job/32043401541