### PR TITLE
Enable SRT model tests on non-CUDA devices

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1002,6 +1002,7 @@ def get_rope(
     rope_scaling: Optional[Dict[str, Any]] = None,
     dtype: Optional[torch.dtype] = None,
     partial_rotary_factor: float = 1.0,
+    device: Optional[str] = "cuda",
 ) -> RotaryEmbedding:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -1142,6 +1143,7 @@ def get_rope(
                 is_neox_style,
                 scaling_factor,
                 dtype,
+                device=device,
                 **extra_kwargs,
             )
         elif scaling_type == "longrope":

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -131,7 +131,7 @@ class ModelRunner:
                     "Please specify the heavy channel type for double sparsity optimization."
                 )
             self.init_double_sparsity_channel_config(
-                self.server_args.ds_heavy_channel_type
+                self.server_args.ds_heavy_channel_type, self.device
             )
 
         if self.is_multimodal:
@@ -708,7 +708,7 @@ class ModelRunner:
                 f"Invalid attention backend: {self.server_args.attention_backend}"
             )
 
-    def init_double_sparsity_channel_config(self, selected_channel):
+    def init_double_sparsity_channel_config(self, selected_channel, device):
         selected_channel = "." + selected_channel + "_proj"
         self.sorted_channels = []
         # load channel config
@@ -722,7 +722,7 @@ class ModelRunner:
                     :, : self.server_args.ds_heavy_channel_num
                 ]
                 .contiguous()
-                .cuda()
+                .to(device)
             )
 
     def init_cuda_graphs(self):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -472,6 +472,7 @@ class DeepseekV2AttentionMLA(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
             is_neox_style=False,
+            device=global_server_args_dict["device"],
         )
 
         if rope_scaling:

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -48,7 +48,7 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     kv_cache_scales_loader,
 )
-from sglang.srt.utils import make_layers
+from sglang.srt.utils import get_device, make_layers
 from sglang.utils import get_exception_traceback
 
 logger = logging.getLogger(__name__)
@@ -566,8 +566,11 @@ class LlamaForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        if "cuda" in get_device():
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+        elif "hpu" in get_device():
+            torch.hpu.synchronize()
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -42,6 +42,7 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaForCausalLM
 from sglang.srt.models.mistral import MistralForCausalLM
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+from sglang.srt.utils import get_device
 
 
 class LlavaBaseForCausalLM(nn.Module):
@@ -416,11 +417,11 @@ class LlavaBaseForCausalLM(nn.Module):
         if "clip" in vision_path:
             self.vision_tower = CLIPVisionModel.from_pretrained(
                 vision_path, torch_dtype=torch.float16
-            ).cuda()
+            ).to(get_device())
         elif "siglip" in vision_path:
             self.vision_tower = SiglipVisionModel.from_pretrained(
                 vision_path, torch_dtype=torch.float16
-            ).cuda()
+            ).to(get_device())
             # Siglip needs all feature tokens
             self.config.mm_vision_select_feature = "full"
         self.vision_tower.eval()

--- a/python/sglang/test/srt/sampling/penaltylib/utils.py
+++ b/python/sglang/test/srt/sampling/penaltylib/utils.py
@@ -10,6 +10,7 @@ from sglang.srt.sampling.penaltylib.orchestrator import (
     _BatchedPenalizer,
     _BatchLike,
 )
+from sglang.srt.utils import get_device
 
 
 @dataclasses.dataclass
@@ -96,7 +97,7 @@ class Case:
 
 class BaseBatchedPenalizerTest(unittest.TestCase):
     Penalizer: Type[_BatchedPenalizer]
-    device = "cuda"
+    device = get_device()
     vocab_size = 5
 
     enabled: Subject = None

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -22,7 +22,7 @@ from sglang.bench_serving import run_benchmark
 from sglang.global_config import global_config
 from sglang.lang.backend.openai import OpenAI
 from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
-from sglang.srt.utils import get_bool_env_var, kill_process_tree
+from sglang.srt.utils import get_bool_env_var, get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.utils import get_exception_traceback
 
@@ -750,6 +750,8 @@ def run_and_check_memory_leak(
         str(chunked_prefill_size),
         "--log-level",
         "debug",
+        "--device",
+        get_device(),
     ]
     if disable_radix_cache:
         other_args += ["--disable-radix-cache"]

--- a/test/lang/test_bind_cache.py
+++ b/test/lang/test_bind_cache.py
@@ -1,6 +1,7 @@
 import unittest
 
 import sglang as sgl
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST
 
 
@@ -9,7 +10,9 @@ class TestBind(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.backend = sgl.Runtime(model_path=DEFAULT_MODEL_NAME_FOR_TEST)
+        cls.backend = sgl.Runtime(
+            model_path=DEFAULT_MODEL_NAME_FOR_TEST, device=get_device()
+        )
         sgl.set_default_backend(cls.backend)
 
     @classmethod

--- a/test/srt/models/test_embedding_models.py
+++ b/test/srt/models/test_embedding_models.py
@@ -13,11 +13,13 @@
 # ==============================================================================
 
 import multiprocessing as mp
+import time
 import unittest
 
 import torch
 from transformers import AutoConfig, AutoTokenizer
 
+from sglang.srt.utils import get_device
 from sglang.test.runners import DEFAULT_PROMPTS, HFRunner, SRTRunner
 from sglang.test.test_utils import get_similarities
 
@@ -67,14 +69,16 @@ class TestEmbeddingModels(unittest.TestCase):
             model_path,
             torch_dtype=torch_dtype,
             model_type="embedding",
+            device=get_device(),
         ) as hf_runner:
             hf_outputs = hf_runner.forward(truncated_prompts)
-
+        time.sleep(60)
         with SRTRunner(
             model_path,
             tp_size=tp_size,
             torch_dtype=torch_dtype,
             model_type="embedding",
+            device=get_device(),
         ) as srt_runner:
             srt_outputs = srt_runner.forward(truncated_prompts)
 

--- a/test/srt/models/test_lora.py
+++ b/test/srt/models/test_lora.py
@@ -17,6 +17,7 @@ import unittest
 
 import torch
 
+from sglang.srt.utils import get_device
 from sglang.test.runners import HFRunner, SRTRunner
 
 LORA_SETS = [
@@ -91,32 +92,40 @@ class TestLoRA(unittest.TestCase):
             max_loras_per_batch=3,
             disable_cuda_graph=True,
             disable_radix_cache=True,
+            device=get_device(),
         ) as srt_runner:
             srt_outputs = srt_runner.forward(
                 prompts, max_new_tokens=max_new_tokens, lora_paths=batch_lora_paths
             )
-
+        sleep(60)
         with HFRunner(
-            base_path, torch_dtype=torch_dtype, model_type="generation"
+            base_path,
+            torch_dtype=torch_dtype,
+            model_type="generation",
+            device=get_device(),
         ) as hf_runner:
             hf_outputs = hf_runner.forward(
                 prompts, max_new_tokens=max_new_tokens, lora_paths=batch_lora_paths
             )
 
+        sleep(60)
         with HFRunner(
             base_path,
             torch_dtype=torch_dtype,
             model_type="generation",
+            device=get_device(),
         ) as hf_runner:
             hf_no_lora_outputs = hf_runner.forward(
                 prompts, max_new_tokens=max_new_tokens
             )
 
+        sleep(60)
         with SRTRunner(
             base_path,
             tp_size=tp_size,
             torch_dtype=torch_dtype,
             model_type="generation",
+            device=get_device(),
         ) as srt_runner:
             srt_no_lora_outputs = srt_runner.forward(
                 prompts, max_new_tokens=max_new_tokens
@@ -201,16 +210,19 @@ class TestLoRA(unittest.TestCase):
             max_loras_per_batch=3,
             disable_cuda_graph=True,
             disable_radix_cache=True,
+            device=get_device(),
         ) as srt_runner:
             srt_outputs = srt_runner.batch_forward(
                 prompts, max_new_tokens=max_new_tokens, lora_paths=batch_lora_paths
             )
+        sleep(60)
 
         with HFRunner(
             base_path,
             torch_dtype=torch_dtype,
             model_type="generation",
             output_str_only=True,
+            device=get_device(),
         ) as hf_runner:
             hf_outputs = hf_runner.forward(
                 prompts, max_new_tokens=max_new_tokens, lora_paths=batch_lora_paths
@@ -236,10 +248,12 @@ class TestLoRA(unittest.TestCase):
             tp_size=tp_size,
             torch_dtype=torch_dtype,
             model_type="generation",
+            device=get_device(),
         ) as srt_runner:
             srt_no_lora_outputs = srt_runner.forward(
                 prompts, max_new_tokens=max_new_tokens
             )
+        sleep(60)
 
         with SRTRunner(
             base_path,
@@ -247,6 +261,7 @@ class TestLoRA(unittest.TestCase):
             torch_dtype=torch_dtype,
             model_type="generation",
             lora_paths=all_lora_paths,
+            device=get_device(),
         ) as srt_runner:
             srt_outputs = srt_runner.forward(
                 prompts, max_new_tokens=max_new_tokens, lora_paths=batch_lora_paths

--- a/test/srt/models/test_qwen_models.py
+++ b/test/srt/models/test_qwen_models.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.few_shot_gsm8k import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -19,7 +19,7 @@ class TestQwen2(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[],
+            other_args=["--device", get_device()],
         )
 
     @classmethod
@@ -50,7 +50,7 @@ class TestQwen2FP8(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[],
+            other_args=["--device", get_device()],
         )
 
     @classmethod

--- a/test/srt/models/test_reward_models.py
+++ b/test/srt/models/test_reward_models.py
@@ -17,6 +17,7 @@ import unittest
 
 import torch
 
+from sglang.srt.utils import get_device
 from sglang.test.runners import HFRunner, SRTRunner
 
 MODELS = [
@@ -59,6 +60,7 @@ class TestRewardModels(unittest.TestCase):
             model_path,
             torch_dtype=torch_dtype,
             model_type="reward",
+            device=get_device(),
         ) as hf_runner:
             hf_outputs = hf_runner.forward(convs)
 
@@ -66,6 +68,7 @@ class TestRewardModels(unittest.TestCase):
             model_path,
             torch_dtype=torch_dtype,
             model_type="reward",
+            device=get_device(),
         ) as srt_runner:
             prompts = srt_runner.tokenizer.apply_chat_template(convs, tokenize=False)
             srt_outputs = srt_runner.forward(prompts)

--- a/test/srt/sampling/penaltylib/test_srt_endpoint_with_penalizers.py
+++ b/test/srt/sampling/penaltylib/test_srt_endpoint_with_penalizers.py
@@ -4,7 +4,7 @@ from multiprocessing import Process
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -26,6 +26,8 @@ class TestBatchPenalizerE2E(unittest.TestCase):
             other_args=(
                 "--random-seed",
                 "0",
+                "--device",
+                get_device(),
             ),
         )
 

--- a/test/srt/test_bench_one_batch.py
+++ b/test/srt/test_bench_one_batch.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_MOE_MODEL_NAME_FOR_TEST,
@@ -11,7 +12,9 @@ from sglang.test.test_utils import (
 
 class TestBenchOneBatch(unittest.TestCase):
     def test_bs1(self):
-        output_throughput = run_bench_one_batch(DEFAULT_MODEL_NAME_FOR_TEST, [])
+        output_throughput = run_bench_one_batch(
+            DEFAULT_MODEL_NAME_FOR_TEST, ["--device", get_device()]
+        )
 
         if is_in_ci():
             write_github_step_summary(
@@ -22,7 +25,7 @@ class TestBenchOneBatch(unittest.TestCase):
 
     def test_moe_tp2_bs1(self):
         output_throughput = run_bench_one_batch(
-            DEFAULT_MOE_MODEL_NAME_FOR_TEST, ["--tp", "2"]
+            DEFAULT_MOE_MODEL_NAME_FOR_TEST, ["--tp", "2", "--device", get_device()]
         )
 
         if is_in_ci():
@@ -35,7 +38,15 @@ class TestBenchOneBatch(unittest.TestCase):
     def test_torch_compile_tp2_bs1(self):
         output_throughput = run_bench_one_batch(
             DEFAULT_MODEL_NAME_FOR_TEST,
-            ["--tp", "2", "--enable-torch-compile", "--cuda-graph-max-bs", "2"],
+            [
+                "--tp",
+                "2",
+                "--enable-torch-compile",
+                "--cuda-graph-max-bs",
+                "2",
+                "--device",
+                get_device(),
+            ],
         )
 
         if is_in_ci():

--- a/test/srt/test_bench_serving.py
+++ b/test/srt/test_bench_serving.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import (
     DEFAULT_EAGLE_DRAFT_MODEL_FOR_TEST,
     DEFAULT_EAGLE_TARGET_MODEL_FOR_TEST,
@@ -19,7 +20,7 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             num_prompts=500,
             request_rate=float("inf"),
-            other_server_args=[],
+            other_server_args=["--device", get_device()],
         )
 
         if is_in_ci():
@@ -34,7 +35,12 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             num_prompts=200,
             request_rate=float("inf"),
-            other_server_args=["--max-running-requests", "10"],
+            other_server_args=[
+                "--max-running-requests",
+                "10",
+                "--device",
+                get_device(),
+            ],
             dataset_name="sharegpt",
             random_input_len=None,
             random_output_len=None,
@@ -56,7 +62,7 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             num_prompts=500,
             request_rate=float("inf"),
-            other_server_args=["--disable-radix-cache"],
+            other_server_args=["--disable-radix-cache", "--device", get_device()],
         )
 
         if is_in_ci():
@@ -71,7 +77,12 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             num_prompts=500,
             request_rate=float("inf"),
-            other_server_args=["--chunked-prefill-size", "-1"],
+            other_server_args=[
+                "--chunked-prefill-size",
+                "-1",
+                "--device",
+                get_device(),
+            ],
         )
 
         if is_in_ci():
@@ -91,6 +102,8 @@ class TestBenchServing(unittest.TestCase):
                 "triton",
                 "--context-length",
                 "8192",
+                "--device",
+                get_device(),
             ],
         )
 
@@ -106,7 +119,7 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_FP8_MODEL_NAME_FOR_TEST,
             num_prompts=500,
             request_rate=float("inf"),
-            other_server_args=[],
+            other_server_args=["--device", get_device()],
         )
 
         if is_in_ci():
@@ -121,7 +134,7 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             num_prompts=100,
             request_rate=1,
-            other_server_args=[],
+            other_server_args=["--device", get_device()],
         )
 
         if is_in_ci():
@@ -155,6 +168,8 @@ class TestBenchServing(unittest.TestCase):
                 "0.7",
                 "--cuda-graph-max-bs",
                 "32",
+                "--device",
+                get_device(),
             ],
         )
 
@@ -170,7 +185,7 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MOE_MODEL_NAME_FOR_TEST,
             num_prompts=300,
             request_rate=float("inf"),
-            other_server_args=["--tp", "2"],
+            other_server_args=["--tp", "2", "--device", get_device()],
         )
 
         if is_in_ci():
@@ -185,7 +200,13 @@ class TestBenchServing(unittest.TestCase):
             model=DEFAULT_MOE_MODEL_NAME_FOR_TEST,
             num_prompts=300,
             request_rate=float("inf"),
-            other_server_args=["--tp", "2", "--disable-radix-cache"],
+            other_server_args=[
+                "--tp",
+                "2",
+                "--disable-radix-cache",
+                "--device",
+                get_device(),
+            ],
         )
 
         if is_in_ci():

--- a/test/srt/test_cache_report.py
+++ b/test/srt/test_cache_report.py
@@ -4,7 +4,7 @@ import unittest
 import openai
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_URL_FOR_TEST,
@@ -25,6 +25,8 @@ class TestCacheReport(unittest.TestCase):
             other_args=[
                 "--chunked-prefill-size=40",
                 "--enable-cache-report",
+                "--device",
+                get_device(),
             ],
         )
         cls.client = openai.Client(api_key="EMPTY", base_url=f"{cls.base_url}/v1")

--- a/test/srt/test_data_parallelism.py
+++ b/test/srt/test_data_parallelism.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -23,7 +23,7 @@ class TestDataParallelism(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--dp", "2"],
+            other_args=["--dp", "2", "--device", get_device()],
         )
 
     @classmethod

--- a/test/srt/test_double_sparsity.py
+++ b/test/srt/test_double_sparsity.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -40,6 +40,8 @@ class TestDoubleSparsity(unittest.TestCase):
                 "0",
                 "--max-total-tokens",
                 "200000",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_dp_attention.py
+++ b/test/srt/test_dp_attention.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
@@ -25,6 +25,8 @@ class TestDPAttention(unittest.TestCase):
                 "--tp",
                 "2",
                 "--enable-dp-attention",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_ebnf_constrained.py
+++ b/test/srt/test_ebnf_constrained.py
@@ -8,7 +8,7 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -27,6 +27,8 @@ def setup_class(cls, disable_overlap: bool):
         "10",
         "--grammar-backend",
         "xgrammar",
+        "--device",
+        get_device(),
     ]
 
     if disable_overlap:

--- a/test/srt/test_embedding_openai_server.py
+++ b/test/srt/test_embedding_openai_server.py
@@ -3,7 +3,7 @@ import unittest
 import openai
 
 from sglang.srt.hf_transformers_utils import get_tokenizer
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -22,6 +22,7 @@ class TestOpenAIServer(unittest.TestCase):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
+            other_args=["--device", get_device()],
         )
         cls.base_url += "/v1"
         cls.tokenizer = get_tokenizer(cls.model)

--- a/test/srt/test_eval_accuracy_large.py
+++ b/test/srt/test_eval_accuracy_large.py
@@ -6,7 +6,7 @@ python -m unittest test_eval_accuracy_large.TestEvalAccuracyLarge.test_mmlu
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -25,7 +25,7 @@ class TestEvalAccuracyLarge(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--log-level-http", "warning"],
+            other_args=["--log-level-http", "warning", "--device", get_device()],
         )
 
     @classmethod

--- a/test/srt/test_eval_accuracy_large_chunked_prefill.py
+++ b/test/srt/test_eval_accuracy_large_chunked_prefill.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -20,7 +20,14 @@ class TestEvalAccuracyLargeChunkedPrefill(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--log-level-http", "warning", "--chunked-prefill-size", "256"],
+            other_args=[
+                "--log-level-http",
+                "warning",
+                "--chunked-prefill-size",
+                "256",
+                "--device",
+                get_device(),
+            ],
         )
 
     @classmethod

--- a/test/srt/test_eval_accuracy_large_mixed_chunked_prefill.py
+++ b/test/srt/test_eval_accuracy_large_mixed_chunked_prefill.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -26,6 +26,8 @@ class TestEvalAccuracyLargeChunkedPrefill(unittest.TestCase):
                 "--chunked-prefill-size",
                 "256",
                 "--enable-mixed-chunk",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_eval_accuracy_mini.py
+++ b/test/srt/test_eval_accuracy_mini.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -17,7 +17,10 @@ class TestEvalAccuracyMini(unittest.TestCase):
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
-            cls.model, cls.base_url, timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--device", get_device()],
         )
 
     @classmethod

--- a/test/srt/test_fp8_kvcache.py
+++ b/test/srt/test_fp8_kvcache.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -35,6 +35,8 @@ class TestFp8KvcacheBase(unittest.TestCase):
                 "fp8_e4m3",
                 "--quantization-param-path",
                 config_file,
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_function_calling.py
+++ b/test/srt/test_function_calling.py
@@ -5,7 +5,7 @@ import unittest
 import openai
 
 from sglang.srt.hf_transformers_utils import get_tokenizer
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -32,6 +32,8 @@ class TestOpenAIServerFunctionCalling(unittest.TestCase):
                 # If your server needs extra parameters to test function calling, please add them here.
                 "--tool-call-parser",
                 "llama3",
+                "--device",
+                get_device(),
             ],
         )
         cls.base_url += "/v1"
@@ -238,11 +240,11 @@ class TestOpenAIServerFunctionCalling(unittest.TestCase):
         self.assertIn("a", args_obj, "Missing parameter 'a'")
         self.assertIn("b", args_obj, "Missing parameter 'b'")
         self.assertEqual(
-            args_obj["a"],
+            int(args_obj["a"]),
             5,
             "Parameter a should be 5",
         )
-        self.assertEqual(args_obj["b"], 7, "Parameter b should be 7")
+        self.assertEqual(int(args_obj["b"]), 7, "Parameter b should be 7")
 
 
 if __name__ == "__main__":

--- a/test/srt/test_gguf.py
+++ b/test/srt/test_gguf.py
@@ -3,6 +3,7 @@ import unittest
 from huggingface_hub import hf_hub_download
 
 import sglang as sgl
+from sglang.srt.utils import get_device
 
 
 class TestGGUF(unittest.TestCase):
@@ -15,7 +16,7 @@ class TestGGUF(unittest.TestCase):
             filename="qwen2-1_5b-instruct-q4_k_m.gguf",
         )
 
-        engine = sgl.Engine(model_path=model_path, random_seed=42)
+        engine = sgl.Engine(model_path=model_path, random_seed=42, device=get_device())
         outputs = engine.generate(prompt, sampling_params)["text"]
         engine.shutdown()
 

--- a/test/srt/test_hidden_states.py
+++ b/test/srt/test_hidden_states.py
@@ -4,6 +4,7 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import sglang as sgl
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import is_in_ci
 
 
@@ -21,6 +22,7 @@ class TestHiddenState(unittest.TestCase):
             random_seed=42,
             return_hidden_states=True,
             skip_tokenizer_init=True,
+            device=get_device(),
         )
         outputs = engine.generate(input_ids=input_ids, sampling_params=sampling_params)
         engine.shutdown()
@@ -36,7 +38,7 @@ class TestHiddenState(unittest.TestCase):
         )
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_path, torch_dtype=torch.bfloat16, device_map="cuda"
+            model_path, torch_dtype=torch.bfloat16, device_map=get_device()
         )
 
         for input_id, output in zip(input_ids, outputs):
@@ -54,7 +56,7 @@ class TestHiddenState(unittest.TestCase):
                     i.unsqueeze(0) if len(i.shape) == 1 else i
                     for i in output["meta_info"]["hidden_states"]
                 ]
-            ).to("cuda")
+            ).to(get_device())
             print("=== SRT Hiddens ===")
             print(sg_hidden_states)
 

--- a/test/srt/test_input_embeddings.py
+++ b/test/srt/test_input_embeddings.py
@@ -4,7 +4,7 @@ import unittest
 import requests
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -24,7 +24,7 @@ class TestInputEmbeds(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--disable-radix"],
+            other_args=["--disable-radix", "--device", get_device()],
         )
         cls.texts = [
             "The capital of France is",

--- a/test/srt/test_json_constrained.py
+++ b/test/srt/test_json_constrained.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 import openai
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -38,6 +38,8 @@ def setup_class(cls, backend: str, disable_overlap: bool):
         "10",
         "--grammar-backend",
         backend,
+        "--device",
+        get_device(),
     ]
 
     if disable_overlap:

--- a/test/srt/test_large_max_new_tokens.py
+++ b/test/srt/test_large_max_new_tokens.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 import openai
 
 from sglang.srt.hf_transformers_utils import get_tokenizer
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -43,6 +43,8 @@ class TestLargeMaxNewTokens(unittest.TestCase):
                 "8192",
                 "--decode-log-interval",
                 "2",
+                "--device",
+                get_device(),
             ),
             env={"SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION": "256", **os.environ},
             return_stdout_stderr=(cls.stdout, cls.stderr),

--- a/test/srt/test_matched_stop.py
+++ b/test/srt/test_matched_stop.py
@@ -3,7 +3,7 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_URL_FOR_TEST,
@@ -27,7 +27,7 @@ class TestMatchedStop(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=300,
-            other_args=["--max-running-requests", "10"],
+            other_args=["--max-running-requests", "10", "--device", get_device()],
         )
 
     @classmethod

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -18,7 +18,7 @@ class TestEnableMetrics(unittest.TestCase):
             DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--enable-metrics"],
+            other_args=["--enable-metrics", "--device", get_device()],
         )
 
         try:

--- a/test/srt/test_mla.py
+++ b/test/srt/test_mla.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
@@ -23,7 +23,7 @@ class TestMLA(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--trust-remote-code"],
+            other_args=["--trust-remote-code", "--device", get_device()],
         )
 
     @classmethod
@@ -62,7 +62,15 @@ class TestDeepseekV3(unittest.TestCase):
         cls.base_url = DEFAULT_URL_FOR_TEST
         other_args = ["--trust-remote-code"]
         if torch.cuda.is_available() and torch.version.cuda:
-            other_args.extend(["--enable-torch-compile", "--cuda-graph-max-bs", "2"])
+            other_args.extend(
+                [
+                    "--enable-torch-compile",
+                    "--cuda-graph-max-bs",
+                    "2",
+                    "--device",
+                    get_device(),
+                ]
+            )
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -115,6 +123,8 @@ class TestDeepseekV3MTP(unittest.TestCase):
                     "4",
                     "--speculative-num-draft-tokens",
                     "4",
+                    "--device",
+                    get_device(),
                 ]
             )
         cls.process = popen_launch_server(

--- a/test/srt/test_mla_fp8.py
+++ b/test/srt/test_mla_fp8.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MLA_FP8_MODEL_NAME_FOR_TEST,
@@ -24,6 +24,8 @@ class TestMLA(unittest.TestCase):
                 "--trust-remote-code",
                 "--kv-cache-dtype",
                 "fp8_e5m2",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_moe_ep.py
+++ b/test/srt/test_moe_ep.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
@@ -27,6 +27,8 @@ class TestEpMoE(unittest.TestCase):
                 "--ep-size",
                 "2",
                 "--enable-ep-moe",
+                "--device",
+                get_device(),
             ],
         )
 
@@ -77,6 +79,8 @@ class TestEpMoEFP8(unittest.TestCase):
                 "--enable-ep-moe",
                 "--quantization",
                 "fp8",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_moe_eval_accuracy_large.py
+++ b/test/srt/test_moe_eval_accuracy_large.py
@@ -6,7 +6,7 @@ python -m unittest test_moe_eval_accuracy_large.TestMoEEvalAccuracyLarge.test_mm
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MOE_MODEL_NAME_FOR_TEST,
@@ -30,6 +30,8 @@ class TestMoEEvalAccuracyLarge(unittest.TestCase):
                 "warning",
                 "--tp",
                 "2",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_nightly_gsm8k_eval.py
+++ b/test/srt/test_nightly_gsm8k_eval.py
@@ -5,7 +5,7 @@ import warnings
 from datetime import datetime
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_NIGHTLY_EVAL_FP8_TP1,
@@ -46,7 +46,13 @@ def parse_models(model_string):
 
 
 def popen_launch_server_wrapper(base_url, model, is_fp8, is_tp2):
-    other_args = ["--log-level-http", "warning", "--trust-remote-code"]
+    other_args = [
+        "--log-level-http",
+        "warning",
+        "--trust-remote-code",
+        "--device",
+        get_device(),
+    ]
     if is_fp8:
         if "Llama-3" in model or "gemma-2" in model:
             other_args.extend(["--kv-cache-dtype", "fp8_e5m2"])

--- a/test/srt/test_no_chunked_prefill.py
+++ b/test/srt/test_no_chunked_prefill.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     run_bench_serving,
@@ -19,7 +20,13 @@ class TestNoChunkedPrefill(unittest.TestCase):
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             num_prompts=10,
             request_rate=float("inf"),
-            other_server_args=["--disable-radix-cache", "--chunked-prefill-size", "-1"],
+            other_server_args=[
+                "--disable-radix-cache",
+                "--chunked-prefill-size",
+                "-1",
+                "--device",
+                get_device(),
+            ],
         )
 
         assert res["completed"] == 10

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -12,7 +12,7 @@ import unittest
 import openai
 
 from sglang.srt.hf_transformers_utils import get_tokenizer
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_EMBEDDING_MODEL_NAME_FOR_TEST,
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -33,6 +33,7 @@ class TestOpenAIServer(unittest.TestCase):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
+            other_args=["--device", get_device()],
         )
         cls.base_url += "/v1"
         cls.tokenizer = get_tokenizer(DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
@@ -549,7 +550,7 @@ class TestOpenAIServerEBNF(unittest.TestCase):
         cls.api_key = "sk-123456"
 
         # passing xgrammar specifically
-        other_args = ["--grammar-backend", "xgrammar"]
+        other_args = ["--grammar-backend", "xgrammar", "--device", get_device()]
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -632,7 +633,7 @@ class TestOpenAIEmbedding(unittest.TestCase):
         cls.api_key = "sk-123456"
 
         # Configure embedding-specific args
-        other_args = ["--is-embedding", "--enable-metrics"]
+        other_args = ["--is-embedding", "--enable-metrics", "--device", get_device()]
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,

--- a/test/srt/test_pytorch_sampling_backend.py
+++ b/test/srt/test_pytorch_sampling_backend.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -22,7 +22,13 @@ class TestPyTorchSamplingBackend(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--sampling-backend", "pytorch", "--disable-radix-cache"],
+            other_args=[
+                "--sampling-backend",
+                "pytorch",
+                "--disable-radix-cache",
+                "--device",
+                get_device(),
+            ],
         )
 
     @classmethod

--- a/test/srt/test_radix_attention.py
+++ b/test/srt/test_radix_attention.py
@@ -4,6 +4,7 @@ import unittest
 
 import requests
 
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -75,6 +76,8 @@ class TestRadixCacheFCFS(unittest.TestCase):
                 "20000",
                 "--schedule-policy",
                 "fcfs",
+                "--device",
+                get_device(),
             ],
         )
 
@@ -103,6 +106,8 @@ class TestRadixCacheLPM(TestRadixCacheFCFS):
                 "20000",
                 "--schedule-policy",
                 "lpm",
+                "--device",
+                get_device(),
             ],
         )
 
@@ -124,6 +129,8 @@ class TestRadixCacheNonOverlapLPM(TestRadixCacheFCFS):
                 "20000",
                 "--schedule-policy",
                 "lpm",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_regex_constrained.py
+++ b/test/srt/test_regex_constrained.py
@@ -8,7 +8,7 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -26,6 +26,8 @@ def setup_class(cls, disable_overlap: bool):
         "10",
         "--grammar-backend",
         "xgrammar",
+        "--device",
+        get_device(),
     ]
 
     if disable_overlap:

--- a/test/srt/test_release_memory_occupation.py
+++ b/test/srt/test_release_memory_occupation.py
@@ -5,6 +5,7 @@ import torch
 from transformers import AutoModelForCausalLM
 
 import sglang as sgl
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 # (temporarily) set to true to observe memory usage in nvidia-smi more clearly
@@ -22,6 +23,7 @@ class TestReleaseMemoryOccupation(unittest.TestCase):
             model_path=model_name,
             random_seed=42,
             enable_memory_saver=True,
+            device=get_device(),
             # disable_cuda_graph=True,  # for debugging only
         )
         hf_model_new = AutoModelForCausalLM.from_pretrained(
@@ -87,8 +89,9 @@ class TestReleaseMemoryOccupation(unittest.TestCase):
 
 def _try_allocate_big_tensor(size: int = 20_000_000_000):
     try:
-        torch.empty((size,), dtype=torch.uint8, device="cuda")
-        torch.cuda.empty_cache()
+        torch.empty((size,), dtype=torch.uint8, device=get_device())
+        if "cuda" in get_device():
+            torch.cuda.empty_cache()
         return True
     except torch.cuda.OutOfMemoryError:
         return False

--- a/test/srt/test_request_length_validation.py
+++ b/test/srt/test_request_length_validation.py
@@ -2,7 +2,7 @@ import unittest
 
 import openai
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -23,7 +23,14 @@ class TestRequestLengthValidation(unittest.TestCase):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
-            other_args=("--max-total-tokens", "1000", "--context-length", "100"),
+            other_args=(
+                "--max-total-tokens",
+                "1000",
+                "--context-length",
+                "100",
+                "--device",
+                get_device(),
+            ),
         )
 
     @classmethod

--- a/test/srt/test_retract_decode.py
+++ b/test/srt/test_retract_decode.py
@@ -1,7 +1,7 @@
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -17,7 +17,10 @@ class TestRetractDecode(unittest.TestCase):
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
-            cls.model, cls.base_url, timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=("--device", get_device()),
         )
 
     @classmethod

--- a/test/srt/test_session_control.py
+++ b/test/srt/test_session_control.py
@@ -14,7 +14,7 @@ import aiohttp
 import requests
 
 from sglang.srt.hf_transformers_utils import get_tokenizer
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -33,7 +33,10 @@ class TestSessionControl(unittest.TestCase):
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
-            cls.model, cls.base_url, timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args={"--device", get_device()},
         )
 
     @classmethod
@@ -503,6 +506,7 @@ class TestSessionControlVision(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args={"--device", get_device()},
             # other_args={"--disable-radix"},
         )
 

--- a/test/srt/test_skip_tokenizer_init.py
+++ b/test/srt/test_skip_tokenizer_init.py
@@ -4,7 +4,7 @@ import unittest
 import requests
 from transformers import AutoTokenizer
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -26,7 +26,7 @@ def setUpModule():
         DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
         DEFAULT_URL_FOR_TEST,
         timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-        other_args=["--skip-tokenizer-init"],
+        other_args=["--skip-tokenizer-init", "--device", get_device()],
     )
     _base_url = DEFAULT_URL_FOR_TEST
 

--- a/test/srt/test_srt_endpoint.py
+++ b/test/srt/test_srt_endpoint.py
@@ -14,7 +14,7 @@ import numpy as np
 import requests
 
 from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -36,6 +36,8 @@ class TestSRTEndpoint(unittest.TestCase):
                 "--enable-custom-logit-processor",
                 "--mem-fraction-static",
                 "0.8",
+                "--device",
+                get_device(),
             ),
         )
 

--- a/test/srt/test_srt_engine_with_quant_args.py
+++ b/test/srt/test_srt_engine_with_quant_args.py
@@ -1,6 +1,7 @@
 import unittest
 
 import sglang as sgl
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 
@@ -27,7 +28,10 @@ class TestSRTEngineWithQuantArgs(unittest.TestCase):
 
         for quantization_args in quantization_args_list:
             engine = sgl.Engine(
-                model_path=model_path, random_seed=42, quantization=quantization_args
+                model_path=model_path,
+                random_seed=42,
+                quantization=quantization_args,
+                device=get_device(),
             )
             engine.generate(prompt, sampling_params)
             engine.shutdown()
@@ -50,7 +54,10 @@ class TestSRTEngineWithQuantArgs(unittest.TestCase):
 
         for torchao_config in torchao_args_list:
             engine = sgl.Engine(
-                model_path=model_path, random_seed=42, torchao_config=torchao_config
+                model_path=model_path,
+                random_seed=42,
+                torchao_config=torchao_config,
+                device=get_device(),
             )
             engine.generate(prompt, sampling_params)
             engine.shutdown()

--- a/test/srt/test_torch_compile.py
+++ b/test/srt/test_torch_compile.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -23,7 +23,13 @@ class TestTorchCompile(unittest.TestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--enable-torch-compile", "--cuda-graph-max-bs", "4"],
+            other_args=[
+                "--enable-torch-compile",
+                "--cuda-graph-max-bs",
+                "4",
+                "--device",
+                get_device(),
+            ],
         )
 
     @classmethod

--- a/test/srt/test_torch_native_attention_backend.py
+++ b/test/srt/test_torch_native_attention_backend.py
@@ -6,7 +6,7 @@ python3 -m unittest test_triton_attention_backend.TestTritonAttnBackend.test_mml
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
@@ -22,7 +22,7 @@ class TestTorchNativeAttnBackend(unittest.TestCase):
     def test_latency(self):
         output_throughput = run_bench_one_batch(
             DEFAULT_MODEL_NAME_FOR_TEST,
-            ["--attention-backend", "torch_native"],
+            ["--attention-backend", "torch_native", "--device", get_device()],
         )
 
         if is_in_ci():
@@ -36,7 +36,12 @@ class TestTorchNativeAttnBackend(unittest.TestCase):
             model,
             base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--attention-backend", "torch_native"],
+            other_args=[
+                "--attention-backend",
+                "torch_native",
+                "--device",
+                get_device(),
+            ],
         )
 
         try:

--- a/test/srt/test_torch_tp.py
+++ b/test/srt/test_torch_tp.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import is_in_ci, run_bench_one_batch
 
 
@@ -13,6 +14,8 @@ class TestTorchTP(unittest.TestCase):
                 "--json-model-override-args",
                 '{"architectures": ["TorchNativeLlamaForCausalLM"]}',
                 "--disable-cuda-graph",
+                "--device",
+                get_device(),
             ],
         )
 

--- a/test/srt/test_update_weights_from_disk.py
+++ b/test/srt/test_update_weights_from_disk.py
@@ -3,7 +3,7 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -18,7 +18,10 @@ class TestUpdateWeights(unittest.TestCase):
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
-            cls.model, cls.base_url, timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--device", get_device()],
         )
 
     @classmethod

--- a/test/srt/test_vision_chunked_prefill.py
+++ b/test/srt/test_vision_chunked_prefill.py
@@ -15,7 +15,7 @@ import requests
 from decord import VideoReader, cpu
 from PIL import Image
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import get_device, kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -134,6 +134,8 @@ class TestVisionChunkedPrefill(unittest.TestCase):
             other_args=[
                 "--chunked-prefill-size",
                 f"{chunked_prefill_size}",
+                "--device",
+                get_device(),
             ],
         )
         try:


### PR DESCRIPTION

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

SGLang’s SRT tests were originally designed to run on CUDA-enabled devices. Added support to run SRT tests on HPU and XPU.

## Modifications
- Updated device selection logic to support XPU and HPU.
- Updated SRT and HF test runner to support device arg.
- Updated SRT models test to run with other then CUDA.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit). Done
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci). Not required
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci). Not required
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results] (https://docs.sglang.ai/references/accuracy_evaluation.html). Not required
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
