### PR TITLE
Remove unused imports from rocm mla kernel. 

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/rocm_mla_decode_rope.py
+++ b/python/sglang/srt/layers/attention/triton_ops/rocm_mla_decode_rope.py
@@ -20,20 +20,12 @@ It supports page size = 1.
 # https://github.com/ModelTC/lightllm/blob/96353e868a840db4d103138caf15ed9dbea8c186/lightllm/models/deepseek2/triton_kernel/gqa_flash_decoding_stage1.py
 # https://github.com/ModelTC/lightllm/blob/96353e868a840db4d103138caf15ed9dbea8c186/lightllm/models/deepseek2/triton_kernel/gqa_flash_decoding_stage2.py
 
-import argparse
-import logging
-import sys
-
-import pytest
-import torch
 import triton
 import triton.language as tl
 
 from sglang.srt.layers.attention.triton_ops.decode_attention import (
     _decode_softmax_reducev_fwd,
 )
-from sglang.srt.layers.rotary_embedding import DeepseekScalingRotaryEmbedding
-
 
 def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"

--- a/python/sglang/srt/layers/attention/triton_ops/rocm_mla_decode_rope.py
+++ b/python/sglang/srt/layers/attention/triton_ops/rocm_mla_decode_rope.py
@@ -27,6 +27,7 @@ from sglang.srt.layers.attention.triton_ops.decode_attention import (
     _decode_softmax_reducev_fwd,
 )
 
+
 def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"
 


### PR DESCRIPTION
Based on #3938 
Removes unused imports in the ROCm fused mla triton kernel. 