### PR TITLE
Escape backwards slash

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -305,7 +305,7 @@ def execute_shell_command(command: str) -> subprocess.Popen:
     Execute a shell command and return the process handle
 
     Args:
-        command: Shell command as a string (can include \ line continuations)
+        command: Shell command as a string (can include \\ line continuations)
     Returns:
         subprocess.Popen: Process handle
     """


### PR DESCRIPTION
## Motivation

Attempting to import sglang caused a syntax error.

```python
>>> import sglang
/root/sglang/python/sglang/utils.py:304: SyntaxWarning: invalid escape sequence '\ '
```

## Modifications

Escaped the backwards slash with another backwards slash.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.