### PR TITLE
feat: support moe_align_block_size_triton

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -26,6 +26,10 @@ if not is_hip():
 logger = logging.getLogger(__name__)
 padding_size = 128 if bool(int(os.getenv("MOE_PADDING", "0"))) else 0
 
+enable_moe_align_block_size_triton = (
+    True if bool(int(os.getenv("ENABLE_MOE_ALIGN_BLOCK_SIZE_TRITON", "0"))) else False
+)
+
 
 @triton.jit
 def fused_moe_kernel(
@@ -222,6 +226,139 @@ def fused_moe_kernel(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+@triton.jit
+def moe_align_block_size_stage1(
+    topk_ids_ptr,
+    tokens_cnts_ptr,
+    num_experts: tl.constexpr,
+    numel: tl.constexpr,
+    tokens_per_thread: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    start_idx = pid * tokens_per_thread
+
+    off_c = (pid + 1) * num_experts
+
+    for i in range(tokens_per_thread):
+        if start_idx + i < numel:
+            idx = tl.load(topk_ids_ptr + start_idx + i)
+            token_cnt = tl.load(tokens_cnts_ptr + off_c + idx)
+            tl.store(tokens_cnts_ptr + off_c + idx, token_cnt + 1)
+
+
+@triton.jit
+def moe_align_block_size_stage2(
+    tokens_cnts_ptr,
+    num_experts: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    last_cnt = 0
+    for i in range(1, num_experts + 1):
+        token_cnt = tl.load(tokens_cnts_ptr + i * num_experts + pid)
+        last_cnt = last_cnt + token_cnt
+        tl.store(tokens_cnts_ptr + i * num_experts + pid, last_cnt)
+
+
+@triton.jit
+def moe_align_block_size_stage3(
+    total_tokens_post_pad_ptr,
+    tokens_cnts_ptr,
+    cumsum_ptr,
+    num_experts: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    last_cumsum = 0
+    off_cnt = num_experts * num_experts
+    for i in range(1, num_experts + 1):
+        token_cnt = tl.load(tokens_cnts_ptr + off_cnt + i - 1)
+        last_cumsum = last_cumsum + tl.cdiv(token_cnt, block_size) * block_size
+        tl.store(cumsum_ptr + i, last_cumsum)
+    tl.store(total_tokens_post_pad_ptr, last_cumsum)
+
+
+@triton.jit
+def moe_align_block_size_stage4(
+    topk_ids_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    tokens_cnts_ptr,
+    cumsum_ptr,
+    num_experts: tl.constexpr,
+    block_size: tl.constexpr,
+    numel: tl.constexpr,
+    tokens_per_thread: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    start_idx = tl.load(cumsum_ptr + pid)
+    end_idx = tl.load(cumsum_ptr + pid + 1)
+
+    for i in range(start_idx, end_idx, block_size):
+        tl.store(expert_ids_ptr + i // block_size, pid)
+
+    start_idx = pid * tokens_per_thread
+    off_t = pid * num_experts
+
+    for i in range(start_idx, tl.minimum(start_idx + tokens_per_thread, numel)):
+        expert_id = tl.load(topk_ids_ptr + i)
+        token_cnt = tl.load(tokens_cnts_ptr + off_t + expert_id)
+        rank_post_pad = token_cnt + tl.load(cumsum_ptr + expert_id)
+        tl.store(sorted_token_ids_ptr + rank_post_pad, i)
+        tl.store(tokens_cnts_ptr + off_t + expert_id, token_cnt + 1)
+
+
+def moe_align_block_size_triton(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+) -> None:
+    numel = topk_ids.numel()
+    grid = (num_experts,)
+    tokens_cnts = torch.zeros(
+        (num_experts + 1, num_experts), dtype=torch.int32, device=topk_ids.device
+    )
+    cumsum = torch.zeros((num_experts + 1,), dtype=torch.int32, device=topk_ids.device)
+    tokens_per_thread = ceil_div(numel, num_experts)
+
+    moe_align_block_size_stage1[grid](
+        topk_ids,
+        tokens_cnts,
+        num_experts,
+        numel,
+        tokens_per_thread,
+    )
+    moe_align_block_size_stage2[grid](
+        tokens_cnts,
+        num_experts,
+    )
+    moe_align_block_size_stage3[(1,)](
+        num_tokens_post_pad,
+        tokens_cnts,
+        cumsum,
+        num_experts,
+        block_size,
+    )
+    moe_align_block_size_stage4[grid](
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        tokens_cnts,
+        cumsum,
+        num_experts,
+        block_size,
+        numel,
+        tokens_per_thread,
+    )
+
+
 def moe_align_block_size(
     topk_ids: torch.Tensor, block_size: int, num_experts: int
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -272,24 +409,36 @@ def moe_align_block_size(
         (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
     )
     num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
-    if not_hip and num_experts >= 224:
-        token_cnts_buffer = torch.empty(
-            (num_experts + 1) * num_experts, dtype=torch.int32, device=topk_ids.device
-        )
-        cumsum_buffer = torch.empty(
-            num_experts + 1, dtype=torch.int32, device=topk_ids.device
-        )
+    if num_experts >= 224:
+        if enable_moe_align_block_size_triton or not not_hip:
+            moe_align_block_size_triton(
+                topk_ids,
+                num_experts,
+                block_size,
+                sorted_ids,
+                expert_ids,
+                num_tokens_post_pad,
+            )
+        else:
+            token_cnts_buffer = torch.empty(
+                (num_experts + 1) * num_experts,
+                dtype=torch.int32,
+                device=topk_ids.device,
+            )
+            cumsum_buffer = torch.empty(
+                num_experts + 1, dtype=torch.int32, device=topk_ids.device
+            )
 
-        sgl_moe_align_block_size(
-            topk_ids,
-            num_experts,
-            block_size,
-            sorted_ids,
-            expert_ids,
-            num_tokens_post_pad,
-            token_cnts_buffer,
-            cumsum_buffer,
-        )
+            sgl_moe_align_block_size(
+                topk_ids,
+                num_experts,
+                block_size,
+                sorted_ids,
+                expert_ids,
+                num_tokens_post_pad,
+                token_cnts_buffer,
+                cumsum_buffer,
+            )
     else:
         ops.moe_align_block_size(
             topk_ids,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

```
# enable Triton implementation
export ENABLE_MOE_ALIGN_BLOCK_SIZE_TRITON=1
```

batch size 1/8/32, input/output 128/256, **around 20% improvement for online cases**

TODO @BBuf will continue to optimize the CUDA version.

```
Prefill. latency: 2.03397 s, throughput:     62.93 token/s
Decode.  latency: 2.15392 s, throughput:      0.46 token/s
Decode.  latency: 0.02824 s, throughput:     35.41 token/s
Decode.  latency: 0.02772 s, throughput:     36.07 token/s
Decode.  latency: 0.02776 s, throughput:     36.02 token/s
Decode.  latency: 0.02775 s, throughput:     36.03 token/s
Decode.  median latency: 0.02776 s, median throughput:     36.02 token/s
Total. latency:  4.355 s, throughput:     31.23 token/s
Benchmark ...
Prefill. latency: 0.14870 s, throughput:    860.77 token/s
Decode.  latency: 0.02796 s, throughput:     35.76 token/s
Decode.  latency: 0.02771 s, throughput:     36.09 token/s
Decode.  latency: 0.02771 s, throughput:     36.09 token/s
Decode.  latency: 0.02771 s, throughput:     36.09 token/s
Decode.  latency: 0.02772 s, throughput:     36.07 token/s
Decode.  median latency: 0.02796 s, median throughput:     35.76 token/s
Total. latency:  7.268 s, throughput:     52.84 token/s

Prefill. latency: 5.71712 s, throughput:    179.11 token/s
Decode.  latency: 2.32011 s, throughput:      3.45 token/s
Decode.  latency: 0.03317 s, throughput:    241.20 token/s
Decode.  latency: 0.03296 s, throughput:    242.74 token/s
Decode.  latency: 0.03353 s, throughput:    238.57 token/s
Decode.  latency: 0.03384 s, throughput:    236.42 token/s
Decode.  median latency: 0.03384 s, median throughput:    236.42 token/s
Total. latency:  8.239 s, throughput:    132.06 token/s
Benchmark ...
Prefill. latency: 0.18112 s, throughput:   5653.82 token/s
Decode.  latency: 0.03253 s, throughput:    245.91 token/s
Decode.  latency: 0.03272 s, throughput:    244.47 token/s
Decode.  latency: 0.03296 s, throughput:    242.74 token/s
Decode.  latency: 0.03349 s, throughput:    238.89 token/s
Decode.  latency: 0.03379 s, throughput:    236.73 token/s
Decode.  median latency: 0.03415 s, median throughput:    234.25 token/s
Total. latency:  8.888 s, throughput:    345.62 token/s

Prefill. latency: 7.90844 s, throughput:    517.93 token/s
Decode.  latency: 1.95407 s, throughput:     16.38 token/s
Decode.  latency: 0.03557 s, throughput:    899.60 token/s
Decode.  latency: 0.03624 s, throughput:    882.95 token/s
Decode.  latency: 0.03713 s, throughput:    861.73 token/s
Decode.  latency: 0.03770 s, throughput:    848.71 token/s
Decode.  median latency: 0.03770 s, median throughput:    848.71 token/s
Total. latency: 10.087 s, throughput:    431.44 token/s
Benchmark ...
Prefill. latency: 0.30875 s, throughput:  13266.22 token/s
Decode.  latency: 0.03496 s, throughput:    915.27 token/s
Decode.  latency: 0.03531 s, throughput:    906.18 token/s
Decode.  latency: 0.03622 s, throughput:    883.53 token/s
Decode.  latency: 0.03698 s, throughput:    865.34 token/s
Decode.  latency: 0.03760 s, throughput:    851.03 token/s
Decode.  median latency: 0.04098 s, median throughput:    780.82 token/s
Total. latency: 10.729 s, throughput:   1145.35 token/s
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contributor_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
