### PR TITLE
AWQ dequant bf16 support

### DIFF
--- a/sgl-kernel/benchmark/bench_awq_dequant.py
+++ b/sgl-kernel/benchmark/bench_awq_dequant.py
@@ -44,9 +44,10 @@ def calculate_diff(qweight_row: int, qweight_col: int):
     )
 
     vllm_out = vllm_awq_dequantize(qweight, scales, qzeros)
-    sglang_out = sglang_awq_dequantize(qweight, scales, qzeros)
+    sglang_out = sglang_awq_dequantize(qweight, scales.to(torch.bfloat16), qzeros)
 
     output_diff = torch.abs(vllm_out.float() - sglang_out.float()).mean().item()
+    print(f"Output difference: {vllm_out.float() - sglang_out.float()}")
 
     if torch.allclose(
         vllm_out.to(torch.float32), sglang_out.to(torch.float32), rtol=1e-3, atol=1e-5
@@ -115,4 +116,4 @@ def benchmark(qweight_row, qweight_col, provider):
 
 if __name__ == "__main__":
     calculate_diff(qweight_row=3584, qweight_col=448)
-    benchmark.run(print_data=True)
+    # benchmark.run(print_data=True)

--- a/sgl-kernel/benchmark/bench_awq_dequant.py
+++ b/sgl-kernel/benchmark/bench_awq_dequant.py
@@ -21,7 +21,7 @@ def sglang_awq_dequantize(
     return awq_dequantize(qweight, scales, qzeros)
 
 
-def calculate_diff(qweight_row: int, qweight_col: int, q_dtype: torch.dtype = torch.float16):
+def calculate_diff(qweight_row: int, qweight_col: int, dst_dtype: torch.dtype):
     """Calculate difference between VLLM and SGLang implementations."""
     device = torch.device("cuda")
     qweight = torch.randint(
@@ -44,31 +44,34 @@ def calculate_diff(qweight_row: int, qweight_col: int, q_dtype: torch.dtype = to
     )
 
     vllm_out = vllm_awq_dequantize(qweight, scales, qzeros)
-    sglang_out = sglang_awq_dequantize(qweight, scales.to(q_dtype), qzeros)
+    sglang_out = sglang_awq_dequantize(qweight, scales.to(dst_dtype), qzeros)
 
     output_diff = torch.abs(vllm_out.float() - sglang_out.float()).mean().item()
-    if q_dtype == torch.bfloat16:
+    if dst_dtype == torch.bfloat16:
+        # Relax the tolerance for bfloat16 when comparing with vllm float16
         rtol = 1e-2
     else:
         rtol = 1e-3
     if torch.allclose(
-            vllm_out.to(torch.float32), sglang_out.to(torch.float32), rtol=rtol, atol=1e-4
-        ):
-        print(f"✅ sglang {q_dtype} implementations match vllm torch.float16")
+        vllm_out.to(torch.float32), sglang_out.to(torch.float32), rtol=rtol, atol=1e-4
+    ):
+        print(f"✅ sglang {dst_dtype} implementations match vllm torch.float16")
     else:
-        print(f"❌ sglang {q_dtype} implementations differ from vllm torch.float16")
+        print(f"❌ sglang {dst_dtype} implementations differ from vllm torch.float16")
 
 
 qweight_row_range = [3584, 18944, 128, 256, 512, 1024]
 qweight_cols_range = [448, 576, 4736, 16, 32, 64, 128]
-q_dtype_range = [torch.float16, torch.bfloat16]
+dst_dtype_range = [torch.float16, torch.bfloat16]
 
-configs = list(itertools.product(qweight_row_range, qweight_cols_range, q_dtype_range))
+configs = list(
+    itertools.product(qweight_row_range, qweight_cols_range, dst_dtype_range)
+)
 
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["qweight_row", "qweight_col", "q_dtype"],
+        x_names=["qweight_row", "qweight_col", "dst_dtype"],
         x_vals=configs,
         line_arg="provider",
         line_vals=["vllm", "sglang"],
@@ -79,7 +82,7 @@ configs = list(itertools.product(qweight_row_range, qweight_cols_range, q_dtype_
         args={},
     )
 )
-def benchmark(qweight_row, qweight_col, q_dtype, provider):
+def benchmark(qweight_row, qweight_col, dst_dtype, provider):
     device = torch.device("cuda")
     qweight = torch.randint(
         0,
@@ -108,7 +111,7 @@ def benchmark(qweight_row, qweight_col, q_dtype, provider):
         )
     elif provider == "sglang":
         fn = lambda: sglang_awq_dequantize(
-            qweight.clone(), scales.to(q_dtype).clone(), qzeros.clone()
+            qweight.clone(), scales.to(dst_dtype).clone(), qzeros.clone()
         )
 
     ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
@@ -117,6 +120,6 @@ def benchmark(qweight_row, qweight_col, q_dtype, provider):
 
 
 if __name__ == "__main__":
-    calculate_diff(qweight_row=3584, qweight_col=448, q_dtype=torch.float16)
-    calculate_diff(qweight_row=3584, qweight_col=448, q_dtype=torch.bfloat16)
+    calculate_diff(qweight_row=3584, qweight_col=448, dst_dtype=torch.float16)
+    calculate_diff(qweight_row=3584, qweight_col=448, dst_dtype=torch.bfloat16)
     benchmark.run(print_data=True)

--- a/sgl-kernel/csrc/gemm/awq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/awq_kernel.cu
@@ -5,38 +5,35 @@
 #include <torch/all.h>
 
 template<bool norm = true>
-inline __device__ uint4 dequantize_s4_to_bf16x2(uint32_t const& src) {
+inline __device__ uint4 dequantize_s4_to_bf16x2(uint32_t const& source) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-  // 01234567 01234567
-  // SEEEEEEE EMMMMMMM
-  //          1...XXXX
-  // (1 + x/2^7) * 2^(e-127) -> e-127=7 -> e=134 -> 0100 0011 -> 0x43
-  static constexpr uint32_t I4s_TO_BF16s_MAGIC_NUM = 0x43004300;
-  static constexpr uint32_t BOTTOM_MASK = 0x000f000f;
-  static constexpr uint32_t TOP_MASK = 0x00f000f0;
-  static constexpr uint32_t immLut   = (0xf0 & 0xcc) | 0xaa;
-
   uint4 result;
 
   uint32_t* h = reinterpret_cast<uint32_t*>(&result);
+  uint32_t const& i4s = reinterpret_cast<uint32_t const&>(source);
 
-  uint32_t const& i4s    = reinterpret_cast<uint32_t const&>(src);
-  const uint32_t  i4s_4  = i4s >> 4;
-  const uint32_t  i4s_8  = i4s >> 8;
-  const uint32_t  i4s_12 = i4s >> 12;
+  // 01234567 01234567
+  // SEEEEEEE EMMMMMMM
+  // 127 + 7 = 134 -> 0100 0011 0 -> 0x43
+  static constexpr uint32_t immLut   = (0xf0 & 0xcc) | 0xaa;
+  static constexpr uint32_t BOTTOM_MASK = 0x000f000f;
+  static constexpr uint32_t TOP_MASK = 0x00f000f0;
+  static constexpr uint32_t I4s_TO_BF16s_MAGIC_NUM = 0x43004300;
+
+  const uint32_t  top_i4s = i4s >> 8;
 
   asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
                : "=r"(h[0])
                : "r"(i4s), "n"(BOTTOM_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
   asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
                : "=r"(h[1])
-               : "r"(i4s_4), "n"(TOP_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
+               : "r"(i4s), "n"(TOP_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
   asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
                : "=r"(h[2])
-               : "r"(i4s_8), "n"(BOTTOM_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
+               : "r"(top_i4s), "n"(BOTTOM_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
   asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
                : "=r"(h[3])
-               : "r"(i4s_12), "n"(TOP_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
+               : "r"(top_i4s), "n"(TOP_MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
 
   // For bottom 4 bits, need to subtract 2 ^ 7 = 128
   static constexpr uint32_t BF16_TOP_MAGIC_NUM = 0x43004300;
@@ -49,11 +46,11 @@ inline __device__ uint4 dequantize_s4_to_bf16x2(uint32_t const& src) {
   static constexpr uint32_t NEG_8 = 0xc100c100;
 
   // Convert elt_01
-  asm volatile("sub.bf16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(I4s_TO_BF16s_MAGIC_NUM));
+  asm volatile("sub.bf16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(BF16_TOP_MAGIC_NUM));
   // Convert elt_23
   asm volatile("fma.rn.bf16x2 %0, %1, %2, %3;\n" : "=r"(h[1]) : "r"(h[1]), "r"(ONE_SIXTEENTH), "r"(NEG_8));
   // Convert elt_45
-  asm volatile("sub.bf16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(I4s_TO_BF16s_MAGIC_NUM));
+  asm volatile("sub.bf16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(BF16_TOP_MAGIC_NUM));
   // Convert elt_67
   asm volatile("fma.rn.bf16x2 %0, %1, %2, %3;\n" : "=r"(h[3]) : "r"(h[3]), "r"(ONE_SIXTEENTH), "r"(NEG_8));
 
@@ -112,6 +109,7 @@ __device__ uint4 dequantize_s4_to_fp16x2(uint32_t const& source) {
   static constexpr uint32_t FP16_TOP_MAGIC_NUM = 0x64006400;
   // This is the half2 {1 / 16, 1 / 16} represented as an integer.
   static constexpr uint32_t ONE_SIXTEENTH = 0x2c002c00;
+  // 1024 / 16 = 64 we need to subtract 64 from the above.
   // This is the half2 {-64, -64} represented as an integer.
   static constexpr uint32_t NEG_64 = 0xd400d400;
 

--- a/sgl-kernel/tests/test_awq_dequant.py
+++ b/sgl-kernel/tests/test_awq_dequant.py
@@ -20,7 +20,7 @@ def sglang_awq_dequantize(
 
 
 @pytest.mark.parametrize(
-    "qweight_row,qweight_col,q_dtype",
+    "qweight_row,qweight_col,dst_dtype",
     list(
         itertools.product(
             [3584, 18944, 128, 256, 512, 1024],
@@ -32,7 +32,7 @@ def sglang_awq_dequantize(
 def test_awq_dequant_compare_implementations(
     qweight_row: int,
     qweight_col: int,
-    q_dtype: torch.dtype,
+    dst_dtype: torch.dtype,
 ):
     device = torch.device("cuda")
 
@@ -57,10 +57,11 @@ def test_awq_dequant_compare_implementations(
 
     # Run both implementations
     vllm_out = vllm_awq_dequantize(qweight, scales, qzeros)
-    sglang_out = sglang_awq_dequantize(qweight, scales.to(q_dtype), qzeros)
+    sglang_out = sglang_awq_dequantize(qweight, scales.to(dst_dtype), qzeros)
 
     # Compare results
-    if q_dtype == torch.bfloat16:
+    if dst_dtype == torch.bfloat16:
+        # Relax the tolerance for bfloat16 when comparing with vllm float16
         rtol = 1e-2
     else:
         rtol = 1e-3


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Add magic function to convert 8xint4 to 8xbf16

Follow up of #4104 

BF16 is slightly slower because of additional bit shifts required.
```
✅ sglang torch.float16 implementations match vllm torch.float16
✅ sglang torch.bfloat16 implementations match vllm torch.float16
awq-dequantize-performance:
    qweight_row  qweight_col       dst_dtype         VLLM  SGL Kernel
0          3584          448   torch.float16    81.487998   28.096000
1          3584          448  torch.bfloat16    81.472002   32.575998
2          3584          576   torch.float16    97.375996   33.312000
3          3584          576  torch.bfloat16    97.439997   37.919998
4          3584         4736   torch.float16   670.495987  183.487996
5          3584         4736  torch.bfloat16   671.904027  188.927993
6          3584           16   torch.float16    16.511999   14.144000
7          3584           16  torch.bfloat16    16.543999   16.896000
8          3584           32   torch.float16    18.975999   14.848000
9          3584           32  torch.bfloat16    18.975999   18.048000
10         3584           64   torch.float16    21.760000   15.936000
11         3584           64  torch.bfloat16    21.792000   20.288000
12         3584          128   torch.float16    30.432001   18.719999
13         3584          128  torch.bfloat16    30.495999   22.784000
14        18944          448   torch.float16   356.959999   99.711999
15        18944          448  torch.bfloat16   357.823998  104.415998
16        18944          576   torch.float16   443.616003  123.616003
17        18944          576  torch.bfloat16   443.327993  128.128007
18        18944         4736   torch.float16  3466.912031  898.064017
19        18944         4736  torch.bfloat16  3476.560116  904.608011
20        18944           16   torch.float16    25.952000   17.600000
21        18944           16  torch.bfloat16    25.920000   20.447999
22        18944           32   torch.float16    34.175999   19.680001
23        18944           32  torch.bfloat16    34.127999   22.688000
24        18944           64   torch.float16    50.560001   24.576001
25        18944           64  torch.bfloat16    50.560001   28.608000
26        18944          128   torch.float16    82.815997   37.184000
27        18944          128  torch.bfloat16    82.847998   41.343998
28          128          448   torch.float16    16.640000   14.400000
29          128          448  torch.bfloat16    16.640000   18.816000
30          128          576   torch.float16    17.632000   14.976000
31          128          576  torch.bfloat16    17.664000   19.455999
32          128         4736   torch.float16    40.256001   20.352000
33          128         4736  torch.bfloat16    40.288001   25.536001
34          128           16   torch.float16    13.568000   13.408000
35          128           16  torch.bfloat16    13.600000   16.063999
36          128           32   torch.float16    13.600000   13.504000
37          128           32  torch.bfloat16    13.600000   16.511999
38          128           64   torch.float16    14.048000   13.888000
39          128           64  torch.bfloat16    14.016000   17.920000
40          128          128   torch.float16    14.112000   14.144000
41          128          128  torch.bfloat16    14.144000   18.464001
42          256          448   torch.float16    19.840000   15.104000
43          256          448  torch.bfloat16    19.808000   19.487999
44          256          576   torch.float16    21.120001   15.648000
45          256          576  torch.bfloat16    21.152001   20.288000
46          256         4736   torch.float16    64.032003   25.152000
47          256         4736  torch.bfloat16    64.191997   30.688001
48          256           16   torch.float16    13.568000   13.408000
49          256           16  torch.bfloat16    13.600000   15.872000
50          256           32   torch.float16    13.920000   13.920000
51          256           32  torch.bfloat16    13.984000   16.864000
52          256           64   torch.float16    14.128000   14.080000
53          256           64  torch.bfloat16    14.144000   18.304000
54          256          128   torch.float16    15.040000   14.272000
55          256          128  torch.bfloat16    15.072000   18.848000
56          512          448   torch.float16    24.704000   16.096000
57          512          448  torch.bfloat16    24.704000   20.671999
58          512          576   torch.float16    28.832000   17.664000
59          512          576  torch.bfloat16    28.832000   22.112001
60          512         4736   torch.float16   110.671997   37.824001
61          512         4736  torch.bfloat16   110.688001   42.943999
62          512           16   torch.float16    13.888000   13.888000
63          512           16  torch.bfloat16    13.920000   16.192000
64          512           32   torch.float16    14.112000   14.112000
65          512           32  torch.bfloat16    14.144000   17.055999
66          512           64   torch.float16    15.200000   14.240000
67          512           64  torch.bfloat16    15.200000   18.656000
68          512          128   torch.float16    16.511999   14.272000
69          512          128  torch.bfloat16    16.543999   18.368000
70         1024          448   torch.float16    35.808001   18.864000
71         1024          448  torch.bfloat16    35.776000   23.200000
72         1024          576   torch.float16    39.903998   19.840000
73         1024          576  torch.bfloat16    39.999999   24.256000
74         1024         4736   torch.float16   204.288006   62.944002
75         1024         4736  torch.bfloat16   204.255998   68.223998
76         1024           16   torch.float16    14.144000   14.080000
77         1024           16  torch.bfloat16    14.112000   16.608000
78         1024           32   torch.float16    15.520000   14.240000
79         1024           32  torch.bfloat16    15.552000   17.408000
80         1024           64   torch.float16    16.384000   14.208000
81         1024           64  torch.bfloat16    16.384000   18.304000
82         1024          128   torch.float16    19.072000   15.040000
83         1024          128  torch.bfloat16    19.072000   19.648001
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
