### PR TITLE
add  benchmark_moe_align_blocks

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_moe_align_blocks.py
@@ -1,0 +1,270 @@
+import torch
+from sgl_kernel import moe_align_block_size
+import triton
+import triton.language as tl
+import time
+import itertools
+import argparse
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+@triton.jit
+def moe_align_block_size_stage1(
+    topk_ids_ptr,
+    tokens_cnts_ptr,
+    num_experts: tl.constexpr,
+    numel: tl.constexpr,
+    tokens_per_thread: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    start_idx = pid * tokens_per_thread
+    off_c = (pid + 1) * num_experts
+
+    for i in range(tokens_per_thread):
+        if start_idx + i < numel:
+            idx = tl.load(topk_ids_ptr + start_idx + i)
+            token_cnt = tl.load(tokens_cnts_ptr + off_c + idx)
+            tl.store(tokens_cnts_ptr + off_c + idx, token_cnt + 1)
+
+@triton.jit
+def moe_align_block_size_stage2(
+    tokens_cnts_ptr,
+    num_experts: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    last_cnt = 0
+    for i in range(1, num_experts + 1):
+        token_cnt = tl.load(tokens_cnts_ptr + i * num_experts + pid)
+        last_cnt = last_cnt + token_cnt
+        tl.store(tokens_cnts_ptr + i * num_experts + pid, last_cnt)
+
+@triton.jit
+def moe_align_block_size_stage3(
+    total_tokens_post_pad_ptr,
+    tokens_cnts_ptr,
+    cumsum_ptr,
+    num_experts: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    last_cumsum = 0
+    off_cnt = num_experts * num_experts
+    for i in range(1, num_experts + 1):
+        token_cnt = tl.load(tokens_cnts_ptr + off_cnt + i - 1)
+        last_cumsum = last_cumsum + tl.cdiv(token_cnt, block_size) * block_size
+        tl.store(cumsum_ptr + i, last_cumsum)
+    tl.store(total_tokens_post_pad_ptr, last_cumsum)
+
+@triton.jit
+def moe_align_block_size_stage4(
+    topk_ids_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    tokens_cnts_ptr,
+    cumsum_ptr,
+    num_experts: tl.constexpr,
+    block_size: tl.constexpr,
+    numel: tl.constexpr,
+    tokens_per_thread: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    start_idx = tl.load(cumsum_ptr + pid)
+    end_idx = tl.load(cumsum_ptr + pid + 1)
+
+    for i in range(start_idx, end_idx, block_size):
+        tl.store(expert_ids_ptr + i // block_size, pid)
+
+    start_idx = pid * tokens_per_thread
+    off_t = pid * num_experts
+
+    for i in range(start_idx, tl.minimum(start_idx + tokens_per_thread, numel)):
+        expert_id = tl.load(topk_ids_ptr + i)
+        token_cnt = tl.load(tokens_cnts_ptr + off_t + expert_id)
+        rank_post_pad = token_cnt + tl.load(cumsum_ptr + expert_id)
+        tl.store(sorted_token_ids_ptr + rank_post_pad, i)
+        tl.store(tokens_cnts_ptr + off_t + expert_id, token_cnt + 1)
+
+def moe_align_block_size_triton(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+) -> None:
+    numel = topk_ids.numel()
+    grid = (num_experts,)
+    tokens_cnts = torch.zeros(
+        (num_experts + 1, num_experts), dtype=torch.int32, device=topk_ids.device
+    )
+    cumsum = torch.zeros((num_experts + 1,), dtype=torch.int32, device=topk_ids.device)
+    tokens_per_thread = ceil_div(numel, num_experts)
+
+    moe_align_block_size_stage1[grid](
+        topk_ids,
+        tokens_cnts,
+        num_experts,
+        numel,
+        tokens_per_thread,
+    )
+    moe_align_block_size_stage2[grid](
+        tokens_cnts,
+        num_experts,
+    )
+    moe_align_block_size_stage3[(1,)](
+        num_tokens_post_pad,
+        tokens_cnts,
+        cumsum,
+        num_experts,
+        block_size,
+    )
+    moe_align_block_size_stage4[grid](
+        topk_ids,
+        sorted_token_ids,
+        expert_ids,
+        tokens_cnts,
+        cumsum,
+        num_experts,
+        block_size,
+        numel,
+        tokens_per_thread,
+    )
+
+def calculate_diff(batch_size, seq_len):
+    num_experts = 256
+    block_size = 128
+    topk_ids = torch.randint(0, num_experts, (batch_size, seq_len), dtype=torch.int32, device="cuda")
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    sorted_ids_cuda = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    sorted_ids_cuda.fill_(topk_ids.numel())
+    max_num_m_blocks = max_num_tokens_padded // block_size
+    expert_ids_cuda = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad_cuda = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
+    token_cnts_buffer = torch.empty(
+        (num_experts + 1) * num_experts, dtype=torch.int32, device=topk_ids.device
+    )
+    cumsum_buffer = torch.empty(
+        num_experts + 1, dtype=torch.int32, device=topk_ids.device
+    )
+
+    sorted_ids_triton = torch.empty_like(sorted_ids_cuda)
+    sorted_ids_triton.fill_(topk_ids.numel())
+    expert_ids_triton = torch.empty_like(expert_ids_cuda)
+    num_tokens_post_pad_triton = torch.empty_like(num_tokens_post_pad_cuda)
+
+    # 运行两个实现
+    moe_align_block_size(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids_cuda,
+        expert_ids_cuda,
+        num_tokens_post_pad_cuda,
+        token_cnts_buffer,
+        cumsum_buffer,
+    )
+    moe_align_block_size_triton(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids_triton,
+        expert_ids_triton,
+        num_tokens_post_pad_triton,
+    )
+
+    if torch.allclose(expert_ids_cuda, expert_ids_triton) and torch.allclose(num_tokens_post_pad_cuda, num_tokens_post_pad_triton):
+        print("✅ CUDA and Triton implementations match")
+    else:
+        print("❌ CUDA and Triton implementations do not match")
+        print("CUDA expert_ids:", expert_ids_cuda)
+        print("Triton expert_ids:", expert_ids_triton)
+        print("CUDA num_tokens_post_pad:", num_tokens_post_pad_cuda)
+        print("Triton num_tokens_post_pad:", num_tokens_post_pad_triton)
+
+batch_size_range = [2**i for i in range(0, 8)]
+seq_length_range = [2**i for i in range(0, 16)]
+configs = list(itertools.product(batch_size_range, seq_length_range))
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "seq_len"],
+        x_vals=[list(_) for _ in configs],
+        line_arg="provider",
+        line_vals=["cuda", "triton"],
+        line_names=["CUDA", "Triton"],
+        styles=[("blue", "-"), ("red", "-")],
+        ylabel="us",
+        plot_name="moe-align-block-size-performance",
+        args={},
+    )
+)
+def benchmark(batch_size, seq_len, provider):
+    num_experts = 256
+    block_size = 128
+    topk_ids = torch.randint(0, num_experts, (batch_size, seq_len), dtype=torch.int32, device="cuda")
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    sorted_ids = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    sorted_ids.fill_(topk_ids.numel())
+    max_num_m_blocks = max_num_tokens_padded // block_size
+    expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
+    token_cnts_buffer = torch.empty(
+        (num_experts + 1) * num_experts, dtype=torch.int32, device=topk_ids.device
+    )
+    cumsum_buffer = torch.empty(
+        num_experts + 1, dtype=torch.int32, device=topk_ids.device
+    )
+
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == "cuda":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: moe_align_block_size(
+                topk_ids,
+                num_experts,
+                block_size,
+                sorted_ids.clone(),
+                expert_ids.clone(),
+                num_tokens_post_pad.clone(),
+                token_cnts_buffer,
+                cumsum_buffer,
+            ),
+            quantiles=quantiles,
+        )
+    else:
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: moe_align_block_size_triton(
+                topk_ids,
+                num_experts,
+                block_size,
+                sorted_ids.clone(),
+                expert_ids.clone(),
+                num_tokens_post_pad.clone(),
+            ),
+            quantiles=quantiles,
+        )
+
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--save_path",
+        type=str,
+        default="./configs/benchmark_ops/moe_align_blocks/",
+        help="Path to save moe align benchmark results",
+    )
+    args = parser.parse_args()
+
+    calculate_diff(batch_size=4, seq_len=1024)
+
+    benchmark.run(print_data=True, save_path=args.save_path)


### PR DESCRIPTION
h100:

```shell
python3 /opt/dlami/nvme/bbuf/sglang/benchmark/kernels/fused_moe_triton/benchmark_moe_align_blocks.py --save_path /opt/dlami/nvme/bbuf/configs
✅ CUDA and Triton implementations match
moe-align-block-size-performance:
     batch_size  seq_len         CUDA       Triton
0           1.0      1.0    24.224000    73.408000
1           1.0      2.0    24.192000    72.127998
2           1.0      4.0    24.256000    71.648002
3           1.0      8.0    24.192000    73.023997
4           1.0     16.0    24.224000    72.191998
5           1.0     32.0    24.192000    71.392000
6           1.0     64.0    24.288001    73.344000
7           1.0    128.0    24.672000    73.536001
8           1.0    256.0    24.800001    72.768003
9           1.0    512.0    25.152000    72.127998
10          1.0   1024.0    25.536001    74.239999
11          1.0   2048.0    26.176000    73.919997
12          1.0   4096.0    28.031999    72.319999
13          1.0   8192.0    32.687999    72.864003
14          1.0  16384.0    45.279998    73.760003
15          1.0  32768.0    **85.104004**    78.560002
16          2.0      1.0    24.192000    72.400004
17          2.0      2.0    24.192000    73.472001
18          2.0      4.0    24.256000    79.584002
19          2.0      8.0    24.288001    79.392001
20          2.0     16.0    24.256000    79.167999
21          2.0     32.0    24.320001    79.552002
22          2.0     64.0    24.704000    77.616006
23          2.0    128.0    24.831999    78.143999
24          2.0    256.0    25.119999    79.135999
25          2.0    512.0    25.536001    78.528002
26          2.0   1024.0    26.240001    79.183996
27          2.0   2048.0    28.031999    78.656003
28          2.0   4096.0    32.639999    78.863993
29          2.0   8192.0    45.184001    80.895998
30          2.0  16384.0    **85.280001**    79.903997
31          2.0  32768.0   **148.287997**   101.120003
32          4.0      1.0    24.288001    79.584002
33          4.0      2.0    24.288001    80.767997
34          4.0      4.0    24.320001    79.552002
35          4.0      8.0    24.288001    79.584002
36          4.0     16.0    24.320001    79.775997
37          4.0     32.0    24.672000    77.791996
38          4.0     64.0    24.800001    78.528002
39          4.0    128.0    25.184000    78.111999
40          4.0    256.0    25.664000    79.007998
41          4.0    512.0    26.272001    78.079998
42          4.0   1024.0    28.000001    79.360001
43          4.0   2048.0    32.559998    78.879997
44          4.0   4096.0    45.248002    77.904001
45          4.0   8192.0    **85.344002**    80.400005
46          4.0  16384.0   **148.256004**   101.120003
47          4.0  32768.0   **272.832006**   146.431997
48          8.0      1.0    23.584001    79.967998
49          8.0      2.0    23.664000    78.896001
50          8.0      4.0    23.568001    79.728007
51          8.0      8.0    23.552001    75.167999
52          8.0     16.0    23.615999    74.975997
53          8.0     32.0    23.680000    75.488001
54          8.0     64.0    24.000000    76.159999
55          8.0    128.0    24.512000    75.407997
56          8.0    256.0    25.664000    76.031998
57          8.0    512.0    27.807999    75.584002
58          8.0   1024.0    32.639999    75.231999
59          8.0   2048.0    44.960000    74.879996
60          8.0   4096.0    **85.472003**    77.951998
61          8.0   8192.0   **149.215996**    99.104002
62          8.0  16384.0   **273.791999**   146.752000
63          8.0  32768.0   **527.520001**   238.463998
64         16.0      1.0    23.552001    75.263999
65         16.0      2.0    23.552001    75.151995
66         16.0      4.0    23.600001    74.720003
67         16.0      8.0    23.712000    75.903997
68         16.0     16.0    23.744000    75.231999
69         16.0     32.0    24.064001    75.360000
70         16.0     64.0    24.351999    75.839996
71         16.0    128.0    25.632000    75.199999
72         16.0    256.0    27.775999    74.816003
73         16.0    512.0    32.671999    75.360000
74         16.0   1024.0    44.976000    75.520001
75         16.0   2048.0    **85.408002**    77.280000
76         16.0   4096.0   **147.440001**    99.072002
77         16.0   8192.0   **274.048001**   146.559998
78         16.0  16384.0   **525.600016**   238.399997
79         16.0  32768.0  **1022.639990**   413.792014
80         32.0      1.0    23.600001    76.800004
81         32.0      2.0    23.584001    77.119999
82         32.0      4.0    23.680000    76.959997
83         32.0      8.0    23.744000    75.312003
84         32.0     16.0    24.032000    76.736003
85         32.0     32.0    24.383999    74.975997
86         32.0     64.0    25.664000    75.920001
87         32.0    128.0    27.775999    75.776003
88         32.0    256.0    32.639999    76.991998
89         32.0    512.0    45.120001    74.720003
90         32.0   1024.0    **85.712001**    78.143999
91         32.0   2048.0   **147.456005**    99.200003
92         32.0   4096.0   **273.631990**   146.704003
93         32.0   8192.0   **525.983989**   238.527998
94         32.0  16384.0  **1023.823977**   413.856000
95         32.0  32768.0  **2023.808002**   769.919991
96         64.0      1.0    23.536000    75.999998
97         64.0      2.0    23.712000    75.135998
98         64.0      4.0    23.744000    75.648002
99         64.0      8.0    24.064001    75.648002
100        64.0     16.0    24.383999    75.552002
101        64.0     32.0    25.664000    75.712003
102        64.0     64.0    27.775999    75.135998
103        64.0    128.0    32.575998    75.263999
104        64.0    256.0    45.040000    76.672003
105        64.0    512.0    **85.327998**    77.344000
106        64.0   1024.0   **147.599995**    99.136002
107        64.0   2048.0   **274.080008**   146.623999
108        64.0   4096.0   **525.056005**   238.912001
109        64.0   8192.0  **1024.320006**   413.695991
110        64.0  16384.0  **2019.808054**   769.919991
111        64.0  32768.0  **4007.391930**  1482.624054
112       128.0      1.0    23.647999    77.696003
113       128.0      2.0    23.744000    78.143999
114       128.0      4.0    24.064001    79.616003
115       128.0      8.0    24.400000    78.240000
116       128.0     16.0    25.664000    78.720003
117       128.0     32.0    27.807999    78.847997
118       128.0     64.0    32.416001    78.624003
119       128.0    128.0    45.088001    79.167999
120       128.0    256.0    **85.376002**    79.744004
121       128.0    512.0   **147.295997**    99.104002
122       128.0   1024.0   **273.983985**   146.495998
123       128.0   2048.0   **526.848018**   238.591999
124       128.0   4096.0  **1023.839951**   413.807988
125       128.0   8192.0  **2023.328066**   769.343972
126       128.0  16384.0  **4007.056236**  1481.424093
127       128.0  32768.0  **8052.288055**  2958.911896
```

Based on the benchmark, currently, when bs * seq_length (i.e., topk.numbel()) is greater than or equal to 32768, using the Triton version yields the best latency. Conversely, when topk.numbel() is less than 32768, using the CUDA kernel provides the optimal latency.