### PR TITLE
Fix RuntimeError when empty string is passed as embedding input

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -1661,6 +1661,11 @@ def v1_embedding_request(all_requests, tokenizer_manager):
     if len(all_requests) == 1:
         prompt = prompts[0]
         if isinstance(prompt, str) or isinstance(prompt[0], str):
+            # Handle empty string inputs
+            if isinstance(prompt, str) and prompt == "":
+                prompt = " "  # Replace empty string with a space character
+            elif isinstance(prompt, list):
+                prompt = [p if p != "" else " " for p in prompt]
             prompt_kwargs = {"text": prompt}
         elif isinstance(prompt, list) and isinstance(
             prompt[0], MultimodalEmbeddingInput
@@ -1686,6 +1691,14 @@ def v1_embedding_request(all_requests, tokenizer_manager):
             prompt_kwargs = {"input_ids": prompt}
     else:
         if isinstance(prompts[0], str) or isinstance(prompts[0][0], str):
+            # Handle empty strings in multiple requests
+            if isinstance(prompts[0], str):
+                prompts = [p if p != "" else " " for p in prompts]
+            else:
+                prompts = [
+                    [p if p != "" else " " for p in prompt_list]
+                    for prompt_list in prompts
+                ]
             prompt_kwargs = {"text": prompts}
         elif isinstance(prompts[0], list) and isinstance(
             prompts[0][0], MultimodalEmbeddingInput

--- a/test/srt/test_embedding_openai_server.py
+++ b/test/srt/test_embedding_openai_server.py
@@ -27,6 +27,27 @@ class TestOpenAIServer(CustomTestCase):
         cls.base_url += "/v1"
         cls.tokenizer = get_tokenizer(cls.model)
 
+    def test_empty_string_embedding(self):
+        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
+
+        response = client.embeddings.create(
+            input="",
+            model=self.model,
+        )
+
+        assert len(response.data) == 1
+        assert isinstance(response.data, list)
+        assert response.data[0].embedding is not None
+        assert len(response.data[0].embedding) > 0
+        assert response.data[0].index == 0
+        assert response.data[0].object == "embedding"
+        assert response.model == self.model
+        assert response.object == "list"
+
+        empty_token_count = len(self.tokenizer.encode(""))
+        assert response.usage.prompt_tokens == empty_token_count
+        assert response.usage.total_tokens == empty_token_count
+
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR addresses an issue where passing an empty string as input to the embedding function causes a RuntimeError: RMSNorm failed with error code invalid configuration argument (similar to issue #3304). The error occurs because some underlying operations cannot handle empty string inputs properly.
During testing of the previous fix, I identified a new issue where the embedding function raises:
```
TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]
```
when processing List[str] inputs in the new version.

## Modifications

I fixed the issue by replacing empty strings "" with spaces. For string lists, I process each element to ensure no empty strings remain. Real-world testing verified the solution works.

Modified v1_embeddings function to:
Preserve all original parameters by cloning the complete request JSON
Only modify the "input" field while ensuring critical parameters (like dimensions) are properly passed
Expanded test coverage in run_batch scenarios

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
