### PR TITLE
sgl scaled_fp8_quant support output padding

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -456,13 +456,10 @@ class Fp8LinearOp:
             if _is_cuda:
                 qinput, x_scale = sgl_scaled_fp8_quant(
                     input_2d,
+                    num_token_padding=self.output_padding,
                     input_scale,
                     use_per_token_if_dynamic=use_per_token_if_dynamic,
                 )
-                if self.output_padding:
-                    pad_size = max(self.output_padding - qinput.shape[0], 0)
-                    if pad_size > 0:
-                        qinput = torch.nn.functional.pad(qinput, (0, 0, 0, pad_size))
             else:
                 qinput, x_scale = ops.scaled_fp8_quant(
                     input_2d,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -456,8 +456,8 @@ class Fp8LinearOp:
             if _is_cuda:
                 qinput, x_scale = sgl_scaled_fp8_quant(
                     input_2d,
-                    num_token_padding=self.output_padding,
                     input_scale,
+                    num_token_padding=self.output_padding,
                     use_per_token_if_dynamic=use_per_token_if_dynamic,
                 )
             else:

--- a/python/sglang/test/test_custom_ops.py
+++ b/python/sglang/test/test_custom_ops.py
@@ -83,6 +83,68 @@ if is_cuda:
         )
 
 
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_scaled_fp8_quant_with_padding(dtype) -> None:
+        original_rows = 5
+        x = (torch.randn(size=(original_rows, 16), device="cuda") * 13).to(dtype)
+        
+        padding_size = 10
+        
+        # Test with dynamic quantization
+        y_dynamic, scale_dynamic = scaled_fp8_quant(x, None, num_token_padding=padding_size)
+        
+        # Verify output shape has the padded size
+        assert y_dynamic.shape[0] == padding_size
+        assert y_dynamic.shape[1] == x.shape[1]
+        
+        # Verify that the actual data in the non-padded region is correctly quantized
+        y_without_padding, scale_without_padding = scaled_fp8_quant(x, None)
+        torch.testing.assert_close(
+            y_dynamic[:original_rows], 
+            y_without_padding
+        )
+        
+        # Test with static quantization
+        # First get a scale
+        _, scale = scaled_fp8_quant(x, None)
+        
+        # Then use it for static quantization with padding
+        y_static, _ = scaled_fp8_quant(x, scale, num_token_padding=padding_size)
+        
+        # Verify output shape has the padded size
+        assert y_static.shape[0] == padding_size
+        assert y_static.shape[1] == x.shape[1]
+        
+        # Verify that the actual data in the non-padded region is correctly quantized
+        y_static_without_padding, _ = scaled_fp8_quant(x, scale)
+        torch.testing.assert_close(
+            y_static[:original_rows], 
+            y_static_without_padding
+        )
+        
+        # Test with per-token dynamic quantization
+        y_per_token, scale_per_token = scaled_fp8_quant(
+            x, None, num_token_padding=padding_size, use_per_token_if_dynamic=True
+        )
+        
+        # Verify output shape has the padded size
+        assert y_per_token.shape[0] == padding_size
+        assert y_per_token.shape[1] == x.shape[1]
+        
+        # Verify that the actual data in the non-padded region is correctly quantized
+        y_per_token_without_padding, scale_per_token_without_padding = scaled_fp8_quant(
+            x, None, use_per_token_if_dynamic=True
+        )
+        torch.testing.assert_close(
+            y_per_token[:original_rows], 
+            y_per_token_without_padding
+        )
+        torch.testing.assert_close(
+            scale_per_token[:original_rows], 
+            scale_per_token_without_padding
+        )
+
+
 if __name__ == "__main__":
     # Run the specific test function directly
     pytest.main([__file__])

--- a/python/sglang/test/test_custom_ops.py
+++ b/python/sglang/test/test_custom_ops.py
@@ -82,66 +82,59 @@ if is_cuda:
             dequantize_per_token(ref_y, scale, dtype),
         )
 
-
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_scaled_fp8_quant_with_padding(dtype) -> None:
         original_rows = 5
         x = (torch.randn(size=(original_rows, 16), device="cuda") * 13).to(dtype)
-        
+
         padding_size = 10
-        
+
         # Test with dynamic quantization
-        y_dynamic, scale_dynamic = scaled_fp8_quant(x, None, num_token_padding=padding_size)
-        
+        y_dynamic, scale_dynamic = scaled_fp8_quant(
+            x, None, num_token_padding=padding_size
+        )
+
         # Verify output shape has the padded size
         assert y_dynamic.shape[0] == padding_size
         assert y_dynamic.shape[1] == x.shape[1]
-        
+
         # Verify that the actual data in the non-padded region is correctly quantized
         y_without_padding, scale_without_padding = scaled_fp8_quant(x, None)
-        torch.testing.assert_close(
-            y_dynamic[:original_rows], 
-            y_without_padding
-        )
-        
+        torch.testing.assert_close(y_dynamic[:original_rows], y_without_padding)
+
         # Test with static quantization
         # First get a scale
         _, scale = scaled_fp8_quant(x, None)
-        
+
         # Then use it for static quantization with padding
         y_static, _ = scaled_fp8_quant(x, scale, num_token_padding=padding_size)
-        
+
         # Verify output shape has the padded size
         assert y_static.shape[0] == padding_size
         assert y_static.shape[1] == x.shape[1]
-        
+
         # Verify that the actual data in the non-padded region is correctly quantized
         y_static_without_padding, _ = scaled_fp8_quant(x, scale)
-        torch.testing.assert_close(
-            y_static[:original_rows], 
-            y_static_without_padding
-        )
-        
+        torch.testing.assert_close(y_static[:original_rows], y_static_without_padding)
+
         # Test with per-token dynamic quantization
         y_per_token, scale_per_token = scaled_fp8_quant(
             x, None, num_token_padding=padding_size, use_per_token_if_dynamic=True
         )
-        
+
         # Verify output shape has the padded size
         assert y_per_token.shape[0] == padding_size
         assert y_per_token.shape[1] == x.shape[1]
-        
+
         # Verify that the actual data in the non-padded region is correctly quantized
         y_per_token_without_padding, scale_per_token_without_padding = scaled_fp8_quant(
             x, None, use_per_token_if_dynamic=True
         )
         torch.testing.assert_close(
-            y_per_token[:original_rows], 
-            y_per_token_without_padding
+            y_per_token[:original_rows], y_per_token_without_padding
         )
         torch.testing.assert_close(
-            scale_per_token[:original_rows], 
-            scale_per_token_without_padding
+            scale_per_token[:original_rows], scale_per_token_without_padding
         )
 
 


### PR DESCRIPTION
## Motivation

- [x] support `num_token_padding` in scaled_fp8_quant op and add tests.
- [x] avoid extra padding in `Fp8LinearOp` .

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
