### PR TITLE
[Fix] print TPOT results in bench_serving.py

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1140,6 +1140,12 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("Mean TTFT (ms):", metrics.mean_ttft_ms))
     print("{:<40} {:<10.2f}".format("Median TTFT (ms):", metrics.median_ttft_ms))
     print("{:<40} {:<10.2f}".format("P99 TTFT (ms):", metrics.p99_ttft_ms))
+    print(
+        "{s:{c}^{n}}".format(s="Time per Output Token (excl. 1st token)", n=50, c="-")
+    )
+    print("{:<40} {:<10.2f}".format("Mean TPOT (ms):", metrics.mean_tpot_ms))
+    print("{:<40} {:<10.2f}".format("Median TPOT (ms):", metrics.median_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P99 TPOT (ms):", metrics.p99_tpot_ms))
     print("{s:{c}^{n}}".format(s="Inter-Token Latency", n=50, c="-"))
     print("{:<40} {:<10.2f}".format("Mean ITL (ms):", metrics.mean_itl_ms))
     print("{:<40} {:<10.2f}".format("Median ITL (ms):", metrics.median_itl_ms))

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1091,7 +1091,7 @@ async def benchmark(
     print("{:<40} {:<10}".format("Traffic request rate:", request_rate))
     print(
         "{:<40} {:<10}".format(
-            "Max reqeuest concurrency:",
+            "Max request concurrency:",
             max_concurrency if max_concurrency else "not set",
         )
     )


### PR DESCRIPTION
TPOT print statements were removed in: #3988 

addressing issue: https://github.com/sgl-project/sglang/issues/4970

example:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                not set   
Successful requests:                     10        
Benchmark duration (s):                  1.76      
Total input tokens:                      1997      
Total generated tokens:                  2798      
Total generated tokens (retokenized):    2798      
Request throughput (req/s):              5.69      
Input token throughput (tok/s):          1136.26   
Output token throughput (tok/s):         1592.01   
Total token throughput (tok/s):          2728.27   
Concurrency:                             5.48      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   963.65    
Median E2E Latency (ms):                 1060.53   
---------------Time to First Token----------------
Mean TTFT (ms):                          62.46     
Median TTFT (ms):                        63.38     
P99 TTFT (ms):                           69.76     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.29      
Median TPOT (ms):                        3.22      
P99 TPOT (ms):                           3.64      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           3.23      
Median ITL (ms):                         3.21      
P95 ITL (ms):                            3.58      
P99 ITL (ms):                            4.92      
Max ITL (ms):                            20.60     
==================================================
```