### PR TITLE
ROCm: update aiter and its usage to fused moe (bloat16, fp8, fp8 block-quant)

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -18,7 +18,7 @@ ARG TRITON_COMMIT="improve_fa_decode_3.0.0"
 
 
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
-ARG AITER_COMMIT="dev/testx"
+ARG AITER_COMMIT="testx"
 
 RUN git clone ${SGL_REPO} \
     && cd sglang \

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,7 +51,7 @@ srt = [
 ]
 
 # HIP (Heterogeneous-computing Interface for Portability) for AMD
-# => base docker rocm/vllm-dev:20241022, not from public vllm whl
+# => base docker rocm/vllm-dev:20250114, not from public vllm whl
 srt_hip = ["sglang[runtime_common]", "sgl-kernel==0.0.3.post6", "torch", "vllm==0.6.7.dev2", "outlines==0.1.11"]
 
 # xpu is not enabled in public vllm and torch whl,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -29,6 +29,9 @@ import logging
 
 is_hip_ = is_hip()
 
+if is_hip_:
+    from aiter import ck_moe
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,18 +176,20 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         )
 
         if is_hip_ and get_bool_env_var("CK_MOE"):
-            import aiter
-            from aiter.fused_moe import fused_experts_ck
-
-            assert activation == "silu", f"{activation=} is not supported."
             assert not no_combine, "unsupported"
-
-            return fused_experts_ck(
-                hidden_states=x,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
+            return ck_moe(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights,
+                topk_ids,
+                None,
+                None,
+                None,
+                None,
+                32,
+                None,
+                activation,
             )
         else:
             return fused_experts(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Performance boost (DSv3 +25~35%)

```
/sgl-workspace/sglang# RCCL_MSCCL_ENABLE=0 CK_MOE=1 python -m sglang.bench_one_batch --batch-size 64 --input 2048 --output 256 --model /data/deepseek-ai/DeepSeek-V3/ --tp 8 --trust-remote-code --quantization fp8
Benchmark ...
Prefill. latency: 8.12619 s, throughput:  16129.57 token/s
Decode.  latency: 0.04280 s, throughput:   1495.39 token/s
Decode.  latency: 0.04312 s, throughput:   1484.21 token/s
Decode.  latency: 0.04336 s, throughput:   1476.03 token/s
Decode.  latency: 0.04345 s, throughput:   1473.09 token/s
Decode.  latency: 0.04419 s, throughput:   1448.45 token/s
Decode.  median latency: 0.04578 s, median throughput:   1397.96 token/s
Total. latency: 19.787 s, throughput:   7452.11 token/s
 
/sgl-workspace/sglang# RCCL_MSCCL_ENABLE=0 CK_MOE=1 python -m sglang.bench_one_batch --batch-size 128 --input 2048 --output 256 --model /data/deepseek-ai/DeepSeek-V3/ --tp 8 --trust-remote-code --quantization fp8
Benchmark ...
Prefill. latency: 13.44756 s, throughput:  19493.80 token/s
Decode.  latency: 0.06238 s, throughput:   2052.02 token/s
Decode.  latency: 0.06148 s, throughput:   2082.02 token/s
Decode.  latency: 0.06213 s, throughput:   2060.28 token/s
Decode.  latency: 0.06288 s, throughput:   2035.71 token/s
Decode.  latency: 0.06297 s, throughput:   2032.69 token/s
Decode.  median latency: 0.06454 s, median throughput:   1983.23 token/s
Total. latency: 29.902 s, throughput:   9862.72 token/s
```

## Modifications

AITER Fused MoE support matrix:
```
TYPE                       ACTIVATION
bfloat16                   SILU/GELU
float8                     SILU (GELU to add)
float8 block quant         SILU (DSv3/R1)
```
`INT4-FP8` coming next (supports silu/gelu)
`CK_MOE=1` in command line or ENV to activate ck/aiter fused moe, in conditions other than that from support matrix, fallback to triton implementation.


<!-- Describe the changes made in this PR. -->

## Checklist

- [+] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [+] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [+] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [+] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [+] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [+] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
