### PR TITLE
feat: fused_moe fp8 monkey patch

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -1,18 +1,19 @@
 # Adapted from https://raw.githubusercontent.com/vllm-project/vllm/v0.5.5/vllm/model_executor/layers/quantization/__init__.py
 
-from typing import Dict, Type
+from typing import Callable, Dict, Optional, Type
 
+import torch
 from vllm.model_executor.layers.quantization.aqlm import AQLMConfig
 from vllm.model_executor.layers.quantization.awq import AWQConfig
 from vllm.model_executor.layers.quantization.awq_marlin import AWQMarlinConfig
 from vllm.model_executor.layers.quantization.bitsandbytes import BitsAndBytesConfig
-from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (  # noqa: E501
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
     CompressedTensorsConfig,
 )
 from vllm.model_executor.layers.quantization.deepspeedfp import DeepSpeedFPConfig
 from vllm.model_executor.layers.quantization.experts_int8 import ExpertsInt8Config
 from vllm.model_executor.layers.quantization.fbgemm_fp8 import FBGEMMFp8Config
-from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
 from vllm.model_executor.layers.quantization.gguf import GGUFConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.gptq_marlin import GPTQMarlinConfig
@@ -30,8 +31,6 @@ QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "tpu_int8": Int8TpuConfig,
     "fp8": Fp8Config,
     "fbgemm_fp8": FBGEMMFp8Config,
-    # The order of gptq methods is important for config.py iteration over
-    # override_quantization_method(..)
     "marlin": MarlinConfig,
     "gguf": GGUFConfig,
     "gptq_marlin_24": GPTQMarlin24Config,
@@ -47,33 +46,70 @@ QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
 
 def get_quantization_config(quantization: str) -> Type[QuantizationConfig]:
     if quantization not in QUANTIZATION_METHODS:
-        raise ValueError(f"Invalid quantization method: {quantization}")
+        raise ValueError(
+            f"Invalid quantization method: {quantization}. "
+            f"Available methods: {list(QUANTIZATION_METHODS.keys())}"
+        )
     return QUANTIZATION_METHODS[quantization]
 
 
-__all__ = [
-    "QuantizationConfig",
-    "get_quantization_config",
-    "QUANTIZATION_METHODS",
-]
+def fp8_moe_apply(
+    self,
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    router_logits: torch.Tensor,
+    top_k: int,
+    renormalize: bool,
+    use_grouped_topk: bool,
+    topk_group: Optional[int] = None,
+    num_expert_group: Optional[int] = None,
+    custom_routing_function: Optional[Callable] = None,
+) -> torch.Tensor:
+    """Enhanced apply method for FP8 MoE."""
+    from sglang.srt.layers.fused_moe_triton import FusedMoE
+    from sglang.srt.layers.fused_moe_triton.fused_moe import fused_experts
+
+    # Expert selection
+    topk_weights, topk_ids = FusedMoE.select_experts(
+        hidden_states=x,
+        router_logits=router_logits,
+        use_grouped_topk=use_grouped_topk,
+        top_k=top_k,
+        renormalize=renormalize,
+        topk_group=topk_group,
+        num_expert_group=num_expert_group,
+        custom_routing_function=custom_routing_function,
+    )
+
+    # Expert fusion with FP8 quantization
+    return fused_experts(
+        x,
+        layer.w13_weight,
+        layer.w2_weight,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        inplace=True,
+        use_fp8_w8a8=True,
+        w1_scale=layer.w13_weight_scale,
+        w2_scale=layer.w2_weight_scale,
+        a1_scale=layer.w13_input_scale,
+        a2_scale=layer.w2_input_scale,
+    )
 
 
 def fp8_get_quant_method(self, layer, prefix):
+    """Enhanced get_quant_method for FP8 config."""
     from vllm.model_executor.layers.linear import LinearBase
-    from vllm.model_executor.layers.quantization.fp8 import (
-        Fp8LinearMethod,
-        Fp8MoEMethod,
-    )
+    from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
     from vllm.model_executor.layers.quantization.utils.quant_utils import (
         is_layer_skipped,
     )
 
     from sglang.srt.layers.fused_moe_triton.layer import FusedMoE
+    from sglang.srt.layers.linear import UnquantizedLinearMethod
 
     if isinstance(layer, LinearBase):
         if is_layer_skipped(prefix, self.ignored_layers):
-            from sglang.srt.layers.linear import UnquantizedLinearMethod
-
             return UnquantizedLinearMethod()
         return Fp8LinearMethod(self)
     elif isinstance(layer, FusedMoE):
@@ -81,4 +117,18 @@ def fp8_get_quant_method(self, layer, prefix):
     return None
 
 
-setattr(Fp8Config, "get_quant_method", fp8_get_quant_method)
+def apply_monkey_patches():
+    """Apply all monkey patches in one place."""
+    setattr(Fp8MoEMethod, "apply", fp8_moe_apply)
+    setattr(Fp8Config, "get_quant_method", fp8_get_quant_method)
+
+
+# Apply patches when module is imported
+apply_monkey_patches()
+
+
+__all__ = [
+    "QuantizationConfig",
+    "get_quantization_config",
+    "QUANTIZATION_METHODS",
+]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

as titled cc @ispobock 

```
root@id:/sgl-workspace/sglang/test/srt# python3 test_mla_fp8.py
[2024-11-25 00:47:01] server_args=ServerArgs(model_path='neuralmagic/DeepSeek-Coder-V2-Lite-Instruct-FP8', tokenizer_path='neuralmagic/DeepSeek-Coder-V2-Lite-Instruct-FP8', tokenizer_mode='auto', skip_tokenizer_init=False, load_format='auto', trust_remote_code=True, dtype='auto', kv_cache_dtype='fp8_e5m2', quantization=None, context_length=None, device='cuda', served_model_name='neuralmagic/DeepSeek-Coder-V2-Lite-Instruct-FP8', chat_template=None, is_embedding=False, host='127.0.0.1', port=2157, mem_fraction_static=0.87, max_running_requests=None, max_total_tokens=None, chunked_prefill_size=8192, max_prefill_tokens=16384, schedule_policy='lpm', schedule_conservativeness=1.0, cpu_offload_gb=0, tp_size=2, stream_interval=1, random_seed=128310829, constrained_json_whitespace_pattern=None, watchdog_timeout=300, download_dir=None, base_gpu_id=0, log_level='info', log_level_http=None, log_requests=False, show_time_cost=False, enable_metrics=False, decode_log_interval=40, api_key=None, file_storage_pth='SGLang_storage', enable_cache_report=False, dp_size=1, load_balance_method='round_robin', dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, lora_paths=None, max_loras_per_batch=8, attention_backend='flashinfer', sampling_backend='flashinfer', grammar_backend='outlines', disable_radix_cache=False, disable_jump_forward=False, disable_cuda_graph=False, disable_cuda_graph_padding=False, disable_disk_cache=False, disable_custom_all_reduce=False, disable_mla=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_torch_compile=False, torch_compile_max_bs=32, cuda_graph_max_bs=160, torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, num_continuous_decode_steps=1, delete_ckpt_after_loading=False)
[2024-11-25 00:47:11 TP0] MLA optimization is turned on. Use triton backend.
[2024-11-25 00:47:11 TP0] Init torch distributed begin.
[2024-11-25 00:47:11 TP1] MLA optimization is turned on. Use triton backend.
[2024-11-25 00:47:11 TP1] Init torch distributed begin.
[2024-11-25 00:47:16 TP0] Load weight begin. avail mem=77.17 GB
[2024-11-25 00:47:16 TP1] Load weight begin. avail mem=77.18 GB
INFO 11-25 00:47:16 config.py:107] Replacing legacy 'type' key with 'rope_type'
INFO 11-25 00:47:16 config.py:107] Replacing legacy 'type' key with 'rope_type'
[2024-11-25 00:47:16 TP0] lm_eval is not installed, GPTQ may not be usable
WARNING 11-25 00:47:16 fp8.py:47] Detected fp8 checkpoint. Please note that the format is experimental and subject to change.
[2024-11-25 00:47:16 TP1] lm_eval is not installed, GPTQ may not be usable
Cache shape torch.Size([163840, 64])
WARNING 11-25 00:47:16 fp8.py:47] Detected fp8 checkpoint. Please note that the format is experimental and subject to change.
Cache shape torch.Size([163840, 64])
INFO 11-25 00:47:17 weight_utils.py:243] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
INFO 11-25 00:47:17 weight_utils.py:243] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:01<00:03,  1.19s/it]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:02<00:02,  1.29s/it]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:03<00:01,  1.30s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:04<00:00,  1.10it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:04<00:00,  1.04s/it]

[2024-11-25 00:47:21 TP0] Load weight end. type=DeepseekV2ForCausalLM, dtype=torch.bfloat16, avail mem=69.58 GB
[2024-11-25 00:47:21 TP1] Load weight end. type=DeepseekV2ForCausalLM, dtype=torch.bfloat16, avail mem=69.60 GB
[2024-11-25 00:47:22 TP0] Memory pool end. avail mem=7.60 GB
[2024-11-25 00:47:22 TP1] Memory pool end. avail mem=7.61 GB
[2024-11-25 00:47:22 TP0] Capture cuda graph begin. This can take up to several minutes.
[2024-11-25 00:47:22 TP1] Capture cuda graph begin. This can take up to several minutes.
[2024-11-25 00:47:27 TP1] Using default MoE config. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang/python/sglang/srt/layers/fused_moe_triton/configs/E=64,N=704,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8.json
[2024-11-25 00:47:27 TP0] Using default MoE config. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang/python/sglang/srt/layers/fused_moe_triton/configs/E=64,N=704,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8.json
INFO 11-25 00:47:41 custom_all_reduce.py:233] Registering 1265 cuda graph addresses
INFO 11-25 00:47:41 custom_all_reduce.py:233] Registering 1265 cuda graph addresses
[2024-11-25 00:47:42 TP1] max_total_num_tokens=4106823, max_prefill_tokens=16384, max_running_requests=4097, context_len=163840
[2024-11-25 00:47:42 TP0] max_total_num_tokens=4106823, max_prefill_tokens=16384, max_running_requests=4097, context_len=163840
[2024-11-25 00:47:42] INFO:     Started server process [833555]
[2024-11-25 00:47:42] INFO:     Waiting for application startup.
[2024-11-25 00:47:42] INFO:     Application startup complete.
[2024-11-25 00:47:42] INFO:     Uvicorn running on http://127.0.0.1:2157 (Press CTRL+C to quit)
[2024-11-25 00:47:43] INFO:     127.0.0.1:55266 - "GET /get_model_info HTTP/1.1" 200 OK
[2024-11-25 00:47:43 TP0] Prefill batch. #new-seq: 1, #new-token: 7, #cached-token: 0, cache hit rate: 0.00%, token usage: 0.00, #running-req: 0, #queue-req: 0
[2024-11-25 00:47:50 TP0] Prefill batch. #new-seq: 1, #new-token: 1, #cached-token: 0, cache hit rate: 0.00%, token usage: 0.00, #running-req: 1, #queue-req: 0
[2024-11-25 00:47:50] INFO:     127.0.0.1:55288 - "GET /health_generate HTTP/1.1" 200 OK
[2024-11-25 00:47:50] INFO:     127.0.0.1:55278 - "POST /generate HTTP/1.1" 200 OK
[2024-11-25 00:47:50] The server is fired up and ready to roll!
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
