### PR TITLE
[CI] Print summary on github actions

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -816,3 +816,8 @@ def run_mulit_request_test(
         chunked_prefill_size,
         assert_has_abort=False,
     )
+
+
+def write_github_step_summary(content):
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+        f.write(content)

--- a/test/srt/test_bench_serving.py
+++ b/test/srt/test_bench_serving.py
@@ -22,7 +22,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_offline_throughput_default\n"
+                f"### test_offline_throughput_default\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 3350)
@@ -42,7 +42,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_offline_throughput_non_stream_small_batch_size\n"
+                f"### test_offline_throughput_non_stream_small_batch_size\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             # There is a regression with torch 2.5
@@ -59,7 +59,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_offline_throughput_without_radix_cache\n"
+                f"### test_offline_throughput_without_radix_cache\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 3350)
@@ -74,7 +74,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_offline_throughput_without_chunked_prefill\n"
+                f"### test_offline_throughput_without_chunked_prefill\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 2600)
@@ -94,7 +94,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_offline_throughput_with_triton_attention_backend\n"
+                f"### test_offline_throughput_with_triton_attention_backend\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 3450)
@@ -109,7 +109,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_offline_throughput_default_fp8\n"
+                f"### test_offline_throughput_default_fp8\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 3850)
@@ -124,7 +124,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_online_latency_default\n"
+                f"### test_online_latency_default\n"
                 f'median_e2e_latency_ms : {res["median_e2e_latency_ms"]:.2f} token/s\n'
             )
             self.assertLess(res["median_e2e_latency_ms"], 12000)
@@ -141,7 +141,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_moe_offline_throughput_default\n"
+                f"### test_moe_offline_throughput_default\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 2150)
@@ -156,7 +156,7 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             write_github_step_summary(
-                f"## test_moe_offline_throughput_without_radix_cache\n"
+                f"### test_moe_offline_throughput_without_radix_cache\n"
                 f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
             self.assertGreater(res["output_throughput"], 2150)

--- a/test/srt/test_bench_serving.py
+++ b/test/srt/test_bench_serving.py
@@ -6,6 +6,7 @@ from sglang.test.test_utils import (
     DEFAULT_MOE_MODEL_NAME_FOR_TEST,
     is_in_ci,
     run_bench_serving,
+    write_github_step_summary,
 )
 
 
@@ -21,6 +22,9 @@ class TestBenchServing(unittest.TestCase):
 
         if is_in_ci():
             self.assertGreater(res["output_throughput"], 3350)
+            write_github_step_summary(
+                f'test_offline_throughput_default: {res["output_throughput"]}'
+            )
 
     def test_offline_throughput_non_stream_small_batch_size(self):
         res = run_bench_serving(

--- a/test/srt/test_bench_serving.py
+++ b/test/srt/test_bench_serving.py
@@ -21,10 +21,11 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
-            self.assertGreater(res["output_throughput"], 3350)
             write_github_step_summary(
-                f'test_offline_throughput_default: {res["output_throughput"]}'
+                f"## test_offline_throughput_default\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
             )
+            self.assertGreater(res["output_throughput"], 3350)
 
     def test_offline_throughput_non_stream_small_batch_size(self):
         res = run_bench_serving(
@@ -40,6 +41,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_offline_throughput_non_stream_small_batch_size\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             # There is a regression with torch 2.5
             # This number was 950 for torch 2.4
             self.assertGreater(res["output_throughput"], 800)
@@ -53,6 +58,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_offline_throughput_without_radix_cache\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             self.assertGreater(res["output_throughput"], 3350)
 
     def test_offline_throughput_without_chunked_prefill(self):
@@ -64,6 +73,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_offline_throughput_without_chunked_prefill\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             self.assertGreater(res["output_throughput"], 2600)
 
     def test_offline_throughput_with_triton_attention_backend(self):
@@ -80,6 +93,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_offline_throughput_with_triton_attention_backend\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             self.assertGreater(res["output_throughput"], 3450)
 
     def test_offline_throughput_default_fp8(self):
@@ -91,6 +108,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_offline_throughput_default_fp8\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             self.assertGreater(res["output_throughput"], 3850)
 
     def test_online_latency_default(self):
@@ -102,6 +123,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_online_latency_default\n"
+                f'median_e2e_latency_ms : {res["median_e2e_latency_ms"]:.2f} token/s\n'
+            )
             self.assertLess(res["median_e2e_latency_ms"], 12000)
             self.assertLess(res["median_ttft_ms"], 86)
             self.assertLess(res["median_itl_ms"], 10)
@@ -115,6 +140,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_moe_offline_throughput_default\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             self.assertGreater(res["output_throughput"], 2150)
 
     def test_moe_offline_throughput_without_radix_cache(self):
@@ -126,6 +155,10 @@ class TestBenchServing(unittest.TestCase):
         )
 
         if is_in_ci():
+            write_github_step_summary(
+                f"## test_moe_offline_throughput_without_radix_cache\n"
+                f'Output throughput: {res["output_throughput"]:.2f} token/s\n'
+            )
             self.assertGreater(res["output_throughput"], 2150)
 
 


### PR DESCRIPTION
We can print the summary of CI tests to `GITHUB_STEP_SUMMARY` so we can have a nice and clean summary