### PR TITLE
Fix the bug in assembling local path in connector.

### DIFF
--- a/python/sglang/srt/connector/s3.py
+++ b/python/sglang/srt/connector/s3.py
@@ -50,7 +50,9 @@ def list_files(
               disallowed by pattern
     """
     parts = path.removeprefix("s3://").split("/")
-    prefix = "/".join(parts[1:])
+    # Compatible with input path that do not end with a '/', or end with consecutive '/'.
+    # e.g. s3://bucket/dirname, s3://bucket/dirname//
+    prefix = "/".join(parts[1:]).rstrip("/") + "/"
     bucket_name = parts[0]
 
     objects = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)


### PR DESCRIPTION
## Motivation

There is a bug in assembling local download destination path in s3 connector. Which can be reproduced in a simple input:

``` python
destination_file = os.path.join(self.local_dir, file.removeprefix(base_dir))
# self.local_dir='/tmp/tmpvfe0jm_l', base_dir='QwQ-32B', file='QwQ-32B/config.json', destination_file='/config.json'

```

## Modifications

Remove the leading '/' with `.lstrip(os.sep)`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
