### PR TITLE
disable custom allreduce on HIP

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -42,6 +42,7 @@ from sglang.srt.utils import (
     direct_register_custom_op,
     is_cuda_alike,
     supports_custom_op,
+    is_hip,
 )
 
 
@@ -952,6 +953,11 @@ _ENABLE_CUSTOM_ALL_REDUCE = True
 def set_custom_all_reduce(enable: bool):
     global _ENABLE_CUSTOM_ALL_REDUCE
     _ENABLE_CUSTOM_ALL_REDUCE = enable
+    if enable and is_hip():
+        logger.warning(
+            "HIP doesn't support custom_all_reduce, so disable it."
+            )
+        _ENABLE_CUSTOM_ALL_REDUCE = False
 
 
 def init_distributed_environment(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -41,8 +41,8 @@ from torch.distributed import Backend, ProcessGroup
 from sglang.srt.utils import (
     direct_register_custom_op,
     is_cuda_alike,
-    supports_custom_op,
     is_hip,
+    supports_custom_op,
 )
 
 
@@ -954,9 +954,7 @@ def set_custom_all_reduce(enable: bool):
     global _ENABLE_CUSTOM_ALL_REDUCE
     _ENABLE_CUSTOM_ALL_REDUCE = enable
     if enable and is_hip():
-        logger.warning(
-            "HIP doesn't support custom_all_reduce, so disable it."
-            )
+        logger.warning("HIP doesn't support custom_all_reduce, so disable it.")
         _ENABLE_CUSTOM_ALL_REDUCE = False
 
 


### PR DESCRIPTION
The custom allreduce is enabled by default, and this hardware feature isn't supported now on AMD GPUs. So this PR disables nvlink on AMD GPUS by default, to reduce user options and to allow better user experience. Thank you.