### PR TITLE
Specify `zmq` Version Requirement

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = ["requests", "tqdm", "numpy", "IPython"]
 [project.optional-dependencies]
 runtime_common = ["aiohttp", "decord", "fastapi", "hf_transfer", "huggingface_hub", "interegular",
     "orjson", "packaging", "pillow", "prometheus-client>=0.20.0", "psutil", "pydantic", "python-multipart",
-    "torchao", "uvicorn", "uvloop", "zmq",
+    "torchao", "uvicorn", "uvloop", "zmq>=25.1.2",
     "outlines>=0.0.44", "modelscope"]
 srt = ["sglang[runtime_common]", "torch", "vllm==0.6.3.post1"]
 


### PR DESCRIPTION
This PR updates the `python/pyproject.toml` file to specify the version requirement for the `zmq` dependency to be `>=25.1.2` instead of having no version specification.