### PR TITLE
fix moe-ep accuracy issue for fp8

### DIFF
--- a/python/sglang/srt/layers/ep_moe/layer.py
+++ b/python/sglang/srt/layers/ep_moe/layer.py
@@ -644,6 +644,10 @@ class Fp8EPMoEMethod(Fp8MoEMethod):
                         "QuantConfig has static quantization, but found "
                         "activation scales are None."
                     )
+                layer.w13_weight_scale = torch.nn.Parameter(
+                    torch.max(layer.w13_weight_scale, dim=1).values,
+                    requires_grad=False,
+                )
             return
 
     def apply(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

 fix moe ep bug, when load fp8 model.  Links to related issues [link](https://github.com/sgl-project/sglang/issues/2482)

Test model : neuralmagic/DeepSeek-Coder-V2-Instruct-FP8
```
Accuracy: 0.932
Invalid: 0.000
Latency: 243.824 s
Output throughput: 1027.530 token/s
```

cc: @ispobock 

## Modifications


## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
