### PR TITLE
Optimize Triton Kernel of Group GEMM in DeepGEMM Benchmark

### DIFF
--- a/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py.py
@@ -484,4 +484,3 @@ if __name__ == "__main__":
 
     print(f"Running performance benchmark for TP size = {args.tp_size}...")
     benchmark.run(print_data=True, save_path=args.save_path)
-xl

--- a/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_group_gemm.py.py
@@ -484,3 +484,4 @@ if __name__ == "__main__":
 
     print(f"Running performance benchmark for TP size = {args.tp_size}...")
     benchmark.run(print_data=True, save_path=args.save_path)
+xl


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

In the previous pull request ([#3993](https://github.com/sgl-project/sglang/pull/3993)), we introduced a vanilla Group GEMM Triton kernel to address the absence of such implementations in SGLang and vLLM. However, we observed that while DeepGEMM demonstrates high performance, our Triton kernel's speed was significantly slower. Upon investigation, we identified two primary issues:

**Data Type Utilization**: The kernel was performing multiplications in FP32 instead of the intended FP8, leading to suboptimal performance.

**Benchmarking Methodology**: The preprocessing steps, such as matrix transposition, were included in the Triton benchmark measurements, skewing the performance results.

**Further Improvement**: While the current kernel serves as a baseline and is not intended for production use, there is potential for optimization. We welcome Triton experts to further optimize this kernel.

### Current Benchmark
```bash
         m        n        k  num_groups  tp_size     DeepGEMM        Triton
0   2048.0    576.0   7168.0         4.0      1.0    39.039999    357.088000
1   2048.0    576.0   7168.0         8.0      1.0    37.567999    359.263986
2   4096.0    576.0   7168.0         4.0      1.0    49.120001    502.671957
3   4096.0    576.0   7168.0         8.0      1.0    52.767999    507.968009
4   2048.0  24576.0   7168.0         4.0      1.0   653.967977   5987.328053
5   2048.0  24576.0   7168.0         8.0      1.0   743.552029   5748.511791
6   4096.0  24576.0   7168.0         4.0      1.0  1332.288027  11158.495903
7   4096.0  24576.0   7168.0         8.0      1.0  1413.615942  11144.335747
8   2048.0  32768.0    512.0         4.0      1.0   122.079998    597.472012
9   2048.0  32768.0    512.0         8.0      1.0   130.048007    601.920009
10  4096.0  32768.0    512.0         4.0      1.0   229.951993   1162.287951
11  4096.0  32768.0    512.0         8.0      1.0   230.399996   1174.944043
12  2048.0   7168.0  16384.0         4.0      1.0   436.735988   4226.719856
13  2048.0   7168.0  16384.0         8.0      1.0   493.184000   4435.584068
14  4096.0   7168.0  16384.0         4.0      1.0   790.768027   7586.080074
15  4096.0   7168.0  16384.0         8.0      1.0   892.448008   7796.480179
16  2048.0   7168.0  18432.0         4.0      1.0   457.920015   4945.967674
17  2048.0   7168.0  18432.0         8.0      1.0   542.271972   4858.143806
18  4096.0   7168.0  18432.0         4.0      1.0   971.584022   8554.575920
19  4096.0   7168.0  18432.0         8.0      1.0   959.071994   8759.952545
20  2048.0  36864.0   7168.0         4.0      1.0  1051.471949   8483.871460
21  2048.0  36864.0   7168.0         8.0      1.0  1139.232039   8499.695778
22  4096.0  36864.0   7168.0         4.0      1.0  1893.664002  16483.423233
23  4096.0  36864.0   7168.0         8.0      1.0  2092.191935  16581.151962
24  2048.0  24576.0   7168.0         4.0      1.0   712.960005   5724.319935
25  2048.0  24576.0   7168.0         8.0      1.0   769.423962   5840.032101
26  4096.0  24576.0   7168.0         4.0      1.0  1191.264033  11092.224121
27  4096.0  24576.0   7168.0         8.0      1.0  1378.351927  11258.255959
28  2048.0  32768.0    512.0         4.0      1.0   126.847997    597.472012
29  2048.0  32768.0    512.0         8.0      1.0   126.432002    603.807986
30  4096.0  32768.0    512.0         4.0      1.0   238.240004   1161.615968
31  4096.0  32768.0    512.0         8.0      1.0   231.279999   1176.704049
32  2048.0  24576.0   1536.0         4.0      1.0   182.720006   1288.928032
33  2048.0  24576.0   1536.0         8.0      1.0   195.455998   1304.656029
34  4096.0  24576.0   1536.0         4.0      1.0   359.135985   2501.664162
35  4096.0  24576.0   1536.0         8.0      1.0   365.135998   2513.055801
36  2048.0   4096.0   7168.0         4.0      1.0   116.287999    998.672009
37  2048.0   4096.0   7168.0         8.0      1.0   133.343995    987.136006
38  4096.0   4096.0   7168.0         4.0      1.0   219.168007   2018.527985
39  4096.0   4096.0   7168.0         8.0      1.0   216.319993   1971.215963
40  2048.0   7168.0  18432.0         4.0      1.0   485.920012   4702.079773
41  2048.0   7168.0  18432.0         8.0      1.0   552.128017   4845.215797
42  4096.0   7168.0  18432.0         4.0      1.0   857.120037   8649.536133
43  4096.0   7168.0  18432.0         8.0      1.0   987.487972   8635.328293
44  2048.0   7168.0  16384.0         4.0      1.0   438.623995   4201.472282
45  2048.0   7168.0  16384.0         8.0      1.0   495.808005   4446.815968
46  4096.0   7168.0  16384.0         4.0      1.0   845.152020   7945.343971
47  4096.0   7168.0  16384.0         8.0      1.0   901.167989   7719.647884
48  2048.0   7168.0   2048.0         4.0      1.0    73.919997    520.079970
49  2048.0   7168.0   2048.0         8.0      1.0    83.312005    558.159947
50  4096.0   7168.0   2048.0         4.0      1.0   132.512003    995.328009
51  4096.0   7168.0   2048.0         8.0      1.0   136.063993    997.424006
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
