### PR TITLE
Remove empty tool function name

### DIFF
--- a/python/sglang/srt/function_call_parser.py
+++ b/python/sglang/srt/function_call_parser.py
@@ -287,7 +287,6 @@ class BaseFormatDetector:
                             calls=[
                                 ToolCallItem(
                                     tool_index=self.current_tool_id,
-                                    name="",
                                     parameters=argument_diff,
                                 )
                             ],


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

Fix https://github.com/sgl-project/sglang/issues/4700

## Modifications

<!-- Describe the changes made in this PR. -->

Consistent with the behavior of vllm and other inference engines, `name` is not output when outputting arguments.