### PR TITLE
Use CUDA_VISIBLE_DEVICES instead of gpu_id variables everywhere.

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -241,6 +241,8 @@ def correctness_test(
     bench_args,
     tp_rank,
 ):
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(tp_rank)
+
     # Configure the logger
     configure_logger(server_args, prefix=f" TP{tp_rank}")
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
@@ -362,6 +364,8 @@ def latency_test(
     bench_args,
     tp_rank,
 ):
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(tp_rank)
+
     # Configure the logger
     configure_logger(server_args, prefix=f" TP{tp_rank}")
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -241,8 +241,6 @@ def correctness_test(
     bench_args,
     tp_rank,
 ):
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(tp_rank)
-
     # Configure the logger
     configure_logger(server_args, prefix=f" TP{tp_rank}")
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
@@ -364,8 +362,6 @@ def latency_test(
     bench_args,
     tp_rank,
 ):
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(tp_rank)
-
     # Configure the logger
     configure_logger(server_args, prefix=f" TP{tp_rank}")
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
@@ -440,6 +436,7 @@ def main(server_args, bench_args):
     else:
         workers = []
         for tp_rank in range(server_args.tp_size):
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(tp_rank)
             proc = multiprocessing.Process(
                 target=work_func,
                 args=(

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -122,7 +122,6 @@ def load_model(server_args, port_args, tp_rank):
     model_runner = ModelRunner(
         model_config=model_config,
         mem_fraction_static=server_args.mem_fraction_static,
-        gpu_id=tp_rank,
         tp_rank=tp_rank,
         tp_size=server_args.tp_size,
         nccl_port=port_args.nccl_port,

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -191,7 +191,7 @@ class DataParallelController:
             args=(server_args, port_args, gpu_id, tp_rank, dp_rank, writer),
         )
         proc.start()
-        os.environ["CUDA_VISIBLE_DEVICES"]
+        del os.environ["CUDA_VISIBLE_DEVICES"]
         send_to = get_zmq_socket(
             self.context, zmq.PUSH, port_args.scheduler_input_ipc_name
         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -538,7 +538,6 @@ class Scheduler:
             or recv_req.session_params.id is None
             or recv_req.session_params.id not in self.sessions
         ):
-
             if recv_req.input_embeds is not None:
                 # Generate fake input_ids based on the length of input_embeds
                 seq_length = len(recv_req.input_embeds)
@@ -1587,8 +1586,6 @@ def run_scheduler_process(
     pipe_writer,
 ):
     setproctitle.setproctitle("sglang::scheduler")
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
-
     # [For Router] if env var "SGLANG_DP_RANK" exist, set dp_rank to the value of the env var
     if dp_rank is None and "SGLANG_DP_RANK" in os.environ:
         dp_rank = int(os.environ["SGLANG_DP_RANK"])

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -41,7 +41,6 @@ class TpModelWorker:
     def __init__(
         self,
         server_args: ServerArgs,
-        gpu_id: int,
         tp_rank: int,
         dp_rank: Optional[int],
         nccl_port: int,
@@ -68,7 +67,6 @@ class TpModelWorker:
         self.model_runner = ModelRunner(
             model_config=self.model_config,
             mem_fraction_static=server_args.mem_fraction_static,
-            gpu_id=gpu_id,
             tp_rank=tp_rank,
             tp_size=server_args.tp_size,
             nccl_port=nccl_port,

--- a/python/sglang/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sglang/srt/managers/tp_worker_overlap_thread.py
@@ -54,16 +54,14 @@ class TpModelWorkerClient:
     def __init__(
         self,
         server_args: ServerArgs,
-        gpu_id: int,
         tp_rank: int,
         dp_rank: Optional[int],
         nccl_port: int,
     ):
         # Load the model
-        self.worker = TpModelWorker(server_args, gpu_id, tp_rank, dp_rank, nccl_port)
+        self.worker = TpModelWorker(server_args, tp_rank, dp_rank, nccl_port)
         self.max_running_requests = self.worker.max_running_requests
         self.device = self.worker.device
-        self.gpu_id = gpu_id
 
         # Init future mappings
         self.future_token_ids_ct = 0

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -222,7 +222,7 @@ class ModelRunner:
                 backend=backend,
                 world_size=self.tp_size,
                 rank=self.tp_rank,
-                local_rank=self.tp_rank % 8,  # Assumes 8 GPUs / node.
+                local_rank=0,  # CUDA_VISIBLE_DEVICES is set to a single GPU.
                 distributed_init_method=dist_init_method,
             )
             initialize_model_parallel(tensor_model_parallel_size=self.tp_size)

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -450,6 +450,7 @@ def launch_engine(
         for tp_rank in tp_rank_range:
             reader, writer = mp.Pipe(duplex=False)
             gpu_id = server_args.base_gpu_id + tp_rank % tp_size_per_node
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
             proc = mp.Process(
                 target=run_scheduler_process,
                 args=(server_args, port_args, gpu_id, tp_rank, None, writer),
@@ -457,6 +458,7 @@ def launch_engine(
             proc.start()
             scheduler_procs.append(proc)
             scheduler_pipe_readers.append(reader)
+        del os.environ["CUDA_VISIBLE_DEVICES"]
 
         if server_args.node_rank >= 1:
             # For other nodes, they do not need to run tokenizer or detokenizer,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -16,11 +16,9 @@ from sglang.srt.speculative.eagle_utils import EAGLEDraftInput
 
 
 class EAGLEWorker(TpModelWorker):
-
     def __init__(
         self,
         server_args: ServerArgs,
-        gpu_id: int,
         tp_rank: int,
         dp_rank: Optional[int],
         nccl_port: int,
@@ -31,7 +29,6 @@ class EAGLEWorker(TpModelWorker):
         backup_disable_cuda_graph = server_args.disable_cuda_graph
         server_args.disable_cuda_graph = True
         super().__init__(
-            gpu_id=gpu_id,
             tp_rank=tp_rank,
             server_args=server_args,
             nccl_port=nccl_port,


### PR DESCRIPTION
## Motivation

This is recommended by PyTorch:

> In most cases it’s better to use CUDA_VISIBLE_DEVICES environmental variable.

(https://pytorch.org/docs/stable/generated/torch.cuda.set_device.html)

It also helps avoid certain classes or errors (e.g., initializing CUDA on the wrong device and using extra memory there).

## Modifications

* Set `CUDA_VISIBLE_DEVICES` at the start of `run_scheduler_process` (annoyingly, Python's `multiprocessing` module gives no way of setting the env variables of the new child process).
* Drop many of the `gpu_id` variables throughout the code.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
