### PR TITLE
Use custom allreduce w/ torch.compile

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -65,7 +65,8 @@ def patch_model(
             _to_torch(model)
             monkey_patch_vllm_all_gather()
             backup_ca_comm = tp_group.ca_comm
-            tp_group.ca_comm = None
+            # Use custom-allreduce here
+            # tp_group.ca_comm = None
             yield torch.compile(
                 torch.no_grad()(model.forward), mode="max-autotune-no-cudagraphs"
             )


### PR DESCRIPTION
It makes torch.compile with tensor parallelism much faster.

llama 3.1 8b w/ tp = 8
```
python3 -m sglang.bench_offline_throughput --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --num-prompt 1 --random-input 1024 --random-output 256 --random-range 1 --tp 8 --enable-torch-compile
```

before: 315.02 token/s
after: 457.22 token/s
