### PR TITLE
Small fixes for torchao quant

### DIFF
--- a/python/sglang/srt/layers/torchao_utils.py
+++ b/python/sglang/srt/layers/torchao_utils.py
@@ -26,11 +26,12 @@ def apply_torchao_config_to_model(
         quantize_,
     )
     from torchao.quantization.observer import PerRow, PerTensor
+    from torchao.quantization.quant_api import _is_linear
 
     if filter_fn is None:
 
         def filter_fn(module, fqn):
-            return "proj" in fqn
+            return _is_linear(module) and "proj" in fqn
 
     if torchao_config == "" or torchao_config is None:
         return model

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -157,6 +157,10 @@ class ModelRunner:
         self.sampler = Sampler()
         self.load_model()
 
+        apply_torchao_config_to_model(
+            self.model, global_server_args_dict["torchao_config"]
+        )
+
         # Apply torch TP if the model supports it
         supports_torch_tp = getattr(self.model, "supports_torch_tp", False)
         if self.tp_size > 1 and supports_torch_tp:
@@ -164,10 +168,6 @@ class ModelRunner:
             self.torch_tp_applied = True
         else:
             self.torch_tp_applied = False
-
-        apply_torchao_config_to_model(
-            self.model, global_server_args_dict["torchao_config"]
-        )
 
         # Init memory pool and attention backends
         if server_args.lora_paths is not None:


### PR DESCRIPTION
Summary:
1. quantization should happen before tp (in the future ideally we can just laod quantized checkpoints, and tp can be different depending on specific deployment env)
2. adding _is_linear check for filter_fn

Test Plan:
```
python3 -m sglang.bench_one_batch --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 128 --output 8 --json-model-override-args '{"architectures": ["TorchNativeLlamaForCausalLM"]}' --enable-torch-compile --torchao-config int4wo-64 --tp-size 2
```

Reviewers:

Subscribers:

Tasks:

Tags:

