### PR TITLE
Tune MI300X fused MoE Triton kernel JSON config.

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/E=256,N=256,device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/E=256,N=256,device_name=AMD_Instinct_MI300X,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -72,10 +72,10 @@
         "waves_per_eu": 0
     },
     "64": {
-        "BLOCK_SIZE_M": 256,
+        "BLOCK_SIZE_M": 32,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 4,
         "num_warps": 4,
         "num_stages": 2,
         "waves_per_eu": 0


### PR DESCRIPTION
## Modifications

Align the JSON configs between MI300X and Radeon Graphics for BS=64, E=256, N=256, dtype=fp8_w8a8, block_shape=[128,128] case. The best tuned config was submitted in #3418 but it was only for Radeon Graphics. Let MI300X adopt the same configuration in this PR.
