### PR TITLE
Better support of tp checkpoint loading

### DIFF
--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -49,7 +49,7 @@ class LoadConfig:
     download_dir: Optional[str] = None
     model_loader_extra_config: Optional[Union[str, dict]] = field(default_factory=dict)
     ignore_patterns: Optional[Union[List[str], str]] = None
-    tp_checkpoint_name_pattern: Optional[str] = None
+    name_pattern_tp_checkpoint: Optional[str] = None
 
     def __post_init__(self):
         model_loader_extra_config = self.model_loader_extra_config or {}

--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -49,6 +49,7 @@ class LoadConfig:
     download_dir: Optional[str] = None
     model_loader_extra_config: Optional[Union[str, dict]] = field(default_factory=dict)
     ignore_patterns: Optional[Union[List[str], str]] = None
+    tp_checkpoint_name_pattern: Optional[str] = None
 
     def __post_init__(self):
         model_loader_extra_config = self.model_loader_extra_config or {}

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -296,7 +296,7 @@ class ModelRunner:
         self.load_config = LoadConfig(
             load_format=self.server_args.load_format,
             download_dir=self.server_args.download_dir,
-            tp_checkpoint_name_pattern=self.server_args.tp_checkpoint_name_pattern,
+            name_pattern_tp_checkpoint=self.server_args.name_pattern_tp_checkpoint,
         )
         if self.server_args.load_format == "gguf":
             monkey_patch_vllm_gguf_config()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -296,6 +296,7 @@ class ModelRunner:
         self.load_config = LoadConfig(
             load_format=self.server_args.load_format,
             download_dir=self.server_args.download_dir,
+            tp_checkpoint_name_pattern=self.server_args.tp_checkpoint_name_pattern,
         )
         if self.server_args.load_format == "gguf":
             monkey_patch_vllm_gguf_config()

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -294,6 +294,13 @@ class DefaultModelLoader(BaseModelLoader):
                 f"Cannot find any model weights with `{model_name_or_path}`"
             )
 
+        if (
+            get_tensor_model_parallel_world_size() > 1
+            and self.load_config.tp_checkpoint_name_pattern
+        ):
+            ranked = f"{self.load_config.tp_checkpoint_name_pattern}{get_tensor_model_parallel_rank()}"
+            hf_weights_files = [f for f in hf_weights_files if ranked in f]
+
         return hf_folder, hf_weights_files, use_safetensors
 
     def _get_weights_iterator(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -296,9 +296,9 @@ class DefaultModelLoader(BaseModelLoader):
 
         if (
             get_tensor_model_parallel_world_size() > 1
-            and self.load_config.tp_checkpoint_name_pattern
+            and self.load_config.name_pattern_tp_checkpoint
         ):
-            ranked = f"{self.load_config.tp_checkpoint_name_pattern}{get_tensor_model_parallel_rank()}"
+            ranked = f"{self.load_config.name_pattern_tp_checkpoint}{get_tensor_model_parallel_rank()}"
             hf_weights_files = [f for f in hf_weights_files if ranked in f]
 
         return hf_folder, hf_weights_files, use_safetensors

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -166,6 +166,9 @@ class ServerArgs:
     tool_call_parser: str = None
     enable_hierarchical_cache: bool = False
 
+    # tensor parallel checkpoint pattern
+    tp_checkpoint_name_pattern: Optional[str] = None
+
     def __post_init__(self):
         # Set missing default values
         if self.tokenizer_path is None:
@@ -908,6 +911,12 @@ class ServerArgs:
             "--enable-hierarchical-cache",
             action="store_true",
             help="Enable hierarchical cache",
+        )
+        parser.add_argument(
+            "--tp-checkpoint-name-pattern",
+            type=str,
+            default=ServerArgs.tp_checkpoint_name_pattern,
+            help="Specify filename pattern for per-tp checkpoint. E.g. `rank-` for rank-`tp`",
         )
 
     @classmethod

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -167,7 +167,7 @@ class ServerArgs:
     enable_hierarchical_cache: bool = False
 
     # tensor parallel checkpoint pattern
-    tp_checkpoint_name_pattern: Optional[str] = None
+    name_pattern_tp_checkpoint: Optional[str] = None
 
     def __post_init__(self):
         # Set missing default values
@@ -913,9 +913,9 @@ class ServerArgs:
             help="Enable hierarchical cache",
         )
         parser.add_argument(
-            "--tp-checkpoint-name-pattern",
+            "--name-pattern-tp-checkpoint",
             type=str,
-            default=ServerArgs.tp_checkpoint_name_pattern,
+            default=ServerArgs.name_pattern_tp_checkpoint,
             help="Specify filename pattern for per-tp checkpoint. E.g. `rank-` for rank-`tp`",
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
We have support of `use_presharded_weights` in various places but didn't have a place to inform each tp rank to load a different tp checkpoint file. 

## Modifications

This PR adds a flag to let each tp rank worker to load a different tp checkpoint file based on the filename pattern. Also plumbed through a LLAMA example. 

```
USE_PRESHARDED_WEIGHTS=1 uv run python third_party/sglang/examples/runtime/engine/offline_batch_inference.py  --model-path /tmp/hf/ --tp-size 2 --tp-checkpoint-name-pattern "rank-"
```

And the files in `/tmp/hf/` is like
```
-rw-rw---- 1 yinghai default  885 Feb  6 18:58 config.json
-rw-rw---- 1 yinghai default 2.8G Feb  6 18:58 model-rank-0-part-0.safetensors
-rw-rw---- 1 yinghai default 2.8G Feb  6 18:58 model-rank-1-part-0.safetensors
-rw-rw---- 1 yinghai default  301 Feb  6 18:58 special_tokens_map.json
-rw-rw---- 1 yinghai default  50K Feb  6 18:58 tokenizer_config.json
-rw-rw---- 1 yinghai default  17M Feb  6 18:58 tokenizer.json
```

## Checklist

- [ x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
