### PR TITLE
Fix update_weights deadlock for DP

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -721,16 +721,3 @@ class TokenizerManager:
                     token_top_logprobs, decode_to_text
                 )
         return top_logprobs
-
-
-"""
-    # Case 1: Direct double set_result
-    print("\nCase 1: Direct double set_result")
-    future = asyncio.Future()
-    future.set_result("First result")
-    try:
-        future.set_result("Second result")  # This will raise InvalidStateError
-    except asyncio.InvalidStateError as e:
-        print(f"Error on second set_result: {e}")
-   
-"""

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -721,3 +721,16 @@ class TokenizerManager:
                     token_top_logprobs, decode_to_text
                 )
         return top_logprobs
+
+
+"""
+    # Case 1: Direct double set_result
+    print("\nCase 1: Direct double set_result")
+    future = asyncio.Future()
+    future.set_result("First result")
+    try:
+        future.set_result("Second result")  # This will raise InvalidStateError
+    except asyncio.InvalidStateError as e:
+        print(f"Error on second set_result: {e}")
+   
+"""

--- a/test/srt/test_data_parallelism.py
+++ b/test/srt/test_data_parallelism.py
@@ -43,8 +43,6 @@ class TestDataParallelism(unittest.TestCase):
         assert metrics["score"] >= 0.65
 
     def test_update_weight(self):
-
-
         response = requests.post(
             self.base_url + "/update_weights",
             json={"model_path": DEFAULT_MODEL_NAME_FOR_TEST},

--- a/test/srt/test_data_parallelism.py
+++ b/test/srt/test_data_parallelism.py
@@ -9,7 +9,8 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     popen_launch_server,
 )
-
+import requests
+import time
 
 class TestDataParallelism(unittest.TestCase):
     @classmethod
@@ -38,6 +39,28 @@ class TestDataParallelism(unittest.TestCase):
 
         metrics = run_eval(args)
         assert metrics["score"] >= 0.65
+
+    def test_update_weight(self):
+
+
+        response = requests.post(
+            self.base_url + "/update_weights",
+            json={"model_path": DEFAULT_MODEL_NAME_FOR_TEST},
+        )
+
+        # check if the response is 200
+        assert response.status_code == 200
+
+        # pause a few seconds then send again
+        time.sleep(5)
+        
+        response = requests.post(
+            self.base_url + "/update_weights",
+            json={"model_path": DEFAULT_MODEL_NAME_FOR_TEST},
+        )
+
+        # check if the response is 200
+        assert response.status_code == 200
 
 
 if __name__ == "__main__":

--- a/test/srt/test_data_parallelism.py
+++ b/test/srt/test_data_parallelism.py
@@ -1,5 +1,8 @@
+import time
 import unittest
 from types import SimpleNamespace
+
+import requests
 
 from sglang.srt.utils import kill_child_process
 from sglang.test.run_eval import run_eval
@@ -9,8 +12,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     popen_launch_server,
 )
-import requests
-import time
+
 
 class TestDataParallelism(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix https://github.com/sgl-project/sglang/issues/1814

In the current DP, when we call update weights

1. tokenizer sends a req to dp controller 
2. dp controller sends reqs to "all" schedulers
3. scheduler updates weights and send response to detokenizer
4. "all" dokenizer sends response to tokenizer


However, the current code assumes there is only one response from the detokenizer. When multiple responses come, it set result on the the same future for many times, causing `asyncio.exceptions.InvalidStateError` and hangs the event loop (async event loop does not crash by default)

```
>>> import asyncio
>>> future = asyncio.Future()
>>> future.set_result("First result")
>>> future.set_result("Sec result")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
asyncio.exceptions.InvalidStateError: invalid state
>>> 
```

## Modifications

<!-- Describe the changes made in this PR. -->

1. Handle dp > 1 separately
2. Create a tmp list to aggregate all responses
3. When all responses are collected, set the future

## Test

Add a test that would fail without this fix

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.