### PR TITLE
Fix port number overflow

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -929,9 +929,9 @@ class PortArgs:
             if is_port_available(port):
                 break
             if port < 60000:
-                port += random.randint(1,100)
+                port += random.randint(1, 100)
             else:
-                port -= random.randint(1,100)
+                port -= random.randint(1, 100)
 
         return PortArgs(
             tokenizer_ipc_name=tempfile.NamedTemporaryFile(delete=False).name,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -931,7 +931,7 @@ class PortArgs:
             if port < 60000:
                 port += 42
             else:
-                port -= random.randint(1, 100)
+                port -= 43
 
         return PortArgs(
             tokenizer_ipc_name=tempfile.NamedTemporaryFile(delete=False).name,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -929,7 +929,7 @@ class PortArgs:
             if is_port_available(port):
                 break
             if port < 60000:
-                port += random.randint(1, 100)
+                port += 42
             else:
                 port -= random.randint(1, 100)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -928,7 +928,10 @@ class PortArgs:
         while True:
             if is_port_available(port):
                 break
-            port += 42
+            if port < 60000:
+                port += random.randint(1,100)
+            else:
+                port -= random.randint(1,100)
 
         return PortArgs(
             tokenizer_ipc_name=tempfile.NamedTemporaryFile(delete=False).name,

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -335,6 +335,8 @@ def is_port_available(port):
             return True
         except socket.error:
             return False
+        except OverflowError:
+            return False
 
 
 def decode_video_base64(video_base64):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When serving with large port number
```
python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
--port 65531 --host 0.0.0.0
```
it will trigger following error
```
Traceback (most recent call last):
  File "/miniconda3/envs/sglang/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/miniconda3/envs/sglang/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "sglang/python/sglang/launch_server.py", line 14, in <module>
    launch_server(server_args)
  File "sglang/python/sglang/srt/server.py", line 534, in launch_server
    launch_engine(server_args=server_args)
  File "sglang/python/sglang/srt/server.py", line 433, in launch_engine
    port_args = PortArgs.init_new(server_args)
  File "sglang/python/sglang/srt/server_args.py", line 929, in init_new
    if is_port_available(port):
  File "sglang/python/sglang/srt/utils.py", line 333, in is_port_available
    s.bind(("", port))
OverflowError: bind(): port must be 0-65535.
```
I check the code and find sglang will use another port for inter-process communications. However, the logic for allocating port number only add random number to the specific port number which will cause overflow of port number. 

## Modifications

<!-- Describe the changes made in this PR. -->
Avoid port number overflow.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
