### PR TITLE
torcho gemlite integration

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -385,6 +385,14 @@ def latency_test(
         8,  # shorter decoding to speed up the warmup
         server_args.device,
     )
+
+    try:
+        from gemlite.core import GemLiteLinearTriton
+        import os, pwd
+        GemLiteLinearTriton.cache_config(f"/tmp/{pwd.getpwuid(os.getuid()).pw_gecos}_gemlite.json")
+    except ImportError:
+        pass
+
     rank_print("Benchmark ...")
 
     # Run the sweep


### PR DESCRIPTION
Summary:

adds support for gemlite kernels

Test Plan:

python3 -m sglang.bench_one_batch --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 1024 --output 512 --json-model-override-args '{"architectures": ["TorchNativeLlamaForCausalLM"]}' --torchao-config gemlite-32-4-64 --dtype float16 --disable-cuda-graph

python3 -m sglang.bench_one_batch --model meta-llama/Meta-Llama-3-8B --batch-size 32 --input 1024 --output 512 --json-model-override-args '{"architectures": ["TorchNativeLlamaForCausalLM"]}' --torchao-config gemlite-32-4-64 --dtype float16 --disable-cuda-graph

python3 -m sglang.bench_one_batch --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 1024 --output 512 --json-model-override-args '{"architectures": ["TorchNativeLlamaForCausalLM"]}' --enable-torch-compile --torchao-config gemlite-32-4-64 --dtype float16

python3 -m sglang.bench_one_batch --model meta-llama/Meta-Llama-3-8B --batch-size 1 --input 1024 --output 512 --json-model-override-args '{"architectures": ["TorchNativeLlamaForCausalLM"]}' --enable-torch-compile --torchao-config gemlite-8-4-64 --dtype float16

Reviewers:

Subscribers:

Tasks:

Tags:

## Motivation

This PR is to add support for teh torchao gemlite integration in SGLang for int4wo quantization, the motivation behind the work is that we expect these kernels to have better TTFT performance compared to the existing int4 integration which is optimized for non prefill performance.

## Modifications

Added some new options to the torchao utils and added a place to store the gemlite cache after warmup

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
