### PR TITLE
Do not load OPENAI_KEY from secrets

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Run test
         timeout-minutes: 10
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd test/lang
           python3 run_suite.py --suite per-commit


### PR DESCRIPTION
It seems the secret only works when the branch is under `sgl-project/sglang`. It does not work for a pull request from other repos.

Therefore, we have to set  `OPENAI_API_KEY` as a local environment variable for CI runners instead of using github secrets.