### PR TITLE
Add Gemlite to Test and Quantization Docs

### DIFF
--- a/docs/references/quantization.md
+++ b/docs/references/quantization.md
@@ -85,6 +85,8 @@ python3 -m sglang.launch_server \
 
 We support the following quantization methods based on torchao `["int8dq", "int8wo", "fp8wo", "fp8dq-per_tensor", "fp8dq-per_row", "int4wo-32", "int4wo-64", "int4wo-128", "int4wo-256"]`.
 
+We also support [gemlite](https://github.com/mobiusml/gemlite) quantization method based on torchao `["gemlite-<packing_bitwidth>-<bit_width>-<group_size>", "gemlite-<bit_width>-<group_size>"]`.
+
 Note: According to [this issue](https://github.com/sgl-project/sglang/issues/2219#issuecomment-2561890230), `"int8dq"` method currently has some bugs when using together with cuda graph capture. So we suggest to disable cuda graph capture when using `"int8dq"` method. Namely, please use the following command:
 
 ```bash

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,12 @@ runtime_common = [
     "hf_transfer", "huggingface_hub", "interegular", "modelscope",
     "orjson", "packaging", "pillow", "prometheus-client>=0.20.0",
     "psutil", "pydantic", "python-multipart", "pyzmq>=25.1.2",
+<<<<<<< HEAD
     "torchao>=0.7.0", "uvicorn", "uvloop", "xgrammar==0.1.10", "ninja", "transformers==4.48.3"
+=======
+    "torchao>=0.7.0", "uvicorn", "uvloop", "xgrammar==0.1.10", "ninja", "transformers==4.48.3",
+    "gemlite>=0.4.2"
+>>>>>>> 2b383acb (Add test for gemlite)
 ]
 srt = [
     "sglang[runtime_common]", "cuda-python",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,12 +21,8 @@ runtime_common = [
     "hf_transfer", "huggingface_hub", "interegular", "modelscope",
     "orjson", "packaging", "pillow", "prometheus-client>=0.20.0",
     "psutil", "pydantic", "python-multipart", "pyzmq>=25.1.2",
-<<<<<<< HEAD
-    "torchao>=0.7.0", "uvicorn", "uvloop", "xgrammar==0.1.10", "ninja", "transformers==4.48.3"
-=======
     "torchao>=0.7.0", "uvicorn", "uvloop", "xgrammar==0.1.10", "ninja", "transformers==4.48.3",
     "gemlite>=0.4.2"
->>>>>>> 2b383acb (Add test for gemlite)
 ]
 srt = [
     "sglang[runtime_common]", "cuda-python",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -861,7 +861,7 @@ class ServerArgs:
             "--torchao-config",
             type=str,
             default=ServerArgs.torchao_config,
-            help="Optimize the model with torchao. Experimental feature. Current choices are: int8dq, int8wo, int4wo-<group_size>, fp8wo, fp8dq-per_tensor, fp8dq-per_row",
+            help="Optimize the model with torchao. Experimental feature. Current choices are: int8dq, int8wo, int4wo-<group_size>, fp8wo, fp8dq-per_tensor, fp8dq-per_row, gemlite-<packing_bitwidth>-<bit_width>-<group_size>",
         )
         parser.add_argument(
             "--enable-nan-detection",

--- a/test/srt/test_srt_engine_with_quant_args.py
+++ b/test/srt/test_srt_engine_with_quant_args.py
@@ -35,16 +35,20 @@ class TestSRTEngineWithQuantArgs(unittest.TestCase):
     def test_2_torchao_args(self):
 
         # we don't test int8dq because currently there is conflict between int8dq and capture cuda graph
-        torchao_args_list = [
-            # "int8dq",
-            "int8wo",
-            "fp8wo",
-            "fp8dq-per_tensor",
-            "fp8dq-per_row",
-        ] + [f"int4wo-{group_size}" for group_size in [32, 64, 128, 256]] + [
-            "gemlite-32-8-None",
-            "gemlite-8-8-None",
-        ]
+        torchao_args_list = (
+            [
+                # "int8dq",
+                "int8wo",
+                "fp8wo",
+                "fp8dq-per_tensor",
+                "fp8dq-per_row",
+            ]
+            + [f"int4wo-{group_size}" for group_size in [32, 64, 128, 256]]
+            + [
+                "gemlite-32-8-None",
+                "gemlite-8-8-None",
+            ]
+        )
         # gemlite-<packing_bitwidth>-<bit_width>-<group_size> or
         # gemlite-<bit_width>-<group_size> (packing_bitwidth defaults to 32)
         # We don't exhausted all combinations, only test the main logic

--- a/test/srt/test_srt_engine_with_quant_args.py
+++ b/test/srt/test_srt_engine_with_quant_args.py
@@ -41,7 +41,13 @@ class TestSRTEngineWithQuantArgs(unittest.TestCase):
             "fp8wo",
             "fp8dq-per_tensor",
             "fp8dq-per_row",
-        ] + [f"int4wo-{group_size}" for group_size in [32, 64, 128, 256]]
+        ] + [f"int4wo-{group_size}" for group_size in [32, 64, 128, 256]] + [
+            "gemlite-32-8-None",
+            "gemlite-8-8-None",
+        ]
+        # gemlite-<packing_bitwidth>-<bit_width>-<group_size> or
+        # gemlite-<bit_width>-<group_size> (packing_bitwidth defaults to 32)
+        # We don't exhausted all combinations, only test the main logic
 
         prompt = "Today is a sunny day and I like"
         model_path = DEFAULT_SMALL_MODEL_NAME_FOR_TEST


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Gemlite is already integrated (See https://github.com/sgl-project/sglang/pulls?q=is:pr+gemlite+is:closed)  in both TorchAO and SGLang, but it's missing in the quantization docs: https://docs.sglang.ai/references/quantization.html

Also I benchmarked Gemlite and found it's indeed faster in decoding, so I raised this PR to cover the test and include Gemlite in the docs.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
- Added Gemlite into pyproject.toml
- Added Gemlite as quantization test
- Modified Quantization Docs.

<!-- Describe the changes made in this PR. -->

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [X] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [X] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [X] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [X] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [X] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
