### PR TITLE
fix(typo): fix `reply` to `replay` in `base_attn_backend.py`

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -47,7 +47,7 @@ class AttentionBackend(ABC):
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
     ):
-        """Init the metadata for a forward pass for replying a cuda graph."""
+        """Init the metadata for a forward pass for replaying a cuda graph."""
         raise NotImplementedError()
 
     def get_cuda_graph_seq_len_fill_value(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Identified a spelling error in python/sglang/srt/layers/attention/base_attn_backend.py where `replay` was incorrectly written as `reply`.

## Modifications

I changed `reply` to `replay` and checked all other occurrences of `reply` in the project, confirming there were no additional misspellings of `replay`.

<!-- Describe the changes made in this PR. -->

