### PR TITLE
[DO NOT MERGE] [ROCm] Adopt default Triton attention KV splits number.

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -276,10 +276,6 @@ class ServerArgs:
         ) and check_gguf_file(self.model_path):
             self.quantization = self.load_format = "gguf"
 
-        # AMD-specific Triton attention KV splits default number
-        if is_hip():
-            self.triton_attention_num_kv_splits = 16
-
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
         # Model and port args


### PR DESCRIPTION
## Modifications

Advancement in Triton compiler has rendered this platform-specific tuning unnecessary.

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).