### PR TITLE
detach two CI for documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,10 +2,11 @@ name: Release Documentation
 
 on:
   push:
-    paths:
-      - 'python/sglang/version.py'
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - 'python/sglang/version.py'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   execute-notebooks:
     runs-on: 1-gpu-runner
-    if: github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request'
+    if: github.repository == 'sgl-project/sglang'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,11 @@
-name: Build Documentation
+name: Release Documentation
 
 on:
+  push:
+    paths:
+      - 'python/sglang/version.py'
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -38,8 +43,9 @@ jobs:
           done
 
   build-and-deploy:
+    needs: execute-notebooks
     if: github.repository == 'sgl-project/sglang'
-    runs-on: 1-gpu-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/execute-notebook.yml
+++ b/.github/workflows/execute-notebook.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  execute-notebooks:
+  run-all-notebooks:
     runs-on: 1-gpu-runner
     if: github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request'
     steps:

--- a/.github/workflows/execute-notebook.yml
+++ b/.github/workflows/execute-notebook.yml
@@ -1,0 +1,42 @@
+name: Execute Notebooks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  execute-notebooks:
+    runs-on: 1-gpu-runner
+    if: github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci_install_dependency.sh
+          pip install -r docs/requirements.txt
+
+      - name: Setup Jupyter Kernel
+        run: |
+          python -m ipykernel install --user --name python3 --display-name "Python 3"
+
+      - name: Execute notebooks
+        run: |
+          cd docs
+          for nb in *.ipynb; do
+            if [ -f "$nb" ]; then
+              echo "Executing $nb"
+              jupyter nbconvert --to notebook --execute --inplace "$nb" \
+                --ExecutePreprocessor.timeout=600 \
+                --ExecutePreprocessor.kernel_name=python3
+            fi
+          done


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

I setup two CIs for our documents.

1. `execute-notebook.yml`. Whenever there is PR to the main branch, this CI will be launched, to make sure modified API's accuracy.
2. `deploy-docs.yml`. Only when manually launched or a new release in it. (`python/sglang/version.py` changed.)

## Modifications

<!-- Describe the changes made in this PR. -->

Modified two yml configuration.

## Checklist

- [X] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [X] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [X] Update documentation as needed, including docstrings or example tutorials.