### PR TITLE
Support llamafy/Qwen-Qwen2.5-7B-Instruct-llamafied

### DIFF
--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -100,6 +100,7 @@ class LlamaAttention(nn.Module):
         max_position_embeddings: int = 8192,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        bias: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -132,14 +133,14 @@ class LlamaAttention(nn.Module):
             self.head_dim,
             self.total_num_heads,
             self.total_num_kv_heads,
-            bias=False,
+            bias=bias,
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
         )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
-            bias=False,
+            bias=bias,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
         )
@@ -194,6 +195,11 @@ class LlamaDecoderLayer(nn.Module):
             )
         rope_is_neox_style = getattr(config, "rope_is_neox_style", True)
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
+        # Support llamafy/Qwen-Qwen2.5-7B-Instruct-llamafied with attention_bias
+        # Support internlm/internlm-7b with bias
+        attention_bias = getattr(config, "attention_bias", False) or getattr(
+            config, "bias", False
+        )
         self.self_attn = LlamaAttention(
             config=config,
             hidden_size=self.hidden_size,
@@ -206,6 +212,7 @@ class LlamaDecoderLayer(nn.Module):
             max_position_embeddings=max_position_embeddings,
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
+            bias=attention_bias,
         )
         self.mlp = LlamaMLP(
             hidden_size=self.hidden_size,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Some models can be converted into the LlamaForCausalLM, but attention_bias may need to set **True**. Additionally, introducing a bias parameter within LlamaAttention is required to accommodate these models，like [llamafy/Qwen-Qwen2.5-7B-Instruct-llamafied](https://huggingface.co/llamafy/Qwen-Qwen2.5-7B-Instruct-llamafied)

```json
{
  "architectures": [
    "LlamaForCausalLM"
   ],
  "attention_bias": true,
......
}
```

## Modifications

add bias in /python/sglang/srt/models/llama.py


## Checklist

- [x]  Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.


Test Code
```python
from openai import OpenAI
openai_api_key = "empty"
openai_api_base = "http://127.0.0.1:30000/v1"

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base
)

models = client.models.list()
model = models.data[0].id
messages = [
    {'role': 'system', 'content': "You are an helpful assistant."},
    {'role': 'user', 'content': "say this is a test"},
]
response = client.chat.completions.create(
    messages = messages,
    max_tokens=100,
    model=model,
    temperature=0.8,
    stop = ["<|im_end|>"],
    stream=False
)
answer = response.choices[0].message.content
print(answer)
```

This PR
```
Sure, this is a test. How can I help you with it?
```

Main branch
```
耀月.newArrayListB parçaGM*$..!
SC
https米 light Cá be antigen月SenderId

隶属1batal雕像..frames2 tendência月 yab, ()
.FindGameObjectWithTagLC72 USSR2Offer</)X.setCellValue冷笑.::
eñaK},



abajo3岙,72 yab1SenderId

eña2东路1勠饿2赍.. setBackgroundImage !");
.Projects42 BREAK4犹1 baiser.:洗礼1版权归原;
$ déco2 Aç

eña1 mexico;ect
```