### PR TITLE
[Feature] Support dynamic loading and unloading of Lora adapters

### DIFF
--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -324,6 +324,7 @@ class LoRAAdapter(nn.Module):
         self.weights = {}
         self.weights_gpu = {}
 
+    @classmethod
     def get_stacked_multiply(self, module_name):
         stacked_rank = {
             "qkv_proj": 3,

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -335,7 +335,7 @@ class LoRAManager:
             return False, error_msg
 
         # Load lora config. Return false if the loading of config is failed.
-        try: 
+        try:
             self.configs[lora_name] = LoRAConfig(lora_path)
         except Exception as e:
             error_msg = (
@@ -344,10 +344,10 @@ class LoRAManager:
             )
             logger.error(error_msg)
             return False, error_msg
-        
+
         # Update target modules.
         added_target_modules = set(self.configs[lora_name].target_modules)
-        if hasattr(self.base_model, "get_module_name"):    
+        if hasattr(self.base_model, "get_module_name"):
             self.target_modules = set(self.target_modules) | {
                 self.base_model.get_module_name(module)
                 for module in added_target_modules
@@ -389,7 +389,7 @@ class LoRAManager:
                 self.lora_modules.append(
                     (module_name, self.set_lora_module(module_name, module))
                 )
-                
+
         # Create new spaces to memory buffer if there are newly added target modules.
         # TODO(Baizhou): This piece of logic can be reused in a helper function.
         num_layer = self.base_hf_config.num_hidden_layers
@@ -418,7 +418,7 @@ class LoRAManager:
                         )
                         for i in range(num_layer)
                     ]
-                    
+
             if module_B not in self.B_buffer:
                 if hasattr(self.base_model, "get_hidden_dim"):
                     _, hidden_dim_B = self.base_model.get_hidden_dim(module_B)
@@ -442,5 +442,5 @@ class LoRAManager:
                     )
                     for i in range(num_layer)
                 ]
-        
+
         return True, "Success"

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -327,3 +327,7 @@ class LoRAManager:
                     seg_indptr,
                     weight_indices,
                 )
+
+    def load_lora_adapter(self, lora_name: str, lora_path: str):
+        # TODO: implement this!
+        pass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -462,11 +462,31 @@ class GetWeightsByNameReqInput:
     name: str
     truncate_size: int = 100
 
-
 @dataclass
 class GetWeightsByNameReqOutput:
     parameter: list
 
+@dataclass
+class LoadLoRAAdapterReqInput:
+    # The name of the lora module to newly loaded.
+    lora_name: str
+    # The path of loading.
+    lora_path: str
+
+@dataclass
+class LoadLoRAAdapterReqOutput:
+    success: bool
+    message: str
+    
+@dataclass
+class UnLoadLoRAAdapterReqInput:
+    # The name of lora module to unload.
+    lora_name: str
+
+@dataclass
+class UnLoadLoRAAdapterReqOutput:
+    success: bool
+    message: str
 
 @dataclass
 class AbortReq:

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -462,9 +462,11 @@ class GetWeightsByNameReqInput:
     name: str
     truncate_size: int = 100
 
+
 @dataclass
 class GetWeightsByNameReqOutput:
     parameter: list
+
 
 @dataclass
 class LoadLoRAAdapterReqInput:
@@ -473,20 +475,24 @@ class LoadLoRAAdapterReqInput:
     # The path of loading.
     lora_path: str
 
+
 @dataclass
 class LoadLoRAAdapterReqOutput:
     success: bool
     message: str
-    
+
+
 @dataclass
 class UnLoadLoRAAdapterReqInput:
     # The name of lora module to unload.
     lora_name: str
 
+
 @dataclass
 class UnLoadLoRAAdapterReqOutput:
     success: bool
     message: str
+
 
 @dataclass
 class AbortReq:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -43,6 +43,8 @@ from sglang.srt.managers.io_struct import (
     GetWeightsByNameReqOutput,
     InitWeightsUpdateGroupReqInput,
     InitWeightsUpdateGroupReqOutput,
+    LoadLoRAAdapterReqInput,
+    LoadLoRAAdapterReqOutput,
     OpenSessionReqInput,
     OpenSessionReqOutput,
     ProfileReq,
@@ -54,8 +56,6 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqOutput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
-    LoadLoRAAdapterReqInput,
-    LoadLoRAAdapterReqOutput
 )
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
@@ -514,7 +514,7 @@ class Scheduler:
                 success, message = self.update_weights_from_tensor(recv_req)
                 self.send_to_tokenizer.send_pyobj(
                     UpdateWeightsFromTensorReqOutput(success, message)
-                )    
+                )
             elif isinstance(recv_req, GetWeightsByNameReqInput):
                 parameter = self.get_weights_by_name(recv_req)
                 self.send_to_tokenizer.send_pyobj(GetWeightsByNameReqOutput(parameter))
@@ -522,7 +522,7 @@ class Scheduler:
                 success, message = self.load_lora_adapter(recv_req)
                 self.send_to_tokenizer.send_pyobj(
                     LoadLoRAAdapterReqOutput(success, message)
-                )   
+                )
             elif isinstance(recv_req, ProfileReq):
                 if recv_req == ProfileReq.START_PROFILE:
                     self.start_profile()
@@ -1552,18 +1552,23 @@ class Scheduler:
 
     def load_lora_adapter(self, recv_req: LoadLoRAAdapterReqInput):
         """In-place loading a new lora adapater from disk or huggingface."""
-        
-        if (not self.server_args.disable_radix_cache) or (not self.server_args.disable_cuda_graph):
-            success, message = False, "Radix cache or cuda graph not supported when Lora is enabled, please try turning it off." 
+
+        if (not self.server_args.disable_radix_cache) or (
+            not self.server_args.disable_cuda_graph
+        ):
+            success, message = (
+                False,
+                "Radix cache or cuda graph not supported when Lora is enabled, please try turning it off.",
+            )
         else:
             success, message = self.tp_worker.load_lora_adapter(recv_req)
-            
+
         if success:
             flash_cache_success = self.flush_cache()
             assert flash_cache_success, "Cache flush failed after updating weights"
         else:
             logger.error(message)
-        return success, message   
+        return success, message
 
     def start_profile(self) -> None:
         if self.profiler is None:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -50,6 +50,8 @@ from sglang.srt.managers.io_struct import (
     GetWeightsByNameReqOutput,
     InitWeightsUpdateGroupReqInput,
     InitWeightsUpdateGroupReqOutput,
+    LoadLoRAAdapterReqInput,
+    LoadLoRAAdapterReqOutput,
     OpenSessionReqInput,
     OpenSessionReqOutput,
     ProfileReq,
@@ -62,8 +64,6 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromDistributedReqOutput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
-    LoadLoRAAdapterReqInput,
-    LoadLoRAAdapterReqOutput
 )
 from sglang.srt.metrics.collector import TokenizerMetricsCollector
 from sglang.srt.sampling.sampling_params import SamplingParams
@@ -172,9 +172,7 @@ class TokenizerManager:
             None
         )
         self.lora_update_lock = RWLock()
-        self.lora_update_result: Optional[Awaitable[LoadLoRAAdapterReqOutput]] = (
-            None
-        )
+        self.lora_update_result: Optional[Awaitable[LoadLoRAAdapterReqOutput]] = None
         self.asyncio_tasks = set()
 
         # For session info
@@ -802,7 +800,7 @@ class TokenizerManager:
                     self.lora_update_tmp_result.append(recv_obj)
                     # set future if the all results are recevied
                     if len(self.lora_update_tmp_result) == self.server_args.dp_size:
-                        self.lora_update_result.set_result(self.lora_update_tmp_result)  
+                        self.lora_update_result.set_result(self.lora_update_tmp_result)
             else:
                 raise ValueError(f"Invalid object: {recv_obj=}")
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -25,6 +25,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromTensorReqInput,
+    LoadLoRAAdapterReqInput
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch, global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -212,3 +213,9 @@ class TpModelWorker:
             recv_req.name, recv_req.truncate_size
         )
         return parameter
+    
+    def load_lora_adapter(self, recv_req: LoadLoRAAdapterReqInput):
+        success, message = self.model_runner.load_lora_adapter(
+            recv_req.lora_name, recv_req.lora_path
+        )
+        return success, message    

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -22,10 +22,10 @@ from sglang.srt.hf_transformers_utils import get_processor, get_tokenizer
 from sglang.srt.managers.io_struct import (
     GetWeightsByNameReqInput,
     InitWeightsUpdateGroupReqInput,
+    LoadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromTensorReqInput,
-    LoadLoRAAdapterReqInput
 )
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch, global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -213,9 +213,9 @@ class TpModelWorker:
             recv_req.name, recv_req.truncate_size
         )
         return parameter
-    
+
     def load_lora_adapter(self, recv_req: LoadLoRAAdapterReqInput):
         success, message = self.model_runner.load_lora_adapter(
             recv_req.lora_name, recv_req.lora_path
         )
-        return success, message    
+        return success, message

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -466,10 +466,15 @@ class ModelRunner:
             return None
 
     def init_lora_manager(self):
-        
+
         # TODO: remove this if-else condition after supporting radix cache or cuda graph.
-        if (not self.server_args.disable_radix_cache) or (not self.server_args.disable_cuda_graph):
-            success, message = False, "Radix cache or cuda graph not supported when Lora is enabled, please try turning it off." 
+        if (not self.server_args.disable_radix_cache) or (
+            not self.server_args.disable_cuda_graph
+        ):
+            success, message = (
+                False,
+                "Radix cache or cuda graph not supported when Lora is enabled, please try turning it off.",
+            )
 
         self.lora_manager = LoRAManager(
             base_model=self.model,
@@ -480,17 +485,15 @@ class ModelRunner:
             dtype=self.dtype,
         )
         logger.info("LoRA manager ready.")
-        
-    def load_lora_adapter(
-        self, lora_name: str, lora_path: str
-    ) -> tuple[bool, str]:
+
+    def load_lora_adapter(self, lora_name: str, lora_path: str) -> tuple[bool, str]:
         """Load a new lora adapter from disk or huggingface."""
-        
+
         logger.info(
             f"Begin loading a new lora adapter: name={lora_name}, path={lora_path}. "
             f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
         )
-        
+
         success, message = self.lora_manager.load_lora_adapter(lora_name, lora_path)
         if success:
             self.server_args.lora_paths.append(lora_path)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -466,6 +466,11 @@ class ModelRunner:
             return None
 
     def init_lora_manager(self):
+        
+        # TODO: remove this if-else condition after supporting radix cache or cuda graph.
+        if (not self.server_args.disable_radix_cache) or (not self.server_args.disable_cuda_graph):
+            success, message = False, "Radix cache or cuda graph not supported when Lora is enabled, please try turning it off." 
+
         self.lora_manager = LoRAManager(
             base_model=self.model,
             lora_paths=self.server_args.lora_paths,
@@ -475,6 +480,22 @@ class ModelRunner:
             dtype=self.dtype,
         )
         logger.info("LoRA manager ready.")
+        
+    def load_lora_adapter(
+        self, lora_name: str, lora_path: str
+    ) -> tuple[bool, str]:
+        """Load a new lora adapter from disk or huggingface."""
+        
+        logger.info(
+            f"Begin loading a new lora adapter: name={lora_name}, path={lora_path}. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
+        )
+        
+        self.lora_manager.load_lora_adapter(lora_name, lora_path)
+        self.server_args.lora_paths.append(lora_path)
+
+        logger.info("Lora loading end.")
+        return True, "Succeeded to load Lora adapter."
 
     def profile_max_num_token(self, total_gpu_memory: int):
         available_gpu_memory = get_available_gpu_memory(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -491,11 +491,12 @@ class ModelRunner:
             f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
         )
         
-        self.lora_manager.load_lora_adapter(lora_name, lora_path)
-        self.server_args.lora_paths.append(lora_path)
+        success, message = self.lora_manager.load_lora_adapter(lora_name, lora_path)
+        if success:
+            self.server_args.lora_paths.append(lora_path)
 
         logger.info("Lora loading end.")
-        return True, "Succeeded to load Lora adapter."
+        return success, message
 
     def profile_max_num_token(self, total_gpu_memory: int):
         available_gpu_memory = get_available_gpu_memory(

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -56,12 +56,12 @@ from sglang.srt.managers.io_struct import (
     GenerateReqInput,
     GetWeightsByNameReqInput,
     InitWeightsUpdateGroupReqInput,
+    LoadLoRAAdapterReqInput,
     OpenSessionReqInput,
+    UnLoadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromTensorReqInput,
-    LoadLoRAAdapterReqInput,
-    UnLoadLoRAAdapterReqInput
 )
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager

--- a/python/sglang/srt/server.py
+++ b/python/sglang/srt/server.py
@@ -60,6 +60,8 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightFromDiskReqInput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromTensorReqInput,
+    LoadLoRAAdapterReqInput,
+    UnLoadLoRAAdapterReqInput
 )
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
@@ -253,6 +255,24 @@ async def get_weights_by_name(obj: GetWeightsByNameReqInput, request: Request):
             return ORJSONResponse(ret, status_code=200)
     except Exception as e:
         return _create_error_response(e)
+
+
+@app.post("/load_lora_adapter")
+@time_func_latency
+async def load_lora_adapter(obj: LoadLoRAAdapterReqInput, request: Request):
+    """Load a new Lora adapter without re-launching the server."""
+    success, message = await tokenizer_manager.load_lora_adapter(obj, request)
+    content = {"success": success, "message": message}
+    if success:
+        return ORJSONResponse(
+            content,
+            status_code=HTTPStatus.OK,
+        )
+    else:
+        return ORJSONResponse(
+            content,
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
 
 
 @app.api_route("/open_session", methods=["GET", "POST"])


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR aims to implement the dynamic LoRA feature mentioned in #2686.
This PR is still under developing, please comment if the code can be improved.

## Modifications

<!-- Describe the changes made in this PR. -->

### Current implementation of LoRA modules

Current LoRA features are implemented under folder `python/sglang/srt/lora`, where three files `lora.py`, `lora_manager.py`, `lora_config.py` are included. Initial support can be referred to #1307.

In the `__init__` function of `ModelRunner`, a `LoraManager` will be created if a valid `lora_path` is passed in `server_args`. The initialization of `LoraManager` contains two parts: first calling `init_loras` to load huggingface LoRA weights to CPU and replace the targeted layers with `BaseLayerWithLoRA` instances, then calling `init_lora_memory_pool` to preallocate the memory pool for S-Lora. The definition of lora modules in `lora.py` are implemented on the basis of [vllm implementation](https://github.com/vllm-project/vllm/blob/4abf6336ec65c270343eb895e7b18786e9274176/vllm/lora/layers.py). 

Before forwarding the batch, `LoraManager` will call `prepare_lora_batch` method to load active Lora adapters from memory pool. During loading, lora weight not used in current batch can be evicted from buffer if necessary.

Unit tests are put under `test/srt/models/test_lora.py`. The test for inference can be passed, but the test for serving is skipped, so the feature of LoRA serving might require further check. The benchmark codes can be found in `benchmark/lora/lora_bench.py`. 

### Implementation of dynamic serving LoRA

Dynamical serving LoRA means the lora adapters can be loaded and unloaded at users' commands during server runtime. This feature has been supported in vllm ([vllm lora doc](https://docs.vllm.ai/en/latest/features/lora.html)). As mentioned in #1433,  current implementation supports multi-lora serving, but the loading and unloading of Lora modules can only be done at initialization of servers.

The design of loading and unloading LoRA at API side can be similar to `update_weights_from_disk` API, since both of their behavior is changing the weights that current server is running on. In this design, the two APIs are named as `load_lora_adapter` and `unload_lora_adapter` as in vllm.

After the user send the `LoadLoraAdapterReq`/`UnloadLoraAdapterReq` request to server, the serve will grab a write lock and wait for the request in progress to be finished. Then, the request will be transmitted to `ModelRunner` through several passes, and be handled by `LoraManager` owned by `ModelRunner`.

At `LoraManager` side, the loading of new lora adapter just follows the process of initialization: collecting new target modules, initialize new lora weights on CPU, and if open new space in memory buffer if needed. 

The implementation of unloading and testing scripts to be done...



## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Add unit tests as outlined in the [Contributor Guide](https://github.com/sgl-project/sglang/blob/main/docs/references/contribution_guide.md).
- [ ] Update documentation as needed, including docstrings or example tutorials.
