### PR TITLE
[PD] Remove invalid parameter

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -158,7 +158,7 @@ class DecodePreallocQueue:
 
         preallocated_reqs = []
         indices_to_remove = set()
-        allocatable_tokens = self._allocatable_tokens(count_retracted=True)
+        allocatable_tokens = self._allocatable_tokens()
 
         for i, decode_req in enumerate(self.queue):
             if not decode_req.waiting_for_input:


### PR DESCRIPTION
The function allocatable_tokens takes no parameter. The caller's wrong use leads to a runtime error.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The function allocatable_tokens takes no parameter. The caller's wrong use leads to a runtime error.
[2025-03-24 17:32:45 TP0] Scheduler hit an exception: Traceback (most recent call last):                                                                                                       
  File "/sglang-pd/python/sglang/srt/managers/scheduler.py", line 1990, in run_scheduler_process                                                                                    
    scheduler.event_loop_normal_disagg_decode()                                                                                                                                                
  File "/vdevel2/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context                                                                            
    return func(*args, **kwargs)                                                                                                                                                               
  File "/sglang-pd/python/sglang/srt/managers/scheduler.py", line 679, in event_loop_normal_disagg_decode                                                                           
    self.process_decode_queue()                                                                                                                                                                
  File "sglang-pd/python/sglang/srt/disaggregation/decode.py", line 490, in process_decode_queue                                                                                   
    req_conns = self.disagg_decode_prealloc_queue.pop_preallocated()                                                                                                                           
  File "/sglang-pd/python/sglang/srt/disaggregation/decode.py", line 161, in pop_preallocated                                                                                       
    allocatable_tokens = self._allocatable_tokens(count_retracted=True)                                                                                                                        
TypeError: DecodePreallocQueue._allocatable_tokens() got an unexpected keyword argument 'count_retracted'

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
