### PR TITLE
fix supported_models Qwen typo

### DIFF
--- a/docs/references/supported_models.md
+++ b/docs/references/supported_models.md
@@ -36,7 +36,7 @@
 
 - LlamaEmbeddingModel
 - Mistral embedding models
-- QWen embedding models
+- Qwen embedding models
   - `python -m sglang.launch_server --model-path Alibaba-NLP/gte-Qwen2-7B-instruct --is-embedding`
 
 ## Reward Models


### PR DESCRIPTION
Hi,

Modified spelling: QWen -> Qwen to be consistent with other Qwen instances in same page.

Didier

