### PR TITLE
Update paged_allocator.py

### DIFF
--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -279,5 +279,5 @@ class PagedTokenToKVPoolAllocator:
         self.free_pages = torch.arange(
             1, self.num_pages + 1, dtype=torch.int64, device=self.device
         )
-        self.is_in_free_group = False
+        self.is_not_in_free_group = True
         self.free_group = []


### PR DESCRIPTION
修复PagedTokenToKVPoolAllocator类中的变量名不一致问题。

在clear方法中，使用了错误的变量名self.is_in_free_group，而在类的其他方法中使用的是self.is_not_in_free_group。这个PR将变量名统一为self.is_not_in_free_group，以保持代码一致性并避免潜在的bug。

Fix the variable name inconsistency in the PagedTokenToKVPoolAllocator class.

In the clear method, the incorrect variable name self.is_in_free_group was used, while self.is_not_in_free_group is used in other methods of the class. This PR unifies the variable name to self.is_not_in_free_group to maintain code consistency and avoid potential bugs.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix the variable name inconsistency in the PagedTokenToKVPoolAllocator class to maintain code consistency and prevent potential bugs.

## Modifications

Changed `self.is_in_free_group = False` to `self.is_not_in_free_group = False` in the clear() method of PagedTokenToKVPoolAllocator class to ensure consistent variable naming throughout the class.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.