### PR TITLE
set content to empty string

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -1166,7 +1166,7 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                         is_first = False
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=index,
-                            delta=DeltaMessage(role="assistant"),
+                            delta=DeltaMessage(role="assistant", content=""),
                             finish_reason=(
                                 finish_reason["type"] if finish_reason else ""
                             ),


### PR DESCRIPTION
## Motivation

OpenAI API server sends empty string `"content": ""` instead of `"content": null` in the first chunk containing the role

I noticed that the first response from the actual OpenAI API was different from what I got from running sglang server. I only realized this because nvim decoded it into a non-falsy value `vim.NIL` and was throwing errors

https://github.com/chottolabs/kznllm.nvim/blob/11d9203fb769259b119a2852b3f97f9d90415f1c/lua/kznllm-v3/specs/openai.lua#L73-L74

```
data: {"id":"chatcmpl-...","object":"chat.completion.chunk","created":...,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"...","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
```

## Modifications

First chunk with role sends `"content": ""` instead of `"content": null`

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.
