### PR TITLE
Fix EAGLE3 for llama3.3 70b

### DIFF
--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -610,6 +610,12 @@ class LlamaForCausalLM(nn.Module):
         return self.model.embed_tokens.weight
 
     def set_embed(self, embed):
+        # NOTE: If draft hidden size != target hidden size, the embed weight cannot be shared for EAGLE3
+        if (
+            hasattr(self.config, "target_hidden_size")
+            and self.config.target_hidden_size != self.config.hidden_size
+        ):
+            return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -105,7 +105,10 @@ class LlamaModel(nn.Module):
             prefix=add_prefix("embed_tokens", prefix),
         )
         self.midlayer = LlamaDecoderLayer(config, 0, quant_config, prefix)
-        self.fc = torch.nn.Linear(config.hidden_size * 3, config.hidden_size)
+        if hasattr(config, "target_hidden_size"):
+            self.fc = torch.nn.Linear(config.target_hidden_size * 3, config.hidden_size)
+        else:
+            self.fc = torch.nn.Linear(config.hidden_size * 3, config.hidden_size)
 
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The [EAGLE3-LLaMA3.3-Instruct-70B](yuhuili/EAGLE3-LLaMA3.3-Instruct-70B) draft model has a different hidden size with the target model. It should be handled in fc layer.
Ref: https://github.com/SafeAILab/EAGLE/blob/08b3e5c48bf7f22c26590d9987574bd99fa5a7c6/eagle/model/cnets.py#L518

cc: @chromecast56 @Liyuhui-12 @hongyanz @merrymercy 