### PR TITLE
fix deepseekv3 moe align blocks benchmark

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
@@ -209,7 +209,6 @@ seq_length_range = [2**i for i in range(0, 16)]
 configs = list(itertools.product(batch_size_range, seq_length_range))
 
 
-@torch.jit.script # JIT decorator
 def get_topk_ids(num_tokens : int, num_experts : int, topk : int) -> torch.Tensor:
     topk_ids = torch.zeros((num_tokens, topk), dtype=torch.int32, device="cuda")
     for i in range(num_tokens):

--- a/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
@@ -7,7 +7,8 @@ import triton
 import triton.language as tl
 from sgl_kernel import moe_align_block_size
 
-USE_RANDOM_PERM=False
+USE_RANDOM_PERM = False
+
 
 def ceil_div(a, b):
     return (a + b - 1) // b
@@ -145,7 +146,10 @@ def calculate_diff(batch_size, seq_len):
     topk = 8
 
     topk_ids = torch.stack(
-        [torch.randperm(num_experts, dtype=torch.int32, device="cuda")[:topk] for _ in range(batch_size * seq_len)]
+        [
+            torch.randperm(num_experts, dtype=torch.int32, device="cuda")[:topk]
+            for _ in range(batch_size * seq_len)
+        ]
     )
 
     max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
@@ -209,10 +213,12 @@ seq_length_range = [2**i for i in range(0, 16)]
 configs = list(itertools.product(batch_size_range, seq_length_range))
 
 
-def get_topk_ids(num_tokens : int, num_experts : int, topk : int) -> torch.Tensor:
+def get_topk_ids(num_tokens: int, num_experts: int, topk: int) -> torch.Tensor:
     topk_ids = torch.zeros((num_tokens, topk), dtype=torch.int32, device="cuda")
     for i in range(num_tokens):
-        topk_ids[i,:] = torch.randperm(num_experts, dtype=torch.int32, device="cuda")[:topk]
+        topk_ids[i, :] = torch.randperm(num_experts, dtype=torch.int32, device="cuda")[
+            :topk
+        ]
     return topk_ids
 
 
@@ -238,9 +244,13 @@ def benchmark(batch_size, seq_len, provider):
         topk_ids = get_topk_ids(batch_size * seq_len, num_experts, topk)
     else:
         topk_ids = torch.randint(
-            0, num_experts, (batch_size * seq_len, topk), dtype=torch.int32, device="cuda"
+            0,
+            num_experts,
+            (batch_size * seq_len, topk),
+            dtype=torch.int32,
+            device="cuda",
         )
-    
+
     max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
     sorted_ids = torch.empty(
         (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

suggested in https://github.com/sgl-project/sglang/pull/2970

## Modifications

<!-- Describe the changes made in this PR. -->
benchmark_deepseekv3_moe_align_blocks.py

- correct topk inputs

NOTE the correction is disabled by default in benchmark tests (but enabled in **calculate_diff**) since it will be much longer for seq_len>16000 when correction used.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html).
