### PR TITLE
support echo=true and logprobs in openai api when logprobs=1 in lm-evaluation-harness 

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -498,6 +498,10 @@ def v1_generate_request(
             )
 
         prompts.append(request.prompt)
+        if request.echo and request.logprobs:
+            current_logprob_start_len = 0
+        else:
+            current_logprob_start_len = -1
         sampling_params_list.append(
             {
                 "temperature": request.temperature,
@@ -517,7 +521,7 @@ def v1_generate_request(
             }
         )
         return_logprobs.append(request.logprobs is not None and request.logprobs > 0)
-        logprob_start_lens.append(-1)
+        logprob_start_lens.append(current_logprob_start_len)
         top_logprobs_nums.append(
             request.logprobs if request.logprobs is not None else 0
         )

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -85,7 +85,9 @@ class TestOpenAIServer(unittest.TestCase):
             # assert ret_num_top_logprobs == logprobs, f"{ret_num_top_logprobs} vs {logprobs}"
             assert ret_num_top_logprobs > 0
 
-            assert response.choices[0].logprobs.token_logprobs[0]
+            # when echo=True and request.logprobs>0, logprob_start_len is 0, so the first token's logprob would be None.
+            if not echo:
+                assert response.choices[0].logprobs.token_logprobs[0]
 
         assert response.id
         assert response.created


### PR DESCRIPTION
Sglang service can't match lm-evaluation-harness, because lm-evaluation-harness set echo=True and logprobs=1 in openai client api: https://github.com/EleutherAI/lm-evaluation-harness/blob/bd80a6c0099ee207e70f4943117739a817eccc0b/lm_eval/models/openai_completions.py#L55

This pr solved it, I can run lm-evaluation-harness with SGLang service now.

![图片](https://github.com/user-attachments/assets/28d2ecc1-9c18-4b5c-bc17-acc6364b392d)
