### PR TITLE
Fix per token fp8 quant precision

### DIFF
--- a/sgl-kernel/csrc/gemm/per_token_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/per_token_quant_fp8.cu
@@ -49,8 +49,6 @@ __global__ void per_token_quant_fp8_kernel(
   }
   __syncthreads();
 
-  const float scale_val = 1.0f / block_max;
-
   // Quantize using vectorized loads
   for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
     vec_t input_vec;
@@ -59,7 +57,7 @@ __global__ void per_token_quant_fp8_kernel(
     FP8_TYPE output_arr[vec_size];
 #pragma unroll
     for (uint32_t j = 0; j < vec_size; ++j) {
-      float val = fmaxf(fminf(static_cast<float>(input_vec[j]) * scale_val, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+      float val = fmaxf(fminf(static_cast<float>(input_vec[j]) / block_max, FP8_E4M3_MAX), -FP8_E4M3_MAX);
 #ifndef USE_ROCM
       output_arr[j] = static_cast<FP8_TYPE>(val);
 #else

--- a/sgl-kernel/tests/test_per_token_quant_fp8.py
+++ b/sgl-kernel/tests/test_per_token_quant_fp8.py
@@ -21,18 +21,16 @@ def vllm_per_token_quant_fp8(
 def sglang_per_token_quant_fp8(
     input: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    scale = torch.zeros(input.size(0), device=input.device, dtype=torch.float32)
+    scale = torch.zeros((input.size(0), 1), device=input.device, dtype=torch.float32)
     output = torch.empty_like(input, device=input.device, dtype=fp8_type_)
 
     sgl_per_token_quant_fp8(input, output, scale)
-    scale = scale.reshape(-1, 1)
-
     return output, scale
 
 
 @pytest.mark.parametrize(
     "num_tokens,hidden_dim",
-    list(itertools.product([128, 256, 512], [512, 2048, 4096])),
+    list(itertools.product([32, 64, 128, 256, 512], [128, 256, 512, 2048, 4096])),
 )
 def test_per_token_quant_compare_implementations(
     num_tokens: int,
@@ -44,7 +42,7 @@ def test_per_token_quant_compare_implementations(
     vllm_out, vllm_scale = vllm_per_token_quant_fp8(x)
     sglang_out, sglang_scale = sglang_per_token_quant_fp8(x)
 
-    torch.testing.assert_close(vllm_scale, sglang_scale, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(vllm_scale, sglang_scale, rtol=1e-3, atol=1e-5)
     torch.testing.assert_close(
         vllm_out.float(), sglang_out.float(), rtol=1e-3, atol=1e-3
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Precision issue of per token quant for small input size (#token x hidden_dim). Scale is computed correctly but quantized output has precision issue for small input sizes.

## Modifications
Remove extra inversion compute `const float scale_val = 1.0f / block_max;` and directly use `block_max` for quantization output computation.

**Misc:**
Change scale input placeholder shape to 2D `[# token, 1]` in test/benchmarking script to align output shape and avoid post reshape

## Tests
Both diff check in benchmark and test cases passed and no speed regression:

```
$ python3 benchmark/bench_per_token_quant_fp8.py 
INFO 03-13 04:10:05 __init__.py:190] Automatically detected platform cuda.
✅ All implementations match
per-token-dynamic-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    26.112000    26.016001
1         16.0    128.0    44.096000    39.808001
2         16.0    256.0    84.352002    69.632001
3         16.0    512.0   155.231997   123.232000
4         16.0   1024.0   296.240002   227.743998
5         16.0   2048.0   578.336000   436.416000
6         16.0   4096.0  1148.512006   857.903957
7         32.0     64.0    44.287998    38.656000
8         32.0    128.0    83.871998    71.039997
9         32.0    256.0   154.272005   122.432001
10        32.0    512.0   296.032012   227.615997
11        32.0   1024.0   579.200029   435.456008
12        32.0   2048.0  1147.968054   857.824028
13        32.0   4096.0  2280.591965  1693.935990
14        64.0     64.0    83.903998    69.983996
15        64.0    128.0   154.208004   123.520002
16        64.0    256.0   296.032012   226.656005
17        64.0    512.0   578.975976   436.576009
18        64.0   1024.0  1148.959994   858.064055
19        64.0   2048.0  2278.192043  1694.128036
20        64.0   4096.0  4540.895939  3365.952015
21       128.0     64.0   154.303998   122.432001
22       128.0    128.0   296.095997   226.656005
23       128.0    256.0   579.136014   436.544001
24       128.0    512.0  1149.055958   857.856035
25       128.0   1024.0  2278.032064  1693.776011
26       128.0   2048.0  4540.832043  3366.080046
27       128.0   4096.0  9064.704895  6707.295895
```

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
