### PR TITLE
deps: lazy import optional dependencies `gguf` and `torchvision`

### DIFF
--- a/python/sglang/srt/configs/deepseekvl2.py
+++ b/python/sglang/srt/configs/deepseekvl2.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import torch
-import torchvision.transforms as T
 from PIL import Image, ImageOps
 from transformers import (
     AutoProcessor,
@@ -75,6 +74,16 @@ class ImageTransform(object):
         self.mean = mean
         self.std = std
         self.normalize = normalize
+
+        # only load torchvision.transforms when needed
+        try:
+            import torchvision.transforms as T
+
+            # FIXME: add version check for gguf
+        except ImportError as err:
+            raise ImportError(
+                "Please install torchvision via `pip install torchvision` to use Deepseek-VL2."
+            ) from err
 
         transform_pipelines = [T.ToTensor()]
 

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -14,7 +14,6 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, cast
 
-import gguf
 import huggingface_hub
 import numpy as np
 import torch
@@ -1155,6 +1154,17 @@ class GGUFModelLoader(BaseModelLoader):
         See "Standardized tensor names" in
         https://github.com/ggerganov/ggml/blob/master/docs/gguf.md for details.
         """
+
+        # only load the gguf module when needed
+        try:
+            import gguf
+
+            # FIXME: add version check for gguf
+        except ImportError as err:
+            raise ImportError(
+                "Please install gguf via `pip install gguf` to use gguf quantizer."
+            ) from err
+
         config = model_config.hf_config
         model_type = config.model_type
         # hack: ggufs have a different name than transformers

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -22,7 +22,6 @@ from typing import (
 )
 
 import filelock
-import gguf
 import huggingface_hub.constants
 import numpy as np
 import safetensors.torch
@@ -464,6 +463,8 @@ def pt_weights_iterator(
 def get_gguf_extra_tensor_names(
     gguf_file: str, gguf_to_hf_name_map: Dict[str, str]
 ) -> List[str]:
+    import gguf
+
     reader = gguf.GGUFReader(gguf_file)
     expected_gguf_keys = set(gguf_to_hf_name_map.keys())
     exact_gguf_keys = set([tensor.name for tensor in reader.tensors])
@@ -478,6 +479,8 @@ def gguf_quant_weights_iterator(
     Iterate over the quant weights in the model gguf files and convert
     them to torch tensors
     """
+
+    import gguf
 
     reader = gguf.GGUFReader(gguf_file)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Current `main` branch has broken dependency. Following packages are not defined as dependency (in [pyproject.toml](https://github.com/sgl-project/sglang/blob/main/python/pyproject.toml)) but is required to run srt (via `sglang.launch_server`):
- `torchvision` - This PR
- `gguf` - This PR
- `compressed_tensors` - ref: https://github.com/sgl-project/sglang/pull/4819
- `openai` - introduced in https://github.com/sgl-project/sglang/pull/4661
- `partial_json_parser` - introduced in https://github.com/sgl-project/sglang/pull/2700
- `einops` - introduced in:
  - https://github.com/sgl-project/sglang/pull/2785
  - https://github.com/sgl-project/sglang/pull/2798
  - https://github.com/sgl-project/sglang/pull/2977
  - https://github.com/sgl-project/sglang/pull/3203
  - https://github.com/sgl-project/sglang/pull/3258
  - https://github.com/sgl-project/sglang/pull/4424

Although this PR does not tackle all the broken dependencies, it fixes two easy ones.

## Modifications

This PR updates codes that use `torchvision`, and `gguf` to lazy load them.

## Next Steps

Something need to be done with remainders:
- `compressed_tensors` - I saw on-going discussion in https://github.com/sgl-project/sglang/pull/4819#issuecomment-2758511990
- `openai` - I think we could define our own `BadRequestError` class or equivalent and refrain from using this type since we have only single usage of `openai` from srt:
  https://github.com/sgl-project/sglang/blob/0bc0bf57341d4b9cdd0a096ff321b5128719a983/python/sglang/srt/managers/multimodal_processors/base_processor.py#L13
- `partial_json_parser` - I think we could include this as srt's dependency as it's being used in the **base** detector class for tool (function) calling.
- `einops` - I think this could be included as srt's dependency as it's being widely used. or we could make it optional (lazy load) since it's seems to be only required for vision models?

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
