### PR TITLE
fix file name spelling mistake and useless variable in minmax-text-01-lightning_attention

### DIFF
--- a/benchmark/kernels/minmax-text-01-lightning_attention/benchmark_lightning_attention_decode.py
+++ b/benchmark/kernels/minmax-text-01-lightning_attention/benchmark_lightning_attention_decode.py
@@ -26,7 +26,6 @@ def _decode_kernel(
     d_original: tl.constexpr,
     e: tl.constexpr,
     e_original: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr = 32,
 ):
     off_bh = tl.program_id(0)
     off_h = off_bh % h

--- a/benchmark/kernels/minmax-text-01-lightning_attention/benchmark_lightning_attention_prefill.py
+++ b/benchmark/kernels/minmax-text-01-lightning_attention/benchmark_lightning_attention_prefill.py
@@ -493,6 +493,8 @@ def test_lightning_attention_implementations(model_params):
         msg="Lightning attention implementations produce different results",
     )
 
+    print("✅ Two implementations match")
+
 
 def get_benchmark():
     batch_size_range = [2**i for i in range(0, 7)]  # max 64


### PR DESCRIPTION
follow https://github.com/sgl-project/sglang/pull/2966#issuecomment-2599813741

@zhyncs 