### PR TITLE
[tools] add fp8 max/min constant in utils

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -73,11 +73,6 @@ show_time_cost = False
 time_infos = {}
 
 HIP_FP8_E4M3_FNUZ_MAX = 224.0
-HIP_FP8_E4M3_FNUZ_MIN_SUB_NORM = 0.0009765625
-
-OCP_FP8_E4M3_FN_MIN_SUB_NORM = 0.001953125
-
-OCP_MXFP8_E8M0_GROUP_QUANT_GRANULARITY = 32
 
 
 # https://pytorch.org/docs/stable/notes/hip.html#checking-for-hip
@@ -87,10 +82,8 @@ def is_hip() -> bool:
 
 if is_hip():
     FP8_E4M3_MAX = HIP_FP8_E4M3_FNUZ_MAX
-    FP8_E4M3_MIN_SUB_NORM = HIP_FP8_E4M3_FNUZ_MIN_SUB_NORM
 else:
     FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
-    FP8_E4M3_MIN_SUB_NORM = OCP_FP8_E4M3_FN_MIN_SUB_NORM
 
 FP8_E4M3_MIN = -FP8_E4M3_MAX
 

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -14,6 +14,7 @@
 """Common utilities."""
 
 import base64
+import builtins
 import ctypes
 import dataclasses
 import io
@@ -77,6 +78,14 @@ HIP_FP8_E4M3_FNUZ_MAX = 224
 # https://pytorch.org/docs/stable/notes/hip.html#checking-for-hip
 def is_hip() -> bool:
     return torch.version.hip is not None
+
+
+if is_hip():
+    FP8_E4M3_MAX = HIP_FP8_E4M3_FNUZ_MAX
+else:
+    FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+builtins.FP8_E4M3_MAX = FP8_E4M3_MAX
 
 
 def is_rocm() -> bool:

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -72,7 +72,12 @@ logger = logging.getLogger(__name__)
 show_time_cost = False
 time_infos = {}
 
-HIP_FP8_E4M3_FNUZ_MAX = 224
+HIP_FP8_E4M3_FNUZ_MAX = 224.0
+HIP_FP8_E4M3_FNUZ_MIN_SUB_NORM = 0.0009765625
+
+OCP_FP8_E4M3_FN_MIN_SUB_NORM = 0.001953125
+
+OCP_MXFP8_E8M0_GROUP_QUANT_GRANULARITY = 32
 
 
 # https://pytorch.org/docs/stable/notes/hip.html#checking-for-hip
@@ -82,10 +87,15 @@ def is_hip() -> bool:
 
 if is_hip():
     FP8_E4M3_MAX = HIP_FP8_E4M3_FNUZ_MAX
+    FP8_E4M3_MIN_SUB_NORM = HIP_FP8_E4M3_FNUZ_MIN_SUB_NORM
 else:
     FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+    FP8_E4M3_MIN_SUB_NORM = OCP_FP8_E4M3_FN_MIN_SUB_NORM
+
+FP8_E4M3_MIN = -FP8_E4M3_MAX
 
 builtins.FP8_E4M3_MAX = FP8_E4M3_MAX
+builtins.FP8_E4M3_MIN = FP8_E4M3_MIN
 
 
 def is_rocm() -> bool:

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -71,6 +71,8 @@ logger = logging.getLogger(__name__)
 show_time_cost = False
 time_infos = {}
 
+HIP_FP8_E4M3_FNUZ_MAX = 224
+
 
 # https://pytorch.org/docs/stable/notes/hip.html#checking-for-hip
 def is_hip() -> bool:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Suggested in [PR#3702](https://github.com/sgl-project/sglang/pull/3702), AMD uses two FP8 formats : 

- OCP fp8 format (fp8_e4m3), and 
- FP8 FNUZ format which is jointly, originally proposed by Graphcore and officialy supported in meta Pytorch with reference to Graphcore uint8 representation format:

> https://github.com/pytorch/pytorch/blob/main/c10/util/Float8_e4m3fnuz.h
 
#### Mismatch of behavior of FP8 in Meta implementation and AMD implementation

In tradition FP8 MAX in torch.float8_e4m3fnuz format is represented with 

 > fp8_max = 0b01111 111 (0b01000 000 is used as NaN) = 2^{15 - 8} * (1+0.875) = 240
 
Currently in AMD, 224 is chosen as FP8 MAX :

 > fp8_max = 0b01111 110 (0b01111 111 is used as NaN in  OCP FP8 format, see [OCP 2023-12-1 specification](https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1)) = 2^{15 - 8} * (1+0.75) = 224

But both values can be represented in AMD device functions. Here is the device function test with ROCm SDK 6.3:

<img width="800" alt="截屏2025-03-08 12 22 17" src="https://github.com/user-attachments/assets/36c68d5c-5dbf-449a-a732-e3d3f3f7d4e7" />


From the above test, both 224, 240 are valid numer in AMD FP8 E4M3 FNUZ format. So what's the problem ?

The problem is round trip. Here is the torch test with AMD device :

<img width="800" alt="截屏2025-03-08 12 44 41" src="https://github.com/user-attachments/assets/4e6ae929-b162-457a-9e8b-14a76aa81d4e" />

Any value great than FP8 MAX will be represented as NaN in pytorch, not clamped to a proper max value. 

However, in AMD device implementation, it is clamp to 240.

In current vllm application, [AMD FP8 MAX is hard coded as 224](https://github.com/vllm-project/vllm/blob/main/csrc/quantization/fp8/common.cuh#L17C10-L19C38) for better precision, though 240 is also valid in ROCM 6.3 SDK 

<s>
Besides I also found, min sub norm value (1e-3 ~ 0.000976562) is not provided by default in torch. So I added them, so it can be useful extend the represetnation of digits below minimum normals, hence can be used to adjust weights.

#### Group Quant efficiency

[MXFP8 was introduced in OCP project](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf) and supported in NVIDIA Blackwell, [AMD Quantization toolkit Quark](https://quark.docs.amd.com/release-0.6.0/onnx/tutorial_mx_quantization.html), and projected to be availabe in [pytorch in 2025 Q1](https://github.com/pytorch/pytorch/issues/146414). This enables `native` group quant with 32 consecutive elements instead of per tensor quant. 

The immediate benefits bought by MXFP8 is that we can use FP8 E8M0 to store scaling number instead of FP32 .

<img width="600" alt="截屏2025-03-08 14 53 49" src="https://github.com/user-attachments/assets/6481967c-306b-4075-8222-b510e0382936" />

Currently SGLang implemented group quant with group size 128, then we can adjust the implementation to support 32-group quant in Blackwell and other chips support OCP MXFP8.
</s>

## Modifications

<!-- Describe the changes made in this PR. -->
Add global constant. Usage example :

```
Python 3.12.8 (main, Dec  4 2024, 08:54:12) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from sglang.srt.utils import is_hip
>>> FP8_E4M3_MAX
224.0
>>> FP8_E4M3_MIN
-224.0
```

Note :  FP8_E4M3_MIN_SUB_NORM , OCP_MXFP8_E8M0_GROUP_QUANT_GRANULARITY will be added in the relevant PRs.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
