### PR TITLE
Enable setting sglang logger from Env Variable `SGLANG_LOGGING_CONFIG_PATH `

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -727,6 +727,16 @@ def prepare_model_and_tokenizer(model_path: str, tokenizer_path: str):
 
 
 def configure_logger(server_args, prefix: str = ""):
+    if SGLANG_LOGGING_CONFIG_PATH := os.getenv("SGLANG_LOGGING_CONFIG_PATH"):
+        if not os.path.exists(SGLANG_LOGGING_CONFIG_PATH):
+            raise Exception(
+                "Setting SGLANG_LOGGING_CONFIG_PATH from env with "
+                f"{SGLANG_LOGGING_CONFIG_PATH} but it does not exist!"
+            )
+        with open(SGLANG_LOGGING_CONFIG_PATH, encoding="utf-8") as file:
+            custom_config = json.loads(file.read())
+        logging.config.dictConfig(custom_config)
+        return
     format = f"[%(asctime)s{prefix}] %(message)s"
     # format = f"[%(asctime)s.%(msecs)03d{prefix}] %(message)s"
     logging.basicConfig(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
sglang's log is output to stdout by default. I need to change the code in `python/sglang/srt/utils.py` to config it to a custom path. It's not convenient. 

This PR allows setting the sglang logger from a Env Variable: `SGLANG_LOGGING_CONFIG_PATH`.
sglang users can config a json file and put the config file path into the Env Variable`SGLANG_LOGGING_CONFIG_PATH` and then the config file can be applied.
The json config file could be:
```json
{
    "formatters": {
        "sglang": {
            "class": "logging.Formatter",
            "datefmt": "%Y-%m-%d %H:%M:%S",
            "format": "%(asctime)s %(levelname)s %(process)d [%(filename)s:%(lineno)d] %(message)s"
        }
    },
    "handlers": {
        "sglang": {
            "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
            "formatter": "sglang",
            "level": "INFO",
            "filename": "/home/admin/logs/sglang.log",
            "maxBytes": 104857600,
            "backupCount": 20
        }
    },
    "loggers": {
        "sglang": {
            "handlers": ["sglang"],
            "level": "INFO",
            "propagate": false
        }
    },
    "version": 1,
    "disable_existing_loggers": false
}
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
Add a few lines to check the env variable in `python/sglang/srt/utils.py`.

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
