### PR TITLE
Fix issue with `stop_token_ids` not being iterable.

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -26,7 +26,7 @@ class SamplingParams:
         max_new_tokens: int = 128,
         min_new_tokens: int = 0,
         stop: Optional[Union[str, List[str]]] = None,
-        stop_token_ids: Optional[List[int]] = None,
+        stop_token_ids: Optional[List[int]] = [],
         temperature: float = 1.0,
         top_p: float = 1.0,
         top_k: int = -1,
@@ -50,10 +50,7 @@ class SamplingParams:
         self.presence_penalty = presence_penalty
         self.repetition_penalty = repetition_penalty
         self.stop_strs = stop
-        if stop_token_ids:
-            self.stop_token_ids = set(stop_token_ids)
-        else:
-            self.stop_token_ids = None
+        self.stop_token_ids = set(stop_token_ids)
         self.max_new_tokens = max_new_tokens
         self.min_new_tokens = min_new_tokens
         self.ignore_eos = ignore_eos


### PR DESCRIPTION
## Motivation

Prevent `'Nonetype' object is not iterable' from being thrown on line 141 after instantiating `SamplingParams` without a `stop_token_ids` list and calling `to_srt_kwargs`. Since the documentation states that the default value is an empty list, there should be no problem in `self.stop_token_ids` being an empty set if not initial list is provided.

## Modifications

Made `self.stop_token_ids` be an empty set is no list of stop token ids is provided.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
  - No unit tests appear to be necessary, although I can add if you notice something missing.
- [x] Update documentation as needed, including docstrings or example tutorials.
  - The [sampling params documentation](https://github.com/sgl-project/sglang/blob/main/docs/references/sampling_params.md) already had the empty list as the default value.