### PR TITLE
Fix logprob for completions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: 1-gpu-runner
     strategy:
       matrix:
-        range: [0-6, 6-16, 16-24, 24-30, 30-100]
+        range: [0-6, 6-15, 15-23, 23-30, 30-100]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -521,7 +521,7 @@ def v1_generate_request(
                 "skip_special_tokens": request.skip_special_tokens,
             }
         )
-        return_logprobs.append(request.logprobs is not None and request.logprobs > 0)
+        return_logprobs.append(request.logprobs is not None)
         logprob_start_lens.append(current_logprob_start_len)
         top_logprobs_nums.append(
             request.logprobs if request.logprobs is not None else 0

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -599,7 +599,6 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
             logprobs = True
         elif (not isinstance(request, list)) and request.logprobs is not None:
             logprobs = True
-        print(f"{logprobs=}")
         if logprobs:
             if echo:
                 input_token_logprobs = ret_item["meta_info"]["input_token_logprobs"]

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -595,10 +595,11 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
             text = prompts[prompt_index] + text
 
         logprobs = False
-        if isinstance(request, list) and request[idx].logprobs:
+        if isinstance(request, list) and request[idx].logprobs is not None:
             logprobs = True
-        elif (not isinstance(request, list)) and request.logprobs:
+        elif (not isinstance(request, list)) and request.logprobs is not None:
             logprobs = True
+        print(f"{logprobs=}")
         if logprobs:
             if echo:
                 input_token_logprobs = ret_item["meta_info"]["input_token_logprobs"]
@@ -739,7 +740,7 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
                             # Prepend prompt in response text.
                             text = prompts + text
 
-                    if request.logprobs:
+                    if request.logprobs is not None:
                         # The first chunk and echo is enabled.
                         if not stream_buffer and request.echo:
                             input_token_logprobs = content["meta_info"][
@@ -1279,7 +1280,7 @@ def v1_embedding_request(all_requests, tokenizer_manager):
     for request in all_requests:
         prompt = request.input
         assert (
-            type(prompt) == first_prompt_type
+            type(prompt) is first_prompt_type
         ), "All prompts must be of the same type in file input settings"
         prompts.append(prompt)
 


### PR DESCRIPTION
We should accept `logprob = 0` in the openai completion requests and only return the logprob of the chosen tokens.