### PR TITLE
UnitTests: Add device-agnostic support and skip CUDA-dependent tests on non-CUDA. Part1

### DIFF
--- a/test/srt/test_fp8_kernel.py
+++ b/test/srt/test_fp8_kernel.py
@@ -6,6 +6,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_fp8,
     w8a8_block_fp8_matmul,
 )
+from sglang.srt.utils import get_device, is_cuda
 
 
 class TestFP8Base(unittest.TestCase):
@@ -18,11 +19,12 @@ class TestFP8Base(unittest.TestCase):
         cls.group_size = 128
         cls.quant_type = torch.float8_e4m3fn
         cls.output_type = torch.bfloat16
+        cls.device = get_device()
 
     @staticmethod
-    def _make_A(M, K, group_size, out_dtype):
+    def _make_A(M, K, group_size, out_dtype, device):
         quant_A = torch.rand(
-            M, K // group_size, group_size, dtype=torch.float32, device="cuda"
+            M, K // group_size, group_size, dtype=torch.float32, device=device
         )
         # -1 ~ 1
         quant_A = quant_A * 2 - 1
@@ -34,7 +36,7 @@ class TestFP8Base(unittest.TestCase):
         quant_A = quant_A.to(out_dtype).to(torch.float32)
 
         # create scale and A
-        scale = torch.rand(M, K // group_size, dtype=torch.float32, device="cuda")
+        scale = torch.rand(M, K // group_size, dtype=torch.float32, device=device)
         scale /= fmax
         A = quant_A * scale[..., None]
 
@@ -43,7 +45,7 @@ class TestFP8Base(unittest.TestCase):
         return A, quant_A, scale
 
     @staticmethod
-    def _make_B(K, N, group_size, out_dtype):
+    def _make_B(K, N, group_size, out_dtype, device):
         def _aligned_size(a, b):
             return (a + b - 1) // b * b
 
@@ -56,7 +58,7 @@ class TestFP8Base(unittest.TestCase):
             N_aligned // group_size,
             group_size,
             dtype=torch.float32,
-            device="cuda",
+            device=device,
         )
         quant_B = quant_B * 2 - 1
 
@@ -73,7 +75,7 @@ class TestFP8Base(unittest.TestCase):
             N_aligned // group_size,
             1,
             dtype=torch.float32,
-            device="cuda",
+            device=device,
         )
         scale /= fmax
 
@@ -87,10 +89,14 @@ class TestFP8Base(unittest.TestCase):
 
 class TestPerTokenGroupQuantFP8(TestFP8Base):
     def test_per_token_group_quant_fp8(self):
-        if torch.cuda.get_device_capability()[0] < 9:
+        if is_cuda() and torch.cuda.get_device_capability()[0] < 9:
             return
         A, A_quant_gt, scale_gt = self._make_A(
-            M=self.M, K=self.K, group_size=self.group_size, out_dtype=self.quant_type
+            M=self.M,
+            K=self.K,
+            group_size=self.group_size,
+            out_dtype=self.quant_type,
+            device=self.device,
         )
         A_quant, scale = per_token_group_quant_fp8(
             x=A, group_size=self.group_size, dtype=self.quant_type
@@ -103,13 +109,21 @@ class TestPerTokenGroupQuantFP8(TestFP8Base):
 
 class TestW8A8BlockFP8Matmul(TestFP8Base):
     def test_w8a8_block_fp8_matmul(self):
-        if torch.cuda.get_device_capability()[0] < 9:
+        if is_cuda() and torch.cuda.get_device_capability()[0] < 9:
             return
         A, A_quant_gt, A_scale_gt = self._make_A(
-            M=self.M, K=self.K, group_size=self.group_size, out_dtype=self.quant_type
+            M=self.M,
+            K=self.K,
+            group_size=self.group_size,
+            out_dtype=self.quant_type,
+            device=self.device,
         )
         B, B_quant_gt, B_scale_gt = self._make_B(
-            K=self.K, N=self.N, group_size=self.group_size, out_dtype=self.quant_type
+            K=self.K,
+            N=self.N,
+            group_size=self.group_size,
+            out_dtype=self.quant_type,
+            device=self.device,
         )
         C_gt = A.to(self.output_type) @ B.to(self.output_type)
         C = w8a8_block_fp8_matmul(

--- a/test/srt/test_get_weights_by_name.py
+++ b/test/srt/test_get_weights_by_name.py
@@ -7,6 +7,7 @@ import torch
 from transformers import AutoModelForCausalLM
 
 import sglang as sgl
+from sglang.srt.utils import get_device, get_device_count, is_cuda
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -28,15 +29,21 @@ def _process_return(ret):
 
 class TestGetWeightsByName(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.device = get_device()
+        cls.num_gpus = get_device_count()
+
     def init_hf_model(self, model_name, tie_word_embeddings):
         self.hf_model = AutoModelForCausalLM.from_pretrained(
             model_name, torch_dtype="bfloat16", tie_word_embeddings=tie_word_embeddings
-        ).to("cuda:0")
+        ).to(self.device)
 
     def init_backend(self, backend, dp, tp, model_name):
         self.backend = backend
         self.dp = dp
         self.tp = tp
+
         if backend == "Engine":
             self.engine = sgl.Engine(
                 model_path=model_name,
@@ -60,7 +67,9 @@ class TestGetWeightsByName(unittest.TestCase):
     def clean_up(self):
         del self.hf_model
         gc.collect()
-        torch.cuda.empty_cache()
+        if is_cuda():
+            torch.cuda.empty_cache()
+
         if self.backend == "Engine":
             self.engine.shutdown()
         else:
@@ -68,6 +77,7 @@ class TestGetWeightsByName(unittest.TestCase):
 
     def assert_tie_word_embeddings(self, truncate_size):
         print("assert_tie_word_embeddings")
+
         if self.backend == "Engine":
             backend_ret = _process_return(
                 self.engine.get_weights_by_name("lm_head.weight", truncate_size)
@@ -79,7 +89,9 @@ class TestGetWeightsByName(unittest.TestCase):
                     json={"name": "lm_head.weight", "truncate_size": truncate_size},
                 ).json()
             )
+
         print("assert_tie_word_embeddings of hf and backend")
+
         assert np.allclose(
             self.hf_model.get_parameter("model.embed_tokens.weight")
             .cpu()
@@ -105,6 +117,7 @@ class TestGetWeightsByName(unittest.TestCase):
         print(
             f"param_name: {param_name}, backend: {self.backend}, dp: {self.dp}, tp: {self.tp}"
         )
+
         param = self.hf_model.get_parameter(param_name)[:truncate_size]
         param_np = param.cpu().detach().float().numpy()
 
@@ -122,6 +135,7 @@ class TestGetWeightsByName(unittest.TestCase):
             np.testing.assert_allclose(runtime_ret, param_np, rtol=1e-5, atol=1e-5)
 
     def test_get_weights_by_name(self):
+
         if is_in_ci():
             test_suits = [
                 ("Engine", 1, 1, DEFAULT_SMALL_MODEL_NAME_FOR_TEST),
@@ -131,11 +145,12 @@ class TestGetWeightsByName(unittest.TestCase):
                 ("Runtime", 1, 1, DEFAULT_SMALL_MODEL_NAME_FOR_TEST),
                 ("Engine", 1, 1, DEFAULT_MODEL_NAME_FOR_TEST),
             ]
-            if torch.cuda.device_count() >= 2:
+
+            if self.num_gpus >= 2:
                 test_suits.append(("Engine", 1, 2, DEFAULT_SMALL_MODEL_NAME_FOR_TEST))
                 test_suits.append(("Runtime", 2, 1, DEFAULT_MODEL_NAME_FOR_TEST))
 
-            if torch.cuda.device_count() >= 4:
+            if self.num_gpus >= 4:
                 test_suits.extend(
                     [
                         ("Engine", 2, 2, DEFAULT_SMALL_MODEL_NAME_FOR_TEST),

--- a/test/srt/test_hidden_states.py
+++ b/test/srt/test_hidden_states.py
@@ -4,10 +4,15 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import sglang as sgl
+from sglang.srt.utils import get_device
 from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
 
 
 class TestHiddenState(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.device = get_device()
+
     def test_return_hidden_states(self):
         prompts = ["Today is", "Today is a sunny day and I like"]
         model_path = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
@@ -45,7 +50,7 @@ class TestHiddenState(unittest.TestCase):
         )
 
         model = AutoModelForCausalLM.from_pretrained(
-            model_path, torch_dtype=torch.bfloat16, device_map="cuda"
+            model_path, torch_dtype=torch.bfloat16, device_map=self.device
         )
 
         for input_id, output in zip(input_ids, outputs):
@@ -63,7 +68,7 @@ class TestHiddenState(unittest.TestCase):
                     i.unsqueeze(0) if len(i.shape) == 1 else i
                     for i in output["meta_info"]["hidden_states"]
                 ]
-            ).to("cuda")
+            ).to(self.device)
             print("=== SRT Hiddens ===")
             print(sg_hidden_states)
 

--- a/test/srt/test_mla_flashinfer.py
+++ b/test/srt/test_mla_flashinfer.py
@@ -28,6 +28,8 @@ class TestFlashinferMLA(unittest.TestCase):
                     "--enable-flashinfer-mla",
                 ]
             )
+        else:
+            raise unittest.SkipTest("CUDA is not available")
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -72,6 +74,8 @@ class TestFlashinferMLANoRagged(unittest.TestCase):
                     "--flashinfer-mla-disable-ragged",
                 ]
             )
+        else:
+            raise unittest.SkipTest("CUDA is not available")
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
@@ -127,6 +131,8 @@ class TestFlashinferMLAMTP(unittest.TestCase):
                     "--enable-flashinfer-mla",
                 ]
             )
+        else:
+            raise unittest.SkipTest("CUDA is not available")
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,

--- a/test/srt/test_release_memory_occupation.py
+++ b/test/srt/test_release_memory_occupation.py
@@ -13,6 +13,8 @@ _DEBUG_EXTRA = True
 
 class TestReleaseMemoryOccupation(unittest.TestCase):
     def test_release_and_resume_occupation(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
         prompt = "Today is a sunny day and I like"
         sampling_params = {"temperature": 0, "max_new_tokens": 8}
         model_name = DEFAULT_SMALL_MODEL_NAME_FOR_TEST

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -29,6 +29,8 @@ class TestTritonAttention(unittest.TestCase):
         torch.backends.cudnn.benchmark = False
 
     def setUp(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
         # Set seeds before each test method
         self._set_all_seeds(42)
 

--- a/test/srt/test_triton_attention_rocm_mla.py
+++ b/test/srt/test_triton_attention_rocm_mla.py
@@ -24,6 +24,8 @@ class TestTritonAttentionMLA(unittest.TestCase):
         torch.backends.cudnn.benchmark = False
 
     def setUp(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
         # Set seeds before each test method
         self._set_all_seeds(42)
 

--- a/test/srt/test_vlm_accuracy.py
+++ b/test/srt/test_vlm_accuracy.py
@@ -16,6 +16,7 @@ from sglang.srt.conversation import generate_chat_conv
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.openai_api.protocol import ChatCompletionRequest
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import get_device
 
 
 # Test the logits output between HF and SGLang
@@ -23,7 +24,7 @@ class VisionLLMLogitsBase(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.image_url = "https://github.com/sgl-project/sglang/blob/main/test/lang/example_image.png?raw=true"
-        cls.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        cls.device = get_device()
         cls.model_path = ""
         cls.chat_template = ""
         cls.processor = ""
@@ -162,7 +163,7 @@ class TestMiniCPMVLogits(VisionLLMLogitsBase):
         )
         cls.chat_template = "minicpmv"
 
-        cls.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        cls.device = device()
         cls.model = AutoModel.from_pretrained(
             cls.model_path, torch_dtype=torch.bfloat16, trust_remote_code=True
         ).eval()


### PR DESCRIPTION

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

The original test code was hardcoded to run on CUDA (device="cuda"), making it incompatible with other device types (e.g., XPU, HPU, CPU). This PR introduces dynamic device selection using get_device() and is_cuda(), ensuring the tests run seamlessly on any supported device.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

- Refactored test initialization to use `get_device()` and `is_cuda()` for device-agnostic execution.
- Replaced hardcoded `cuda` device references with dynamic device selection.
- Added `unittest.SkipTest` for CUDA-dependent tests when CUDA is not available.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
