### PR TITLE
[unittest] add unit test to test quant args of srt engine

### DIFF
--- a/test/srt/test_srt_engine_with_quant_args.py
+++ b/test/srt/test_srt_engine_with_quant_args.py
@@ -1,0 +1,60 @@
+import unittest
+
+import sglang as sgl
+from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+
+
+class TestSRTEngineWithQuantArgs(unittest.TestCase):
+
+    def test_1_quantization_args(self):
+
+        # we only test fp8 because other methods are currenly depend on vllm. We can add other methods back to test after vllm depency is resolved.
+        quantization_args_list = [
+            # "awq",
+            "fp8",
+            # "gptq",
+            # "marlin",
+            # "gptq_marlin",
+            # "awq_marlin",
+            # "bitsandbytes",
+            # "gguf",
+        ]
+
+        prompt = "Today is a sunny day and I like"
+        model_path = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+
+        sampling_params = {"temperature": 0, "max_new_tokens": 8}
+
+        for quantization_args in quantization_args_list:
+            engine = sgl.Engine(
+                model_path=model_path, random_seed=42, quantization=quantization_args
+            )
+            engine.generate(prompt, sampling_params)
+            engine.shutdown()
+
+    def test_2_torchao_args(self):
+
+        # we don't test int8dq because currently there is conflict between int8dq and capture cuda graph
+        torchao_args_list = [
+            # "int8dq",
+            "int8wo",
+            "fp8wo",
+            "fp8dq-per_tensor",
+            "fp8dq-per_row",
+        ] + [f"int4wo-{group_size}" for group_size in [32, 64, 128, 256]]
+
+        prompt = "Today is a sunny day and I like"
+        model_path = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+
+        sampling_params = {"temperature": 0, "max_new_tokens": 8}
+
+        for torchao_config in torchao_args_list:
+            engine = sgl.Engine(
+                model_path=model_path, random_seed=42, torchao_config=torchao_config
+            )
+            engine.generate(prompt, sampling_params)
+            engine.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

According to [this comment](https://github.com/sgl-project/sglang/issues/2219#issuecomment-2510489460) in issue #2219, some quantization arguments may not run properly. So this PR adds a unit test for checking each quantization argument can run properly.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

This PR adds a new unit test file `test/srt/test_srt_engine_with_quant_args.py`. The unit test contains two parts:
1. Test `--quantization` argument. Currently it only tests `fp8`. This is because other methods are currently depend on vllm. We can add other methods back to test after vllm dependency is resolved.
2. Test `--torchao-config` argument. Currently it doesn't test `int8dq`. This is because because currently there is conflict between int8dq and capture cuda graph, as mentioned in **Motivation** Section. 

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.
