### PR TITLE
Fix `debug_tensor_dump_output_folder` optional key missing

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -206,9 +206,9 @@ class LogitsProcessor(nn.Module):
 
         from sglang.srt.managers.schedule_batch import global_server_args_dict
 
-        self.debug_tensor_dump_output_folder = global_server_args_dict[
-            "debug_tensor_dump_output_folder"
-        ]
+        self.debug_tensor_dump_output_folder = global_server_args_dict.get(
+            "debug_tensor_dump_output_folder", None
+        )
 
     def forward(
         self,


### PR DESCRIPTION
## Motivation

Fix regression 

## Modifications

Return `None` if `debug_tensor_dump_output_folder` optional arg key does not exists.

Fix CI test failing in https://github.com/sgl-project/sglang/pull/3790/

Caused by merged changes in https://github.com/sgl-project/sglang/pull/3988

https://github.com/sgl-project/sglang/actions/runs/13643964727/job/38139337684?pr=3790#step:4:273

```
======================================================================
ERROR: test_gptq_marlin_module (__main__.TestGPTQModelDynamicWithMarlin)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/test/srt/test_gptqmodel_dynamic.py", line 207, in test_gptq_marlin_module
    check_quant_method(self.MODEL_PATH, use_marlin_kernel=True)
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/test/srt/test_gptqmodel_dynamic.py", line 58, in check_quant_method
    model = get_model(
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/python/sglang/srt/model_loader/__init__.py", line 22, in get_model
    return loader.load_model(
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/python/sglang/srt/model_loader/loader.py", line 357, in load_model
    model = _initialize_model(
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/python/sglang/srt/model_loader/loader.py", line 138, in _initialize_model
    return model_class(
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/python/sglang/srt/models/qwen2.py", line 359, in __init__
    self.logits_processor = LogitsProcessor(config)
  File "/public_sglang_ci/runner-a-gpu-0/_work/sglang/sglang/python/sglang/srt/layers/logits_processor.py", line 209, in __init__
    self.debug_tensor_dump_output_folder = global_server_args_dict[
KeyError: 'debug_tensor_dump_output_folder'
```