### PR TITLE
Remove the vllm dependency from the moe_align function 

### DIFF
--- a/sgl-kernel/tests/test_moe_align.py
+++ b/sgl-kernel/tests/test_moe_align.py
@@ -138,18 +138,20 @@ def moe_align_block_size_triton(
 
 
 @pytest.mark.parametrize(
-    "block_size,num_tokens,topk",
+    "block_size,num_tokens,topk,num_experts",
     list(
         itertools.product(
             [32, 64, 128, 256],  # block_size
             [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096],  # num_tokens
             [1, 2, 4, 8, 16, 32, 64],  # topk
+            [64, 160, 256],  #  num_experts
         )
     ),
 )
-def test_moe_align_block_size_compare_implementations(block_size, num_tokens, topk):
+def test_moe_align_block_size_compare_implementations(
+    block_size, num_tokens, topk, num_experts
+):
     # For DeepSeek V3, we have 256 experts
-    num_experts = 256
 
     topk_ids = torch.stack(
         [


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->
Remove the vllm dependency from the moe_align function and support the sgl_moe_align_block_size with expert sizes that are multiples of 32.
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Test Case

- [ ] DeepSeek v2 accuracy
- [ ] DeepSeek v2 prediction speed
- [ ] DeepSeek v3 accuracy
- [ ] DeepSeek v3 prediction speed
