### PR TITLE
[Fix] Include long_prompt.txt in package distribution

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -110,6 +110,7 @@ dev_cpu = ["sglang[all_cpu]", "sglang[test]"]
 "sglang" = [
     "srt/layers/moe/fused_moe_triton/configs/*.json",
     "srt/layers/quantization/configs/*.json",
+    "test/long_prompt.txt",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Motivation

This PR fixes the issue reported in #4976  where the `long_prompt.txt` file was not included in the distribution package when installing sglang via pip. This caused errors for users running code that depends on this file, forcing them to manually download and place the file in the correct location.

## Modifications

Added `"test/long_prompt.txt"` entry to the `[tool.setuptools.package-data]` section in `python/pyproject.toml` to ensure the file is properly included during packaging:

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
