### PR TITLE
Add Eagle Speculative Decoding to FA3 Backend

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -438,23 +438,23 @@ class FlashAttentionBackend(AttentionBackend):
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
         """
-        raise NotImplementedError(
-            "FlashAttentionBackend does not support CUDA graph yet, stay tuned!"
-        )
+        if self.speculative_num_steps > 0:
+            raise NotImplementedError(
+                "FlashAttentionBackend Spec Decoding does not support CUDA graph yet, stay tuned!"
+            )
 
-        # Initialize fixed size tensors for decode operations
-        # self.decode_cuda_graph_metadata = {
-        #     # Page table for token mapping (batch_size, max_context_len)
-        #     "page_table": torch.zeros(
-        #         max_bs,
-        #         (self.max_context_len + self.page_size - 1) // self.page_size,
-        #         dtype=torch.int32,
-        #         device=self.device,
-        #     ),
-        #     "strided_indices": torch.arange(
-        #         0, self.max_context_len, self.page_size, device=self.device
-        #     ),
-        # }
+        self.decode_cuda_graph_metadata = {
+            # Page table for token mapping (batch_size, max_context_len)
+            "page_table": torch.zeros(
+                max_bs,
+                (self.max_context_len + self.page_size - 1) // self.page_size,
+                dtype=torch.int32,
+                device=self.device,
+            ),
+            "strided_indices": torch.arange(
+                0, self.max_context_len, self.page_size, device=self.device
+            ),
+        }
 
     def init_forward_metadata_capture_cuda_graph(
         self,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -438,19 +438,23 @@ class FlashAttentionBackend(AttentionBackend):
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
         """
+        raise NotImplementedError(
+            "FlashAttentionBackend does not support CUDA graph yet, stay tuned!"
+        )
+
         # Initialize fixed size tensors for decode operations
-        self.decode_cuda_graph_metadata = {
-            # Page table for token mapping (batch_size, max_context_len)
-            "page_table": torch.zeros(
-                max_bs,
-                (self.max_context_len + self.page_size - 1) // self.page_size,
-                dtype=torch.int32,
-                device=self.device,
-            ),
-            "strided_indices": torch.arange(
-                0, self.max_context_len, self.page_size, device=self.device
-            ),
-        }
+        # self.decode_cuda_graph_metadata = {
+        #     # Page table for token mapping (batch_size, max_context_len)
+        #     "page_table": torch.zeros(
+        #         max_bs,
+        #         (self.max_context_len + self.page_size - 1) // self.page_size,
+        #         dtype=torch.int32,
+        #         device=self.device,
+        #     ),
+        #     "strided_indices": torch.arange(
+        #         0, self.max_context_len, self.page_size, device=self.device
+        #     ),
+        # }
 
     def init_forward_metadata_capture_cuda_graph(
         self,

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -45,9 +45,9 @@ class FlashAttentionBackend(AttentionBackend):
         self,
         model_runner: ModelRunner,
         skip_prefill: bool = False,
-        topk = 0,
-        speculative_num_steps = 0,
-        step_id = 0
+        topk=0,
+        speculative_num_steps=0,
+        step_id=0,
     ):
         super().__init__()
 
@@ -82,48 +82,49 @@ class FlashAttentionBackend(AttentionBackend):
         batch_size = len(seqlens_in_batch)
         device = seqlens_in_batch.device
 
-        metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-        metadata.cu_seqlens_k = torch.nn.functional.pad(
-            torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
-        )
-        # Precompute maximum sequence length
-        metadata.max_seq_len_k = seqlens_in_batch.max().item()
-        # Precompute page table
-        metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
-            forward_batch.req_pool_indices, : metadata.max_seq_len_k
-        ]
-
-
         if forward_batch.forward_mode == ForwardMode.DECODE:
             if self.skip_prefill:
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size * self.topk + 1, dtype=torch.int32, device=device
                 )
-                seq_lens_with_decode = seqlens_in_batch +  (self.step_id + 1)
-                metadata.cache_seqlens_int32 = (seq_lens_with_decode).repeat_interleave(self.topk).to(torch.int32)
+                seq_lens_with_decode = seqlens_in_batch + (self.step_id + 1)
+                metadata.cache_seqlens_int32 = (
+                    (seq_lens_with_decode).repeat_interleave(self.topk).to(torch.int32)
+                )
                 metadata.cu_seqlens_k = torch.nn.functional.pad(
                     torch.cumsum(
-                        metadata.cache_seqlens_int32, 
-                        dim=0, dtype=torch.int32),
-                        (1, 0)
+                        metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
+                    ),
+                    (1, 0),
                 )
                 # .repeat_interleave(self.topk) # tensor([7, 7, 7, 8, 8, 8])
                 # .repeat(self.topk) # tensor([7, 8, 7, 8, 7, 8])
-                metadata.max_seq_len_k = metadata.cache_seqlens_int32.max().item()
+                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
+                    self.step_id + 1
+                )
                 metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
                     forward_batch.req_pool_indices, : metadata.max_seq_len_k
-                ]      # (bsz, max_seq_len)
-                metadata.page_table = metadata.page_table.repeat_interleave(self.topk, dim=0)
-                cache_loc = forward_batch.out_cache_loc.view(self.speculative_num_steps, -1).T
+                ]  # (bsz, max_seq_len)
+                metadata.page_table = metadata.page_table.repeat_interleave(
+                    self.topk, dim=0
+                )
+                cache_loc = forward_batch.out_cache_loc.view(
+                    self.speculative_num_steps, -1
+                ).T
 
                 for idx, single_seq_len in enumerate(seq_lens_with_decode):
-                    real_bsz_start_idx = idx * self.topk 
-                    real_bsz_end_idx = (idx+1) * self.topk
-                    metadata.page_table[real_bsz_start_idx : real_bsz_end_idx, (single_seq_len-(self.step_id + 1)):single_seq_len] = cache_loc[real_bsz_start_idx:real_bsz_end_idx, :(self.step_id + 1)]
+                    real_bsz_start_idx = idx * self.topk
+                    real_bsz_end_idx = (idx + 1) * self.topk
+                    metadata.page_table[
+                        real_bsz_start_idx:real_bsz_end_idx,
+                        (single_seq_len - (self.step_id + 1)) : single_seq_len,
+                    ] = cache_loc[
+                        real_bsz_start_idx:real_bsz_end_idx, : (self.step_id + 1)
+                    ]
             else:
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
-                )               
+                )
         elif forward_batch.forward_mode == ForwardMode.TARGET_VERIFY:
             draft_token_num = forward_batch.spec_info.draft_token_num
 
@@ -132,25 +133,50 @@ class FlashAttentionBackend(AttentionBackend):
             )
 
             aug_seq_lens = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
-            metadata.cache_seqlens_int32 = aug_seq_lens.repeat_interleave(forward_batch.spec_info.draft_token_num)
-            metadata.cu_seqlens_k = torch.nn.functional.pad(
-                torch.cumsum(
-                    metadata.cache_seqlens_int32, 
-                    dim=0, dtype=torch.int32),
-                    (1, 0)
+            metadata.cache_seqlens_int32 = aug_seq_lens.repeat_interleave(
+                forward_batch.spec_info.draft_token_num
             )
-            metadata.max_seq_len_k = metadata.cache_seqlens_int32.max().item()
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
+                (1, 0),
+            )
+            metadata.max_seq_len_k = (
+                forward_batch.seq_lens_cpu.max().item() + draft_token_num
+            )
             metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
                 forward_batch.req_pool_indices, : metadata.max_seq_len_k
             ].repeat_interleave(draft_token_num, dim=0)
-            aug_cum_len = torch.nn.functional.pad(torch.cumsum(aug_seq_lens, dim=0, dtype=torch.int32), (1, 0))
+            aug_cum_len = torch.nn.functional.pad(
+                torch.cumsum(aug_seq_lens, dim=0, dtype=torch.int32), (1, 0)
+            )
             for idx, single_seq_len in enumerate(aug_seq_lens):
-                metadata.page_table[idx *draft_token_num :(idx+1)*draft_token_num, : single_seq_len] *= forward_batch.spec_info.custom_mask[aug_cum_len[idx] * draft_token_num: aug_cum_len[idx+1] * draft_token_num].view(draft_token_num, -1)
+                metadata.page_table[
+                    idx * draft_token_num : (idx + 1) * draft_token_num, :single_seq_len
+                ] *= forward_batch.spec_info.custom_mask[
+                    aug_cum_len[idx]
+                    * draft_token_num : aug_cum_len[idx + 1]
+                    * draft_token_num
+                ].view(
+                    draft_token_num, -1
+                )
 
-            metadata.max_seq_len_q = 1         
+            metadata.max_seq_len_q = 1
         else:
+            metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+            )
+            # Precompute maximum sequence length
+            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+            # Precompute page table
+            metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : metadata.max_seq_len_k
+            ]
             # Precompute cumulative sequence lengths
-            if any(forward_batch.extend_prefix_lens_cpu) or forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND:
+            if (
+                any(forward_batch.extend_prefix_lens_cpu)
+                or forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND
+            ):
                 extend_seq_lens = forward_batch.extend_seq_lens
                 metadata.cu_seqlens_q = torch.nn.functional.pad(
                     torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
@@ -159,7 +185,6 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 metadata.cu_seqlens_q = metadata.cu_seqlens_k
                 metadata.max_seq_len_q = metadata.max_seq_len_k
-
 
         # Precompute strided indices
         # [0, page_size, 2 * page_size, ...]
@@ -490,9 +515,12 @@ class FlashAttentionBackend(AttentionBackend):
         """Get the fill value for sequence length in CUDA graph."""
         return 0
 
+
 class FlashAttentionMultiStepBackend:
 
-    def __init__(self, model_runner: ModelRunner, topk: int, speculative_num_steps: int):
+    def __init__(
+        self, model_runner: ModelRunner, topk: int, speculative_num_steps: int
+    ):
         self.model_runner = model_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
@@ -503,9 +531,9 @@ class FlashAttentionMultiStepBackend:
                 FlashAttentionBackend(
                     model_runner,
                     skip_prefill=True,
-                    topk = self.topk,
+                    topk=self.topk,
                     speculative_num_steps=self.speculative_num_steps,
-                    step_id = i,
+                    step_id=i,
                 )
             )
 
@@ -531,7 +559,10 @@ class FlashAttentionMultiStepBackend:
                 forward_mode=ForwardMode.DECODE,
                 spec_info=forward_batch.spec_info,
             )
-    def init_forward_metadata_replay_cuda_graph(self, forward_batch: ForwardBatch, bs: int):
+
+    def init_forward_metadata_replay_cuda_graph(
+        self, forward_batch: ForwardBatch, bs: int
+    ):
         assert forward_batch.spec_info is not None
         assert isinstance(forward_batch.spec_info, EagleDraftInput)
 
@@ -546,4 +577,3 @@ class FlashAttentionMultiStepBackend:
                 spec_info=forward_batch.spec_info,
                 seq_lens_cpu=forward_batch.decode_seq_lens_cpu,
             )
-

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -97,8 +97,6 @@ class FlashAttentionBackend(AttentionBackend):
                     ),
                     (1, 0),
                 )
-                # .repeat_interleave(self.topk) # tensor([7, 7, 7, 8, 8, 8])
-                # .repeat(self.topk) # tensor([7, 8, 7, 8, 7, 8])
                 metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
                     self.step_id + 1
                 )
@@ -112,15 +110,22 @@ class FlashAttentionBackend(AttentionBackend):
                     self.speculative_num_steps, -1
                 ).T
 
-                for idx, single_seq_len in enumerate(seq_lens_with_decode):
-                    real_bsz_start_idx = idx * self.topk
-                    real_bsz_end_idx = (idx + 1) * self.topk
-                    metadata.page_table[
-                        real_bsz_start_idx:real_bsz_end_idx,
-                        (single_seq_len - (self.step_id + 1)) : single_seq_len,
-                    ] = cache_loc[
-                        real_bsz_start_idx:real_bsz_end_idx, : (self.step_id + 1)
-                    ]
+                # page table indices to update
+                # [bsz, topk]
+                row_indices = torch.arange(batch_size * self.topk, device=device, dtype=torch.int32).view(batch_size, self.topk)
+                # [max_seq_len : max_seq_len + step_id + 1]
+                col_indices = torch.arange(forward_batch.seq_lens_cpu.max().item(), metadata.max_seq_len_k, device=device, dtype=torch.int32)
+                # mask for all valid page table indices
+                valid_mask = (col_indices.view(1, -1) >= seqlens_in_batch.view(-1, 1)) & (col_indices.view(1, -1) < seq_lens_with_decode.view(-1, 1))
+
+                # cache indices to read
+                cache_indices = torch.arange(self.step_id + 1, device=device, dtype=torch.int32)
+
+                metadata.page_table[row_indices, col_indices] = torch.where(
+                    valid_mask,
+                    cache_loc[row_indices, cache_indices].to(torch.int32),
+                    metadata.page_table[row_indices, col_indices]
+                )
             else:
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -82,58 +82,59 @@ class FlashAttentionBackend(AttentionBackend):
         batch_size = len(seqlens_in_batch)
         device = seqlens_in_batch.device
 
-        if forward_batch.forward_mode == ForwardMode.DECODE and self.skip_prefill:
-            metadata.cu_seqlens_q = torch.arange(
-                0, batch_size * self.topk + 1, dtype=torch.int32, device=device
-            )
-            seq_lens_with_decode = seqlens_in_batch + (self.step_id + 1)
-            metadata.cache_seqlens_int32 = (
-                (seq_lens_with_decode).repeat_interleave(self.topk).to(torch.int32)
-            )
-            metadata.cu_seqlens_k = torch.nn.functional.pad(
-                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
-                (1, 0),
-            )
-            metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
-                self.step_id + 1
-            )
-            metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
-                forward_batch.req_pool_indices, : metadata.max_seq_len_k
-            ]  # (bsz, max_seq_len)
-            metadata.page_table = metadata.page_table.repeat_interleave(
-                self.topk, dim=0
-            )
-            cache_loc = forward_batch.out_cache_loc.view(
-                self.speculative_num_steps, -1
-            ).T
+        if forward_batch.forward_mode == ForwardMode.DECODE:
+            if self.skip_prefill:
+                metadata.cu_seqlens_q = torch.arange(
+                    0, batch_size * self.topk + 1, dtype=torch.int32, device=device
+                )
+                seq_lens_with_decode = seqlens_in_batch + (self.step_id + 1)
+                metadata.cache_seqlens_int32 = (
+                    (seq_lens_with_decode).repeat_interleave(self.topk).to(torch.int32)
+                )
+                metadata.cu_seqlens_k = torch.nn.functional.pad(
+                    torch.cumsum(
+                        metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
+                    ),
+                    (1, 0),
+                )
+                # .repeat_interleave(self.topk) # tensor([7, 7, 7, 8, 8, 8])
+                # .repeat(self.topk) # tensor([7, 8, 7, 8, 7, 8])
+                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item() + (
+                    self.step_id + 1
+                )
+                metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
+                    forward_batch.req_pool_indices, : metadata.max_seq_len_k
+                ]  # (bsz, max_seq_len)
+                metadata.page_table = metadata.page_table.repeat_interleave(
+                    self.topk, dim=0
+                )
+                cache_loc = forward_batch.out_cache_loc.view(
+                    self.speculative_num_steps, -1
+                ).T
 
-            # page table indices to update
-            # [bsz, topk]
-            row_indices = torch.arange(
-                batch_size * self.topk, device=device, dtype=torch.int32
-            ).view(batch_size, self.topk)
-            # [max_seq_len : max_seq_len + step_id + 1]
-            col_indices = torch.arange(
-                forward_batch.seq_lens_cpu.max().item(),
-                metadata.max_seq_len_k,
-                device=device,
-                dtype=torch.int32,
-            )
-            # mask for all valid page table indices
-            valid_mask = (col_indices.view(1, -1) >= seqlens_in_batch.view(-1, 1)) & (
-                col_indices.view(1, -1) < seq_lens_with_decode.view(-1, 1)
-            )
-
-            # cache indices to read
-            cache_indices = torch.arange(
-                self.step_id + 1, device=device, dtype=torch.int32
-            )
-
-            metadata.page_table[row_indices, col_indices] = torch.where(
-                valid_mask,
-                cache_loc[row_indices, cache_indices].to(torch.int32),
-                metadata.page_table[row_indices, col_indices],
-            )
+                for idx, single_seq_len in enumerate(seq_lens_with_decode):
+                    real_bsz_start_idx = idx * self.topk
+                    real_bsz_end_idx = (idx + 1) * self.topk
+                    metadata.page_table[
+                        real_bsz_start_idx:real_bsz_end_idx,
+                        (single_seq_len - (self.step_id + 1)) : single_seq_len,
+                    ] = cache_loc[
+                        real_bsz_start_idx:real_bsz_end_idx, : (self.step_id + 1)
+                    ]
+            else:
+                metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
+                metadata.cu_seqlens_k = torch.nn.functional.pad(
+                    torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+                )
+                # Precompute maximum sequence length
+                metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+                # Precompute page table
+                metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
+                    forward_batch.req_pool_indices, : metadata.max_seq_len_k
+                ]
+                metadata.cu_seqlens_q = torch.arange(
+                    0, batch_size + 1, dtype=torch.int32, device=device
+                )
         elif forward_batch.forward_mode == ForwardMode.TARGET_VERIFY:
             draft_token_num = forward_batch.spec_info.draft_token_num
 
@@ -182,11 +183,7 @@ class FlashAttentionBackend(AttentionBackend):
                 forward_batch.req_pool_indices, : metadata.max_seq_len_k
             ]
             # Precompute cumulative sequence lengths
-            if forward_batch.forward_mode == ForwardMode.DECODE:
-                metadata.cu_seqlens_q = torch.arange(
-                    0, batch_size + 1, dtype=torch.int32, device=device
-                )
-            elif (
+            if (
                 any(forward_batch.extend_prefix_lens_cpu)
                 or forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND
             ):

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -45,6 +45,9 @@ class FlashAttentionBackend(AttentionBackend):
         self,
         model_runner: ModelRunner,
         skip_prefill: bool = False,
+        topk = 0,
+        speculative_num_steps = 0,
+        step_id = 0
     ):
         super().__init__()
 
@@ -63,6 +66,10 @@ class FlashAttentionBackend(AttentionBackend):
         self.use_mla = (
             model_runner.model_config.attention_arch == AttentionArch.MLA
         ) and (not global_server_args_dict["disable_mla"])
+        self.skip_prefill = skip_prefill
+        self.topk = topk
+        self.speculative_num_steps = speculative_num_steps
+        self.step_id = step_id
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize forward metadata to cache repetitive calculations."""
@@ -72,18 +79,87 @@ class FlashAttentionBackend(AttentionBackend):
         # Get sequence information
         seqlens_in_batch = forward_batch.seq_lens
         # Precompute int32 version of sequence lengths
-        metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
         batch_size = len(seqlens_in_batch)
         device = seqlens_in_batch.device
+
+        metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
         metadata.cu_seqlens_k = torch.nn.functional.pad(
             torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
         )
         # Precompute maximum sequence length
-        metadata.max_seq_len_k = forward_batch.seq_lens_cpu.max().item()
+        metadata.max_seq_len_k = seqlens_in_batch.max().item()
         # Precompute page table
         metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, : metadata.max_seq_len_k
         ]
+
+
+        if forward_batch.forward_mode == ForwardMode.DECODE:
+            if self.skip_prefill:
+                metadata.cu_seqlens_q = torch.arange(
+                    0, batch_size * self.topk + 1, dtype=torch.int32, device=device
+                )
+                seq_lens_with_decode = seqlens_in_batch +  (self.step_id + 1)
+                metadata.cache_seqlens_int32 = (seq_lens_with_decode).repeat_interleave(self.topk).to(torch.int32)
+                metadata.cu_seqlens_k = torch.nn.functional.pad(
+                    torch.cumsum(
+                        metadata.cache_seqlens_int32, 
+                        dim=0, dtype=torch.int32),
+                        (1, 0)
+                )
+                # .repeat_interleave(self.topk) # tensor([7, 7, 7, 8, 8, 8])
+                # .repeat(self.topk) # tensor([7, 8, 7, 8, 7, 8])
+                metadata.max_seq_len_k = metadata.cache_seqlens_int32.max().item()
+                metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
+                    forward_batch.req_pool_indices, : metadata.max_seq_len_k
+                ]      # (bsz, max_seq_len)
+                metadata.page_table = metadata.page_table.repeat_interleave(self.topk, dim=0)
+                cache_loc = forward_batch.out_cache_loc.view(self.speculative_num_steps, -1).T
+
+                for idx, single_seq_len in enumerate(seq_lens_with_decode):
+                    real_bsz_start_idx = idx * self.topk 
+                    real_bsz_end_idx = (idx+1) * self.topk
+                    metadata.page_table[real_bsz_start_idx : real_bsz_end_idx, (single_seq_len-(self.step_id + 1)):single_seq_len] = cache_loc[real_bsz_start_idx:real_bsz_end_idx, :(self.step_id + 1)]
+            else:
+                metadata.cu_seqlens_q = torch.arange(
+                    0, batch_size + 1, dtype=torch.int32, device=device
+                )               
+        elif forward_batch.forward_mode == ForwardMode.TARGET_VERIFY:
+            draft_token_num = forward_batch.spec_info.draft_token_num
+
+            metadata.cu_seqlens_q = torch.arange(
+                0, batch_size * draft_token_num + 1, dtype=torch.int32, device=device
+            )
+
+            aug_seq_lens = (forward_batch.seq_lens + draft_token_num).to(torch.int32)
+            metadata.cache_seqlens_int32 = aug_seq_lens.repeat_interleave(forward_batch.spec_info.draft_token_num)
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(
+                    metadata.cache_seqlens_int32, 
+                    dim=0, dtype=torch.int32),
+                    (1, 0)
+            )
+            metadata.max_seq_len_k = metadata.cache_seqlens_int32.max().item()
+            metadata.page_table = forward_batch.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : metadata.max_seq_len_k
+            ].repeat_interleave(draft_token_num, dim=0)
+            aug_cum_len = torch.nn.functional.pad(torch.cumsum(aug_seq_lens, dim=0, dtype=torch.int32), (1, 0))
+            for idx, single_seq_len in enumerate(aug_seq_lens):
+                metadata.page_table[idx *draft_token_num :(idx+1)*draft_token_num, : single_seq_len] *= forward_batch.spec_info.custom_mask[aug_cum_len[idx] * draft_token_num: aug_cum_len[idx+1] * draft_token_num].view(draft_token_num, -1)
+
+            metadata.max_seq_len_q = 1         
+        else:
+            # Precompute cumulative sequence lengths
+            if any(forward_batch.extend_prefix_lens_cpu) or forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND:
+                extend_seq_lens = forward_batch.extend_seq_lens
+                metadata.cu_seqlens_q = torch.nn.functional.pad(
+                    torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
+                )
+                metadata.max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
+            else:
+                metadata.cu_seqlens_q = metadata.cu_seqlens_k
+                metadata.max_seq_len_q = metadata.max_seq_len_k
+
 
         # Precompute strided indices
         # [0, page_size, 2 * page_size, ...]
@@ -94,23 +170,6 @@ class FlashAttentionBackend(AttentionBackend):
             metadata.page_table = (
                 metadata.page_table[:, self.strided_indices] // self.page_size
             )
-
-        if forward_batch.forward_mode == ForwardMode.DECODE:
-            # Precompute cumulative sequence lengths
-            metadata.cu_seqlens_q = torch.arange(
-                0, batch_size + 1, dtype=torch.int32, device=device
-            )
-        else:
-            # Precompute cumulative sequence lengths
-            if any(forward_batch.extend_prefix_lens_cpu):
-                extend_seq_lens = forward_batch.extend_seq_lens
-                metadata.cu_seqlens_q = torch.nn.functional.pad(
-                    torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
-                )
-                metadata.max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
-            else:
-                metadata.cu_seqlens_q = metadata.cu_seqlens_k
-                metadata.max_seq_len_q = metadata.max_seq_len_k
         self.forward_metadata = metadata
 
     def forward_extend(
@@ -281,8 +340,6 @@ class FlashAttentionBackend(AttentionBackend):
 
             # Pre-reshape query tensor
             q_reshaped = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
-
-            # Run attention with precomputed values
             o = flash_attn_with_kvcache(
                 q=q_reshaped,
                 k_cache=key_cache,
@@ -385,7 +442,7 @@ class FlashAttentionBackend(AttentionBackend):
         metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
             req_pool_indices, :
         ]
-        if forward_mode == ForwardMode.DECODE:
+        if forward_mode.is_cuda_graph():
             # Precompute cumulative sequence lengths
             metadata.cu_seqlens_q = torch.arange(
                 0, batch_size + 1, dtype=torch.int32, device=device
@@ -432,3 +489,61 @@ class FlashAttentionBackend(AttentionBackend):
     def get_cuda_graph_seq_len_fill_value(self):
         """Get the fill value for sequence length in CUDA graph."""
         return 0
+
+class FlashAttentionMultiStepBackend:
+
+    def __init__(self, model_runner: ModelRunner, topk: int, speculative_num_steps: int):
+        self.model_runner = model_runner
+        self.topk = topk
+        self.speculative_num_steps = speculative_num_steps
+
+        self.attn_backends = []
+        for i in range(self.speculative_num_steps):
+            self.attn_backends.append(
+                FlashAttentionBackend(
+                    model_runner,
+                    skip_prefill=True,
+                    topk = self.topk,
+                    speculative_num_steps=self.speculative_num_steps,
+                    step_id = i,
+                )
+            )
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        for i in range(self.speculative_num_steps - 1):
+            self.attn_backends[i].init_forward_metadata(forward_batch)
+
+    def init_cuda_graph_state(self, max_bs: int):
+        for i in range(self.speculative_num_steps):
+            self.attn_backends[i].init_cuda_graph_state(max_bs)
+
+    def init_forward_metadata_capture_cuda_graph(self, forward_batch: ForwardBatch):
+        assert forward_batch.spec_info is not None
+        assert isinstance(forward_batch.spec_info, EagleDraftInput)
+
+        for i in range(self.speculative_num_steps - 1):
+            self.attn_backends[i].init_forward_metadata_capture_cuda_graph(
+                forward_batch.batch_size,
+                forward_batch.batch_size * self.topk,
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                encoder_lens=None,
+                forward_mode=ForwardMode.DECODE,
+                spec_info=forward_batch.spec_info,
+            )
+    def init_forward_metadata_replay_cuda_graph(self, forward_batch: ForwardBatch, bs: int):
+        assert forward_batch.spec_info is not None
+        assert isinstance(forward_batch.spec_info, EagleDraftInput)
+
+        for i in range(self.speculative_num_steps - 1):
+            self.attn_backends[i].init_forward_metadata_replay_cuda_graph(
+                bs,
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                forward_batch.seq_lens_sum,
+                encoder_lens=None,
+                forward_mode=ForwardMode.DECODE,
+                spec_info=forward_batch.spec_info,
+                seq_lens_cpu=forward_batch.decode_seq_lens_cpu,
+            )
+

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -580,5 +580,5 @@ class FlashAttentionMultiStepBackend:
                 encoder_lens=None,
                 forward_mode=ForwardMode.DECODE,
                 spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.decode_seq_lens_cpu,
+                seq_lens_cpu=forward_batch.seq_lens_cpu,
             )

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -186,7 +186,7 @@ class EAGLEWorker(TpModelWorker):
             self.has_prefill_wrapper_verify = True
         elif self.server_args.attention_backend == "fa3":
             from sglang.srt.layers.attention.flashattention_backend import (
-                FlashAttentionMultiStepBackend
+                FlashAttentionMultiStepBackend,
             )
 
             self.draft_attn_backend = FlashAttentionMultiStepBackend(

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -184,6 +184,19 @@ class EAGLEWorker(TpModelWorker):
             self.draft_extend_attn_backend = None
             self.padded_static_len = self.speculative_num_steps + 1
             self.has_prefill_wrapper_verify = True
+        elif self.server_args.attention_backend == "fa3":
+            from sglang.srt.layers.attention.flashattention_backend import (
+                FlashAttentionMultiStepBackend
+            )
+
+            self.draft_attn_backend = FlashAttentionMultiStepBackend(
+                self.draft_model_runner,
+                self.topk,
+                self.speculative_num_steps,
+            )
+            self.draft_extend_attn_backend = None
+            self.padded_static_len = self.speculative_num_steps + 1
+            self.has_prefill_wrapper_verify = False
         else:
             raise ValueError(
                 f"EAGLE is not supportted in attention backend {self.server_args.attention_backend}"


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Support Spec Decoding for FA3 Backend


## Benchmark on Latency


**Baseline**

```bash
python3 -m sglang.launch_server --model /shared/public/elr-models/m
eta-llama/Meta-Llama-3.1-8B-Instruct/07eb05b21d191a58c577b4a45982fe0c049d0693  --dtype float16 -
-trust-remote-code --attention-backend fa3 --disable-cuda-graph

python3 /home/jobuser/sglang/python/sglang/test/send_one.py

acc_length=1.00
speed=84.82 token/s
```

**With Spec Decoding**
```bash
python3 -m sglang.launch_server --model /shared/public/elr-models/meta-llama/Meta-Llama-3.1-8B-Instruct/07eb05b21d191a58c577b4a45982fe0c049d0693  --speculative-algorithm EAGLE3     --speculative-draft-model-path /shared/public/elr-models/jamesliu1/sglang-EAGLE3-Llama-3.1-Instruct-8B/e5ed08d66f528a95ce89f5d4fd136a28f6def714 --speculative-num-steps 4 --speculative-eagle-topk 2 --speculative-num-draft-tokens 4 --mem-fraction 0.6         --cuda-graph-max-bs 2 --dtype float16 --trust-remote-code --attention-backend fa3 --disable-cuda-graph

python3 /home/jobuser/sglang/python/sglang/test/send_one.py

acc_length=2.20
speed=125.59 token/s
```

**Sanity Check about FA3 without decoding's latency with Cuda Graph**
```bash
python -m sglang.bench_one_batch --model /shared/public/elr-models/meta-llama/Meta-Llama-3.1-8B-Instruct/07eb05b21d191a58c577b4a45982fe0c049d0693  --batch-size 16 --input 1024 --output 512 --attention-backend fa3

Benchmark ...
Prefill. latency: 0.36639 s, throughput:  44717.26 token/s
Decode.  median latency: 0.00657 s, median throughput:   2434.57 token/s
Total. latency:  3.729 s, throughput:   6589.93 token/s
```

**Sanity Check about FA3 without decoding's latency without Cuda Graph**
```bash
python -m sglang.bench_one_batch --model /shared/public/elr-models/meta-llama/Meta-Llama-3.1-8B-Instruct/07eb05b21d191a58c577b4a45982fe0c049d0693  --batch-size 16 --input 1024 --output 512 --attention-backend fa3

Prefill. latency: 0.36539 s, throughput:  44839.46 token/s
Decode.  median latency: 0.01224 s, median throughput:   1307.66 token/s
Total. latency:  6.661 s, throughput:   3689.27 token/s
```


## Benchmark on Accuracy (GSM8K)
Config: `--speculative-num-steps 4 --speculative-eagle-topk 2 --speculative-num-draft-tokens 4`
```bash

Accuracy: 0.775
Invalid: 0.000
Latency: 12.063 s
Output throughput: 1395.627 token/s

Accuracy: 0.775
Invalid: 0.000
Latency: 8.072 s
Output throughput: 2091.660 token/s

Accuracy: 0.775
Invalid: 0.000
Latency: 8.065 s
Output throughput: 2089.109 token/s
```


**Todo in next PR:**

- Support Cuda Graph for Spec Decoding
- Support Page Size > 1 for Spec Decoding

> Currently if user tried to spawn sglang fa3 without `--disable-cuda-graph`, it will error out with:
> `NotImplementedError: FlashAttentionBackend does not support CUDA graph yet, stay tuned!`
> 




<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add Eagle Speculative Decoding to FA3 Backend.

co-author with @zcnrex @Fridge003 @hebiao064 

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
