### PR TITLE
[Cache Offload] Remove device sync overhead

### DIFF
--- a/benchmark/hicache/bench_order.py
+++ b/benchmark/hicache/bench_order.py
@@ -1,0 +1,153 @@
+import argparse
+import json
+import random
+import time
+
+import requests
+from lorem_text import lorem
+
+import sglang as sgl
+from sglang import RuntimeEndpoint, set_default_backend
+
+
+def generate_text(num_tokens):
+    """Generates a text with approximately num_tokens."""
+    num_words = int(num_tokens / 1.93)  # Assuming average word length
+    return lorem.words(num_words)
+
+
+def generate_prompts(
+    num_groups=100,
+    group_size=100,
+    context_length=1000,
+    cache_rate=0.8,
+    order="random",
+    max_tokens=1,
+):
+    """
+    Generate prompts for the benchmark.
+
+    Args:
+        num_groups (int): Number of groups, each with shared context.
+        group_size (int): Number of requests in each group.
+        context_length (int): Length of the context.
+        cache_rate (float): Proportion of context cached across prompts within a group.
+        order (str): Order of prompts, one of 'random', 'sequential', or 'interleaved'.
+        max_tokens (int): Maximum tokens to generate.
+
+    Returns:
+        list: List of generated prompts.
+    """
+    assert order in ["random", "sequential", "interleaved"], "Invalid prompt order"
+    prompts = []
+
+    for _ in range(num_groups):
+        shared_context = generate_text(context_length * cache_rate)
+        for _ in range(group_size):
+            prompt = shared_context + generate_text(context_length * (1 - cache_rate))
+            prompts.append({"prompt": prompt, "max_tokens": max_tokens})
+
+    if order == "random":
+        return random.sample(prompts, len(prompts))
+    elif order == "sequential":
+        return prompts
+    else:  # interleaved
+        interleaved_prompts = [prompts[i::group_size] for i in range(group_size)]
+        return [item for sublist in interleaved_prompts for item in sublist]
+
+
+@sgl.function
+def test_sgl(s, prompt, max_tokens):
+    """SGLang function for generating text based on a prompt."""
+    s += prompt
+    s += sgl.gen(max_tokens=max_tokens, ignore_eos=True)
+
+
+def main():
+    # Set up command-line arguments
+    parser = argparse.ArgumentParser(
+        description="Benchmark prompt generation and SGLang execution."
+    )
+    parser.add_argument(
+        "--order",
+        type=str,
+        default="random",
+        choices=["random", "sequential", "interleaved"],
+        help="Order of prompt execution",
+    )
+    parser.add_argument(
+        "--num_groups", type=int, default=100, help="Number of prompt groups"
+    )
+    parser.add_argument(
+        "--group_size", type=int, default=100, help="Size of each prompt group"
+    )
+    parser.add_argument(
+        "--context_length", type=int, default=1000, help="Length of the context"
+    )
+    parser.add_argument(
+        "--cache_rate", type=float, default=0.8, help="Cache rate for shared context"
+    )
+    parser.add_argument("--output_length", type=int, default=1, help="Output length")
+    parser.add_argument("--num_threads", type=int, default=64, help="Number of threads")
+
+    args = parser.parse_args()
+
+    # Initialize SGLang runtime
+    set_default_backend(RuntimeEndpoint("http://localhost:30000"))
+    result_jsonl = []
+
+    # Log current parameters
+    print(
+        f"Running with num_threads: {args.num_threads}, output_length: {args.output_length}"
+    )
+    print(f"Cache rate: {args.cache_rate}, Context length: {args.context_length}")
+    print(
+        f"Group size: {args.group_size}, Num groups: {args.num_groups}, Order: {args.order}"
+    )
+
+    # Generate prompts based on input arguments
+    prompts = generate_prompts(
+        num_groups=args.num_groups,
+        group_size=args.group_size,
+        context_length=args.context_length,
+        cache_rate=args.cache_rate,
+        order=args.order,
+        max_tokens=args.output_length,
+    )
+
+    url = "http://localhost:30000/flush_cache"
+    requests.post(url)
+    # sgl.flush_cache()
+    time.sleep(1)  # Wait for the cache to be flushed
+
+    # Measure the time taken for batch execution
+    tic = time.time()
+    test_sgl.run_batch(prompts, num_threads=args.num_threads, progress_bar=True)
+    toc = time.time()
+
+    # Record results
+    duration = toc - tic
+    result_jsonl.append(
+        {
+            "cache_rate": args.cache_rate,
+            "context_length": args.context_length,
+            "group_size": args.group_size,
+            "num_groups": args.num_groups,
+            "order": args.order,
+            "output_length": args.output_length,
+            "duration": duration,
+        }
+    )
+
+    # Display throughput information
+    throughput = len(prompts) / duration
+    print(f"Throughput: {throughput:.2f} requests per second")
+
+    # Write the results to a JSONL file
+    with open("result.jsonl", "a") as f:
+        for line in result_jsonl:
+            f.write(json.dumps(line) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -1,0 +1,441 @@
+import torch
+import threading
+import time
+import queue
+from queue import PriorityQueue, Queue
+from typing import Optional
+import logging
+
+
+from sglang.srt.mem_cache.memory_pool import (
+    MHATokenToKVPool,
+    MLATokenToKVPoolHost,
+    MemoryStateInt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CacheOperation:
+
+    counter = 0
+
+    def __init__(
+        self,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        priority: Optional[int] = None,
+    ):
+        self.host_indices = host_indices
+        self.device_indices = device_indices
+        self.data = None
+
+        self.id = CacheOperation.counter
+        CacheOperation.counter += 1
+        self.priority = priority if priority is not None else self.id
+
+    def merge(self, other: "CacheOperation") -> None:
+        self.host_indices = torch.cat([self.host_indices, other.host_indices])
+        self.device_indices = torch.cat([self.device_indices, other.device_indices])
+        self.priority = min(self.priority, other.priority)
+
+    def __lt__(self, other: "CacheOperation"):
+        return self.priority < other.priority
+
+
+class TransferBuffer:
+    def __init__(self, buffer_count: int = 2, buffer_size: int = 1000) -> None:
+        self.buffers = Queue()
+        self.buffer_count = buffer_count
+        # todo: adjust the buffer size based on throughput profile of the system
+        self.buffer_size = buffer_size
+        self.condition = threading.Condition()
+        self.timeout = 1
+
+        self.revoke_list = []
+        self.lock = threading.Lock()
+
+        # todo: alternative fixed size buffer implementation
+
+    def full(self) -> bool:
+        return self.buffers.qsize() >= self.buffer_count
+
+    def empty(self) -> bool:
+        return self.buffers.empty()
+
+    def put(self, buffer) -> None:
+        self.buffers.put(buffer)
+
+    def get(self) -> Optional[CacheOperation]:
+        try:
+            return self.buffers.get(timeout=self.timeout)
+        except queue.Empty:
+            return None
+
+    # def add_revoke(self, host_indices):
+    #     self.revoke_list.append(host_indices)
+    #     logger.info(f"revoke added: {len(host_indices)}")
+
+    # def check_revoke(self, operation: CacheOperation):
+    #     matched_revoke = []
+    #     for idx, revoked in enumerate(self.revoke_list):
+    #         mask = torch.tensor([True] * len(operation.host_indices), dtype=torch.bool)
+    #         for i in range(len(operation.host_indices) - len(revoked) + 1):
+    #             if torch.equal(operation.host_indices[i : i + len(revoked)], revoked):
+    #                 mask[i : i + len(revoked)] = False
+    #                 operation.host_indices = operation.host_indices[mask]
+    #                 operation.device_indices = operation.device_indices[mask]
+    #                 matched_revoke.append(idx)
+    #                 logger.info(f"revoke matched: {len(revoked)}")
+    #                 break
+
+    #     self.revoke_list = [
+    #         r for idx, r in enumerate(self.revoke_list) if idx not in matched_revoke
+    #     ]
+    #     return operation
+
+
+class RevokableQueue(PriorityQueue):
+    def revoke(self, host_indices):
+        num_tokens = len(host_indices)
+        with self.mutex:
+            for i, item in enumerate(self.queue):
+                if torch.equal(item.host_indices[-num_tokens:], host_indices):
+                    if len(item.host_indices) == num_tokens:
+                        del self.queue[i]
+                        break
+                    else:
+                        self.queue[i].host_indices = item.host_indices[:-num_tokens]
+                        self.queue[i].device_indices = item.device_indices[:-num_tokens]
+                        break
+            else:
+                return False
+        return True
+
+
+class HiCacheController:
+
+    def __init__(
+        self, mem_pool_device: MHATokenToKVPool, mem_pool_host: MLATokenToKVPoolHost
+    ):
+
+        self.mem_pool_device = mem_pool_device
+        self.mem_pool_host = mem_pool_host
+
+        self.write_queue = RevokableQueue()
+        self.load_queue = PriorityQueue()
+
+        self.write_buffer = TransferBuffer()
+        self.load_buffer = TransferBuffer()
+
+        self.write_stream = torch.cuda.Stream()
+        self.load_stream = torch.cuda.Stream()
+
+        self.write_thread = threading.Thread(
+            target=self.write_thread_func_buffer, daemon=True
+        )
+        self.load_thread = threading.Thread(
+            target=self.load_thread_func_buffer, daemon=True
+        )
+        self.write_thread.start()
+        self.load_thread.start()
+
+    def write_through(
+        self, device_indices: torch.Tensor, priority: Optional[torch.Tensor] = None
+    ):
+        """
+        Optimistically write through calculated KV caches to host memory.
+        Certain KV caches may not be written through due to runtime memory requirements.
+        """
+        host_indices = self.mem_pool_host.alloc(len(device_indices))
+        if host_indices is None:
+            return None
+        self.write_queue.put(CacheOperation(host_indices, device_indices, priority))
+        return host_indices
+
+    def load_back(self, host_indices, priority: Optional[int] = None):
+        """
+        Load KV caches from host memory to device memory.
+        """
+        device_indices = self.mem_pool_device.alloc(len(host_indices))
+        if device_indices is None:
+            return None
+        self.load_queue.put(CacheOperation(host_indices, device_indices, priority))
+        self.mem_pool_host.protect_load(host_indices)
+        return device_indices
+
+    def write_thread_func_direct(self):
+        """
+        Directly write through KV caches to host memory without buffering.
+        """
+        with torch.cuda.stream(self.write_stream):
+            while True:
+                if self.write_queue.empty():
+                    time.sleep(0.1)
+                try:
+                    operation = self.write_queue.get(timeout=1)
+                    self.mem_pool_host.protect_write(operation.host_indices)
+                    # with self.mem_pool_host.lock:
+                    #     operation = self.write_buffer.check_revoke(operation)
+                    #     if len(operation.host_indices) == 0:
+                    #         continue
+                    #     self.mem_pool_host.protect_write(operation.host_indices)
+                    operation.data = self.mem_pool_device.get_flat_data(
+                        operation.device_indices
+                    )
+                    self.mem_pool_host.transfer(operation.host_indices, operation.data)
+                    self.mem_pool_host.complete_io(operation.host_indices)
+                except queue.Empty:
+                    continue
+                except Exception as e:
+                    logger.error(e)
+
+    def load_thread_func_direct(self):
+        """
+        Directly load KV caches from host memory to device memory without buffering.
+        """
+        with torch.cuda.stream(self.load_stream):
+            while True:
+                if self.load_queue.empty():
+                    time.sleep(0.1)
+                try:
+                    operation = self.load_queue.get(timeout=1)
+                    operation.data = self.mem_pool_host.get_flat_data(
+                        operation.host_indices
+                    ).pin_memory()
+                    self.mem_pool_device.transfer(
+                        operation.device_indices, operation.data
+                    )
+                    self.mem_pool_host.complete_io(operation.host_indices)
+                except queue.Empty:
+                    continue
+                except Exception as e:
+                    logger.error(e)
+
+    def write_aux_func(self, no_wait=False):
+        buffer = None
+        while True:
+            if self.write_queue.empty() or self.write_buffer.full():
+                time.sleep(0.1)
+            try:
+                operation = self.write_queue.get(timeout=1)
+                self.mem_pool_host.protect_write(operation.host_indices)
+                if buffer is None:
+                    buffer = operation
+                else:
+                    buffer.merge(operation)
+                if (
+                    no_wait
+                    or len(buffer.host_indices) >= self.write_buffer.buffer_size
+                    or self.write_queue.empty()
+                    or self.write_buffer.empty()
+                ):
+                    if len(buffer.host_indices) == 0:
+                        buffer = None
+                        continue
+                    buffer.data = self.mem_pool_device.get_flat_data(
+                        buffer.device_indices
+                    ).contiguous()
+                    self.write_buffer.put(buffer)
+                    buffer = None
+            except queue.Empty:
+                continue
+            except Exception as e:
+                logger.error(e)
+
+    def load_aux_func(self):
+        buffer = None
+        while True:
+            if self.load_queue.empty() or self.load_buffer.full():
+                time.sleep(0.1)
+            try:
+                operation = self.load_queue.get(timeout=1)
+                if buffer is None:
+                    buffer = operation
+                else:
+                    buffer.merge(operation)
+                if (
+                    len(buffer.host_indices) >= self.load_buffer.buffer_size
+                    or self.load_queue.empty()
+                    or self.load_buffer.empty()
+                ):
+                    buffer.data = (
+                        self.mem_pool_host.get_flat_data(buffer.host_indices)
+                        .contiguous()
+                        .pin_memory()
+                    )
+                    self.load_buffer.put(buffer)
+                    buffer = None
+            except queue.Empty:
+                continue
+            except Exception as e:
+                logger.error(e)
+
+    def write_thread_func_(self):
+        while True:
+            operation = self.write_buffer.get()
+            if operation is None:
+                continue
+            self.mem_pool_host.transfer(operation.host_indices, operation.data)
+            self.mem_pool_host.complete_io(operation.host_indices)
+
+    def load_thread_func_(self):
+        while True:
+            operation = self.load_buffer.get()
+            if operation is None:
+                continue
+            self.mem_pool_device.transfer(operation.device_indices, operation.data)
+            self.mem_pool_host.complete_io(operation.host_indices)
+
+    def write_thread_func_buffer(self):
+        aux_thread = threading.Thread(target=self.write_aux_func, daemon=True)
+        aux_thread.start()
+        with torch.cuda.stream(self.write_stream):
+            self.write_thread_func_()
+
+    def load_thread_func_buffer(self):
+        aux_thread = threading.Thread(target=self.load_aux_func, daemon=True)
+        aux_thread.start()
+        with torch.cuda.stream(self.load_stream):
+            self.load_thread_func_()
+
+    def evict_device(
+        self, device_indices: torch.Tensor, host_indices: torch.Tensor
+    ) -> int:
+        with self.mem_pool_host.lock:
+            host_mem_state = self.mem_pool_host.get_state(host_indices)
+
+            if host_mem_state == MemoryStateInt.PROTECTED:
+                return 0
+            elif host_mem_state == MemoryStateInt.IDLE:
+                self.mem_pool_device.free(device_indices)
+                return len(device_indices)
+            elif host_mem_state == MemoryStateInt.RESERVED:
+                # pending write through, revoke to free device memory
+                if self.write_queue.revoke(host_indices):
+                    self.mem_pool_host.free(host_indices)
+                    self.mem_pool_device.free(device_indices)
+                else:
+                    # failed to revoke, wait for the write operation to complete instead
+                    return 0
+                return len(device_indices)
+            elif host_mem_state == MemoryStateInt.SYNCED:
+                self.mem_pool_device.free(device_indices)
+                self.mem_pool_host.update_backup(host_indices)
+                return len(device_indices)
+            elif host_mem_state == MemoryStateInt.BACKUP:
+                raise ValueError("Inconsistent states.")
+            else:
+                raise ValueError(f"Invalid state: {host_mem_state}")
+
+    def evict_host(self, host_indices: torch.Tensor, backup_only: bool = True) -> int:
+        with self.mem_pool_host.lock:
+            host_mem_state = self.mem_pool_host.get_state(host_indices)
+
+            if backup_only and host_mem_state != MemoryStateInt.BACKUP:
+                # it is recommended to evict host-only KV caches
+                return 0
+
+            # todo: a more versatile protocol
+
+            if host_mem_state == MemoryStateInt.BACKUP:
+                self.mem_pool_host.free(host_indices)
+                return len(host_indices)
+            elif host_mem_state == MemoryStateInt.IDLE:
+                raise ValueError("Double free detected.")
+            elif host_mem_state == MemoryStateInt.RESERVED:
+                # not supposed to compete with pending write through
+                return 0
+            elif host_mem_state == MemoryStateInt.PROTECTED:
+                return 0
+            elif host_mem_state == MemoryStateInt.SYNCED:
+                self.mem_pool_host.free(host_indices)
+                return len(host_indices)
+            else:
+                raise ValueError(f"Invalid state: {host_mem_state}")
+
+
+if __name__ == "__main__":
+    mem_pool_device = MHATokenToKVPool(
+        size=10000,
+        dtype=torch.float16,
+        head_num=12,
+        head_dim=512,
+        layer_num=12,
+        device="cuda:0",
+    )
+
+    mem_pool_host = MLATokenToKVPoolHost(mem_pool_device)
+    controller = HiCacheController(mem_pool_device, mem_pool_host)
+
+    allocations = []
+    host_backups = []
+
+    def evict_device(need_size):
+        i = 0
+        while need_size > 0:
+            if i >= len(allocations):
+                time.sleep(0.1)
+                i = 0  # Reset index to start over
+                continue
+            device_indices, host_indices = allocations[i]
+            num_evicted = controller.evict_device(device_indices, host_indices)
+            if num_evicted > 0:
+                need_size -= num_evicted
+                if mem_pool_host.is_backup(host_indices):
+                    host_backups.append(host_indices)
+                allocations.pop(i)
+            else:
+                i += 1  # Only increment if no eviction happened
+            if need_size <= 0:
+                break
+
+    def evict_host(need_size):
+        i = 0
+        while need_size > 0:
+            if i >= len(host_backups):
+                time.sleep(0.1)
+                i = 0  # Reset index to start over
+                continue
+            host_indices = host_backups[i]
+            num_evicted = controller.evict_host(host_indices)
+            if num_evicted > 0:
+                need_size -= num_evicted
+                # Remove the evicted host backup
+                host_backups.pop(i)
+            else:
+                i += 1  # Only increment if no eviction happened
+            if need_size <= 0:
+                break
+
+    import random
+
+    for i in range(100):
+        input_size = random.randint(100, 1000)
+        device_indices = mem_pool_device.alloc(input_size)
+        if device_indices is None:
+            # no sufficient device memory available
+            need_size = input_size - mem_pool_device.available_size()
+            evict_device(need_size)
+            device_indices = mem_pool_device.alloc(input_size)
+        host_indices = controller.write_through(device_indices=device_indices)
+        if host_indices is None:
+            # no sufficient host memory available
+            need_size = input_size - mem_pool_host.available_size()
+            evict_host(need_size)
+
+            host_indices = controller.write_through(device_indices=device_indices)
+        allocations.append((device_indices, host_indices))
+        time.sleep(0.01)
+
+    host_backup_copy = [i for i in host_backups]
+    for i, host_indices in enumerate(host_backup_copy):
+        if mem_pool_host.is_backup(host_indices):
+            device_indices = controller.load_back(host_indices=host_indices)
+            if device_indices is None:
+                need_size = len(host_indices) - mem_pool_device.available_size()
+                evict_device(need_size)
+                device_indices = controller.load_back(host_indices=host_indices)
+            allocations.append((device_indices, host_indices))
+
+    time.sleep(1)

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -72,28 +72,6 @@ class TransferBuffer:
         except queue.Empty:
             return None
 
-    # def add_revoke(self, host_indices):
-    #     self.revoke_list.append(host_indices)
-    #     logger.info(f"revoke added: {len(host_indices)}")
-
-    # def check_revoke(self, operation: CacheOperation):
-    #     matched_revoke = []
-    #     for idx, revoked in enumerate(self.revoke_list):
-    #         mask = torch.tensor([True] * len(operation.host_indices), dtype=torch.bool)
-    #         for i in range(len(operation.host_indices) - len(revoked) + 1):
-    #             if torch.equal(operation.host_indices[i : i + len(revoked)], revoked):
-    #                 mask[i : i + len(revoked)] = False
-    #                 operation.host_indices = operation.host_indices[mask]
-    #                 operation.device_indices = operation.device_indices[mask]
-    #                 matched_revoke.append(idx)
-    #                 logger.info(f"revoke matched: {len(revoked)}")
-    #                 break
-
-    #     self.revoke_list = [
-    #         r for idx, r in enumerate(self.revoke_list) if idx not in matched_revoke
-    #     ]
-    #     return operation
-
 
 class RevokableQueue(PriorityQueue):
     def revoke(self, host_indices):
@@ -175,11 +153,6 @@ class HiCacheController:
                 try:
                     operation = self.write_queue.get(timeout=1)
                     self.mem_pool_host.protect_write(operation.host_indices)
-                    # with self.mem_pool_host.lock:
-                    #     operation = self.write_buffer.check_revoke(operation)
-                    #     if len(operation.host_indices) == 0:
-                    #         continue
-                    #     self.mem_pool_host.protect_write(operation.host_indices)
                     operation.data = self.mem_pool_device.get_flat_data(
                         operation.device_indices
                     )

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -214,7 +214,7 @@ class HiCacheController:
                     operation = self.load_queue.get(timeout=1)
                     operation.data = self.mem_pool_host.get_flat_data(
                         operation.host_indices
-                    ).pin_memory()
+                    )
                     self.mem_pool_device.transfer(
                         operation.device_indices, operation.data
                     )
@@ -246,6 +246,9 @@ class HiCacheController:
                     if len(buffer.host_indices) == 0:
                         buffer = None
                         continue
+                    buffer.device_indices.to(
+                        device=self.mem_pool_device.device, copy=True
+                    )
                     buffer.data = self.mem_pool_device.get_flat_data(
                         buffer.device_indices
                     ).contiguous()
@@ -276,6 +279,9 @@ class HiCacheController:
                         self.mem_pool_host.get_flat_data(buffer.host_indices)
                         .contiguous()
                         .pin_memory()
+                    )
+                    buffer.device_indices.to(
+                        device=self.mem_pool_device.device, copy=True
                     )
                     self.load_buffer.put(buffer)
                     buffer = None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -87,8 +87,6 @@ class SchedulePolicy:
                 )
                 # to prevent evicting nodes referenced by other requests in waiting queue
                 self.tree_cache.inc_lock_ref(r.last_node)
-            for r in waiting_queue:
-                self.tree_cache.dec_lock_ref(r.last_node)
 
                 # NOTE(sang): This logic is for in-batch prefix caching;
                 # If there are more than 1 request that have small matching prefix from
@@ -113,8 +111,7 @@ class SchedulePolicy:
                         self.waiting_queue_radix_tree.insert(
                             prefix_ids, torch.empty(len(prefix_ids), dtype=torch.bool)
                         )
-                # to prevent evicting nodes referenced by other requests in waiting queue
-                self.tree_cache.inc_lock_ref(r.last_node)
+
             for r in waiting_queue:
                 self.tree_cache.dec_lock_ref(r.last_node)
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -85,6 +85,10 @@ class SchedulePolicy:
                 r.prefix_indices, r.last_node = self.tree_cache.match_prefix(
                     rid=r.rid, key=prefix_ids
                 )
+                # to prevent evicting nodes referenced by other requests in waiting queue
+                self.tree_cache.inc_lock_ref(r.last_node)
+            for r in waiting_queue:
+                self.tree_cache.dec_lock_ref(r.last_node)
 
                 # NOTE(sang): This logic is for in-batch prefix caching;
                 # If there are more than 1 request that have small matching prefix from
@@ -109,6 +113,10 @@ class SchedulePolicy:
                         self.waiting_queue_radix_tree.insert(
                             prefix_ids, torch.empty(len(prefix_ids), dtype=torch.bool)
                         )
+                # to prevent evicting nodes referenced by other requests in waiting queue
+                self.tree_cache.inc_lock_ref(r.last_node)
+            for r in waiting_queue:
+                self.tree_cache.dec_lock_ref(r.last_node)
 
             prefix_computed = True
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -699,6 +699,7 @@ class Scheduler:
         available_size = (
             self.token_to_kv_pool.available_size() + self.tree_cache.evictable_size()
         )
+        # todo, locked memory for hierarchical cache is not leaked
         if available_size != self.max_total_num_tokens:
             msg = (
                 "KV cache pool leak detected!"
@@ -813,7 +814,9 @@ class Scheduler:
             res = adder.add_one_req(req)
             if res != AddReqResult.CONTINUE:
                 if res == AddReqResult.NO_TOKEN:
-                    self.batch_is_full = True
+                    # todo: to be aware of the locked memory for hierarchical cache
+                    # self.batch_is_full = True
+                    pass
                 break
 
         # Update waiting queue

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -23,6 +23,10 @@ BaseTokenToKVPool maps a token location to its KV cache data.
 
 import logging
 from typing import List, Tuple, Union
+import threading
+import psutil
+from enum import IntEnum
+from functools import wraps
 
 import torch
 
@@ -30,6 +34,30 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.utils import get_compiler_backend
 
 logger = logging.getLogger(__name__)
+
+
+def debug_timing(func):
+    # todo: replace with a more organized instrumentation
+    def wrapper(*args, **kwargs):
+        if logger.isEnabledFor(logging.DEBUG):
+            tic = torch.cuda.Event(enable_timing=True)
+            toc = torch.cuda.Event(enable_timing=True)
+            tic.record()
+            result = func(*args, **kwargs)
+            toc.record()
+            torch.cuda.synchronize()  # Ensure all CUDA operations are complete
+            elapsed = tic.elapsed_time(toc)
+            indices = kwargs.get("indices", args[1] if len(args) > 1 else None)
+            num_tokens = len(indices) if indices is not None else 0
+            throughput = num_tokens / elapsed * 1000 if elapsed > 0 else 0
+            logger.debug(
+                f"Transfer time: {elapsed} ms, throughput: {throughput} tokens/s"
+            )
+            return result
+        else:
+            return func(*args, **kwargs)
+
+    return wrapper
 
 
 class ReqToTokenPool:
@@ -213,6 +241,23 @@ class MHATokenToKVPool(BaseTokenToKVPool):
         del self.k_buffer
         del self.v_buffer
 
+    def get_flat_data(self, indices):
+        flatten = torch.stack(
+            [
+                torch.stack([self.k_buffer[i][indices] for i in range(self.layer_num)]),
+                torch.stack([self.v_buffer[i][indices] for i in range(self.layer_num)]),
+            ]
+        )
+        return flatten
+
+    @debug_timing
+    def transfer(self, indices, flat_data):
+        flat_data = flat_data.to(device=self.device)
+        k_data, v_data = flat_data[0], flat_data[1]
+        for i in range(self.layer_num):
+            self.k_buffer[i][indices] = k_data[i]
+            self.v_buffer[i][indices] = v_data[i]
+
     def get_key_buffer(self, layer_id: int):
         if self.store_dtype != self.dtype:
             return self.k_buffer[layer_id].view(self.dtype)
@@ -361,3 +406,164 @@ class DoubleSparseTokenToKVPool(BaseTokenToKVPool):
         self.k_buffer[layer_id][loc] = cache_k
         self.v_buffer[layer_id][loc] = cache_v
         self.label_buffer[layer_id][loc] = cache_label
+
+
+class MemoryStateInt(IntEnum):
+    IDLE = 0
+    RESERVED = 1
+    PROTECTED = 2
+    SYNCED = 3
+    BACKUP = 4
+
+
+def synchronized(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with self.lock:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+class MLATokenToKVPoolHost:
+
+    def __init__(
+        self,
+        device_pool: MHATokenToKVPool,
+        host_to_device_ratio: float = 2,
+        pin_memory: bool = True,
+    ):
+        assert (
+            host_to_device_ratio >= 1
+        ), "The host memory should be larger than the device memory with the current protocol"
+        # todo, other ways of configuring the size
+        self.size = int(device_pool.size * host_to_device_ratio)
+        self.dtype = device_pool.store_dtype
+        self.head_num = device_pool.head_num
+        self.head_dim = device_pool.head_dim
+        self.layer_num = device_pool.layer_num
+        self.device = "cpu"
+
+        # checking if there is enough host memory
+        self.size_per_token = (
+            self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize * 2
+        )
+        host_mem = psutil.virtual_memory()
+        # preserve at least 10GB for other usage
+        if self.size * self.size_per_token > host_mem.available - 10 * 1e9:
+            raise ValueError(
+                f"Not enough host memory available, asking for {self.size * self.size_per_token / 1e9} GB but only have {host_mem.available / 1e9} GB available, please reduce the size of the hierarchical cache"
+            )
+        else:
+            logger.info(
+                f"Allocating {self.size * self.size_per_token / 1e9} GB host memory for hierarchical cache"
+            )
+
+        self.kv_buffer = torch.empty(
+            (2, self.layer_num, self.size, self.head_num, self.head_dim),
+            dtype=self.dtype,
+            device=self.device,
+            pin_memory=pin_memory,
+        )
+
+        self.mem_state = torch.zeros(
+            (self.size,), dtype=torch.uint8, device=self.device
+        )
+        self.free_slots = torch.arange(self.size, dtype=torch.int32)
+        self.can_use_mem_size = self.size
+        # this lock is for transactional operations to the memory pool states
+        self.lock = threading.RLock()
+
+    def get_flat_data(self, indices):
+        return self.kv_buffer[:, :, indices]
+
+    @debug_timing
+    def transfer(self, indices, flat_data):
+        # todo: ensure host memory synchronization
+        flat_data = flat_data.to(device=self.device, non_blocking=True)
+        self.kv_buffer[:, :, indices] = flat_data
+
+    @synchronized
+    def clear(self):
+        self.mem_state.fill_(0)
+        self.can_use_mem_size = self.size
+        self.free_slots = torch.arange(self.size, dtype=torch.int32)
+
+    @synchronized
+    def get_state(self, indices: torch.Tensor) -> MemoryStateInt:
+        states = self.mem_state[indices]
+        assert (
+            states == states[0]
+        ).all(), "The memory slots should have the same state {}".format(states)
+        return MemoryStateInt(states[0].item())
+
+    @synchronized
+    def alloc(self, need_size: int) -> torch.Tensor:
+        if need_size > self.can_use_mem_size:
+            return None
+        # todo: de-fragementation
+        select_index = self.free_slots[:need_size]
+        self.free_slots = self.free_slots[need_size:]
+        self.mem_state[select_index] = MemoryStateInt.RESERVED
+        self.can_use_mem_size -= need_size
+
+        return select_index
+
+    @synchronized
+    def is_backup(self, indices: torch.Tensor) -> bool:
+        return self.get_state(indices) == MemoryStateInt.BACKUP
+
+    @synchronized
+    def is_synced(self, indices: torch.Tensor) -> bool:
+        return self.get_state(indices) == MemoryStateInt.SYNCED
+
+    @synchronized
+    def update_backup(self, indices: torch.Tensor):
+        # assert torch.all(
+        #     self.mem_state[indices] == MemoryStateInt.SYNCED
+        # ), "The host memory slots should be synced after I/O operations"
+        self.mem_state[indices] = MemoryStateInt.BACKUP
+
+    @synchronized
+    def update_synced(self, indices: torch.Tensor):
+        # assert (
+        #     self.get_state(indices) == MemoryStateInt.BACKUP
+        # ), "The host memory slots should be backup before read operations"
+        self.mem_state[indices] = MemoryStateInt.SYNCED
+
+    @synchronized
+    def protect_write(self, indices: torch.Tensor):
+        if not self.get_state(indices) == MemoryStateInt.RESERVED:
+            raise ValueError(
+                "The host memory slots should be reserved before write operations",
+                self.get_state(indices),
+            )
+        self.mem_state[indices] = MemoryStateInt.PROTECTED
+
+    @synchronized
+    def protect_load(self, indices: torch.Tensor):
+        if not self.get_state(indices) == MemoryStateInt.BACKUP:
+            raise ValueError(
+                "The host memory slots should be backup before read operations",
+                self.get_state(indices),
+            )
+        self.mem_state[indices] = MemoryStateInt.PROTECTED
+
+    @synchronized
+    def complete_io(self, indices: torch.Tensor):
+        if not self.get_state(indices) == MemoryStateInt.PROTECTED:
+            raise ValueError(
+                "The host memory slots should be protected during I/O operations",
+                self.get_state(indices),
+            )
+        self.mem_state[indices] = MemoryStateInt.SYNCED
+
+    def available_size(self):
+        return len(self.free_slots)
+
+    @synchronized
+    def free(self, indices: torch.Tensor) -> int:
+        self.mem_state[indices] = MemoryStateInt.IDLE
+        self.free_slots = torch.concat([self.free_slots, indices])
+        self.can_use_mem_size += len(indices)
+        return len(indices)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -45,7 +45,7 @@ def debug_timing(func):
             tic.record()
             result = func(*args, **kwargs)
             toc.record()
-            torch.cuda.synchronize()  # Ensure all CUDA operations are complete
+            toc.synchronize() # Ensure event has been recorded and ready for query in the stream.
             elapsed = tic.elapsed_time(toc)
             indices = kwargs.get("indices", args[1] if len(args) > 1 else None)
             num_tokens = len(indices) if indices is not None else 0

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -431,7 +431,7 @@ class MLATokenToKVPoolHost:
         self,
         device_pool: MHATokenToKVPool,
         host_to_device_ratio: float = 2,
-        pin_memory: bool = True,
+        pin_memory: bool = True,  # not necessary pin memory with the double buffering
     ):
         assert (
             host_to_device_ratio >= 1

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -253,8 +253,6 @@ class MHATokenToKVPool(BaseTokenToKVPool):
     @debug_timing
     def transfer(self, indices, flat_data):
         flat_data = flat_data.to(device=self.device, non_blocking=False)
-        # todo: less expensive protection
-        torch.cuda.synchronize()
         k_data, v_data = flat_data[0], flat_data[1]
         for i in range(self.layer_num):
             self.k_buffer[i][indices] = k_data[i]
@@ -482,9 +480,7 @@ class MLATokenToKVPoolHost:
 
     @debug_timing
     def transfer(self, indices, flat_data):
-        # todo: ensure host memory synchronization
         flat_data = flat_data.to(device=self.device, non_blocking=False)
-        torch.cuda.synchronize()
         self.kv_buffer[:, :, indices] = flat_data
 
     @synchronized

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -101,7 +101,6 @@ class RadixCache(BasePrefixCache):
     ##### Public API #####
 
     def reset(self):
-        TreeNode.counter = 0
         self.root_node = TreeNode()
         self.root_node.key = []
         self.root_node.value = []
@@ -371,6 +370,10 @@ class HiRadixCache(RadixCache):
         self.write_through_threshold = 1
         self.load_back_threshold = 10
         super().__init__(req_to_token_pool, token_to_kv_pool, disable=False)
+
+    def reset(self):
+        TreeNode.counter = 0
+        super().reset()
 
     def get_height(self, node: TreeNode):
         height = 0

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -458,7 +458,7 @@ class HiRadixCache(RadixCache):
         else:
             return False
 
-    def match_prefix(self, key: List, load_cache: bool = False, **kwargs):
+    def match_prefix(self, key: List, load_cache: bool = True, **kwargs):
         value, last_node = super().match_prefix(key, **kwargs)
 
         if load_cache:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -144,6 +144,7 @@ class ServerArgs:
     triton_attention_num_kv_splits: int = 8
     num_continuous_decode_steps: int = 1
     delete_ckpt_after_loading: bool = False
+    enable_hierarchical_cache: bool = False
 
     def __post_init__(self):
         # Set missing default values
@@ -775,6 +776,11 @@ class ServerArgs:
             "--delete-ckpt-after-loading",
             action="store_true",
             help="Delete the model checkpoint after loading the model.",
+        )
+        parser.add_argument(
+            "--enable-hierarchical-cache",
+            action="store_true",
+            help="Enable hierarchical cache",
         )
 
         # Deprecated arguments


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Device synchronization is expensive. In most cases we can use event or stream sync. https://developer.download.nvidia.com/compute/DevZone/docs/html/C/doc/html/group__CUDART__EVENT_g14c387cc57ce2e328f6669854e6020a5.html

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
1. Replace device sync with event sync, which only blocks a single stream.
2. Removed device sync after tensor.to(). It should block the current stream until completion. I ran the benchmark and didn't encounter any `illegal memory access` issues. If you want to use [another stream to write through](https://github.com/sgl-project/sglang/blob/4fd25f3127ddc37852218f0209e92196487da10c/python/sglang/srt/managers/cache_controller.py#L187) in the background, we will also need `pin_memory()`?
cc @xiezhq-hermann , would appreciate if you could share a bug reproducer for that.
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
