### PR TITLE
 Optimize Triton decoding kernel for dynamic workload

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -39,6 +39,7 @@ class AttentionBackend(ABC):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_kv_heads: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -349,6 +349,7 @@ class FlashInferAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_kv_heads: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
@@ -1062,6 +1063,7 @@ class FlashInferMultiStepDraftBackend:
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
                 bs,
+                -1,
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
                 seq_lens_sum=-1,

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -279,6 +279,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_kv_heads: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
@@ -791,6 +792,7 @@ class FlashInferMLAMultiStepDraftBackend:
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
                 bs,
+                -1,
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
                 seq_lens_sum=-1,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -596,6 +596,9 @@ class TritonMultiStepDraftBackend:
                 )
             )
         self.max_context_len = self.attn_backends[0].max_context_len
+        self.num_head = (
+            model_runner.model_config.num_attention_heads // get_attention_tp_size()
+        )
         self.device = model_runner.device
         # Cached variables for generate_draft_decode_kv_indices
         self.pool_len = model_runner.req_to_token_pool.req_to_token.shape[1]

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -158,7 +158,7 @@ class TritonAttnBackend(AttentionBackend):
             if spec_info is None:
                 kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
                 kv_indptr = kv_indptr[: bs + 1]
-                kv_indices = torch.zeros(
+                kv_indices = torch.empty(
                     forward_batch.seq_lens_sum, dtype=torch.int32, device=self.device
                 )
                 create_flashinfer_kv_indices_triton[(bs,)](
@@ -175,7 +175,7 @@ class TritonAttnBackend(AttentionBackend):
                 bs = kv_indptr.shape[0] - 1
 
             attn_logits = [
-                torch.zeros(
+                torch.empty(
                     (
                         bs,
                         self.num_head,
@@ -185,7 +185,7 @@ class TritonAttnBackend(AttentionBackend):
                     dtype=torch.float32,
                     device=self.device,
                 ),
-                torch.zeros(
+                torch.empty(
                     (
                         bs,
                         self.num_head,
@@ -195,7 +195,7 @@ class TritonAttnBackend(AttentionBackend):
                     device=self.device,
                 ),
             ]
-            num_kv_splits = torch.zeros((bs,), dtype=torch.int32, device=self.device)
+            num_kv_splits = torch.empty((bs,), dtype=torch.int32, device=self.device)
 
             num_kv_heads = self.num_head
             if hasattr(forward_batch.token_to_kv_pool, "k_buffer"):
@@ -221,7 +221,7 @@ class TritonAttnBackend(AttentionBackend):
             # Different with flashinfer kv_indptr and kv_indices construction
             kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
             kv_indptr = kv_indptr[: bs + 1]
-            kv_indices = torch.zeros(
+            kv_indices = torch.empty(
                 kv_indptr[-1], dtype=torch.int32, device=self.device
             )
             create_flashinfer_kv_indices_triton[(bs,)](
@@ -262,7 +262,7 @@ class TritonAttnBackend(AttentionBackend):
                 forward_batch.extend_prefix_lens, dim=0
             )
             kv_indptr = kv_indptr[: bs + 1]
-            kv_indices = torch.zeros(
+            kv_indices = torch.empty(
                 forward_batch.extend_prefix_lens.sum().item(),
                 dtype=torch.int32,
                 device=self.device,
@@ -652,7 +652,7 @@ class TritonMultiStepDraftBackend:
             call_fn(i, forward_batch)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        kv_indices = torch.zeros(
+        kv_indices = torch.empty(
             (
                 self.speculative_num_steps,
                 forward_batch.batch_size * self.topk * self.max_context_len,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -4,16 +4,51 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 import triton
+import triton.language as tl
 
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.utils import get_bool_env_var, get_device_core_count
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
+
+
+@triton.jit
+def get_num_kv_splits_triton(
+    num_kv_splits_ptr,
+    max_seq_len_ptr,
+    bs,
+    num_head,
+    num_kv_head,
+    max_kv_splits,
+    device_core_count,
+):
+    # TODO: this method is tunable
+    max_seq_len = tl.load(max_seq_len_ptr)
+
+    # NOTE: this is a hack to let num_kv_split grows up with seqlen gradually
+    ext_seq_len = tl.cast((max_seq_len + 256 - 1) // 256, tl.float32)
+    ext_device_core_count = device_core_count * tl.maximum(
+        tl.cast(tl.log(ext_seq_len), tl.int32), 1
+    )
+    block_h, num_kv_group = 16, num_head // num_kv_head
+    if num_kv_group == 1:
+        bh_grid = bs * num_head
+    else:
+        # from triton_ops/decode_attention.py:_decode_grouped_att_m_fwd
+        block_h = tl.minimum(block_h, num_kv_group)
+        bh_grid = bs * (num_head + block_h - 1) // block_h
+
+    num_kv_splits = tl.minimum(
+        (ext_device_core_count + bh_grid - 1) // bh_grid, max_kv_splits
+    )
+
+    tl.store(num_kv_splits_ptr, num_kv_splits)
 
 
 class TritonAttnBackend(AttentionBackend):
@@ -64,7 +99,11 @@ class TritonAttnBackend(AttentionBackend):
             model_runner.model_config.num_attention_heads // get_attention_tp_size()
         )
 
-        self.num_kv_splits = model_runner.server_args.triton_attention_num_kv_splits
+        self.static_kv_splits = get_bool_env_var(
+            "SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS", "false"
+        )
+        print(f"static_kv_splits = {self.static_kv_splits}")
+        self.max_kv_splits = model_runner.server_args.triton_attention_num_kv_splits
         self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[-1]
 
         self.forward_metadata = None
@@ -72,6 +111,29 @@ class TritonAttnBackend(AttentionBackend):
         self.max_context_len = model_runner.model_config.context_len
 
         self.device = model_runner.device
+        self.device_core_count = get_device_core_count(model_runner.gpu_id)
+
+    def get_num_kv_splits(
+        self,
+        num_kv_splits: torch.Tensor,
+        seq_lens: torch.Tensor,
+        bs: int,
+        num_kv_head: int,
+    ):
+        if self.static_kv_splits or self.device_core_count <= 0:
+            num_kv_splits[:] = self.max_kv_splits
+            return
+
+        max_seq_len, _ = torch.max(seq_lens, dim=0)
+        get_num_kv_splits_triton[(1,)](
+            num_kv_splits,
+            max_seq_len,
+            bs,
+            self.num_head,
+            num_kv_head,
+            self.max_kv_splits,
+            self.device_core_count,
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init auxiliary variables for triton attention backend."""
@@ -100,16 +162,34 @@ class TritonAttnBackend(AttentionBackend):
                 kv_indptr, kv_indices = spec_info.kv_indptr, spec_info.kv_indices
                 bs = kv_indptr.shape[0] - 1
 
-            attn_logits = torch.empty(
-                (
-                    bs,
-                    self.num_head,
-                    self.num_kv_splits,
-                    self.v_head_dim + 1,
+            attn_logits = [
+                torch.empty(
+                    (
+                        bs,
+                        self.num_head,
+                        self.max_kv_splits,
+                        self.v_head_dim,
+                    ),
+                    dtype=torch.float32,
+                    device=self.device,
                 ),
-                dtype=torch.float32,
-                device=self.device,
-            )
+                torch.empty(
+                    (
+                        bs,
+                        self.num_head,
+                        self.max_kv_splits,
+                    ),
+                    dtype=torch.float32,
+                    device=self.device,
+                ),
+            ]
+            num_kv_splits = torch.empty(1, dtype=torch.int32, device=self.device)
+
+            num_kv_heads = self.num_head
+            if hasattr(forward_batch.token_to_kv_pool, "k_buffer"):
+                if isinstance(forward_batch.token_to_kv_pool.k_buffer, list):
+                    num_kv_heads = forward_batch.token_to_kv_pool.k_buffer[0].shape[1]
+            self.get_num_kv_splits(num_kv_splits, forward_batch.seq_lens, bs, num_kv_heads)
 
             qo_indptr = None
             custom_mask = None
@@ -148,6 +228,7 @@ class TritonAttnBackend(AttentionBackend):
             mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
             mask_indptr = mask_indptr[: bs + 1]
             max_extend_len = self.num_draft_tokens
+            num_kv_splits = None
             attn_logits = None
         elif forward_batch.forward_mode.is_draft_extend():
             kv_indices, kv_indptr, qo_indptr, custom_mask = (
@@ -160,6 +241,7 @@ class TritonAttnBackend(AttentionBackend):
             )
             mask_indptr = None
             max_extend_len = torch.max(spec_info.accept_length).item()
+            num_kv_splits = None
             attn_logits = None
         else:
             kv_indptr[1 : bs + 1] = torch.cumsum(
@@ -188,10 +270,12 @@ class TritonAttnBackend(AttentionBackend):
             mask_indptr = None
             attn_logits = None
             max_extend_len = torch.max(forward_batch.extend_seq_lens).item()
+            num_kv_splits = None
 
         self.forward_metadata = (
             attn_logits,
             max_extend_len,
+            num_kv_splits,
             kv_indptr,
             kv_indices,
             qo_indptr,
@@ -202,10 +286,20 @@ class TritonAttnBackend(AttentionBackend):
     def init_cuda_graph_state(
         self, max_bs: int, kv_indices_buf: Optional[torch.Tensor] = None
     ):
-        self.cuda_graph_attn_logits = torch.zeros(
-            (max_bs, self.num_head, self.num_kv_splits, self.v_head_dim + 1),
-            dtype=torch.float32,
-            device=self.device,
+        self.cuda_graph_attn_logits = [
+            torch.zeros(
+                (max_bs, self.num_head, self.max_kv_splits, self.v_head_dim),
+                dtype=torch.float32,
+                device=self.device,
+            ),
+            torch.zeros(
+                (max_bs, self.num_head, self.max_kv_splits),
+                dtype=torch.float32,
+                device=self.device,
+            ),
+        ]
+        self.cuda_graph_num_kv_splits = torch.tensor(
+            self.max_kv_splits, dtype=torch.int32, device=self.device
         )
         if kv_indices_buf is None:
             self.cuda_graph_kv_indices = torch.zeros(
@@ -255,6 +349,7 @@ class TritonAttnBackend(AttentionBackend):
 
             attn_logits = self.cuda_graph_attn_logits
             max_extend_len = None
+            num_kv_splits = self.cuda_graph_num_kv_splits
             qo_indptr = None
             custom_mask = None
             mask_indptr = None
@@ -285,6 +380,7 @@ class TritonAttnBackend(AttentionBackend):
             mask_indptr = self.mask_indptr[: bs + 1]
             mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
             max_extend_len = self.num_draft_tokens
+            num_kv_splits = None
             attn_logits = None
         else:
             raise ValueError(
@@ -294,6 +390,7 @@ class TritonAttnBackend(AttentionBackend):
         self.forward_metadata = (
             attn_logits,
             max_extend_len,
+            num_kv_splits,
             kv_indptr,
             kv_indices,
             qo_indptr,
@@ -304,6 +401,7 @@ class TritonAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_kv_head: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
@@ -317,6 +415,7 @@ class TritonAttnBackend(AttentionBackend):
             # Update kv_indptr, kv_indices
             kv_indptr = self.kv_indptr
             kv_indices = self.cuda_graph_kv_indices
+            num_kv_splits = self.cuda_graph_num_kv_splits
             if spec_info is None:
                 kv_indptr[1 : bs + 1] = torch.cumsum(seq_lens[:bs], dim=0)
                 kv_indptr = kv_indptr[: bs + 1]
@@ -332,6 +431,7 @@ class TritonAttnBackend(AttentionBackend):
             else:
                 kv_indptr[: spec_info.kv_indptr.shape[0]] = spec_info.kv_indptr
                 kv_indices[: spec_info.kv_indices.shape[0]] = spec_info.kv_indices
+            self.get_num_kv_splits(num_kv_splits, seq_lens, bs, num_kv_head)
         elif forward_mode.is_target_verify():
             # Update qo_indptr, kv_indptr, kv_indices, custom_mask, mask_indptr
             bs = len(req_pool_indices)
@@ -391,6 +491,7 @@ class TritonAttnBackend(AttentionBackend):
         (
             _,
             max_extend_len,
+            _,
             kv_indptr,
             kv_indices,
             qo_indptr,
@@ -435,7 +536,9 @@ class TritonAttnBackend(AttentionBackend):
         else:
             o = torch.empty_like(q)
 
-        attn_logits, _, kv_indptr, kv_indices, _, _, _ = self.forward_metadata
+        attn_logits, _, num_kv_splits, kv_indptr, kv_indices, _, _, _ = (
+            self.forward_metadata
+        )
 
         if save_kv_cache:
             forward_batch.token_to_kv_pool.set_kv_buffer(
@@ -450,7 +553,8 @@ class TritonAttnBackend(AttentionBackend):
             kv_indptr,
             kv_indices,
             attn_logits,
-            self.num_kv_splits,
+            num_kv_splits,
+            self.max_kv_splits,
             layer.scaling,
             layer.logit_cap,
         )
@@ -579,9 +683,15 @@ class TritonMultiStepDraftBackend:
     def init_forward_metadata_replay_cuda_graph(
         self, forward_batch: ForwardBatch, bs: int
     ):
+        num_kv_heads = self.num_head
+        if hasattr(forward_batch.token_to_kv_pool, "k_buffer"):
+            if isinstance(forward_batch.token_to_kv_pool.k_buffer, list):
+                num_kv_heads = forward_batch.token_to_kv_pool.k_buffer[0].shape[1]
+
         def call_fn(i, forward_batch):
             self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
                 bs,
+                num_kv_heads,
                 forward_batch.req_pool_indices,
                 forward_batch.seq_lens,
                 seq_lens_sum=-1,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -158,7 +158,7 @@ class TritonAttnBackend(AttentionBackend):
             if spec_info is None:
                 kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
                 kv_indptr = kv_indptr[: bs + 1]
-                kv_indices = torch.empty(
+                kv_indices = torch.zeros(
                     forward_batch.seq_lens_sum, dtype=torch.int32, device=self.device
                 )
                 create_flashinfer_kv_indices_triton[(bs,)](
@@ -175,7 +175,7 @@ class TritonAttnBackend(AttentionBackend):
                 bs = kv_indptr.shape[0] - 1
 
             attn_logits = [
-                torch.empty(
+                torch.zeros(
                     (
                         bs,
                         self.num_head,
@@ -185,7 +185,7 @@ class TritonAttnBackend(AttentionBackend):
                     dtype=torch.float32,
                     device=self.device,
                 ),
-                torch.empty(
+                torch.zeros(
                     (
                         bs,
                         self.num_head,
@@ -195,7 +195,7 @@ class TritonAttnBackend(AttentionBackend):
                     device=self.device,
                 ),
             ]
-            num_kv_splits = torch.empty((bs,), dtype=torch.int32, device=self.device)
+            num_kv_splits = torch.zeros((bs,), dtype=torch.int32, device=self.device)
 
             num_kv_heads = self.num_head
             if hasattr(forward_batch.token_to_kv_pool, "k_buffer"):
@@ -221,7 +221,7 @@ class TritonAttnBackend(AttentionBackend):
             # Different with flashinfer kv_indptr and kv_indices construction
             kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
             kv_indptr = kv_indptr[: bs + 1]
-            kv_indices = torch.empty(
+            kv_indices = torch.zeros(
                 kv_indptr[-1], dtype=torch.int32, device=self.device
             )
             create_flashinfer_kv_indices_triton[(bs,)](
@@ -262,7 +262,7 @@ class TritonAttnBackend(AttentionBackend):
                 forward_batch.extend_prefix_lens, dim=0
             )
             kv_indptr = kv_indptr[: bs + 1]
-            kv_indices = torch.empty(
+            kv_indices = torch.zeros(
                 forward_batch.extend_prefix_lens.sum().item(),
                 dtype=torch.int32,
                 device=self.device,
@@ -652,7 +652,7 @@ class TritonMultiStepDraftBackend:
             call_fn(i, forward_batch)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
-        kv_indices = torch.empty(
+        kv_indices = torch.zeros(
             (
                 self.speculative_num_steps,
                 forward_batch.batch_size * self.topk * self.max_context_len,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -189,7 +189,9 @@ class TritonAttnBackend(AttentionBackend):
             if hasattr(forward_batch.token_to_kv_pool, "k_buffer"):
                 if isinstance(forward_batch.token_to_kv_pool.k_buffer, list):
                     num_kv_heads = forward_batch.token_to_kv_pool.k_buffer[0].shape[1]
-            self.get_num_kv_splits(num_kv_splits, forward_batch.seq_lens, bs, num_kv_heads)
+            self.get_num_kv_splits(
+                num_kv_splits, forward_batch.seq_lens, bs, num_kv_heads
+            )
 
             qo_indptr = None
             custom_mask = None

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -100,7 +100,6 @@ class TritonAttnBackend(AttentionBackend):
         self.static_kv_splits = get_bool_env_var(
             "SGLANG_TRITON_DECODE_ATTN_STATIC_KV_SPLITS", "false"
         )
-        print(f"static_kv_splits = {self.static_kv_splits}")
         self.max_kv_splits = model_runner.server_args.triton_attention_num_kv_splits
         self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[-1]
 

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -92,7 +92,9 @@ def _fwd_kernel_stage1(
 
     off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
 
-    kv_len_per_split = tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
     split_kv_start = kv_len_per_split * split_kv_id
     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
@@ -303,7 +305,9 @@ def _fwd_grouped_kernel_stage1(
             cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_dpe[None, :]
         )
 
-    kv_len_per_split = tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
     split_kv_start = kv_len_per_split * split_kv_id
     split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
 
@@ -523,7 +527,9 @@ def _fwd_kernel_stage2(
 
     offs_v = cur_batch * stride_mid_ob + cur_head * stride_mid_oh + offs_d
     offs_logic = (cur_batch * stride_mid_ob + cur_head * stride_mid_oh) // Lv
-    kv_len_per_split = tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    kv_len_per_split = (
+        tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
+    )
 
     for split_kv_id in range(0, MAX_KV_SPLITS):
         split_kv_start = kv_len_per_split * split_kv_id

--- a/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/decode_attention.py
@@ -88,7 +88,7 @@ def _fwd_kernel_stage1(
 
     cur_batch_kv_start_idx = tl.load(kv_indptr + cur_batch)
     cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - cur_batch_kv_start_idx
-    kv_splits = tl.load(num_kv_splits)
+    kv_splits = tl.load(num_kv_splits + cur_batch)
 
     off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
 
@@ -294,7 +294,7 @@ def _fwd_grouped_kernel_stage1(
 
     cur_batch_kv_start_idx = tl.load(kv_indptr + cur_batch)
     cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - cur_batch_kv_start_idx
-    kv_splits = tl.load(num_kv_splits)
+    kv_splits = tl.load(num_kv_splits + cur_batch)
 
     offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
 
@@ -516,7 +516,7 @@ def _fwd_kernel_stage2(
     cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - tl.load(
         kv_indptr + cur_batch
     )
-    kv_splits = tl.load(num_kv_splits)
+    kv_splits = tl.load(num_kv_splits + cur_batch)
 
     offs_d = tl.arange(0, BLOCK_DV)
     mask_d = offs_d < Lv

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -26,6 +26,7 @@ import tqdm
 from sglang.srt.custom_op import CustomOp
 from sglang.srt.distributed import get_tensor_model_parallel_rank
 from sglang.srt.distributed.parallel_state import GroupCoordinator, graph_capture
+from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.moe.fused_moe_native import fused_moe_forward_native
 from sglang.srt.layers.torchao_utils import save_gemlite_cache
@@ -195,6 +196,9 @@ class CudaGraphRunner:
         # Attention backend
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.num_tokens_per_bs
+        self.num_head = (
+            model_runner.model_config.num_attention_heads // get_attention_tp_size()
+        )
         self.model_runner.attn_backend.init_cuda_graph_state(self.max_num_token)
         self.seq_len_fill_value = (
             self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
@@ -491,9 +495,15 @@ class CudaGraphRunner:
         if hasattr(forward_batch.spec_info, "hidden_states"):
             self.hidden_states[:raw_num_token] = forward_batch.spec_info.hidden_states
 
+        num_kv_heads = self.num_head
+        if hasattr(forward_batch.token_to_kv_pool, "k_buffer"):
+            if isinstance(forward_batch.token_to_kv_pool.k_buffer, list):
+                num_kv_heads = forward_batch.token_to_kv_pool.k_buffer[0].shape[1]
+
         # Attention backend
         self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
             bs,
+            num_kv_heads,
             self.req_pool_indices,
             self.seq_lens,
             forward_batch.seq_lens_sum + (bs - raw_bs),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -165,7 +165,7 @@ class ServerArgs:
     enable_nan_detection: bool = False
     enable_p2p_check: bool = False
     triton_attention_reduce_in_fp32: bool = False
-    triton_attention_num_kv_splits: int = 16
+    triton_attention_num_kv_splits: int = 8
     num_continuous_decode_steps: int = 1
     delete_ckpt_after_loading: bool = False
     enable_memory_saver: bool = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -165,7 +165,7 @@ class ServerArgs:
     enable_nan_detection: bool = False
     enable_p2p_check: bool = False
     triton_attention_reduce_in_fp32: bool = False
-    triton_attention_num_kv_splits: int = 8
+    triton_attention_num_kv_splits: int = 16
     num_continuous_decode_steps: int = 1
     delete_ckpt_after_loading: bool = False
     enable_memory_saver: bool = False

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -228,7 +228,8 @@ class TestTritonAttention(unittest.TestCase):
         seq_len = 10  # This represents the number of tokens already in the sequence
         total_tokens = B * seq_len
         sm_scale = 1.0 / (D**0.5)
-        num_kv_splits = 8
+        max_kv_splits = 8
+        num_kv_splits = torch.tensor(4, dtype=torch.int32, device="cuda")
 
         # q represents the new token being generated, one per batch
         q = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")
@@ -247,7 +248,12 @@ class TestTritonAttention(unittest.TestCase):
         kv_indices = torch.arange(total_tokens, device="cuda")
 
         attn_logits = torch.empty(
-            (B, H_Q, num_kv_splits, D + 1),
+            (B, H_Q, max_kv_splits, D),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        attn_lse = torch.empty(
+            (B, H_Q, max_kv_splits),
             dtype=torch.float32,
             device="cuda",
         )
@@ -259,8 +265,9 @@ class TestTritonAttention(unittest.TestCase):
             o,
             kv_indptr,
             kv_indices,
-            attn_logits,
+            (attn_logits, attn_lse),
             num_kv_splits,
+            max_kv_splits,
             sm_scale,
         )
 
@@ -284,7 +291,8 @@ class TestTritonAttention(unittest.TestCase):
         seq_len = S  # This represents the number of tokens already in the sequence
         total_tokens = B * seq_len
         sm_scale = 1.0 / (D**0.5)
-        num_kv_splits = 8
+        max_kv_splits = 8
+        num_kv_splits = torch.tensor(4, dtype=torch.int32, device="cuda")
 
         # q represents the new token being generated, one per batch
         q = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")
@@ -304,7 +312,12 @@ class TestTritonAttention(unittest.TestCase):
         kv_indices = torch.arange(total_tokens, device="cuda")
 
         attn_logits = torch.empty(
-            (B, H_Q, num_kv_splits, D_V + 1),
+            (B, H_Q, max_kv_splits, D_V),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        attn_lse = torch.empty(
+            (B, H_Q, max_kv_splits),
             dtype=torch.float32,
             device="cuda",
         )
@@ -316,13 +329,19 @@ class TestTritonAttention(unittest.TestCase):
             o,
             kv_indptr,
             kv_indices,
-            attn_logits,
+            (attn_logits, attn_lse),
             num_kv_splits,
+            max_kv_splits,
             sm_scale,
         )
 
         attn_logits1 = torch.empty(
-            (B, H_Q, num_kv_splits, D_V + 1),
+            (B, H_Q, max_kv_splits, D_V),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        attn_lse1 = torch.empty(
+            (B, H_Q, max_kv_splits, D_V),
             dtype=torch.float32,
             device="cuda",
         )
@@ -334,8 +353,9 @@ class TestTritonAttention(unittest.TestCase):
             o_grouped,
             kv_indptr,
             kv_indices,
-            attn_logits1,
+            (attn_logits1, attn_lse1),
             num_kv_splits,
+            max_kv_splits,
             sm_scale,
         )
 

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -229,7 +229,7 @@ class TestTritonAttention(unittest.TestCase):
         total_tokens = B * seq_len
         sm_scale = 1.0 / (D**0.5)
         max_kv_splits = 8
-        num_kv_splits = torch.tensor(4, dtype=torch.int32, device="cuda")
+        num_kv_splits = torch.full((B,), 4, dtype=torch.int32, device="cuda")
 
         # q represents the new token being generated, one per batch
         q = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")
@@ -292,7 +292,7 @@ class TestTritonAttention(unittest.TestCase):
         total_tokens = B * seq_len
         sm_scale = 1.0 / (D**0.5)
         max_kv_splits = 8
-        num_kv_splits = torch.tensor(4, dtype=torch.int32, device="cuda")
+        num_kv_splits = torch.full((B,), 4, dtype=torch.int32, device="cuda")
 
         # q represents the new token being generated, one per batch
         q = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The current implementation of triton decode attention uses a static split for KV, which makes it unable to adapt to dynamically changing context lengths and batch sizes in an online environment, leading to performance degradation. Therefore, I refactored the code to improve performance under different workloads.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

1. Split `attn_out` into `attn_out` and `attn_lse` to ensure that `attn_out` is aligned with `v_head_dim`.  
2. Use `max_kv_splits` to launch kernels, while scheduling the actual `num_kv_splits` for each batch based on `sm_count`, `seq_lens`, `num_kv_head`, and `batch_size`. This helps optimize different workloads in online services.  
3. Align `kv_chunk_size` to 32, limiting the actual `num_kv_splits` for shorter contexts. 

<!-- Describe the changes made in this PR. -->

## Benchmark Simple

### Before Optimizing
- 1-batch gets actual num_kv_splits=8
```
Decode batch. #running-req: 1, #token: 194, token usage: 0.00, gen throughput (token/s): 155.01, #queue-req: 0,
...
Decode batch. #running-req: 1, #token: 2154, token usage: 0.00, gen throughput (token/s): 141.59, #queue-req: 0,
```
- 128-batch gets actual num_kv_splits=8
```
Decode batch. #running-req: 128, #token: 24477, token usage: 0.06, gen throughput (token/s): 12940.23, #queue-req: 0,
...
Decode batch. #running-req: 128, #token: 275357, token usage: 0.62, gen throughput (token/s): 5662.88, #queue-req: 0,
```

### After Optimizing
- 1-batch gets actual num_kv_splits=8, throught no changes
```
Decode batch. #running-req: 1, #token: 194, token usage: 0.00, gen throughput (token/s): 155.05, #queue-req: 0,
...
Decode batch. #running-req: 1, #token: 2154, token usage: 0.00, gen throughput (token/s): 141.34, #queue-req: 0,
```
- 128-batch gets actual num_kv_splits=1, get 10%+ improvement, faster than flashinfer backend
```
Decode batch. #running-req: 128, #token: 24477, token usage: 0.06, gen throughput (token/s): 14403.42, #queue-req: 0,
...
Decode batch. #running-req: 128, #token: 275357, token usage: 0.62, gen throughput (token/s): 6234.16, #queue-req: 0,
```

### flashinfer
- 1-batch
```
Decode batch. #running-req: 1, #token: 194, token usage: 0.00, gen throughput (token/s): 148.51, #queue-req: 0,
...
Decode batch. #running-req: 1, #token: 2154, token usage: 0.00, gen throughput (token/s): 148.80, #queue-req: 0,
```
- 128-batch
```
Decode batch. #running-req: 128, #token: 24477, token usage: 0.06, gen throughput (token/s): 14296.91, #queue-req: 0,
...
Decode batch. #running-req: 128, #token: 275357, token usage: 0.62, gen throughput (token/s): 5802.22, #queue-req: 0,
```

## Switch `triton_attention_num_kv_splits` to 16
- 1-batch
```
Decode batch. #running-req: 1, #token: 194, token usage: 0.00, gen throughput (token/s): 155.18, #queue-req: 0,
...
Decode batch. #running-req: 1, #token: 2154, token usage: 0.00, gen throughput (token/s): 145.84, #queue-req: 0,
```

## Benchmark CI case

Slightly improvement on CI offline benchmark.

### Before Optimizing
```
python3 -m unittest test_bench_serving.TestBenchServing.test_offline_throughput_with_triton_attention_backend

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max reqeuest concurrency:                not set   
Successful requests:                     500       
Benchmark duration (s):                  145.07    
Total input tokens:                      1011340   
Total generated tokens:                  521573    
Total generated tokens (retokenized):    521971    
Request throughput (req/s):              3.45      
Input token throughput (tok/s):          6971.19   
Output token throughput (tok/s):         3595.21   
Total token throughput (tok/s):          10566.40  
Concurrency:                             291.50    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   84579.50  
Median E2E Latency (ms):                 86010.16  
---------------Time to First Token----------------
Mean TTFT (ms):                          46107.03  
Median TTFT (ms):                        44009.99  
P99 TTFT (ms):                           109690.89 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           36.92     
Median ITL (ms):                         31.34     
P95 ITL (ms):                            66.71     
P99 ITL (ms):                            145.06    
Max ITL (ms):                            8973.56   
==================================================
```
### After Optimizing
```
python3 -m unittest test_bench_serving.TestBenchServing.test_offline_throughput_with_triton_attention_backend

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max reqeuest concurrency:                not set   
Successful requests:                     500       
Benchmark duration (s):                  140.72    
Total input tokens:                      1011340   
Total generated tokens:                  521573    
Total generated tokens (retokenized):    521757    
Request throughput (req/s):              3.55      
Input token throughput (tok/s):          7187.08   
Output token throughput (tok/s):         3706.55   
Total token throughput (tok/s):          10893.63  
Concurrency:                             291.70    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   82093.30  
Median E2E Latency (ms):                 83537.30  
---------------Time to First Token----------------
Mean TTFT (ms):                          44954.60  
Median TTFT (ms):                        42916.35  
P99 TTFT (ms):                           106357.07 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           35.64     
Median ITL (ms):                         29.93     
P95 ITL (ms):                            64.49     
P99 ITL (ms):                            143.75    
Max ITL (ms):                            9095.72   
==================================================
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
