### PR TITLE
Use `tl.range()` in block GEMM kernels with `num_stages=2`.

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -299,7 +299,7 @@ def _w8a8_block_fp8_matmul(
     Bs_ptrs = Bs + offs_bsn * stride_Bs_n
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K), num_stages=2):
         a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
         b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 
@@ -386,7 +386,7 @@ def _w8a8_block_fp8_matmul_unrolledx4(
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     # manually unroll to 4 iterations
     UNROLL_FACTOR = 4
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K * UNROLL_FACTOR)):
+    for k in tl.range(0, tl.cdiv(K, BLOCK_SIZE_K * UNROLL_FACTOR), num_stages=2):
         # 1st iteration
         a = tl.load(
             a_ptrs,


### PR DESCRIPTION
## Modifications

Inspired by the idea from @vgokhale, use `tl.range()` in block GEMM kernels with `num_stages=2` to improve software pipelining. The modification shall generally be applicable on all accelerator platforms.

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
