### PR TITLE
[Fix]eagle2 health_generate is first request,apiserver will core

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -40,6 +40,7 @@ class EAGLEWorker(TpModelWorker):
         )
         self.target_worker = target_worker
         self.server_args = server_args
+        self.finish_extend_len = []
 
         # Share the embedding and lm_head
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
https://github.com/sgl-project/sglang/pull/2730#issuecomment-2586118911

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
runing in EAGLE2 apiserver,health_generate is the first request
health_generate,input_ids=[0] and max_new_tokens = 1

- runing Eagle2 prefile, generate one token.
- in stream_output, req.finished() is True.
- but EAGLEWorker.finish_extend_len never been valued again.

![image](https://github.com/user-attachments/assets/50de25d5-474c-454f-b22e-dd2b730f0016)

Now when EAGLEWorker initialize it, assigning the value of 'finic_xend_len' to [] can solve the problem.
@merrymercy

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [x] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [x] Update documentation as needed, including docstrings or example tutorials.
