### PR TITLE
Add gen-shared-prefix dataset in bench_serving

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -659,14 +659,14 @@ def sample_generated_shared_prefix_requests(
     input_requests = []
     total_input_tokens = 0
     total_output_tokens = 0
-    
+
     for group_idx in range(num_groups):
         system_prompt = system_prompts[group_idx]
         for prompt_idx in range(prompts_per_group):
             question = questions[group_idx * prompts_per_group + prompt_idx]
             full_prompt = f"{system_prompt}\n\n{question}"
             prompt_len = len(tokenizer.encode(full_prompt))
-            
+
             input_requests.append((full_prompt, prompt_len, output_len))
             total_input_tokens += prompt_len
             total_output_tokens += output_len
@@ -677,10 +677,15 @@ def sample_generated_shared_prefix_requests(
     print(f"Total prompts: {len(input_requests)}")
     print(f"Total input tokens: {total_input_tokens}")
     print(f"Total output tokens: {total_output_tokens}")
-    print(f"Average system prompt length: {sum(len(tokenizer.encode(sp)) for sp in system_prompts) / len(system_prompts):.1f} tokens")
-    print(f"Average question length: {sum(len(tokenizer.encode(q)) for q in questions) / len(questions):.1f} tokens\n")
-    
+    print(
+        f"Average system prompt length: {sum(len(tokenizer.encode(sp)) for sp in system_prompts) / len(system_prompts):.1f} tokens"
+    )
+    print(
+        f"Average question length: {sum(len(tokenizer.encode(q)) for q in questions) / len(questions):.1f} tokens\n"
+    )
+
     return input_requests
+
 
 async def get_request(
     input_requests: List[Tuple[str, int, int]],
@@ -1273,7 +1278,6 @@ if __name__ == "__main__":
         "additional generate params like sampling params.",
     )
 
-
     group = parser.add_argument_group("generated-shared-prefix dataset arguments")
     group.add_argument(
         "--gen-num-groups",
@@ -1282,7 +1286,7 @@ if __name__ == "__main__":
         help="Number of system prompt groups for generated-shared-prefix dataset",
     )
     group.add_argument(
-        "--gen-prompts-per-group", 
+        "--gen-prompts-per-group",
         type=int,
         default=16,
         help="Number of prompts per system prompt group for generated-shared-prefix dataset",
@@ -1305,6 +1309,6 @@ if __name__ == "__main__":
         default=256,
         help="Target length in tokens for outputs in generated-shared-prefix dataset",
     )
-    
+
     args = parser.parse_args()
     run_benchmark(args)

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -627,6 +627,61 @@ def sample_random_requests(
     return input_requests
 
 
+def gen_prompt(tokenizer, token_num):
+    """Generate a random prompt of specified token length using tokenizer vocabulary."""
+    all_available_tokens = list(tokenizer.get_vocab().values())
+    selected_tokens = random.choices(all_available_tokens, k=token_num)
+    return tokenizer.decode(selected_tokens)
+
+
+def sample_generated_shared_prefix_requests(
+    num_groups: int,
+    prompts_per_group: int,
+    system_prompt_len: int,
+    question_len: int,
+    output_len: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[Tuple[str, int, int]]:
+    """Generate benchmark requests with shared system prompts using random tokens."""
+    # Generate system prompts for each group
+    system_prompts = []
+    for _ in range(num_groups):
+        system_prompt = gen_prompt(tokenizer, system_prompt_len)
+        system_prompts.append(system_prompt)
+
+    # Generate questions
+    questions = []
+    for _ in range(num_groups * prompts_per_group):
+        question = gen_prompt(tokenizer, question_len)
+        questions.append(question)
+
+    # Combine system prompts with questions
+    input_requests = []
+    total_input_tokens = 0
+    total_output_tokens = 0
+    
+    for group_idx in range(num_groups):
+        system_prompt = system_prompts[group_idx]
+        for prompt_idx in range(prompts_per_group):
+            question = questions[group_idx * prompts_per_group + prompt_idx]
+            full_prompt = f"{system_prompt}\n\n{question}"
+            prompt_len = len(tokenizer.encode(full_prompt))
+            
+            input_requests.append((full_prompt, prompt_len, output_len))
+            total_input_tokens += prompt_len
+            total_output_tokens += output_len
+
+    print(f"\nGenerated shared prefix dataset statistics:")
+    print(f"Number of groups: {num_groups}")
+    print(f"Prompts per group: {prompts_per_group}")
+    print(f"Total prompts: {len(input_requests)}")
+    print(f"Total input tokens: {total_input_tokens}")
+    print(f"Total output tokens: {total_output_tokens}")
+    print(f"Average system prompt length: {sum(len(tokenizer.encode(sp)) for sp in system_prompts) / len(system_prompts):.1f} tokens")
+    print(f"Average question length: {sum(len(tokenizer.encode(q)) for q in questions) / len(questions):.1f} tokens\n")
+    
+    return input_requests
+
 async def get_request(
     input_requests: List[Tuple[str, int, int]],
     request_rate: float,
@@ -1048,6 +1103,15 @@ def run_benchmark(args_: argparse.Namespace):
             tokenizer=tokenizer,
             dataset_path=args.dataset_path,
         )
+    elif args.dataset_name == "generated-shared-prefix":
+        input_requests = sample_generated_shared_prefix_requests(
+            num_groups=args.gen_num_groups,
+            prompts_per_group=args.gen_prompts_per_group,
+            system_prompt_len=args.gen_system_prompt_len,
+            question_len=args.gen_question_len,
+            output_len=args.gen_output_len,
+            tokenizer=tokenizer,
+        )
     else:
         raise ValueError(f"Unknown dataset: {args.dataset_name}")
 
@@ -1121,7 +1185,7 @@ if __name__ == "__main__":
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "random"],
+        choices=["sharegpt", "random", "generated-shared-prefix"],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument(
@@ -1208,5 +1272,39 @@ if __name__ == "__main__":
         help="Append given JSON object to the request payload. You can use this to specify"
         "additional generate params like sampling params.",
     )
+
+
+    group = parser.add_argument_group("generated-shared-prefix dataset arguments")
+    group.add_argument(
+        "--gen-num-groups",
+        type=int,
+        default=64,
+        help="Number of system prompt groups for generated-shared-prefix dataset",
+    )
+    group.add_argument(
+        "--gen-prompts-per-group", 
+        type=int,
+        default=16,
+        help="Number of prompts per system prompt group for generated-shared-prefix dataset",
+    )
+    group.add_argument(
+        "--gen-system-prompt-len",
+        type=int,
+        default=2048,
+        help="Target length in tokens for system prompts in generated-shared-prefix dataset",
+    )
+    group.add_argument(
+        "--gen-question-len",
+        type=int,
+        default=128,
+        help="Target length in tokens for questions in generated-shared-prefix dataset",
+    )
+    group.add_argument(
+        "--gen-output-len",
+        type=int,
+        default=256,
+        help="Target length in tokens for outputs in generated-shared-prefix dataset",
+    )
+    
     args = parser.parse_args()
     run_benchmark(args)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Add a new dataset `gen-shared-prefix` in `bench_serving` to evaluate the performance of the engine on the shared prefix generation task. The format of the requests is `<system prompt> <question>`. This benchmark is useful for evaluating cache-aware optimization like cache-aware DP.

## Modifications

<!-- Describe the changes made in this PR. -->
1. Add function to generate shared prefix requests
2. Add related arguments


## Tests


Python `--dp 4` (round robin)

```bash

python DP = 4 
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Successful requests:                     1024      
Benchmark duration (s):                  54.54     
Total input tokens:                      2326152   
Total generated tokens:                  262144    
Total generated tokens (retokenized):    253772    
Request throughput (req/s):              18.78     
Input token throughput (tok/s):          42651.75  
Output token throughput (tok/s):         4806.61   
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   53560.65  
Median E2E Latency (ms):                 53362.96  
---------------Time to First Token----------------
Mean TTFT (ms):                          33504.17  
Median TTFT (ms):                        35524.99  
P99 TTFT (ms):                           36763.44  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          78.65     
Median TPOT (ms):                        70.23     
P99 TPOT (ms):                           180.28    
---------------Inter-token Latency----------------
Mean ITL (ms):                           78.92     
Median ITL (ms):                         68.45     
P99 ITL (ms):                            527.79    
==================================================

[2024-11-11 00:06:15 DP3 TP0] Prefill batch. #new-seq: 2, #new-token: 699, #cached-token: 3827, cache hit rate: 21.75%, token usage: 0.40, #running-req: 254, #queue-req: 1
```

Rust Approx Tree `--dp 4`

```bash

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Successful requests:                     1024      
Benchmark duration (s):                  28.27     
Total input tokens:                      2327209   
Total generated tokens:                  262144    
Total generated tokens (retokenized):    256144    
Request throughput (req/s):              36.23     
Input token throughput (tok/s):          82328.91  
Output token throughput (tok/s):         9273.78   
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   26073.70  
Median E2E Latency (ms):                 27724.49  
---------------Time to First Token----------------
Mean TTFT (ms):                          7005.06   
Median TTFT (ms):                        7061.64   
P99 TTFT (ms):                           7995.75   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          74.78     
Median TPOT (ms):                        79.34     
P99 TPOT (ms):                           99.97     
---------------Inter-token Latency----------------
Mean ITL (ms):                           75.60     
Median ITL (ms):                         74.43     
P99 ITL (ms):                            94.90     
==================================================

[2024-11-11 00:12:58 TP0] Prefill batch. #new-seq: 27, #new-token: 3517, #cached-token: 57525, cache hit rate: 84.86%, token usage: 0.16, #running-req: 245, #queue-req: 1
```

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.
