### PR TITLE
[MOE] Try to optimize moe align block size multiblocks cuda kernel

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
@@ -300,11 +300,6 @@ def benchmark(batch_size, seq_len, provider):
 
 
 if __name__ == "__main__":
-    torch.manual_seed(SEED)
-
-    import numpy as np
-    np.random.seed(SEED)
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--save_path",

--- a/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_deepseekv3_moe_align_blocks.py
@@ -300,6 +300,11 @@ def benchmark(batch_size, seq_len, provider):
 
 
 if __name__ == "__main__":
+    torch.manual_seed(SEED)
+
+    import numpy as np
+    np.random.seed(SEED)
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--save_path",

--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -10,8 +10,11 @@
 
 #ifdef USE_ROCM
 #include <hip/hip_runtime.h>
-#endif
-
+#include <hip/hip_cooperative_groups.h>
+#else
+#include <cooperative_groups.h>
+#endif // USE_ROCM
+#include <iostream> // TODO (yiakwy) : remove
 #ifndef USE_ROCM
 #define WARP_SIZE 32
 #else
@@ -24,9 +27,17 @@
 #else
 #define DevFuncAttribute_SET_MaxDynamicSharedMemorySize(FUNC, VAL) \
   hipFuncSetAttribute(FUNC, hipFuncAttributeMaxDynamicSharedMemorySize, VAL)
+
+  // NOTE(yiakwy) : func alias
+  template <typename... Args>
+  static __inline__ __host__ __device__
+  auto cudaLaunchCooperativeKernel(Args&&... args) -> decltype(cudaLaunchCooperativeKernel(std::forward<Args>(args)...)) {
+    return cudaLaunchCooperativeKernel(std::forward<Args>(args)...);
+  }
 #endif
 
 #define CEILDIV(x, y) (((x) + (y)-1) / (y))
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
 
 #define DISPATCH_CASE_INTEGRAL_TYPES(...)              \
   AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__)  \
@@ -42,7 +53,9 @@ __device__ __forceinline__ int32_t index(int32_t total_col, int32_t row, int32_t
   // don't worry about overflow because num_experts is relatively small
   return row * total_col + col;
 }
+
 #define OFFSETS_PAD 1
+
 template <typename scalar_t>
 __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int32_t* sorted_token_ids,
                                             int32_t* expert_ids, int32_t* total_tokens_post_pad, int32_t num_experts,
@@ -53,17 +66,14 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
   __shared__ int32_t local_offsets_buf[16];
 
   const int tid = threadIdx.x;
-  const int warp_id = threadIdx.x / WARP_SIZE;
   const int experts_per_warp = 8;
-  const int my_expert_start = warp_id * experts_per_warp;
 
   const size_t tokens_per_thread = CEILDIV(numel, blockDim.x);
   const size_t start_idx = threadIdx.x * tokens_per_thread;
 
-  for (int i = 0; i < experts_per_warp; ++i) {
-    if (my_expert_start + i < num_experts) {
-      shared_counts[warp_id][i] = 0;
-    }
+  int *shared_counts_base = &(shared_counts[0][0]);
+  if (threadIdx.x < 256) {
+    *(shared_counts_base + threadIdx.x) = 0;
   }
 
   // NOTE (yiakwy) : this warp of threads may access other warp of threads based on the value of expert id fetched
@@ -82,72 +92,71 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 
   {
 
-  int active_threads = CEILDIV(num_experts, kElementsPerThr);
-  if (tid == 0) {
-    local_offsets[0] = 0;
-  }
-  if (tid < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
+    int active_threads = CEILDIV(num_experts, kElementsPerThr);
+    if (tid == 0) {
+      local_offsets[0] = 0;
+    }
+    if (tid < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
 
-    // NOTE (yiakwy) : loop body, a simple reduction prototype, useful for workload with the number of experts upto 256
-    // NOTE (yiakwy) : each thread process 16 expert, then only 2 steps needed
+      // NOTE (yiakwy) : loop body, a simple reduction prototype, useful for workload with the number of experts upto 256
+      // NOTE (yiakwy) : each thread process 16 expert, then only 2 steps needed
 
-    // NOTE (yiakwy) : step 1, loop body
-    // [1, 17)
-    for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
-      int warp_idx = (i-1) / experts_per_warp;
-      int expert_offset = (i-1) % experts_per_warp;
+      // NOTE (yiakwy) : step 1, loop body
+      for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
+        int warp_idx = (i-1) / experts_per_warp;
+        int expert_offset = (i-1) % experts_per_warp;
 
-      int expert_count = shared_counts[warp_idx][expert_offset];
+        int expert_count = shared_counts[warp_idx][expert_offset];
 
-      int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
-      local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+        int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+        local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+      }
+
+      local_offsets_buf[tid] = local_offsets[(tid + 1)*kElementsPerThr];
+
     }
 
-    local_offsets_buf[tid] = local_offsets[(tid + 1)*kElementsPerThr];
+    // NOTE (yiakwy) : step 1, unroll loop tail
+    if (tid == active_threads - 1) {
+      #pragma unroll
+      for (int i=tid * kElementsPerThr+1; i < num_experts+1; ++i) {
+        int warp_idx = (i-1) / experts_per_warp;
+        int expert_offset = (i-1) % experts_per_warp;
 
-  }
+        int expert_count = shared_counts[warp_idx][expert_offset];
 
-  // NOTE (yiakwy) : step 1, unroll loop tail
-  if (tid == active_threads - 1) {
-    #pragma unroll
-    for (int i=tid * kElementsPerThr+1; i < num_experts+1; ++i) {
-      int warp_idx = (i-1) / experts_per_warp;
-      int expert_offset = (i-1) % experts_per_warp;
+        int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+        local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+      }
 
-      int expert_count = shared_counts[warp_idx][expert_offset];
+      local_offsets_buf[tid] = local_offsets[num_experts];
 
-      int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
-      local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
     }
 
-    local_offsets_buf[tid] = local_offsets[num_experts];
+    __syncthreads();
 
-  }
+    // NOTE (yiakwy) : step 2, loop body
+    if (tid < active_threads - 1 && tid > 0) {
+      int offset = 0;
+      for (int j=0; j < tid; ++j) {
+        offset += local_offsets_buf[j];
+      }
 
-  __syncthreads();
-
-  // NOTE (yiakwy) : step 2, loop body
-  if (tid < active_threads - 1 && tid > 0) {
-    int offset = 0;
-    for (int j=0; j < tid; ++j) {
-      offset += local_offsets_buf[j];
+      for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
+        local_offsets[i] += offset;
+      }
     }
 
-    for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
-      local_offsets[i] += offset;
+    // NOTE (yiakwy) : step 2, loop tail
+    if (tid == active_threads - 1) {
+      int offset = 0;
+      for (int j=0; j < tid; ++j) {
+        offset += local_offsets_buf[j];
+      }
+      for (int i=tid*kElementsPerThr+1; i < num_experts+1; ++i) {
+        local_offsets[i] += offset;
+      }
     }
-  }
-
-  // NOTE (yiakwy) : step 2, loop tail
-  if (tid == active_threads - 1) {
-    int offset = 0;
-    for (int j=0; j < tid; ++j) {
-      offset += local_offsets_buf[j];
-    }
-    for (int i=tid*kElementsPerThr+1; i < num_experts+1; ++i) {
-      local_offsets[i] += offset;
-    }
-  }
 
   } // code block of computing cumsum
 
@@ -158,26 +167,26 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 
   {
 
-  int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
-  if (tid < active_threads - 1) {
+    int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
+    if (tid < active_threads - 1) {
 
-    // NOTE(yiakwy) : loop body useful for workload with the number of experts upto 256
-    for (int i=tid * kElementsPerThr ; i < (tid + 1) * kElementsPerThr; i += kElementsPerAccess) {
-      *(int4 *)(cumsum + i) = *(int4 *)(local_offsets + i);
+      // NOTE(yiakwy) : loop body useful for workload with the number of experts upto 256
+      for (int i=tid * kElementsPerThr ; i < (tid + 1) * kElementsPerThr; i += kElementsPerAccess) {
+        *(int4 *)(cumsum + i) = *(int4 *)(local_offsets + i);
+      }
     }
-  }
 
-  if (tid == active_threads - 1) {
-    // NOTE(yiakwy) : unroll loop tail
-    #pragma unroll
-    for (int i=tid * kElementsPerThr; i < num_experts+1; i++) {
-      *(cumsum + i) = *(local_offsets + i);
+    if (tid == active_threads - 1) {
+      // NOTE(yiakwy) : unroll loop tail
+      #pragma unroll
+      for (int i=tid * kElementsPerThr; i < num_experts+1; i++) {
+        *(cumsum + i) = *(local_offsets + i);
+      }
     }
-  }
 
-  if (tid == active_threads) {
-    *total_tokens_post_pad = local_offsets[num_experts];
-  }
+    if (tid == active_threads) {
+      *total_tokens_post_pad = local_offsets[num_experts];
+    }
 
   } // code block of storing to cumsum
 
@@ -198,15 +207,354 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
   }
 }
 
+
+#define checkCudaErrors(val) check ( (val), #val, __FILE__, __LINE__ )
+template< typename T >
+void check(T result, char const *const func, const char *const file, int const line)
+{
+    if (result)
+    {
+        fprintf(stderr, "CUDA error at %s:%d code=%d(%s) \"%s\" \n", file, line, static_cast<unsigned int>(result), cudaGetErrorString(result), func);
+        cudaDeviceReset();
+        exit(EXIT_FAILURE);
+    }
+}
+
+
+template <typename scalar_t>
+__global__ void moe_align_block_size_multiblocks_kernel(scalar_t* __restrict__ topk_ids, int32_t* sorted_token_ids,
+                                            int32_t* expert_ids, int32_t* total_tokens_post_pad, int32_t num_experts,
+                                            int32_t block_size, size_t numel, int32_t* tokens_cnts, int32_t* cumsum, const int tokens_per_block, const int tokens_per_thread, const int K) {
+  __shared__ int32_t shared_counts[32][8];
+  // NOTE (yiakwy) : this assumes num_experts <= 256
+  __shared__ int32_t local_offsets[256+OFFSETS_PAD];
+  __shared__ int32_t local_offsets_buf[16];
+
+  const int tid = threadIdx.x + blockDim.x * blockIdx.x;
+  // NOTE (yiakwy) : we use local warp_id, lane_id for warp aggregation of shared_counts
+  const int warp_id = threadIdx.x / WARP_SIZE;
+  const int lane_id = threadIdx.x % WARP_SIZE;
+  const int experts_per_warp = 8;
+
+  // NOTE (yiakwy) : used to synchronize blocks,
+  cooperative_groups::grid_group grid = cooperative_groups::this_grid();
+
+  // NOTE (yiakwy) : not all threads participate in
+  const size_t start_idx = tokens_per_block * blockIdx.x + tokens_per_thread * threadIdx.x;
+  const size_t end_idx = start_idx + tokens_per_thread;
+
+  int *shared_counts_base = &(shared_counts[0][0]);
+  if (threadIdx.x < 256) {
+    *(shared_counts_base + threadIdx.x) = 0;
+  }
+
+  // NOTE (yiakwy) : this warp of threads may access other warp of threads based on the value of expert id fetched
+  __syncthreads();
+
+  // NOTE (yiakwy) : since each block processes less tokens, less possibility for threads acces these localtions ([0][0], [4][0], [8][0], ...) simutaneously
+  if (threadIdx.x < tokens_per_block) {
+    for (int i = start_idx; i < MIN(numel, end_idx); ++i) {
+      int expert_id = topk_ids[i];
+      int warp_idx = expert_id / experts_per_warp;
+      int expert_offset = expert_id % experts_per_warp;
+      atomicAdd(&shared_counts[warp_idx][expert_offset], 1);
+    }
+  }
+
+  __syncthreads();
+
+#define kElementsPerThr    16
+
+  {
+
+    int active_threads = CEILDIV(num_experts, kElementsPerThr);
+    if (threadIdx.x == 0) {
+      local_offsets[0] = 0;
+    }
+    if (threadIdx.x < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
+
+      // NOTE (yiakwy) : loop body, a simple reduction prototype, useful for workload with the number of experts upto 256
+      // NOTE (yiakwy) : each thread process 16 expert, then only 2 steps needed
+
+      // NOTE (yiakwy) : step 1, loop body
+      for (int i=threadIdx.x*kElementsPerThr+1; i < (threadIdx.x + 1)*kElementsPerThr+1; ++i) {
+        int warp_idx = (i-1) / experts_per_warp;
+        int expert_offset = (i-1) % experts_per_warp;
+
+        int expert_count = shared_counts[warp_idx][expert_offset];
+
+        int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+        // local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+        local_offsets[i] = last_val + expert_count;
+      }
+
+      local_offsets_buf[threadIdx.x] = local_offsets[(threadIdx.x + 1)*kElementsPerThr];
+
+    }
+
+    // NOTE (yiakwy) : step 1, unroll loop tail
+    if (threadIdx.x == active_threads - 1) {
+      #pragma unroll
+      for (int i=threadIdx.x * kElementsPerThr+1; i < num_experts+1; ++i) {
+        int warp_idx = (i-1) / experts_per_warp;
+        int expert_offset = (i-1) % experts_per_warp;
+
+        int expert_count = shared_counts[warp_idx][expert_offset];
+
+        int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+        // local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+        local_offsets[i] = last_val + expert_count;
+      }
+
+      local_offsets_buf[threadIdx.x] = local_offsets[num_experts];
+
+    }
+
+    __syncthreads();
+
+    // NOTE (yiakwy) : step 2, loop body
+    if (threadIdx.x < active_threads - 1 && threadIdx.x > 0) {
+      int offset = 0;
+      for (int j=0; j < threadIdx.x; ++j) {
+        offset += local_offsets_buf[j];
+      }
+
+      for (int i=threadIdx.x*kElementsPerThr+1; i < (threadIdx.x + 1)*kElementsPerThr+1; ++i) {
+        local_offsets[i] += offset;
+      }
+    }
+
+    // NOTE (yiakwy) : step 2, loop tail
+    if (threadIdx.x == active_threads - 1) {
+      int offset = 0;
+      for (int j=0; j < threadIdx.x; ++j) {
+        offset += local_offsets_buf[j];
+      }
+      for (int i=threadIdx.x*kElementsPerThr+1; i < num_experts+1; ++i) {
+        local_offsets[i] += offset;
+      }
+    }
+
+  } // code block of computing local unaligned cumsum
+
+  __syncthreads();
+
+#ifdef DEBUG
+  if (threadIdx.x == 0) {
+    printf("[Block#%d] local_offsets[1:num_experts+1] = [%d, %d, ..., %d, %d]\n", blockIdx.x, local_offsets[1], local_offsets[2], local_offsets[num_experts-1], local_offsets[num_experts]);
+  }
+  __syncthreads();
+#endif
+
+  {
+    if (tid < num_experts) {
+      *(tokens_cnts + tid) = 0;
+    }
+    if (threadIdx.x < num_experts) {
+      *(tokens_cnts + (blockIdx.x + 1) * num_experts + threadIdx.x) = *(local_offsets + threadIdx.x + 1);
+      *(local_offsets + threadIdx.x + 1) = 0;
+    } else if (threadIdx.x < 256) {
+      *(local_offsets + threadIdx.x + 1) = 0;
+    }
+    __threadfence_system();
+    grid.sync();
+
+#define BLOCK_SIZE_M      16
+#define BLOCK_SIZE_N      16
+
+#define kElementsPerAccess 4
+#define kWarpsToLoad       2
+
+    int total_fragments = CEILDIV(num_experts, BLOCK_SIZE_N);
+    int fragments_per_block = CEILDIV(total_fragments, gridDim.x);
+
+    if (blockIdx.x * fragments_per_block < total_fragments) {
+      int *tokens_cnts_ptr = &(tokens_cnts[0]);
+
+      for (int i=0; i < gridDim.x; i += BLOCK_SIZE_M) {
+        if (warp_id < kWarpsToLoad * fragments_per_block) { // NOTE (yiakwy) : kWarpsToLoad warps (CUDA) for loading 16x16 fragment
+          const int kNumThrPerRow = WARP_SIZE / BLOCK_SIZE_N;
+          int sRow = lane_id / kNumThrPerRow ; // sRow=7, lane_id=14
+          int sCol = lane_id % kNumThrPerRow * kElementsPerAccess + warp_id * (kNumThrPerRow * kElementsPerAccess);
+
+          int gRow = i * BLOCK_SIZE_M + sRow;
+          int gCol = blockIdx.x * fragments_per_block * BLOCK_SIZE_N + sCol;
+
+          if (gRow < num_experts && gCol < num_experts) { // NOTE (yiakwy) : defensive guard
+            // NOTE (yiakwy) : useful to coalesce memory transaction when loading a column of data
+            int4 *tokens_cnts_4i_ptr = (int4 *)(tokens_cnts_ptr + (gRow+1) * num_experts + gCol);
+            int4 *shared_counts_4i_ptr = (int4 *)(shared_counts_base + sRow * BLOCK_SIZE_N + sCol);
+
+            *shared_counts_4i_ptr = *tokens_cnts_4i_ptr;
+          }
+        }
+        __syncthreads();
+
+        if (warp_id < kWarpsToLoad * fragments_per_block && warp_id % kWarpsToLoad == 0) { // NOTE (yiakwy) : 1 warp (CUDA) for processing 16x16 fragment
+          for (int k=0; k < BLOCK_SIZE_N; k+=2) { // NOTE (yiakwy) : this simple arangement enables thread 0 accessing addresses limited to bank 0, thread 16 accesses limited to bank 16, etc in CUDA.
+            int sRow = lane_id / BLOCK_SIZE_N + k;
+            int sCol = lane_id % BLOCK_SIZE_N;
+
+            int gCol = blockIdx.x * fragments_per_block * BLOCK_SIZE_N + sCol;
+            if (gCol < num_experts) { // NOTE (yiakwy) : defensive guard
+              atomicAdd(tokens_cnts_ptr + gCol, *(shared_counts_base + sRow * BLOCK_SIZE_N + sCol));
+            }
+          }
+        }
+        __syncthreads();
+
+      }
+    }
+    __threadfence_system();
+    grid.sync();
+
+    // NOTE (yiakwy) : sync unaigned offsets in block#0
+    if (tid < num_experts) {
+      *(local_offsets + tid + 1) = *(tokens_cnts + tid);
+    }
+     __syncthreads();
+
+#ifdef DEBUG
+    if (tid == 0) {
+      printf("[Block#%d] unaligned global offsets[1:num_experts+1] = [%d, %d, ..., %d, %d]\n", blockIdx.x, local_offsets[1], local_offsets[2], local_offsets[num_experts-1], local_offsets[num_experts]);
+    }
+    __syncthreads();
+#endif
+
+  } // code block of computing global cumsum
+
+  __syncthreads();
+
+  // NOTE (yiakwy) : convert unaligned cumsum to aligned cumsum
+  // TODO (yiakwy) : distribute work to other threads
+  if (tid == 0) {
+    for (int i=num_experts; i > 0; i--) {
+      local_offsets[i] = local_offsets[i] - local_offsets[i-1];
+    }
+    for (int i=1; i < num_experts+1; i++) {
+      local_offsets[i] = local_offsets[i-1] + CEILDIV(local_offsets[i], block_size) * block_size;
+    }
+  }
+  __syncthreads();
+
+#ifdef DEBUG
+  if (tid == 0) {
+    printf("[Block#%d] aligned global offsets[1:num_experts+1] = [%d, %d, ..., %d, %d]\n", blockIdx.x, local_offsets[1], local_offsets[2], local_offsets[num_experts-1], local_offsets[num_experts]);
+  }
+  __syncthreads();
+#endif
+
+#define kElementsPerThr    16
+#define kElementsPerAccess 4
+
+  {
+
+    int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
+    if (tid < active_threads - 1) {
+
+      // NOTE(yiakwy) : loop body useful for workload with the number of experts upto 256
+      for (int i=tid * kElementsPerThr ; i < (tid + 1) * kElementsPerThr; i += kElementsPerAccess) {
+        *(int4 *)(cumsum + i) = *(int4 *)(local_offsets + i);
+      }
+    }
+
+    if (tid == active_threads - 1) {
+      // NOTE(yiakwy) : unroll loop tail
+      #pragma unroll
+      for (int i=tid * kElementsPerThr; i < num_experts+1; i++) {
+        *(cumsum + i) = *(local_offsets + i);
+      }
+    }
+
+    if (tid == active_threads) {
+      *total_tokens_post_pad = local_offsets[num_experts];
+    }
+
+  } // code block of storing to cumsum
+
+  __syncthreads();
+
+  if (tid < num_experts) {
+    for (int i = local_offsets[tid]; i < local_offsets[tid + 1]; i += block_size) {
+      expert_ids[i / block_size] = tid;
+    }
+  }
+
+  __syncthreads();
+
+  // NOTE (yiakwy) : sync cumsum to each block
+  if (blockIdx.x > 0) {
+    int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
+
+    if (threadIdx.x < active_threads - 1) {
+      for (int i=threadIdx.x * kElementsPerThr ; i < (threadIdx.x + 1) * kElementsPerThr; i += kElementsPerAccess) {
+        *(int4 *)(local_offsets + i) = *(int4 *)(cumsum + i);
+      }
+    }
+
+    if (threadIdx.x == active_threads - 1) {
+      #pragma unroll
+      for (int i=threadIdx.x * kElementsPerThr; i < num_experts+1; i++) {
+        *(local_offsets + i) = *(cumsum + i);
+      }
+    }
+  }
+
+  __syncthreads();
+
+  if (threadIdx.x < tokens_per_block) {
+    for (int i = start_idx; i < MIN(numel, end_idx); ++i) {
+      int32_t expert_id = topk_ids[i];
+      int32_t rank_post_pad = atomicAdd(&local_offsets[expert_id], 1);
+      sorted_token_ids[rank_post_pad] = i;
+    }
+  }
+}
+
+
 void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t block_size,
                           torch::Tensor sorted_token_ids, torch::Tensor experts_ids, torch::Tensor num_tokens_post_pad,
                           torch::Tensor token_cnts_buffer, torch::Tensor cumsum_buffer) {
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_INTEGRAL_TYPES(topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
-    auto kernel = moe_align_block_size_kernel<scalar_t>;
-    // NOTE(yiakwy) : this assumes a single block execution, will be slow if too many tokens (>1024) feeded in
-    kernel<<<1, 1024, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
-                                   experts_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
-                                   num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
+    if (false/*topk_ids.sizes()[0] < 16384 / 2*/) {
+      auto kernel = moe_align_block_size_kernel<scalar_t>;
+      // NOTE(yiakwy) : this assumes a single block execution, will be slow if too many tokens (>1024) feeded in
+      kernel<<<1, 1024, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
+                                    experts_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
+                                    num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
+      // printf("%d blocks used.\n", 1);
+    } else {
+      auto kernel = moe_align_block_size_multiblocks_kernel<scalar_t>;
+// NOTE (yiakwy) : reduce registers consumed
+#define BLOCK_SIZE 512
+      auto BLOCKS = MIN( CEILDIV(topk_ids.sizes()[0], BLOCK_SIZE), num_experts );
+
+      int32_t tokens_per_block = CEILDIV(topk_ids.sizes()[0], BLOCKS) * topk_ids.sizes()[1];
+      int32_t tokens_per_thread = CEILDIV(tokens_per_block, BLOCK_SIZE);
+
+      // printf("%d BLOCKS used. %d tokens per block. %d tokens per thread\n", BLOCKS, tokens_per_block, tokens_per_thread);
+      /*
+      kernel<<<BLOCKS, BLOCK_SIZE, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
+                                    experts_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
+                                    num_experts, block_size, topk_ids.numel(), token_cnts_buffer.data_ptr<int32_t>(), cumsum_buffer.data_ptr<int32_t>(), tokens_per_block, tokens_per_thread, topk_ids.sizes()[1]);
+       */
+      // NOTE (yiakwy) : remove const decorator for kernel args
+      scalar_t* topk_ids_ptr = topk_ids.data_ptr<scalar_t>();
+      int32_t* sorted_token_ids_ptr = sorted_token_ids.data_ptr<int32_t>();
+      int32_t* experts_ids_ptr = experts_ids.data_ptr<int32_t>();
+      int32_t* num_tokens_post_pad_ptr = num_tokens_post_pad.data_ptr<int32_t>();
+      size_t num_tokens = topk_ids.numel();
+      int32_t* token_cnts_buffer_ptr = token_cnts_buffer.data_ptr<int32_t>();
+      int32_t* cumsum_buffer_ptr = cumsum_buffer.data_ptr<int32_t>();
+      int K = topk_ids.sizes()[1];
+
+      void *kernelArgs[] = { &topk_ids_ptr, &sorted_token_ids_ptr,
+        &experts_ids_ptr, &num_tokens_post_pad_ptr,
+        &num_experts, &block_size, &num_tokens, &token_cnts_buffer_ptr, &cumsum_buffer_ptr, &tokens_per_block, &tokens_per_thread, &K
+      };
+      cudaLaunchCooperativeKernel((void*)kernel, BLOCKS, BLOCK_SIZE, kernelArgs);
+      checkCudaErrors(cudaDeviceSynchronize());
+    }
   });
 }

--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -42,17 +42,23 @@ __device__ __forceinline__ int32_t index(int32_t total_col, int32_t row, int32_t
   // don't worry about overflow because num_experts is relatively small
   return row * total_col + col;
 }
-
+#define OFFSETS_PAD 1
 template <typename scalar_t>
 __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int32_t* sorted_token_ids,
                                             int32_t* expert_ids, int32_t* total_tokens_post_pad, int32_t num_experts,
                                             int32_t block_size, size_t numel, int32_t* cumsum) {
   __shared__ int32_t shared_counts[32][8];
-  __shared__ int32_t local_offsets[256];
+  // NOTE (yiakwy) : this assumes num_experts <= 256
+  __shared__ int32_t local_offsets[256+OFFSETS_PAD];
+  __shared__ int32_t local_offsets_buf[16];
 
+  const int tid = threadIdx.x;
   const int warp_id = threadIdx.x / WARP_SIZE;
   const int experts_per_warp = 8;
   const int my_expert_start = warp_id * experts_per_warp;
+
+  const size_t tokens_per_thread = CEILDIV(numel, blockDim.x);
+  const size_t start_idx = threadIdx.x * tokens_per_thread;
 
   for (int i = 0; i < experts_per_warp; ++i) {
     if (my_expert_start + i < num_experts) {
@@ -60,8 +66,8 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
     }
   }
 
-  const size_t tokens_per_thread = CEILDIV(numel, blockDim.x);
-  const size_t start_idx = threadIdx.x * tokens_per_thread;
+  // NOTE (yiakwy) : this warp of threads may access other warp of threads based on the value of expert id fetched
+  __syncthreads();
 
   for (int i = start_idx; i < numel && i < start_idx + tokens_per_thread; ++i) {
     int expert_id = topk_ids[i];
@@ -72,26 +78,115 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 
   __syncthreads();
 
-  if (threadIdx.x == 0) {
-    cumsum[0] = 0;
-    for (int i = 1; i <= num_experts; ++i) {
-      int expert_count = 0;
-      int warp_idx = (i - 1) / experts_per_warp;
-      int expert_offset = (i - 1) % experts_per_warp;
-      expert_count = shared_counts[warp_idx][expert_offset];
+#define kElementsPerThr    16
 
-      cumsum[i] = cumsum[i - 1] + CEILDIV(expert_count, block_size) * block_size;
+  {
+
+  int active_threads = CEILDIV(num_experts, kElementsPerThr);
+  if (tid == 0) {
+    local_offsets[0] = 0; 
+  }
+  if (tid < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
+
+    // NOTE (yiakwy) : loop body, a simple reduction prototype, useful for workload with the number of experts upto 256
+    // NOTE (yiakwy) : each thread process 16 expert, then only 2 steps needed
+
+    // NOTE (yiakwy) : step 1, loop body
+    // [1, 17)
+    for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
+      int warp_idx = (i-1) / experts_per_warp;
+      int expert_offset = (i-1) % experts_per_warp;
+
+      int expert_count = shared_counts[warp_idx][expert_offset];
+
+      int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+      local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
     }
-    *total_tokens_post_pad = cumsum[num_experts];
+
+    local_offsets_buf[tid] = local_offsets[(tid + 1)*kElementsPerThr];
+
+  }
+
+  // NOTE (yiakwy) : step 1, unroll loop tail
+  if (tid == active_threads - 1) {
+    #pragma unroll
+    for (int i=tid * kElementsPerThr+1; i < num_experts+1; ++i) {
+      int warp_idx = (i-1) / experts_per_warp;
+      int expert_offset = (i-1) % experts_per_warp;
+
+      int expert_count = shared_counts[warp_idx][expert_offset];
+
+      int last_val = (i-1) % kElementsPerThr == 0 ? 0 : local_offsets[i-1];
+      local_offsets[i] = last_val + CEILDIV(expert_count, block_size) * block_size;
+    }
+
+    local_offsets_buf[tid] = local_offsets[num_experts];
+    
   }
 
   __syncthreads();
 
+  // NOTE (yiakwy) : step 2, loop body
+  if (tid < active_threads - 1 && tid > 0) {
+    int offset = 0;
+    for (int j=0; j < tid; ++j) {
+      offset += local_offsets_buf[j];
+    }
+
+    for (int i=tid*kElementsPerThr+1; i < (tid + 1)*kElementsPerThr+1; ++i) {
+      local_offsets[i] += offset;
+    }
+  }
+    
+  // NOTE (yiakwy) : step 2, loop tail
+  if (tid == active_threads - 1) {
+    int offset = 0;
+    for (int j=0; j < tid; ++j) {
+      offset += local_offsets_buf[j];
+    }
+    for (int i=tid*kElementsPerThr+1; i < num_experts+1; ++i) {
+      local_offsets[i] += offset;
+    }
+  }
+
+  } // code block of computing cumsum
+
+  __syncthreads();
+
+#define kElementsPerThr    16
+#define kElementsPerAccess 4
+
+  {
+  
+  int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
+  if (tid < active_threads - 1) {
+
+    // NOTE(yiakwy) : loop body useful for workload with the number of experts upto 256
+    for (int i=tid * kElementsPerThr ; i < (tid + 1) * kElementsPerThr; i += kElementsPerAccess) {
+      *(int4 *)(cumsum + i) = *(int4 *)(local_offsets + i);
+    }
+  }
+
+  if (tid == active_threads - 1) {
+    // NOTE(yiakwy) : unroll loop tail
+    #pragma unroll
+    for (int i=tid * kElementsPerThr; i < num_experts+1; i++) {
+      *(cumsum + i) = *(local_offsets + i);
+    }
+  }
+
+  if (tid == active_threads) {
+    *total_tokens_post_pad = local_offsets[num_experts];
+  }
+  
+  } // code block of storing to cumsum
+
+  __syncthreads();
+
   if (threadIdx.x < num_experts) {
-    for (int i = cumsum[threadIdx.x]; i < cumsum[threadIdx.x + 1]; i += block_size) {
+    for (int i = local_offsets[threadIdx.x]; i < local_offsets[threadIdx.x + 1]; i += block_size) {
       expert_ids[i / block_size] = threadIdx.x;
     }
-    local_offsets[threadIdx.x] = cumsum[threadIdx.x];
   }
 
   __syncthreads();
@@ -109,8 +204,10 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t b
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_INTEGRAL_TYPES(topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
     auto kernel = moe_align_block_size_kernel<scalar_t>;
+    // NOTE(yiakwy) : this assumes a single block execution, will be slow if too many tokens (>1024) feeded in
     kernel<<<1, 1024, 0, stream>>>(topk_ids.data_ptr<scalar_t>(), sorted_token_ids.data_ptr<int32_t>(),
                                    experts_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
                                    num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
   });
 }
+   

--- a/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
+++ b/sgl-kernel/src/sgl-kernel/csrc/moe_align_kernel.cu
@@ -84,7 +84,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 
   int active_threads = CEILDIV(num_experts, kElementsPerThr);
   if (tid == 0) {
-    local_offsets[0] = 0; 
+    local_offsets[0] = 0;
   }
   if (tid < active_threads - 1) { // NOTE(yaikwy) : algo here assumes single block execution
 
@@ -121,7 +121,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
     }
 
     local_offsets_buf[tid] = local_offsets[num_experts];
-    
+
   }
 
   __syncthreads();
@@ -137,7 +137,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
       local_offsets[i] += offset;
     }
   }
-    
+
   // NOTE (yiakwy) : step 2, loop tail
   if (tid == active_threads - 1) {
     int offset = 0;
@@ -157,7 +157,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
 #define kElementsPerAccess 4
 
   {
-  
+
   int active_threads = CEILDIV(num_experts+1, kElementsPerThr);
   if (tid < active_threads - 1) {
 
@@ -178,7 +178,7 @@ __global__ void moe_align_block_size_kernel(scalar_t* __restrict__ topk_ids, int
   if (tid == active_threads) {
     *total_tokens_post_pad = local_offsets[num_experts];
   }
-  
+
   } // code block of storing to cumsum
 
   __syncthreads();
@@ -210,4 +210,3 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts, int64_t b
                                    num_experts, block_size, topk_ids.numel(), cumsum_buffer.data_ptr<int32_t>());
   });
 }
-   


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This is follow up of [PR#2970](https://github.com/sgl-project/sglang/pull/2970) which enables efficient mutli-blocks execution.

The codes pass correctness test in many simple configurations (seq_len=16384): 

<img width="792" alt="截屏2025-01-26 11 05 29" src="https://github.com/user-attachments/assets/a8642f4f-df7f-418d-9cfd-dff8ebe4619f" />

The enbles distributed cusum for a single GPU (**cudaLaunchCooperativeKernel**) at large scale workload.

To make it possible, note Sum(F(a + b)) != Sum(F(a)) + Sum(b) , where F = floor((a + c - 1) / c)  (we can make a = m*c + p, b = n * c + q, where q, p are both integers and ranging from [1, c) to prove this mathmatically ). 

##### Algorithm Structure

The codes in kernel **moe_align_block_size_multiblocks_kernel** organized in the following manner :

```
// stage 1: compute local shared_counts
...
// stage 2: compute local unaligned cumsum (since bad property of 'F' function mentioned above) using 16x16 fragments in many warps and cache them to tokens_cnt 
...
    __threadfence_system();
    grid.sync();
// stage 3: compute global unaligned cumsum using our newly introduced distributed cumsum algorithm in https://github.com/sgl-project/sglang/pull/2970
{
   ...
    __threadfence_system();
    grid.sync();
}
// stage 4: compute global aligned cumsum and store back to cumsum_ptr
...
// stage 5: compute expert_ids, sorted_ids
...
```

The overal steps are very similar to what in this triton version : [PR#2913](https://github.com/sgl-project/sglang/pull/2913)

Considering ROCM support, the stategy is using Ampere technique to develop this multi-blocks codes, no fancy features from arch above sm90 needed after my simple evaluation.

## Modifications

<!-- Describe the changes made in this PR. -->
We introduce cooperative_groups control valid since from Volta arch and typical strategy in Ampere arch :

```
#ifdef USE_ROCM
#include <hip/hip_runtime.h>
#include <hip/hip_cooperative_groups.h>
#else
#include <cooperative_groups.h>
#endif // USE_ROCM
```

After careful study, I believe 16x16 warp fragment is suitable for distributed cumsum computation. The numbers will benchmarked later.

#### Correctness 
<img width="792" alt="截屏2025-01-26 11 05 29" src="https://github.com/user-attachments/assets/db94f016-c731-47e3-88d9-1fab2018ee55" />


#### Benchmark for large scale data
(WIP)

#### Next Steps
- [ ] Verify in MI300X @HaiShaw 
- [ ] refactor codes to make them simple and nicer :
   - [ ] using flashinfer vec_t to to 128 bit copy for int32_t (int16_t may also possible)
   - [ ] cutlass as replacement

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html).
