### PR TITLE
[Fix] avoid stream sync and torch compile in prefill for fa3 backend

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -79,7 +79,7 @@ class FlashAttentionBackend(AttentionBackend):
             torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
         )
         # Precompute maximum sequence length
-        metadata.max_seq_len_k = seqlens_in_batch.max().item()
+        metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
         # Precompute page table
         metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, : metadata.max_seq_len_k

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -797,7 +797,7 @@ class FlashInferMLAMultiStepDraftBackend:
                 encoder_lens=None,
                 forward_mode=ForwardMode.DECODE,
                 spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.decode_seq_lens_cpu,
+                seq_lens_cpu=forward_batch.seq_lens_cpu,
             )
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -92,7 +92,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         if forward_batch.forward_mode.is_decode_or_idle():
             if spec_info is None:
                 max_seqlen_pad = triton.cdiv(
-                    forward_batch.decode_seq_lens_cpu.max().item(), PAGE_SIZE
+                    forward_batch.seq_lens_cpu.max().item(), PAGE_SIZE
                 )
                 block_kv_indices = torch.full(
                     (bs, max_seqlen_pad),

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1373,20 +1373,21 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def get_model_worker_batch(self) -> ModelWorkerBatch:
         if self.forward_mode.is_decode_or_idle():
-            if (
-                global_server_args_dict["enable_flashinfer_mla"]
-                or global_server_args_dict["enable_flashmla"]
-                or global_server_args_dict["attention_backend"] == "fa3"
-            ):
-                decode_seq_lens = self.seq_lens.cpu()
-            else:
-                decode_seq_lens = None
             extend_seq_lens = extend_prefix_lens = extend_logprob_start_lens = None
         else:
-            decode_seq_lens = None
             extend_seq_lens = self.extend_lens
             extend_prefix_lens = self.prefix_lens
             extend_logprob_start_lens = self.extend_logprob_start_lens
+
+        # Create seq_lens_cpu when needed
+        if (
+            global_server_args_dict["enable_flashinfer_mla"]
+            or global_server_args_dict["enable_flashmla"]
+            or global_server_args_dict["attention_backend"] == "fa3"
+        ):
+            seq_lens_cpu = self.seq_lens.cpu()
+        else:
+            seq_lens_cpu = None
 
         if self.sampling_info:
             if self.has_grammar:
@@ -1410,7 +1411,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             global_num_tokens=self.global_num_tokens,
             global_num_tokens_for_logprob=self.global_num_tokens_for_logprob,
             can_run_dp_cuda_graph=self.can_run_dp_cuda_graph,
-            decode_seq_lens=decode_seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
             extend_num_tokens=self.extend_num_tokens,
             extend_seq_lens=extend_seq_lens,
             extend_prefix_lens=extend_prefix_lens,
@@ -1471,6 +1472,7 @@ class ModelWorkerBatch:
     req_pool_indices: torch.Tensor
     # The sequence length
     seq_lens: torch.Tensor
+    seq_lens_cpu: Optional[torch.Tensor]
     # The indices of output tokens in the token_to_kv_pool_allocator
     out_cache_loc: torch.Tensor
 
@@ -1486,9 +1488,6 @@ class ModelWorkerBatch:
     global_num_tokens: Optional[List[int]]
     global_num_tokens_for_logprob: Optional[List[int]]
     can_run_dp_cuda_graph: bool
-
-    # For decode
-    decode_seq_lens: Optional[torch.Tensor]
 
     # For extend
     extend_num_tokens: Optional[int]

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -489,10 +489,10 @@ class CudaGraphRunner:
         self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
         self.out_cache_loc[:raw_num_token].copy_(forward_batch.out_cache_loc)
         self.positions[:raw_num_token].copy_(forward_batch.positions)
-        if forward_batch.decode_seq_lens_cpu is not None:
+        if forward_batch.seq_lens_cpu is not None:
             if bs != raw_bs:
                 self.seq_lens_cpu.fill_(1)
-            self.seq_lens_cpu[:raw_bs].copy_(forward_batch.decode_seq_lens_cpu)
+            self.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
 
         if self.is_encoder_decoder:
             self.encoder_lens[:raw_bs].copy_(forward_batch.encoder_lens)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -214,10 +214,10 @@ class EAGLEDraftCudaGraphRunner:
             forward_batch.positions = self.positions[:num_tokens]
 
         # Special handle for seq_len_cpu used when flashinfer mla is used
-        if (forward_batch.decode_seq_lens_cpu is not None) and (bs != raw_bs):
+        if (forward_batch.seq_lens_cpu is not None) and (bs != raw_bs):
             self.seq_lens_cpu.fill_(1)
-            self.seq_lens_cpu[:raw_bs].copy_(forward_batch.decode_seq_lens_cpu)
-            forward_batch.decode_seq_lens_cpu = self.seq_lens_cpu[:bs]
+            self.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
+            forward_batch.seq_lens_cpu = self.seq_lens_cpu[:bs]
 
         self.model_runner.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
             forward_batch, bs
@@ -233,7 +233,7 @@ class EAGLEDraftCudaGraphRunner:
             forward_batch.positions = self.positions[:raw_num_token]
             forward_batch.seq_lens = self.seq_lens[:raw_bs]
             forward_batch.req_pool_indices = self.req_pool_indices[:raw_bs]
-            if forward_batch.decode_seq_lens_cpu is not None:
-                forward_batch.decode_seq_lens_cpu = self.seq_lens_cpu[:raw_bs]
+            if forward_batch.seq_lens_cpu is not None:
+                forward_batch.seq_lens_cpu = self.seq_lens_cpu[:raw_bs]
 
         return out


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

During profiling, I found two potential places for improvement when utilizing fa3 backend:
![fig1](https://github.com/user-attachments/assets/8aa4607a-1bb1-42d0-b26c-1a8422012fd2)

As shown in the figure, 
- circle a is a cuda stream synchronization bubble, caused by `.item()` operation in `init_forward_metadata`. This overhead happens during every prefill/extend batch and costs ~100ms.
- circle b is the long overhead caused by torch compiler, we found the compiled function was `clamp_position` called by `ForwardBathch.init_new`. This overhead only happens once during launching, but costs ~4s.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

- Avoid the stream sync bubble with `seq_len_cpu`. To obtain this variable during prefill time, the worker batch will copy this tensor to cpu during extend mode. Also, we renamed all the `decode_seq_len_cpu` to `seq_len_cpu` so there will be no confusion.
- Replace the `clamp_position` function compiled by torch with uncompiled ones.

After modifications, these two places will disappear on profile result:
![fig2](https://github.com/user-attachments/assets/552f0440-8151-4168-a540-8aa6c1e50b9b)


## Accuracy

```bash
python3 -m sglang.launch_server --model /dev/shm/DeepSeek-V3-0324 --tp 8 --trust-remote-code --attention-backend fa3 
```

GSM8K
```bash
Accuracy: 0.941
Invalid: 0.000
Latency: 103.672 s
Output throughput: 1392.455 token/s
```

MMLU:
```bash
Total latency: 134.649
Average accuracy: 0.876
```
<!-- Describe the changes made in this PR. -->


## Benchmark
The benchmark is run on 8*H200. Deepgemm has been warmed up, and the benchmark is run instantly after launching the server (so the time of torch compiler is also included).

To mark the difference made by this PR, the test should send a lot of prompts:
```bash
python3 -m sglang.bench_serving --backend sglang --dataset-name random --random-input 4000 --random-output 200 --request-rate 8 --num-prompt 480
```

Result before this PR:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max reqeuest concurrency:                not set   
Successful requests:                     480       
Benchmark duration (s):                  197.78    
Total input tokens:                      968990    
Total generated tokens:                  48770     
Total generated tokens (retokenized):    48368     
Request throughput (req/s):              2.43      
Input token throughput (tok/s):          4899.24   
Output token throughput (tok/s):         246.58    
Total token throughput (tok/s):          5145.82   
Concurrency:                             315.69    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   130081.39 
Median E2E Latency (ms):                 140826.91 
---------------Time to First Token----------------
Mean TTFT (ms):                          54368.99  
Median TTFT (ms):                        49322.13  
P99 TTFT (ms):                           121388.64 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           752.66    
Median ITL (ms):                         515.59    
P95 ITL (ms):                            1814.19   
P99 ITL (ms):                            4400.30   
Max ITL (ms):                            43452.53  
==================================================
```

Result after this PR:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max reqeuest concurrency:                not set   
Successful requests:                     480       
Benchmark duration (s):                  156.86    
Total input tokens:                      968990    
Total generated tokens:                  48770     
Total generated tokens (retokenized):    48368     
Request throughput (req/s):              3.06      
Input token throughput (tok/s):          6177.40   
Output token throughput (tok/s):         310.91    
Total token throughput (tok/s):          6488.31   
Concurrency:                             287.44    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   93933.39  
Median E2E Latency (ms):                 100534.36 
---------------Time to First Token----------------
Mean TTFT (ms):                          35401.94  
Median TTFT (ms):                        33130.96  
P99 TTFT (ms):                           80988.51  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           581.91    
Median ITL (ms):                         268.09    
P95 ITL (ms):                            1515.95   
P99 ITL (ms):                            4600.80   
Max ITL (ms):                            37746.54  
==================================================
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
