### PR TITLE
fix draft cuda graph capture failure

### DIFF
--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -85,6 +85,7 @@ class EAGLEDraftCudaGraphRunner:
                 "1. disable cuda graph by --disable-cuda-graph\n"
                 "2. set --mem-fraction-static to a smaller value (e.g., 0.8 or 0.7)\n"
                 "3. disable torch compile by not using --enable-torch-compile\n"
+                "4. specify --dtype to the same dtype (e.g. bfloat16)\n"
                 "Open an issue on GitHub https://github.com/sgl-project/sglang/issues/new/choose \n"
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

fix `Capture cuda graph failed: mat1 and mat2 must have the same dtype, but got Float and Half`

```bash
python3 -m sglang.launch_server --model meta-llama/Meta-Llama-3-8B-Instruct  \
--speculative-algo EAGLE --speculative-draft lmzheng/sglang-EAGLE-LLaMA3-Instruct-8B  \
--speculative-num-steps 5 --speculative-eagle-topk 8 --speculative-num-draft-tokens 64 \
--disable-radix-cache --mem-fraction 0.7 --cuda-graph-max-bs 32 --dtype bfloat16
```
https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/blob/main/config.json#L23
https://huggingface.co/lmzheng/sglang-EAGLE-LLaMA3-Instruct-8B/blob/main/config.json#L19

We should **explicitly specify `--dtype`** when the target model and draft model use different dtype (such as bfloat16 and float16).

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
