### PR TITLE
[WIP] [Feature] Support DeepSeek-v3 gptq

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -299,7 +299,8 @@ class FusedMoE(torch.nn.Module):
             num_experts=num_experts,
             hidden_size=hidden_size,
             # FIXME: figure out which intermediate_size to use
-            intermediate_size=self.intermediate_size_per_partition,
+            # intermediate_size=self.intermediate_size_per_partition,
+	        intermediate_size_full=intermediate_size,
             intermediate_size_per_partition=self.intermediate_size_per_partition,
             params_dtype=params_dtype,
             weight_loader=self.weight_loader,
@@ -596,8 +597,10 @@ class FusedMoE(torch.nn.Module):
             topk_group=self.topk_group,
             num_expert_group=self.num_expert_group,
             custom_routing_function=self.custom_routing_function,
-            correction_bias=self.correction_bias,
-            activation=self.activation,
+	        scoring_func="sigmoid",
+            e_score_correction_bias=self.correction_bias,
+            #correction_bias=self.correction_bias,
+            #activation=self.activation,
         )
 
         if self.reduce_results and self.tp_size > 1:

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.quantization.gguf import GGUFConfig
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.gptq_marlin import GPTQMarlinConfig
 from vllm.model_executor.layers.quantization.gptq_marlin_24 import GPTQMarlin24Config
+from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.layers.quantization.qqq import QQQConfig
 from vllm.model_executor.layers.quantization.tpu_int8 import Int8TpuConfig
@@ -65,13 +66,15 @@ def gptq_get_quant_method(self, layer, prefix):
         GPTQMarlinMoEMethod,
     )
 
+    from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Method
     from sglang.srt.layers.linear import LinearBase
     from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 
     if isinstance(layer, LinearBase):
         return GPTQMarlinLinearMethod(self)
     elif isinstance(layer, FusedMoE):
-        return GPTQMarlinMoEMethod(self)
+        return MoeWNA16Method(MoeWNA16Config.from_config(self.full_config))
+        # return GPTQMarlinMoEMethod(self)
     return None
 
 


### PR DESCRIPTION
This PR Supports the gptq-int4 version of  DeepSeek-V3.

The Model:
https://huggingface.co/OPEA/DeepSeek-V3-int4-sym-gptq-inc

Main Modification:
1. Add gptq dequant for kv_b_proj weights.
2. Use MoeWNA16Method for FusedMoE compute which is faster.