### PR TITLE
add __half22bfloat162 __bfloat1622half2 for awq_kernel with cu121 SDK

### DIFF
--- a/sgl-kernel/benchmark/bench_awq_dequant.py
+++ b/sgl-kernel/benchmark/bench_awq_dequant.py
@@ -92,9 +92,7 @@ configs = list(
         args={},
     )
 )
-def benchmark(
-    kernel_name, dtype, qweight_row, qweight_col, provider
-):
+def benchmark(kernel_name, dtype, qweight_row, qweight_col, provider):
     device = torch.device("cuda")
     qweight = torch.randint(
         0,

--- a/sgl-kernel/benchmark/bench_awq_dequant.py
+++ b/sgl-kernel/benchmark/bench_awq_dequant.py
@@ -59,14 +59,14 @@ def calculate_diff(dtype: torch.dtype, qweight_row: int, qweight_col: int):
         print("❌ Implementations differ")
 
 
-use_fp16x2_ptx_intrinsics_for_bf16x2 = [False]
+kernel_name = ["awq_dequantize"]
 dtypes = [torch.float16, torch.bfloat16]
 qweight_row_range = [3584, 18944, 128, 256, 512, 1024]
 qweight_cols_range = [448, 576, 4736, 16, 32, 64, 128]
 
 configs = list(
     itertools.product(
-        use_fp16x2_ptx_intrinsics_for_bf16x2,
+        kernel_name,
         dtypes,
         qweight_row_range,
         qweight_cols_range,
@@ -77,7 +77,7 @@ configs = list(
 @triton.testing.perf_report(
     triton.testing.Benchmark(
         x_names=[
-            "use_fp16x2_ptx_intrinsics_for_bf16x2",
+            "kernel_name",
             "dtype",
             "qweight_row",
             "qweight_col",
@@ -93,7 +93,7 @@ configs = list(
     )
 )
 def benchmark(
-    use_fp16x2_ptx_intrinsics_for_bf16x2, dtype, qweight_row, qweight_col, provider
+    kernel_name, dtype, qweight_row, qweight_col, provider
 ):
     device = torch.device("cuda")
     qweight = torch.randint(

--- a/sgl-kernel/benchmark/bench_awq_dequant.py
+++ b/sgl-kernel/benchmark/bench_awq_dequant.py
@@ -21,7 +21,7 @@ def sglang_awq_dequantize(
     return awq_dequantize(qweight, scales, qzeros)
 
 
-def calculate_diff(qweight_row: int, qweight_col: int):
+def calculate_diff(dtype: torch.dtype, qweight_row: int, qweight_col: int):
     """Calculate difference between VLLM and SGLang implementations."""
     device = torch.device("cuda")
     qweight = torch.randint(
@@ -43,7 +43,10 @@ def calculate_diff(qweight_row: int, qweight_col: int):
         device=device,
     )
 
-    vllm_out = vllm_awq_dequantize(qweight, scales, qzeros)
+    if dtype == torch.bfloat16:
+        vllm_out = vllm_awq_dequantize(qweight, scales.to(torch.float16), qzeros)
+    else:
+        vllm_out = vllm_awq_dequantize(qweight, scales, qzeros)
     sglang_out = sglang_awq_dequantize(qweight, scales, qzeros)
 
     output_diff = torch.abs(vllm_out.float() - sglang_out.float()).mean().item()
@@ -56,15 +59,29 @@ def calculate_diff(qweight_row: int, qweight_col: int):
         print("❌ Implementations differ")
 
 
+use_fp16x2_ptx_intrinsics_for_bf16x2 = [False]
+dtypes = [torch.float16, torch.bfloat16]
 qweight_row_range = [3584, 18944, 128, 256, 512, 1024]
 qweight_cols_range = [448, 576, 4736, 16, 32, 64, 128]
 
-configs = list(itertools.product(qweight_row_range, qweight_cols_range))
+configs = list(
+    itertools.product(
+        use_fp16x2_ptx_intrinsics_for_bf16x2,
+        dtypes,
+        qweight_row_range,
+        qweight_cols_range,
+    )
+)
 
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["qweight_row", "qweight_col"],
+        x_names=[
+            "use_fp16x2_ptx_intrinsics_for_bf16x2",
+            "dtype",
+            "qweight_row",
+            "qweight_col",
+        ],
         x_vals=configs,
         line_arg="provider",
         line_vals=["vllm", "sglang"],
@@ -75,8 +92,9 @@ configs = list(itertools.product(qweight_row_range, qweight_cols_range))
         args={},
     )
 )
-def benchmark(qweight_row, qweight_col, provider):
-    dtype = torch.float16
+def benchmark(
+    use_fp16x2_ptx_intrinsics_for_bf16x2, dtype, qweight_row, qweight_col, provider
+):
     device = torch.device("cuda")
     qweight = torch.randint(
         0,
@@ -88,7 +106,7 @@ def benchmark(qweight_row, qweight_col, provider):
     group_size = qweight_row
     scales_row = qweight_row // group_size
     scales_col = qweight_col * 8
-    scales = torch.rand(scales_row, scales_col, dtype=torch.float16, device=device)
+    scales = torch.rand(scales_row, scales_col, dtype=dtype, device=device)
     qzeros = torch.randint(
         0,
         torch.iinfo(torch.int32).max,
@@ -101,7 +119,7 @@ def benchmark(qweight_row, qweight_col, provider):
 
     if provider == "vllm":
         fn = lambda: vllm_awq_dequantize(
-            qweight.clone(), scales.clone(), qzeros.clone()
+            qweight.clone(), scales.clone().to(torch.float16), qzeros.clone()
         )
     elif provider == "sglang":
         fn = lambda: sglang_awq_dequantize(
@@ -114,5 +132,6 @@ def benchmark(qweight_row, qweight_col, provider):
 
 
 if __name__ == "__main__":
-    calculate_diff(qweight_row=3584, qweight_col=448)
+    calculate_diff(dtype=torch.float16, qweight_row=3584, qweight_col=448)
+    calculate_diff(dtype=torch.bfloat16, qweight_row=3584, qweight_col=448)
     benchmark.run(print_data=True)

--- a/sgl-kernel/csrc/gemm/awq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/awq_kernel.cu
@@ -9,6 +9,8 @@
 
 #include "nv_math_def.h"
 
+#define USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 false
+
 template <int lut>
 __device__ inline int lop3(int a, int b, int c) {
   int res;
@@ -156,30 +158,91 @@ __global__ void __launch_bounds__(256) dequantize_weights(
     OutputT* output_ptr = output + 8 * col + 8 * row * qweight_cols;
     *(uint4*)output_ptr = weight_fp16;
   } else if constexpr (std::is_same<OutputT, __nv_bfloat16>::value) {
-    uint4 weight_raw = dequantize_s4_to_bf16x2(qweight[col + row * qweight_cols]);
-    uint4 zero_raw = dequantize_s4_to_bf16x2(qzeros[col + group_idx * qweight_cols]);
-    uint4 scale_raw = *reinterpret_cast<uint4*>(scales + scale_offset);
+#if USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 && __CUDA_ARCH__ < 900
+    // FP16 path
+    uint4 zero = dequantize_s4_to_fp16x2(qzeros[col + group_idx * qweight_cols]);
+    uint4 weight_fp16 = dequantize_s4_to_fp16x2(qweight[col + row * qweight_cols]);
+    uint4 scale = *reinterpret_cast<uint4*>(scales + scale_offset);
+#else
+    uint4 zero = dequantize_s4_to_bf16x2(qzeros[col + group_idx * qweight_cols]);
+    uint4 weight_bf16 = dequantize_s4_to_bf16x2(qweight[col + row * qweight_cols]);
+    uint4 scale = *reinterpret_cast<uint4*>(scales + scale_offset);
+#endif  // USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 && __CUDA_ARCH__ < 900
 
-    // Vectorized processing (each uint4 contains 4 nv_bfloat162)
-    nv_bfloat162* weight_vec = reinterpret_cast<nv_bfloat162*>(&weight_raw);
-    nv_bfloat162* zero_vec = reinterpret_cast<nv_bfloat162*>(&zero_raw);
-    nv_bfloat162* scale_vec = reinterpret_cast<nv_bfloat162*>(&scale_raw);
+#if defined(__CUDA_ARCH__)
 
-// Single instruction dual-channel operation
+#if __CUDA_ARCH__ >= 900
+
+    nvgpu::__hsub2_inplace<nv_bfloat162>(&(weight_bf16.x), zero.x);
+    nvgpu::__hmul2_inplace<nv_bfloat162>(&(weight_bf16.x), scale.x);
+    nvgpu::__hsub2_inplace<nv_bfloat162>(&(weight_bf16.y), zero.y);
+    nvgpu::__hmul2_inplace<nv_bfloat162>(&(weight_bf16.y), scale.y);
+    nvgpu::__hsub2_inplace<nv_bfloat162>(&(weight_bf16.z), zero.z);
+    nvgpu::__hmul2_inplace<nv_bfloat162>(&(weight_bf16.z), scale.z);
+    nvgpu::__hsub2_inplace<nv_bfloat162>(&(weight_bf16.w), zero.w);
+    nvgpu::__hmul2_inplace<nv_bfloat162>(&(weight_bf16.w), scale.w);
+
+#else
+
+#if USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2
+
+    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.x), zero.x);
+    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.x), scale.x);
+    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.y), zero.y);
+    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.y), scale.y);
+    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.z), zero.z);
+    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.z), scale.z);
+    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.w), zero.w);
+    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.w), scale.w);
+
+    // converted back to bf16 after applying fp16 PTX intrincs
+    half2* weight_fp16x2_vec_view = reinterpret_cast<half2*>(&weight_fp16);
+    nv_bfloat162* weight_bf16x2_vec_view = reinterpret_cast<nv_bfloat162*>(&weight_fp16);
+
 #pragma unroll
     for (int i = 0; i < 4; ++i) {  // uint4 = 4 * nv_bfloat162
-#if defined(CUDA_VERSION) && CUDA_VERSION <= 12020
+      weight_bf16x2_vec_view[i] = __half22bfloat162(weight_fp16x2_vec_view[i]);
+    }
+
+#else
+
+    nv_bfloat162* zero_vec = reinterpret_cast<nv_bfloat162*>(&zero);
+    nv_bfloat162* weight_vec = reinterpret_cast<nv_bfloat162*>(&weight_bf16);
+    nv_bfloat162* scale_vec = reinterpret_cast<nv_bfloat162*>(&scale);
+
+#if __CUDA_ARCH__ >= 800  // sm_75 does not defines __hsub2 or __hmul2 for bfloat16 in cu121
+
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {  // uint4 = 4 * nv_bfloat162
+      weight_vec[i] = __hmul2(__hsub2(weight_vec[i], zero_vec[i]), scale_vec[i]);
+    }
+
+#elif __CUDA_ARCH__ >= 750
+
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {  // uint4 = 4 * nv_bfloat162
       weight_vec[i] = __half22bfloat162(__hmul2(
           __hsub2(__bfloat1622half2(weight_vec[i]), __bfloat1622half2(zero_vec[i])), __bfloat1622half2(scale_vec[i])));
-#else
-      weight_vec[i] = __hmul2(__hsub2(weight_vec[i], zero_vec[i]), scale_vec[i]);
-#endif
     }
+
+#else
+#error "Computability ability < SM_75 is not supported."
+#endif  // __CUDA_ARCH__ >= 800
+
+#endif  // USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2
+
+#endif  // __CUDA_ARCH__ >= 900
+
+#endif  // defined(__CUDA_ARCH__)
 
     // Directly store to OutputT array (guaranteed contiguous memory)
     OutputT* output_ptr = output + 8 * col + row * qweight_cols * 8;
     static_assert(sizeof(uint4) == 8 * sizeof(OutputT), "Memory layout mismatch");
-    *reinterpret_cast<uint4*>(output_ptr) = weight_raw;
+#if USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 && __CUDA_ARCH__ < 900
+    *reinterpret_cast<uint4*>(output_ptr) = weight_fp16;
+#else
+    *reinterpret_cast<uint4*>(output_ptr) = weight_bf16;
+#endif  // USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2
   }
 }
 

--- a/sgl-kernel/csrc/gemm/awq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/awq_kernel.cu
@@ -210,14 +210,14 @@ __global__ void __launch_bounds__(256) dequantize_weights(
     nv_bfloat162* weight_vec = reinterpret_cast<nv_bfloat162*>(&weight_bf16);
     nv_bfloat162* scale_vec = reinterpret_cast<nv_bfloat162*>(&scale);
 
-#if __CUDA_ARCH__ >= 800  // sm_75 does not defines __hsub2 or __hmul2 for bfloat16 in cu121
+#if __CUDA_ARCH__ >= 800  // sm_80 does not defines __hmul2 for bfloat16 in cu121
 
 #pragma unroll
     for (int i = 0; i < 4; ++i) {  // uint4 = 4 * nv_bfloat162
       weight_vec[i] = __hmul2(__hsub2(weight_vec[i], zero_vec[i]), scale_vec[i]);
     }
 
-#elif __CUDA_ARCH__ >= 750
+#elif __CUDA_ARCH__ >= 750  // sm_75 does not defines __hsub2 or __hmul2 for bfloat16 in cu121
 
 #pragma unroll
     for (int i = 0; i < 4; ++i) {  // uint4 = 4 * nv_bfloat162

--- a/sgl-kernel/csrc/gemm/awq_kernel.cu
+++ b/sgl-kernel/csrc/gemm/awq_kernel.cu
@@ -9,8 +9,6 @@
 
 #include "nv_math_def.h"
 
-#define USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 false
-
 template <int lut>
 __device__ inline int lop3(int a, int b, int c) {
   int res;
@@ -158,16 +156,9 @@ __global__ void __launch_bounds__(256) dequantize_weights(
     OutputT* output_ptr = output + 8 * col + 8 * row * qweight_cols;
     *(uint4*)output_ptr = weight_fp16;
   } else if constexpr (std::is_same<OutputT, __nv_bfloat16>::value) {
-#if USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 && __CUDA_ARCH__ < 900
-    // FP16 path
-    uint4 zero = dequantize_s4_to_fp16x2(qzeros[col + group_idx * qweight_cols]);
-    uint4 weight_fp16 = dequantize_s4_to_fp16x2(qweight[col + row * qweight_cols]);
-    uint4 scale = *reinterpret_cast<uint4*>(scales + scale_offset);
-#else
     uint4 zero = dequantize_s4_to_bf16x2(qzeros[col + group_idx * qweight_cols]);
     uint4 weight_bf16 = dequantize_s4_to_bf16x2(qweight[col + row * qweight_cols]);
     uint4 scale = *reinterpret_cast<uint4*>(scales + scale_offset);
-#endif  // USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 && __CUDA_ARCH__ < 900
 
 #if defined(__CUDA_ARCH__)
 
@@ -181,28 +172,6 @@ __global__ void __launch_bounds__(256) dequantize_weights(
     nvgpu::__hmul2_inplace<nv_bfloat162>(&(weight_bf16.z), scale.z);
     nvgpu::__hsub2_inplace<nv_bfloat162>(&(weight_bf16.w), zero.w);
     nvgpu::__hmul2_inplace<nv_bfloat162>(&(weight_bf16.w), scale.w);
-
-#else
-
-#if USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2
-
-    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.x), zero.x);
-    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.x), scale.x);
-    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.y), zero.y);
-    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.y), scale.y);
-    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.z), zero.z);
-    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.z), scale.z);
-    nvgpu::__hsub2_inplace<half2>(&(weight_fp16.w), zero.w);
-    nvgpu::__hmul2_inplace<half2>(&(weight_fp16.w), scale.w);
-
-    // converted back to bf16 after applying fp16 PTX intrincs
-    half2* weight_fp16x2_vec_view = reinterpret_cast<half2*>(&weight_fp16);
-    nv_bfloat162* weight_bf16x2_vec_view = reinterpret_cast<nv_bfloat162*>(&weight_fp16);
-
-#pragma unroll
-    for (int i = 0; i < 4; ++i) {  // uint4 = 4 * nv_bfloat162
-      weight_bf16x2_vec_view[i] = __half22bfloat162(weight_fp16x2_vec_view[i]);
-    }
 
 #else
 
@@ -229,8 +198,6 @@ __global__ void __launch_bounds__(256) dequantize_weights(
 #error "Computability ability < SM_75 is not supported."
 #endif  // __CUDA_ARCH__ >= 800
 
-#endif  // USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2
-
 #endif  // __CUDA_ARCH__ >= 900
 
 #endif  // defined(__CUDA_ARCH__)
@@ -238,11 +205,7 @@ __global__ void __launch_bounds__(256) dequantize_weights(
     // Directly store to OutputT array (guaranteed contiguous memory)
     OutputT* output_ptr = output + 8 * col + row * qweight_cols * 8;
     static_assert(sizeof(uint4) == 8 * sizeof(OutputT), "Memory layout mismatch");
-#if USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2 && __CUDA_ARCH__ < 900
-    *reinterpret_cast<uint4*>(output_ptr) = weight_fp16;
-#else
     *reinterpret_cast<uint4*>(output_ptr) = weight_bf16;
-#endif  // USE_FP16x2_PTX_INTRINSICS_FOR_BF16x2
   }
 }
 

--- a/sgl-kernel/include/nv_math_def.h
+++ b/sgl-kernel/include/nv_math_def.h
@@ -1,0 +1,41 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#if defined(CUDA_VERSION) && CUDA_VERSION <= 12020
+
+__inline__ __device__ half __bfloat162half(const __nv_bfloat16 bf16_val) {
+  return half(__bfloat162float(bf16_val));
+}
+
+__inline__ __device__ half2 __bfloat1622half2(const __nv_bfloat162 bf162_val) {
+  half2 ret;
+  ret.x = __bfloat162half(bf162_val.x);
+  ret.y = __bfloat162half(bf162_val.y);
+  return ret;
+}
+
+__inline__ __device__ __nv_bfloat16 __half2bfloat16(const half hval) {
+  return __nv_bfloat16(__half2float(hval));
+}
+
+__inline__ __device__ __nv_bfloat162 __half22bfloat162(const half2 h2val) {
+  __nv_bfloat162 ret;
+  ret.x = __half2bfloat16(h2val.x);
+  ret.y = __half2bfloat16(h2val.y);
+  return ret;
+}
+
+#endif  // CUDA_VERSION <= 12020

--- a/sgl-kernel/include/nv_math_def.h
+++ b/sgl-kernel/include/nv_math_def.h
@@ -14,21 +14,28 @@ limitations under the License.
 
 #include <cuda_runtime.h>
 
-#if defined(CUDA_VERSION) && CUDA_VERSION <= 12020
+#if defined(__CUDA_ARCH__)
+
+// Add backward support of bf16, bf162 PTX intrinsics
+#if __CUDA_ARCH__ >= 750 && __CUDA_ARCH__ < 900  // bf16x2 requires compute ability >= sm80
 
 __inline__ __device__ half __bfloat162half(const __nv_bfloat16 bf16_val) {
   return half(__bfloat162float(bf16_val));
 }
+
+__inline__ __device__ __nv_bfloat16 __half2bfloat16(const half hval) {
+  return __nv_bfloat16(__half2float(hval));
+}
+
+// #endif // __CUDA_ARCH__ >= 750 && __CUDA_ARCH__ < 900
+
+// #if __CUDA_ARCH__ >= 800 && __CUDA_ARCH__ < 900
 
 __inline__ __device__ half2 __bfloat1622half2(const __nv_bfloat162 bf162_val) {
   half2 ret;
   ret.x = __bfloat162half(bf162_val.x);
   ret.y = __bfloat162half(bf162_val.y);
   return ret;
-}
-
-__inline__ __device__ __nv_bfloat16 __half2bfloat16(const half hval) {
-  return __nv_bfloat16(__half2float(hval));
 }
 
 __inline__ __device__ __nv_bfloat162 __half22bfloat162(const half2 h2val) {
@@ -38,4 +45,64 @@ __inline__ __device__ __nv_bfloat162 __half22bfloat162(const half2 h2val) {
   return ret;
 }
 
-#endif  // CUDA_VERSION <= 12020
+#endif  //  __CUDA_ARCH__ >= 800 && __CUDA_ARCH__ < 900
+
+namespace nvgpu {  // Add new semantics
+
+// By default we use rounding to nearest even mode, but other modes will be supported soon; see
+// https://docs.nvidia.com/cuda/floating-point/index.html
+template <typename T>
+__inline__ __device__ void __hsub2_inplace(uint* a, const uint b);
+
+template <typename T>
+__inline__ __device__ void __hmul2_inplace(uint* a, const uint b);
+
+// ===== speicalization =====
+
+// fp16, fp162 PTX intrinsics
+template <>
+__inline__ __device__ void __hsub2_inplace<half2>(uint* a, const uint b) {
+  asm volatile("sub.f16x2 %0, %1, %2;\n" : "+r"(*a) : "r"(*a), "r"(b));
+}
+
+template <>
+__inline__ __device__ void __hmul2_inplace<half2>(uint* a, const uint b) {
+  asm volatile("mul.rn.f16x2 %0, %1, %2;\n" : "+r"(*a) : "r"(*a), "r"(b));
+}
+
+#if __CUDA_ARCH__ >= 900
+
+template <>
+__inline__ __device__ void __hsub2_inplace<nv_bfloat162>(uint* a, const uint b) {
+  asm volatile("sub.bf16x2 %0, %1, %2;\n" : "+r"(*a) : "r"(*a), "r"(b));
+}
+
+template <>
+__inline__ __device__ void __hmul2_inplace<nv_bfloat162>(uint* a, const uint b) {
+  asm volatile("mul.rn.bf16x2 %0, %1, %2;\n" : "+r"(*a) : "r"(*a), "r"(b));
+}
+
+#elif __CUDA_ARCH__ >= 800
+
+template <>
+__inline__ __device__ void __hsub2_inplace<nv_bfloat162>(uint* a, const uint b) {
+  asm volatile("sub.bf16x2 %0, %1, %2;\n" : "+r"(*a) : "r"(*a), "r"(b));
+}
+
+template <>
+__inline__ __device__ void __hmul2_inplace<nv_bfloat162>(uint* a, const uint b) {
+#warning "mul.rn.bf16x2 not supported __CUDA_ARCH__(800) <= 900)"
+
+  nv_bfloat162* bf16x2_view_lhs = reinterpret_cast<nv_bfloat162*>(a);
+  const nv_bfloat162* bf16x2_view_rhs = reinterpret_cast<const nv_bfloat162*>(&b);
+
+  *bf16x2_view_lhs = __hmul2(*bf16x2_view_lhs, *bf16x2_view_rhs);
+}
+
+#else
+
+#endif  // __CUDA_ARCH__ >= 900
+
+}  // namespace nvgpu
+
+#endif  // CUDA

--- a/sgl-kernel/include/nv_math_def.h
+++ b/sgl-kernel/include/nv_math_def.h
@@ -27,10 +27,6 @@ __inline__ __device__ __nv_bfloat16 __half2bfloat16(const half hval) {
   return __nv_bfloat16(__half2float(hval));
 }
 
-// #endif // __CUDA_ARCH__ >= 750 && __CUDA_ARCH__ < 900
-
-// #if __CUDA_ARCH__ >= 800 && __CUDA_ARCH__ < 900
-
 __inline__ __device__ half2 __bfloat1622half2(const __nv_bfloat162 bf162_val) {
   half2 ret;
   ret.x = __bfloat162half(bf162_val.x);


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Add bf16 in benchmark test
- Optimize performance of **awk_kernel** for SM_90 with bf16 PTX intrinsics
- Add backward compatibility of SM_75, SM_80 for awk_kernel: cuda121 does not support device conversion between bf162 and half2
-  With new BF PTX support, running in Hopper arch is 

## Modifications

<!-- Describe the changes made in this PR. -->
- include/nv_math_def.h
- gemm/awq_kernel : add explict bf162 to half2 and half2 to bf162 convertions in CU121

## Test

#### A100

Correctness:

<img width="400" alt="update" src="https://github.com/user-attachments/assets/e23ee4af-5bf7-4f79-962c-2c2b7a433544" />

Benchmark (disable fp16x2 ptx for bf16x2 by default, see discussion below)

<img width="400" alt="bf16 intrinsics" src="https://github.com/user-attachments/assets/e9472f83-cc6a-4419-af99-94b99cb5b83b" />

#### H100 (PTX acceleration for bf16x2)

old (by cherry-picking new benchmark tests to show bf16 performance):

<img width="400" alt="截屏2025-03-31 22 32 14" src="https://github.com/user-attachments/assets/2cfe320e-9c8b-4455-a469-8d3a8d734d80" />

new:
<img width="400" alt="sm_90" src="https://github.com/user-attachments/assets/874f03f3-fa88-4a73-9851-45acdb18f426" />

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
