### PR TITLE
Support building Dockerfile and Dockerfile.rocm using local repo.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-ARG CUDA_VERSION=12.5.1
+# Set to "local" to build from local repo, repo root must be set as docker context.
+ARG SGL_REPO_SOURCE="remote"
 
 FROM nvcr.io/nvidia/tritonserver:24.04-py3-min
 
@@ -26,9 +27,22 @@ RUN pip3 install datamodel_code_generator
 
 WORKDIR /sgl-workspace
 
-ARG CUDA_VERSION
+FROM base AS sglang-remote
+RUN git clone ${SGL_REPO} \
+    && cd sglang \
+    && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
+         echo "Using ${SGL_DEFAULT}, default branch."; \
+       else \
+         echo "Using ${SGL_BRANCH} branch."; \
+         git checkout ${SGL_BRANCH}; \
+       fi
+
+FROM base AS sglang-local
+COPY . /sgl-workspace/sglang
+
+FROM sglang-${SGL_REPO_SOURCE} AS sglang
+ARG CUDA_VERSION=12.5.1
 RUN python3 -m pip install --upgrade pip setuptools wheel html5lib six \
-    && git clone --depth=1 https://github.com/sgl-project/sglang.git \
     && if [ "$CUDA_VERSION" = "12.1.1" ]; then \
          python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu121; \
        elif [ "$CUDA_VERSION" = "12.4.1" ]; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Set to "local" to build from local repo, repo root must be set as docker context.
 ARG SGL_REPO_SOURCE="remote"
 
-FROM nvcr.io/nvidia/tritonserver:24.04-py3-min
+FROM nvcr.io/nvidia/tritonserver:24.04-py3-min AS base
 
 ARG BUILD_TYPE=all
 ENV DEBIAN_FRONTEND=noninteractive
@@ -26,6 +26,9 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
 RUN pip3 install datamodel_code_generator
 
 WORKDIR /sgl-workspace
+ARG SGL_REPO="https://github.com/sgl-project/sglang"
+ENV SGL_DEFAULT="main"
+ARG SGL_BRANCH=${SGL_DEFAULT}
 
 FROM base AS sglang-remote
 RUN git clone ${SGL_REPO} \

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -3,6 +3,8 @@
 
 # default base image
 ARG BASE_IMAGE="rocm/vllm-dev:20250114"
+# Set to "local" to build from local repo, repo root must be set as docker context.
+ARG SGL_REPO_SOURCE="remote"
 
 FROM $BASE_IMAGE AS base
 USER root
@@ -20,6 +22,7 @@ ARG TRITON_COMMIT="improve_fa_decode_3.0.0"
 ARG ATER_REPO="https://github.com/HaiShaw/ater"
 ARG CK_COMMITS="fa05ae"
 
+FROM base AS sglang-remote
 RUN git clone ${SGL_REPO} \
     && cd sglang \
     && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
@@ -27,8 +30,14 @@ RUN git clone ${SGL_REPO} \
        else \
          echo "Using ${SGL_BRANCH} branch."; \
          git checkout ${SGL_BRANCH}; \
-       fi \
-    && cd sgl-kernel \
+       fi
+
+FROM base AS sglang-local
+COPY . /sgl-workspace/sglang
+
+FROM sglang-${SGL_REPO_SOURCE} AS sglang
+
+RUN cd sglang/sgl-kernel \
     && python setup_rocm.py install \
     && cd .. \
     && if [ "$BUILD_TYPE" = "srt" ]; then \


### PR DESCRIPTION
## Motivation

When regularly building docker images to test I eventually got annoyed enough to add an option to copy sglang code from local instead of cloning from a remote.

## Modifications

Support copying sglang code from local, as well as still defaulting to cloning from a remote.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
