### PR TITLE
Fix qwen accuracy issue

### DIFF
--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -356,8 +356,6 @@ class Qwen2ForCausalLM(nn.Module):
                 break
             else:
                 # Skip loading extra bias for GPTQ models.
-                if "lm_head.weight" in name:
-                    continue
                 if name.endswith(".bias") and name not in params_dict:
                     continue
                 param = params_dict[name]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Revert https://github.com/sgl-project/sglang/pull/2910. 
Nightly eval failed for `neuralmagic/Qwen2-72B-Instruct-FP8`. https://github.com/sgl-project/sglang/actions/runs/12820064955

I tried other Qwen models like `Qwen/Qwen2-7B` and `Qwen/Qwen1.5-7B-Chat-AWQ`. They also facing this issue.

```
python3 -m sglang.launch_server --model Qwen/Qwen2-7B 
python3 benchmark/gsm8k/bench_sglang.py

Accuracy: 0.000
Invalid: 1.000
Latency: 17.218 s
```

Will add Qwen PR test soon.

cc: @RinRin-32 @merrymercy 