### PR TITLE
Support recording experts workload in QWen2-MoE

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -51,6 +51,7 @@ from sglang.srt.utils import add_prefix
 
 expert_distribution_recorder = ExpertDistributionRecorder()
 
+
 class Qwen2MoeMLP(nn.Module):
     def __init__(
         self,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -44,10 +44,12 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from sglang.srt.managers.utils import ExpertDistributionRecorder
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 
+expert_distribution_recorder = ExpertDistributionRecorder()
 
 class Qwen2MoeMLP(nn.Module):
     def __init__(
@@ -366,6 +368,7 @@ class Qwen2MoeModel(nn.Module):
             hidden_states = input_embeds
         residual = None
         for i in range(len(self.layers)):
+            expert_distribution_recorder.set_current_layer(i)
             layer = self.layers[i]
             hidden_states, residual = layer(
                 positions, hidden_states, forward_batch, residual


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Our jupyter notebook uses a QWen2-MoE model to demonstrate how to record experts' workload. Unfortunately, this feature was not supported for this model. Therefore, the layer_ids of output were always "UNKNOWN". This PR fixes this issue by supporting recording experts workload in QWen2-MoE.