### PR TITLE
Use an env var SGLANG_SET_CPU_AFFINITY to set cpu affinity; turn it off by default

### DIFF
--- a/python/sglang/bench_one_batch_server.py
+++ b/python/sglang/bench_one_batch_server.py
@@ -5,9 +5,9 @@ This script launches a server and uses the HTTP interface.
 It accepts server arguments (the same as launch_server.py) and benchmark arguments (e.g., batch size, input lengths).
 
 Usage:
-python3 -m sglang.bench_server_latency --model meta-llama/Meta-Llama-3.1-8B --batch-size 1 16 64 --input-len 1024 --output-len 8
+python3 -m sglang.bench_one_batch_server --model meta-llama/Meta-Llama-3.1-8B --batch-size 1 16 64 --input-len 1024 --output-len 8
 
-python3 -m sglang.bench_server_latency --model None --base-url http://localhost:30000 --batch-size 16 --input-len 1024 --output-len 8
+python3 -m sglang.bench_one_batch_server --model None --base-url http://localhost:30000 --batch-size 16 --input-len 1024 --output-len 8
 """
 
 import argparse

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -14,13 +14,13 @@
 
 import json
 import logging
-import os
 from enum import IntEnum, auto
 from typing import List, Optional
 
 from transformers import PretrainedConfig
 
 from sglang.srt.hf_transformers_utils import get_config, get_context_length
+from sglang.srt.utils import get_bool_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +59,9 @@ class ModelConfig:
 
         # Derive context length
         derived_context_len = get_context_length(self.hf_text_config)
-        allow_long_context = os.environ.get(
-            "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", None
-        )
-
         if context_length is not None:
             if context_length > derived_context_len:
-                if allow_long_context:
+                if get_bool_env_var("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN"):
                     logger.warning(
                         f"Warning: User-specified context_length ({context_length}) is greater than the derived context_length ({derived_context_len}). "
                         f"This may lead to incorrect model outputs or CUDA errors."

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -18,7 +18,7 @@ import triton.language as tl
 from sglang.global_config import global_config
 from sglang.srt.layers.attention import AttentionBackend
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.utils import is_flashinfer_available
+from sglang.srt.utils import get_bool_env_var, is_flashinfer_available
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
@@ -47,8 +47,8 @@ class FlashInferAttnBackend(AttentionBackend):
 
         # Parse constants
         if "SGLANG_FLASHINFER_USE_TENSOR_CORE" in os.environ:
-            self.decode_use_tensor_cores = (
-                os.environ["SGLANG_FLASHINFER_USE_TENSOR_CORE"].lower() == "true"
+            self.decode_use_tensor_cores = get_bool_env_var(
+                "SGLANG_FLASHINFER_USE_TENSOR_CORE"
             )
         else:
             if not _grouped_size_compiled_for_decode_kernels(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -73,8 +73,8 @@ from sglang.srt.utils import (
     crash_on_warnings,
     get_bool_env_var,
     get_zmq_socket,
-    gpu_proc_affinity,
     kill_parent_process,
+    set_gpu_proc_affinity,
     set_random_seed,
     suppress_other_loggers,
 )
@@ -1407,7 +1407,7 @@ def run_scheduler_process(
 ):
     # set cpu affinity to this gpu process
     if get_bool_env_var("SGLANG_SET_CPU_AFFINITY"):
-        gpu_proc_affinity(server_args.tp_size, server_args.nnodes, gpu_id)
+        set_gpu_proc_affinity(server_args.tp_size, server_args.nnodes, gpu_id)
 
     # [For Router] if env var "DP_RANK" exist, set dp_rank to the value of the env var
     if dp_rank is None and "DP_RANK" in os.environ:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -71,6 +71,7 @@ from sglang.srt.utils import (
     broadcast_pyobj,
     configure_logger,
     crash_on_warnings,
+    get_bool_env_var,
     get_zmq_socket,
     gpu_proc_affinity,
     kill_parent_process,
@@ -82,7 +83,7 @@ from sglang.utils import get_exception_traceback
 logger = logging.getLogger(__name__)
 
 # Test retract decode
-test_retract = os.getenv("SGLANG_TEST_RETRACT", "false").lower() == "true"
+test_retract = get_bool_env_var("SGLANG_TEST_RETRACT")
 
 
 class Scheduler:
@@ -1405,7 +1406,8 @@ def run_scheduler_process(
     pipe_writer,
 ):
     # set cpu affinity to this gpu process
-    gpu_proc_affinity(server_args.tp_size, server_args.nnodes, gpu_id)
+    if get_bool_env_var("SGLANG_SET_CPU_AFFINITY"):
+        gpu_proc_affinity(server_args.tp_size, server_args.nnodes, gpu_id)
 
     # [For Router] if env var "DP_RANK" exist, set dp_rank to the value of the env var
     if dp_rank is None and "DP_RANK" in os.environ:

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -72,7 +72,7 @@ def is_flashinfer_available():
     Check whether flashinfer is available.
     As of Oct. 6, 2024, it is only available on NVIDIA GPUs.
     """
-    if get_bool_env_var("SGLANG_IS_FLASHINFER_AVAILABLE"):
+    if get_bool_env_var("SGLANG_IS_FLASHINFER_AVAILABLE", default="true"):
         return False
     return torch.cuda.is_available() and not is_hip()
 
@@ -990,7 +990,7 @@ def direct_register_custom_op(
         my_lib._register_fake(op_name, fake_impl)
 
 
-def gpu_proc_affinity(
+def set_gpu_proc_affinity(
     tp_size: int,
     nnodes: int,
     gpu_id: int,
@@ -1024,8 +1024,6 @@ def gpu_proc_affinity(
     logger.info(f"Process {pid} gpu_id {gpu_id} is running on CPUs: {p.cpu_affinity()}")
 
 
-def get_bool_env_var(name: str) -> bool:
-    value = os.getenv(name)
-    if value is None:
-        return False
+def get_bool_env_var(name: str, default: str = "false") -> bool:
+    value = os.getenv(name, default)
     return value.lower() in ("true", "1")

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -72,7 +72,7 @@ def is_flashinfer_available():
     Check whether flashinfer is available.
     As of Oct. 6, 2024, it is only available on NVIDIA GPUs.
     """
-    if os.environ.get("SGLANG_IS_FLASHINFER_AVAILABLE", "true") == "false":
+    if get_bool_env_var("SGLANG_IS_FLASHINFER_AVAILABLE"):
         return False
     return torch.cuda.is_available() and not is_hip()
 
@@ -626,7 +626,7 @@ def add_api_key_middleware(app, api_key: str):
 
 
 def prepare_model_and_tokenizer(model_path: str, tokenizer_path: str):
-    if "SGLANG_USE_MODELSCOPE" in os.environ:
+    if get_bool_env_var("SGLANG_USE_MODELSCOPE"):
         if not os.path.exists(model_path):
             from modelscope import snapshot_download
 
@@ -931,7 +931,7 @@ def get_nvgpu_memory_capacity():
 
 def crash_on_warnings():
     # Crash on warning if we are running CI tests
-    return os.getenv("SGLANG_IS_IN_CI", "false").lower() == "true"
+    return get_bool_env_var("SGLANG_IS_IN_CI")
 
 
 def get_device_name(device_id: int = 0) -> str:
@@ -1022,3 +1022,10 @@ def gpu_proc_affinity(
     # set cpu_affinity to current process
     p.cpu_affinity(bind_cpu_ids)
     logger.info(f"Process {pid} gpu_id {gpu_id} is running on CPUs: {p.cpu_affinity()}")
+
+
+def get_bool_env_var(name: str) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return False
+    return value.lower() in ("true", "1")

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -24,7 +24,7 @@ from sglang.lang.backend.openai import OpenAI
 from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
 from sglang.srt.utils import kill_child_process
 from sglang.test.run_eval import run_eval
-from sglang.utils import get_exception_traceback
+from sglang.utils import get_bool_env_var, get_exception_traceback
 
 DEFAULT_FP8_MODEL_NAME_FOR_TEST = "neuralmagic/Meta-Llama-3.1-8B-FP8"
 DEFAULT_MODEL_NAME_FOR_TEST = "meta-llama/Llama-3.1-8B-Instruct"
@@ -44,7 +44,7 @@ DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_QUANT_TP1 = "hugging-quants/Meta-Llama-3.1-8
 
 def is_in_ci():
     """Return whether it is in CI runner."""
-    return os.getenv("SGLANG_IS_IN_CI", "false").lower() == "true"
+    return get_bool_env_var("SGLANG_IS_IN_CI")
 
 
 if is_in_ci():

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -22,9 +22,9 @@ from sglang.bench_serving import run_benchmark
 from sglang.global_config import global_config
 from sglang.lang.backend.openai import OpenAI
 from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-from sglang.srt.utils import kill_child_process
+from sglang.srt.utils import get_bool_env_var, kill_child_process
 from sglang.test.run_eval import run_eval
-from sglang.utils import get_bool_env_var, get_exception_traceback
+from sglang.utils import get_exception_traceback
 
 DEFAULT_FP8_MODEL_NAME_FOR_TEST = "neuralmagic/Meta-Llama-3.1-8B-FP8"
 DEFAULT_MODEL_NAME_FOR_TEST = "meta-llama/Llama-3.1-8B-Instruct"


### PR DESCRIPTION
It will conflict with some other libraries (e.g. Ray). We see an error message like below, so we want to turn it off by default.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/data/dhou/runner/actions-runner/_work/sglang-private/sglang-private/python/sglang/srt/managers/scheduler.py", line 1526, in run_scheduler_process
    gpu_proc_affinity(server_args.tp_size, server_args.nnodes, gpu_id)
  File "/data/dhou/runner/actions-runner/_work/sglang-private/sglang-private/python/sglang/srt/utils.py", line 1053, in gpu_proc_affinity
    p.cpu_affinity(bind_cpu_ids)
  File "/usr/local/lib/python3.10/dist-packages/ray/thirdparty_files/psutil/__init__.py", line [89](https://github.com/xai-org/sglang-private/actions/runs/12041611115/job/33575335155#step:4:90)3, in cpu_affinity
    self._proc.cpu_affinity_set(list(set(cpus)))
  File "/usr/local/lib/python3.10/dist-packages/ray/thirdparty_files/psutil/_pslinux.py", line 1717, in wrapper
    return fun(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/ray/thirdparty_files/psutil/_pslinux.py", line 2234, in cpu_affinity_set
    raise ValueError(
ValueError: CPU number 96 is not eligible; choose between [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73]
Process Process-6:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ray/thirdparty_files/psutil/_pslinux.py", line 2222, in cpu_affinity_set
    cext.proc_cpu_affinity_set(self.pid, cpus)
OSError: [Errno 22] Invalid argument
```