### PR TITLE
[Refactor] Reducing code duplication across FP8 CUDA quantization kernels

### DIFF
--- a/sgl-kernel/benchmark/bench_per_token_group_quant_fp8.py
+++ b/sgl-kernel/benchmark/bench_per_token_group_quant_fp8.py
@@ -1,13 +1,12 @@
 import itertools
-import math
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Tuple
 
 import torch
 import triton
 import triton.language as tl
 from sgl_kernel import sgl_per_token_group_quant_fp8
 
-from sglang.srt.utils import get_device_core_count, get_device_name, is_hip
+from sglang.srt.utils import is_hip
 
 is_hip_ = is_hip()
 fp8_type_ = torch.float8_e4m3fnuz if is_hip_ else torch.float8_e4m3fn

--- a/sgl-kernel/benchmark/bench_per_token_quant_fp8.py
+++ b/sgl-kernel/benchmark/bench_per_token_quant_fp8.py
@@ -40,9 +40,6 @@ def calculate_diff(batch_size: int, seq_len: int):
     scale_diff = torch.abs(vllm_scale - sglang_scale).mean().item()
     output_diff = torch.abs(vllm_out.float() - sglang_out.float()).mean().item()
 
-    print(f"Scale difference: {scale_diff}")
-    print(f"Output difference: {output_diff}")
-
     if torch.allclose(
         vllm_out.to(torch.float32), sglang_out.to(torch.float32), rtol=1e-3, atol=1e-5
     ) and torch.allclose(vllm_scale, sglang_scale, rtol=1e-3, atol=1e-5):

--- a/sgl-kernel/src/sgl-kernel/include/utils.h
+++ b/sgl-kernel/src/sgl-kernel/include/utils.h
@@ -104,6 +104,7 @@ using FP8_TYPE = c10::Float8_e4m3fn;
 C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
 #else
 #include <c10/util/Float8_e4m3fnuz.h>
+
 #include "amd/quant_utils.cuh"
 using FP8_TYPE = c10::Float8_e4m3fnuz;
 constexpr auto FP8_E4M3_MAX = 224.0f;

--- a/sgl-kernel/src/sgl-kernel/include/utils.h
+++ b/sgl-kernel/src/sgl-kernel/include/utils.h
@@ -95,3 +95,32 @@ inline int getSMVersion() {
   AT_DISPATCH_SWITCH(TYPE, NAME, DISPATCH_CASE_INTEGRAL_TYPES(__VA_ARGS__))
 
 #define CEILDIV(x, y) (((x) + (y)-1) / (y))
+
+#define WARP_SIZE 32
+
+#ifndef USE_ROCM
+#include <c10/util/Float8_e4m3fn.h>
+using FP8_TYPE = c10::Float8_e4m3fn;
+C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
+#else
+#include <c10/util/Float8_e4m3fnuz.h>
+#include "amd/quant_utils.cuh"
+using FP8_TYPE = c10::Float8_e4m3fnuz;
+constexpr auto FP8_E4M3_MAX = 224.0f;
+#endif
+
+__device__ __forceinline__ float atomicMaxFloat(float* addr, float value) {
+  float old;
+  old = (value >= 0) ? __int_as_float(atomicMax((int*)addr, __float_as_int(value)))
+                     : __uint_as_float(atomicMin((unsigned int*)addr, __float_as_uint(value)));
+  return old;
+}
+
+__device__ __forceinline__ float warpReduceMax(float max_value) {
+  max_value = fmaxf(max_value, __shfl_xor_sync(0xffffffff, max_value, 16));
+  max_value = fmaxf(max_value, __shfl_xor_sync(0xffffffff, max_value, 8));
+  max_value = fmaxf(max_value, __shfl_xor_sync(0xffffffff, max_value, 4));
+  max_value = fmaxf(max_value, __shfl_xor_sync(0xffffffff, max_value, 2));
+  max_value = fmaxf(max_value, __shfl_xor_sync(0xffffffff, max_value, 1));
+  return max_value;
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Refactor quantization kernels to improve code maintainability by:
- Centralizing shared CUDA utility functions and type definitions in utils.h
- Reducing code duplication across quantization kernels

Part of https://github.com/sgl-project/sglang/issues/2965

## Modifications
- Moved shared code to `sglang/sgl-kernel/src/sgl-kernel/include/utils.h`:
  - FP8 type definitions and constants
  - CUDA warp utility functions (warpReduceMax, atomicMaxFloat)
  - Common preprocessor definitions
- Updated quantization kernels to use shared code:
  - `per_token_quant_fp8.cu`
  - `per_tensor_quant_fp8.cu`

## Benchmark
```bash
python /home/jobuser/sglang/sgl-kernel/benchmark/bench_per_tensor_quant_fp8.py
INFO 03-07 06:43:21 __init__.py:190] Automatically detected platform cuda.
✅ All implementations match
per-tensor-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    37.760001    27.264001
1         16.0    128.0    61.280001    40.352002
2         16.0    256.0   119.967997    73.664002
3         16.0    512.0   232.832000   147.136003
4         16.0   1024.0   443.392009   274.271995
5         16.0   2048.0   861.968040   524.160028
6         32.0     64.0    61.087999    40.415999
7         32.0    128.0   119.887993    73.504001
8         32.0    256.0   232.960001   148.031995
9         32.0    512.0   443.744004   274.223983
10        32.0   1024.0   862.128019   524.208009
11        32.0   2048.0  1703.008056  1024.335980
12        64.0     64.0   120.127998    73.472001
13        64.0    128.0   232.991993   148.064002
14        64.0    256.0   443.264008   274.048001
15        64.0    512.0   862.240016   524.576008
16        64.0   1024.0  1706.112027  1023.136020
17        64.0   2048.0  3378.895998  2011.231899
18       128.0     64.0   232.927993   148.016006
19       128.0    128.0   443.455994   273.503989
20       128.0    256.0   861.599982   523.504019
21       128.0    512.0  1706.560016  1023.551941
22       128.0   1024.0  3375.808001  2009.759903
23       128.0   2048.0  6724.080086  3977.504015
```

```bash
python /home/jobuser/sglang/sgl-kernel/benchmark/bench_per_token_group_quant_fp8.py
✅ All implementations match
per-token-group-quant-fp8-performance:
    batch_size  seq_len  group_size       Triton   SGL Kernel
0          1.0     64.0       128.0    10.848000     9.568000
1          1.0    128.0       128.0    14.848000    12.224000
2          1.0    256.0       128.0    20.160001    14.944000
3          1.0    512.0       128.0    31.776000    21.248000
4          1.0   1024.0       128.0    55.039998    33.920001
5          1.0   2048.0       128.0   101.792000    62.399998
6          2.0     64.0       128.0    14.688000    12.320000
7          2.0    128.0       128.0    20.191999    14.944000
8          2.0    256.0       128.0    31.711999    21.183999
9          2.0    512.0       128.0    55.103999    33.920001
10         2.0   1024.0       128.0   101.712003    62.336002
11         2.0   2048.0       128.0   193.120003   112.864003
12         4.0     64.0       128.0    20.191999    14.912000
13         4.0    128.0       128.0    31.711999    21.183999
14         4.0    256.0       128.0    55.071998    33.920001
15         4.0    512.0       128.0   101.696000    62.431999
16         4.0   1024.0       128.0   193.151996   112.816006
17         4.0   2048.0       128.0   375.200003   212.927997
18         8.0     64.0       128.0    31.679999    21.215999
19         8.0    128.0       128.0    55.103999    33.952001
20         8.0    256.0       128.0   101.696000    62.511995
21         8.0    512.0       128.0   193.248004   112.896003
22         8.0   1024.0       128.0   375.135988   213.088006
23         8.0   2048.0       128.0   738.879979   412.943989
24        16.0     64.0       128.0    55.071998    33.952001
25        16.0    128.0       128.0   101.792000    62.560000
26        16.0    256.0       128.0   193.087995   112.768002
27        16.0    512.0       128.0   375.167996   213.024005
28        16.0   1024.0       128.0   739.232004   413.056016
29        16.0   2048.0       128.0  1467.216015   813.471973
30        32.0     64.0       128.0   101.952001    62.560000
31        32.0    128.0       128.0   193.087995   112.832002
32        32.0    256.0       128.0   375.167996   212.896004
33        32.0    512.0       128.0   739.199996   412.959993
34        32.0   1024.0       128.0  1470.479965   813.567996
35        32.0   2048.0       128.0  2922.784090  1612.895966
36        64.0     64.0       128.0   193.151996   112.896003
37        64.0    128.0       128.0   375.200003   213.152006
38        64.0    256.0       128.0   739.296019   412.831992
39        64.0    512.0       128.0  1471.168041   813.279986
40        64.0   1024.0       128.0  2922.271967  1612.576008
41        64.0   2048.0       128.0  5828.479767  3213.583946
```

```bash
python /home/jobuser/sglang/sgl-kernel/benchmark/bench_per_token_quant_fp8.py
INFO 03-07 06:46:42 __init__.py:190] Automatically detected platform cuda.
✅ All implementations match
per-token-dynamic-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    26.144000    30.239999
1         16.0    128.0    44.415999    42.080000
2         16.0    256.0    83.839998    85.055999
3         16.0    512.0   154.944003   157.856002
4         16.0   1024.0   297.152013   290.592015
5         16.0   2048.0   581.471980   551.519990
6         16.0   4096.0  1153.807998  1075.600028
7         32.0     64.0    44.192001    42.080000
8         32.0    128.0    84.608003    83.967999
9         32.0    256.0   155.808002   156.992003
10        32.0    512.0   297.280014   291.424006
11        32.0   1024.0   581.152022   551.072001
12        32.0   2048.0  1152.511954  1074.719906
13        32.0   4096.0  2289.920092  2109.503984
14        64.0     64.0    84.608003    84.096000
15        64.0    128.0   155.727997   158.720002
16        64.0    256.0   297.087997   290.304005
17        64.0    512.0   581.344008   551.168025
18        64.0   1024.0  1153.632045  1074.320078
19        64.0   2048.0  2290.719986  2109.951973
20        64.0   4096.0  4562.816143  4179.647923
21       128.0     64.0   155.616000   157.184005
22       128.0    128.0   297.055990   291.359991
23       128.0    256.0   580.864012   551.072001
24       128.0    512.0  1152.511954  1074.847937
25       128.0   1024.0  2290.240049  2109.247923
26       128.0   2048.0  4562.655926  4180.416107
27       128.0   4096.0  9109.968185  8315.551758
```


<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
