### PR TITLE
solve the mrope position bugs for qwen2-vl

### DIFF
--- a/python/sglang/srt/configs/qwen2vl.py
+++ b/python/sglang/srt/configs/qwen2vl.py
@@ -123,8 +123,8 @@ class Qwen2VLConfig(PretrainedConfig):
 
         # NOTE(HandH1998): This is necessary for configuring the `rope_type`` of qwen2vl models after removing dependencies on vllm.
         if self.rope_scaling is not None and "type" in self.rope_scaling:
-            if self.rope_scaling["type"] == "mrope":
-                self.rope_scaling["type"] = "default"
+            # if self.rope_scaling["type"] == "mrope":
+            #     self.rope_scaling["type"] = "default"
             self.rope_scaling["rope_type"] = self.rope_scaling["type"]
 
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -118,6 +118,7 @@ class Engine:
         # The image input. It can be a file name, a url, or base64 encoded string.
         # See also python/sglang/srt/utils.py:load_image.
         image_data: Optional[Union[List[str], str]] = None,
+        modalities: Optional[Union[List[str], str]] = None,
         return_logprob: Optional[Union[List[bool], bool]] = False,
         logprob_start_len: Optional[Union[List[int], int]] = None,
         top_logprobs_num: Optional[Union[List[int], int]] = None,
@@ -129,9 +130,6 @@ class Engine:
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
         Please refer to `GenerateReqInput` for the documentation.
         """
-        modalities_list = []
-        if image_data is not None:
-            modalities_list.append("image")
 
         obj = GenerateReqInput(
             text=prompt,
@@ -142,7 +140,7 @@ class Engine:
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,
             lora_path=lora_path,
-            modalities=modalities_list,
+            modalities=modalities,
             custom_logit_processor=custom_logit_processor,
             stream=stream,
         )

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -874,7 +874,6 @@ class MRotaryEmbedding(RotaryEmbedding):
         image_token_id: int,
         video_token_id: int,
         vision_start_token_id: int,
-        vision_end_token_id: int,
         spatial_merge_size: int,
         context_len: int = 0,
         seq_len: Optional[int] = None,
@@ -1056,7 +1055,7 @@ def get_rope(
                 high_freq_factor,
                 original_max_position,
             )
-        elif scaling_type == "default":
+        elif scaling_type == "default" or scaling_type == "mrope":
             if "mrope_section" in rope_scaling:
                 rotary_emb = MRotaryEmbedding(
                     head_size,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -328,15 +328,20 @@ class ForwardBatch:
                     ] * 3
                 else:
                     # TODO: current qwen2-vl do not support radix cache since mrope position calculation
+                    image_grid_thw = getattr(image_inputs, "image_grid_thws", None)
+                    video_grid_thw = getattr(image_inputs, "video_grid_thws", None)
                     mrope_positions, mrope_position_delta = (
                         MRotaryEmbedding.get_input_positions(
                             input_tokens=self.input_ids[
                                 extend_start_loc : extend_start_loc + extend_seq_len
-                            ],
-                            image_grid_thw=image_inputs.image_grid_thws,
+                            ].tolist(),
+                            image_grid_thw=image_grid_thw,
+                            video_grid_thw=video_grid_thw,
+                            image_token_id=image_inputs.pad_values[0],
+                            video_token_id=hf_config.video_token_id,
                             vision_start_token_id=hf_config.vision_start_token_id,
                             spatial_merge_size=hf_config.vision_config.spatial_merge_size,
-                            context_len=0,
+                            context_len=0
                         )
                     )
                     batch.image_inputs[i].mrope_position_delta = mrope_position_delta


### PR DESCRIPTION
## Motivation

Current qwen2-vl implementation has severe bug causing the inconsistency between huggingface inference and vllm. inference.

## Modifications

1. Change rope_scaling type name to 'mrope'
2. fixe _compute_mrope_positions error

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
