### PR TITLE
[fix] added support for vlm in offline inference

### DIFF
--- a/examples/runtime/engine/offline_batch_inference_vlm.py
+++ b/examples/runtime/engine/offline_batch_inference_vlm.py
@@ -1,6 +1,6 @@
 """
 Usage:
-python offline_batch_inference_vlm.py  --model-path Qwen/Qwen2-VL-7B-Instruct --chat-template=qwen2-vl
+python offline_batch_inference_vlm.py --model-path Qwen/Qwen2-VL-7B-Instruct --chat-template=qwen2-vl
 """
 
 import argparse
@@ -37,7 +37,7 @@ def main(
     ]
     chat_request = ChatCompletionRequest(
         messages=messages,
-        model="Qwen/Qwen2-VL-7B-Instruct",
+        model=server_args.model_path,
         temperature=0.8,
         top_p=0.95,
     )

--- a/examples/runtime/engine/offline_batch_inference_vlm.py
+++ b/examples/runtime/engine/offline_batch_inference_vlm.py
@@ -1,6 +1,6 @@
 """
 Usage:
-python3 offline_batch_inference.py  --model meta-llama/Llama-3.1-8B-Instruct
+python offline_batch_inference_vlm.py  --model-path Qwen/Qwen2-VL-7B-Instruct --chat-template=qwen2-vl
 """
 
 import argparse
@@ -35,14 +35,14 @@ def main(
             ],
         }
     ]
-    request = ChatCompletionRequest(
+    chat_request = ChatCompletionRequest(
         messages=messages,
         model="Qwen/Qwen2-VL-7B-Instruct",
         temperature=0.8,
         top_p=0.95,
     )
     gen_request, _ = v1_chat_generate_request(
-        [request],
+        [chat_request],
         vlm.tokenizer_manager,
     )
 

--- a/examples/runtime/engine/offline_batch_inference_vlm.py
+++ b/examples/runtime/engine/offline_batch_inference_vlm.py
@@ -1,0 +1,67 @@
+"""
+Usage:
+python3 offline_batch_inference.py  --model meta-llama/Llama-3.1-8B-Instruct
+"""
+
+import argparse
+import dataclasses
+
+from transformers import AutoProcessor
+
+import sglang as sgl
+from sglang.srt.openai_api.adapter import v1_chat_generate_request
+from sglang.srt.openai_api.protocol import ChatCompletionRequest
+from sglang.srt.server_args import ServerArgs
+
+
+def main(
+    server_args: ServerArgs,
+):
+    # Create an LLM.
+    vlm = sgl.Engine(**dataclasses.asdict(server_args))
+
+    # prepare prompts.
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What’s in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://github.com/sgl-project/sglang/blob/main/test/lang/example_image.png?raw=true",
+                    },
+                },
+            ],
+        }
+    ]
+    request = ChatCompletionRequest(
+        messages=messages,
+        model="Qwen/Qwen2-VL-7B-Instruct",
+        temperature=0.8,
+        top_p=0.95,
+    )
+    gen_request, _ = v1_chat_generate_request(
+        [request],
+        vlm.tokenizer_manager,
+    )
+
+    outputs = vlm.generate(
+        input_ids=gen_request.input_ids,
+        image_data=gen_request.image_data,
+        sampling_params=gen_request.sampling_params,
+    )
+
+    print("===============================")
+    print(f"Prompt: {messages[0]['content'][0]['text']}")
+    print(f"Generated text: {outputs['text']}")
+
+
+# The __main__ condition is necessary here because we use "spawn" to create subprocesses
+# Spawn starts a fresh program every time, if there is no __main__, it will run into infinite loop to keep spawning processes from sgl.Engine
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    ServerArgs.add_cli_args(parser)
+    args = parser.parse_args()
+    server_args = ServerArgs.from_cli_args(args)
+    main(server_args)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -115,6 +115,9 @@ class Engine:
         sampling_params: Optional[Union[List[Dict], Dict]] = None,
         # The token ids for text; one can either specify text or input_ids.
         input_ids: Optional[Union[List[List[int]], List[int]]] = None,
+        # The image input. It can be a file name, a url, or base64 encoded string.
+        # See also python/sglang/srt/utils.py:load_image.
+        image_data: Optional[Union[List[str], str]] = None,
         return_logprob: Optional[Union[List[bool], bool]] = False,
         logprob_start_len: Optional[Union[List[int], int]] = None,
         top_logprobs_num: Optional[Union[List[int], int]] = None,
@@ -126,14 +129,20 @@ class Engine:
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
         Please refer to `GenerateReqInput` for the documentation.
         """
+        modalities_list = []
+        if image_data is not None:
+            modalities_list.append("image")
+
         obj = GenerateReqInput(
             text=prompt,
             input_ids=input_ids,
             sampling_params=sampling_params,
+            image_data=image_data,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,
             lora_path=lora_path,
+            modalities=modalities_list,
             custom_logit_processor=custom_logit_processor,
             stream=stream,
         )
@@ -162,6 +171,9 @@ class Engine:
         sampling_params: Optional[Union[List[Dict], Dict]] = None,
         # The token ids for text; one can either specify text or input_ids.
         input_ids: Optional[Union[List[List[int]], List[int]]] = None,
+        # The image input. It can be a file name, a url, or base64 encoded string.
+        # See also python/sglang/srt/utils.py:load_image.
+        image_data: Optional[Union[List[str], str]] = None,
         return_logprob: Optional[Union[List[bool], bool]] = False,
         logprob_start_len: Optional[Union[List[int], int]] = None,
         top_logprobs_num: Optional[Union[List[int], int]] = None,
@@ -177,6 +189,7 @@ class Engine:
             text=prompt,
             input_ids=input_ids,
             sampling_params=sampling_params,
+            image_data=image_data,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR aims to fix the issue #3545 by enhancing the engine with the support of vision language models such as Qwen2-VL for offline inference.

## Modifications

First of all, it should be noted that the design of current code has some issues which make this PR an imperfect solution, as a result, I have not added any documentation or unit test yet and wish to look for discussion on how to improve the code as a whole.

The root causes of #3545 are that:
1. VLMs require the prompt to be pre-processed by the chat template. This is because that the processor will add in some image-related tokens in the prompt. For exmaple, Qwen2-VL adds the following tokens to the prompt: `<|vision_start|><|image_pad|><|vision_end|>`. Thus, VLMs are different from LLMs in the sense that the chat template is a must for VLM but not always for LLMs (LLMs can still generate sensible outputs even without the template).
2. `sgl.Engine` is not responsible for applying the chat template to the prompts
3. the current API for applying the chat template is only for online serving, i.e. `v1_chat_generate_request`

As a result, the current proposed workflow for running VLMs offline is shown below:
![WechatIMG469](https://github.com/user-attachments/assets/773efb5d-fdd4-44e7-8667-684220e83519)


It is not so elegant because it counter-intuitively uses a API used for online serving in the offline inference scenario. I would suggest we extract the preprocessing logic to independent APIs or create a new API for preprocessing in offline cases.

Open for discussion.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
