### PR TITLE
[Feature] Support HASS (speculative decoding)

### DIFF
--- a/python/sglang/srt/models/llama_eagle.py
+++ b/python/sglang/srt/models/llama_eagle.py
@@ -143,4 +143,7 @@ class LlamaForCausalLMEagle(LlamaForCausalLM):
                 super().load_weights([(name, loaded_weight)])
 
 
-EntryClass = [LlamaForCausalLMEagle]
+class LlamaForCausalLMHass(LlamaForCausalLMEagle):
+    pass
+
+EntryClass = [LlamaForCausalLMEagle, LlamaForCausalLMHass]

--- a/python/sglang/srt/models/llama_eagle.py
+++ b/python/sglang/srt/models/llama_eagle.py
@@ -146,4 +146,5 @@ class LlamaForCausalLMEagle(LlamaForCausalLM):
 class LlamaForCausalLMHass(LlamaForCausalLMEagle):
     pass
 
+
 EntryClass = [LlamaForCausalLMEagle, LlamaForCausalLMHass]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -287,6 +287,10 @@ class ServerArgs:
             # NEXTN shares the same implementation of EAGLE
             self.speculative_algorithm = "EAGLE"
 
+        if self.speculative_algorithm == "HASS":
+            # HASS shares the same implementation of EAGLE
+            self.speculative_algorithm = "EAGLE"
+
         if (
             self.speculative_algorithm == "EAGLE"
             or self.speculative_algorithm == "EAGLE3"
@@ -782,7 +786,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE", "EAGLE3", "NEXTN"],
+            choices=["EAGLE", "EAGLE3", "NEXTN", "HASS"],
             help="Speculative algorithm.",
         )
         parser.add_argument(

--- a/test/srt/test_eagle_infer.py
+++ b/test/srt/test_eagle_infer.py
@@ -179,6 +179,21 @@ class TestEAGLE3Engine(TestEAGLEEngine):
     NUM_CONFIGS = 1
 
 
+class TestHASSEngine(TestEAGLEEngine):
+    BASE_CONFIG = {
+        "model_path": "meta-llama/Llama-3.1-8B-Instruct",
+        "speculative_draft_model_path": "amosyou/sglang-HASS-LLaMA3-Instruct-8B",
+        "speculative_algorithm": "HASS",
+        "speculative_num_steps": 5,
+        "speculative_eagle_topk": 16,
+        "speculative_num_draft_tokens": 64,
+        "mem_fraction_static": 0.7,
+        "cuda_graph_max_bs": 5,
+        "dtype": "float16",
+    }
+    NUM_CONFIGS = 1
+
+
 class TestEAGLEServer(unittest.TestCase):
     PROMPTS = [
         "[INST] <<SYS>>\\nYou are a helpful assistant.\\n<</SYS>>\\nToday is a sunny day and I like[/INST]"


### PR DESCRIPTION
## Motivation

Adds support for HArmonized Speculative Sampling (HASS), ICLR 2025 paper: [https://arxiv.org/abs/2408.15766](https://arxiv.org/abs/2408.15766)

## Modifications

- Add HASS speculative method to server args
- Inherit draft model architecture from EAGLE
- Test for HASSEngine

## Benchmarks

using test script from #2150

Autoregressive (normal)
```
python3 -m sglang.launch_server --model meta-llama/Llama-3.1-8B-Instruct --mem-fraction 0.7 --dtype float16 --port 30000
speed: 50.70 token/s
```

EAGLE-2
```
python3 -m sglang.launch_server --model meta-llama/Llama-3.1-8B-Instruct --speculative-algo EAGLE --speculative-draft lmsys/sglang-EAGLE-LLaMA3-Instruct-8B --speculative-num-steps 5 --speculative-eagle-topk 8 --speculative-num-draft-tokens 64 --cuda-graph-max-bs 1 --mem-fraction 0.7 --dtype float16 --port 30000
speed: 84.80 token/s
```

HASS
```
python3 -m sglang.launch_server --model meta-llama/Llama-3.1-8B-Instruct --speculative-algo HASS --speculative-draft amosyou/sglang-HASS-LLaMA3-Instruct-8B --speculative-num-steps 5 --speculative-eagle-topk 8 --speculative-num-draft-tokens 64 --cuda-graph-max-bs 1 --mem-fraction 0.7 --dtype float16 --port 30000
speed: 91.10 token/s
```

---

running Engine unit tests under `test/`

EAGLE-3
```
acc_length=2.7675675675675677
```

HASS
```
acc_length=3.710144927536232
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
