### PR TITLE
[WIP] Upgrade transformers to 4.49.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,7 +37,7 @@ runtime_common = [
     "uvloop",
     "xgrammar==0.1.14",
     "ninja",
-    "transformers==4.48.3",
+    "transformers==4.49.0",
     "llguidance>=0.6.15"
 ]
 srt = [


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

`transformers==4.49.0` Introduces fixes for Phi-4-mini and configs for Qwen2.5VL

!!! this will break the repo with the following error:
```bash
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/workspace/sglang/python/sglang/launch_server.py", line 6, in <module>
    from sglang.srt.entrypoints.http_server import launch_server
  File "/workspace/sglang/python/sglang/srt/entrypoints/http_server.py", line 41, in <module>
    from sglang.srt.entrypoints.engine import _launch_subprocesses
  File "/workspace/sglang/python/sglang/srt/entrypoints/engine.py", line 36, in <module>
    from sglang.srt.managers.data_parallel_controller import (
  File "/workspace/sglang/python/sglang/srt/managers/data_parallel_controller.py", line 27, in <module>
    from sglang.srt.managers.io_struct import (
  File "/workspace/sglang/python/sglang/srt/managers/io_struct.py", line 24, in <module>
    from sglang.srt.managers.schedule_batch import BaseFinishReason
  File "/workspace/sglang/python/sglang/srt/managers/schedule_batch.py", line 42, in <module>
    from sglang.srt.configs.model_config import ModelConfig
  File "/workspace/sglang/python/sglang/srt/configs/__init__.py", line 4, in <module>
    from sglang.srt.configs.qwen2_5_vl_config import (
  File "/workspace/sglang/python/sglang/srt/configs/qwen2_5_vl_config.py", line 1008, in <module>
    AutoImageProcessor.register(Qwen2_5_VLConfig, None, Qwen2_5_VLImageProcessor, None)
  File "/usr/local/lib/python3.11/dist-packages/transformers/models/auto/image_processing_auto.py", line 628, in register
    IMAGE_PROCESSOR_MAPPING.register(
  File "/usr/local/lib/python3.11/dist-packages/transformers/models/auto/auto_factory.py", line 833, in register
    raise ValueError(f"'{key}' is already used by a Transformers model.")
ValueError: '<class 'sglang.srt.configs.qwen2_5_vl_config.Qwen2_5_VLConfig'>' is already used by a Transformers model.
```

