### PR TITLE
[WIP] Enable DeepSeek Models on Intel Gaudi device

### DIFF
--- a/python/sglang/srt/custom_op.py
+++ b/python/sglang/srt/custom_op.py
@@ -3,6 +3,7 @@ from torch import nn
 
 _is_cuda = torch.cuda.is_available() and torch.version.cuda
 _is_rocm = torch.cuda.is_available() and torch.version.hip
+_is_hpu = torch.hpu.is_available() # TODO torch.version.hpu is not supported
 
 
 class CustomOp(nn.Module):
@@ -36,5 +37,7 @@ class CustomOp(nn.Module):
             return self.forward_cuda
         elif _is_rocm:
             return self.forward_hip
+        elif _is_hpu:
+            return self.forward_hpu
         else:
             return self.forward_native

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -18,7 +18,10 @@ from sglang.srt.layers.quantization.fp8_kernel import per_token_group_quant_fp8
 from sglang.srt.utils import direct_register_custom_op, get_device_name, is_hip
 
 is_hip_flag = is_hip()
-from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
+if torch.cuda.is_available():
+    from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
+else:
+    sgl_moe_align_block_size = None
 
 logger = logging.getLogger(__name__)
 padding_size = 128 if bool(int(os.getenv("MOE_PADDING", "0"))) else 0

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -216,6 +216,34 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             correction_bias,
         )
 
+    def forward_hpu(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        use_grouped_topk: bool,
+        top_k: int,
+        router_logits: torch.Tensor,
+        renormalize: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        custom_routing_function: Optional[Callable] = None,
+        correction_bias: Optional[torch.Tensor] = None,
+        activation: str = "silu",
+    ) -> torch.Tensor:
+        return moe_forward_native(
+            layer,
+            x,
+            use_grouped_topk,
+            top_k,
+            router_logits,
+            renormalize,
+            topk_group,
+            num_expert_group,
+            custom_routing_function,
+            correction_bias,
+            activation,
+        )
+
     def forward_tpu(self, *args, **kwargs) -> torch.Tensor:
         raise NotImplementedError("The TPU backend currently does not support MoE.")
 

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1254,7 +1254,7 @@ def get_rope_wrapper(
     partial_rotary_factor: float = 1.0,
     device: Optional[str] = None,
 ):
-    if device != "cpu":
+    if device != "cpu" and device != "hpu":
         return get_rope(
             head_size,
             rotary_dim,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -109,7 +109,7 @@ class ModelRunner:
             and not self.server_args.disable_mla
         ):
             # TODO: add MLA optimization on CPU
-            if self.server_args.device != "cpu":
+            if self.server_args.device != "cpu" and self.server_args.device != "hpu":
                 logger.info("MLA optimization is turned on. Use triton backend.")
                 self.server_args.attention_backend = "triton"
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -461,13 +461,14 @@ class DeepseekV2AttentionMLA(nn.Module):
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
 
-        self.rotary_emb = get_rope(
+        self.rotary_emb = get_rope_wrapper(
             qk_rope_head_dim,
             rotary_dim=qk_rope_head_dim,
             max_position=max_position_embeddings,
             base=rope_theta,
             rope_scaling=rope_scaling,
             is_neox_style=False,
+            device=global_server_args_dict["device"],
         )
 
         if rope_scaling:

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1063,9 +1063,10 @@ def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
         try:
             major, minor = torch.hpu.get_device_capability(device_id)
         except Exception as e:
-            raise RuntimeError(
-                f"An error occurred while getting device capability of hpu: {e}."
-            ) from e
+            pass
+            # raise RuntimeError(
+            #     f"An error occurred while getting device capability of hpu: {e}."
+            # ) from e
 
     return major, minor
 


### PR DESCRIPTION
## Example
### DeepSeek-V2-Lite
Run on single Gaudi2
```shell
python examples/runtime/engine/offline_batch_inference.py \
    --device hpu \
    --model-path deepseek-ai/DeepSeek-V2-Lite \
    --trust-remote-code \
    --disable-mla
```
```shell
python3 -m sglang.bench_one_batch \
    --batch-size 1 \
    --input 1024 \
    --output 8 \
    --model deepseek-ai/DeepSeek-V2-Lite \
    --trust-remote-code \
    --device hpu \
    --disable-mla
```

### DeepSeek-R1
Run on x8 Gaudi3
```shell
python3 -m sglang.bench_one_batch \
    --batch-size 1 \
    --input 1024 \
    --output 8 \
    --model /software/data/DeepSeek-R1 \
    --trust-remote-code \
    --device hpu \
    --tp 8 \
    --load-format dummy \
    --disable-mla
```
