### PR TITLE
[ROCm] Logic to decide whether to used manually unrolled kernel.

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1046,6 +1046,13 @@ def get_device_name(device_id: int = 0) -> str:
         return torch.hpu.get_device_name(device_id)
 
 
+def get_device_core_count(device_id: int = 0) -> int:
+    if hasattr(torch, "cuda") and torch.cuda.is_available():
+        return torch.cuda.get_device_properties(device_id).multi_processor_count
+
+    return 0
+
+
 def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
     major, minor = None, None
     if hasattr(torch, "cuda") and torch.cuda.is_available():


### PR DESCRIPTION
## Motivation

PR #3299 introduced a manually unrolled kernel. It proves to improve decode performance, but hurts prefill performance. An improvement is defined in this PR to introduce a hueristic.

## Modifications

Introduced an utility function to retrieve the number of compute units available on the device.
Use manually unrolledx4 kernel on AMD GPU when the grid size (number of workgroups) is small.
Empirical testing shows the sweet spot lies when the number of workgroup is less than the number of compute units available on the device.

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
