### PR TITLE
fix: return null instead of "" for finish_reason when unfinished

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -631,7 +631,7 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 "index": 0,
                 "text": text,
                 "logprobs": logprobs,
-                "finish_reason": (finish_reason["type"] if finish_reason else ""),
+                "finish_reason": (finish_reason["type"] if finish_reason else None),
                 "matched_stop": (
                     finish_reason["matched"]
                     if finish_reason and "matched" in finish_reason
@@ -643,7 +643,7 @@ def v1_generate_response(request, ret, tokenizer_manager, to_file=False):
                 index=idx,
                 text=text,
                 logprobs=logprobs,
-                finish_reason=(finish_reason["type"] if finish_reason else ""),
+                finish_reason=(finish_reason["type"] if finish_reason else None),
                 matched_stop=(
                     finish_reason["matched"]
                     if finish_reason and "matched" in finish_reason
@@ -782,7 +782,9 @@ async def v1_completions(tokenizer_manager, raw_request: Request):
                         index=index,
                         text=delta,
                         logprobs=logprobs,
-                        finish_reason=(finish_reason["type"] if finish_reason else ""),
+                        finish_reason=(
+                            finish_reason["type"] if finish_reason else None
+                        ),
                         matched_stop=(
                             finish_reason["matched"]
                             if finish_reason and "matched" in finish_reason
@@ -1108,7 +1110,7 @@ def v1_chat_generate_response(
                     "tool_calls": tool_calls,
                 },
                 "logprobs": choice_logprobs,
-                "finish_reason": (finish_reason["type"] if finish_reason else ""),
+                "finish_reason": (finish_reason["type"] if finish_reason else None),
                 "matched_stop": (
                     finish_reason["matched"]
                     if finish_reason and "matched" in finish_reason
@@ -1124,7 +1126,7 @@ def v1_chat_generate_response(
                     tool_calls=tool_calls,
                 ),
                 logprobs=choice_logprobs,
-                finish_reason=(finish_reason["type"] if finish_reason else ""),
+                finish_reason=(finish_reason["type"] if finish_reason else None),
                 matched_stop=(
                     finish_reason["matched"]
                     if finish_reason and "matched" in finish_reason
@@ -1262,7 +1264,7 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                             index=index,
                             delta=DeltaMessage(role="assistant", content=""),
                             finish_reason=(
-                                finish_reason["type"] if finish_reason else ""
+                                finish_reason["type"] if finish_reason else None
                             ),
                             matched_stop=(
                                 finish_reason["matched"]
@@ -1299,7 +1301,7 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                                 index=index,
                                 delta=DeltaMessage(content=normal_text),
                                 finish_reason=(
-                                    finish_reason["type"] if finish_reason else ""
+                                    finish_reason["type"] if finish_reason else None
                                 ),
                             )
                             chunk = ChatCompletionStreamResponse(
@@ -1368,7 +1370,7 @@ async def v1_chat_completions(tokenizer_manager, raw_request: Request):
                             index=index,
                             delta=DeltaMessage(content=delta),
                             finish_reason=(
-                                finish_reason["type"] if finish_reason else ""
+                                finish_reason["type"] if finish_reason else None
                             ),
                             matched_stop=(
                                 finish_reason["matched"]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Return `null` instead of `""` for `finish_reason` when unfinished to comply with OpenAI's behavior. Example can be seen at their example [1]. See the code on the right.

Fixes #1407

[1] https://platform.openai.com/docs/api-reference/chat/streaming

## Modifications

<!-- Describe the changes made in this PR. -->
Return `null` instead of `""` for `finish_reason` when unfinished.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
