### PR TITLE
Disable graceful shutdown of tokenizer manager when not in the main thread

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -250,6 +250,10 @@ class TokenizerManager:
             input_embeds = obj.input_embeds
             input_ids = obj.input_ids
         elif obj.input_ids is None:
+            if self.tokenizer is None:
+                raise ValueError(
+                    "Only accept request with input_ids when skip_tokenizer_init=True"
+                )
             input_ids = self.tokenizer.encode(input_text)
         else:
             input_ids = obj.input_ids

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -249,14 +249,16 @@ class TokenizerManager:
                 )
             input_embeds = obj.input_embeds
             input_ids = obj.input_ids
-        elif obj.input_ids is None:
+        elif obj.input_ids is not None:
+            input_ids = obj.input_ids
+        else:
             if self.tokenizer is None:
                 raise ValueError(
-                    "Only accept request with input_ids when skip_tokenizer_init=True"
+                    "The engine initialized with skip_tokenizer_init=True cannot "
+                    "accept text prompts. Please provide input_ids or re-initialize "
+                    "the engine with skip_tokenizer_init=False."
                 )
             input_ids = self.tokenizer.encode(input_text)
-        else:
-            input_ids = obj.input_ids
 
         if self.is_generation:
             # TODO: also support getting embeddings for multimodal models


### PR DESCRIPTION
## Motivation

Fixes #1987

Error message:

```
add_signal_handler() can only be called from the main thread
```

The root cause is Ray Data async streamer uses a separate thread to run UDF (user defined function), so that SGLang engine is not located in the main thread anymore. In this case, due to the CPython limitation, we cannot add signal handler to the tokenizer manager.

## Modifications

This PR simply avoids adding signal handler when the tokenizer manager is not in the main thread. This should solve the use case with Ray Data, but since I'm not sure if this change will result in any side effects, I added a warning for future developers.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
