### PR TITLE
Fix gemlite import

### DIFF
--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -322,18 +322,6 @@ def throughput_test(
         )
         time.sleep(0.5)
 
-    try:
-        import os
-        import pwd
-
-        from gemlite.core import GemLiteLinearTriton
-
-        GemLiteLinearTriton.cache_config(
-            f"/tmp/{pwd.getpwuid(os.getuid()).pw_gecos}_gemlite.json"
-        )
-    except ImportError:
-        pass
-
     logging.info("\nBenchmark...")
     result = throughput_test_once(
         backend_name=bench_args.backend,

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -63,7 +63,12 @@ from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server import _set_envs_and_config
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import configure_logger, kill_process_tree, suppress_other_loggers
+from sglang.srt.utils import (
+    configure_logger,
+    kill_process_tree,
+    load_gemlite_cache,
+    suppress_other_loggers,
+)
 
 
 @dataclasses.dataclass
@@ -385,18 +390,6 @@ def latency_test(
         8,  # shorter decoding to speed up the warmup
         server_args.device,
     )
-
-    try:
-        import os
-        import pwd
-
-        from gemlite.core import GemLiteLinearTriton
-
-        GemLiteLinearTriton.cache_config(
-            f"/tmp/{pwd.getpwuid(os.getuid()).pw_gecos}_gemlite.json"
-        )
-    except ImportError:
-        pass
 
     rank_print("Benchmark ...")
 

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -63,12 +63,7 @@ from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server import _set_envs_and_config
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import (
-    configure_logger,
-    kill_process_tree,
-    load_gemlite_cache,
-    suppress_other_loggers,
-)
+from sglang.srt.utils import configure_logger, kill_process_tree, suppress_other_loggers
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import pickle
+import pwd
 import random
 import re
 import resource
@@ -1273,3 +1274,14 @@ def dataclass_to_string_truncated(data, max_length=2048):
         )
     else:
         return str(data)
+
+
+def load_gemlite_cache():
+    try:
+        from gemlite.core import GemLiteLinearTriton
+
+        GemLiteLinearTriton.cache_config(
+            f"/tmp/{pwd.getpwuid(os.getuid()).pw_gecos}_gemlite.json"
+        )
+    except ImportError:
+        pass

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 import pickle
-import pwd
 import random
 import re
 import resource
@@ -1276,12 +1275,3 @@ def dataclass_to_string_truncated(data, max_length=2048):
         return str(data)
 
 
-def load_gemlite_cache():
-    try:
-        from gemlite.core import GemLiteLinearTriton
-
-        GemLiteLinearTriton.cache_config(
-            f"/tmp/{pwd.getpwuid(os.getuid()).pw_gecos}_gemlite.json"
-        )
-    except ImportError:
-        pass

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1273,5 +1273,3 @@ def dataclass_to_string_truncated(data, max_length=2048):
         )
     else:
         return str(data)
-
-


### PR DESCRIPTION
We do not need to import gemlite cache in the benchmark scripts.
They should already be set from `python/sglang/srt/layers/torchao_utils.py`