### PR TITLE
Automatically truncate when the maximum tokens are exceeded instead of throwing an error

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -424,15 +424,21 @@ class TokenizerManager:
             and obj.sampling_params.get("max_new_tokens") + input_token_num
             >= self.context_len
         ):
-            raise ValueError(
-                f"Requested token count exceeds the model's maximum context length "
-                f"of {self.context_len} tokens. You requested a total of "
-                f"{obj.sampling_params.get('max_new_tokens') + input_token_num} "
-                f"tokens: {input_token_num} tokens from the input messages and "
-                f"{obj.sampling_params.get('max_new_tokens')} tokens for the "
-                f"completion. Please reduce the number of tokens in the input "
-                f"messages or the completion to fit within the limit."
-            )
+            if self.server_args.allow_auto_truncate:
+                logger.warning(
+                    f"Requested token count exceeds the model's maximum context length "
+                    f"of {self.context_len} tokens. The completion will be truncated."
+                )
+            else:
+                raise ValueError(
+                    f"Requested token count exceeds the model's maximum context length "
+                    f"of {self.context_len} tokens. You requested a total of "
+                    f"{obj.sampling_params.get('max_new_tokens') + input_token_num} "
+                    f"tokens: {input_token_num} tokens from the input messages and "
+                    f"{obj.sampling_params.get('max_new_tokens')} tokens for the "
+                    f"completion. Please reduce the number of tokens in the input "
+                    f"messages or the completion to fit within the limit."
+                )
 
         # Parse sampling parameters
         sampling_params = SamplingParams(**obj.sampling_params)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Previously, if request token count exceeded max context length, an error would be raised even if --allow-auto-truncate was enabled. We want automatic truncation in this case for  better user experience. 
Fix #3642 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
When --allow-auto-truncate is set, sglang will output a warning instead of raising an error.
<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
