### PR TITLE
[Docs] Improve DPSK docs in dark mode

### DIFF
--- a/docs/references/deepseek.md
+++ b/docs/references/deepseek.md
@@ -8,74 +8,94 @@ Special thanks to Meituan's Search & Recommend Platform Team and Baseten's Model
 
 SGLang is recognized as one of the top engines for [DeepSeek model inference](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3). To run DeepSeek V3/R1 models, the requirements are as follows:
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Weight Configurations</title>
-    <style>
-        table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 20px 0;
-        }
-        th, td {
-            border: 1px solid #ddd;
-            padding: 12px;
-            text-align: left;
-        }
-        th {
-            background-color: #f2f2f2;
-        }
-        tr:nth-child(even) {
-            background-color: #f9f9f9;
-        }
-    </style>
-</head>
-<body>
-    <table>
-        <thead>
-            <tr>
-                <th>Weight Type</th>
-                <th>Configuration</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td rowspan="3"><b>Full precision FP8 (recommended)</b></td>
-                <td>8 x H200</td>
-            </tr>
-            <tr>
-                <td>8 x MI300X</td>
-            </tr>
-            <tr>
-                <td>2 x 8 x H100/800/20</td>
-            </tr>
-            <tr>
-                <td rowspan="4">Full precision BF16</td>
-                <td>2 x 8 x H200</td>
-            </tr>
-            <tr>
-                <td>2 x 8 x MI300X</td>
-            </tr>
-            <tr>
-                <td>4 x 8 x H100/800/20</td>
-            </tr>
-            <tr>
-                <td>4 x 8 x A100/A800</td>
-            </tr>
-            <tr>
-                <td rowspan="2">Quantized weights (AWQ)</td>
-                <td>8 x H100/800/20</td>
-            </tr>
-            <tr>
-                <td>8 x A100/A800</td>
-            </tr>
-        </tbody>
-    </table>
-</body>
-</html>
+<div class="table-container">
+<style>
+  .table-container {
+    overflow-x: auto;
+    margin: 20px 0;
+  }
+  .config-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  }
+  .config-table th {
+    background-color: #1a2b47;
+    color: white;
+    padding: 12px 15px;
+    text-align: left;
+    font-weight: 600;
+  }
+  .config-table td {
+    padding: 10px 15px;
+    border-bottom: 1px solid #333;
+    color: white;
+  }
+  .config-table tr:nth-child(odd) td {
+    background-color: #2c3e50;
+  }
+  .config-table tr:nth-child(even) td {
+    background-color: #34495e;
+  }
+  .config-table tr:hover td {
+    background-color: #1a2b47;
+  }
+  .weight-type {
+    background-color: #243342 !important;
+    font-weight: 500;
+  }
+  .recommended {
+    color: #2ecc71;
+    font-size: 0.9em;
+    font-style: italic;
+  }
+</style>
+
+  <table class="config-table">
+    <thead>
+      <tr>
+        <th>Weight Type</th>
+        <th>Configuration</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td rowspan="3" class="weight-type"><strong>Full precision FP8</strong><br><span class="recommended">(recommended)</span></td>
+        <td>8 x H200</td>
+      </tr>
+      <tr>
+        <td>8 x MI300X</td>
+      </tr>
+      <tr>
+        <td>2 x 8 x H100/800/20</td>
+      </tr>
+      <tr>
+        <td rowspan="4" class="weight-type"><strong>Full precision BF16</strong></td>
+        <td>2 x 8 x H200</td>
+      </tr>
+      <tr>
+        <td>2 x 8 x MI300X</td>
+      </tr>
+      <tr>
+        <td>4 x 8 x H100/800/20</td>
+      </tr>
+      <tr>
+        <td>4 x 8 x A100/A800</td>
+      </tr>
+      <tr>
+        <td rowspan="2" class="weight-type"><strong>Quantized weights (AWQ)</strong></td>
+        <td>8 x H100/800/20</td>
+      </tr>
+      <tr>
+        <td>8 x A100/A800</td>
+      </tr>
+    </tbody>
+  </table>
+
+</div>
+
 
 Detailed commands for reference:
 

--- a/docs/references/deepseek.md
+++ b/docs/references/deepseek.md
@@ -8,94 +8,46 @@ Special thanks to Meituan's Search & Recommend Platform Team and Baseten's Model
 
 SGLang is recognized as one of the top engines for [DeepSeek model inference](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3). To run DeepSeek V3/R1 models, the requirements are as follows:
 
-<div class="table-container">
+| Weight Type | Configuration |
+|------------|-------------------|
+| **Full precision FP8**<br>*(recommended)* | 8 x H200 |
+| | 8 x MI300X |
+| | 2 x 8 x H100/800/20 |
+| **Full precision BF16** | 2 x 8 x H200 |
+| | 2 x 8 x MI300X |
+| | 4 x 8 x H100/800/20 |
+| | 4 x 8 x A100/A800 |
+| **Quantized weights (AWQ)** | 8 x H100/800/20 |
+| | 8 x A100/A800 |
+
 <style>
-  .table-container {
-    overflow-x: auto;
-    margin: 20px 0;
-  }
-  .config-table {
-    width: 100%;
-    border-collapse: collapse;
-    border-radius: 8px;
-    overflow: hidden;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-  }
-  .config-table th {
-    background-color: #1a2b47;
-    color: white;
-    padding: 12px 15px;
-    text-align: left;
-    font-weight: 600;
-  }
-  .config-table td {
-    padding: 10px 15px;
-    border-bottom: 1px solid #333;
-    color: white;
-  }
-  .config-table tr:nth-child(odd) td {
-    background-color: #2c3e50;
-  }
-  .config-table tr:nth-child(even) td {
-    background-color: #34495e;
-  }
-  .config-table tr:hover td {
-    background-color: #1a2b47;
-  }
-  .weight-type {
-    background-color: #243342 !important;
-    font-weight: 500;
-  }
-  .recommended {
-    color: #2ecc71;
-    font-size: 0.9em;
-    font-style: italic;
-  }
+.md-typeset__table {
+  width: 100%;
+}
+
+.md-typeset__table table {
+  border-collapse: collapse;
+  margin: 1em 0;
+  border: 2px solid var(--md-typeset-table-color);
+  table-layout: fixed;
+}
+
+.md-typeset__table th {
+  border: 1px solid var(--md-typeset-table-color);
+  border-bottom: 2px solid var(--md-typeset-table-color);
+  background-color: var(--md-default-bg-color--lighter);
+  padding: 12px;
+}
+
+.md-typeset__table td {
+  border: 1px solid var(--md-typeset-table-color);
+  padding: 12px;
+}
+
+.md-typeset__table tr:nth-child(2n) {
+  background-color: var(--md-default-bg-color--lightest);
+}
 </style>
-
-  <table class="config-table">
-    <thead>
-      <tr>
-        <th>Weight Type</th>
-        <th>Configuration</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td rowspan="3" class="weight-type"><strong>Full precision FP8</strong><br><span class="recommended">(recommended)</span></td>
-        <td>8 x H200</td>
-      </tr>
-      <tr>
-        <td>8 x MI300X</td>
-      </tr>
-      <tr>
-        <td>2 x 8 x H100/800/20</td>
-      </tr>
-      <tr>
-        <td rowspan="4" class="weight-type"><strong>Full precision BF16</strong></td>
-        <td>2 x 8 x H200</td>
-      </tr>
-      <tr>
-        <td>2 x 8 x MI300X</td>
-      </tr>
-      <tr>
-        <td>4 x 8 x H100/800/20</td>
-      </tr>
-      <tr>
-        <td>4 x 8 x A100/A800</td>
-      </tr>
-      <tr>
-        <td rowspan="2" class="weight-type"><strong>Quantized weights (AWQ)</strong></td>
-        <td>8 x H100/800/20</td>
-      </tr>
-      <tr>
-        <td>8 x A100/A800</td>
-      </tr>
-    </tbody>
-  </table>
-
-</div>
-
 
 Detailed commands for reference:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Fix https://github.com/sgl-project/sglang/issues/3908 


Note: Both Light and Dark mode will be having the same visualization for this table.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
### Dark Mdoe
<img width="1249" alt="Screenshot 2025-02-26 at 11 42 23 PM" src="https://github.com/user-attachments/assets/acb22e74-348e-4e7c-ac8c-ff8c2623666d" />

### Light Mode

<img width="1245" alt="Screenshot 2025-02-26 at 11 42 11 PM" src="https://github.com/user-attachments/assets/4332a34e-4ec9-4614-9f97-0bc203c3b17b" />

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
