### PR TITLE
[MOE] try to optimize cu kernel single block execution - distribute cumsum workload from thread 0 to other threads

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
@@ -300,11 +300,6 @@ def benchmark(batch_size, seq_len, provider):
 
 
 if __name__ == "__main__":
-    torch.manual_seed(SEED)
-
-    import numpy as np
-    np.random.seed(SEED)
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--save_path",

--- a/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
@@ -300,6 +300,11 @@ def benchmark(batch_size, seq_len, provider):
 
 
 if __name__ == "__main__":
+    torch.manual_seed(SEED)
+
+    import numpy as np
+    np.random.seed(SEED)
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--save_path",

--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -42,17 +42,23 @@ __device__ __forceinline__ int32_t index(int32_t total_col, int32_t row, int32_t
   // don't worry about overflow because num_experts is relatively small
   return row * total_col + col;
 }
-
+#define OFFSETS_PAD 1
 template <typename scalar_t>
 __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int32_t* sorted_token_ids,
                                             int32_t* expert_ids, int32_t* total_tokens_post_pad, int32_t num_experts,
                                             int32_t block_size, size_t numel, int32_t* cumsum) {
   __shared__ int32_t shared_counts[32][8];
-  __shared__ int32_t local_offsets[256];
+  // NOTE (yiakwy) : this assumes num_experts <= 256
+  __shared__ int32_t local_offsets[256+OFFSETS_PAD];
+  __shared__ int32_t local_offsets_buf[16];
 
+  const int tid = threadIdx.x;
   const int warp_id = threadIdx.x / WARP_SIZE;
   const int experts_per_warp = 8;
   const int my_expert_start = warp_id * experts_per_warp;
+
+  const size_t tokens_per_thread = CEILDIV(numel, blockDim.x);
+  const size_t start_idx = threadIdx.x * tokens_per_thread;
 
   for (int i = 0; i < experts_per_warp; ++i) {
     if (my_expert_start + i < num_experts) {
@@ -60,8 +66,8 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
     }
   }
 
-  const size_t tokens_per_thread = CEILDIV(numel, blockDim.x);
-  const size_t start_idx = threadIdx.x * tokens_per_thread;
+  // NOTE (yiakwy) : this warp of threads may access other warp of threads based on the value of expert id fetched
+  __syncthreads();
 
   for (int i = start_idx; i < numel && i < start_idx + tokens_per_thread; ++i) {
     int expert_id = topk_ids[i];
@@ -72,26 +78,115 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 
   __syncthreads();
 
-  if (threadIdx.x == 0) {
-    cumsum[0] = 0;
-    for (int i = 1; i <= num_experts; ++i) {
-      int expert_count = 0;
-      int warp_idx = (i - 1) / experts_per_warp;
-      int expert_offset = (i - 1) % experts_per_warp;
-      expert_count = shared_counts[warp_idx][expert_offset];
+#define kElementsPerThr    16
 
-      cumsum[i] = cumsum[i - 1] + CEILDIV(expert_count, block_size) * block_size;
+  {
+
+  int active_threads = CEILDIV(num_experts, kElementsPerThr);
+  if (tid == 0) {
+    local_offsets[0] = 0; 
+  }
+  if (tid < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
+
+    // NOTE (yiakwy) : loop body, a simple reduction prototype, useful for workload with the number of experts upto 256
+    // NOTE (yiakwy) : each thread process 16 expert, then only 2 steps needed
+
+    // NOTE (yiakwy) : step 1, loop body
+    // [1, 17)
+    for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
+      int warp_idx = (i-1) / experts_per_warp;
+      int expert_offset = (i-1) % experts_per_warp;
+
+      int expert_count = shared_counts[warp_idx][expert_offset];
+
+      int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+      local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
     }
-    *total_tokens_post_pad = cumsum[num_experts];
+
+    local_offsets_buf[tid] = local_offsets[(tid + 1)*kElementsPerThr];
+
+  }
+
+  // NOTE (yiakwy) : step 1, unroll loop tail
+  if (tid == active_threads - 1) {
+    #pragma unroll
+    for (int i=tid * kElementsPerThr+1; i < num_experts+1; ++i) {
+      int warp_idx = (i-1) / experts_per_warp;
+      int expert_offset = (i-1) % experts_per_warp;
+
+      int expert_count = shared_counts[warp_idx][expert_offset];
+
+      int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+      local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+    }
+
+    local_offsets_buf[tid] = local_offsets[num_experts];
+    
   }
 
   __syncthreads();
 
+  // NOTE (yiakwy) : step 2, loop body
+  if (tid < active_threads - 1 && tid > 0) {
+    int offset = 0;
+    for (int j=0; j < tid; ++j) {
+      offset += local_offsets_buf[j];
+    }
+
+    for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
+      local_offsets[i] += offset;
+    }
+  }
+    
+  // NOTE (yiakwy) : step 2, loop tail
+  if (tid == active_threads - 1) {
+    int offset = 0;
+    for (int j=0; j < tid; ++j) {
+      offset += local_offsets_buf[j];
+    }
+    for (int i=tid*kElementsPerThr+1; i < num_experts+1; ++i) {
+      local_offsets[i] += offset;
+    }
+  }
+
+  } // code block of computing cumsum
+
+  __syncthreads();
+
+#define kElementsPerThr    16
+#define kElementsPerAccess 4
+
+  {
+  
+  int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
+  if (tid < active_threads - 1) {
+
+    // NOTE(yiakwy) : loop body useful for workload with the number of experts upto 256
+    for (int i=tid * kElementsPerThr ; i < (tid + 1) * kElementsPerThr; i += kElementsPerAccess) {
+      *(int4 *)(cumsum + i) = *(int4 *)(local_offsets + i);
+    }
+  }
+
+  if (tid == active_threads - 1) {
+    // NOTE(yiakwy) : unroll loop tail
+    #pragma unroll
+    for (int i=tid * kElementsPerThr; i < num_experts+1; i++) {
+      *(cumsum + i) = *(local_offsets + i);
+    }
+  }
+
+  if (tid == active_threads) {
+    *total_tokens_post_pad = local_offsets[num_experts];
+  }
+  
+  } // code block of storing to cumsum
+
+  __syncthreads();
+
   if (threadIdx.x < num_experts) {
-    for (int i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1]; i += block_size) {
+    for (int i = local_offsets[threadIdx.x]; i < local_offsets[threadIdx.x + 1]; i += block_size) {
       expert_ids[i / block_size] = threadIdx.x;
     }
-    local_offsets[threadIdx.x] = cumsum[threadIdx.x];
   }
 
   __syncthreads();
@@ -109,8 +204,10 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t b
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_INTEGRAL_TYPES(topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
     auto kernel = moe_align_block_size_kernel<scalar_t>;
+    // NOTE(yiakwy) : this assumes a single block execution, will be slow if too many tokens (>1024) feeded in
     kernel<<<1, 1024, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
                                    experts_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
                                    num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
   });
 }
+   

--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -84,7 +84,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 
   int active_threads = CEILDIV(num_experts, kElementsPerThr);
   if (tid == 0) {
-    local_offsets[0] = 0; 
+    local_offsets[0] = 0;
   }
   if (tid < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
 
@@ -121,7 +121,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
     }
 
     local_offsets_buf[tid] = local_offsets[num_experts];
-    
+
   }
 
   __syncthreads();
@@ -137,7 +137,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
       local_offsets[i] += offset;
     }
   }
-    
+
   // NOTE (yiakwy) : step 2, loop tail
   if (tid == active_threads - 1) {
     int offset = 0;
@@ -157,7 +157,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 #define kElementsPerAccess 4
 
   {
-  
+
   int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
   if (tid < active_threads - 1) {
 
@@ -178,7 +178,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
   if (tid == active_threads) {
     *total_tokens_post_pad = local_offsets[num_experts];
   }
-  
+
   } // code block of storing to cumsum
 
   __syncthreads();
@@ -210,4 +210,3 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t b
                                    num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
   });
 }
-   


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Current cuda kernel runs best when work load fitted into a single block execution (when workload large enough triton has better performance since data is more evenly distributed to many blocks, and less possibility for two threads in warp accessing same bank by expert_id )

Before adapting the kernel to the multi-block exeuction. Existing kernel computes expert cumsum in thread 0. Cumsum is a actually very simliar to precan:

![cumsum optimization drawio](https://github.com/user-attachments/assets/d174770f-ecf2-4ee3-b4eb-4eb1e9f4355a)

For expert number (256 ) In previous single block execution, thread 0 (warp 0) process 256 elements; while in the load balance version, thread 15 has 16 + 16 = 32 elements to process. Hence wavefront is faster to reach.

## Modifications

<!-- Describe the changes made in this PR. -->

- reduce cusum direct access , not too much positive effects, perhaps expert_num is too small to have influence [x]
- load balance cumsum computation , ~25% boost for **small batches**; **no effect **for large batches (where existing triton implementation outperforms cuda)

#### old moe align kernel
<img width="428" alt="截屏2025-01-18 13 48 00" src="https://github.com/user-attachments/assets/9708161b-28a1-4042-bd4e-c50af8492b68" />

#### new moe align kernel

<img width="551" alt="截屏2025-01-19 08 28 41" src="https://github.com/user-attachments/assets/c99a3d4f-aaf5-4cba-85d6-0b7a353a6081" />

#### Test Env

- A100 GPU
- Latest SGLang CUDA Env 

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html).

## Next Step

- (algorithm) Enable efficient multiple blocks execution and adjust threads blocks to large work loads
- enable cuRadix with cub (suported by @BBuf )