### PR TITLE
[Bugfix] Fix bug in fork logic caused by null text_

### DIFF
--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -347,7 +347,7 @@ class StreamExecutor:
         size: int = 1,
         position_ids_offset: Optional[List[int]] = None,
     ):
-        if size > 1:
+        if size > 1 and str(self.text_):
             self.submit(SglCommitLazy())
 
         self.sync()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

As indicated in issue #2755, forking the state before submitting any string causes a backend crash. This occurs because the frontend executes a null SglCommitLazy, with the null text causing the backend to crash.

## Modifications

I added extra logic to the fork process. The new logic checks whether the text_ string is null. When the fork number is greater than 1 and text_ is not null, submitting SglCommitLazy is deemed meaningful.

## Checklist

- [x] Format your code according to the [[Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md)](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Add unit tests as outlined in the [[Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md)](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.