### PR TITLE
move max_position_embeddings to the last

### DIFF
--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -81,9 +81,9 @@ def get_config(
 CONTEXT_LENGTH_KEYS = [
     "max_sequence_length",
     "seq_length",
-    "max_position_embeddings",
     "max_seq_len",
     "model_max_length",
+    "max_position_embeddings",
 ]
 
 


### PR DESCRIPTION
Models don't use the same configuration key for determining the maximum context length. There are some models use max_position_embeddings and another keyword in the same config.json, such as model_max_length. In this case, the priority of max_position_embeddings should be lower.