### PR TITLE
Remove delay after cancelled streaming requests are aborted

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -597,7 +597,6 @@ class TokenizerManager:
     def create_abort_task(self, obj: GenerateReqInput):
         # Abort the request if the client is disconnected.
         async def abort_request():
-            await asyncio.sleep(1)
             if obj.is_single:
                 self.abort_request(obj.rid)
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The purpose of this PR is to reduce wasted compute on cancelled streaming requests

## Modifications

<!-- Describe the changes made in this PR. -->
In this PR I removed the `asyncio.sleep` in the `StreamingResponse` `BackgroundTasks` so that the `abort_request` is sent immediately after a request is cancelled/completed

## Checklist

- [X] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [X] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
  - It doesn't seem necessary (provided benchmarking below) 
- [X] Update documentation as needed, including docstrings or example tutorials.

## Benchmarking

I ran this before/after building from source with/without this PR's change:
```
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 500 --random-input 1024 --random-output 1024 --random-range-ratio 0.5
```
... and received very comparable results.

Before my change:
<img width="308" alt="1s-delay-stream" src="https://github.com/user-attachments/assets/f222a849-1dfb-4b07-937e-2441ff14053a">
After my change:
<img width="308" alt="no-delay-stream" src="https://github.com/user-attachments/assets/8d1c6a78-9af6-4da3-9218-784f686bee27">

