### PR TITLE
Unify variable naming: replace is_in_free_group with is_not_in_free_group

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -190,7 +190,7 @@ class TokenToKVPoolAllocator:
         self.free_slots = torch.arange(
             1, self.size + 1, dtype=torch.int64, device=self.device
         )
-        self.is_in_free_group = False
+        self.is_not_in_free_group = True
         self.free_group = []
 
 

--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -279,5 +279,5 @@ class PagedTokenToKVPoolAllocator:
         self.free_pages = torch.arange(
             1, self.num_pages + 1, dtype=torch.int64, device=self.device
         )
-        self.is_in_free_group = False
+        self.is_not_in_free_group = True
         self.free_group = []


### PR DESCRIPTION

Fix the variable name inconsistency in the `TokenToKVPoolAllocator` and `PagedTokenToKVPoolAllocator` classes.

In the `clear` method, the incorrect variable name `self.is_in_free_group` was used, while `self.is_not_in_free_group` is used in other methods of the classes. This PR unifies the variable name to `self.is_not_in_free_group` to maintain code consistency and avoid potential bugs.

## Motivation

Fix the variable name inconsistency in both `TokenToKVPoolAllocator` and `PagedTokenToKVPoolAllocator` classes to maintain code consistency and prevent potential bugs.

## Modifications

Corrected the typo in the description and clarified the modification:

✅ **Changed** `self.is_in_free_group = False` **to** `self.is_not_in_free_group = True` in the `clear()` method of both `TokenToKVPoolAllocator` and `PagedTokenToKVPoolAllocator` classes to ensure consistent variable naming throughout the classes.

## Checklist

- [x] Format your code according to the [[Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit)](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [[Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci)](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [[Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci)](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [[Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html)](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [[Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html)](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai/ to discuss your PR.
