### PR TITLE
Update decode kernel benchmark with new Triton backend interface

### DIFF
--- a/benchmark/kernels/decoding_attention_triton/triton_flashinfer_cudnn.py
+++ b/benchmark/kernels/decoding_attention_triton/triton_flashinfer_cudnn.py
@@ -8,8 +8,8 @@ import triton
 import triton.language as tl
 from flashinfer import BatchDecodeWithPagedKVCacheWrapper
 
-from sglang.srt.layers.attention.triton_ops.decode_attention import decode_attention_fwd
 from sglang.srt.layers.attention.flashinfer_backend import should_use_tensor_core
+from sglang.srt.layers.attention.triton_ops.decode_attention import decode_attention_fwd
 
 
 def benchmark_forward(


### PR DESCRIPTION
## Motivation

The Triton kernel for decode attention was updated with a new backend interface in #3292, breaking the benchmark code.

## Modifications

Corrected the import for `should_use_tensor_core` and replaced `req_to_token`, `b_req_idx`, `b_seq_len` with `kv_indptr` and `kv_indices`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
