### PR TITLE
[Feature]Support ragged prefill in flashinfer mla backend

### DIFF
--- a/docs/backend/server_arguments.md
+++ b/docs/backend/server_arguments.md
@@ -133,7 +133,6 @@ Please consult the documentation below to learn more about the parameters you ma
 
 * `attention_backend`: The backend for attention computation and KV cache management.
 * `sampling_backend`: The backend for sampling.
-* `enable_flashinfer_mla`: The backend for flashinfer MLA wrapper that accelerates deepseek models. (In Experiment Stage)
 
 ## Constrained Decoding
 
@@ -186,3 +185,5 @@ Please consult the documentation below to learn more about the parameters you ma
 * `cuda_graph_bs`: The batch sizes to capture by `CudaGraphRunner`. By default this is done for you.
 * `torchao_config`: Experimental feature that optimizes the model with [torchao](https://github.com/pytorch/ao). Possible choices are: int8dq, int8wo, int4wo-<group_size>, fp8wo, fp8dq-per_tensor, fp8dq-per_row.
 * `triton_attention_num_kv_splits`: Use to adjust the number of KV splits in triton kernels. Default is 8.
+* `enable_flashinfer_mla`: The backend for flashinfer MLA wrapper that accelerates deepseek models.
+* `flashinfer_mla_disable_ragged`: Disable usage of ragged prefill wrapper for flashinfer mla attention backend. Should be used when `enable_flashinfer_mla` is turned on.

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -902,7 +902,7 @@ class FlashInferMultiStepDraftBackend:
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.generate_draft_decode_kv_indices = generate_draft_decode_kv_indices
-        max_bs = model_runner.req_to_token_pool.size
+        max_bs = model_runner.req_to_token_pool.size * self.topk
         self.kv_indptr = torch.zeros(
             (
                 self.speculative_num_steps,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -37,7 +37,6 @@ if is_flashinfer_available():
         BatchPrefillWithRaggedKVCacheWrapper,
     )
     from flashinfer.cascade import merge_state
-    from flashinfer.mla import BatchMLAPagedAttentionWrapper
 
 
 class WrapperDispatch(Enum):
@@ -47,16 +46,12 @@ class WrapperDispatch(Enum):
 
 @dataclass
 class DecodeMetadata:
-    decode_wrappers: List[
-        Union[BatchDecodeWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper]
-    ]
+    decode_wrappers: List[BatchDecodeWithPagedKVCacheWrapper]
 
 
 @dataclass
 class PrefillMetadata:
-    prefill_wrappers: List[
-        Union[BatchPrefillWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper]
-    ]
+    prefill_wrappers: List[BatchPrefillWithPagedKVCacheWrapper]
     use_ragged: bool
     extend_no_prefix: bool
 
@@ -109,12 +104,6 @@ class FlashInferAttnBackend(AttentionBackend):
         if "Qwen2ForCausalLM" in model_runner.model_config.hf_config.architectures:
             global_config.flashinfer_workspace_size = 512 * 1024 * 1024
 
-        self.enable_flashinfer_mla = False
-        if "DeepseekV3ForCausalLM" in model_runner.model_config.hf_config.architectures:
-            if global_server_args_dict["enable_flashinfer_mla"]:
-                self.enable_flashinfer_mla = True
-                global_config.enable_flashinfer_mla = True
-
         # Allocate buffers
         global global_workspace_buffer
         if global_workspace_buffer is None:
@@ -132,13 +121,6 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
                 for _ in range(self.num_wrappers)
             ]
-            if self.enable_flashinfer_mla:
-                self.qo_indptr = [
-                    torch.zeros(
-                        (max_bs + 1,), dtype=torch.int32, device=model_runner.device
-                    )
-                    for _ in range(self.num_wrappers)
-                ]
         else:
             assert self.num_wrappers == 1
             self.kv_indptr = [kv_indptr_buf]
@@ -162,48 +144,24 @@ class FlashInferAttnBackend(AttentionBackend):
         self.decode_wrappers = []
         for _ in range(self.num_wrappers):
             if not skip_prefill:
-                if (
-                    self.enable_flashinfer_mla
-                    and not global_server_args_dict["disable_radix_cache"]
-                ):
-                    # use mla paged prefill
-                    self.prefill_wrappers_paged.append(
-                        BatchMLAPagedAttentionWrapper(
-                            self.workspace_buffer,
-                            backend="fa2",
-                        )
-                    )
-                    self.prefill_wrappers_verify.append(
-                        BatchMLAPagedAttentionWrapper(
-                            self.workspace_buffer,
-                            backend="fa2",
-                        )
-                    )
-                else:
-                    self.prefill_wrappers_paged.append(
-                        BatchPrefillWithPagedKVCacheWrapper(
-                            self.workspace_buffer,
-                            "NHD",
-                            backend="fa2",
-                        )
-                    )
-                    self.prefill_wrappers_verify.append(
-                        BatchPrefillWithPagedKVCacheWrapper(
-                            self.workspace_buffer, "NHD"
-                        )
-                    )
-            if self.enable_flashinfer_mla:
-                self.decode_wrappers.append(
-                    BatchMLAPagedAttentionWrapper(self.workspace_buffer, backend="fa2")
-                )
-            else:
-                self.decode_wrappers.append(
-                    BatchDecodeWithPagedKVCacheWrapper(
+                self.prefill_wrappers_paged.append(
+                    BatchPrefillWithPagedKVCacheWrapper(
                         self.workspace_buffer,
                         "NHD",
-                        use_tensor_cores=self.decode_use_tensor_cores,
+                        backend="fa2",
                     )
                 )
+                self.prefill_wrappers_verify.append(
+                    BatchPrefillWithPagedKVCacheWrapper(self.workspace_buffer, "NHD")
+                )
+
+            self.decode_wrappers.append(
+                BatchDecodeWithPagedKVCacheWrapper(
+                    self.workspace_buffer,
+                    "NHD",
+                    use_tensor_cores=self.decode_use_tensor_cores,
+                )
+            )
 
         # Create indices updater
         if not skip_prefill:
@@ -259,10 +217,7 @@ class FlashInferAttnBackend(AttentionBackend):
         else:
             prefix_lens = forward_batch.extend_prefix_lens
 
-            if self.is_multimodal or (
-                self.enable_flashinfer_mla
-                and not global_server_args_dict["disable_radix_cache"]
-            ):
+            if self.is_multimodal:
                 use_ragged = False
                 extend_no_prefix = False
             else:
@@ -321,32 +276,20 @@ class FlashInferAttnBackend(AttentionBackend):
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
             for i in range(self.num_wrappers):
-                if self.enable_flashinfer_mla:
-                    decode_wrappers.append(
-                        BatchMLAPagedAttentionWrapper(
-                            self.workspace_buffer,
-                            use_cuda_graph=True,
-                            qo_indptr=self.qo_indptr[i][: num_tokens + 1],
-                            kv_indptr=self.kv_indptr[i][: num_tokens + 1],
-                            kv_indices=self.cuda_graph_kv_indices[i],
-                            kv_len_arr=self.kv_last_page_len[:num_tokens],
-                            backend="fa2",
-                        )
+                decode_wrappers.append(
+                    BatchDecodeWithPagedKVCacheWrapper(
+                        self.workspace_buffer,
+                        "NHD",
+                        use_cuda_graph=True,
+                        use_tensor_cores=self.decode_use_tensor_cores,
+                        paged_kv_indptr_buffer=self.kv_indptr[i][: num_tokens + 1],
+                        paged_kv_indices_buffer=self.cuda_graph_kv_indices[i],
+                        paged_kv_last_page_len_buffer=self.kv_last_page_len[
+                            :num_tokens
+                        ],
                     )
-                else:
-                    decode_wrappers.append(
-                        BatchDecodeWithPagedKVCacheWrapper(
-                            self.workspace_buffer,
-                            "NHD",
-                            use_cuda_graph=True,
-                            use_tensor_cores=self.decode_use_tensor_cores,
-                            paged_kv_indptr_buffer=self.kv_indptr[i][: num_tokens + 1],
-                            paged_kv_indices_buffer=self.cuda_graph_kv_indices[i],
-                            paged_kv_last_page_len_buffer=self.kv_last_page_len[
-                                :num_tokens
-                            ],
-                        )
-                    )
+                )
+
             seq_lens_sum = seq_lens.sum().item()
             self.indices_updater_decode.update(
                 req_pool_indices,
@@ -435,114 +378,64 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_batch: ForwardBatch,
         save_kv_cache=True,
     ):
-        if global_config.enable_flashinfer_mla:
-            cache_loc = (
-                forward_batch.out_cache_loc
-                if not layer.is_cross_attention
-                else forward_batch.encoder_out_cache_loc
-            )
+        prefill_wrapper_paged = self.forward_metadata.prefill_wrappers[
+            self._get_wrapper_idx(layer)
+        ]
+        cache_loc = (
+            forward_batch.out_cache_loc
+            if not layer.is_cross_attention
+            else forward_batch.encoder_out_cache_loc
+        )
 
-            logits_soft_cap = layer.logit_cap
+        logits_soft_cap = layer.logit_cap
 
-            if global_server_args_dict["disable_radix_cache"]:
-                # use mla ragged prefill
-                o, _ = self.prefill_wrapper_ragged.forward_return_lse(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                    v.view(-1, layer.tp_v_head_num, layer.v_head_dim),
-                    causal=True,
-                    sm_scale=layer.scaling,
-                    logits_soft_cap=logits_soft_cap,
-                )
-
-                if save_kv_cache:
-                    forward_batch.token_to_kv_pool.set_kv_buffer(
-                        layer,
-                        cache_loc,
-                        k,
-                        v,
-                    )
-            else:
-                # use mla paged prefill
-                prefill_wrapper_paged = self.forward_metadata.prefill_wrappers[
-                    self._get_wrapper_idx(layer)
-                ]
-                if k is not None:
-                    assert v is not None
-                    if save_kv_cache:
-                        forward_batch.token_to_kv_pool.set_kv_buffer(
-                            layer, cache_loc, k, v
-                        )
-                qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
-                k_buf = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
-
-                o = prefill_wrapper_paged.run(
-                    qall[:, :, : layer.v_head_dim],
-                    qall[:, :, layer.v_head_dim :],
-                    k_buf[:, :, : layer.v_head_dim],
-                    k_buf[:, :, layer.v_head_dim :],
-                )
-
-            return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-        else:
-            prefill_wrapper_paged = self.forward_metadata.prefill_wrappers[
-                self._get_wrapper_idx(layer)
-            ]
-            cache_loc = (
-                forward_batch.out_cache_loc
-                if not layer.is_cross_attention
-                else forward_batch.encoder_out_cache_loc
-            )
-
-            logits_soft_cap = layer.logit_cap
-
-            if not self.forward_metadata.use_ragged:
-                if k is not None:
-                    assert v is not None
-                    if save_kv_cache:
-                        forward_batch.token_to_kv_pool.set_kv_buffer(
-                            layer, cache_loc, k, v, layer.k_scale, layer.v_scale
-                        )
-
-                o = prefill_wrapper_paged.forward(
-                    q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
-                    forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
-                    causal=not layer.is_cross_attention,
-                    sm_scale=layer.scaling,
-                    window_left=layer.sliding_window_size,
-                    logits_soft_cap=logits_soft_cap,
-                    k_scale=layer.k_scale,
-                    v_scale=layer.v_scale,
-                )
-            else:
-                o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                    v.view(-1, layer.tp_v_head_num, layer.head_dim),
-                    causal=True,
-                    sm_scale=layer.scaling,
-                    logits_soft_cap=logits_soft_cap,
-                )
-
-                if self.forward_metadata.extend_no_prefix:
-                    o = o1
-                else:
-                    o2, s2 = prefill_wrapper_paged.forward_return_lse(
-                        q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
-                        forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
-                        causal=False,
-                        sm_scale=layer.scaling,
-                        logits_soft_cap=layer.logit_cap,
-                    )
-
-                    o, _ = merge_state(o1, s1, o2, s2)
-
+        if not self.forward_metadata.use_ragged:
+            if k is not None:
+                assert v is not None
                 if save_kv_cache:
                     forward_batch.token_to_kv_pool.set_kv_buffer(
                         layer, cache_loc, k, v, layer.k_scale, layer.v_scale
                     )
 
-            return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+            o = prefill_wrapper_paged.forward(
+                q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
+                causal=not layer.is_cross_attention,
+                sm_scale=layer.scaling,
+                window_left=layer.sliding_window_size,
+                logits_soft_cap=logits_soft_cap,
+                k_scale=layer.k_scale,
+                v_scale=layer.v_scale,
+            )
+        else:
+            o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
+                q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                v.view(-1, layer.tp_v_head_num, layer.head_dim),
+                causal=True,
+                sm_scale=layer.scaling,
+                logits_soft_cap=logits_soft_cap,
+            )
+
+            if self.forward_metadata.extend_no_prefix:
+                o = o1
+            else:
+                o2, s2 = prefill_wrapper_paged.forward_return_lse(
+                    q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
+                    causal=False,
+                    sm_scale=layer.scaling,
+                    logits_soft_cap=layer.logit_cap,
+                )
+
+                o, _ = merge_state(o1, s1, o2, s2)
+
+            if save_kv_cache:
+                forward_batch.token_to_kv_pool.set_kv_buffer(
+                    layer, cache_loc, k, v, layer.k_scale, layer.v_scale
+                )
+
+        return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
     def forward_decode(
         self,
@@ -562,45 +455,23 @@ class FlashInferAttnBackend(AttentionBackend):
             else forward_batch.encoder_out_cache_loc
         )
 
-        if self.enable_flashinfer_mla:
-            if k is not None:
-                assert v is not None
-                if save_kv_cache:
-                    forward_batch.token_to_kv_pool.set_kv_buffer(
-                        layer,
-                        cache_loc,
-                        k,
-                        v,
-                    )
-            reshaped_q = q.view(-1, layer.tp_q_head_num, layer.head_dim)
-            k_buffer = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
-            reshaped_k = k_buffer.view(-1, 1, layer.head_dim)
-            o = decode_wrapper.run(
-                reshaped_q[:, :, : layer.v_head_dim],
-                reshaped_q[:, :, layer.v_head_dim :],
-                reshaped_k[:, :, : layer.v_head_dim],
-                reshaped_k[:, :, layer.v_head_dim :],
-            )
+        if k is not None:
+            assert v is not None
+            if save_kv_cache:
+                forward_batch.token_to_kv_pool.set_kv_buffer(
+                    layer, cache_loc, k, v, layer.k_scale, layer.v_scale
+                )
 
-            return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-        else:
-            if k is not None:
-                assert v is not None
-                if save_kv_cache:
-                    forward_batch.token_to_kv_pool.set_kv_buffer(
-                        layer, cache_loc, k, v, layer.k_scale, layer.v_scale
-                    )
+        o = decode_wrapper.forward(
+            q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+            forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
+            sm_scale=layer.scaling,
+            logits_soft_cap=layer.logit_cap,
+            k_scale=layer.k_scale,
+            v_scale=layer.v_scale,
+        )
 
-            o = decode_wrapper.forward(
-                q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
-                forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),
-                sm_scale=layer.scaling,
-                logits_soft_cap=layer.logit_cap,
-                k_scale=layer.k_scale,
-                v_scale=layer.v_scale,
-            )
-
-            return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+        return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
     def _get_wrapper_idx(self, layer: RadixAttention):
         if self.num_wrappers == 1:
@@ -648,9 +519,7 @@ class FlashInferIndicesUpdaterDecode:
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
-        decode_wrappers: List[
-            Union[BatchDecodeWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper]
-        ],
+        decode_wrappers: List[BatchDecodeWithPagedKVCacheWrapper],
         encoder_lens: Optional[torch.Tensor],
         spec_info: Optional[SpecInfo],
     ):
@@ -662,9 +531,7 @@ class FlashInferIndicesUpdaterDecode:
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
-        decode_wrappers: List[
-            Union[BatchDecodeWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper]
-        ],
+        decode_wrappers: List[BatchDecodeWithPagedKVCacheWrapper],
         encoder_lens: Optional[torch.Tensor],
         spec_info: Optional[SpecInfo],
     ):
@@ -745,9 +612,7 @@ class FlashInferIndicesUpdaterDecode:
 
     def call_begin_forward(
         self,
-        wrapper: Union[
-            BatchDecodeWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper
-        ],
+        wrapper: BatchDecodeWithPagedKVCacheWrapper,
         req_pool_indices: torch.Tensor,
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
@@ -775,37 +640,18 @@ class FlashInferIndicesUpdaterDecode:
             kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
             bs = kv_indptr.shape[0] - 1
 
-        if global_config.enable_flashinfer_mla:
-            sm_scale = 1.0 / math.sqrt(192)
-            q_indptr = torch.arange(0, bs + 1).to(0).int()
-            kv_lens = paged_kernel_lens.to(torch.int32)
-            wrapper.plan(
-                q_indptr,
-                kv_indptr,
-                kv_indices,
-                kv_lens,
-                self.num_qo_heads,
-                512,
-                64,
-                1,
-                False,
-                sm_scale,
-                self.data_type,
-                self.data_type,
-            )
-        else:
-            wrapper.begin_forward(
-                kv_indptr,
-                kv_indices,
-                self.kv_last_page_len[:bs],
-                self.num_qo_heads,
-                self.num_kv_heads,
-                self.head_dim,
-                1,
-                data_type=self.data_type,
-                q_data_type=self.q_data_type,
-                non_blocking=True,
-            )
+        wrapper.begin_forward(
+            kv_indptr,
+            kv_indices,
+            self.kv_last_page_len[:bs],
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            1,
+            data_type=self.data_type,
+            q_data_type=self.q_data_type,
+            non_blocking=True,
+        )
 
 
 class FlashInferIndicesUpdaterPrefill:
@@ -845,9 +691,7 @@ class FlashInferIndicesUpdaterPrefill:
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
         prefix_lens: torch.Tensor,
-        prefill_wrappers: List[
-            Union[BatchPrefillWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper]
-        ],
+        prefill_wrappers: List[BatchPrefillWithPagedKVCacheWrapper],
         use_ragged: bool,
         encoder_lens: Optional[torch.Tensor],
         spec_info: Optional[SpecInfo],
@@ -861,9 +705,7 @@ class FlashInferIndicesUpdaterPrefill:
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
         prefix_lens: torch.Tensor,
-        prefill_wrappers: List[
-            Union[BatchPrefillWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper]
-        ],
+        prefill_wrappers: List[BatchPrefillWithPagedKVCacheWrapper],
         use_ragged: bool,
         encoder_lens: Optional[torch.Tensor],
         spec_info: Optional[SpecInfo],
@@ -972,9 +814,7 @@ class FlashInferIndicesUpdaterPrefill:
     def call_begin_forward(
         self,
         wrapper_ragged: BatchPrefillWithRaggedKVCacheWrapper,
-        wrapper_paged: Union[
-            BatchPrefillWithPagedKVCacheWrapper, BatchMLAPagedAttentionWrapper
-        ],
+        wrapper_paged: BatchPrefillWithPagedKVCacheWrapper,
         req_pool_indices: torch.Tensor,
         paged_kernel_lens: torch.Tensor,
         paged_kernel_lens_sum: int,
@@ -1020,61 +860,29 @@ class FlashInferIndicesUpdaterPrefill:
 
         # extend part
         if use_ragged:
-            if global_config.enable_flashinfer_mla:
-                wrapper_ragged.begin_forward(
-                    qo_indptr=qo_indptr,
-                    kv_indptr=qo_indptr,
-                    num_qo_heads=self.num_qo_heads,
-                    num_kv_heads=self.num_kv_heads,
-                    head_dim_qk=192,
-                    head_dim_vo=128,
-                    q_data_type=self.q_data_type,
-                )
-            else:
-                wrapper_ragged.begin_forward(
-                    qo_indptr,
-                    qo_indptr,
-                    self.num_qo_heads,
-                    self.num_kv_heads,
-                    self.head_dim,
-                    q_data_type=self.q_data_type,
-                )
-
-        if not global_config.enable_flashinfer_mla:
-            # cached part
-            wrapper_paged.begin_forward(
+            wrapper_ragged.begin_forward(
                 qo_indptr,
-                kv_indptr,
-                kv_indices,
-                self.kv_last_page_len[:bs],
+                qo_indptr,
                 self.num_qo_heads,
                 self.num_kv_heads,
                 self.head_dim,
-                1,
                 q_data_type=self.q_data_type,
-                custom_mask=custom_mask,
-                non_blocking=True,
             )
-        elif (
-            global_config.enable_flashinfer_mla
-            and not global_server_args_dict["disable_radix_cache"]
-        ):
-            # mla paged prefill
-            kv_len_arr = kv_indptr[1:] - kv_indptr[:-1]
-            wrapper_paged.plan(
-                qo_indptr,
-                kv_indptr,
-                kv_indices,
-                kv_len_arr,
-                self.num_qo_heads,
-                512,
-                64,
-                1,
-                True,
-                1 / math.sqrt(192),
-                self.data_type,
-                self.data_type,
-            )
+
+        # cached part
+        wrapper_paged.begin_forward(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            self.kv_last_page_len[:bs],
+            self.num_qo_heads,
+            self.num_kv_heads,
+            self.head_dim,
+            1,
+            q_data_type=self.q_data_type,
+            custom_mask=custom_mask,
+            non_blocking=True,
+        )
 
 
 class FlashInferMultiStepDraftBackend:
@@ -1094,7 +902,7 @@ class FlashInferMultiStepDraftBackend:
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
         self.generate_draft_decode_kv_indices = generate_draft_decode_kv_indices
-        max_bs = model_runner.req_to_token_pool.size * self.topk
+        max_bs = model_runner.req_to_token_pool.size
         self.kv_indptr = torch.zeros(
             (
                 self.speculative_num_steps,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -67,6 +67,7 @@ global_server_args_dict = {
     "device": ServerArgs.device,
     "enable_flashinfer_mla": ServerArgs.enable_flashinfer_mla,
     "disable_radix_cache": ServerArgs.disable_radix_cache,
+    "flashinfer_mla_disable_ragged": ServerArgs.flashinfer_mla_disable_ragged,
 }
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -182,6 +182,7 @@ class ModelRunner:
                 "device": server_args.device,
                 "enable_flashinfer_mla": server_args.enable_flashinfer_mla,
                 "disable_radix_cache": server_args.disable_radix_cache,
+                "flashinfer_mla_disable_ragged": server_args.flashinfer_mla_disable_ragged,
             }
         )
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -520,10 +520,11 @@ class DeepseekV2AttentionMLA(nn.Module):
 
         def no_absorb() -> bool:
             if global_server_args_dict["enable_flashinfer_mla"]:
-                # Flashinfer MLA: Only do not use absorb when prefilling/extending without radix cache
+                # Flashinfer MLA: Do not absorb when enabling ragged prefill
                 return (
-                    global_server_args_dict["disable_radix_cache"]
+                    not global_server_args_dict["flashinfer_mla_disable_ragged"]
                     and forward_batch.forward_mode.is_extend()
+                    and forward_batch.extend_prefix_lens.sum() == 0
                 )
             else:
                 # Triton: Use normal computation for prefill and use weight absorption for extend/decode

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -167,6 +167,7 @@ class ServerArgs:
     tool_call_parser: str = None
     enable_hierarchical_cache: bool = False
     enable_flashinfer_mla: bool = False
+    flashinfer_mla_disable_ragged: bool = False
 
     def __post_init__(self):
         # Set missing default values
@@ -712,6 +713,11 @@ class ServerArgs:
             "--enable-flashinfer-mla",
             action="store_true",
             help="Enable FlashInfer MLA optimization",
+        )
+        parser.add_argument(
+            "--flashinfer-mla-disable-ragged",
+            action="store_true",
+            help="Not using ragged prefill wrapper when running flashinfer mla",
         )
 
         # Speculative decoding

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -23,6 +23,7 @@ suites = {
         "test_gguf.py",
         "test_input_embeddings.py",
         "test_mla.py",
+        "test_mla_flashinfer.py",
         "test_mla_fp8.py",
         "test_json_constrained.py",
         "test_large_max_new_tokens.py",

--- a/test/srt/test_mla_flashinfer.py
+++ b/test/srt/test_mla_flashinfer.py
@@ -1,0 +1,104 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    popen_launch_server,
+)
+
+
+class TestFlashinferMLA(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "sgl-project/sglang-ci-dsv3-test"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = ["--trust-remote-code"]
+        if torch.cuda.is_available() and torch.version.cuda:
+            other_args.extend(
+                [
+                    "--enable-torch-compile",
+                    "--cuda-graph-max-bs",
+                    "2",
+                    "--enable-flashinfer-mla",
+                ]
+            )
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(metrics)
+
+        self.assertGreater(metrics["accuracy"], 0.62)
+
+
+class TestFlashinferMLANoRagged(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "sgl-project/sglang-ci-dsv3-test"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = ["--trust-remote-code"]
+        if torch.cuda.is_available() and torch.version.cuda:
+            other_args.extend(
+                [
+                    "--enable-torch-compile",
+                    "--disable-cuda-graph",
+                    "--cuda-graph-max-bs",
+                    "2",
+                    "--enable-flashinfer-mla",
+                    "--flashinfer-mla-disable-ragged",
+                ]
+            )
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(metrics)
+
+        self.assertGreater(metrics["accuracy"], 0.62)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Current flashinfer mla backend only uses MLA paged wrapper for both prefilling and decoding. This PR supports the usage of Ragged prefill wrapper during prefilling with empty cache, and adds an argument that controls this usage.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Usage

By default, ragged prefill wrapper is used in flashinfer mla backend.
To turn it off and use only mla paged wrapper:
```bash
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1 --tp 8 --trust-remote-code --enable-flashinfer-mla --flashinfer-mla-disable-ragged
```

## Modifications

- Support ragged prefill wrapper in `flashinfer_mla_backend.py`
- Fix a bug of `q_indptr` in `flashinfer_mla_backend.py`
- Remove MLA related logic in `flashinfer_backend.py`
- Adding tests for flashinfer mla backend

<!-- Describe the changes made in this PR. -->

## Accuracy Test
### Launch
```bash
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1 --tp 8 --trust-remote-code --enable-flashinfer-mla
```

### GSM8K
```bash
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
```
```bash
Accuracy: 0.955
Invalid: 0.000
Latency: 102.206 s
Output throughput: 1315.749 token/s
```

### MMLU
```bash
bash benchmark/mmlu/download_data.sh
python3 benchmark/mmlu/bench_sglang.py --nsub 100 --ntrain 5 --parallel 2000
```
```bash
Total latency: 163.212
Average accuracy: 0.871
```
## Benchmark

We tested the workloads listed in [this file](https://github.com/sgl-project/sglang/blob/main/test/srt/configs/random_flashinfer_vs_triton_config.yaml). The result shows that flashinfer is much stronger on long inputs. For short inputs there is little difference, so there is still room for improvement. The benchmark is run on H200. For H100 and H20, the performance might be different.

### Launch Server
Flashinfer:
```bash
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1 --tp 8 --trust-remote-code --enable-flashinfer-mla
```
Triton:
```bash
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-R1 --tp 8 --trust-remote-code
```

### Input-128-Output-4

```bash
python3 -m sglang.bench_serving --backend sglang --dataset-name random --random-input 128 --random-output 4 --request-rate 24 --num-prompt 1440
```

| Throughput (tok/s)| Flashinfer  | Triton |
| --------- | -------- | ------- |
| Prefill | 1406.22  |  1404.31  |
| Decode | 44.60     |   44.54 |

### Input-2000-Output-100
```bash
python3 -m sglang.bench_serving --backend sglang --dataset-name random --random-input 2000 --random-output 100 --request-rate 2 --num-prompt 120
```

| Throughput (tok/s)| Flashinfer  | Triton |
| --------- | -------- | ------- |
| Prefill | 2342.41 |  2318.98 |
| Decode | 110.45     |   109.35 |

### Input-4000-Output-200
```bash
python3 -m sglang.bench_serving --backend sglang --dataset-name random --random-input 4000 --random-output 200 --request-rate 8 --num-prompt 480
```
| Throughput (tok/s)| Flashinfer  | Triton |
| --------- | -------- | ------- |
| Prefill | 7172.12 |  5371.54 |
| Decode | 350.97     |   270.35 |

### Input-32000-Output-100
```bash
python3 -m sglang.bench_serving --backend sglang --dataset-name random --random-input 32000 --random-output 100 --request-rate 1 --num-prompt 60
```
| Throughput (tok/s)| Flashinfer  | Triton |
| --------- | -------- | ------- |
| Prefill | 6717.99 |  2644.08 |
| Decode |  20.01    |  7.87 |

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
