### PR TITLE
Make torch TP composable with torch.compile

### DIFF
--- a/python/sglang/srt/model_parallel.py
+++ b/python/sglang/srt/model_parallel.py
@@ -54,11 +54,7 @@ class RowwiseParallelMaybeWait(RowwiseParallel):
         )._prepare_output_fn(
             output_layouts, use_local_output, mod, outputs, device_mesh
         )
-        # wait for the output to be ready
-        if isinstance(outputs, AsyncCollectiveTensor):
-            return outputs.wait()
-        else:
-            return outputs
+        return torch.distributed._functional_collectives.wait_tensor(outputs)
 
 
 def tensor_parallel(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Previously we have this block of code in `RowwiseParallel`:

```
# wait for the output to be ready
if isinstance(outputs, AsyncCollectiveTensor):
  return outputs.wait()
else:
  return outputs
```

When dynamo traces, outputs is an `AsyncCollectiveTensor`, so it burns in the `outputs.wait()` call. But at run time, somehow `outputs` become a normal tensor, thus we hit the following error:
```
AttributeError: 'FunctionalTensor' object has no attribute 'wait'
```

This is a bug in Dynamo.

## Modifications

To work around the above Dynamo bug, we swap the above if-else block with a determined behavior:
```
torch.distributed._functional_collectives.wait_tensor(outputs)
```

`wait_tensor` accepts both regular tensor and `AsyncCollectiveTensor`. How it handles them is implementation detail it keeps inside. This would work in both eager and compiled mode.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.

cc @jerryzh168 @bdhirsh