### PR TITLE
Replace prob based with threshold based load balancing 

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -37,6 +37,7 @@ from transformers import (
     PreTrainedTokenizerBase,
     PreTrainedTokenizerFast,
 )
+from pathlib import Path
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 
@@ -693,6 +694,16 @@ def gen_prompt(tokenizer, token_num):
     return tokenizer.decode(selected_tokens)
 
 
+def get_gen_prefix_cache_path(args, tokenizer):
+    """Create cache directory under ~/.cache/sglang/benchmark"""
+    cache_dir = Path.home() / ".cache" / "sglang" / "benchmark"
+    
+    # Create a unique cache filename based on the generation parameters
+    cache_key = (f"gen_prefix_{args.gen_num_groups}_{args.gen_prompts_per_group}_"
+                f"{args.gen_system_prompt_len}_{args.gen_question_len}_{args.gen_output_len}_"
+                f"{tokenizer.__class__.__name__}.pkl")
+    return cache_dir / cache_key
+
 def sample_generated_shared_prefix_requests(
     num_groups: int,
     prompts_per_group: int,
@@ -701,12 +712,17 @@ def sample_generated_shared_prefix_requests(
     output_len: int,
     tokenizer: PreTrainedTokenizerBase,
 ) -> List[Tuple[str, int, int]]:
-    if args.generated_input_path and os.path.exists(args.generated_input_path):
-        print(f"\nloading generated input data from {args.generated_input_path}")
-        with open(args.generated_input_path, "rb") as f:
+    """Generate benchmark requests with shared system prompts using random tokens and caching."""
+    cache_path = get_gen_prefix_cache_path(args, tokenizer)
+    
+    # Try to load from cache first
+    if cache_path.exists():
+        print(f"\nLoading cached generated input data from {cache_path}")
+        with open(cache_path, "rb") as f:
             return pickle.load(f)
 
-    """Generate benchmark requests with shared system prompts using random tokens."""
+    print("\nGenerating new input data...")
+    
     # Generate system prompts for each group
     system_prompts = []
     for _ in range(num_groups):
@@ -719,9 +735,6 @@ def sample_generated_shared_prefix_requests(
         question = gen_prompt(tokenizer, question_len)
         questions.append(question)
 
-    # Shuffle questions
-    random.shuffle(questions)
-
     # Combine system prompts with questions
     input_requests = []
     total_input_tokens = 0
@@ -729,7 +742,7 @@ def sample_generated_shared_prefix_requests(
 
     for group_idx in tqdm(range(num_groups), desc="Generating system prompt"):
         system_prompt = system_prompts[group_idx]
-        for prompt_idx in tqdm(range(prompts_per_group), desc="Generating questions"):
+        for prompt_idx in tqdm(range(prompts_per_group), desc="Generating questions", leave=False):
             question = questions[group_idx * prompts_per_group + prompt_idx]
             full_prompt = f"{system_prompt}\n\n{question}"
             prompt_len = len(tokenizer.encode(full_prompt))
@@ -738,23 +751,24 @@ def sample_generated_shared_prefix_requests(
             total_input_tokens += prompt_len
             total_output_tokens += output_len
 
+    # Shuffle questions
+    random.shuffle(input_requests)
+
+    # Print statistics
     print(f"\nGenerated shared prefix dataset statistics:")
     print(f"Number of groups: {num_groups}")
     print(f"Prompts per group: {prompts_per_group}")
     print(f"Total prompts: {len(input_requests)}")
     print(f"Total input tokens: {total_input_tokens}")
     print(f"Total output tokens: {total_output_tokens}")
-    print(
-        f"Average system prompt length: {sum(len(tokenizer.encode(sp)) for sp in system_prompts) / len(system_prompts):.1f} tokens"
-    )
-    print(
-        f"Average question length: {sum(len(tokenizer.encode(q)) for q in questions) / len(questions):.1f} tokens\n"
-    )
-    if args.generated_input_save_path:
-        print(f"Saving generated input data to {args.generated_input_save_path}")
-        os.makedirs(os.path.dirname(args.generated_input_save_path), exist_ok=True)
-        with open(args.generated_input_save_path, "wb") as f:
-            pickle.dump(input_requests, f)
+    print(f"Average system prompt length: {sum(len(tokenizer.encode(sp)) for sp in system_prompts) / len(system_prompts):.1f} tokens")
+    print(f"Average question length: {sum(len(tokenizer.encode(q)) for q in questions) / len(questions):.1f} tokens\n")
+
+    # Save to cache
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Caching generated input data to {cache_path}")
+    with open(cache_path, "wb") as f:
+        pickle.dump(input_requests, f)
 
     return input_requests
 
@@ -1421,16 +1435,6 @@ if __name__ == "__main__":
         type=int,
         default=256,
         help="Target length in tokens for outputs in generated-shared-prefix dataset",
-    )
-    parser.add_argument(
-        "--generated-input-save-path",
-        type=str,
-        help="Path to save generated input data",
-    )
-    parser.add_argument(
-        "--generated-input-path",
-        type=str,
-        help="Path to load previously generated input data",
     )
     parser.add_argument(
         "--profile",

--- a/rust/py_src/sglang_router/launch_router.py
+++ b/rust/py_src/sglang_router/launch_router.py
@@ -17,7 +17,8 @@ class RouterArgs:
     # Routing policy
     policy: str = "cache_aware"
     cache_threshold: float = 0.5
-    imbalance_threshold: float = 2.0
+    balance_abs_threshold: int = 32
+    balance_rel_threshold: float = 1.0001
     eviction_interval: int = 60
     max_tree_size: int = 2**24
 
@@ -74,10 +75,16 @@ class RouterArgs:
             help="Cache threshold (0.0-1.0) for cache-aware routing",
         )
         parser.add_argument(
-            f"--{prefix}imbalance-threshold",
+            f"--{prefix}balance-abs-threshold",
+            type=int,
+            default=RouterArgs.balance_abs_threshold,
+            help="Load balancing is triggered when (max_load - min_load) > abs_threshold AND max_load > min_load * rel_threshold. Otherwise, use cache aware",
+        )
+        parser.add_argument(
+            f"--{prefix}balance-rel-threshold",
             type=float,
-            default=RouterArgs.imbalance_threshold,
-            help="Threshold for load imbalance (>= 1.0). Load balancing is used when max_load > min_load * threshold",
+            default=RouterArgs.balance_rel_threshold,
+            help="Load balancing is triggered when (max_load - min_load) > abs_threshold AND max_load > min_load * rel_threshold. Otherwise, use cache aware",
         )
         parser.add_argument(
             f"--{prefix}eviction-interval",
@@ -110,7 +117,8 @@ class RouterArgs:
             port=args.port,
             policy=getattr(args, f"{prefix}policy"),
             cache_threshold=getattr(args, f"{prefix}cache_threshold"),
-            imbalance_threshold=getattr(args, f"{prefix}imbalance_threshold"),
+            balance_abs_threshold=getattr(args, f"{prefix}balance_abs_threshold"),
+            balance_rel_threshold=getattr(args, f"{prefix}balance_rel_threshold"),
             eviction_interval=getattr(args, f"{prefix}eviction_interval"),
             max_tree_size=getattr(args, f"{prefix}max_tree_size"),
         )
@@ -150,7 +158,8 @@ def launch_router(args: argparse.Namespace) -> Optional[Router]:
             host=router_args.host,
             port=router_args.port,
             cache_threshold=router_args.cache_threshold,
-            imbalance_threshold=router_args.imbalance_threshold,
+            balance_abs_threshold=router_args.balance_abs_threshold,
+            balance_rel_threshold=router_args.balance_rel_threshold,
             eviction_interval_secs=router_args.eviction_interval,
             max_tree_size=router_args.max_tree_size,
         )
@@ -181,7 +190,7 @@ multi-node setups or when you want to start workers and router separately.
 
 Examples:
   python -m sglang_router.launch_router --worker-urls http://worker1:8000 http://worker2:8000
-  python -m sglang_router.launch_router --worker-urls http://worker1:8000 http://worker2:8000 --cache-threshold 0.7 --imbalance-threshold 3.0
+  python -m sglang_router.launch_router --worker-urls http://worker1:8000 http://worker2:8000 --cache-threshold 0.7 --balance-abs-threshold 64 --balance-rel-threshold 1.2
 
     """,
         formatter_class=CustomHelpFormatter,

--- a/rust/py_src/sglang_router/launch_router.py
+++ b/rust/py_src/sglang_router/launch_router.py
@@ -176,6 +176,7 @@ class CustomHelpFormatter(
     argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
 ):
     """Custom formatter that preserves both description formatting and shows defaults"""
+
     pass
 
 

--- a/rust/py_src/sglang_router/launch_router.py
+++ b/rust/py_src/sglang_router/launch_router.py
@@ -17,7 +17,7 @@ class RouterArgs:
     # Routing policy
     policy: str = "cache_aware"
     cache_threshold: float = 0.5
-    cache_routing_prob: float = 1.0
+    imbalance_threshold: float = 2.0
     eviction_interval: int = 60
     max_tree_size: int = 2**24
 
@@ -74,10 +74,10 @@ class RouterArgs:
             help="Cache threshold (0.0-1.0) for cache-aware routing",
         )
         parser.add_argument(
-            f"--{prefix}cache-routing-prob",
+            f"--{prefix}imbalance-threshold",
             type=float,
-            default=RouterArgs.cache_routing_prob,
-            help="Probability of using cache-aware routing (0.0-1.0)",
+            default=RouterArgs.imbalance_threshold,
+            help="Threshold for load imbalance (>= 1.0). Load balancing is used when max_load > min_load * threshold",
         )
         parser.add_argument(
             f"--{prefix}eviction-interval",
@@ -110,7 +110,7 @@ class RouterArgs:
             port=args.port,
             policy=getattr(args, f"{prefix}policy"),
             cache_threshold=getattr(args, f"{prefix}cache_threshold"),
-            cache_routing_prob=getattr(args, f"{prefix}cache_routing_prob"),
+            imbalance_threshold=getattr(args, f"{prefix}imbalance_threshold"),
             eviction_interval=getattr(args, f"{prefix}eviction_interval"),
             max_tree_size=getattr(args, f"{prefix}max_tree_size"),
         )
@@ -150,7 +150,7 @@ def launch_router(args: argparse.Namespace) -> Optional[Router]:
             host=router_args.host,
             port=router_args.port,
             cache_threshold=router_args.cache_threshold,
-            cache_routing_prob=router_args.cache_routing_prob,
+            imbalance_threshold=router_args.imbalance_threshold,
             eviction_interval_secs=router_args.eviction_interval,
             max_tree_size=router_args.max_tree_size,
         )
@@ -167,7 +167,6 @@ class CustomHelpFormatter(
     argparse.RawDescriptionHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
 ):
     """Custom formatter that preserves both description formatting and shows defaults"""
-
     pass
 
 
@@ -182,7 +181,7 @@ multi-node setups or when you want to start workers and router separately.
 
 Examples:
   python -m sglang_router.launch_router --worker-urls http://worker1:8000 http://worker2:8000
-  python -m sglang_router.launch_router --worker-urls http://worker1:8000 http://worker2:8000 --cache-threshold 0.7 --cache-routing-prob 0.5
+  python -m sglang_router.launch_router --worker-urls http://worker1:8000 http://worker2:8000 --cache-threshold 0.7 --imbalance-threshold 3.0
 
     """,
         formatter_class=CustomHelpFormatter,

--- a/rust/py_src/sglang_router/router.py
+++ b/rust/py_src/sglang_router/router.py
@@ -20,9 +20,9 @@ class Router:
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to cached worker
             if the match rate exceeds threshold, otherwise routes to the worker with the smallest
             tree. Default: 0.5
-        balance_abs_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold 
+        balance_abs_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold
             AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 32
-        balance_rel_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold 
+        balance_rel_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold
             AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 1.0001
         eviction_interval_secs: Interval in seconds between cache eviction operations in cache-aware
             routing. Default: 60

--- a/rust/py_src/sglang_router/router.py
+++ b/rust/py_src/sglang_router/router.py
@@ -14,15 +14,16 @@ class Router:
         policy: Load balancing policy to use. Options:
             - PolicyType.Random: Randomly select workers
             - PolicyType.RoundRobin: Distribute requests in round-robin fashion
-            - PolicyType.CacheAware: Distribute requests in cache-aware fashion
+            - PolicyType.CacheAware: Distribute requests based on cache state and load balance
         host: Host address to bind the router server. Default: '127.0.0.1'
         port: Port number to bind the router server. Default: 3001
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to cached worker
             if the match rate exceeds threshold, otherwise routes to the worker with the smallest
             tree. Default: 0.5
-        imbalance_threshold: Threshold for load imbalance (>= 1.0). Load balancing is used when
-            max_load > min_load * threshold. Default: 2.0 meaning load balancing triggers when any
-            worker has more than double the load of the least loaded worker.
+        balance_abs_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold 
+            AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 32
+        balance_rel_threshold: Load balancing is triggered when (max_load - min_load) > abs_threshold 
+            AND max_load > min_load * rel_threshold. Otherwise, use cache aware. Default: 1.0001
         eviction_interval_secs: Interval in seconds between cache eviction operations in cache-aware
             routing. Default: 60
         max_tree_size: Maximum size of the approximation tree for cache-aware routing. Default: 2^24
@@ -35,7 +36,8 @@ class Router:
         host: str = "127.0.0.1",
         port: int = 3001,
         cache_threshold: float = 0.50,
-        imbalance_threshold: float = 2.0,
+        balance_abs_threshold: int = 32,
+        balance_rel_threshold: float = 1.0001,
         eviction_interval_secs: int = 60,
         max_tree_size: int = 2**24,
     ):
@@ -45,7 +47,8 @@ class Router:
             host=host,
             port=port,
             cache_threshold=cache_threshold,
-            imbalance_threshold=imbalance_threshold,
+            balance_abs_threshold=balance_abs_threshold,
+            balance_rel_threshold=balance_rel_threshold,
             eviction_interval_secs=eviction_interval_secs,
             max_tree_size=max_tree_size,
         )

--- a/rust/py_src/sglang_router/router.py
+++ b/rust/py_src/sglang_router/router.py
@@ -20,9 +20,9 @@ class Router:
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to cached worker
             if the match rate exceeds threshold, otherwise routes to the worker with the smallest
             tree. Default: 0.5
-        cache_routing_prob: Probability of using cache-aware routing (0.0-1.0). Default 1.0 for
-            full cache-aware routing, suitable for perfectly divided prefix workloads. For uneven
-            workloads, use a lower value to better distribute requests
+        imbalance_threshold: Threshold for load imbalance (>= 1.0). Load balancing is used when
+            max_load > min_load * threshold. Default: 2.0 meaning load balancing triggers when any
+            worker has more than double the load of the least loaded worker.
         eviction_interval_secs: Interval in seconds between cache eviction operations in cache-aware
             routing. Default: 60
         max_tree_size: Maximum size of the approximation tree for cache-aware routing. Default: 2^24
@@ -35,7 +35,7 @@ class Router:
         host: str = "127.0.0.1",
         port: int = 3001,
         cache_threshold: float = 0.50,
-        cache_routing_prob: float = 1.0,
+        imbalance_threshold: float = 2.0,
         eviction_interval_secs: int = 60,
         max_tree_size: int = 2**24,
     ):
@@ -45,7 +45,7 @@ class Router:
             host=host,
             port=port,
             cache_threshold=cache_threshold,
-            cache_routing_prob=cache_routing_prob,
+            imbalance_threshold=imbalance_threshold,
             eviction_interval_secs=eviction_interval_secs,
             max_tree_size=max_tree_size,
         )

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,7 +18,8 @@ struct Router {
     worker_urls: Vec<String>,
     policy: PolicyType,
     cache_threshold: f32,
-    imbalance_threshold: f32,
+    balance_abs_threshold: usize,
+    balance_rel_threshold: f32,
     eviction_interval_secs: u64,
     max_tree_size: usize,
 }
@@ -32,7 +33,8 @@ impl Router {
         host = String::from("127.0.0.1"),
         port = 3001,
         cache_threshold = 0.50,
-        imbalance_threshold = 2.0,
+        balance_abs_threshold = 32,
+        balance_rel_threshold = 1.0001,
         eviction_interval_secs = 60,
         max_tree_size = 2usize.pow(24)
     ))]
@@ -42,7 +44,8 @@ impl Router {
         host: String,
         port: u16,
         cache_threshold: f32,
-        imbalance_threshold: f32,
+        balance_abs_threshold: usize,
+        balance_rel_threshold: f32,
         eviction_interval_secs: u64,
         max_tree_size: usize,
     ) -> PyResult<Self> {
@@ -52,7 +55,8 @@ impl Router {
             worker_urls,
             policy,
             cache_threshold,
-            imbalance_threshold,
+            balance_abs_threshold,
+            balance_rel_threshold,
             eviction_interval_secs,
             max_tree_size,
         })
@@ -68,7 +72,8 @@ impl Router {
             PolicyType::RoundRobin => router::PolicyConfig::RoundRobinConfig,
             PolicyType::CacheAware => router::PolicyConfig::CacheAwareConfig {
                 cache_threshold: self.cache_threshold,
-                imbalance_threshold: self.imbalance_threshold,
+                balance_abs_threshold: self.balance_abs_threshold,
+                balance_rel_threshold: self.balance_rel_threshold,
                 eviction_interval_secs: self.eviction_interval_secs,
                 max_tree_size: self.max_tree_size,
             },

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,7 +18,7 @@ struct Router {
     worker_urls: Vec<String>,
     policy: PolicyType,
     cache_threshold: f32,
-    cache_routing_prob: f32,
+    imbalance_threshold: f32,
     eviction_interval_secs: u64,
     max_tree_size: usize,
 }
@@ -32,7 +32,7 @@ impl Router {
         host = String::from("127.0.0.1"),
         port = 3001,
         cache_threshold = 0.50,
-        cache_routing_prob = 1.0,
+        imbalance_threshold = 2.0,
         eviction_interval_secs = 60,
         max_tree_size = 2usize.pow(24)
     ))]
@@ -42,7 +42,7 @@ impl Router {
         host: String,
         port: u16,
         cache_threshold: f32,
-        cache_routing_prob: f32,
+        imbalance_threshold: f32,
         eviction_interval_secs: u64,
         max_tree_size: usize,
     ) -> PyResult<Self> {
@@ -52,7 +52,7 @@ impl Router {
             worker_urls,
             policy,
             cache_threshold,
-            cache_routing_prob,
+            imbalance_threshold,
             eviction_interval_secs,
             max_tree_size,
         })
@@ -68,7 +68,7 @@ impl Router {
             PolicyType::RoundRobin => router::PolicyConfig::RoundRobinConfig,
             PolicyType::CacheAware => router::PolicyConfig::CacheAwareConfig {
                 cache_threshold: self.cache_threshold,
-                cache_routing_prob: self.cache_routing_prob,
+                imbalance_threshold: self.imbalance_threshold,
                 eviction_interval_secs: self.eviction_interval_secs,
                 max_tree_size: self.max_tree_size,
             },

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,4 +1,3 @@
-// src/main.rs
 use clap::Parser;
 use clap::ValueEnum;
 
@@ -57,12 +56,12 @@ struct Args {
 
     #[arg(
         long,
-        default_value_t = 1.0,
+        default_value_t = 2.0,
         requires = "policy",
         required_if_eq("policy", "cache_aware"),
-        help = "Probability of using cache-aware routing (0.0-1.0). Default 1.0 for full cache-aware routing, suitable for perfectly divided prefix workloads. For uneven workloads, use a lower value to better distribute requests"
+        help = "Threshold for load imbalance (>= 1.0). Load balancing is used when max_load > min_load * threshold. Default: 2.0 meaning load balancing triggers when any worker has more than double the load of the least loaded worker"
     )]
-    cache_routing_prob: f32,
+    imbalance_threshold: f32,
 
     #[arg(
         long,
@@ -90,7 +89,7 @@ impl Args {
             PolicyType::RoundRobin => PolicyConfig::RoundRobinConfig,
             PolicyType::CacheAware => PolicyConfig::CacheAwareConfig {
                 cache_threshold: self.cache_threshold,
-                cache_routing_prob: self.cache_routing_prob,
+                imbalance_threshold: self.imbalance_threshold,
                 eviction_interval_secs: self.eviction_interval_secs,
                 max_tree_size: self.max_tree_size,
             },

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -249,6 +249,8 @@ impl Router {
                 balance_rel_threshold,
                 ..
             } => {
+                // TODO: delay scheduling if cache hit rate is high because it may cause imbalance. prioritize low hit rate ones
+
                 let mut tree = tree.lock().unwrap();
                 let mut running_queue = running_queue.lock().unwrap();
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Prob based LB can disturb cache aware when the load is actually balanced. Switching to threshold based LB can help improve the cache hit rate and also makes the behavior more deterministic.

## Modifications

<!-- Describe the changes made in this PR. -->

1. `bench_serving`: for generated shared prefix dataset, Remove argument-based data caching and use auto caching with the key as the dataset params, so users don't have to manually configure the arguments
2. Shortest queue load balancing is triggered when the load is imbalanced. The imbalanced is defined as `(max_load - min_load) > abs_threshold AND max_load > min_load * rel_threshold`. By default it only uses `abs_threshold`, and `rel_threshold` was set to a very small value.

## Benchmark

## Benchmark Results

TLDR: the perf is on par with v1 on perfectly divided and low hit rate cases. In one long sys prompt case, it can outperform original RR DP, while it is slower than v1 because one worker will have "abs_threshold" more requests.

### Generated Shared Prefix Dataset
```bash
python bench_serving.py --host 127.0.0.1 --port 30000 --dataset-name generated-shared-prefix \
    --generated-input-path ~/.cache/gen.json --generated-input-save-path ~/.cache/gen.json
```

| Method | Throughput | Cache Rate |
|--------|------------|------------|
| Original RR DP | 82,665 | 20% |
| Cache Aware v1 | 158,596.72 | 75% |
| Perfect | 160,288 | 75% |
| **Cache Aware v1.1** | 158554 | 75% |

### SharedGPT Dataset
```bash
python bench_serving.py --host 127.0.0.1 --port 30000
```


| Method | Throughput | Cache Rate |
|--------|------------|------------|
| Original RR DP | 17,164 | 2% |
| Cache Aware v1 | 17,775 | 2% |
| **Cache Aware v1** | 17,779 | 2% |

### Multi Turn Dataset
```bash
python long_prompt_multi_turn.py --port 30000 --tokenizer "/shared/public/elr-models/meta-llama/Meta-Llama-3.1-8B-Instruct/07eb05b21d191a58c577b4a45982fe0c049d0693/" | tee client.log
```

| Method | Latency | Cache Rate |
|--------|---------|------------|
| Original RR DP | 34 | 35% |
| Cache Aware v1 | 19 | 88% |
| Perfect | 19 | 88% |
| **Cache Aware v1.1** | 19 | 88% |


### Generated Shared Prefix Dataset but only has one system prompt
```bash
python bench_serving.py --host 127.0.0.1 --port 30000 --dataset-name generated-shared-prefix --gen-num-groups 8 --gen-num-groups 1 --gen-prompts-per-group 1024
```

| Version | Throughput | Cache Rate |
|---------|------------|------------|
| Original RR DP | 154535.56 | |
| Cache aware v1 | 36510.71 | |
| Cache aware v1 - routing prob 0.5 | 190026.64 | |
| **Cache aware v1.1** | 174807 | |


## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.
