### PR TITLE
Fixing a typo engine.py

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -328,7 +328,7 @@ def _set_envs_and_config(server_args: ServerArgs):
     # This process then clean up the whole process tree
     def sigquit_handler(signum, frame):
         logger.error(
-            "Received sigquit from a child proces. It usually means the child failed."
+            "Received sigquit from a child process. It usually means the child failed."
         )
         kill_process_tree(os.getpid())
 


### PR DESCRIPTION
Just fixing a typo in message "proces" -> "process"

Best,

Didier
