### PR TITLE
Adjust flashinfer workspace size for Qwen2 models

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -84,6 +84,10 @@ class FlashInferAttnBackend(AttentionBackend):
             self.num_wrappers = 1
             self.dispatch_reason = None
 
+        # Qwen2 models require higher flashinfer workspace size
+        if "Qwen2ForCausalLM" in model_runner.model_config.hf_config.architectures:
+            global_config.flashinfer_workspace_size = 512 * 1024 * 1024
+
         # Allocate buffers
         self.workspace_buffer = torch.empty(
             global_config.flashinfer_workspace_size,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix issues https://github.com/sgl-project/sglang/issues/2344, https://github.com/sgl-project/sglang/issues/2102, https://github.com/sgl-project/sglang/issues/1405.

Qwen2 models (mostly Qwen2-7B) require higher flashinfer workspace size. This issue occurs on different types of hardware (SM80 & SM90). Temporarily fixed it with specific adjustments.

cc: @yzh119 @merrymercy @Ying1123 @xiezhq-hermann 