### PR TITLE
gemma3: impl `get_attention_sliding_window_size` for attn init

### DIFF
--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -268,6 +268,12 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.language_model.get_input_embeddings()
 
+    def get_attention_sliding_window_size(self):
+        """
+        This value is used to initialize attention backends in `ForwardBatch`.
+        """
+        return self.language_model.get_attention_sliding_window_size()
+
     def get_image_feature(self, image_input: MultimodalInputs):
         """
         Projects the last hidden state from the vision model into language model space.


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

I've been testing Gemma 3 and it's fine-tunes with SGLang for couple days, and noticed weird behavior where it starts to generate garbage tokens as soon as context length (input + generated) starts to exceed somewhere around 2k.

and seems like few others are experiencing the same thing.
- https://github.com/sgl-project/sglang/pull/4424#issuecomment-2737301031
- https://github.com/sgl-project/sglang/issues/4807

I've ran the same prompt through vLLM and it did not generate garbage tokens.

## Modifications

This PR implements method `get_attention_sliding_window_size` in `Gemma3ForConditionalGeneration` and `Gemma3ForCausalLM`, so that attention backends can be initialized with proper sliding window size.

`get_attention_sliding_window_size` implementation was brought from Gemma 2:
https://github.com/sgl-project/sglang/blob/f60f293195ae5ddd09759d66001e0af49c67a66d/python/sglang/srt/models/gemma2.py#L45-L48

## Investigations

After thorough investigation (trust me, it took the whole night for me as I'm not that familiar) including deeper comparison with vLLM's Gemma implementations and SGLang's Gemma implementations (1, 2, and 3), I have found following.

Current `Gemma3Attention` initializes `RadixAttention` with `sliding_window_size`:
https://github.com/sgl-project/sglang/blob/f60f293195ae5ddd09759d66001e0af49c67a66d/python/sglang/srt/models/gemma3_causal.py#L180-L189

but it seems like it does nothing but to store it as property only:
https://github.com/sgl-project/sglang/blob/f60f293195ae5ddd09759d66001e0af49c67a66d/python/sglang/srt/layers/radix_attention.py#L35

In fact, the actual backend gets initialized alongside with `ForwardBatch`, and it uses `model_runner.sliding_window_size`:
https://github.com/sgl-project/sglang/blob/f60f293195ae5ddd09759d66001e0af49c67a66d/python/sglang/srt/layers/attention/flashinfer_backend.py#L92

and this value gets set by looking at `get_attention_sliding_window_size` of the model:
https://github.com/sgl-project/sglang/blob/f60f293195ae5ddd09759d66001e0af49c67a66d/python/sglang/srt/model_executor/model_runner.py#L422-L427

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Future Works

- It was kinda confusing that `RadixAttention` takes `sliding_window_size` as it's parameter but the model actually needed to have `get_attention_sliding_window_size` defined.
- The updated (fixed) Gemma 3 implementation in SGLang still seems to generate a bit little different than vLLM. Although I am not sure which one is the correct one (https://github.com/vllm-project/vllm/pull/14660 points out that vLLM's implementation could have less accuracy). It will be nice to compare generation result with the [official implementation](https://github.com/google-deepmind/gemma).

## Inference Comparison

Started server with:
```
$ python3 -m python.sglang.launch_server --model-path google/gemma-3-4b-it --context-length 8192
```

Ran inference with:
```javascript
const res = await fetch(`http://localhost:${process.argv[2] || '30000'}/v1/chat/completions`, {
  method: "POST",
  headers: {
    "Content-Type": "application/json",
  },
  body: JSON.stringify({
    model: "google/gemma-3-4b-it",
    max_tokens: 4096,
    // temperature: 1,
    top_p: .95,
    // frequency_penalty: 0,
    // presence_penalty: 0,
    // repetition_penalty: 1,
    top_k: 64,
    // min_p: 0,
    messages: [
      {
        role: "system",
        content:
          "Read the introduction of an individual as provided. Please translate it into Korean.",
      },
      {
        role: "user",
        // following content is machine inferenced by random commercial LLM
        content: `The first thing most people notice about Dr. Maya Chen is her laugh—a rich, unrestrained sound that starts somewhere deep in her chest and erupts with surprising force from her petite frame. It's a laugh that seems at odds with her carefully cultivated professional image: the immaculate lab coat, the sensible shoes, the dark hair always pulled back in a practical bun. But that juxtaposition is perfectly Maya—a woman of seeming contradictions who has spent a lifetime defying expectations and carving her own path through the world.

Born in 1982 to Chinese immigrants in a small town outside Portland, Oregon, Maya grew up straddling two worlds. At home, her parents—her father a civil engineer and her mother a former concert pianist—maintained many of their cultural traditions, speaking Mandarin, celebrating lunar new year, and instilling in Maya a deep respect for education and familial duty. Outside the home, Maya navigated the complexities of being one of the few Asian-American students in her school, developing a chameleon-like ability to adapt to different social situations while maintaining her core sense of self....[TRUNCATED]`
      },
    ],
    stream: true,
  }),
});

try {
  for await (const event of streamCompletions(res)) {
    const { role, content } = event.choices?.[0]?.delta || {};
    if (role) {
      process.stdout.write(`${role}: `);
    }
    if (content) {
      process.stdout.write(`${content}`);
    }
  }
} finally {
  process.stdout.write("\n");
}
```

on `main` branch (f60f293195ae5ddd09759d66001e0af49c67a66d):
```
Okay, yet—

Read more than…

***

Read more »

***

Read more »

Read more »

Read

Read
...[TRUNCATED]
```

on this branch (7bc9bfb77fce33c98966f301ed66893f9e9bb024):
```
Okay, here's a Korean translation of the provided introduction to Dr. Maya Chen, aiming for a balance of accuracy and natural-sounding Korean:

**마야 천 박사의 소개**

대부분의 사람들은 먼저 그녀의 웃음소리를 알아차립니다. 그것은 가슴에서부터 우러나오는 풍부하고, 억제되지 않은 소리입니다. 그녀의 작은 체구에서 뿜어져 나오는 놀라운 힘으로 시작되는 웃음이죠. 이 웃음소리는 그녀가 정성 들여 쌓아 올린 전문적인 이미지와 어울리지 않는 것처럼 보입니다. 완벽한 실험복, 편안한 신발, 항상 실용적인 똥머리로 묶어 kept는 검은 머리 말입니다. 하지만 이러한 대비는 마야를 완벽하게 정의합니다. 그녀는 예상을 깨고 자신만의 길을 개척해 온, 겉으로는 모순되는 듯한 여성입니다.

1982년 오리건주 포틀랜드 외곽의 작은 마을에서 중국 이민자 가정에서 태어난 마야는 두 세계 사이에서 자랐습니다. 집에서는 그녀의 부모님, 아버지께서는 시공사로서, 어머니께서는 은퇴한 무대 의상가로서, 많은 문화적 전통을 유지하며, 마야에게 교육과 가족의 의무에 대한 깊은 존경심을 심어주셨습니다. 집 밖에서는 마야는 학교에서 유일한 아시아-미국 학생으로서 다양한 사회적 상황에 적응하는 데 능숙해졌습니다. 동시에 자신의 핵심적인 자아를 유지하면서 말입니다.

“저는 코드를 바꾸는 법을 알아차리기 훨씬 전에 유창하게 구사하게 되었어요.” 마야는 종종 그 특유의 웃음소리와 함께 말합니다. “저는 학교에서 수학과 과학을 excel하는 마야, 중국 커뮤니티 노인들에게 의료 문서 번역을 도와주는 마야, 피아노 레슨 시간에 책상 밑에서 비밀리에 SF 소설을 읽는 마야였습니다. 왈츠 위트만이라고 한다면 저는 다중성을 품고 있었습니다.”

이러한 다양한 정체성은 마야가 교육을 받을 때 도움이 되었습니다. 먼저 MIT에서 생화학과 비교 문학을 복수 전공했고, (또 다른 모순되는 것 같지만 그녀에게는 말이 안 됐어요) 이후 스탠포드 대학에서 분자 생물학 박사 과정을 이수했고, 마지막으로 존스  Hopkins에서 의학 학위를 취득했습니다. 그 과정에서 그녀는 궁극적으로 그녀의 삶의 기반이 될, 전통 중국 의학과 최첨단 유전체 연구의 융합이라는 특이한 전문 분야를 개발했습니다.

“제 할머니는 광주에서 전통적인 치유사로 불렸어요.” 마야는 설명합니다. “어릴 적에는 그녀가 약초 요법을 준비하는 것을 보았어요. 그녀의 굳은 손가락은 엄청난 정밀함과 확신으로 움직였죠. 그녀는 이러한 조합이 작동하는 이유에 대한 분자 메커니즘을 설명할 수 없었습니다. 단순히 그것이 효과가 있다는 것을 알고 있었어요. 수세기 동안 관찰과 실천을 통해 말입니다. 서구 과학 교육을 계속하면서 저는 이러한 고대 요법과 현대 의학 사이의 잠재적인 연결고리에 매료되었습니다.”

이러한 매력으로 인해 마야는 2018년에 전 세계의 전통 요법을 조사하는 엄격한 과학적 방법을 적용하는 선구적인 기관인 Integrative Genomic Medicine Research Center를 설립했습니다. 그녀의 지도 아래 센터는 여러 문화권의 전통 약초에서 신경 퇴행성 질환 치료에 도움이 될 수 있는 몇 가지 화합물을 식별했습니다. 이 작업은 논란의 여지가 없지 않았습니다. 전통주의자들로부터 고대의 치유 관행을 분자 구성 요소로 줄이는 것에 대해 비판을 받았고, 일부 과학계에서는 그것을 허위 과학으로 간주하여 신뢰성을 더하는 것에 대해 비판을 받았습니다.

마야는 이러한 비판 모두에 침착하게 대처합니다. “과학은 우리가 우리의 가정에 의문을 제기할 때 발전합니다.” 그녀는 말합니다. “전통적인 치유 시스템과 현대 의학 모두는 눈먼 곳이 있습니다. 제 작업은 그들 사이의 공간에 있습니다.”
...[TRUNCATED]
```