### PR TITLE
[fix] Clamp logprob with dtype min to prevent `-inf`

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -215,6 +215,11 @@ def top_p_normalize_probs_torch(
     probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
     probs_sum = torch.cumsum(probs_sort, dim=-1)
     probs_sort[(probs_sum - probs_sort) > top_ps.view(-1, 1)] = 0.0
+
+    # Add small epsilon to prevent division by zero
+    # Use a small value that's appropriate for the dtype
+    eps = torch.finfo(probs.dtype).eps
+    probs_sort.add_(eps)
     probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
     return torch.zeros_like(probs_sort).scatter_(-1, probs_idx, probs_sort)
 

--- a/test/srt/sampling/penaltylib/test_srt_endpoint_with_penalizers.py
+++ b/test/srt/sampling/penaltylib/test_srt_endpoint_with_penalizers.py
@@ -36,7 +36,7 @@ class TestBatchPenalizerE2E(unittest.TestCase):
     def run_decode(
         self,
         return_logprob=True,
-        top_logprobs_num=3,
+        top_logprobs_num=5,
         return_text=True,
         n=1,
         **sampling_params,
@@ -58,8 +58,7 @@ class TestBatchPenalizerE2E(unittest.TestCase):
                 "logprob_start_len": 0,
             },
         )
-        print(json.dumps(response.json()))
-        print("=" * 100)
+        assert response.status_code == 200, "Request failed: " + response.text
 
     def test_default_values(self):
         self.run_decode()
@@ -112,4 +111,4 @@ class TestBatchPenalizerE2E(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=3)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

To fix https://github.com/sgl-project/sglang/issues/2955
Follow up https://github.com/sgl-project/sglang/pull/3212

The probs can have `0` and after `torch.log` it becomes `-inf`, making fastapi not able to construct response https://github.com/sgl-project/sglang/issues/2955.

This PR adds a clamp (https://pytorch.org/docs/stable/type_info.html) based on dtype to prevent `-inf`.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html).
