### PR TITLE
Fix: Complete int32 to int64 conversion

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1178,7 +1178,9 @@ class ScheduleBatch:
                 self.seq_lens, last_loc
             )
 
-        self.req_to_token_pool.write((self.req_pool_indices, locs), self.out_cache_loc)
+        self.req_to_token_pool.write(
+            (self.req_pool_indices, locs), self.out_cache_loc.to(torch.int32)
+        )
 
     def filter_batch(
         self,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1178,9 +1178,7 @@ class ScheduleBatch:
                 self.seq_lens, last_loc
             )
 
-        self.req_to_token_pool.write(
-            (self.req_pool_indices, locs), self.out_cache_loc.to(torch.int32)
-        )
+        self.req_to_token_pool.write((self.req_pool_indices, locs), self.out_cache_loc)
 
     def filter_batch(
         self,

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -305,7 +305,7 @@ class HiRadixCache(RadixCache):
         if value:
             value = torch.concat(value)
         else:
-            value = torch.tensor([], dtype=torch.int32)
+            value = torch.tensor([], dtype=torch.int64)
 
         last_node_global = last_node
         while last_node.evicted:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -62,7 +62,7 @@ class ReqToTokenPool:
         self.device = device
         with memory_saver_adapter.region():
             self.req_to_token = torch.zeros(
-                (size, max_context_len), dtype=torch.int64, device=device
+                (size, max_context_len), dtype=torch.int32, device=device
             )
         self.free_slots = list(range(size))
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -62,7 +62,7 @@ class ReqToTokenPool:
         self.device = device
         with memory_saver_adapter.region():
             self.req_to_token = torch.zeros(
-                (size, max_context_len), dtype=torch.int32, device=device
+                (size, max_context_len), dtype=torch.int64, device=device
             )
         self.free_slots = list(range(size))
 
@@ -622,11 +622,10 @@ class HostKVCache(abc.ABC):
         self.mem_state = torch.zeros(
             (self.size,), dtype=torch.uint8, device=self.device
         )
-        self.free_slots = torch.arange(self.size, dtype=torch.int32)
-        self.can_use_mem_size = self.size
 
         # A lock for synchronized operations on memory allocation and state transitions.
         self.lock = threading.RLock()
+        self.clear()
 
     @abc.abstractmethod
     def get_size_per_token(self):
@@ -656,7 +655,7 @@ class HostKVCache(abc.ABC):
     def clear(self):
         self.mem_state.fill_(0)
         self.can_use_mem_size = self.size
-        self.free_slots = torch.arange(self.size, dtype=torch.int32)
+        self.free_slots = torch.arange(self.size, dtype=torch.int64)
 
     @synchronized
     def get_state(self, indices: torch.Tensor) -> MemoryStateInt:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -140,7 +140,7 @@ class RadixCache(BasePrefixCache):
             return (
                 torch.empty(
                     (0,),
-                    dtype=torch.int32,
+                    dtype=torch.int64,
                     device=self.device,
                 ),
                 self.root_node,
@@ -154,7 +154,7 @@ class RadixCache(BasePrefixCache):
         if value:
             value = torch.concat(value)
         else:
-            value = torch.empty((0,), dtype=torch.int32, device=self.device)
+            value = torch.empty((0,), dtype=torch.int64, device=self.device)
         return value, last_node
 
     def insert(self, key: List, value=None):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
In a prior PR https://github.com/sgl-project/sglang/pull/4356 the data type for KV cache memory pool indices was changed from int32 to int64, but the change was not complete.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
This PR amends following type change:
~~1. Indices in `req_to_token_pool`~~
2. Default 0 tensor in Radix and HiRadix tree
3. Host KV cache memory pool

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
