### PR TITLE
[Bug] Handle max_new_tokens=0 correctly

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -568,6 +568,13 @@ class Req:
         if self.finished():
             return
 
+        if self.sampling_params.max_new_tokens == 0 and len(self.output_ids) <= 1:
+            self.finished_reason = FINISH_LENGTH(length=0)
+            # If a token was just added, remove it to reflect 0 completion tokens accurately.
+            if len(self.output_ids) == 1:
+                self.output_ids.pop()
+            return
+
         if self.to_abort:
             self.finished_reason = FINISH_ABORT(
                 message=self.to_abort_message,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -586,6 +586,9 @@ class Req:
             )
             return
 
+        if not self.output_ids:
+            return
+
         last_token_id = self.output_ids[-1]
 
         if not self.sampling_params.ignore_eos:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -570,7 +570,6 @@ class Req:
 
         if self.sampling_params.max_new_tokens == 0 and len(self.output_ids) <= 1:
             self.finished_reason = FINISH_LENGTH(length=0)
-            # If a token was just added, remove it to reflect 0 completion tokens accurately.
             if len(self.output_ids) == 1:
                 self.output_ids.pop()
             return

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -88,20 +88,6 @@ class SchedulerOutputProcessorMixin:
                     req.output_ids.append(next_token_id)
                     req.check_finished()
 
-                    is_finished_zero_tokens = (
-                        isinstance(req.finished_reason, FINISH_LENGTH)
-                        and req.finished_reason.length == 0
-                    )
-                    if is_finished_zero_tokens:
-                        if current_req_extend_len > 0:
-                            token_slot_to_free = batch.out_cache_loc[
-                                out_cache_loc_offset
-                                + current_req_extend_len
-                                - 1 : out_cache_loc_offset
-                                + current_req_extend_len
-                            ]
-                            self.token_to_kv_pool_allocator.free(token_slot_to_free)
-
                     if req.finished():
                         self.tree_cache.cache_finished_req(req)
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:


### PR DESCRIPTION
## Motivation
Giving this issue a try: https://github.com/sgl-project/sglang/issues/4892

## Issue and Fix:
While understanding the flow on how prefill and decode is done, I figured:

even though `max_new_tokens=0`, the standard flow after an EXTEND forward pass includes sampling the next token based on the final logits computed. this sampled token x is redundant.

Currently, `check_finished ` checked `len(req.output_ids) >= req.sampling_params.max_new_tokens`. Since len([x]) is 1, and max_new_tokens is 0, this condition 1 >= 0 was TRUE. but, the function continued to check for EOS tokens or stop strings. If the sampled token itself wasn't an EOS token and did not trigger the stop string
https://github.com/sgl-project/sglang/blob/e119f04215faea2aff2353faac20c53e8f52517b/python/sglang/srt/managers/schedule_batch.py#L577-L581

https://github.com/sgl-project/sglang/blob/e119f04215faea2aff2353faac20c53e8f52517b/python/sglang/srt/managers/schedule_batch.py#L585-L601

We add a check `if self.sampling_params.max_new_tokens == 0 and len(self.output_ids) <= 1:` that triggers immediately when `max_new_tokens` is 0 and sets `req.finished_reason = FINISH_LENGTH(length=0)`, pops our redundant token.

This triggers another memory leak issue.

cc: @zhyncs @merrymercy would love for some pointers