### PR TITLE
add dp controller signal

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -30,7 +30,7 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.server_args import PortArgs, ServerArgs
-from sglang.srt.utils import bind_port, configure_logger, get_zmq_socket
+from sglang.srt.utils import bind_port, configure_logger, get_zmq_socket, process_and_transfer_signal
 from sglang.utils import get_exception_traceback
 
 logger = logging.getLogger(__name__)
@@ -257,6 +257,7 @@ def run_data_parallel_controller_process(
     setproctitle.setproctitle("sglang::data_parallel_controller")
     configure_logger(server_args)
     parent_process = psutil.Process().parent()
+    process_and_transfer_signal()
 
     try:
         controller = DataParallelController(server_args, port_args)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

when we enable dp_attention, the scheduler will be a child process for data_parallel_controller, so when scheduler raise exeption, it will quit the data_parallel_controller by the following code but the other process will hang!

```python
    try:
        scheduler = Scheduler(server_args, port_args, gpu_id, tp_rank, dp_rank)
        pipe_writer.send(
            {
                "status": "ready",
                "max_total_num_tokens": scheduler.max_total_num_tokens,
                "max_req_input_len": scheduler.max_req_input_len,
            }
        )
        if scheduler.enable_overlap:
            scheduler.event_loop_overlap()
        else:
            scheduler.event_loop_normal()
    except Exception:
        traceback = get_exception_traceback()
        logger.error(f"Scheduler hit an exception: {traceback}")
        parent_process.send_signal(signal.SIGQUIT)
```
here is an example

```
DP2 TP2] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/conda/lib/python3.9/site-packages/sglang/srt/managers/scheduler.py", line 1906, in run_scheduler_process
    scheduler.event_loop_overlap()
  File "/usr/local/conda/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/usr/local/conda/lib/python3.9/site-packages/sglang/srt/managers/scheduler.py", line 509, in event_loop_overlap
    recv_reqs = self.recv_requests()
  File "/usr/local/conda/lib/python3.9/site-packages/sglang/srt/managers/scheduler.py", line 586, in recv_requests
    control_reqs = broadcast_pyobj(
  File "/usr/local/conda/lib/python3.9/site-packages/sglang/srt/utils.py", line 707, in broadcast_pyobj
    dist.broadcast(tensor_size, src=src, group=dist_group)
  File "/usr/local/conda/lib/python3.9/site-packages/torch/distributed/c10d_logger.py", line 83, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/conda/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py", line 2425, in broadcast
    work.wait()
RuntimeError: [../third_party/gloo/gloo/transport/tcp/pair.cc:534] Connection closed by peer [10.245.228.12]:11664
```

and then the server will hang!

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->
add signal_handler in data_parallel_controller process
## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
