### PR TITLE
[Performance, Triton Kernel Args] _decode_grouped_softmax_reducev_fwd…

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -24,6 +24,7 @@ It supports page size = 1.
 import triton
 import triton.language as tl
 
+from sglang.srt.utils import is_hip
 
 @triton.jit
 def tanh(x):
@@ -553,6 +554,12 @@ def _decode_grouped_softmax_reducev_fwd(
     Lv = v_buffer.shape[-1]
     BLOCK_DMODEL = triton.next_power_of_2(Lv)
 
+    extra_kargs = {}
+    if is_hip():
+        # https://rocm.docs.amd.com/en/docs-6.2.0/how-to/llm-fine-tuning-optimization/optimizing-triton-kernel.html
+        # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
+        extra_kargs = {"waves_per_eu": 4, "matrix_instr_nonkdim": 16, "kpack": 2}
+
     _fwd_grouped_kernel_stage2[grid](
         logits,
         v_buffer,
@@ -575,6 +582,7 @@ def _decode_grouped_softmax_reducev_fwd(
         Lv=Lv,
         num_warps=num_warps,
         num_stages=1,
+        **extra_kargs,
     )
 
 

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -26,6 +26,7 @@ import triton.language as tl
 
 from sglang.srt.utils import is_hip
 
+
 @triton.jit
 def tanh(x):
     # Tanh is just a scaled sigmoid


### PR DESCRIPTION
… speedup on ROCm

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Speedup `_decode_grouped_softmax_reducev_fwd`.
Test shows ~1.0% improvement to median decode throughput on MI300x with Grok-1 and FP8 (b32/i1024/o256)

## Modifications

Setting optimal kernel arguments to `_fwd_grouped_kernel_stage2` on ROCm.

## Checklist

- [+] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [+] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [+] Update documentation as needed, including docstrings or example tutorials.