### PR TITLE
Turn off autotune for scaled mm for fp8 dynamic quant in torchao

### DIFF
--- a/python/sglang/srt/models/torch_native_llama.py
+++ b/python/sglang/srt/models/torch_native_llama.py
@@ -72,6 +72,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 tp_size = get_tensor_model_parallel_world_size()
 tp_rank = get_tensor_model_parallel_rank()
 
+
 def gate_up_proj_weight_loader(
     self,
     param: Parameter,


### PR DESCRIPTION
Summary:
Currently we do autotune in torch.compile (max-autotune-no-cudagraph), that will call triton kernel autotune for fp8 dynamic quant, but it increases compilation time significantly and not much benefit for llama models, so we turn this off for now

Test Plan:
python3 -m sglang.bench_latency --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --json-model-override-args '{"architectures": ["TorchNativeLlamaForCausalLM"]}' --enable-torch-compile --torchao-config fp8dq-per_row

Reviewers:

Subscribers:

Tasks:

Tags:
