### PR TITLE
docs: add shm size for docker run

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -34,6 +34,7 @@ Replace `<secret>` below with your huggingface hub [token](https://huggingface.c
 
 ```bash
 docker run --gpus all \
+    --shm-size 32g \
     -p 30000:30000 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     --env "HF_TOKEN=<secret>" \


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This configuration is not mandatory. Under 8B, errors are rare if it's not set up. However, with 70B TP 8, the default setup can cause NCCL errors. It's generally better to explicitly specify shm size in the default configuration.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
