### PR TITLE
Fix #2037 - Context length check does not take into out pad tokens for visual models

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -557,6 +557,15 @@ class Scheduler:
                 req.origin_input_ids_unpadded, req.image_inputs
             )
 
+            if len(req.origin_input_ids) > self.max_req_input_len:
+                req.finished_reason = FINISH_ABORT(
+                    "Image request length is longer than the KV cache pool size or "
+                    "the max context length aborting because you cannot truncate the image embeds"
+                )
+                self.waiting_queue.append(req)
+                return
+
+
         req.return_logprob = recv_req.return_logprob
         req.top_logprobs_num = recv_req.top_logprobs_num
         req.stream = recv_req.stream

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -562,9 +562,9 @@ class Scheduler:
                     "Image request length is longer than the KV cache pool size or "
                     "the max context length aborting because you cannot truncate the image embeds"
                 )
+                req.sampling_params.max_new_tokens = 0
                 self.waiting_queue.append(req)
                 return
-
 
         req.return_logprob = recv_req.return_logprob
         req.top_logprobs_num = recv_req.top_logprobs_num

--- a/test/srt/test_vision_openai_server.py
+++ b/test/srt/test_vision_openai_server.py
@@ -364,6 +364,72 @@ class TestQWen2VLServer(TestOpenAIVisionServer):
         cls.base_url += "/v1"
 
 
+class TestQWen2VLServerContextLengthIssue(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "Qwen/Qwen2-VL-7B-Instruct"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+            other_args=[
+                "--chat-template",
+                "qwen2-vl",
+                "--context-length",
+                "300",
+
+                # TODO Remove this later
+                "--mem-fraction-static=0.80",
+            ],
+        )
+        cls.base_url += "/v1"    
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_child_process(cls.process.pid, include_self=True)
+
+    def test_chat_completion(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+
+        response = client.chat.completions.create(
+            model="default",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://github.com/sgl-project/sglang/blob/main/test/lang/example_image.png?raw=true"
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": "Give a lengthy description of this picture",
+                        },
+                    ],
+                },
+            ],
+            temperature=0,
+        )
+
+        print(response)
+
+        assert response.choices[0].message.role == "assistant"
+        text = response.choices[0].message.content
+        assert isinstance(text, str)
+        assert "man" in text or "cab" in text, text
+        assert response.id
+        assert response.created
+        assert response.usage.prompt_tokens > 0
+        assert response.usage.completion_tokens > 0
+        assert response.usage.total_tokens > 0
+    
+
+
 class TestMllamaServer(TestOpenAIVisionServer):
     @classmethod
     def setUpClass(cls):

--- a/test/srt/test_vision_openai_server.py
+++ b/test/srt/test_vision_openai_server.py
@@ -380,12 +380,10 @@ class TestQWen2VLServerContextLengthIssue(unittest.TestCase):
                 "qwen2-vl",
                 "--context-length",
                 "300",
-
-                # TODO Remove this later
                 "--mem-fraction-static=0.80",
             ],
         )
-        cls.base_url += "/v1"    
+        cls.base_url += "/v1"
 
     @classmethod
     def tearDownClass(cls):
@@ -416,18 +414,12 @@ class TestQWen2VLServerContextLengthIssue(unittest.TestCase):
             temperature=0,
         )
 
-        print(response)
-
-        assert response.choices[0].message.role == "assistant"
-        text = response.choices[0].message.content
-        assert isinstance(text, str)
-        assert "man" in text or "cab" in text, text
+        assert response.choices[0].finish_reason == "abort"
         assert response.id
         assert response.created
         assert response.usage.prompt_tokens > 0
         assert response.usage.completion_tokens > 0
         assert response.usage.total_tokens > 0
-    
 
 
 class TestMllamaServer(TestOpenAIVisionServer):


### PR DESCRIPTION
## Motivation

Found a bug a few days ago when running Qwen2-VL through VLLM: https://github.com/sgl-project/sglang/issues/2037

I have tracked down the issue to the fact that the context-length limit is not respected once you account for padding tokens in visual language models.

Ex. you might have a request like this "user: what is in the following image?<image_pad>" in your initial request, which is below your context-limit.

But then, the provided image might expand out <image_pad> into 500 new tokens, pushing you over the limit, and leading to crashes (see #2037 for stack trace)

## Modifications

I tried to add a check for this in the scheduler, however now I get a crash in a new location:

```
[2024-11-20 14:05:10 TP0] Traceback (most recent call last):
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 1403, in run_scheduler_process
    scheduler.event_loop_overlap()
  File "/root/.conda/envs/sglang/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 390, in event_loop_overlap
    batch = self.get_next_batch_to_run()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 744, in get_next_batch_to_run
    new_batch = self.get_new_batch_prefill()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/managers/scheduler.py", line 822, in get_new_batch_prefill
    req.init_next_round_input(None if prefix_computed else self.tree_cache)
  File "/root/sglang/python/sglang/srt/managers/schedule_batch.py", line 271, in init_next_round_input
    rid=self.rid, key=self.adjust_max_prefix_ids()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sglang/python/sglang/srt/managers/schedule_batch.py", line 283, in adjust_max_prefix_ids
    if self.sampling_params.max_new_tokens > 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

Can someone from the team please help and let me know what expected path I should go in resolving this issue?

There is at least a nice neat repro test case you can use to see the issue for yourselves.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [X] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.
