### PR TITLE
[BugFix] send Finish_Abort req to tokenizer, not always in waiting queue

### DIFF
--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -3,8 +3,38 @@ from http import HTTPStatus
 from typing import Optional
 
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req
+from sglang.srt.managers.io_struct import (
+    BatchTokenIDOut
+)
 
 logger = logging.getLogger(__name__)
+
+
+def pack_err_batch_tokenid_out(req: Req):
+    decode_ids, read_offset = req.init_incremental_detokenize()
+    return BatchTokenIDOut(rids=[req.rid],
+                           finished_reasons=[req.finished_reason.to_json()],
+                           vids=[req.vid],
+                           decoded_texts=[req.decoded_text],
+                           decode_ids=[decode_ids],
+                           read_offsets=[read_offset],
+                           output_ids=[req.output_ids],
+                           skip_special_tokens=[req.sampling_params.skip_special_tokens],
+                           spaces_between_special_tokens=[req.sampling_params.spaces_between_special_tokens],
+                           no_stop_trim=[req.sampling_params.no_stop_trim],
+                           prompt_tokens=[len(req.origin_input_ids)],
+                           completion_tokens=[len(req.output_ids)],
+                           cached_tokens=[req.cached_tokens],
+                           spec_verify_ct=[req.spec_verify_ct],
+                           input_token_logprobs_val=[req.input_token_logprobs_val],
+                           input_token_logprobs_idx=[req.input_token_logprobs_idx],
+                           output_token_logprobs_val=[req.output_token_logprobs_val],
+                           output_token_logprobs_idx=[req.output_token_logprobs_idx],
+                           input_top_logprobs_val=[req.input_top_logprobs_val],
+                           input_top_logprobs_idx=[req.input_top_logprobs_idx],
+                           output_top_logprobs_val=[req.output_top_logprobs_val],
+                           output_top_logprobs_idx=[req.output_top_logprobs_idx]
+                          )
 
 
 def validate_input_length(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

We met an online problem, when a long context req comes, for its context length is larger than max_total_tokens, it will be appended in waiting queue, and never be sent to tokenizer.
It will cause that our client waiting for req until timeout.

## Modifications

if the finish reason of the req has been set when handling recv req, just send to tokenizer as a batchTokenIDOut
Then tokenizer could get this req and return resp to client.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
