### PR TITLE
Remove unused var in moe_align_kernel

### DIFF
--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -51,7 +51,6 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
   __shared__ int32_t local_offsets[256];
 
   const int warp_id = threadIdx.x / WARP_SIZE;
-  const int lane_id = threadIdx.x % WARP_SIZE;
   const int experts_per_warp = 8;
   const int my_expert_start = warp_id * experts_per_warp;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix warning `variable "lane_id" was declared but never referenced`.
