### PR TITLE
fix #3708: prevent scheduler for hogging a full CPU thread when idle

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -481,6 +481,8 @@ class Scheduler:
                 # When the server is idle, so self-check and re-init some states
                 self.check_memory()
                 self.new_token_ratio = self.init_new_token_ratio
+                # Wait for a bit to prevent heavy single thread load
+                time.sleep(0.01)
 
             self.last_batch = batch
 
@@ -521,6 +523,8 @@ class Scheduler:
                 # When the server is idle, so self-check and re-init some states
                 self.check_memory()
                 self.new_token_ratio = self.init_new_token_ratio
+                # Wait for a bit to prevent heavy single thread load
+                time.sleep(0.01)
 
             self.last_batch = batch
 


### PR DESCRIPTION
Seems to work without much impact on performance - and it keeps the scheduler thread from hammering a single thread 100%. I suppose maybe TTFB might be delayed by a max of 0.01 second.

Do we maybe want to make this time configurable? Or dynamic (slowly increase sleep time)?

## Motivation

https://github.com/sgl-project/sglang/issues/3708

## Modifications

Added a small sleep (0.01 second) in the scheduler when server is idle.

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [X] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [X] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
