### PR TITLE
[FP8 KV Cache, Mixtral] Avoid KeyError at loading pre-quantized FP8 m…

### DIFF
--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -369,6 +369,9 @@ class MixtralForCausalLM(nn.Module):
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
                         continue
+                    # Skip loading kv_scale from ckpts towards new design.
+                    if name.endswith(".kv_scale") and name not in params_dict:
+                        continue
                     if name is None:
                         continue
 


### PR DESCRIPTION
…odel with kv_scale

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Reuse FP8 quantized Mixtral models, to avoid KeyError, just skip/ignore `kv_scale` for now.
E.g. `amd/Mixtral-8x7B-Instruct-v0.1-FP8-KV` has `kv_scale` embedded, run following command to ignore them for now.
`python -m sglang.bench_latency --model amd/Mixtral-8x7B-Instruct-v0.1-FP8-KV --tp 8 --batch-size 32 --input 1024 --output 256 --quant fp8`

Similar run command to `neuralmagic/Mixtral-8x7B-Instruct-v0.1-FP8`

## Modifications

Skip loading named parameter ends with `.kv_scale`.
None scaled FP8 kv cache still works, just add `--kv-cache-dtype fp8_e5m2`
Later, we will revisit this as part of e4m3, etc. format kv scaling design.

## Checklist

- [+] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [+] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [+] Update documentation as needed, including docstrings or example tutorials.