### PR TITLE
Tiny update scripts to fail fast

### DIFF
--- a/scripts/ci_install_dependency.sh
+++ b/scripts/ci_install_dependency.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
 # Install the dependency in CI.
 
 # Use repo from environment variable, passed from GitHub Actions

--- a/scripts/ci_install_rust.sh
+++ b/scripts/ci_install_rust.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
 # these are required for actix
 apt-get update
 apt-get install -y libssl-dev pkg-config

--- a/scripts/killall_sglang.sh
+++ b/scripts/killall_sglang.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euxo pipefail
 
 # Show current GPU status
 nvidia-smi

--- a/scripts/killall_sglang.sh
+++ b/scripts/killall_sglang.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # Show current GPU status
 nvidia-smi

--- a/scripts/version_branch_to_tag.sh
+++ b/scripts/version_branch_to_tag.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # This script is used for release.
 # It tags all remote branches starting with 'v' with the same name as the branch,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

`set -euxo pipefail` is frequently used to allow scripts to e.g. fail fast. I noticed this because when debugging the CI environment locally, a `pip install` failed but the script continues, causing less intuitive errors later.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
