### PR TITLE
[Fix] fix assertion error for chunked prefill when disabling cache

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -231,6 +231,9 @@ class PrefillAdder:
                             break
                     self.req_states.insert(i, (tokens_left, tokens_occupied))
 
+        if len(self.can_run_list) != 0:
+            return AddReqResult.OTHER
+
         if self.req_states is None:
             self.req_states = []
             add_req_state(req)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When using chunked prefill with disabled radix cache, the scheduler will fail at the assertion error [here](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/scheduler.py#L852).

The error is described in detail in https://github.com/sgl-project/sglang/issues/2255.

## Modifications

This PR simply skips chunking the current request if there is already an inflight request, following the same code path as in `add_one_req`.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
