### PR TITLE
[feat] Add math eval to CI

### DIFF
--- a/test/srt/test_eval_accuracy_large.py
+++ b/test/srt/test_eval_accuracy_large.py
@@ -68,6 +68,17 @@ class TestEvalAccuracyLarge(unittest.TestCase):
         metrics = run_eval(args)
         self.assertGreater(metrics["score"], 0.835)
 
+    def test_math(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="math",
+            num_examples=5000,
+            num_threads=1024
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.519 - 0.01) # -1% to account for sampling variance
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/srt/test_eval_accuracy_mini.py
+++ b/test/srt/test_eval_accuracy_mini.py
@@ -37,6 +37,18 @@ class TestEvalAccuracyMini(unittest.TestCase):
         metrics = run_eval(args)
         self.assertGreaterEqual(metrics["score"], 0.65)
 
+    def test_math(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="math",
+            num_examples=64,
+            num_threads=32,
+            temperature=0.1,
+        )
 
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.519 - 0.03) # -3% to account for sampling variance
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Issue https://github.com/sgl-project/sglang/issues/2504
- Compared SGL and vLLM's math eval score to address concerns on SGL being constant low on this eval (res linked below)
- Add math eval to CI

Setup:
- Prompt: simple eval from openai
- Grading Model: `gemini-1.5-flash`
- Temperature 0.0

| inference engine | Model | # Examples | score | model official score |
| ----------------  | ------ | ------------ | -----  |--------------|
| vllm | llama 3.2 1b | 500 | 0.248 | 0.306 |
| sgl | llama 3.2 1b | 500 | 0.248 | 0.306 |
| vllm | llama 3.2 3b | 500 | 0.476 | 0.48 |
| sgl | llama 3.2 3b | 500 | 0.484  | 0.48|
| vllm | llama 3.1 8b | 500 | 0.50 | 0.519 |
| sgl | llama 3.1 8b | 500 | 0.496 | 0.519 |
| sgl | llama 3.1 8b | 65 | 0.492 | 0.519 |
