### PR TITLE
Let S3 connector compatible with path that do not end with a '/'

### DIFF
--- a/python/sglang/srt/connector/s3.py
+++ b/python/sglang/srt/connector/s3.py
@@ -50,7 +50,9 @@ def list_files(
               disallowed by pattern
     """
     parts = path.removeprefix("s3://").split("/")
-    prefix = "/".join(parts[1:])
+    # Compatible with input path that do not end with a '/', or end with consecutive '/'.
+    # e.g. s3://bucket/dirname, s3://bucket/dirname//
+    prefix = "/".join(parts[1:]).rstrip("/") + "/"
     bucket_name = parts[0]
 
     objects = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)


### PR DESCRIPTION

## Motivation

When an S3 bucket contains multiple directories sharing the same prefix, such as `s3://model/QwQ-32B` and `s3://model/QwQ-32B-TP2`. Specifying `--load-format remote --model-path s3://model/QwQ-32B` will access and download `s3://model/QwQ-32B-TP2/*` files, which is not expected.

## Modifications

Let S3 connector compatible with path that do not end with a '/' by rstrip '/' and force add a new '/'. 

Test Case:

```python
sglang.srt.connector.s3.list_files(..., path='s3://model/QwQ-32B', allow_pattern=["*config.json"])
```

Before:

```
returns: 
bucket_name='model', prefix='QwQ-32B', paths=['QwQ-32B-TP2/config.json', 'QwQ-32B-TP2/generation_config.json', 'QwQ-32B-TP2/tokenizer_config.json', 'QwQ-32B/config.json', 'QwQ-32B/generation_config.json', 'QwQ-32B/tokenizer_config.json']
```

After:
```
returns: 
bucket_name='model', prefix='QwQ-32B/', paths=['QwQ-32B/config.json', 'QwQ-32B/generation_config.json', 'QwQ-32B/tokenizer_config.json']
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
