### PR TITLE
[HotFix] fix fp8 scale load failed in tp>1

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -437,7 +437,7 @@ class ColumnParallelLinear(LinearBase):
         if len(loaded_weight.shape) == 0:
             assert loaded_weight.numel() == 1
             loaded_weight = loaded_weight.reshape(1)
-        load_column_parallel_weight(param, loaded_weight, self.tp_rank)
+        param.load_column_parallel_weight(loaded_weight=loaded_weight)
 
     def forward(self, input_):
         bias = self.bias if not self.skip_bias_add else None
@@ -1247,12 +1247,7 @@ class RowParallelLinear(LinearBase):
             assert loaded_weight.numel() == 1
             loaded_weight = loaded_weight.reshape(1)
 
-        load_row_parallel_weight(
-            param,
-            loaded_weight,
-            self.tp_rank,
-            use_presharded_weights=self.use_presharded_weights,
-        )
+        param.load_row_parallel_weight(loaded_weight=loaded_weight)
 
     def forward(self, input_):
         if self.input_is_parallel:


### PR DESCRIPTION
To solve error when serving deepseekv3 in main branch:

```shell
Loading safetensors checkpoint shards:   1% Completed | 1/163 [00:00<02:13,  1.21it/s]
[2025-01-10 04:40:02 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/managers/scheduler.py", line 1613, in run_scheduler_process
    scheduler = Scheduler(server_args, port_args, gpu_id, tp_rank, dp_rank)
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/managers/scheduler.py", line 203, in __init__
    self.tp_worker = TpWorkerClass(
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 63, in __init__
    self.worker = TpModelWorker(server_args, gpu_id, tp_rank, dp_rank, nccl_port)
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/managers/tp_worker.py", line 68, in __init__
    self.model_runner = ModelRunner(
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/model_executor/model_runner.py", line 170, in __init__
    self.load_model()
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/model_executor/model_runner.py", line 274, in load_model
    self.model = get_model(
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/model_loader/__init__.py", line 22, in get_model
    return loader.load_model(
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/model_loader/loader.py", line 362, in load_model
    model.load_weights(self._get_all_weights(model_config, model))
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/models/deepseek_v2.py", line 939, in load_weights
    weight_loader(param, loaded_weight)
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/layers/linear.py", line 1250, in weight_loader_v2
    load_row_parallel_weight(
  File "/mnt/co-research/home/yineng/bbuf/sglang/python/sglang/srt/layers/linear.py", line 151, in load_row_parallel_weight
    self.data.copy_(loaded_weight)
RuntimeError: The size of tensor a (2) must match the size of tensor b (16) at non-singleton dimension 1
```

It caused by https://github.com/sgl-project/sglang/commit/8a6906127a81421e06c904273f8e06dff85039a7 .

By the fix, Deepseek V3 can serving normaly now.

![图片](https://github.com/user-attachments/assets/7dc33686-e114-4fe4-8523-c11f31da7032)

