### PR TITLE
[optimize][scheduler] implement shortest-queue method

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -568,3 +568,15 @@ class FunctionCallReqInput:
     tool_call_parser: Optional[str] = (
         None  # Specify the parser type, e.g. 'llama3', 'qwen25', or 'mistral'. If not specified, tries all.
     )
+
+
+@dataclass
+class WorkerPayloadStatus:
+    running_reqs: int
+    queued_reqs: int
+
+
+@dataclass
+class DPWorkerPayloadStatus:
+    dp_rank: int
+    status: WorkerPayloadStatus


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
We experience a high unbalanced workload for different DP workers when we `--enable-dp-attention`.

For example, note how DP5 is overloaded, while DP2 only has 2 requests running:
![CleanShot 2025-02-12 at 23 52 54@2x](https://github.com/user-attachments/assets/c69e4ca5-42a9-4029-a87f-f92c7ddcdeae)

And the overloaded rank will not recover due to current schedule policy.

To solve this problem, we should use `shortest_queue` schedule method, but it is not implemented now.

So, in this PR, we propose to implement `shortest_queue` method.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

We made the following modifications:
- We use a new zmq PUSH/PULL channel for schedulers to report their workload to `data_parallel_controller`
- We modified each scheduler to report its `#running-reqs` and `#queue-reqs` periodically from a thread called `report_workload_status_thread`.
- In `data_parallel_controller`, we use a heap to find the scheduler with the shortest waiting queue, and schedule to that instance

To schedule to the least loaded scheduler, we should first find the shortest queue. If there's a tie, we should schedule to the scheduler with lowest running reqs. To implement this, we use a tuple `(queue-reqs, running-reqs, dp-rank)` to represent the actual payload of each scheduler. 

The result shows now the ranks are pretty balanced:
![CleanShot 2025-02-13 at 00 03 13@2x](https://github.com/user-attachments/assets/00624db2-8fa2-4493-9cb2-a28f60f79d7d)


<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
