### PR TITLE
Fix constrained generation errors by adding datasets dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,7 +38,8 @@ runtime_common = [
     "xgrammar==0.1.14",
     "ninja",
     "transformers==4.48.3",
-    "llguidance>=0.6.15"
+    "llguidance>=0.6.15",
+    "datasets"
 ]
 
 srt = [


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Generation requests with a JSON schema specified cause an error in SGLang due to an attempt to import datasets, which is not installed.

I am using the SGLang-provided Docker image, so have been working around this by manually installing datasets to the Python environment inside the container, but this change should prevent the need for the workaround.

Example error log:

```
inference_engine  | [2025-02-12 12:54:32 TP0] Scheduler hit an exception: Traceback (most recent call last):
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1796, in run_scheduler_process
inference_engine  |     scheduler.event_loop_overlap()
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
inference_engine  |     return func(*args, **kwargs)
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 496, in event_loop_overlap
inference_engine  |     batch = self.get_next_batch_to_run()
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 877, in get_next_batch_to_run
inference_engine  |     new_batch = self.get_new_batch_prefill()
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 898, in get_new_batch_prefill
inference_engine  |     self.move_ready_grammar_requests()
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1565, in move_ready_grammar_requests
inference_engine  |     req.grammar = req.grammar.result(timeout=0.05)
inference_engine  |   File "/usr/lib/python3.10/concurrent/futures/_base.py", line 458, in result
inference_engine  |     return self.__get_result()
inference_engine  |   File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
inference_engine  |     raise self._exception
inference_engine  |   File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
inference_engine  |     result = self.fn(*self.args, **self.kwargs)
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/constrained/base_grammar_backend.py", line 53, in init_value
inference_engine  |     entry.value = self.init_value_impl(key)
inference_engine  |   File "/sgl-workspace/sglang/python/sglang/srt/constrained/outlines_backend.py", line 173, in init_value_impl
inference_engine  |     guide = RegexGuide.from_regex(regex, self.outlines_tokenizer)
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines/fsm/guide.py", line 92, in from_regex
inference_engine  |     return super().from_regex(
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines_core/fsm/guide.py", line 212, in from_regex
inference_engine  |     ) = _create_states_mapping(
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines/fsm/guide.py", line 76, in cached_create_states_mapping
inference_engine  |     return uncached_create_states_mapping(regex_string, tokenizer, *args, **kwargs)
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines_core/fsm/guide.py", line 141, in create_states_mapping
inference_engine  |     return create_states_mapping_from_fsm(regex_fsm, tokenizer, frozen_tokens)
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines_core/fsm/guide.py", line 178, in create_states_mapping_from_fsm
inference_engine  |     states_to_token_maps, empty_token_ids = create_fsm_index_tokenizer(
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines_core/fsm/regex.py", line 473, in create_fsm_index_tokenizer
inference_engine  |     tokens_to_token_ids, empty_token_ids = reduced_vocabulary(tokenizer)
inference_engine  |   File "/usr/local/lib/python3.10/dist-packages/outlines/models/transformers.py", line 117, in __hash__
inference_engine  |     from datasets.fingerprint import Hasher
inference_engine  | ModuleNotFoundError: No module named 'datasets'
```

## Modifications

- Add `datasets` as a dependency of the SGLang Python package.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
