### PR TITLE
[bug] fixed batch api

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -162,6 +162,7 @@ class DetokenizerManager:
 
             # Incremental decoding
             output_strs = []
+            finished_reqs = []
             for i in range(bs):
                 try:
                     s = self.decode_status[recv_obj.rids[i]]
@@ -184,6 +185,8 @@ class DetokenizerManager:
                         new_text = ""
                     else:
                         new_text = find_printable_text(new_text)
+                else:
+                    finished_reqs.append(recv_obj.rids[i])
 
                 output_strs.append(
                     self.trim_matched_stop(
@@ -213,6 +216,10 @@ class DetokenizerManager:
                     output_hidden_states=recv_obj.output_hidden_states,
                 )
             )
+
+            # remove decodestatus for completed requests
+            for rid in finished_reqs:
+                self.decode_status.pop(rid)
 
 
 class LimitedCapacityDict(OrderedDict):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When using the [batch API](https://docs.sglang.ai/backend/openai_api_completions.html#Batches), the server crashes due to assertion error (assert len(output) > 0) as stated in #3477 and #2762

## Modifications

This PR fixed this bug. The bug occurred because the detokenizer manager fails manage the lifecycle of `DecodeStatus`. 

Causes of Error:
- When the user creates multiple requests with the same "custom_id", for example, a user executes the scripts provided in [batch API](https://docs.sglang.ai/backend/openai_api_completions.html#Batches) for multiple times.
- For the first time, the server will create a new `DecodeStatus` object to track the decoding progress. However, for the subsequence requests, the server checks that since they are using the same `custom-id`, the detokenizer manager will find the `DecodeStatus` object created for the first request and re-uses it instead of creating a new one.
- this will mess up the tracking stats such as offset, as a result, the `surr_offset` is actually larger than the output length at completition. As a result, the output is trimmed to an empty list, leading to the assertion error.

Fix:
- Remove the `DecodeStatus` when a request is marked as finished.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
