### PR TITLE
[kernel optimize] benchmark write_req_to_token_pool_triton and optimize kernel

### DIFF
--- a/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
+++ b/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
@@ -1,0 +1,347 @@
+import itertools
+import os
+from typing import List
+
+import numpy as np
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def write_req_to_token_pool_triton(
+    req_to_token_ptr,  # [max_batch, max_context_len]
+    req_pool_indices,
+    pre_lens,
+    seq_lens,
+    extend_lens,
+    out_cache_loc,
+    req_to_token_ptr_stride: tl.constexpr,
+):
+    BLOCK_SIZE: tl.constexpr = 512
+    pid = tl.program_id(0)
+
+    req_pool_index = tl.load(req_pool_indices + pid)
+    pre_len = tl.load(pre_lens + pid)
+    seq_len = tl.load(seq_lens + pid)
+
+    # TODO: optimize this?
+    cumsum_start = 0
+    for i in range(pid):
+        cumsum_start += tl.load(extend_lens + i)
+
+    num_loop = tl.cdiv(seq_len - pre_len, BLOCK_SIZE)
+    for i in range(num_loop):
+        offset = tl.arange(0, BLOCK_SIZE) + i * BLOCK_SIZE
+        mask = offset < (seq_len - pre_len)
+        value = tl.load(out_cache_loc + cumsum_start + offset, mask=mask)
+        tl.store(
+            req_to_token_ptr
+            + req_pool_index * req_to_token_ptr_stride
+            + offset
+            + pre_len,
+            value,
+            mask=mask,
+        )
+
+
+@triton.jit
+def write_req_to_token_pool_triton_optimize(
+    req_to_token_ptr,  # [max_batch, max_context_len]
+    req_pool_indices,
+    pre_lens,
+    seq_lens,
+    extend_lens,
+    out_cache_loc,
+    req_to_token_ptr_stride: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_batch = tl.program_id(0)
+    pid_token = tl.program_id(1)
+
+    req_pool_index = tl.load(req_pool_indices + pid_batch)
+    pre_len = tl.load(pre_lens + pid_batch)
+    seq_len = tl.load(seq_lens + pid_batch)
+    extend_len = seq_len - pre_len
+
+    cumsum_start = 0
+    for i in range(pid_batch):
+        cumsum_start += tl.load(extend_lens + i)
+
+    token_start = pid_token * BLOCK_SIZE
+
+    offset = tl.arange(0, BLOCK_SIZE)
+    actual_offset = token_start + offset
+    mask = actual_offset < extend_len
+
+    src_ptr = out_cache_loc + cumsum_start + actual_offset
+    src_ptr = tl.max_contiguous(tl.multiple_of(src_ptr, BLOCK_SIZE), BLOCK_SIZE)
+    value = tl.load(src_ptr, mask=mask)
+    dst_ptr = (
+        req_to_token_ptr
+        + req_pool_index * req_to_token_ptr_stride
+        + actual_offset
+        + pre_len
+    )
+    dst_ptr = tl.max_contiguous(tl.multiple_of(dst_ptr, BLOCK_SIZE), BLOCK_SIZE)
+
+    tl.store(dst_ptr, value, mask=mask)
+
+
+def write_req_to_token_pool_reference(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    pre_lens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    extend_lens: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+) -> None:
+    """Reference implementation using PyTorch"""
+    for i in range(len(req_pool_indices)):
+        req_pool_idx = req_pool_indices[i].item()
+        pre_len = pre_lens[i].item()
+        seq_len = seq_lens[i].item()
+        extend_len = extend_lens[i].item()
+
+        cumsum_start = sum(extend_lens[:i].tolist())
+
+        # Copy values from out_cache_loc to req_to_token
+        req_to_token[req_pool_idx, pre_len:seq_len] = out_cache_loc[
+            cumsum_start : cumsum_start + extend_len
+        ]
+
+
+def test_write_req_to_token_pool():
+    max_batch = 4097
+    max_context_len = 6148
+    batch_size = 1
+    extend_len = 14
+
+    # Initialize input tensors
+    req_to_token = torch.zeros(
+        (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+    )
+    req_pool_indices = torch.tensor([42], dtype=torch.int32, device="cuda")
+    pre_lens = torch.tensor([8], dtype=torch.int32, device="cuda")
+    seq_lens = torch.tensor([22], dtype=torch.int32, device="cuda")
+    extend_lens = torch.tensor([extend_len], dtype=torch.int32, device="cuda")
+    out_cache_loc = torch.arange(extend_len, dtype=torch.int32, device="cuda")
+
+    # Create copies for reference implementation
+    req_to_token_ref = req_to_token.clone()
+    req_to_token_opt = req_to_token.clone()
+
+    # Run original triton kernel
+    write_req_to_token_pool_triton[(batch_size,)](
+        req_to_token,
+        req_pool_indices,
+        pre_lens,
+        seq_lens,
+        extend_lens,
+        out_cache_loc,
+        max_context_len,
+    )
+
+    # Run optimized triton kernel
+    def grid(batch_size, extend_len):
+        num_token_blocks = triton.cdiv(
+            extend_len, 512
+        )
+        return (batch_size, num_token_blocks)
+
+    write_req_to_token_pool_triton_optimize[grid(batch_size, extend_len)](
+        req_to_token_opt,
+        req_pool_indices,
+        pre_lens,
+        seq_lens,
+        extend_lens,
+        out_cache_loc,
+        max_context_len,
+        BLOCK_SIZE=512,
+    )
+
+    # Run reference implementation
+    write_req_to_token_pool_reference(
+        req_to_token_ref,
+        req_pool_indices,
+        pre_lens,
+        seq_lens,
+        extend_lens,
+        out_cache_loc,
+    )
+
+    # Compare results
+    torch.testing.assert_close(req_to_token, req_to_token_ref)
+    torch.testing.assert_close(req_to_token_opt, req_to_token_ref)
+
+    # Test case 2: batch size > 1
+    batch_size = 3
+    extend_lens_list = [14, 20, 30]
+    total_extend_len = sum(extend_lens_list)
+
+    req_to_token = torch.zeros(
+        (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+    )
+    req_pool_indices = torch.tensor([42, 100, 200], dtype=torch.int32, device="cuda")
+    pre_lens = torch.tensor([8, 10, 15], dtype=torch.int32, device="cuda")
+    seq_lens = torch.tensor([22, 30, 45], dtype=torch.int32, device="cuda")
+    extend_lens = torch.tensor(extend_lens_list, dtype=torch.int32, device="cuda")
+    out_cache_loc = torch.arange(total_extend_len, dtype=torch.int32, device="cuda")
+
+    req_to_token_ref = req_to_token.clone()
+    req_to_token_opt = req_to_token.clone()
+
+    # Run original triton kernel
+    write_req_to_token_pool_triton[(batch_size,)](
+        req_to_token,
+        req_pool_indices,
+        pre_lens,
+        seq_lens,
+        extend_lens,
+        out_cache_loc,
+        max_context_len,
+    )
+
+    # Run optimized triton kernel
+    max_extend_len = max(extend_lens_list)
+    write_req_to_token_pool_triton_optimize[grid(batch_size, max_extend_len)](
+        req_to_token_opt,
+        req_pool_indices,
+        pre_lens,
+        seq_lens,
+        extend_lens,
+        out_cache_loc,
+        max_context_len,
+        BLOCK_SIZE=512,
+    )
+
+    # Run reference implementation
+    write_req_to_token_pool_reference(
+        req_to_token_ref,
+        req_pool_indices,
+        pre_lens,
+        seq_lens,
+        extend_lens,
+        out_cache_loc,
+    )
+
+    # Compare results
+    torch.testing.assert_close(req_to_token, req_to_token_ref)
+    torch.testing.assert_close(req_to_token_opt, req_to_token_ref)
+
+
+def get_benchmark():
+    batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128]
+    extend_lens = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
+    configs = list(itertools.product(batch_sizes, extend_lens))
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["batch_size", "extend_len"],
+            x_vals=configs,
+            line_arg="provider",
+            line_vals=["reference", "triton", "triton_optimize"],
+            line_names=["PyTorch", "Triton", "Triton Optimized"],
+            styles=[("blue", "-"), ("green", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name="write-req-to-token-pool-performance",
+            args={},
+        )
+    )
+    def benchmark(batch_size, extend_len, provider):
+        max_batch = 256
+        max_context_len = 16384
+
+        extend_lens_list = [extend_len] * batch_size
+        total_extend_len = sum(extend_lens_list)
+
+        req_to_token = torch.zeros(
+            (max_batch, max_context_len), dtype=torch.int32, device="cuda"
+        )
+        req_pool_indices = torch.arange(batch_size, dtype=torch.int32, device="cuda")
+        pre_lens = torch.ones(batch_size, dtype=torch.int32, device="cuda") * 8
+        seq_lens = pre_lens + extend_len
+        extend_lens = torch.tensor(extend_lens_list, dtype=torch.int32, device="cuda")
+        out_cache_loc = torch.arange(total_extend_len, dtype=torch.int32, device="cuda")
+
+        quantiles = [0.5, 0.2, 0.8]
+
+        if provider == "reference":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: write_req_to_token_pool_reference(
+                    req_to_token.clone(),
+                    req_pool_indices,
+                    pre_lens,
+                    seq_lens,
+                    extend_lens,
+                    out_cache_loc,
+                ),
+                quantiles=quantiles,
+            )
+        elif provider == "triton":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: write_req_to_token_pool_triton[(batch_size,)](
+                    req_to_token.clone(),
+                    req_pool_indices,
+                    pre_lens,
+                    seq_lens,
+                    extend_lens,
+                    out_cache_loc,
+                    max_context_len,
+                ),
+                quantiles=quantiles,
+            )
+        else:
+
+            def run_optimized():
+                block_size = 128 if extend_len <= 1024 else 512
+                grid_config = (batch_size, triton.cdiv(extend_len, block_size))
+                write_req_to_token_pool_triton_optimize[grid_config](
+                    req_to_token.clone(),
+                    req_pool_indices,
+                    pre_lens,
+                    seq_lens,
+                    extend_lens,
+                    out_cache_loc,
+                    max_context_len,
+                    BLOCK_SIZE=block_size,
+                )
+
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                run_optimized, quantiles=quantiles
+            )
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+def run_benchmark(save_path: str = "./configs/benchmark_ops/write_req_to_token_pool/"):
+    """Run benchmark and save results"""
+
+    # Ensure save path exists
+    os.makedirs(save_path, exist_ok=True)
+
+    # Run correctness test
+    test_write_req_to_token_pool()
+    print("Correctness test passed!")
+
+    # Run performance test
+    benchmark = get_benchmark()
+    benchmark.run(print_data=True, save_path=save_path)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--save_path",
+        type=str,
+        default="./configs/benchmark_ops/write_req_to_token_pool/",
+        help="Path to save benchmark results",
+    )
+    args = parser.parse_args()
+
+    run_benchmark(args.save_path)

--- a/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
+++ b/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
@@ -145,9 +145,7 @@ def test_write_req_to_token_pool():
 
     # Run optimized triton kernel
     def grid(batch_size, extend_len):
-        num_token_blocks = triton.cdiv(
-            extend_len, 512
-        )
+        num_token_blocks = triton.cdiv(extend_len, 512)
         return (batch_size, num_token_blocks)
 
     write_req_to_token_pool_triton_optimize[grid(batch_size, extend_len)](


### PR DESCRIPTION
- [x] add a correctless test for `write_req_to_token_pool_triton`
- [x] optimize `write_req_to_token_pool_triton`
- [x] add benchmark test for `write_req_to_token_pool_triton`

Peformance with  `write_req_to_token_pool_triton_optimize` in 4090:

```shell
Correctness test passed!
write-req-to-token-pool-performance:
    batch_size  extend_len      PyTorch     Triton  Triton Optimized
    batch_size  extend_len      PyTorch     Triton  Triton Optimized
0          1.0        32.0    93.184002  47.104001         46.080001
1          1.0        64.0    93.184002  46.080001         46.080001
2          1.0       128.0    93.184002  46.080001         46.080001
3          1.0       256.0    94.208002  46.080001         46.080001
4          1.0       512.0    92.160001  46.080001         46.080001
5          1.0      1024.0    93.184002  47.104001         46.080001
6          1.0      2048.0    93.184002  47.104001         46.080001
7          1.0      4096.0    93.184002  **48.128001**         46.080001
8          1.0      8192.0    93.184002  **50.175998**         46.080001
9          2.0        32.0   141.312003  46.080001         46.080001
10         2.0        64.0   143.360004  46.080001         46.080001
11         2.0       128.0   142.335996  46.080001         46.080001
12         2.0       256.0   143.360004  47.104001         46.080001
13         2.0       512.0   141.312003  46.080001         46.080001
14         2.0      1024.0   141.312003  **47.104001**         46.080001
15         2.0      2048.0   144.383997  **47.104001**         46.080001
16         2.0      4096.0   144.383997  **49.152002**         46.080001
17         2.0      8192.0   142.335996  51.199999         47.104001
18         4.0        32.0   240.640000  46.080001         46.080001
19         4.0        64.0   241.664007  46.080001         46.080001
20         4.0       128.0   243.711993  46.080001         46.080001
21         4.0       256.0   242.688000  47.104001         46.080001
22         4.0       512.0   247.807994  46.592001         46.080001
23         4.0      1024.0   247.807994  47.104001         47.104001
24         4.0      2048.0   243.711993  47.104001         47.104001
25         4.0      4096.0   246.784002  **49.152002**         47.104001
26         4.0      8192.0   250.880003  **51.199999**         47.104001
27         8.0        32.0   439.296007  46.080001         46.080001
28         8.0        64.0   436.224014  46.080001         46.080001
29         8.0       128.0   435.200006  47.104001         46.080001
30         8.0       256.0   437.247992  46.080001         46.080001
31         8.0       512.0   445.439994  47.104001         46.080001
32         8.0      1024.0   434.175998  47.104001         47.104001
33         8.0      2048.0   434.175998  **48.128001**         47.104001
34         8.0      4096.0   431.104004  **49.152002**         47.104001
35         8.0      8192.0   430.079997  **51.199999**         47.104001
36        16.0        32.0   839.680016  47.104001         47.104001
37        16.0        64.0   844.799995  47.104001         47.104001
38        16.0       128.0   821.247995  47.104001         47.104001
39        16.0       256.0   818.175972  47.104001         47.104001
40        16.0       512.0   830.464005  47.104001         47.104001
41        16.0      1024.0   821.247995  47.104001         47.104001
42        16.0      2048.0   827.391982  48.128001         47.104001
43        16.0      4096.0   829.439998  **49.152002**         48.128001
44        16.0      8192.0   845.824003  **52.223999**         48.128001
45        32.0        32.0  1599.488020  47.104001         47.104001
46        32.0        64.0  1629.696012  47.104001         47.104001
47        32.0       128.0  1596.415997  47.104001         47.104001
48        32.0       256.0  1615.872025  47.104001         47.104001
49        32.0       512.0  1597.440004  47.104001         47.104001
50        32.0      1024.0  1592.319965  48.128001         48.128001
51        32.0      2048.0  1616.896033  **49.152002**         48.128001
52        32.0      4096.0  1600.000024  **50.175998**         49.152002
53        32.0      8192.0  1595.391989  **54.272000**         50.175998
54        64.0        32.0  3230.207920  48.128001         48.128001
55        64.0        64.0  3264.512062  48.128001         48.128001
56        64.0       128.0  3148.799896  48.128001         48.128001
57        64.0       256.0  3176.448107  48.128001         48.128001
58        64.0       512.0  3241.983891  48.128001         48.128001
59        64.0      1024.0  3195.904016  49.152002         49.152002
60        64.0      2048.0  3179.519892  **50.175998**         49.152002
61        64.0      4096.0  3219.455957  **53.247999**         50.175998
62        64.0      8192.0  3189.759970  **58.368001**         53.247999
63       128.0        32.0  6406.144142  50.175998         50.175998
64       128.0        64.0  6292.479992  50.175998         50.175998
65       128.0       128.0  6459.392071  50.175998         50.175998
66       128.0       256.0  6463.487625  50.175998         50.175998
67       128.0       512.0  6325.247765  50.175998         50.175998
68       128.0      1024.0  6372.352123  51.199999         51.199999
69       128.0      2048.0  6453.760147  **53.247999**         52.223999
70       128.0      4096.0  6390.783787  **57.344001**         55.296000
71       128.0      8192.0  6376.448154  **65.536000**         60.416002
```

> From the highlighted data, we can observe that the optimized kernel achieves lower latency when batch size or sequence length increases.

From the ncu profile result below, we can see that the `write_req_to_token_pool_triton` kernel only parallelizes along the batch dimension. This leads to underutilization of SMs when the batch size is small. This issue can be mitigated by introducing parallelism along the token dimension. Additionally, since this kernel is memory-bound and only involves read/write operations, we can further optimize it by improving memory coalescing. The benchmark results above show that the optimized kernel achieves some performance gains when increasing batch size or sequence length. In most cases, this kernel doesn't present significant performance bottlenecks, so I believe a CUDA implementation isn't necessary.

<img width="1263" alt="图片" src="https://github.com/user-attachments/assets/2e469902-93a3-4892-855b-1234dab0bb0c" />



