### PR TITLE
fused moe triton moe_align_blcok_size interface change

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -422,15 +422,6 @@ def moe_align_block_size(
                 num_tokens_post_pad,
             )
         else:
-            token_cnts_buffer = torch.empty(
-                (num_experts + 1) * num_experts,
-                dtype=torch.int32,
-                device=topk_ids.device,
-            )
-            cumsum_buffer = torch.empty(
-                num_experts + 1, dtype=torch.int32, device=topk_ids.device
-            )
-
             sgl_moe_align_block_size(
                 topk_ids,
                 num_experts,
@@ -438,8 +429,6 @@ def moe_align_block_size(
                 sorted_ids,
                 expert_ids,
                 num_tokens_post_pad,
-                token_cnts_buffer,
-                cumsum_buffer,
             )
     else:
         ops.moe_align_block_size(

--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -46,12 +46,12 @@ __device__ __forceinline__ int32_t index(int32_t total_col, int32_t row, int32_t
 template <typename scalar_t>
 __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int32_t* sorted_token_ids,
                                             int32_t* expert_ids, int32_t* total_tokens_post_pad, int32_t num_experts,
-                                            int32_t block_size, size_t numel, int32_t* cumsum) {
+                                            int32_t block_size, size_t numel) {
   __shared__ int32_t shared_counts[32][8];
   __shared__ int32_t local_offsets[256];
+  __shared__ int32_t shared_cumsum[257];
 
   const int warp_id = threadIdx.x / WARP_SIZE;
-  const int lane_id = threadIdx.x % WARP_SIZE;
   const int experts_per_warp = 8;
   const int my_expert_start = warp_id * experts_per_warp;
 
@@ -74,25 +74,25 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
   __syncthreads();
 
   if (threadIdx.x == 0) {
-    cumsum[0] = 0;
+    shared_cumsum[0] = 0;
     for (int i = 1; i <= num_experts; ++i) {
       int expert_count = 0;
       int warp_idx = (i - 1) / experts_per_warp;
       int expert_offset = (i - 1) % experts_per_warp;
       expert_count = shared_counts[warp_idx][expert_offset];
 
-      cumsum[i] = cumsum[i - 1] + CEILDIV(expert_count, block_size) * block_size;
+      shared_cumsum[i] = shared_cumsum[i - 1] + CEILDIV(expert_count, block_size) * block_size;
     }
-    *total_tokens_post_pad = cumsum[num_experts];
+    *total_tokens_post_pad = shared_cumsum[num_experts];
   }
 
   __syncthreads();
 
   if (threadIdx.x < num_experts) {
-    for (int i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1]; i += block_size) {
+    for (int i = shared_cumsum[threadIdx.x]; i < shared_cumsum[threadIdx.x + 1]; i += block_size) {
       expert_ids[i / block_size] = threadIdx.x;
     }
-    local_offsets[threadIdx.x] = cumsum[threadIdx.x];
+    local_offsets[threadIdx.x] = shared_cumsum[threadIdx.x];
   }
 
   __syncthreads();
@@ -105,13 +105,14 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 }
 
 void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t block_size,
-                          torch::Tensor sorted_token_ids, torch::Tensor experts_ids, torch::Tensor num_tokens_post_pad,
-                          torch::Tensor token_cnts_buffer, torch::Tensor cumsum_buffer) {
+                          torch::Tensor sorted_token_ids, torch::Tensor experts_ids, torch::Tensor num_tokens_post_pad) {
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int threads_per_block = 1024;
+  assert(num_experts == 256 && "num_experts must be 256 now.");
   DISPATCH_INTEGRAL_TYPES(topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
     auto kernel = moe_align_block_size_kernel<scalar_t>;
-    kernel<<<1, 1024, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
+    kernel<<<1, threads_per_block, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
                                    experts_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
-                                   num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
+                                   num_experts, block_size, topk_ids.numel());
   });
 }

--- a/sgl-kernel/src/sgl-kernel/csrc/sgl_kernel_ops.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/sgl_kernel_ops.cu
@@ -9,8 +9,8 @@ void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out);
 
 // moe_align_block_size
 void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t block_size,
-                          torch::Tensor sorted_token_ids, torch::Tensor experts_ids, torch::Tensor num_tokens_post_pad,
-                          torch::Tensor token_cnts_buffer, torch::Tensor cumsum_buffer);
+                          torch::Tensor sorted_token_ids, torch::Tensor experts_ids, torch::Tensor num_tokens_post_pad);
+
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // trt_reduce

--- a/sgl-kernel/src/sgl-kernel/ops/__init__.py
+++ b/sgl-kernel/src/sgl-kernel/ops/__init__.py
@@ -3,6 +3,7 @@ from sgl_kernel.ops._kernels import dispose as _dispose
 from sgl_kernel.ops._kernels import init_custom_ar as _init_custom_ar
 from sgl_kernel.ops._kernels import moe_align_block_size as _moe_align_block_size
 
+
 def init_custom_reduce(rank_id, num_devices, buffers, barrier_in, barrier_out):
     return _init_custom_ar(rank_id, num_devices, buffers, barrier_in, barrier_out)
 

--- a/sgl-kernel/src/sgl-kernel/ops/__init__.py
+++ b/sgl-kernel/src/sgl-kernel/ops/__init__.py
@@ -3,7 +3,6 @@ from sgl_kernel.ops._kernels import dispose as _dispose
 from sgl_kernel.ops._kernels import init_custom_ar as _init_custom_ar
 from sgl_kernel.ops._kernels import moe_align_block_size as _moe_align_block_size
 
-
 def init_custom_reduce(rank_id, num_devices, buffers, barrier_in, barrier_out):
     return _init_custom_ar(rank_id, num_devices, buffers, barrier_in, barrier_out)
 
@@ -23,8 +22,6 @@ def moe_align_block_size(
     sorted_token_ids,
     experts_ids,
     num_tokens_post_pad,
-    token_cnts_buffer,
-    cumsum_buffer,
 ):
     _moe_align_block_size(
         topk_ids,
@@ -33,6 +30,4 @@ def moe_align_block_size(
         sorted_token_ids,
         experts_ids,
         num_tokens_post_pad,
-        token_cnts_buffer,
-        cumsum_buffer,
     )

--- a/sgl-kernel/tests/test_moe_align.py
+++ b/sgl-kernel/tests/test_moe_align.py
@@ -5,7 +5,7 @@ from sgl_kernel import moe_align_block_size
 def test_moe_align_block_size():
     num_experts = 256
     block_size = 128
-    topk_ids = torch.randint(0, num_experts, (3, 4), dtype=torch.int32, device="cuda")
+    topk_ids = torch.randint(0, num_experts, (128, 4096), dtype=torch.int32, device="cuda")
 
     max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
     sorted_ids = torch.empty(
@@ -18,12 +18,6 @@ def test_moe_align_block_size():
     )
     num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
 
-    token_cnts_buffer = torch.empty(
-        (num_experts + 1) * num_experts, dtype=torch.int32, device=topk_ids.device
-    )
-    cumsum_buffer = torch.empty(
-        num_experts + 1, dtype=torch.int32, device=topk_ids.device
-    )
 
     moe_align_block_size(
         topk_ids,
@@ -32,9 +26,6 @@ def test_moe_align_block_size():
         sorted_ids,
         expert_ids,
         num_tokens_post_pad,
-        token_cnts_buffer,
-        cumsum_buffer,
     )
-
 
 test_moe_align_block_size()

--- a/sgl-kernel/tests/test_moe_align.py
+++ b/sgl-kernel/tests/test_moe_align.py
@@ -5,7 +5,9 @@ from sgl_kernel import moe_align_block_size
 def test_moe_align_block_size():
     num_experts = 256
     block_size = 128
-    topk_ids = torch.randint(0, num_experts, (128, 4096), dtype=torch.int32, device="cuda")
+    topk_ids = torch.randint(
+        0, num_experts, (128, 4096), dtype=torch.int32, device="cuda"
+    )
 
     max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
     sorted_ids = torch.empty(
@@ -18,7 +20,6 @@ def test_moe_align_block_size():
     )
     num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
 
-
     moe_align_block_size(
         topk_ids,
         num_experts,
@@ -27,5 +28,6 @@ def test_moe_align_block_size():
         expert_ids,
         num_tokens_post_pad,
     )
+
 
 test_moe_align_block_size()


### PR DESCRIPTION
- [x] use shared memory cusum in `moe_align_block_size` kernel.
- [x] delete global memory buffer in `fused_moe_triton` .
- [x] add `num_experts` check for deepseekv3 in SGLang `moe_align_block_size`


The PR is an optimization of the writing style, and it should have minimal impact on performance. Later, we can continue to explore using multiple blocks to further optimize the `moe_align_block_size` kernel.

