### PR TITLE
Simplify prometheus metrics

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -31,7 +31,6 @@ ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 
 import dataclasses
 import logging
-import time
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -256,14 +255,8 @@ class Req:
         self.mrope_position_delta = []  # use mutable object
 
         # Lifetime traces
-        # time when request is created and added to waitlist
-        self.created_time = None
-        # time when request is added to prefill batch
-        self.queued_time = None
-        # time when request is being processed
-        self.started_time = None
-        # time when request is finished
-        self.finished_time = None
+        # time when request is created, started, and finished
+        self.created_time = self.started_time = self.finished_time = None
 
     # whether request reached finished condition
     def finished(self) -> bool:
@@ -1037,10 +1030,6 @@ class ScheduleBatch:
             f"ScheduleBatch(forward_mode={self.forward_mode.name}, "
             f"#req={(len(self.reqs))})"
         )
-
-    def mark_reqs_started(self):
-        for req in self.reqs:
-            req.started_time = time.time()
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -254,10 +254,6 @@ class Req:
         # For Qwen2-VL
         self.mrope_position_delta = []  # use mutable object
 
-        # Lifetime traces
-        # time when request is created, started, and finished
-        self.created_time = self.started_time = self.finished_time = None
-
     # whether request reached finished condition
     def finished(self) -> bool:
         return self.finished_reason is not None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 import os
 import random
-import time
 from collections import defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
@@ -307,7 +306,6 @@ class PrefillAdder:
             ):
                 # Non-chunked prefill
                 self.can_run_list.append(req)
-                req.queued_time = time.time()
                 self.tree_cache.inc_lock_ref(req.last_node)
                 self._prefill_one_req(
                     prefix_len,
@@ -326,7 +324,6 @@ class PrefillAdder:
                 req.extend_input_len = trunc_len
                 req.fill_ids = req.fill_ids[: len(req.prefix_indices) + trunc_len]
                 self.can_run_list.append(req)
-                req.queued_time = time.time()
                 self.new_inflight_req = req
                 self.tree_cache.inc_lock_ref(req.last_node)
                 self._prefill_one_req(prefix_len, trunc_len, 0)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -62,8 +62,7 @@ from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.managers.tp_worker_overlap_thread import TpModelWorkerClient
 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 from sglang.srt.mem_cache.radix_cache import RadixCache
-from sglang.srt.metrics.metrics_collector import PrometheusMetricsCollector
-from sglang.srt.metrics.metrics_types import Stats
+from sglang.srt.metrics.collector import SchedulerMetricsCollector, SchedulerStats
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import (
     broadcast_pyobj,
@@ -296,9 +295,9 @@ class Scheduler:
             )
 
         # Init metrics stats
-        self.stats = Stats()
+        self.stats = SchedulerStats()
         if self.enable_metrics:
-            self.metrics_collector = PrometheusMetricsCollector(
+            self.metrics_collector = SchedulerMetricsCollector(
                 labels={
                     "model_name": self.server_args.served_model_name,
                     # TODO: Add lora name/path in the future,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -715,7 +715,7 @@ class Scheduler:
 
         # Print stats
         if self.tp_rank == 0:
-            self.log_prefill_stats()
+            self.log_prefill_stats(adder, can_run_list, running_bs, has_inflight)
 
         # Create a new batch
         new_batch = ScheduleBatch.init_new(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -303,7 +303,6 @@ class Scheduler:
                     "model_name": self.server_args.served_model_name,
                     # TODO: Add lora name/path in the future,
                 },
-                context_len=self.model_config.context_len,
             )
 
     def watchdog_thread(self):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -554,7 +554,7 @@ class TokenizerManager:
 
                 if self.enable_metrics:
                     if state.first_token_time is None:
-                        self.metrics_collector.observe_e2e_request_latency(
+                        self.metrics_collector.observe_time_to_first_token(
                             time.time() - state.created_time
                         )
                         state.first_token_time = time.time()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -574,6 +574,10 @@ class TokenizerManager:
                         self.metrics_collector.observe_e2e_request_latency(
                             time.time() - state.created_time
                         )
+                        self.metrics_collector.observe_time_per_output_token(
+                            (time.time() - state.created_time)
+                            / recv_obj.meta_info[i]["completion_tokens"]
+                        )
 
     def convert_logprob_style(
         self,

--- a/python/sglang/srt/metrics/func_timer.py
+++ b/python/sglang/srt/metrics/func_timer.py
@@ -13,44 +13,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-"""Metrics Types"""
+"""
+Records the latency of some functions
+"""
 
 import asyncio
-import logging
 import time
-from dataclasses import dataclass, field
 from functools import wraps
 from typing import Any, Callable, List, Optional
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass
-class Stats:
-    num_running_reqs: int = 0
-    num_used_tokens: int = 0
-    token_usage: float = 0.0
-    gen_throughput: float = 0.0
-    num_queue_reqs: int = 0
-    cache_hit_rate: float = 0.0
-
-    prompt_tokens_total: int = 0
-    generation_tokens_total: int = 0
-
-    time_to_first_token_list: List[float] = field(default_factory=list)
-    time_per_output_token_list: List[float] = field(default_factory=list)
-    e2e_request_latency_list: List[float] = field(default_factory=list)
-
 
 enable_metrics = False
 
 
-def set_enable_metrics(value: bool):
+def enable_func_timer():
     # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
     from prometheus_client import Histogram
 
     global enable_metrics, FUNC_LATENCY
-    enable_metrics = value
+    enable_metrics = True
 
     FUNC_LATENCY = Histogram(
         "sglang:func_latency_seconds",

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -15,374 +15,60 @@ limitations under the License.
 
 """Utilities for Prometheus Metrics Collection."""
 
-import logging
-from abc import ABC, abstractmethod
 from typing import Counter as CollectionsCounter
 from typing import Dict, List, Union
 
-import numpy as np
 from prometheus_client import Counter, Gauge, Histogram
 
 from sglang.srt.metrics.metrics_types import Stats
 
 
-class Metrics:
-    """
-    SGLang Metrics
-    """
+class PrometheusMetricsCollector:
 
-    def __init__(self, labelnames: List[str], max_model_len):
+    def __init__(self, labels: Dict[str, str], context_len: int) -> None:
+        self.labels = labels
 
-        # Configuration Stats
-        self.max_total_num_tokens = Gauge(
-            name="sglang:max_total_num_tokens",
-            documentation="Maximum total number of tokens",
-            labelnames=labelnames,
-            multiprocess_mode="min",
-        )  # static across processes
-
-        self.max_prefill_tokens = Gauge(
-            name="sglang:max_prefill_tokens",
-            documentation="Maximum prefill tokens",
-            labelnames=labelnames,
-            multiprocess_mode="min",
-        )  # static across processes
-
-        self.max_running_requests = Gauge(
-            name="sglang:max_running_requests",
-            documentation="Maximum running requests",
-            labelnames=labelnames,
-            multiprocess_mode="min",
-        )  # static across processes
-
-        self.context_len = Gauge(
-            name="sglang:context_len",
-            documentation="Context length",
-            labelnames=labelnames,
-            multiprocess_mode="min",
-        )  # static across processes
-        # Decode Stats
-        self.num_running_sys = Gauge(
-            name="sglang:num_requests_running",
-            documentation="Number of requests currently running on GPU",
-            labelnames=labelnames,
+        self.num_running_reqs = Gauge(
+            name="sglang:num_running_reqs",
+            documentation="The number of running requests",
+            labelnames=labels,
             multiprocess_mode="sum",
         )
-        self.num_waiting_sys = Gauge(
-            name="sglang:num_requests_waiting",
-            documentation="Number of requests waiting to be processed.",
-            labelnames=labelnames,
+
+        self.num_used_tokens = Gauge(
+            name="sglang:num_used_tokens",
+            documentation="The number of used tokens",
+            labelnames=labels,
             multiprocess_mode="sum",
         )
-        self.gen_throughput = Gauge(
-            name="sglang:gen_throughput",
-            documentation="Gen token throughput (token/s)",
-            labelnames=labelnames,
-            multiprocess_mode="sum",
-        )
+
         self.token_usage = Gauge(
             name="sglang:token_usage",
-            documentation="Total token usage",
-            labelnames=labelnames,
-            multiprocess_mode="sum",
+            documentation="The token usage",
+            labelnames=labels,
+            multiprocess_mode="mostrecent",
         )
-        # System Stats
-        #   KV Cache Usage in %
-        # self.gpu_cache_usage_sys = Gauge(
-        #     "gpu_cache_usage_perc",
-        #     "GPU KV-cache usage. 1 means 100 percent usage.",
-        #     labelnames=labelnames,
-        #     multiprocess_mode="sum")
 
-        self.new_seq = Gauge(
-            name="sglang:new_seq",
-            documentation="Number of new sequences",
-            labelnames=labelnames,
+        self.gen_throughput = Gauge(
+            name="sglang:gen_throughput",
+            documentation="The generate throughput (token/s)",
+            labelnames=labels,
             multiprocess_mode="sum",
         )
-        self.new_token = Gauge(
-            name="sglang:new_token",
-            documentation="Number of new token",
-            labelnames=labelnames,
+
+        self.num_queue_reqs = Gauge(
+            name="sglang:num_queue_reqs",
+            documentation="The number of requests in the waiting queue",
+            labelnames=labels,
             multiprocess_mode="sum",
         )
-        #   Prefix caching block hit rate
-        self.cached_token = Gauge(
-            name="sglang:cached_token",
-            documentation="Number of cached token",
-            labelnames=labelnames,
-            multiprocess_mode="sum",
-        )
+
         self.cache_hit_rate = Gauge(
             name="sglang:cache_hit_rate",
-            documentation="Cache hit rate",
-            labelnames=labelnames,
-            multiprocess_mode="sum",
+            documentation="The cache hit rate",
+            labelnames=labels,
+            multiprocess_mode="mostrecent",
         )
-        self.queue_req = Gauge(
-            name="sglang:queue_req",
-            documentation="Number of queued requests",
-            labelnames=labelnames,
-            multiprocess_mode="sum",
-        )
-
-        # Iteration stats
-        self.counter_prompt_tokens = Counter(
-            name="sglang:prompt_tokens_total",
-            documentation="Number of prefill tokens processed.",
-            labelnames=labelnames,
-        )
-        self.counter_generation_tokens = Counter(
-            name="sglang:generation_tokens_total",
-            documentation="Number of generation tokens processed.",
-            labelnames=labelnames,
-        )
-        self.histogram_time_to_first_token = Histogram(
-            name="sglang:time_to_first_token_seconds",
-            documentation="Histogram of time to first token in seconds.",
-            labelnames=labelnames,
-            buckets=[
-                0.001,
-                0.005,
-                0.01,
-                0.02,
-                0.04,
-                0.06,
-                0.08,
-                0.1,
-                0.25,
-                0.5,
-                0.75,
-                1.0,
-                2.5,
-                5.0,
-                7.5,
-                10.0,
-                15.0,
-                20.0,
-                25.0,
-                30.0,
-            ],
-        )
-        self.histogram_time_per_output_token = Histogram(
-            name="sglang:time_per_output_token_seconds",
-            documentation="Histogram of time per output token in seconds.",
-            labelnames=labelnames,
-            buckets=[
-                0.005,
-                0.01,
-                0.015,
-                0.02,
-                0.025,
-                0.03,
-                0.04,
-                0.05,
-                0.075,
-                0.1,
-                0.15,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.75,
-                1.0,
-                2.5,
-            ],
-        )
-
-        # Request Stats
-        #   Metadata
-        self.num_prompt_tokens_requests = Histogram(
-            name="sglang:request_prompt_tokens",
-            documentation="Number of prefill tokens processed",
-            labelnames=labelnames,
-            buckets=build_1_2_5_buckets(max_model_len),
-        )
-        self.num_generation_tokens_requests = Histogram(
-            name="sglang:request_generation_tokens",
-            documentation="Number of generation tokens processed.",
-            labelnames=labelnames,
-            buckets=build_1_2_5_buckets(max_model_len),
-        )
-        self.finished_reason_requests = Counter(
-            name="sglang:request_success_total",
-            documentation="Count of successfully processed requests.",
-            labelnames=labelnames + ["finished_reason"],
-        )
-        self.histogram_time_e2e_requests = Histogram(
-            name="sglang:e2e_request_latency_seconds",
-            documentation="Histogram of End-to-end request latency in seconds",
-            labelnames=labelnames,
-            buckets=[
-                0.3,
-                0.5,
-                0.8,
-                1.0,
-                1.5,
-                2.0,
-                2.5,
-                5.0,
-                10.0,
-                15.0,
-                20.0,
-                30.0,
-                40.0,
-                50.0,
-                60.0,
-            ],
-        )
-        self.histogram_time_waiting_requests = Histogram(
-            name="sglang:waiting_request_latency_seconds",
-            documentation="Histogram of request waiting time in seconds",
-            labelnames=labelnames,
-            buckets=[
-                0.3,
-                0.5,
-                0.8,
-                1.0,
-                1.5,
-                2.0,
-                2.5,
-                5.0,
-                10.0,
-                15.0,
-                20.0,
-                30.0,
-                40.0,
-                50.0,
-                60.0,
-            ],
-        )
-        self.histogram_time_decode_requests = Histogram(
-            name="sglang:decode_request_latency_seconds",
-            documentation="Histogram of request decoding time in seconds",
-            labelnames=labelnames,
-            buckets=[
-                0.3,
-                0.5,
-                0.8,
-                1.0,
-                1.5,
-                2.0,
-                2.5,
-                5.0,
-                10.0,
-                15.0,
-                20.0,
-                30.0,
-                40.0,
-                50.0,
-                60.0,
-            ],
-        )
-
-
-class MetricsCollector(ABC):
-    """
-    SGLang Metrics Collector
-    """
-
-    @abstractmethod
-    def log_stats(self, stats: Stats) -> None:
-        pass
-
-
-class PrometheusMetricsCollector(MetricsCollector):
-    """
-    SGLang Metrics Collector
-    """
-
-    def __init__(self, labels: Dict[str, str], max_model_len: int) -> None:
-        self.labels = labels
-        self.metrics = Metrics(
-            labelnames=list(labels.keys()), max_model_len=max_model_len
-        )
-
-    def _log_gauge(self, gauge, data: Union[int, float]) -> None:
-        # Convenience function for logging to gauge.
-        gauge.labels(**self.labels).set(data)
-
-    def _log_counter(self, counter, data: Union[int, float]) -> None:
-        # Convenience function for logging to counter.
-        counter.labels(**self.labels).inc(data)
-
-    def _log_counter_labels(
-        self, counter, data: CollectionsCounter, label_key: str
-    ) -> None:
-        # Convenience function for collection counter of labels.
-        for label, count in data.items():
-            counter.labels(**{**self.labels, label_key: label}).inc(count)
-
-    def _log_histogram(self, histogram, data: Union[List[int], List[float]]) -> None:
-        # Convenience function for logging list to histogram.
-        for datum in data:
-            histogram.labels(**self.labels).observe(datum)
 
     def log_stats(self, stats: Stats) -> None:
-        self._log_gauge(self.metrics.max_total_num_tokens, stats.max_total_num_tokens)
-        self._log_gauge(self.metrics.max_prefill_tokens, stats.max_prefill_tokens)
-        self._log_gauge(self.metrics.max_running_requests, stats.max_running_requests)
-        self._log_gauge(self.metrics.context_len, stats.context_len)
-        self._log_histogram(
-            self.metrics.num_prompt_tokens_requests, stats.num_prompt_tokens_requests
-        )
-        self._log_histogram(
-            self.metrics.num_generation_tokens_requests,
-            stats.num_generation_tokens_requests,
-        )
-
-        self._log_counter(
-            self.metrics.counter_prompt_tokens, stats.num_prompt_tokens_iter
-        )
-        self._log_counter(
-            self.metrics.counter_generation_tokens, stats.num_generation_tokens_iter
-        )
-        self._log_histogram(
-            self.metrics.histogram_time_to_first_token, stats.time_to_first_tokens_iter
-        )
-        self._log_histogram(
-            self.metrics.histogram_time_per_output_token,
-            stats.time_per_output_tokens_iter,
-        )
-
-        # self._log_gauge(self.metrics.gpu_cache_usage_sys, stats.gpu_cache_usage_sys)
-        self._log_gauge(self.metrics.num_running_sys, stats.num_running_req)
-        self._log_gauge(self.metrics.num_waiting_sys, stats.num_waiting_req)
-        self._log_gauge(self.metrics.gen_throughput, stats.gen_throughput)
-        self._log_gauge(self.metrics.token_usage, stats.token_usage)
-        self._log_histogram(
-            self.metrics.histogram_time_e2e_requests, stats.time_e2e_requests
-        )
-        self._log_histogram(
-            self.metrics.histogram_time_waiting_requests, stats.time_waiting_requests
-        )
-        self._log_histogram(
-            self.metrics.histogram_time_decode_requests, stats.time_decode_requests
-        )
-        self._log_gauge(self.metrics.new_seq, stats.new_seq)
-        self._log_gauge(self.metrics.new_token, stats.new_token)
-        self._log_gauge(self.metrics.cached_token, stats.cached_token)
-        self._log_gauge(self.metrics.cache_hit_rate, stats.cache_hit_rate)
-        self._log_gauge(self.metrics.queue_req, stats.queue_req)
-
-
-def build_1_2_5_buckets(max_value: int) -> List[int]:
-    """
-    Builds a list of buckets with increasing powers of 10 multiplied by
-    mantissa values (1, 2, 5) until the value exceeds the specified maximum.
-
-    Example:
-    >>> build_1_2_5_buckets(100)
-    [1, 2, 5, 10, 20, 50, 100]
-    """
-    mantissa_lst = [1, 2, 5]
-    exponent = 0
-    buckets: List[int] = []
-    while True:
-        for m in mantissa_lst:
-            value = m * 10**exponent
-            if value <= max_value:
-                buckets.append(value)
-            else:
-                return buckets
-        exponent += 1
+        self.num_running_reqs.set(stats.num_running_reqs)

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -23,7 +23,7 @@ from sglang.srt.metrics.metrics_types import Stats
 class PrometheusMetricsCollector:
 
     def __init__(self, labels: Dict[str, str], context_len: int) -> None:
-        # We need to import this one after the environment variable `PROMETHEUS_MULTIPROC_DIR` is set
+        # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
         from prometheus_client import Counter, Gauge, Histogram
 
         self.labels = labels

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -71,4 +71,9 @@ class PrometheusMetricsCollector:
         )
 
     def log_stats(self, stats: Stats) -> None:
-        self.num_running_reqs.set(stats.num_running_reqs)
+        self.num_running_reqs.labels(**self.labels).set(stats.num_running_reqs)
+        self.num_used_tokens.labels(**self.labels).set(stats.num_used_tokens)
+        self.token_usage.labels(**self.labels).set(stats.token_usage)
+        self.gen_throughput.labels(**self.labels).set(stats.gen_throughput)
+        self.num_queue_reqs.labels(**self.labels).set(stats.num_queue_reqs)
+        self.cache_hit_rate.labels(**self.labels).set(stats.cache_hit_rate)

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -15,14 +15,15 @@ limitations under the License.
 
 """Utilities for Prometheus Metrics Collection."""
 
-from typing import Dict
+from typing import Counter as CollectionsCounter
+from typing import Dict, List, Union
 
 from sglang.srt.metrics.metrics_types import Stats
 
 
 class PrometheusMetricsCollector:
 
-    def __init__(self, labels: Dict[str, str], context_len: int) -> None:
+    def __init__(self, labels: Dict[str, str]) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
         from prometheus_client import Counter, Gauge, Histogram
 
@@ -70,10 +71,123 @@ class PrometheusMetricsCollector:
             multiprocess_mode="mostrecent",
         )
 
+        self.prompt_tokens_total = Gauge(
+            name="sglang:prompt_tokens_total",
+            documentation="Number of prefill tokens processed.",
+            labelnames=labels.keys(),
+            multiprocess_mode="sum",
+        )
+
+        self.generation_tokens_total = Gauge(
+            name="sglang:generation_tokens_total",
+            documentation="Number of generation tokens processed.",
+            labelnames=labels.keys(),
+            multiprocess_mode="sum",
+        )
+
+        self.histogram_time_to_first_token = Histogram(
+            name="sglang:time_to_first_token_seconds",
+            documentation="Histogram of time to first token in seconds.",
+            labelnames=labels.keys(),
+            buckets=[
+                0.001,
+                0.005,
+                0.01,
+                0.02,
+                0.04,
+                0.06,
+                0.08,
+                0.1,
+                0.25,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+                5.0,
+                7.5,
+                10.0,
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+            ],
+        )
+
+        self.histogram_time_per_output_token = Histogram(
+            name="sglang:time_per_output_token_seconds",
+            documentation="Histogram of time per output token in seconds.",
+            labelnames=labels.keys(),
+            buckets=[
+                0.005,
+                0.01,
+                0.015,
+                0.02,
+                0.025,
+                0.03,
+                0.04,
+                0.05,
+                0.075,
+                0.1,
+                0.15,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                0.75,
+                1.0,
+                2.5,
+            ],
+        )
+
+        self.histogram_e2e_request_latency = Histogram(
+            name="sglang:e2e_request_latency_seconds",
+            documentation="Histogram of End-to-end request latency in seconds",
+            labelnames=labels.keys(),
+            buckets=[
+                0.3,
+                0.5,
+                0.8,
+                1.0,
+                1.5,
+                2.0,
+                2.5,
+                5.0,
+                10.0,
+                15.0,
+                20.0,
+                30.0,
+                40.0,
+                50.0,
+                60.0,
+            ],
+        )
+
+    def _log_gauge(self, gauge, data: Union[int, float]) -> None:
+        # Convenience function for logging to gauge.
+        gauge.labels(**self.labels).set(data)
+
+    def _log_histogram(self, histogram, data: Union[List[int], List[float]]) -> None:
+        # Convenience function for logging list to histogram.
+        for datum in data:
+            histogram.labels(**self.labels).observe(datum)
+
     def log_stats(self, stats: Stats) -> None:
-        self.num_running_reqs.labels(**self.labels).set(stats.num_running_reqs)
-        self.num_used_tokens.labels(**self.labels).set(stats.num_used_tokens)
-        self.token_usage.labels(**self.labels).set(stats.token_usage)
-        self.gen_throughput.labels(**self.labels).set(stats.gen_throughput)
-        self.num_queue_reqs.labels(**self.labels).set(stats.num_queue_reqs)
-        self.cache_hit_rate.labels(**self.labels).set(stats.cache_hit_rate)
+        self._log_gauge(self.num_running_reqs, stats.num_running_reqs)
+        self._log_gauge(self.num_used_tokens, stats.num_used_tokens)
+        self._log_gauge(self.token_usage, stats.token_usage)
+        self._log_gauge(self.gen_throughput, stats.gen_throughput)
+        self._log_gauge(self.num_queue_reqs, stats.num_queue_reqs)
+        self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+
+        self._log_gauge(self.prompt_tokens_total, stats.prompt_tokens_total)
+        self._log_gauge(self.generation_tokens_total, stats.generation_tokens_total)
+
+        self._log_histogram(
+            self.histogram_time_to_first_token, stats.time_to_first_token_list
+        )
+        self._log_histogram(
+            self.histogram_time_per_output_token, stats.time_per_output_token_list
+        )
+        self._log_histogram(
+            self.histogram_e2e_request_latency, stats.e2e_request_latency_list
+        )

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -15,10 +15,7 @@ limitations under the License.
 
 """Utilities for Prometheus Metrics Collection."""
 
-from typing import Counter as CollectionsCounter
-from typing import Dict, List, Union
-
-from prometheus_client import Counter, Gauge, Histogram
+from typing import Dict
 
 from sglang.srt.metrics.metrics_types import Stats
 
@@ -26,47 +23,50 @@ from sglang.srt.metrics.metrics_types import Stats
 class PrometheusMetricsCollector:
 
     def __init__(self, labels: Dict[str, str], context_len: int) -> None:
+        # We need to import this one after the environment variable `PROMETHEUS_MULTIPROC_DIR` is set
+        from prometheus_client import Counter, Gauge, Histogram
+
         self.labels = labels
 
         self.num_running_reqs = Gauge(
             name="sglang:num_running_reqs",
             documentation="The number of running requests",
-            labelnames=labels,
+            labelnames=list(labels.keys()),
             multiprocess_mode="sum",
         )
 
         self.num_used_tokens = Gauge(
             name="sglang:num_used_tokens",
             documentation="The number of used tokens",
-            labelnames=labels,
+            labelnames=list(labels.keys()),
             multiprocess_mode="sum",
         )
 
         self.token_usage = Gauge(
             name="sglang:token_usage",
             documentation="The token usage",
-            labelnames=labels,
+            labelnames=list(labels.keys()),
             multiprocess_mode="mostrecent",
         )
 
         self.gen_throughput = Gauge(
             name="sglang:gen_throughput",
             documentation="The generate throughput (token/s)",
-            labelnames=labels,
+            labelnames=list(labels.keys()),
             multiprocess_mode="sum",
         )
 
         self.num_queue_reqs = Gauge(
             name="sglang:num_queue_reqs",
             documentation="The number of requests in the waiting queue",
-            labelnames=labels,
+            labelnames=list(labels.keys()),
             multiprocess_mode="sum",
         )
 
         self.cache_hit_rate = Gauge(
             name="sglang:cache_hit_rate",
             documentation="The cache hit rate",
-            labelnames=labels,
+            labelnames=list(labels.keys()),
             multiprocess_mode="mostrecent",
         )
 

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -15,7 +15,6 @@ limitations under the License.
 
 """Utilities for Prometheus Metrics Collection."""
 
-from typing import Counter as CollectionsCounter
 from typing import Dict, List, Union
 
 from sglang.srt.metrics.metrics_types import Stats
@@ -25,7 +24,7 @@ class PrometheusMetricsCollector:
 
     def __init__(self, labels: Dict[str, str]) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
-        from prometheus_client import Counter, Gauge, Histogram
+        from prometheus_client import Gauge, Histogram
 
         self.labels = labels
 

--- a/python/sglang/srt/metrics/metrics_collector.py
+++ b/python/sglang/srt/metrics/metrics_collector.py
@@ -31,42 +31,42 @@ class PrometheusMetricsCollector:
         self.num_running_reqs = Gauge(
             name="sglang:num_running_reqs",
             documentation="The number of running requests",
-            labelnames=list(labels.keys()),
+            labelnames=labels.keys(),
             multiprocess_mode="sum",
         )
 
         self.num_used_tokens = Gauge(
             name="sglang:num_used_tokens",
             documentation="The number of used tokens",
-            labelnames=list(labels.keys()),
+            labelnames=labels.keys(),
             multiprocess_mode="sum",
         )
 
         self.token_usage = Gauge(
             name="sglang:token_usage",
             documentation="The token usage",
-            labelnames=list(labels.keys()),
+            labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
 
         self.gen_throughput = Gauge(
             name="sglang:gen_throughput",
             documentation="The generate throughput (token/s)",
-            labelnames=list(labels.keys()),
+            labelnames=labels.keys(),
             multiprocess_mode="sum",
         )
 
         self.num_queue_reqs = Gauge(
             name="sglang:num_queue_reqs",
             documentation="The number of requests in the waiting queue",
-            labelnames=list(labels.keys()),
+            labelnames=labels.keys(),
             multiprocess_mode="sum",
         )
 
         self.cache_hit_rate = Gauge(
             name="sglang:cache_hit_rate",
             documentation="The cache hit rate",
-            labelnames=list(labels.keys()),
+            labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
 

--- a/python/sglang/srt/metrics/metrics_types.py
+++ b/python/sglang/srt/metrics/metrics_types.py
@@ -18,7 +18,7 @@ limitations under the License.
 import asyncio
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import wraps
 from typing import Any, Callable, List, Optional
 
@@ -33,6 +33,13 @@ class Stats:
     gen_throughput: float = 0.0
     num_queue_reqs: int = 0
     cache_hit_rate: float = 0.0
+
+    prompt_tokens_total: int = 0
+    generation_tokens_total: int = 0
+
+    time_to_first_token_list: List[float] = field(default_factory=list)
+    time_per_output_token_list: List[float] = field(default_factory=list)
+    e2e_request_latency_list: List[float] = field(default_factory=list)
 
 
 enable_metrics = False

--- a/python/sglang/srt/metrics/metrics_types.py
+++ b/python/sglang/srt/metrics/metrics_types.py
@@ -15,7 +15,14 @@ limitations under the License.
 
 """Metrics Types"""
 
+import asyncio
+import logging
+import time
 from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Callable, List
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -26,3 +33,90 @@ class Stats:
     gen_throughput: float = 0.0
     num_queue_reqs: int = 0
     cache_hit_rate: float = 0.0
+
+
+enable_metrics = False
+
+
+def set_enable_metrics(value: bool):
+    # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
+    from prometheus_client import Histogram
+
+    global enable_metrics, FUNC_LATENCY
+    enable_metrics = value
+
+    FUNC_LATENCY = Histogram(
+        "sglang:func_latency_seconds",
+        "Function latency in seconds",
+        # captures latency in range [50ms - ~50s]
+        buckets=exponential_buckets(start=0.05, width=1.5, length=18),
+        labelnames=["name"],
+    )
+
+
+FUNC_LATENCY = None
+
+
+def exponential_buckets(start: float, width: float, length: int) -> List[float]:
+    buckets = []
+    for i in range(length):
+        buckets.append(start * (width**i))
+    return buckets
+
+
+def time_func_latency(*labelvalues: Any, **labelkwargs: Any) -> Callable[..., Any]:
+    """
+    A decorator to measure latency of a function's execution. Supports both sync and async functions.
+
+    NOTE: We invent our own implementation of a timer decorator since prometheus_client does not support async
+    context manager yet.
+
+    Overhead: The overhead introduced here in case of an async function could likely be because of `await` introduced
+    which will return in another coroutine object creation and under heavy load could see longer wall time
+    (scheduling delays due to introduction of another awaitable).
+
+    @param metric: The prometheus histogram to record the time elapsed in.
+    @param labelvalues: The label values to record in the prometheus metric.
+    @param labelkwargs: The label kwargs to record in the prometheus metric.
+
+    @return: A function that wraps the given function and measures its execution time in prometheus metric.
+    """
+
+    def measure(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            if not enable_metrics:
+                return await func(*args, **kwargs)
+
+            metric = FUNC_LATENCY
+            start = time.monotonic()
+            ret = func(*args, **kwargs)
+            if isinstance(ret, asyncio.Future) or asyncio.iscoroutine(ret):
+                try:
+                    ret = await ret
+                finally:
+                    metric.labels(*labelvalues, **labelkwargs).observe(
+                        time.monotonic() - start
+                    )
+            return ret
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            if not enable_metrics:
+                return func(*args, **kwargs)
+
+            metric = FUNC_LATENCY
+            start = time.monotonic()
+            try:
+                ret = func(*args, **kwargs)
+            finally:
+                metric.labels(*labelvalues, **labelkwargs).observe(
+                    time.monotonic() - start
+                )
+            return ret
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return measure

--- a/python/sglang/srt/metrics/metrics_types.py
+++ b/python/sglang/srt/metrics/metrics_types.py
@@ -15,40 +15,14 @@ limitations under the License.
 
 """Metrics Types"""
 
-from dataclasses import dataclass, field
-from typing import List
+from dataclasses import dataclass
 
 
 @dataclass
 class Stats:
-    # config
-    max_total_num_tokens: int = 0
-    max_prefill_tokens: int = 0
-    max_running_requests: int = 0
-    context_len: int = 0
-    # request stats
-    num_prompt_tokens_requests: List[int] = field(default_factory=list)
-    num_generation_tokens_requests: List[int] = field(default_factory=list)
-    finished_reason_requests: List[str] = field(default_factory=list)
-    # decode stats
-    num_running_req: int = 0
-    num_waiting_req: int = 0
-    gen_throughput: float = 0.0
-    waiting_queue: int = 0
-    time_e2e_requests: List[float] = field(default_factory=list)
-    time_waiting_requests: List[float] = field(default_factory=list)
-    time_decode_requests: List[float] = field(default_factory=list)
-    # system stats
+    num_running_reqs: int = 0
+    num_used_tokens: int = 0
     token_usage: float = 0.0
-    new_seq: int = 0
-    new_token: int = 0
-    cached_token: int = 0
+    gen_throughput: float = 0.0
+    num_queue_reqs: int = 0
     cache_hit_rate: float = 0.0
-    running_req: int = 0
-    queue_req: int = 0
-
-    # Iteration stats (should have _iter suffix)
-    num_prompt_tokens_iter: int = 0
-    num_generation_tokens_iter: int = 0
-    time_to_first_tokens_iter: List[float] = field(default_factory=list)
-    time_per_output_tokens_iter: List[float] = field(default_factory=list)

--- a/python/sglang/srt/metrics/metrics_types.py
+++ b/python/sglang/srt/metrics/metrics_types.py
@@ -64,7 +64,9 @@ def exponential_buckets(start: float, width: float, length: int) -> List[float]:
     return buckets
 
 
-def time_func_latency(name: Optional[str] = None) -> Callable[..., Any]:
+def time_func_latency(
+    func: Callable = None, name: Optional[str] = None
+) -> Callable[..., Any]:
     """
     A decorator to observe the latency of a function's execution. Supports both sync and async functions.
 
@@ -74,10 +76,6 @@ def time_func_latency(name: Optional[str] = None) -> Callable[..., Any]:
     Overhead: The overhead introduced here in case of an async function could likely be because of `await` introduced
     which will return in another coroutine object creation and under heavy load could see longer wall time
     (scheduling delays due to introduction of another awaitable).
-
-    @param name: The name of this function
-
-    @return: A function that wraps the given function and measures its execution time in prometheus metric.
     """
 
     def measure(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -117,4 +115,7 @@ def time_func_latency(name: Optional[str] = None) -> Callable[..., Any]:
             return async_wrapper
         return sync_wrapper
 
-    return measure
+    if func:
+        return measure(func)
+    else:
+        return measure

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -56,7 +56,7 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
-from sglang.srt.metrics.metrics_types import set_enable_metrics, time_func_latency
+from sglang.srt.metrics.func_timer import enable_func_timer, time_func_latency
 from sglang.srt.openai_api.adapter import (
     load_chat_template_for_openai_api,
     v1_batches,
@@ -456,7 +456,7 @@ def launch_server(
     # add prometheus middleware
     if server_args.enable_metrics:
         add_prometheus_middleware(app)
-        set_enable_metrics(True)
+        enable_func_timer()
 
     # Send a warmup request
     t = threading.Thread(

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -190,7 +190,7 @@ async def get_memory_pool_size():
 
 
 @app.post("/update_weights")
-@time_func_latency(name="/update_weights")
+@time_func_latency
 async def update_weights(obj: UpdateWeightReqInput, request: Request):
     """Update the weights inplace without re-launching the server."""
     success, message = await tokenizer_manager.update_weights(obj, request)
@@ -207,7 +207,7 @@ async def update_weights(obj: UpdateWeightReqInput, request: Request):
         )
 
 
-@time_func_latency(name="/generate_request")
+@time_func_latency
 async def generate_request(obj: GenerateReqInput, request: Request):
     """Handle a generate request."""
     if obj.stream:
@@ -245,7 +245,7 @@ app.post("/generate")(generate_request)
 app.put("/generate")(generate_request)
 
 
-@time_func_latency(name="/encode")
+@time_func_latency
 async def encode_request(obj: EmbeddingReqInput, request: Request):
     """Handle an embedding request."""
     try:
@@ -261,7 +261,7 @@ app.post("/encode")(encode_request)
 app.put("/encode")(encode_request)
 
 
-@time_func_latency(name="/classify")
+@time_func_latency
 async def classify_request(obj: EmbeddingReqInput, request: Request):
     """Handle a reward model request. Now the arguments and return values are the same as embedding models."""
     try:
@@ -281,19 +281,19 @@ app.put("/classify")(classify_request)
 
 
 @app.post("/v1/completions")
-@time_func_latency(name="/v1/completions")
+@time_func_latency
 async def openai_v1_completions(raw_request: Request):
     return await v1_completions(tokenizer_manager, raw_request)
 
 
 @app.post("/v1/chat/completions")
-@time_func_latency(name="/v1/chat/completions")
+@time_func_latency
 async def openai_v1_chat_completions(raw_request: Request):
     return await v1_chat_completions(tokenizer_manager, raw_request)
 
 
 @app.post("/v1/embeddings", response_class=ORJSONResponse)
-@time_func_latency(name="/v1/embeddings")
+@time_func_latency
 async def openai_v1_embeddings(raw_request: Request):
     response = await v1_embeddings(tokenizer_manager, raw_request)
     return response

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -781,7 +781,7 @@ def set_prometheus_multiproc_dir():
 
 
 def add_prometheus_middleware(app):
-    # We need to import this one after the environment variable `PROMETHEUS_MULTIPROC_DIR` is set
+    # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
     from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess
 
     registry = CollectorRegistry()

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -781,6 +781,7 @@ def set_prometheus_multiproc_dir():
 
 
 def add_prometheus_middleware(app):
+    # We need to import this one after the environment variable `PROMETHEUS_MULTIPROC_DIR` is set
     from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess
 
     registry = CollectorRegistry()

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -22,9 +22,20 @@ class TestEnableMetrics(unittest.TestCase):
         )
 
         try:
-            # Make a request to generate some metrics
+            # Make some requests to generate some metrics
             response = requests.get(f"{DEFAULT_URL_FOR_TEST}/health_generate")
             self.assertEqual(response.status_code, 200)
+
+            response = requests.post(
+                f"{DEFAULT_URL_FOR_TEST}/generate",
+                json={
+                    "text": "The capital of France is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                    },
+                },
+            )
 
             # Get metrics
             metrics_response = requests.get(f"{DEFAULT_URL_FOR_TEST}/metrics")

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -33,6 +33,21 @@ class TestEnableMetrics(unittest.TestCase):
 
             print(f"metrics_content=\n{metrics_content}")
 
+            # Verify essential metrics are present
+            essential_metrics = [
+                "sglang:num_running_reqs",
+                "sglang:token_usage",
+                "sglang:gen_throughput",
+                "sglang:cache_hit_rate",
+            ]
+
+            for metric in essential_metrics:
+                self.assertIn(metric, metrics_content, f"Missing metric: {metric}")
+
+            # Verify model name label is present and correct
+            expected_model_name = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+            self.assertIn(f'model_name="{expected_model_name}"', metrics_content)
+
         finally:
             kill_child_process(process.pid, include_self=True)
 

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -50,6 +50,7 @@ class TestEnableMetrics(unittest.TestCase):
                 "sglang:token_usage",
                 "sglang:gen_throughput",
                 "sglang:cache_hit_rate",
+                "sglang:func_latency_seconds",
             ]
 
             for metric in essential_metrics:
@@ -58,6 +59,11 @@ class TestEnableMetrics(unittest.TestCase):
             # Verify model name label is present and correct
             expected_model_name = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
             self.assertIn(f'model_name="{expected_model_name}"', metrics_content)
+
+            # Verify metrics have values (not empty)
+            self.assertIn("_sum{", metrics_content)
+            self.assertIn("_count{", metrics_content)
+            self.assertIn("_bucket{", metrics_content)
 
         finally:
             kill_child_process(process.pid, include_self=True)

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -46,16 +46,16 @@ class TestEnableMetrics(unittest.TestCase):
 
             # Verify essential metrics are present
             essential_metrics = [
-                "sglang:prompt_tokens_total",
-                "sglang:generation_tokens_total",
                 "sglang:num_running_reqs",
                 "sglang:token_usage",
                 "sglang:gen_throughput",
                 "sglang:cache_hit_rate",
                 "sglang:func_latency_seconds",
-                "sglang:time_to_first_token_seconds",
-                "sglang:time_per_output_token_seconds",
-                "sglang:e2e_request_latency_seconds",
+                "sglang:prompt_tokens_total",
+                "sglang:generation_tokens_total",
+                # "sglang:time_to_first_token_seconds",
+                # "sglang:time_per_output_token_seconds",
+                # "sglang:e2e_request_latency_seconds",
             ]
 
             for metric in essential_metrics:

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -31,29 +31,7 @@ class TestEnableMetrics(unittest.TestCase):
             self.assertEqual(metrics_response.status_code, 200)
             metrics_content = metrics_response.text
 
-            print(f"{metrics_content=}")
-
-            # Verify essential metrics are present
-            essential_metrics = [
-                "sglang:prompt_tokens_total",
-                "sglang:generation_tokens_total",
-                "sglang:max_total_num_tokens",
-                "sglang:context_len",
-                "sglang:time_to_first_token_seconds",
-                "sglang:time_per_output_token_seconds",
-                "sglang:e2e_request_latency_seconds",
-            ]
-
-            for metric in essential_metrics:
-                self.assertIn(metric, metrics_content, f"Missing metric: {metric}")
-
-            # Verify model name label is present and correct
-            expected_model_name = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
-            self.assertIn(f'model_name="{expected_model_name}"', metrics_content)
-            # Verify metrics have values (not empty)
-            self.assertIn("_sum{", metrics_content)
-            self.assertIn("_count{", metrics_content)
-            self.assertIn("_bucket{", metrics_content)
+            print(f"metrics_content=\n{metrics_content}")
 
         finally:
             kill_child_process(process.pid, include_self=True)

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -46,11 +46,16 @@ class TestEnableMetrics(unittest.TestCase):
 
             # Verify essential metrics are present
             essential_metrics = [
+                "sglang:prompt_tokens_total",
+                "sglang:generation_tokens_total",
                 "sglang:num_running_reqs",
                 "sglang:token_usage",
                 "sglang:gen_throughput",
                 "sglang:cache_hit_rate",
                 "sglang:func_latency_seconds",
+                "sglang:time_to_first_token_seconds",
+                "sglang:time_per_output_token_seconds",
+                "sglang:e2e_request_latency_seconds",
             ]
 
             for metric in essential_metrics:

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -34,8 +34,12 @@ class TestEnableMetrics(unittest.TestCase):
                         "temperature": 0,
                         "max_new_tokens": 32,
                     },
+                    "stream": True,
                 },
+                stream=True,
             )
+            for _ in response.iter_lines(decode_unicode=False):
+                pass
 
             # Get metrics
             metrics_response = requests.get(f"{DEFAULT_URL_FOR_TEST}/metrics")

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -53,9 +53,9 @@ class TestEnableMetrics(unittest.TestCase):
                 "sglang:func_latency_seconds",
                 "sglang:prompt_tokens_total",
                 "sglang:generation_tokens_total",
-                # "sglang:time_to_first_token_seconds",
-                # "sglang:time_per_output_token_seconds",
-                # "sglang:e2e_request_latency_seconds",
+                "sglang:time_to_first_token_seconds",
+                "sglang:time_per_output_token_seconds",
+                "sglang:e2e_request_latency_seconds",
             ]
 
             for metric in essential_metrics:


### PR DESCRIPTION
- Reduce the overhead of metrics collection.
- Split the metrics collection into two parts: `SchedulerMetricsCollector` and `TokenizerMetricsCollector`
  - metrics such as TTFT, TPOP, prompt_tokens_total, generation_tokens_total are now collected in `TokenizerManager`.
- Simplify redundant code. Remove unessential metrics.
