### PR TITLE
reduce watchdog interval to 5s

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -573,7 +573,7 @@ class TokenizerManager:
 
     async def sigterm_watchdog(self):
         while not self.gracefully_exit:
-            await asyncio.sleep(60)
+            await asyncio.sleep(5)
 
         # drain requests
         while True:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The current watchdog interval is 60s, which is a bit too long. Say if i want to gracefully terminate a idle sglang server by sending a TERM signal, it needs to wait around ~60s to take effect.

## Modifications

<!-- Describe the changes made in this PR. -->

This PR reduces the interval to 5s

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
