### PR TITLE
[Fix] Avoid calling fill_vocab_mask for terminated requests

### DIFF
--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -170,7 +170,10 @@ class SamplingBatchInfo:
 
         for i, grammar in enumerate(self.grammars):
             if grammar is not None:
-                grammar.fill_vocab_mask(self.vocab_mask, i)
+                try:
+                    grammar.fill_vocab_mask(self.vocab_mask, i)
+                except Exception as e:
+                    continue
 
     def filter_batch(self, unfinished_indices: List[int], new_indices: torch.Tensor):
         self.penalizer_orchestrator.filter(unfinished_indices, new_indices)

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -172,7 +172,7 @@ class SamplingBatchInfo:
             if grammar is not None:
                 try:
                     grammar.fill_vocab_mask(self.vocab_mask, i)
-                except Exception as e:
+                except RuntimeError:
                     continue
 
     def filter_batch(self, unfinished_indices: List[int], new_indices: torch.Tensor):


### PR DESCRIPTION
This PR avoids calling fill_vocab_mask for terminated requests through try-catch block. 