### PR TITLE
use sgl_per_token_group_quant_fp8 kernel

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ runtime_common = [
 ]
 srt = [
     "sglang[runtime_common]", "cuda-python",
-    "sgl-kernel>=0.0.3.post3", "torch", "vllm>=0.6.4.post1,<=0.7.2",
+    "sgl-kernel>=0.0.3.post4", "torch", "vllm>=0.6.4.post1,<=0.7.2",
     "flashinfer_python>=0.2.0.post2", "outlines>=0.0.44,<=0.1.11"
 ]
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -19,6 +19,7 @@ from sglang.srt.utils import direct_register_custom_op, get_device_name, is_hip
 
 is_hip_flag = is_hip()
 
+
 logger = logging.getLogger(__name__)
 padding_size = 128 if bool(int(os.getenv("MOE_PADDING", "0"))) else 0
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -14,7 +14,7 @@ import triton.language as tl
 from vllm import _custom_ops as ops
 
 from sglang.srt.layers.moe.topk import select_experts
-from sglang.srt.layers.quantization.fp8_kernel import per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.utils import direct_register_custom_op, get_device_name, is_hip
 
 is_hip_flag = is_hip()
@@ -488,7 +488,7 @@ def invoke_fused_moe_kernel(
         else:
             assert len(block_shape) == 2
             block_n, block_k = block_shape[0], block_shape[1]
-            A, A_scale = per_token_group_quant_fp8(A, block_k)
+            A, A_scale = sglang_per_token_group_quant_fp8(A, block_k)
             assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -14,11 +14,10 @@ import triton.language as tl
 from vllm import _custom_ops as ops
 
 from sglang.srt.layers.moe.topk import select_experts
-from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.quantization.fp8_kernel import per_token_group_quant_fp8
 from sglang.srt.utils import direct_register_custom_op, get_device_name, is_hip
 
 is_hip_flag = is_hip()
-
 
 logger = logging.getLogger(__name__)
 padding_size = 128 if bool(int(os.getenv("MOE_PADDING", "0"))) else 0
@@ -32,6 +31,10 @@ _is_rocm = torch.cuda.is_available() and torch.version.hip
 
 if _is_cuda:
     from sgl_kernel import gelu_and_mul, silu_and_mul
+
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
 
 if _is_cuda or _is_rocm:
     from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
@@ -488,7 +491,10 @@ def invoke_fused_moe_kernel(
         else:
             assert len(block_shape) == 2
             block_n, block_k = block_shape[0], block_shape[1]
-            A, A_scale = sglang_per_token_group_quant_fp8(A, block_k)
+            if _is_cuda:
+                A, A_scale = sglang_per_token_group_quant_fp8(A, block_k)
+            else:
+                A, A_scale = per_token_group_quant_fp8(A, block_k)
             assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -23,6 +23,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.utils import get_device_core_count, get_device_name, is_hip
+from sgl_kernel import sgl_per_token_group_quant_fp8
 
 is_hip_ = is_hip()
 fp8_type_ = torch.float8_e4m3fnuz if is_hip_ else torch.float8_e4m3fn
@@ -134,6 +135,34 @@ def per_token_group_quant_fp8(
 
     return x_q, x_s
 
+def sglang_per_token_group_quant_fp8(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float = 1e-10,
+    dtype: torch.dtype = fp8_type_,
+):
+    assert (
+        x.shape[-1] % group_size == 0
+    ), "the last dimension of `x` cannot be divisible by `group_size`"
+    assert x.is_contiguous(), "`x` is not contiguous"
+
+    finfo = torch.finfo(dtype)
+    fp8_max = finfo.max
+
+    fp8_min = -fp8_max
+
+    x_q = torch.empty_like(x, device=x.device, dtype=dtype)
+    M = x.numel() // group_size
+    N = group_size
+    x_s = torch.empty(
+        x.shape[:-1] + (x.shape[-1] // group_size,),
+        device=x.device,
+        dtype=torch.float32,
+    )
+
+    sgl_per_token_group_quant_fp8(x, x_q, x_s, group_size, eps, fp8_min, fp8_max)
+
+    return x_q, x_s
 
 @triton.jit
 def _w8a8_block_fp8_matmul(

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -23,10 +23,13 @@ import triton
 import triton.language as tl
 
 from sglang.srt.utils import get_device_core_count, get_device_name, is_hip
-from sgl_kernel import sgl_per_token_group_quant_fp8
 
 is_hip_ = is_hip()
 fp8_type_ = torch.float8_e4m3fnuz if is_hip_ else torch.float8_e4m3fn
+
+_is_cuda = torch.cuda.is_available() and torch.version.cuda
+if _is_cuda:
+    from sgl_kernel import sgl_per_token_group_quant_fp8
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +138,7 @@ def per_token_group_quant_fp8(
 
     return x_q, x_s
 
+
 def sglang_per_token_group_quant_fp8(
     x: torch.Tensor,
     group_size: int,
@@ -163,6 +167,7 @@ def sglang_per_token_group_quant_fp8(
     sgl_per_token_group_quant_fp8(x, x_q, x_s, group_size, eps, fp8_min, fp8_max)
 
     return x_q, x_s
+
 
 @triton.jit
 def _w8a8_block_fp8_matmul(


### PR DESCRIPTION
end2end perfomance:

```shell
```shell
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code --port 30000

# Run 2 times commands:

python3 -m sglang.bench_serving --backend sglang --num-prompts 1000 --request-rate 8
```


### first time

main:

```shell
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max reqeuest concurrency:                not set   
Successful requests:                     1000      
Benchmark duration (s):                  234.70    
Total input tokens:                      301701    
Total generated tokens:                  188375    
Total generated tokens (retokenized):    187534    
Request throughput (req/s):              4.26      
Input token throughput (tok/s):          1285.46   
Output token throughput (tok/s):         802.61    
Total token throughput (tok/s):          2088.07   
Concurrency:                             262.34    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   61571.47  
Median E2E Latency (ms):                 52159.16  
---------------Time to First Token----------------
Mean TTFT (ms):                          2047.59   
Median TTFT (ms):                        630.04    
P99 TTFT (ms):                           19879.67  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          580.62    
Median TPOT (ms):                        461.36    
P99 TPOT (ms):                           2277.66   
---------------Inter-token Latency----------------
Mean ITL (ms):                           319.34    
Median ITL (ms):                         157.48    
P99 ITL (ms):                            3867.63   
==================================================
```

pr:


```shell
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max reqeuest concurrency:                not set   
Successful requests:                     1000      
Benchmark duration (s):                  234.13    
Total input tokens:                      301701    
Total generated tokens:                  188375    
Total generated tokens (retokenized):    187556    
Request throughput (req/s):              4.27      
Input token throughput (tok/s):          1288.58   
Output token throughput (tok/s):         804.56    
Total token throughput (tok/s):          2093.14   
Concurrency:                             261.91    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   61322.63  
Median E2E Latency (ms):                 51756.45  
---------------Time to First Token----------------
Mean TTFT (ms):                          2185.78   
Median TTFT (ms):                        605.41    
P99 TTFT (ms):                           21702.75  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          593.39    
Median TPOT (ms):                        484.39    
P99 TPOT (ms):                           2621.74   
---------------Inter-token Latency----------------
Mean ITL (ms):                           318.73    
Median ITL (ms):                         154.98    
P99 ITL (ms):                            2892.38   
==================================================
```

### second time

main:

```shell
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max reqeuest concurrency:                not set   
Successful requests:                     1000      
Benchmark duration (s):                  231.16    
Total input tokens:                      301701    
Total generated tokens:                  188375    
Total generated tokens (retokenized):    187505    
Request throughput (req/s):              4.33      
Input token throughput (tok/s):          1305.18   
Output token throughput (tok/s):         814.92    
Total token throughput (tok/s):          2120.10   
Concurrency:                             245.80    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   56819.06  
Median E2E Latency (ms):                 47473.95  
---------------Time to First Token----------------
Mean TTFT (ms):                          834.04    
Median TTFT (ms):                        522.79    
P99 TTFT (ms):                           4564.58   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          465.60    
Median TPOT (ms):                        388.09    
P99 TPOT (ms):                           1439.86   
---------------Inter-token Latency----------------
Mean ITL (ms):                           299.96    
Median ITL (ms):                         157.45    
P99 ITL (ms):                            2379.64   
==================================================
```

pr:
```shell
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max reqeuest concurrency:                not set   
Successful requests:                     1000      
Benchmark duration (s):                  229.98    
Total input tokens:                      301701    
Total generated tokens:                  188375    
Total generated tokens (retokenized):    187525    
Request throughput (req/s):              4.35      
Input token throughput (tok/s):          1311.87   
Output token throughput (tok/s):         819.10    
Total token throughput (tok/s):          2130.97   
Concurrency:                             242.99    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   55881.33  
Median E2E Latency (ms):                 46573.34  
---------------Time to First Token----------------
Mean TTFT (ms):                          772.20    
Median TTFT (ms):                        513.58    
P99 TTFT (ms):                           3324.78   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          447.66    
Median TPOT (ms):                        388.91    
P99 TPOT (ms):                           1173.11   
---------------Inter-token Latency----------------
Mean ITL (ms):                           295.57    
Median ITL (ms):                         155.52    
P99 ITL (ms):                            2161.58   
==================================================
```


Both latency and throughput achieved an end-to-end speedup of approximately 1% in DeepSeek R1.

@zhyncs 
