### PR TITLE
add sglang version to get_server_info

### DIFF
--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -86,6 +86,7 @@ from sglang.srt.utils import (
     set_ulimit,
 )
 from sglang.utils import get_exception_traceback
+from sglang.version import __version__
 
 logger = logging.getLogger(__name__)
 
@@ -527,6 +528,7 @@ async def _get_server_info():
         **dataclasses.asdict(tokenizer_manager.server_args),  # server args
         "memory_pool_size": await tokenizer_manager.get_memory_pool_size(),  # memory pool size
         "max_total_num_tokens": _max_total_num_tokens,  # max total num tokens
+        "version": __version__,
     }
 
 

--- a/test/srt/test_srt_endpoint.py
+++ b/test/srt/test_srt_endpoint.py
@@ -226,6 +226,9 @@ class TestSRTEndpoint(unittest.TestCase):
         attention_backend = response_json["attention_backend"]
         self.assertIsInstance(attention_backend, str)
 
+        version = response_json["version"]
+        self.assertIsInstance(version, str)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This pr address the issue #2205 .

## Modifications

Be able to check and verify sglang server backend version through `get_server_info`

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
