### PR TITLE
remove spaces_between_special_tokens from batch_decode

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -138,12 +138,12 @@ class DetokenizerManager:
             surr_texts = self.tokenizer.batch_decode(
                 surr_ids,
                 skip_special_tokens=recv_obj.skip_special_tokens[0],
-                spaces_between_special_tokens=recv_obj.spaces_between_special_tokens[0],
+                # spaces_between_special_tokens=recv_obj.spaces_between_special_tokens[0],
             )
             read_texts = self.tokenizer.batch_decode(
                 read_ids,
                 skip_special_tokens=recv_obj.skip_special_tokens[0],
-                spaces_between_special_tokens=recv_obj.spaces_between_special_tokens[0],
+                # spaces_between_special_tokens=recv_obj.spaces_between_special_tokens[0],
             )
 
             # Incremental decoding


### PR DESCRIPTION
b/c TikTokenizer does not support it... 