### PR TITLE
add extral logic for all_reduce/all_gather when using pynccl

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -398,7 +398,7 @@ class GroupCoordinator:
             ipex.distributed.all_reduce(input_, group=self.device_group)
             return input_
 
-        if not supports_custom_op():
+        if not supports_custom_op() or self.use_pynccl:
             self._all_reduce_in_place(input_)
             return input_
 
@@ -445,7 +445,7 @@ class GroupCoordinator:
             )
 
     def all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
-        if not supports_custom_op():
+        if not supports_custom_op() or self.use_pynccl:
             self._all_gather_into_tensor(output, input)
         else:
             torch.ops.sglang.reg_all_gather_into_tensor(


### PR DESCRIPTION
## Motivation
When switching the Torch version from 2.3 to 2.5, the logic of supports_custom_op will no longer be suitable. This will cause it to go to the sgl-kernel custom op kernel, which is not the same action as before the change.


## Modifications
add the extra logic when using pynccl to communicate on  all_reduce/all_gather between intranode or internode.



