### PR TITLE
[1/2] support mla dp: custom alltoall

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -207,6 +207,7 @@ string(REPLACE "-D__CUDA_NO_HALF2_OPERATORS__"      "" CMAKE_CUDA_FLAGS "${CMAKE
 set(SOURCES
     "csrc/allreduce/mscclpp_allreduce.cu"
     "csrc/allreduce/custom_all_reduce.cu"
+    "csrc/alltoall/custom_all_to_all.cu"
     "csrc/attention/cascade.cu"
     "csrc/attention/merge_attn_states.cu"
     "csrc/attention/cutlass_mla_kernel.cu"

--- a/sgl-kernel/csrc/allreduce/custom_all_reduce.cuh
+++ b/sgl-kernel/csrc/allreduce/custom_all_reduce.cuh
@@ -18,21 +18,23 @@
 namespace sglang {
 
 constexpr int kMaxBlocks = 36;
+constexpr int kMaxAll2AllBlocks = 78;
+constexpr int kSignalBlocks = std::max(kMaxBlocks, kMaxAll2AllBlocks);
 // Counter may overflow, but it's fine since unsigned int overflow is
 // well-defined behavior.
 using FlagType = uint32_t;
 struct Signal {
-  alignas(128) FlagType self_counter[kMaxBlocks][8];
+  alignas(128) FlagType self_counter[kSignalBlocks][8];
   // Two sets of peer counters are needed for two syncs. The reason is that
   // it's possible for peer GPU block to arrive at the second sync point while
   // the current GPU block haven't passed the first sync point. Thus, peer GPU
   // may write counter+1 while current GPU is busy waiting for counter. We use
   // alternating counter array to avoid this possibility.
-  alignas(128) FlagType peer_counter[2][kMaxBlocks][8];
+  alignas(128) FlagType peer_counter[2][kSignalBlocks][8];
 };
 
 struct __align__(16) RankData {
-  const void* __restrict__ ptrs[8];
+  void* __restrict__ ptrs[8];
 };
 
 struct __align__(16) RankSignals {

--- a/sgl-kernel/csrc/alltoall/custom_all_to_all.cu
+++ b/sgl-kernel/csrc/alltoall/custom_all_to_all.cu
@@ -1,0 +1,501 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// reference:
+// https://github.com/NVIDIA/TensorRT-LLM/blob/release/0.14/cpp/tensorrt_llm/kernels/customAllReduceKernels.cu
+/*
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/cuda/Exceptions.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <tuple>
+
+#include "allreduce/custom_all_reduce.cuh"
+#include "utils.h"
+
+using namespace sglang;
+
+constexpr int MAX_RANKS_PER_NODE = 8;
+constexpr int MAX_ALL_TO_ALL_BLOCKS = kMaxAll2AllBlocks;
+constexpr int MAX_ALL_TO_ALL_WARPS = 16;
+// Fake pointer type, must match fptr_t type in ops.h.
+// We use this type alias to indicate when pointers are passed in as int64_t.
+using fptr_t = int64_t;
+static_assert(sizeof(void*) == sizeof(fptr_t));
+int g_sm_count = 0;
+
+namespace {
+inline int divUp(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+struct All2AllParams {
+  int64_t elts_size;
+  int64_t rank;
+  int64_t ranks_per_node;
+  RankData* peer_comm_buffer_ptrs;
+  void* local_input_buffer_ptr;
+  int64_t* plan_meta_ptr;
+
+  int64_t output_elts_total;
+  int64_t input_elts_total;
+
+  int64_t input_stride0;
+  int64_t input_stride1;
+  int64_t input_dim1;
+
+  RankSignals sg;
+  Signal* self_sg;
+};
+
+struct All2AllPlanParams {
+  int64_t elts_size;
+  int64_t rank;
+  int64_t ranks_per_node;
+  int64_t* output_split_sizes;
+  int64_t* input_split_sizes;
+  int64_t* output_split_offsets;
+  int64_t* input_split_offsets;
+  int64_t* plan_meta_ptr;
+
+  int64_t output_elts_total;
+  int64_t input_elts_total;
+
+  int64_t chunk_size;
+  int64_t output_stride0;
+  int64_t output_stride1;
+  int64_t output_dim1;
+
+  int64_t blocks_per_grid;
+  int64_t threads_per_block;
+
+  RankSignals sg;
+  Signal* self_sg;
+};
+
+struct __align__(16) AllToAllCommMeta {
+  int32_t output_elts_offset[MAX_RANKS_PER_NODE];
+  int32_t output_elts_length[MAX_RANKS_PER_NODE];
+  int32_t output_dim1;
+  int32_t output_stride0;
+  int32_t output_stride1;
+};
+
+struct __align__(16) AllToAllPeerMeta {
+  int32_t output_elts_offset;
+  int32_t output_dim1;
+  int32_t output_stride0;
+  int32_t output_stride1;
+};
+
+struct __align__(16) AllToAllPlanMeta {
+  int32_t local_input_elts_offset[MAX_RANKS_PER_NODE];
+  int32_t local_input_elts_length[MAX_RANKS_PER_NODE];
+
+  AllToAllPeerMeta peer_meta[MAX_RANKS_PER_NODE];
+  int32_t chunk_size;
+  int32_t input_split_elts_total;
+  int32_t total_opt_warps_count;
+  int32_t warps_beg[MAX_RANKS_PER_NODE];
+  int8_t warp_peer_gpu[8];  // real size total_opt_warps_count
+};
+
+inline int getSmCount() {
+  if (g_sm_count <= 0) {
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, 0);
+    g_sm_count = prop.multiProcessorCount;
+  }
+  return g_sm_count;
+}
+
+template <int ngpus>
+static __global__ void __launch_bounds__(32, 1) all2AllPlanKernel(All2AllPlanParams params) {
+  int const bidx = blockIdx.x;
+  int const tidx = threadIdx.x;
+  const int chunk_size = params.chunk_size;
+  auto input_split_sizes = params.input_split_sizes;
+  auto output_split_sizes = params.output_split_sizes;
+
+  int64_t* split_offset_size[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    split_offset_size[i] = get_tmp_buf<int64_t>(params.sg.signals[i]);
+  }
+  auto& cur_meta = *reinterpret_cast<struct AllToAllCommMeta*>(split_offset_size[params.rank]);
+
+  auto& plan_meta = *reinterpret_cast<struct AllToAllPlanMeta*>(params.plan_meta_ptr);
+  if (bidx == 0 && tidx == 0) {
+    plan_meta.chunk_size = params.chunk_size;
+
+    int32_t cur_offset = 0;
+    int32_t cur_total_len = 0;
+    int32_t offset;
+    int32_t len;
+    // Set the length and offset of each device's output copied from current device
+    for (int i = 0; i < ngpus; i++) {
+      len = output_split_sizes[i];
+      if (params.output_split_offsets != nullptr) {
+        offset = params.output_split_offsets[i];
+        cur_offset = std::max(cur_offset, offset + len);
+      } else {
+        offset = cur_offset;
+        cur_offset += output_split_sizes[i];
+      }
+      if (cur_offset * chunk_size > params.output_elts_total) {
+        assert(false & "invalid output_split_sizes");
+        return;
+      }
+      cur_meta.output_elts_offset[i] = offset * chunk_size;
+      cur_meta.output_elts_length[i] = len * chunk_size;
+      cur_total_len += len;
+    }
+    cur_meta.output_dim1 = params.output_dim1;
+    cur_meta.output_stride0 = params.output_stride0;
+    cur_meta.output_stride1 = params.output_stride1;
+
+    cur_offset = 0;
+    cur_total_len = 0;
+    // Calculate the length and offset of the current device's input copied to each device's output
+    for (int i = 0; i < ngpus; i++) {
+      len = input_split_sizes[i];
+      if (params.input_split_offsets != nullptr) {
+        offset = params.input_split_offsets[i];
+        cur_offset = std::max(cur_offset, offset + len);
+      } else {
+        offset = cur_offset;
+        cur_offset += input_split_sizes[i];
+      }
+      if (cur_offset * chunk_size > params.input_elts_total) {
+        assert(false & "invalid input_split_sizes");
+        return;
+      }
+      plan_meta.local_input_elts_offset[i] = offset * chunk_size;
+      plan_meta.local_input_elts_length[i] = len * chunk_size;
+      cur_total_len += len;
+    }
+    plan_meta.input_split_elts_total = cur_total_len * chunk_size;
+  }
+  multi_gpu_barrier<ngpus, true>(params.sg, params.self_sg, params.rank);
+
+  // Get the length and offset of each target device's output
+  if (bidx == 0 && tidx < ngpus) {
+    int peer_rank = tidx;
+    // get peer output offset and length from current rank
+    auto& peer_meta = *reinterpret_cast<struct AllToAllCommMeta*>(split_offset_size[peer_rank]);
+    // offset in peer output buffer
+    int64_t peer_elts_offset = peer_meta.output_elts_offset[params.rank];
+    // element count copy to peer output buffer
+    int64_t peer_elts_cnt = peer_meta.output_elts_length[params.rank];
+    if (peer_elts_cnt != input_split_sizes[peer_rank] * chunk_size) {
+      assert(false & "input_split_sizes mismatch peer output_split_sizes");
+      multi_gpu_barrier<ngpus, false>(params.sg, params.self_sg, params.rank);
+      return;
+    }
+    plan_meta.peer_meta[peer_rank].output_elts_offset = peer_elts_offset;
+    plan_meta.peer_meta[peer_rank].output_dim1 = peer_meta.output_dim1;
+    plan_meta.peer_meta[peer_rank].output_stride0 = peer_meta.output_stride0;
+    plan_meta.peer_meta[peer_rank].output_stride1 = peer_meta.output_stride1;
+  }
+  // Calculate the number of warps used to copy to each target device
+  int total_opt_warps_count = 0;
+  const int elts_once = sizeof(int4) / params.elts_size * WARP_SIZE;
+  for (int i = 0; i < ngpus; i++) {
+    const int peer_rank = (i + params.rank) % ngpus;
+    const int opt_warps_count = (input_split_sizes[peer_rank] * chunk_size + elts_once - 1) / elts_once;
+    for (int k = bidx * blockDim.x + tidx; k < opt_warps_count; k += gridDim.x * blockDim.x) {
+      plan_meta.warp_peer_gpu[k + total_opt_warps_count] = peer_rank;
+    }
+    if (bidx == 0 && tidx == 0) {
+      plan_meta.warps_beg[peer_rank] = total_opt_warps_count;
+    }
+    total_opt_warps_count += opt_warps_count;
+  }
+  if (bidx == 0 && tidx == 0) {
+    plan_meta.total_opt_warps_count = total_opt_warps_count;
+  }
+  multi_gpu_barrier<ngpus, false>(params.sg, params.self_sg, params.rank);
+}
+
+__device__ __forceinline__ int32_t
+real_offset(int32_t offset, int32_t dim1, int32_t chunk_size, int32_t stride0, int32_t stride1) {
+  auto dim01 = offset / chunk_size;
+  return (dim01 / dim1) * stride0 + (dim01 % dim1) * stride1 + offset % chunk_size;
+}
+
+template <typename T, int ngpus>
+static __global__ void __launch_bounds__(MAX_ALL_TO_ALL_WARPS* WARP_SIZE, 1) all2AllKernel(All2AllParams params) {
+  int const bidx = blockIdx.x;
+  int const tidx = threadIdx.x;
+  int const lane_id = tidx % WARP_SIZE;
+  // The source pointers. Distributed round-robin for the different warps.
+  auto peer_comm_buffer_ptrs = params.peer_comm_buffer_ptrs->ptrs;
+  // Start and end offsets of the thread
+  const auto& plan_meta = *reinterpret_cast<struct AllToAllPlanMeta*>(params.plan_meta_ptr);
+  int32_t input_split_elts_total = plan_meta.input_split_elts_total;
+  if (input_split_elts_total > params.input_elts_total) {
+    assert(false & "invalid input_split_sizes");
+    return;
+  }
+
+  constexpr int VEC_SIZE = 16 / sizeof(T);  // every copy element cnt
+
+  const int32_t chunk_size = plan_meta.chunk_size;
+  const int32_t cur_dim1 = params.input_dim1;
+  const int32_t cur_stride0 = params.input_stride0;
+  const int32_t cur_stride1 = params.input_stride1;
+  const T* __restrict__ const local_input = reinterpret_cast<const T*>(params.local_input_buffer_ptr);
+
+  int warp_idx = (bidx * blockDim.x + tidx) / WARP_SIZE;
+  const int warp_stride = gridDim.x * blockDim.x / WARP_SIZE;
+  const int total_opt_warps_count = plan_meta.total_opt_warps_count;
+  for (; warp_idx < total_opt_warps_count; warp_idx += warp_stride) {
+    int peer_rank = plan_meta.warp_peer_gpu[warp_idx];
+    auto warp_beg = plan_meta.warps_beg[peer_rank];
+    const int32_t local_offset = plan_meta.local_input_elts_offset[peer_rank];
+
+    auto& peer_meta = plan_meta.peer_meta[peer_rank];
+    const int32_t peer_offset = peer_meta.output_elts_offset;
+    const int32_t peer_dim1 = peer_meta.output_dim1;
+    const int32_t peer_stride0 = peer_meta.output_stride0;
+    const int32_t peer_stride1 = peer_meta.output_stride1;
+
+    T* __restrict__ const peer_output = reinterpret_cast<T*>(peer_comm_buffer_ptrs[peer_rank]);
+
+    int32_t chunk_start = ((warp_idx - warp_beg) * WARP_SIZE + lane_id) * VEC_SIZE;
+
+    auto output_offset = real_offset(chunk_start + peer_offset, peer_dim1, chunk_size, peer_stride0, peer_stride1);
+    auto input_offset = real_offset(chunk_start + local_offset, cur_dim1, chunk_size, cur_stride0, cur_stride1);
+    *reinterpret_cast<int4*>(peer_output + output_offset) = *reinterpret_cast<int4 const*>(local_input + input_offset);
+  }
+  multi_gpu_barrier<ngpus, false>(params.sg, params.self_sg, params.rank);
+}
+
+std::tuple<int, int> all2AllkernelLaunchConfig(int64_t output_elts_total, int64_t input_elts_total, int64_t elts_size) {
+  int chunk_size = sizeof(int4) * WARP_SIZE / elts_size;
+  int elts_total = input_elts_total;
+  int total_splits = std::max(1, divUp(elts_total, chunk_size));
+  int sm_count = getSmCount();
+  int blocks_per_grid = std::min(sm_count, MAX_ALL_TO_ALL_BLOCKS);
+  int splits_per_block = divUp(total_splits, blocks_per_grid);
+
+  int num_warps = std::min(MAX_ALL_TO_ALL_WARPS, splits_per_block);
+  int threads_per_block = num_warps * WARP_SIZE;
+  return std::make_tuple(blocks_per_grid, threads_per_block);
+}
+
+template <typename T>
+void invokeAll2AllKernel(All2AllParams& params, cudaStream_t stream) {
+  auto [blocks_per_grid, threads_per_block] =
+      all2AllkernelLaunchConfig(params.output_elts_total, params.input_elts_total, params.elts_size);
+
+#define A2A_KERNEL(ngpus) all2AllKernel<T, ngpus><<<blocks_per_grid, threads_per_block, 0, stream>>>(params)
+  switch (params.ranks_per_node) {
+    case 2:
+      A2A_KERNEL(2);
+      break;
+    case 4:
+      A2A_KERNEL(4);
+      break;
+    case 6:
+      A2A_KERNEL(6);
+      break;
+    case 8:
+      A2A_KERNEL(8);
+      break;
+    default:
+      throw std::runtime_error("invalid world size " + std::to_string(params.ranks_per_node));
+  }
+#undef A2A_KERNEL
+
+  CHECK_CUDA_SUCCESS(cudaGetLastError());
+}
+
+void trtCustomAll2All(All2AllParams& params, cudaStream_t stream) {
+  switch (params.elts_size) {
+    case 2:
+      invokeAll2AllKernel<half>(params, stream);
+      break;
+    case 4:
+      invokeAll2AllKernel<float>(params, stream);
+      break;
+    default:
+      throw std::runtime_error("Unsupported data element size " + std::to_string(params.elts_size));
+  }
+}
+
+void invokeAll2AllPlanKernel(All2AllPlanParams& params, cudaStream_t stream) {
+  switch (params.ranks_per_node) {
+    case 2:
+      all2AllPlanKernel<2><<<32, 32, 0, stream>>>(params);
+      break;
+    case 4:
+      all2AllPlanKernel<4><<<32, 32, 0, stream>>>(params);
+      break;
+    case 6:
+      all2AllPlanKernel<6><<<32, 32, 0, stream>>>(params);
+      break;
+    case 8:
+      all2AllPlanKernel<8><<<32, 32, 0, stream>>>(params);
+      break;
+    default:
+      throw std::runtime_error("invalid world size " + std::to_string(params.ranks_per_node));
+  }
+  CHECK_CUDA_SUCCESS(cudaGetLastError());
+}
+}  // namespace
+
+void all_to_all(fptr_t _fa, torch::Tensor& out, torch::Tensor& inp, torch::Tensor& plan_meta, fptr_t _reg_buffer) {
+  auto fa = reinterpret_cast<CustomAllreduce*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  if (inp.dim() != 3 || out.dim() != 3) {
+    throw std::runtime_error(
+        "custom all_to_all currently requires input or output dim count to be 3, but got input dim count " +
+        std::to_string(inp.dim()) + " and output dim count of " + std::to_string(out.dim()) + ".");
+    return;
+  }
+
+  TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());
+  All2AllParams params;
+  auto reg_buffer = reinterpret_cast<void*>(_reg_buffer);
+  auto it = fa->buffers_.find(reg_buffer);
+  if (it == fa->buffers_.end()) throw std::runtime_error("output buffer address is not registered!");
+  params.peer_comm_buffer_ptrs = it->second;
+
+  params.ranks_per_node = fa->world_size_;
+  params.rank = fa->rank_;
+  params.sg = fa->sg_;
+  params.self_sg = fa->self_sg_;
+
+  params.local_input_buffer_ptr = inp.data_ptr();
+  params.plan_meta_ptr = reinterpret_cast<int64_t*>(plan_meta.data_ptr());
+
+  params.input_elts_total = inp.numel();
+  params.output_elts_total = out.numel();
+  params.elts_size = inp.element_size();
+  params.input_stride0 = inp.stride(0);
+  params.input_stride1 = inp.stride(1);
+  params.input_dim1 = inp.size(1);
+
+  trtCustomAll2All(params, stream);
+  if (out.numel() != 0 && out.data_ptr() != reg_buffer) {
+    auto output_size = out.numel() * out.element_size();
+    AT_CUDA_CHECK(cudaMemcpyAsync(out.data_ptr(), reg_buffer, output_size, cudaMemcpyDeviceToDevice, stream));
+  }
+}
+
+void all_to_all_plan(
+    fptr_t _fa,
+    torch::Tensor& out,
+    torch::Tensor& inp,
+    torch::Tensor& output_split_sizes,
+    torch::Tensor& input_split_sizes,
+    int64_t chunk_size,
+    torch::Tensor& output_split_offsets,
+    torch::Tensor& input_split_offsets,
+    torch::Tensor& plan_meta) {
+  auto fa = reinterpret_cast<CustomAllreduce*>(_fa);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  auto stream = c10::cuda::getCurrentCUDAStream().stream();
+
+  if (plan_meta.numel() * plan_meta.element_size() < sizeof(AllToAllPlanMeta)) {
+    assert(false && "Invalid plan meta size");
+    throw std::runtime_error(
+        "custom all_to_all: invalid plan meta size, requires >= " + std::to_string(sizeof(AllToAllPlanMeta)) +
+        ", but got " + std::to_string(plan_meta.numel() * plan_meta.element_size()) + ".");
+    return;
+  }
+  if (inp.dim() != 3 || out.dim() != 3) {
+    throw std::runtime_error(
+        "custom all_to_all currently requires input or output dim count to be 3, but got input dim count " +
+        std::to_string(inp.dim()) + " and output dim count of " + std::to_string(out.dim()) + ".");
+    return;
+  }
+
+  All2AllPlanParams params;
+  params.ranks_per_node = fa->world_size_;
+  params.rank = fa->rank_;
+  params.sg = fa->sg_;
+  params.self_sg = fa->self_sg_;
+
+  params.input_elts_total = inp.numel();
+  params.output_elts_total = out.numel();
+
+  params.output_split_sizes = reinterpret_cast<int64_t*>(output_split_sizes.data_ptr());
+  params.input_split_sizes = reinterpret_cast<int64_t*>(input_split_sizes.data_ptr());
+  if (output_split_offsets.numel() == 0) {
+    params.output_split_offsets = nullptr;
+  } else {
+    params.output_split_offsets = reinterpret_cast<int64_t*>(output_split_offsets.data_ptr());
+  }
+  if (input_split_offsets.numel() == 0) {
+    params.input_split_offsets = nullptr;
+  } else {
+    params.input_split_offsets = reinterpret_cast<int64_t*>(input_split_offsets.data_ptr());
+  }
+
+  params.plan_meta_ptr = reinterpret_cast<int64_t*>(plan_meta.data_ptr());
+
+  params.chunk_size = chunk_size;
+  params.output_stride0 = out.stride(0);
+  params.output_stride1 = out.stride(1);
+  params.output_dim1 = out.size(1);
+
+  params.elts_size = inp.element_size();
+  int d = sizeof(int4) * WARP_SIZE / params.elts_size;
+  if (params.input_elts_total % d != 0) {
+    throw std::runtime_error(
+        "custom all_to_all currently requires input length to be multiple "
+        "of " +
+        std::to_string(d));
+    return;
+  }
+  if (params.input_elts_total % d != 0) {
+    throw std::runtime_error(
+        "custom all_to_all currently requires output length to be multiple "
+        "of " +
+        std::to_string(d));
+    return;
+  }
+  auto [blocks_per_grid, threads_per_block] =
+      all2AllkernelLaunchConfig(params.output_elts_total, params.input_elts_total, params.elts_size);
+  params.blocks_per_grid = blocks_per_grid;
+  params.threads_per_block = threads_per_block;
+  invokeAll2AllPlanKernel(params, stream);
+}

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -47,6 +47,15 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def("mscclpp_allreduce(int context, Tensor inp, Tensor! out, int nthreads, int nblocks) -> ()");
   m.impl("mscclpp_allreduce", torch::kCUDA, &mscclpp_allreduce);
+
+  m.def("all_to_all(int fa, Tensor! out, Tensor inp, Tensor plan_meta, int _reg_buffer) -> ()");
+  m.impl("all_to_all", torch::kCUDA, &all_to_all);
+
+  m.def(
+      "all_to_all_plan(int fa, Tensor out, Tensor inp, Tensor output_split_sizes, "
+      "Tensor input_split_sizes, int chunk_size, Tensor output_split_offsets, Tensor input_split_offsets, "
+      "Tensor !plan_meta) -> ()");
+  m.impl("all_to_all_plan", torch::kCUDA, &all_to_all_plan);
   /*
    * From csrc/attention
    */

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -86,6 +86,17 @@ fptr_t mscclpp_init_context(
     const std::vector<int64_t>& rank_to_ib,
     const int64_t context_selection);
 void mscclpp_allreduce(fptr_t _context, torch::Tensor& inp, torch::Tensor& out, int64_t nthreads, int64_t nblocks);
+void all_to_all(fptr_t _fa, torch::Tensor& output, torch::Tensor& input, torch::Tensor& plan_meta, fptr_t _reg_buffer);
+void all_to_all_plan(
+    fptr_t _fa,
+    torch::Tensor& output,
+    torch::Tensor& input,
+    torch::Tensor& output_split_sizes,
+    torch::Tensor& input_split_sizes,
+    int64_t chunk_size,
+    torch::Tensor& output_split_offsets,
+    torch::Tensor& input_split_offsets,
+    torch::Tensor& plan_meta);
 #endif
 
 /*

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -12,6 +12,7 @@ if os.path.exists(cuda_path):
 
 from sgl_kernel import common_ops
 from sgl_kernel.allreduce import *
+from sgl_kernel.alltoall import *
 from sgl_kernel.attention import (
     cutlass_mla_decode,
     cutlass_mla_get_workspace_size,

--- a/sgl-kernel/python/sgl_kernel/alltoall.py
+++ b/sgl-kernel/python/sgl_kernel/alltoall.py
@@ -1,0 +1,49 @@
+import torch
+
+if torch.version.hip is None:
+
+    def all_to_all(
+        fa,
+        output,
+        input,
+        plan_meta,
+        reg_buffer: int,
+    ):
+        torch.ops.sgl_kernel.all_to_all.default(
+            fa,
+            output,
+            input,
+            plan_meta,
+            reg_buffer,
+        )
+
+    def all_to_all_plan(
+        fa,
+        output,
+        input,
+        output_split_sizes,
+        input_split_sizes,
+        chunk_size,
+        output_split_offsets,
+        input_split_offsets,
+        plan_meta,
+    ):
+        if output_split_offsets is None:
+            output_split_offsets = torch.zeros(
+                (0,), dtype=torch.int64, device=input.device
+            )
+        if input_split_offsets is None:
+            input_split_offsets = torch.zeros(
+                (0,), dtype=torch.int64, device=input.device
+            )
+        return torch.ops.sgl_kernel.all_to_all_plan.default(
+            fa,
+            output,
+            input,
+            output_split_sizes,
+            input_split_sizes,
+            chunk_size,
+            output_split_offsets,
+            input_split_offsets,
+            plan_meta,
+        )

--- a/sgl-kernel/tests/test_custom_alltoall.py
+++ b/sgl-kernel/tests/test_custom_alltoall.py
@@ -1,0 +1,410 @@
+import ctypes
+import multiprocessing as mp
+import random
+import socket
+import time
+import unittest
+from typing import Any, List, Optional
+
+import sgl_kernel as custom_ops
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+from sglang.srt.utils import is_cuda
+
+_is_cuda = is_cuda()
+
+
+def _run_correctness_worker(world_size, rank, distributed_init_port):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    distributed_init_method = f"tcp://localhost:{distributed_init_port}"
+    dist.init_process_group(
+        backend="nccl",
+        init_method=distributed_init_method,
+        rank=rank,
+        world_size=world_size,
+    )
+    group = dist.group.WORLD
+
+    test_sizes = [16, 32, 64, 128, 256, 512, 1024, 4096]
+    head_sizes = [512, 576]
+    pad_lens = [0, 10]
+
+    custom_ptr = None
+
+    peer_output_size = 256  # 8*8*2
+    max_size = (max(test_sizes) + 8 * max(pad_lens)) * 128 * max(head_sizes)
+
+    try:
+        device = torch.device(f"cuda:{rank}")
+        meta_ptrs = TestCustomAllToAll.create_shared_buffer(
+            custom_ops.meta_size() + peer_output_size, group=group
+        )
+
+        rank_data = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=device)
+        custom_ptr = custom_ops.init_custom_ar(meta_ptrs, rank_data, rank, True)
+
+        output_buffer = torch.empty(max_size, dtype=torch.bfloat16, device=device)
+        buffer_ptrs = TestCustomAllToAll.register_output_buffers(
+            custom_ptr, output_buffer, group
+        )
+
+        test_loop = 10
+        for sz in test_sizes:
+            for dtype in [torch.bfloat16]:
+                for head_size in head_sizes:
+                    for pad in pad_lens:
+                        for _ in range(test_loop):
+                            TestCustomAllToAll.run_acc_tp2dp(
+                                custom_ptr,
+                                buffer_ptrs[rank],
+                                world_size,
+                                head_size,
+                                sz,
+                                pad,
+                                dtype,
+                                group,
+                                output_buffer,
+                            )
+                        for _ in range(test_loop):
+                            TestCustomAllToAll.run_acc_dp2tp(
+                                custom_ptr,
+                                buffer_ptrs[rank],
+                                world_size,
+                                head_size,
+                                sz,
+                                pad,
+                                dtype,
+                                group,
+                                output_buffer,
+                            )
+
+    finally:
+        dist.barrier(group=group)
+        if custom_ptr is not None:
+            custom_ops.dispose(custom_ptr)
+        if meta_ptrs:
+            TestCustomAllToAll.free_shared_buffer(meta_ptrs, group)
+
+        dist.destroy_process_group(group=group)
+
+
+def get_open_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+    except OSError:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return s.getsockname()[1]
+
+
+def multi_process_parallel(
+    world_size: int, test_target: Any, target_args: tuple = ()
+) -> None:
+    mp.set_start_method("spawn", force=True)
+
+    procs = []
+    distributed_init_port = get_open_port()
+    for i in range(world_size):
+        proc_args = (world_size, i, distributed_init_port) + target_args
+        proc = mp.Process(target=test_target, args=proc_args, name=f"Worker-{i}")
+        proc.start()
+        procs.append(proc)
+
+    for i in range(world_size):
+        procs[i].join()
+        assert (
+            procs[i].exitcode == 0
+        ), f"Process {i} failed with exit code {procs[i].exitcode}"
+
+
+class TestCustomAllToAll(unittest.TestCase):
+    world_sizes = [2, 4, 8]
+
+    @staticmethod
+    def create_shared_buffer(
+        size_in_bytes: int, group: Optional[ProcessGroup] = None
+    ) -> List[int]:
+        lib = CudaRTLibrary()
+        pointer = lib.cudaMalloc(size_in_bytes)
+        handle = lib.cudaIpcGetMemHandle(pointer)
+        if group is None:
+            group = dist.group.WORLD
+        world_size = dist.get_world_size(group=group)
+        rank = dist.get_rank(group=group)
+
+        handle_bytes = ctypes.string_at(ctypes.addressof(handle), ctypes.sizeof(handle))
+        input_tensor = torch.ByteTensor(list(handle_bytes)).to(f"cuda:{rank}")
+        gathered_tensors = [torch.empty_like(input_tensor) for _ in range(world_size)]
+        dist.all_gather(gathered_tensors, input_tensor, group=group)
+
+        handles = []
+        handle_type = type(handle)
+        for tensor in gathered_tensors:
+            bytes_list = tensor.cpu().tolist()
+            bytes_data = bytes(bytes_list)
+            handle_obj = handle_type()
+            ctypes.memmove(ctypes.addressof(handle_obj), bytes_data, len(bytes_data))
+            handles.append(handle_obj)
+
+        pointers: List[int] = []
+        for i, h in enumerate(handles):
+            if i == rank:
+                pointers.append(pointer.value)
+            else:
+                try:
+                    opened_ptr = lib.cudaIpcOpenMemHandle(h)
+                    pointers.append(opened_ptr.value)
+                except Exception as e:
+                    print(f"Rank {rank}: Failed to open IPC handle from rank {i}: {e}")
+                    raise
+
+        dist.barrier(group=group)
+        return pointers
+
+    @staticmethod
+    def register_output_buffers(
+        custom_ptr, output_buffer, group: Optional[ProcessGroup] = None
+    ):
+        lib = CudaRTLibrary()
+        pointer = output_buffer.untyped_storage().data_ptr()
+        handle = lib.cudaIpcGetMemHandle(pointer)
+        world_size = dist.get_world_size(group=group)
+        rank = dist.get_rank(group=group)
+        handles = [None] * world_size
+        dist.all_gather_object(handles, handle, group=group)
+
+        pointers: List[int] = []
+        for i, h in enumerate(handles):
+            if i == rank:
+                pointers.append(pointer)  # type: ignore
+            else:
+                pointers.append(lib.cudaIpcOpenMemHandle(h).value)  # type: ignore
+        # self.output_ptrs = pointers
+        custom_ops.register_buffer(custom_ptr, pointers)
+        return pointers
+
+    @staticmethod
+    def free_shared_buffer(
+        pointers: List[int], group: Optional[ProcessGroup] = None
+    ) -> None:
+        if group is None:
+            group = dist.group.WORLD
+        rank = dist.get_rank(group=group)
+        lib = CudaRTLibrary()
+        if pointers and len(pointers) > rank and pointers[rank] is not None:
+            lib.cudaFree(ctypes.c_void_p(pointers[rank]))
+        dist.barrier(group=group)
+
+    def test_correctness(self):
+        if not _is_cuda:
+            return
+        for world_size in self.world_sizes:
+            available_gpus = torch.cuda.device_count()
+            if world_size > available_gpus:
+                print(
+                    f"Skipping world_size={world_size}, requires {world_size} GPUs, found {available_gpus}"
+                )
+                continue
+
+            print(f"Running test for world_size={world_size}")
+            multi_process_parallel(
+                world_size, _run_correctness_worker, target_args=tuple()
+            )
+            print(f"custom allreduce tp = {world_size}: OK")
+
+    @staticmethod
+    def custom_alltoall(
+        custom_ptr,
+        buffer_ptr,
+        output,
+        input,
+        output_split_sizes,
+        input_split_sizes,
+        chunk_size,
+        output_split_offsets,
+        input_split_offsets,
+    ):
+        output_split_sizes = torch.tensor(
+            output_split_sizes,
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+        input_split_sizes = torch.tensor(
+            input_split_sizes,
+            dtype=torch.int64,
+            device=torch.cuda.current_device(),
+        )
+        if output_split_offsets is not None:
+            output_split_offsets = torch.tensor(
+                output_split_offsets,
+                dtype=torch.int64,
+                device=torch.cuda.current_device(),
+            )
+        if input_split_offsets is not None:
+            input_split_offsets = torch.tensor(
+                input_split_offsets,
+                dtype=torch.int64,
+                device=torch.cuda.current_device(),
+            )
+        meta_extra = (input.numel() * input.dtype.itemsize // 512 + 7) // 8
+        plan_meta = torch.zeros(
+            128 + meta_extra, dtype=torch.int64, device=input.device
+        )
+        custom_ops.all_to_all_plan(
+            custom_ptr,
+            output,
+            input,
+            output_split_sizes,
+            input_split_sizes,
+            chunk_size,
+            output_split_offsets,
+            input_split_offsets,
+            plan_meta,
+        )
+        custom_ops.all_to_all(
+            custom_ptr,
+            output,
+            input,
+            plan_meta,
+            buffer_ptr,
+        )
+
+    @staticmethod
+    def run_acc_tp2dp(
+        custom_ptr,
+        buffer_ptr,
+        world_size,
+        head_size,
+        sz,
+        pad,
+        dtype,
+        group,
+        output_buffer,
+    ):
+        global_head = 128
+        local_head = global_head // world_size
+        chunk_size = head_size * local_head
+        out1 = output_buffer[: (sz // world_size + pad) * global_head * head_size].view(
+            sz // world_size + pad, world_size, local_head * head_size
+        )
+
+        inp1 = torch.randn(
+            sz,
+            1,
+            local_head * head_size,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+        out_split_size = [sz // world_size] * world_size
+        inp_split_size = [sz // world_size] * world_size
+        out_split_offset = [0] * world_size
+        inp_split_offset = None
+        for i in range(1, world_size):
+            out_split_offset[i] = out_split_size[i - 1] + pad + out_split_offset[i - 1]
+        TestCustomAllToAll.custom_alltoall(
+            custom_ptr,
+            buffer_ptr,
+            out1.transpose(0, 1),
+            inp1,
+            out_split_size,
+            inp_split_size,
+            chunk_size,
+            out_split_offset,
+            inp_split_offset,
+        )
+        cmp_out1 = out1[: sz // world_size].view(
+            sz // world_size, global_head, head_size
+        )
+        out2 = torch.randn(
+            world_size,
+            sz // world_size,
+            chunk_size,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+        inp2 = inp1[:sz]
+        dist.all_to_all_single(
+            out2.view(-1, chunk_size),
+            inp2.view(-1, chunk_size),
+            out_split_size,
+            inp_split_size,
+            group=group,
+        )
+        out2 = (
+            out2.transpose(0, 1)
+            .contiguous()
+            .view(sz // world_size, global_head, head_size)
+        )
+        torch.testing.assert_close(cmp_out1, out2)
+
+    @staticmethod
+    def run_acc_dp2tp(
+        custom_ptr,
+        buffer_ptr,
+        world_size,
+        head_size,
+        sz,
+        pad,
+        dtype,
+        group,
+        output_buffer,
+    ):
+        global_head = 128
+        local_head = global_head // world_size
+        chunk_size = head_size * local_head
+        out1 = output_buffer[: sz * local_head * head_size].view(
+            sz, 1, local_head * head_size
+        )
+
+        inp1 = torch.randn(
+            sz // world_size + pad,
+            world_size,
+            local_head * head_size,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+        out_split_size = [sz // world_size] * world_size
+        inp_split_size = [sz // world_size] * world_size
+        out_split_offset = None
+        inp_split_offset = [0] * world_size
+        for i in range(1, world_size):
+            inp_split_offset[i] = inp_split_size[i - 1] + pad + inp_split_offset[i - 1]
+        TestCustomAllToAll.custom_alltoall(
+            custom_ptr,
+            buffer_ptr,
+            out1,
+            inp1.transpose(0, 1),
+            out_split_size,
+            inp_split_size,
+            chunk_size,
+            out_split_offset,
+            inp_split_offset,
+        )
+        cmp_out1 = out1.view(sz, local_head, head_size)
+        out2 = torch.randn(
+            sz,
+            local_head,
+            head_size,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+        # world_size, sz//world_size, local_head*head_size
+        inp2 = inp1[: sz // world_size].transpose(0, 1).contiguous()
+        dist.all_to_all_single(
+            out2.view(-1, chunk_size),
+            inp2.view(-1, chunk_size),
+            out_split_size,
+            inp_split_size,
+            group=group,
+        )
+        torch.testing.assert_close(cmp_out1, out2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This pr is for dp mla #5001

About dp mla:
On an 8*H20(96GB), weight mem usage=87.19 GB when `--dp-size 4 --enable-dp-attention`, not enough memory left.

This optimization is similar to data parallelism attention, but it applies to MLA core instead of the entire attention. Compared with data parallelism attention, it does not additionally increase the memory occupied by weights. It allows for a significant reduction in the KV cache size and enables larger batch sizes with only 1-3ms additional decode latency.

On an 8×H20 (96GB) node, with data parallelism MLA enabled, we have achieved up to **1.85x(dp=4)** ~ **2.34x(dp=8)** decoding throughput improvement compared to the previous version. And, the number of kvcaches has been increased by **3.3x(dp=4)** and **6.6x(dp=8)**.

## Modifications

<!-- Describe the changes made in this PR. -->
Implement a custom all_to_all for dynamic input/output splitting (split_sizes) based on sglang allreduce IPC, currently limited to single-machine use.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
