### PR TITLE
fix accuracy issue

### DIFF
--- a/sgl-kernel/benchmark/bench_per_token_quant_fp8.py
+++ b/sgl-kernel/benchmark/bench_per_token_quant_fp8.py
@@ -22,9 +22,10 @@ def vllm_per_token_quant_fp8(
 def sglang_per_token_quant_fp8(
     input: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    scale = torch.zeros((input.size(0), 1), device=input.device, dtype=torch.float32)
+    scale = torch.zeros(input.size(0), device=input.device, dtype=torch.float32)
     output = torch.empty_like(input, device=input.device, dtype=fp8_type_)
     sgl_per_token_quant_fp8(input, output, scale)
+
     return output, scale
 
 
@@ -35,6 +36,9 @@ def calculate_diff(batch_size: int, seq_len: int):
 
     vllm_out, vllm_scale = vllm_per_token_quant_fp8(x)
     sglang_out, sglang_scale = sglang_per_token_quant_fp8(x)
+
+    scale_diff = torch.abs(vllm_scale - sglang_scale).mean().item()
+    output_diff = torch.abs(vllm_out.float() - sglang_out.float()).mean().item()
 
     if torch.allclose(
         vllm_out.to(torch.float32), sglang_out.to(torch.float32), rtol=1e-3, atol=1e-5

--- a/sgl-kernel/csrc/gemm/per_token_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/per_token_quant_fp8.cu
@@ -49,6 +49,8 @@ __global__ void per_token_quant_fp8_kernel(
   }
   __syncthreads();
 
+  const float scale_val = 1.0f / block_max;
+
   // Quantize using vectorized loads
   for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
     vec_t input_vec;
@@ -57,7 +59,7 @@ __global__ void per_token_quant_fp8_kernel(
     FP8_TYPE output_arr[vec_size];
 #pragma unroll
     for (uint32_t j = 0; j < vec_size; ++j) {
-      float val = fmaxf(fminf(static_cast<float>(input_vec[j]) / block_max, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+      float val = fmaxf(fminf(static_cast<float>(input_vec[j]) * scale_val, FP8_E4M3_MAX), -FP8_E4M3_MAX);
 #ifndef USE_ROCM
       output_arr[j] = static_cast<FP8_TYPE>(val);
 #else

--- a/sgl-kernel/setup.py
+++ b/sgl-kernel/setup.py
@@ -178,6 +178,8 @@ if torch.cuda.is_available():
     if cuda_version >= (12, 8) and sm_version >= 100:
         nvcc_flags.append("-gencode=arch=compute_100,code=sm_100")
         nvcc_flags.append("-gencode=arch=compute_100a,code=sm_100a")
+    else:
+        nvcc_flags.append("-use_fast_math")
     if sm_version >= 90:
         nvcc_flags.extend(nvcc_flags_fp8)
     if sm_version >= 80:
@@ -188,6 +190,8 @@ else:
         nvcc_flags.append("-gencode=arch=compute_90a,code=sm_90a")
     if enable_sm100a:
         nvcc_flags.append("-gencode=arch=compute_100a,code=sm_100a")
+    else:
+        nvcc_flags.append("-use_fast_math")
     if enable_fp8:
         nvcc_flags.extend(nvcc_flags_fp8)
     if enable_bf16:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

```
➜  tests git:(zhyncs/math) ls | grep test_per | xargs -n 1 python3
INFO 03-13 09:03:35 __init__.py:190] Automatically detected platform cuda.
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /sgl-workspace/sglang/sgl-kernel
configfile: pyproject.toml
plugins: anyio-4.8.0, typeguard-4.3.0
collected 9 items

test_per_tensor_quant_fp8.py .........                                                                                                                                              [100%]

==================================================================================== warnings summary =====================================================================================
../../../../usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1277
  /usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1277: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: anyio
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== 9 passed, 1 warning in 0.53s ===============================================================================
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /sgl-workspace/sglang/sgl-kernel
configfile: pyproject.toml
plugins: anyio-4.8.0, typeguard-4.3.0
collected 240 items

test_per_token_group_quant_fp8.py ................................................................................................................................................. [ 60%]
...............................................................................................                                                                                     [100%]

==================================================================================== warnings summary =====================================================================================
../../../../usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1277
  /usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1277: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: anyio
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 240 passed, 1 warning in 1.25s ==============================================================================
INFO 03-13 09:03:46 __init__.py:190] Automatically detected platform cuda.
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /sgl-workspace/sglang/sgl-kernel
configfile: pyproject.toml
plugins: anyio-4.8.0, typeguard-4.3.0
collected 9 items

test_per_token_quant_fp8.py .........                                                                                                                                               [100%]

==================================================================================== warnings summary =====================================================================================
../../../../usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1277
  /usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py:1277: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: anyio
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================== 9 passed, 1 warning in 0.51s ===============================================================================
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
