### PR TITLE
[Benchmark] add a benchmark for hf/vllm/sglang rmsnorm

### DIFF
--- a/benchmark/kernels/rmsnorm/benchmark_rmsnorm.py
+++ b/benchmark/kernels/rmsnorm/benchmark_rmsnorm.py
@@ -1,11 +1,13 @@
 import itertools
+from typing import Optional, Tuple, Union
+
 import torch
 import triton
 import triton.language as tl
-from typing import Optional, Union, Tuple
-from torch import nn
 from flashinfer.norm import fused_add_rmsnorm, rmsnorm
+from torch import nn
 from vllm import _custom_ops as vllm_ops
+
 
 class HuggingFaceRMSNorm(nn.Module):
     def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
@@ -32,48 +34,66 @@ class HuggingFaceRMSNorm(nn.Module):
         else:
             return x, residual
 
-def rmsnorm_naive(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch.Tensor] = None, eps: float = 1e-6):
+
+def rmsnorm_naive(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+):
     naive_norm = HuggingFaceRMSNorm(x.shape[-1], eps=eps)
     naive_norm.weight = nn.Parameter(weight)
     naive_norm = naive_norm.to(x.device)
-    
+
     orig_shape = x.shape
     x = x.view(-1, x.shape[-1])
     if residual is not None:
         residual = residual.view(-1, residual.shape[-1])
-    
+
     output = naive_norm(x, residual)
-    
+
     if isinstance(output, tuple):
         output = (output[0].view(orig_shape), output[1].view(orig_shape))
     else:
         output = output.view(orig_shape)
     return output
 
-def rmsnorm_flashinfer(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch.Tensor] = None, eps: float = 1e-6):
+
+def rmsnorm_flashinfer(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+):
     orig_shape = x.shape
     x = x.view(-1, x.shape[-1])
     if residual is not None:
         residual = residual.view(-1, residual.shape[-1])
-    
+
     if residual is not None:
         fused_add_rmsnorm(x, residual, weight, eps)
         output = (x, residual)
     else:
         output = rmsnorm(x, weight, eps)
-    
+
     if isinstance(output, tuple):
         output = (output[0].view(orig_shape), output[1].view(orig_shape))
     else:
-            output = output.view(orig_shape)
+        output = output.view(orig_shape)
     return output
 
-def rmsnorm_vllm(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch.Tensor] = None, eps: float = 1e-6):
+
+def rmsnorm_vllm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+    eps: float = 1e-6,
+):
     orig_shape = x.shape
     x = x.view(-1, x.shape[-1])
     if residual is not None:
         residual = residual.view(-1, residual.shape[-1])
-    
+
     if residual is not None:
         vllm_ops.fused_add_rms_norm(x, residual, weight, eps)
         output = (x, residual)
@@ -81,12 +101,13 @@ def rmsnorm_vllm(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch
         out = torch.empty_like(x)
         vllm_ops.rms_norm(out, x, weight, eps)
         output = out
-    
+
     if isinstance(output, tuple):
         output = (output[0].view(orig_shape), output[1].view(orig_shape))
     else:
         output = output.view(orig_shape)
     return output
+
 
 def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
     dtype = torch.bfloat16
@@ -94,9 +115,15 @@ def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
     weight = torch.ones(hidden_size, dtype=dtype, device="cuda")
     residual = torch.randn_like(x) if use_residual else None
 
-    output_naive = rmsnorm_naive(x.clone(), weight, residual.clone() if residual is not None else None)
-    output_flashinfer = rmsnorm_flashinfer(x.clone(), weight, residual.clone() if residual is not None else None)
-    output_vllm = rmsnorm_vllm(x.clone(), weight, residual.clone() if residual is not None else None)
+    output_naive = rmsnorm_naive(
+        x.clone(), weight, residual.clone() if residual is not None else None
+    )
+    output_flashinfer = rmsnorm_flashinfer(
+        x.clone(), weight, residual.clone() if residual is not None else None
+    )
+    output_vllm = rmsnorm_vllm(
+        x.clone(), weight, residual.clone() if residual is not None else None
+    )
 
     if use_residual:
         output_naive = output_naive[0]
@@ -106,17 +133,20 @@ def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
     print(f"Naive output={output_naive}")
     print(f"FlashInfer output={output_flashinfer}")
     print(f"VLLM output={output_vllm}")
-    
-    if (torch.allclose(output_naive, output_flashinfer, atol=1e-2, rtol=1e-2) and 
-        torch.allclose(output_naive, output_vllm, atol=1e-2, rtol=1e-2)):
+
+    if torch.allclose(
+        output_naive, output_flashinfer, atol=1e-2, rtol=1e-2
+    ) and torch.allclose(output_naive, output_vllm, atol=1e-2, rtol=1e-2):
         print("✅ All implementations match")
     else:
         print("❌ Implementations differ")
+
 
 batch_size_range = [2**i for i in range(0, 7, 2)]
 seq_length_range = [2**i for i in range(6, 11, 1)]
 head_num_range = [32, 48]
 configs = list(itertools.product(head_num_range, batch_size_range, seq_length_range))
+
 
 def get_benchmark(use_residual):
     @triton.testing.perf_report(
@@ -135,43 +165,66 @@ def get_benchmark(use_residual):
     def benchmark(head_num, batch_size, seq_len, provider):
         dtype = torch.bfloat16
         hidden_size = head_num * 128  # assuming head_dim = 128
-        
+
         x = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device="cuda")
         weight = torch.ones(hidden_size, dtype=dtype, device="cuda")
         residual = torch.randn_like(x) if use_residual else None
-        
+
         quantiles = [0.5, 0.2, 0.8]
-        
+
         if provider == "huggingface":
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_naive(x.clone(), weight, residual.clone() if residual is not None else None),
+                lambda: rmsnorm_naive(
+                    x.clone(),
+                    weight,
+                    residual.clone() if residual is not None else None,
+                ),
                 quantiles=quantiles,
             )
         elif provider == "flashinfer":
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_flashinfer(x.clone(), weight, residual.clone() if residual is not None else None),
+                lambda: rmsnorm_flashinfer(
+                    x.clone(),
+                    weight,
+                    residual.clone() if residual is not None else None,
+                ),
                 quantiles=quantiles,
             )
         else:
             ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: rmsnorm_vllm(x.clone(), weight, residual.clone() if residual is not None else None),
+                lambda: rmsnorm_vllm(
+                    x.clone(),
+                    weight,
+                    residual.clone() if residual is not None else None,
+                ),
                 quantiles=quantiles,
             )
-        
+
         return 1000 * ms, 1000 * max_ms, 1000 * min_ms
-    
+
     return benchmark
+
 
 if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--use_residual", action="store_true", help="Whether to use residual connection")
-    parser.add_argument("--save_path", type=str, default="./configs/benchmark_ops/rmsnorm/", help="Path to save rmsnorm benchmark results")
+    parser.add_argument(
+        "--use_residual", action="store_true", help="Whether to use residual connection"
+    )
+    parser.add_argument(
+        "--save_path",
+        type=str,
+        default="./configs/benchmark_ops/rmsnorm/",
+        help="Path to save rmsnorm benchmark results",
+    )
     args = parser.parse_args()
 
     # Run correctness test
-    calculate_diff(batch_size=4, seq_len=128, hidden_size=4096, use_residual=args.use_residual)
-    
+    calculate_diff(
+        batch_size=4, seq_len=128, hidden_size=4096, use_residual=args.use_residual
+    )
+
     # Get the benchmark function with proper use_residual setting
     benchmark = get_benchmark(args.use_residual)
     # Run performance benchmark

--- a/benchmark/kernels/rmsnorm/benchmark_rmsnorm.py
+++ b/benchmark/kernels/rmsnorm/benchmark_rmsnorm.py
@@ -155,7 +155,7 @@ def get_benchmark(use_residual):
             x_vals=[list(_) for _ in configs],
             line_arg="provider",
             line_vals=["huggingface", "flashinfer", "vllm"],
-            line_names=["HuggingFace", "FlashInfer", "VLLM"],
+            line_names=["HuggingFace", "FlashInfer", "vLLM"],
             styles=[("blue", "-"), ("green", "-"), ("red", "-")],
             ylabel="us",
             plot_name=f"rmsnorm-performance-{'with' if use_residual else 'without'}-residual",

--- a/benchmark/kernels/rmsnorm/benchmark_rmsnorm.py
+++ b/benchmark/kernels/rmsnorm/benchmark_rmsnorm.py
@@ -1,0 +1,178 @@
+import itertools
+import torch
+import triton
+import triton.language as tl
+from typing import Optional, Union, Tuple
+from torch import nn
+from flashinfer.norm import fused_add_rmsnorm, rmsnorm
+from vllm import _custom_ops as vllm_ops
+
+class HuggingFaceRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        orig_dtype = x.dtype
+        x = x.to(torch.float32)
+        if residual is not None:
+            x = x + residual.to(torch.float32)
+            residual = x.to(orig_dtype)
+
+        variance = x.pow(2).mean(dim=-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.variance_epsilon)
+        x = x.to(orig_dtype) * self.weight
+        if residual is None:
+            return x
+        else:
+            return x, residual
+
+def rmsnorm_naive(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch.Tensor] = None, eps: float = 1e-6):
+    naive_norm = HuggingFaceRMSNorm(x.shape[-1], eps=eps)
+    naive_norm.weight = nn.Parameter(weight)
+    naive_norm = naive_norm.to(x.device)
+    
+    orig_shape = x.shape
+    x = x.view(-1, x.shape[-1])
+    if residual is not None:
+        residual = residual.view(-1, residual.shape[-1])
+    
+    output = naive_norm(x, residual)
+    
+    if isinstance(output, tuple):
+        output = (output[0].view(orig_shape), output[1].view(orig_shape))
+    else:
+        output = output.view(orig_shape)
+    return output
+
+def rmsnorm_flashinfer(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch.Tensor] = None, eps: float = 1e-6):
+    orig_shape = x.shape
+    x = x.view(-1, x.shape[-1])
+    if residual is not None:
+        residual = residual.view(-1, residual.shape[-1])
+    
+    if residual is not None:
+        fused_add_rmsnorm(x, residual, weight, eps)
+        output = (x, residual)
+    else:
+        output = rmsnorm(x, weight, eps)
+    
+    if isinstance(output, tuple):
+        output = (output[0].view(orig_shape), output[1].view(orig_shape))
+    else:
+            output = output.view(orig_shape)
+    return output
+
+def rmsnorm_vllm(x: torch.Tensor, weight: torch.Tensor, residual: Optional[torch.Tensor] = None, eps: float = 1e-6):
+    orig_shape = x.shape
+    x = x.view(-1, x.shape[-1])
+    if residual is not None:
+        residual = residual.view(-1, residual.shape[-1])
+    
+    if residual is not None:
+        vllm_ops.fused_add_rms_norm(x, residual, weight, eps)
+        output = (x, residual)
+    else:
+        out = torch.empty_like(x)
+        vllm_ops.rms_norm(out, x, weight, eps)
+        output = out
+    
+    if isinstance(output, tuple):
+        output = (output[0].view(orig_shape), output[1].view(orig_shape))
+    else:
+        output = output.view(orig_shape)
+    return output
+
+def calculate_diff(batch_size, seq_len, hidden_size, use_residual=True):
+    dtype = torch.bfloat16
+    x = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device="cuda")
+    weight = torch.ones(hidden_size, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x) if use_residual else None
+
+    output_naive = rmsnorm_naive(x.clone(), weight, residual.clone() if residual is not None else None)
+    output_flashinfer = rmsnorm_flashinfer(x.clone(), weight, residual.clone() if residual is not None else None)
+    output_vllm = rmsnorm_vllm(x.clone(), weight, residual.clone() if residual is not None else None)
+
+    if use_residual:
+        output_naive = output_naive[0]
+        output_flashinfer = output_flashinfer[0]
+        output_vllm = output_vllm[0]
+
+    print(f"Naive output={output_naive}")
+    print(f"FlashInfer output={output_flashinfer}")
+    print(f"VLLM output={output_vllm}")
+    
+    if (torch.allclose(output_naive, output_flashinfer, atol=1e-2, rtol=1e-2) and 
+        torch.allclose(output_naive, output_vllm, atol=1e-2, rtol=1e-2)):
+        print("✅ All implementations match")
+    else:
+        print("❌ Implementations differ")
+
+batch_size_range = [2**i for i in range(0, 7, 2)]
+seq_length_range = [2**i for i in range(6, 11, 1)]
+head_num_range = [32, 48]
+configs = list(itertools.product(head_num_range, batch_size_range, seq_length_range))
+
+def get_benchmark(use_residual):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["head_num", "batch_size", "seq_len"],
+            x_vals=[list(_) for _ in configs],
+            line_arg="provider",
+            line_vals=["huggingface", "flashinfer", "vllm"],
+            line_names=["HuggingFace", "FlashInfer", "VLLM"],
+            styles=[("blue", "-"), ("green", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name=f"rmsnorm-performance-{'with' if use_residual else 'without'}-residual",
+            args={},
+        )
+    )
+    def benchmark(head_num, batch_size, seq_len, provider):
+        dtype = torch.bfloat16
+        hidden_size = head_num * 128  # assuming head_dim = 128
+        
+        x = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device="cuda")
+        weight = torch.ones(hidden_size, dtype=dtype, device="cuda")
+        residual = torch.randn_like(x) if use_residual else None
+        
+        quantiles = [0.5, 0.2, 0.8]
+        
+        if provider == "huggingface":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: rmsnorm_naive(x.clone(), weight, residual.clone() if residual is not None else None),
+                quantiles=quantiles,
+            )
+        elif provider == "flashinfer":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: rmsnorm_flashinfer(x.clone(), weight, residual.clone() if residual is not None else None),
+                quantiles=quantiles,
+            )
+        else:
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: rmsnorm_vllm(x.clone(), weight, residual.clone() if residual is not None else None),
+                quantiles=quantiles,
+            )
+        
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+    
+    return benchmark
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--use_residual", action="store_true", help="Whether to use residual connection")
+    parser.add_argument("--save_path", type=str, default="./configs/benchmark_ops/rmsnorm/", help="Path to save rmsnorm benchmark results")
+    args = parser.parse_args()
+
+    # Run correctness test
+    calculate_diff(batch_size=4, seq_len=128, hidden_size=4096, use_residual=args.use_residual)
+    
+    # Get the benchmark function with proper use_residual setting
+    benchmark = get_benchmark(args.use_residual)
+    # Run performance benchmark
+    benchmark.run(print_data=True, save_path=args.save_path)


### PR DESCRIPTION
## Motivation

When deploying qwen2-7b, I compared the nsys profile results between vllm and sglang and found that `rmsnorm` in vllm was somewhat slower. To easily verify the kernel performance of `rmsnorm` with different input tensor sizes, I submitted this benchmark script. The script allows us to test the performance of `rmsnorm` kernels with or without residual connections by using the `--use_residual` flag. Below are the results obtained on an NVIDIA GeForce RTX 4090 GPU. As shown, the flashinfer `rmsnorm` kernels achieved much better performance across almost all shapes specified in the script.

## rmsnorm without residual

```shell
python3 benchmark/kernels/rmsnorm/benchmark_fused_rms_norm.py
```

benchmark result:

```shell
✅ All implementations match
rmsnorm-performance-without-residual:
    head_num  batch_size  seq_len   HuggingFace   FlashInfer         VLLM
0       32.0         1.0     64.0     30.719999     9.216000    10.240000
1       32.0         1.0    128.0     35.840001    12.288000    13.312000
2       32.0         1.0    256.0     41.983999    14.336000    16.384000
3       32.0         1.0    512.0     60.416002    20.479999    25.599999
4       32.0         1.0   1024.0     97.280003    34.816001    41.983999
5       32.0         4.0     64.0     43.008000    13.312000    16.384000
6       32.0         4.0    128.0     60.416002    20.479999    25.599999
7       32.0         4.0    256.0     97.280003    34.816001    41.983999
8       32.0         4.0    512.0    177.151993    60.416002    70.656002
9       32.0         4.0   1024.0    632.831991   113.664001   130.048007
10      32.0        16.0     64.0     97.280003    34.816001    41.983999
11      32.0        16.0    128.0    177.151993    59.392001    70.656002
12      32.0        16.0    256.0    632.831991   113.664001   130.048007
13      32.0        16.0    512.0   1468.415976   299.008012   345.088005
14      32.0        16.0   1024.0   2933.759928   589.824021   662.527978
15      32.0        64.0     64.0    632.831991   113.664001   130.048007
16      32.0        64.0    128.0   1467.391968   300.031990   345.088005
17      32.0        64.0    256.0   2933.759928   589.824021   662.527978
18      32.0        64.0    512.0   5834.239960  1174.528003  1305.600047
19      32.0        64.0   1024.0  11636.735916  2344.959974  2589.695930
20      48.0         1.0     64.0     33.792000    10.240000    12.288000
21      48.0         1.0    128.0     40.959999    13.312000    16.384000
22      48.0         1.0    256.0     53.247999    17.408000    21.504000
23      48.0         1.0    512.0     80.895998    28.672000    33.792000
24      48.0         1.0   1024.0    139.264002    47.104001    55.296000
25      48.0         4.0     64.0     53.247999    17.408000    21.504000
26      48.0         4.0    128.0     80.895998    28.672000    33.792000
27      48.0         4.0    256.0    139.264002    47.104001    55.296000
28      48.0         4.0    512.0    382.975996    87.040000    99.327996
29      48.0         4.0   1024.0   1071.104050   189.439997   252.927989
30      48.0        16.0     64.0    139.264002    47.104001    55.296000
31      48.0        16.0    128.0    382.975996    87.040000    99.327996
32      48.0        16.0    256.0   1072.128057   189.439997   252.927989
33      48.0        16.0    512.0   2214.399815   444.415987   492.543995
34      48.0        16.0   1024.0   4390.912056   881.663978   964.608014
35      48.0        64.0     64.0   1072.128057   190.464005   252.927989
36      48.0        64.0    128.0   2213.887930   444.415987   492.543995
37      48.0        64.0    256.0   4390.912056   881.663978   964.608014
38      48.0        64.0    512.0   8738.816261  1757.184029  1902.591944
39      48.0        64.0   1024.0  17432.575226  3509.248018  3782.655954
```

## rmsnorm with residual

```shell
python3 benchmark/kernels/rmsnorm/benchmark_fused_rms_norm.py --use_residual
```

benchmark result:

```shell
✅ All implementations match
rmsnorm-performance-with-residual:
    head_num  batch_size  seq_len   HuggingFace   FlashInfer         VLLM
0       32.0         1.0     64.0     41.983999    12.288000    13.312000
1       32.0         1.0    128.0     49.152002    17.408000    17.408000
2       32.0         1.0    256.0     60.416002    20.479999    21.504000
3       32.0         1.0    512.0     95.232002    35.312001    33.792000
4       32.0         1.0   1024.0    154.624000    57.344001    58.368001
5       32.0         4.0     64.0     60.416002    21.504000    21.504000
6       32.0         4.0    128.0     93.184002    34.816001    33.792000
7       32.0         4.0    256.0    154.624000    57.344001    58.368001
8       32.0         4.0    512.0    374.783993   102.399997   102.399997
9       32.0         4.0   1024.0   1134.592056   237.568006   238.591999
10      32.0        16.0     64.0    154.624000    57.344001    58.368001
11      32.0        16.0    128.0    369.664013   102.399997   101.375997
12      32.0        16.0    256.0   1134.592056   237.568006   239.616007
13      32.0        16.0    512.0   2484.224081   588.800013   592.895985
14      32.0        16.0   1024.0   4967.423916  1172.479987  1179.648042
15      32.0        64.0     64.0   1135.615945   237.568006   239.616007
16      32.0        64.0    128.0   2484.224081   588.800013   591.871977
17      32.0        64.0    256.0   4966.400146  1172.479987  1179.648042
18      32.0        64.0    512.0   9902.079582  2340.863943  2351.104021
19      32.0        64.0   1024.0  19777.023315  4678.656101  4694.015980
20      48.0         1.0     64.0     46.080001    14.336000    14.336000
21      48.0         1.0    128.0     57.344001    19.455999    19.455999
22      48.0         1.0    256.0     77.823997    25.599999    27.648000
23      48.0         1.0    512.0    126.975998    46.080001    46.080001
24      48.0         1.0   1024.0    243.711993    79.871997    80.895998
25      48.0         4.0     64.0     77.823997    26.624000    27.648000
26      48.0         4.0    128.0    126.975998    46.080001    45.056000
27      48.0         4.0    256.0    243.711993    78.847997    80.895998
28      48.0         4.0    512.0    753.664017   150.527999   150.527999
29      48.0         4.0   1024.0   1841.151953   435.200006   437.247992
30      48.0        16.0     64.0    243.711993    79.871997    80.895998
31      48.0        16.0    128.0    754.688025   149.504006   151.552007
32      48.0        16.0    256.0   1841.151953   434.175998   436.224014
33      48.0        16.0    512.0   3737.600088   881.663978   890.879989
34      48.0        16.0   1024.0   7436.287880  1756.160021  1771.520019
35      48.0        64.0     64.0   1840.127945   435.200006   437.247992
36      48.0        64.0    128.0   3737.600088   881.663978   890.879989
37      48.0        64.0    256.0   7437.312126  1756.160021  1771.520019
38      48.0        64.0    512.0  14835.712433  3506.175995  3525.631905
39      48.0        64.0   1024.0  29655.040741  7011.328220  7044.095993
```