### PR TITLE
[Feature] Support for qwen2vl radix cache

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -151,12 +151,10 @@ class ModelRunner:
             if self.model_config.hf_config.architectures == [
                 "Qwen2VLForConditionalGeneration"
             ]:
-                # TODO: qwen2-vl does not support radix cache now, set disable_radix_cache=True automatically
                 logger.info(
-                    "Automatically turn off --chunked-prefill-size and disable radix cache for qwen2-vl."
+                    "Automatically turn off --chunked-prefill-size for qwen2-vl."
                 )
                 server_args.chunked_prefill_size = -1
-                server_args.disable_radix_cache = True
 
         # Global vars
         if server_args.show_time_cost:


### PR DESCRIPTION

## Motivation

Support the radix cache for the Qwen2VL model to enhance performance and provide conditions for regex.

## Modifications

Previously, Qwen2VL disabled radix cache due to considerations for ViT mrope. However, it is possible to add limiting conditions, similar to those in LLaVA, to avoid radix cache in the ViT part.
The unit tests are already available at test/srt/test_radix_attention.py and test/srt/test_chunked_prefill.py.

## Checklist

- [✓ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
