### PR TITLE
[2/2] support dp mla

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_to_all.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_to_all.py
@@ -1,0 +1,357 @@
+# Adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/distributed/device_communicators/custom_all_reduce.py
+
+import ctypes
+import logging
+import os
+from typing import List, Optional, TypeVar, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from typing_extensions import ParamSpec
+
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+from sglang.srt.distributed.device_communicators.custom_all_reduce import (
+    _can_p2p,
+    is_full_nvlink,
+)
+from sglang.srt.distributed.parallel_state import in_the_same_node_as
+from sglang.srt.utils import is_cuda
+
+logger = logging.getLogger(__name__)
+
+_is_cuda = is_cuda()
+
+
+try:
+    import sgl_kernel
+
+    custom_ar = True
+except Exception:
+    # For CPUs
+    custom_ar = False
+
+logger = logging.getLogger(__name__)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def support_custom_all_to_all():
+    try:
+        from sgl_kernel import all_to_all
+
+        return True
+    except Exception:
+        return False
+
+
+class CustomAlltoAll:
+    # todo: multi-node all to all
+    _SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: Union[int, str, torch.device],
+    ) -> None:
+        """
+        Args:
+            group: the process group to work on. If None, it will use the
+                default process group.
+            device: the device to bind the CustomAllreduce to. If None,
+                it will be bind to f"cuda:{local_rank}".
+        It is the caller's responsibility to make sure each communicator
+        is bind to a unique device, and all communicators in this group
+        are in the same node.
+        """
+        self._IS_CAPTURING = False
+        self.disabled = True
+
+        if not custom_ar:
+            # disable because of missing custom allreduce library
+            # e.g. in a non-cuda environment
+            return
+        if not _is_cuda:
+            logger.warning("Custom alltoall is disabled because cuda is not available.")
+            return
+        if not support_custom_all_to_all():
+            logger.warning(
+                "Custom alltoall is not available, please use the latest sgl-kernel."
+            )
+            return
+
+        self.group = group
+
+        assert (
+            dist.get_backend(group) != dist.Backend.NCCL
+        ), "Custom alltoall should be attached to a non-NCCL group."
+
+        if not all(in_the_same_node_as(group, source_rank=0)):
+            # No need to initialize custom allreduce for multi-node case.
+            logger.warning(
+                "Custom alltoall is disabled because this process group"
+                " spans across nodes."
+            )
+            return
+
+        rank = dist.get_rank(group=self.group)
+        world_size = dist.get_world_size(group=self.group)
+        if world_size == 1:
+            # No need to initialize custom alltoall for single GPU case.
+            return
+
+        if world_size not in CustomAlltoAll._SUPPORTED_WORLD_SIZES:
+            logger.warning(
+                "Custom alltoall is disabled due to an unsupported world"
+                " size: %d. Supported world sizes: %s.",
+                world_size,
+                str(CustomAlltoAll._SUPPORTED_WORLD_SIZES),
+            )
+            return
+
+        if isinstance(device, int):
+            device = torch.device(f"cuda:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        # now `device` is a `torch.device` object
+        assert isinstance(device, torch.device)
+        self.device = device
+
+        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+        if cuda_visible_devices:
+            device_ids = list(map(int, cuda_visible_devices.split(",")))
+        else:
+            device_ids = list(range(torch.cuda.device_count()))
+
+        physical_device_id = device_ids[device.index]
+        tensor = torch.tensor([physical_device_id], dtype=torch.int, device="cpu")
+        gather_list = [
+            torch.tensor([0], dtype=torch.int, device="cpu") for _ in range(world_size)
+        ]
+        dist.all_gather(gather_list, tensor, group=self.group)
+        physical_device_ids = [t.item() for t in gather_list]
+
+        # test nvlink first, this will filter out most of the cases
+        # where custom allreduce is not supported
+        # this checks hardware and driver support for NVLink
+        full_nvlink = is_full_nvlink(physical_device_ids, world_size)
+
+        if world_size > 2 and not full_nvlink:
+            logger.warning(
+                "Custom alltoall is disabled because it's not supported on"
+                " more than two PCIe-only GPUs. To silence this warning, "
+                "specify disable_custom_all_reduce=True explicitly."
+            )
+            return
+        # test P2P capability, this checks software/cudaruntime support
+        # this is expensive to compute at the first time
+        # then we cache the result
+        # On AMD GPU, p2p is always enabled between XGMI connected GPUs
+        if not _can_p2p(rank, world_size):
+            logger.warning(
+                "Custom alltoall is disabled because your platform lacks "
+                "GPU P2P capability or P2P test failed. To silence this "
+                "warning, specify disable_custom_all_reduce=True explicitly."
+            )
+            return
+        self.peer_output_size = 256  # (3+2*8)*size8, other reserved
+        self.rank = rank
+        self.world_size = world_size
+        self.full_nvlink = full_nvlink
+
+        # Buffers memory are owned by this Python class and passed to C++.
+        # Meta data composes of two parts: meta data for synchronization and a
+        # temporary buffer for storing intermediate alltoall results.
+        self.meta_ptrs = self.create_shared_buffer(
+            sgl_kernel.meta_size() + self.peer_output_size, group=group
+        )
+        # This is a buffer for storing the tuples of pointers pointing to
+        # IPC buffers from all ranks. Each registered tuple has size of
+        # 8*world_size bytes where world_size is at most 8. Allocating 8MB
+        # is enough for 131072 such tuples. The largest model I've seen only
+        # needs less than 10000 of registered tuples.
+        self.rank_data = torch.empty(
+            8 * 1024 * 1024, dtype=torch.uint8, device=self.device
+        )
+        self._ptr = sgl_kernel.init_custom_ar(
+            self.meta_ptrs, self.rank_data, rank, self.full_nvlink
+        )
+        self.disabled = False
+        self.buffer_ptrs = {}
+
+    @staticmethod
+    def create_shared_buffer(
+        size_in_bytes: int, group: Optional[ProcessGroup] = None
+    ) -> List[int]:
+        """
+        Creates a shared buffer and returns a list of pointers
+        representing the buffer on all processes in the group.
+        """
+        lib = CudaRTLibrary()
+        pointer = lib.cudaMalloc(size_in_bytes)
+        handle = lib.cudaIpcGetMemHandle(pointer)
+        world_size = dist.get_world_size(group=group)
+        rank = dist.get_rank(group=group)
+        handles = [None] * world_size
+        dist.all_gather_object(handles, handle, group=group)
+
+        pointers: List[int] = []
+        for i, h in enumerate(handles):
+            if i == rank:
+                pointers.append(pointer.value)  # type: ignore
+            else:
+                pointers.append(lib.cudaIpcOpenMemHandle(h).value)  # type: ignore
+
+        return pointers
+
+    @staticmethod
+    def free_shared_buffer(
+        pointers: List[int], group: Optional[ProcessGroup] = None
+    ) -> None:
+        rank = dist.get_rank(group=group)
+        lib = CudaRTLibrary()
+        lib.cudaFree(ctypes.c_void_p(pointers[rank]))
+
+    def register_output_buffer(self, output: torch.Tensor, buffer_tag: str):
+        lib = CudaRTLibrary()
+        pointer = output.untyped_storage().data_ptr()
+        handle = lib.cudaIpcGetMemHandle(pointer)
+        world_size = dist.get_world_size(group=self.group)
+        rank = dist.get_rank(group=self.group)
+        handles = [None] * world_size
+        dist.all_gather_object(handles, handle, group=self.group)
+
+        pointers: List[int] = []
+        for i, h in enumerate(handles):
+            if i == rank:
+                pointers.append(pointer)  # type: ignore
+            else:
+                pointers.append(lib.cudaIpcOpenMemHandle(h).value)  # type: ignore
+        sgl_kernel.register_buffer(self._ptr, pointers)
+        assert buffer_tag not in self.buffer_ptrs
+        self.buffer_ptrs[buffer_tag] = pointers
+
+    def should_custom_ar(self, inp: torch.Tensor):
+        if self.disabled:
+            return False
+        inp_size = inp.numel() * inp.element_size()
+        # custom allreduce requires input byte size to be multiples of 16
+        if inp_size % 16 != 0:
+            return False
+        return True
+
+    def check_inputs(
+        self,
+        output: torch.Tensor,  # out_dim0, head_dim
+        input: torch.Tensor,  # in_dim0, head_dim
+        output_split_sizes: Union[torch.Tensor, List[int]],
+        input_split_sizes: Union[torch.Tensor, List[int]],
+        chunk_size: int,
+    ):
+        """Performs an out-of-place all to all.
+
+        If registered is True, this assumes inp's pointer is already
+        IPC-registered. Otherwise, inp is first copied into a pre-registered
+        buffer.
+        """
+        if isinstance(output_split_sizes, list):
+            output_split_sizes = torch.tensor(
+                output_split_sizes, dtype=torch.int64, device=input.device
+            )
+        else:
+            output_split_sizes = output_split_sizes.to(torch.int64)
+        if isinstance(input_split_sizes, list):
+            input_split_sizes = torch.tensor(
+                input_split_sizes, dtype=torch.int64, device=input.device
+            )
+        else:
+            input_split_sizes = input_split_sizes.to(torch.int64)
+        assert (
+            len(output_split_sizes.shape) == 1
+            and output_split_sizes.shape[0] == self.world_size
+        ), f"output_split_sizes shape {output_split_sizes.shape} should be world_size {self.world_size}"
+        assert (
+            len(input_split_sizes.shape) == 1
+            and input_split_sizes.shape[0] == self.world_size
+        ), f"input_split_sizes shape {output_split_sizes.shape} should be world_size {self.world_size}"
+        assert (
+            len(output.shape) == 3
+        ), f"output must be a 3D(dim0,dim1,chunk_size) tensor, got {output.shape}"
+        assert (
+            len(input.shape) == 3
+        ), f"input must be a 3D(dim0,dim1,chunk_size) tensor, got {input.shape}"
+        assert (
+            input.shape[-1] == chunk_size
+        ), f"input last dim should be chunk_size {chunk_size}, got shape {input.shape}"
+        assert (
+            output.shape[-1] == chunk_size
+        ), f"output last dim should be chunk_size {chunk_size}, got shape {output.shape}"
+        return output_split_sizes, input_split_sizes
+
+    @torch.compiler.disable
+    def custom_all_to_all(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+        plan_meta: torch.Tensor,
+        buffer_tag: str,
+    ):
+        if self.disabled:
+            return
+        if self.disabled or not self.should_custom_ar(input):
+            return None
+        assert buffer_tag in self.buffer_ptrs, "buffer_ptrs is not initialized"
+        buffer_ptrs = self.buffer_ptrs[buffer_tag]
+        sgl_kernel.all_to_all(
+            self._ptr, output, input, plan_meta, buffer_ptrs[self.rank]
+        )
+
+    def custom_all_to_all_plan(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+        output_split_sizes: Union[torch.Tensor, List[int]],
+        input_split_sizes: Union[torch.Tensor, List[int]],
+        chunk_size: int,
+        output_split_offsets: Optional[torch.Tensor],
+        input_split_offsets: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if self.disabled or not self.should_custom_ar(input):
+            return
+        output_split_sizes, input_split_sizes = self.check_inputs(
+            output,
+            input,
+            output_split_sizes,
+            input_split_sizes,
+            chunk_size,
+        )
+        # 256,16,576; 64,64,512; 32,128,512
+        meta_extra = (input.numel() * input.dtype.itemsize // 512 + 7) // 8
+        plan_meta = torch.zeros(
+            128 + meta_extra, dtype=torch.int64, device=input.device
+        )
+        sgl_kernel.all_to_all_plan(
+            self._ptr,
+            output,
+            input,
+            output_split_sizes,
+            input_split_sizes,
+            chunk_size,
+            output_split_offsets,
+            input_split_offsets,
+            plan_meta,
+        )
+        return plan_meta
+
+    def close(self):
+        if not self.disabled and self._ptr:
+            if sgl_kernel is None:
+                return
+            sgl_kernel.dispose(self._ptr)
+            if _is_cuda:
+                self.free_shared_buffer(self.meta_ptrs)
+            self._ptr = 0
+
+    def __del__(self):
+        self.close()

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -20,6 +20,7 @@ from typing import Dict, Optional
 import torch.distributed
 
 from sglang.srt.distributed import (
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
@@ -237,9 +238,14 @@ class CommunicateContext:
 
     @classmethod
     def init_new(cls):
-        attn_tp_rank = get_attention_tp_rank()
-        attn_tp_size = get_attention_tp_size()
-        local_attn_dp_size = get_local_attention_dp_size()
+        if global_server_args_dict["enable_dp_mla"]:
+            attn_tp_rank = get_tensor_model_parallel_rank()
+            attn_tp_size = get_tensor_model_parallel_world_size()
+            local_attn_dp_size = 1
+        else:
+            attn_tp_rank = get_attention_tp_rank()
+            attn_tp_size = get_attention_tp_size()
+            local_attn_dp_size = get_local_attention_dp_size()
         tp_size = get_tensor_model_parallel_world_size()
         process_group_sizes = {
             ScatterMode.SCATTERED: 1,

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -235,9 +235,12 @@ def _dp_gather(
     assert global_tokens.is_contiguous()
 
     if local_tokens.shape[0] > 0 and (is_partial or get_attention_tp_rank() == 0):
+        """# cause torch compile warning: Graph break due to unsupported builtin None._SimpleCData.__new__.
+            # and error: Cannot call CUDAGeneratorImpl::current_seed during CUDA graph capture
         assert (
             local_tokens.untyped_storage() is not global_tokens.untyped_storage()
         ), "aliasing between global_tokens and local_tokens not allowed"
+        """
         memcpy_triton(
             global_tokens, local_tokens, 0, local_start_pos, local_num_tokens, False
         )
@@ -285,9 +288,11 @@ def dp_scatter(
     assert local_tokens.is_contiguous()
     assert global_tokens.is_contiguous()
     if local_tokens.shape[0] > 0:
+        """# cause torch compile warning: Graph break due to unsupported builtin None._SimpleCData.__new__.
         assert (
             local_tokens.untyped_storage() is not global_tokens.untyped_storage()
         ), "aliasing between local_tokens and global_tokens not allowed"
+        """
         memcpy_triton(
             local_tokens, global_tokens, 0, local_start_pos, local_num_tokens, True
         )

--- a/python/sglang/srt/layers/dp_mla.py
+++ b/python/sglang/srt/layers/dp_mla.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import torch
+
+from sglang.srt.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+)
+from sglang.srt.layers.dp_attention import (
+    dp_gather_replicate,
+    dp_scatter,
+    get_attention_dp_rank,
+    get_attention_dp_size,
+    get_attention_tp_rank,
+    get_attention_tp_size,
+)
+from sglang.srt.managers.schedule_batch import global_server_args_dict
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class DpMlaWrapper:
+    def __init__(self):
+        self.enable_dp_mla = global_server_args_dict["enable_dp_mla"]
+        if not self.enable_dp_mla:
+            return
+        self.group = get_tp_group()
+        self.rank_in_node = get_tensor_model_parallel_rank()
+        self.world_size_in_node = get_tensor_model_parallel_world_size()
+        self.dp_tp_size = get_attention_tp_size()
+        self.dp_tp_rank = get_attention_tp_rank()
+        self.dp_size_in_node = get_attention_dp_size()
+        self.dp_rank_in_node = get_attention_dp_rank()
+        self.mla_mask = None
+        self.gathered_buffer_tp2dp = None
+        self.gathered_buffer_dp2tp = None
+
+    def get_tp_to_dp_plan_meta(
+        self,
+        forward_batch: "ForwardBatch",
+        output,
+        input,
+        chunk_size,
+    ):
+        if forward_batch.dp_mla_tp2dp_plan_meta is None:
+            dp_size = self.dp_size_in_node  # 8//4=2
+            world_size = self.world_size_in_node
+            dp_tp_rank = self.dp_tp_rank
+
+            all_lens = forward_batch.global_num_tokens_gpu.to(torch.int64)
+            new_seq = all_lens[self.dp_rank_in_node]
+            # dp0~3[h0,h1,h2,h3,h4,h5,h6,h7] -> [dp0[h0~3],dp0[h4~7],dp1[h0~3],dp1[h4~7],...]
+            # recv from every rank
+            output_split_sizes = torch.zeros(
+                world_size, dtype=torch.int64, device=all_lens.device
+            )
+            seq_with_pad = forward_batch.gathered_buffer_tp2dp.shape[0]
+            output_split_sizes[dp_tp_rank * dp_size : (dp_tp_rank + 1) * dp_size] = (
+                new_seq
+            )
+            output_split_offsets = torch.zeros(
+                world_size, dtype=torch.int64, device=all_lens.device
+            )
+            if seq_with_pad > 0:
+                output_split_offsets[
+                    dp_tp_rank * dp_size : (dp_tp_rank + 1) * dp_size
+                ] = torch.arange(
+                    0,
+                    seq_with_pad * dp_size,
+                    seq_with_pad,
+                    dtype=torch.int64,
+                    device=all_lens.device,
+                )
+
+            # send to every rank
+            input_split_sizes = all_lens.unsqueeze(-1) * self.mla_mask
+            input_split_sizes = input_split_sizes.view(-1)
+
+            forward_batch.dp_mla_tp2dp_plan_meta = self.group.custom_all_to_all_plan(
+                output,
+                input,
+                output_split_sizes,
+                input_split_sizes,
+                chunk_size=chunk_size,
+                output_split_offsets=output_split_offsets,
+            )
+
+        return forward_batch.dp_mla_tp2dp_plan_meta
+
+    @torch.compiler.disable
+    def tp_to_dp(
+        self,
+        input_tensor: torch.Tensor,
+        forward_batch: "ForwardBatch",
+    ):
+        world_size = self.world_size_in_node
+        dp_size = self.dp_size_in_node
+
+        # input_tensor: [seq0+seq1+seq2+..., head/8, head_dim] -> [seq0, head/2, head_dim], [seq1, head/2, head_dim]
+        if world_size == 1:
+            return input_tensor
+        # seq, 16, (128+64) or 576
+        total_seq, local_head, seq_head_dim = input_tensor.shape
+        new_head = local_head * dp_size
+
+        output_tensor = forward_batch.gathered_buffer_tp2dp
+
+        chunk_size = local_head * seq_head_dim
+        input_tensor = input_tensor.view(-1, 1, chunk_size)
+        output_tensor = output_tensor.view(-1, dp_size, chunk_size)
+        # to dp_size, seq+seq_pad, chunk_size
+        output_tensor_t = output_tensor.transpose(0, 1)
+        plan_meta = self.get_tp_to_dp_plan_meta(
+            forward_batch,
+            output_tensor_t,
+            input_tensor,
+            chunk_size,
+        )
+        self.group.custom_all_to_all(output_tensor_t, input_tensor, plan_meta, "tp2dp")
+        return output_tensor.view(-1, new_head, seq_head_dim)
+
+    def get_dp_to_tp_plan_meta(
+        self,
+        forward_batch: "ForwardBatch",
+        output,
+        input,
+        chunk_size,
+    ):
+        if forward_batch.dp_mla_dp2tp_plan_meta is None:
+            world_size = self.world_size_in_node
+            dp_size = self.dp_size_in_node  # 8//2==4
+            dp_tp_rank = self.dp_tp_rank
+
+            all_lens = forward_batch.global_num_tokens_gpu.to(torch.int64)
+            cur_seq = all_lens[self.dp_rank_in_node]
+
+            # [dp0[h0~3],dp0[h4~7],dp1[h0~3],dp1[h4~7],...] -> dp0~3[h0,h1,h2,h3,h4,h5,h6,h7]
+            # recv from every rank
+            output_split_sizes = all_lens.unsqueeze(-1) * self.mla_mask
+            output_split_sizes = output_split_sizes.view(-1)
+            # send to every rank
+            input_split_sizes = torch.zeros(
+                world_size, dtype=torch.int64, device=all_lens.device
+            )
+            input_split_sizes[dp_tp_rank * dp_size : (dp_tp_rank + 1) * dp_size] = (
+                cur_seq
+            )
+            seq_with_pad = forward_batch.gathered_buffer_tp2dp.shape[0]
+            input_split_offsets = torch.zeros(
+                world_size, dtype=torch.int64, device=all_lens.device
+            )
+            if seq_with_pad > 0:
+                input_split_offsets[
+                    dp_tp_rank * dp_size : (dp_tp_rank + 1) * dp_size
+                ] = torch.arange(
+                    0,
+                    seq_with_pad * dp_size,
+                    seq_with_pad,
+                    dtype=torch.int64,
+                    device=all_lens.device,
+                )
+            forward_batch.dp_mla_dp2tp_plan_meta = self.group.custom_all_to_all_plan(
+                output,
+                input,
+                output_split_sizes,
+                input_split_sizes,
+                chunk_size=chunk_size,
+                input_split_offsets=input_split_offsets,
+            )
+        return forward_batch.dp_mla_dp2tp_plan_meta
+
+    @torch.compiler.disable
+    def dp_to_tp(
+        self,
+        input_tensor: torch.Tensor,
+        forward_batch: "ForwardBatch",
+    ):
+        world_size = self.world_size_in_node
+        dp_tp_size = self.dp_tp_size
+
+        if world_size == 1:
+            return input_tensor
+        # input_tensor: [seq_r0, head/2, 512], [seq_r1, head/2, 512], ... -> [seq_r0+seq_r1+seq_r2+...,head/8, 512]
+        _, local_head, seq_head_dim = input_tensor.shape
+
+        dp_size = world_size // dp_tp_size
+        new_head = local_head // dp_size
+
+        output_tensor = forward_batch.gathered_buffer_dp2tp
+
+        chunk_size = new_head * seq_head_dim
+        output_tensor = output_tensor.view(-1, 1, chunk_size)
+        input_tensor = input_tensor.view(-1, dp_size, chunk_size)
+        # to [dp_size, seq+seq_pad, new_head, seq_head_dim)
+        input_tensor_t = input_tensor.transpose(0, 1)
+        plan_meta = self.get_dp_to_tp_plan_meta(
+            forward_batch,
+            output_tensor,
+            input_tensor_t,
+            chunk_size,
+        )
+        self.group.custom_all_to_all(output_tensor, input_tensor_t, plan_meta, "dp2tp")
+        return output_tensor.view(-1, new_head, seq_head_dim)
+
+    def mla_inputs_tp_to_dp(
+        self,
+        q_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.enable_dp_mla:
+            if q_pe is not None:
+                last_dims = [q_nope.shape[-1], q_pe.shape[-1]]
+                q_nope = torch.cat([q_nope, q_pe], dim=-1)
+            q_nope = self.tp_to_dp(
+                q_nope.contiguous(),
+                forward_batch,
+            )
+            if q_pe is not None:
+                q_nope, q_pe = q_nope.split(last_dims, dim=-1)
+
+            hidden_states = self._scatter_hidden_states(
+                hidden_states.contiguous(),
+                forward_batch,
+            )
+        return q_nope, q_pe, hidden_states
+
+    def _scatter_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if hidden_states.shape[0] == 0:
+            return hidden_states
+        if forward_batch.can_run_dp_cuda_graph:
+            first_dim = forward_batch.input_ids.shape[0]
+            last_dim = hidden_states.shape[-1]
+            hidden_states, global_hidden_states = (
+                forward_batch.gathered_buffer.view(-1)[: first_dim * last_dim].view(
+                    first_dim, last_dim
+                ),
+                hidden_states,
+            )
+            dp_scatter(
+                hidden_states,
+                global_hidden_states,
+                forward_batch,
+            )
+        else:
+            all_lens = forward_batch.global_num_tokens_cpu
+            start_pos = sum(all_lens[: self.dp_rank_in_node])
+            end_pos = start_pos + all_lens[self.dp_rank_in_node]
+            hidden_states = hidden_states[start_pos:end_pos]
+        return hidden_states
+
+    def mla_outputs_dp_to_tp(
+        self,
+        attn_output: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if self.enable_dp_mla:
+            attn_output = self.dp_to_tp(
+                attn_output,
+                forward_batch,
+            )
+        return attn_output
+
+    def model_inputs_dp_to_tp(
+        self,
+        input_ids: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if self.enable_dp_mla and forward_batch.gathered_buffer.shape[0] != 0:
+            input_ids, local_input_ids = (
+                torch.empty(
+                    (forward_batch.gathered_buffer.shape[0],),
+                    dtype=input_ids.dtype,
+                    device=input_ids.device,
+                ),
+                input_ids,
+            )
+            dp_gather_replicate(input_ids, local_input_ids, forward_batch)
+        return input_ids
+
+    def model_outputs_tp_to_dp(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if self.enable_dp_mla:
+            hidden_states = self._scatter_hidden_states(
+                hidden_states,
+                forward_batch,
+            )
+        return hidden_states
+
+    def init_gathered_buffer(self, runner: "ModelRunner"):
+        if self.enable_dp_mla:
+            self.get_gathered_buffer_dp2tp(runner)
+            self.get_gathered_buffer_dp2tp(runner)
+
+    def get_gathered_buffer_tp2dp(self, runner: "ModelRunner"):
+        if self.gathered_buffer_tp2dp is None:
+            config = runner.model_config
+            server_args = runner.server_args
+            dp_mla_tp_size = server_args.tp_size // server_args.dp_size
+            num_dp_key_value_heads = config.num_key_value_heads // dp_mla_tp_size
+            q_dim = config.kv_lora_rank + config.qk_rope_head_dim
+            self.gathered_buffer_tp2dp = torch.empty(
+                (
+                    server_args.chunked_prefill_size,
+                    num_dp_key_value_heads,
+                    q_dim,
+                ),
+                dtype=config.dtype,
+                device=runner.device,
+            )
+            self.group.register_output_buffer(self.gathered_buffer_tp2dp, "tp2dp")
+
+            mla_mask = torch.zeros(
+                self.dp_tp_size, dtype=torch.int64, device=runner.device
+            )
+            # to dp0~n tp dp_tp_rank
+            mla_mask[self.rank_in_node // self.dp_size_in_node] = 1
+            self.mla_mask = mla_mask
+        return self.gathered_buffer_tp2dp
+
+    def get_gathered_buffer_dp2tp(self, runner: "ModelRunner"):
+        if self.gathered_buffer_dp2tp is None:
+            config = runner.model_config
+            server_args = runner.server_args
+            num_tp_key_value_heads = (
+                config.num_key_value_heads // self.world_size_in_node
+            )
+            kv_lora_rank = config.kv_lora_rank
+
+            sum_len = server_args.chunked_prefill_size * self.dp_size_in_node
+            self.gathered_buffer_dp2tp = torch.empty(
+                (
+                    sum_len,
+                    num_tp_key_value_heads,
+                    kv_lora_rank,
+                ),
+                dtype=config.dtype,
+                device=runner.device,
+            )
+            self.group.register_output_buffer(self.gathered_buffer_dp2tp, "dp2tp")
+        return self.gathered_buffer_dp2tp
+
+
+_DP_MLA_WRAPPER_INSTANCE: Optional[DpMlaWrapper] = None
+
+
+def get_dp_mla_wrapper() -> DpMlaWrapper:
+    global _DP_MLA_WRAPPER_INSTANCE
+    if _DP_MLA_WRAPPER_INSTANCE is None:
+        _DP_MLA_WRAPPER_INSTANCE = DpMlaWrapper()
+    return _DP_MLA_WRAPPER_INSTANCE

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -80,6 +80,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "disable_chunked_prefix_cache",
     "disable_radix_cache",
     "enable_dp_attention",
+    "enable_dp_mla",
     "enable_two_batch_overlap",
     "enable_dp_lm_head",
     "enable_deepep_moe",

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -246,6 +246,10 @@ class ForwardBatch:
     gathered_buffer: Optional[torch.Tensor] = None
     can_run_dp_cuda_graph: bool = False
     global_forward_mode: Optional[ForwardMode] = None
+    gathered_buffer_tp2dp: Optional[torch.Tensor] = None
+    gathered_buffer_dp2tp: Optional[torch.Tensor] = None
+    dp_mla_tp2dp_plan_meta: Optional[torch.Tensor] = None
+    dp_mla_dp2tp_plan_meta: Optional[torch.Tensor] = None
 
     # Speculative decoding
     spec_info: Optional[Union[EagleVerifyInput, EagleDraftInput]] = None
@@ -332,6 +336,13 @@ class ForwardBatch:
                 dtype=model_runner.dtype,
                 device=device,
             )
+            if model_runner.server_args.enable_dp_mla:
+                ret.gathered_buffer_tp2dp = model_runner.get_gathered_buffer_tp2dp()[
+                    : batch.input_ids.shape[0]
+                ]
+                ret.gathered_buffer_dp2tp = model_runner.get_gathered_buffer_dp2tp()[
+                    :sum_len
+                ]
 
         if ret.forward_mode.is_idle():
             ret.positions = torch.empty((0,), device=device)

--- a/test/srt/test_dp_mla.py
+++ b/test/srt/test_dp_mla.py
@@ -1,0 +1,94 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MLA_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+def support_custom_all_to_all():
+    try:
+        from sgl_kernel import all_to_all
+
+        return True
+    except Exception:
+        return False
+
+
+is_all_to_all_supported = support_custom_all_to_all()
+
+
+class TestDPMla(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        if not is_all_to_all_supported:
+            print("custom_all_to_all is not supported, skip test_dp_mla")
+            return
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp-size",
+                "2",
+                "--dp-size",
+                "2",
+                "--attention-backend",
+                "flashinfer",
+                "--enable-dp-mla",
+                "--enable-torch-compile",
+                "--torch-compile-max-bs",
+                "2",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if not is_all_to_all_supported:
+            return
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        if not is_all_to_all_supported:
+            print("custom_all_to_all is not supported, skip test_dp_mla::test_mmlu")
+            return
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.5)
+
+    def test_mgsm_en(self):
+        if not is_all_to_all_supported:
+            print("custom_all_to_all is not supported, skip test_dp_mla::test_mgsm_en")
+            return
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mgsm_en",
+            num_examples=None,
+            num_threads=1024,
+        )
+
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Base on dp_mla_kernel  PR #5000

**Description**:  
On an 8*H20(96GB), weight mem usage=87.19 GB when `--dp-size 4 --enable-dp-attention`, not enough memory left.

This optimization is similar to data parallelism attention, but it applies to MLA core instead of the entire attention. Compared with data parallelism attention, it does not additionally increase the memory occupied by weights. It allows for a significant reduction in the KV cache size and enables larger batch sizes with only 1-3ms additional decode latency.

On an 8×H20 (96GB) node, with data parallelism MLA enabled, we have achieved up to **1.85x(dp=4)** ~ **2.34x(dp=8)** decoding throughput improvement compared to the previous version. And, the number of kvcaches has been increased by **3.3x(dp=4)** and **6.6x(dp=8)**.

For 8*H20 (96GB), when the input is 4000, the output is 1500, and there are 128 concurrent requests, the output throughput per card for decoding can reach **266** tokens/s.

**gsm8k**:
```shell
#  dp=4
Accuracy: 0.958
Invalid: 0.000
Latency: 166.961 s
Output throughput: 765.964 token/s

# dp=4 fa3
Accuracy: 0.958
Invalid: 0.000
Latency: 147.353 s
Output throughput: 863.553 token/s
```

```shell
#  dp=8
Accuracy: 0.955
Invalid: 0.000
Latency: 165.833 s
Output throughput: 781.248 token/s
```

```shell
#  tp=8
Accuracy: 0.954
Invalid: 0.000
Latency: 177.669 s
Output throughput: 719.521 token/s
```

**Usage**:

***Restrictions***:
- The currently implemented custom all-to-all operation is only restricted within a single node. Cross-node is not supported for the time being.

On an 8×H20 (96GB) node, on top of `--attention-backend flashinfer` or `--attention-backend fa3`, **remove `--enable-dp-lm-head`**, additional parameters:

```shell
# dp=4:
--max-running-requests 128 --mem-fraction-static 0.94 --chunked-prefill-size 8192 --enable-dp-mla --dp-size 4
```

```shell
# dp=8:
--max-running-requests 128 --mem-fraction-static 0.94 --chunked-prefill-size 8192 --enable-dp-mla --dp-size 8
```

We set the switch `flashinfer_mla_disable_ragged` to `True` when `--enable-dp-mla` to avoid the following issues:
- There is a problem with the accuracy of requests after running `sglang.bench_one_batch_server`. Through testing the model `deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct`, we found that after the warmup process, there are NaN values in the kvcache, which leads to NaN values in the results of subsequent requests. After troubleshooting, it was determined that the result of the flashinfer-mla ragged process is NaN. The reproduction parameters are: 

```shell
python -m sglang.launch_server --model-path deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct/  \
--host 0.0.0.0 --port 8188 --trust-remote-code --tp-size 8 --dp-size 8 --log-level info \
--enable-flashinfer-mla --enable-dp-mla --mem-fraction-static 0.9 --disable-cuda-graph 
```

- The aot version of the flashinfer package reports an error.

**Background**:
For DeepSeek R1 on a single machine with 8*H20 (96GB), we aimed to deploy enable_dp_attention. We found:
1. enable_dp_attention duplicates the weights of the attention, which consumes both memory and time.
  - A single machine with eight cards can't accommodate it due to more memory usage (10+GB).
  - Weight calculations for kv_u/q_u/o_proj are very time-consuming, slowing down Decode by 8ms in a dp=4, tp=2 scenario compared to tp=8 in the case of a short sequence of requests. With dp=8, the delay is expected to be worse.
  - The latest dp attention update doesn't split M (seq dimension).
  - Keeping the linear split strategy in attention may be a better approach.
2. The row number M in wgmma calculation is fixed at 64. For Flash MLA and Flash Infer MLA, when TP = 8 and the number of heads is 16, only 1/4 of their computing power is utilized. When MLA DP = 4, the TP is 2 and the number of heads is 64 (calculated as 128/2), which can maintain good latency. When MLA DP = 8, the TP is 1 and the number of heads is 128. In this case, the time consumption of the MLA core may increase by 50% to 100%, but more kvcache can be obtained.

**TODO**:
- ~~Accuracy and performance testing and optimization for various scenarios.~~
- ~~Performance optimization of custom all to all.~~
- Fix the above issue with ragged support in FlashInfer MLA.

**Memory**:

|                                             | default mem=0.95	 | dp mla, dp-size=4	 | dp mla, dp-size=8 |
|---------------------------------------------|-------------------|--------------------|-------------------|
| mem-fraction-static                         | 	0.95	            | 0.94	              | 0.94              |
| distributed ends. mem usage                 | 	1.81	            | 1.95	              | 1.95              |
| Load weight end. avail mem/mem usage        | 11.23/81.64       | 	11.08/81.65	      | 11.08/81.65       |
| Capture cuda graph end. avail mem/mem usage | 	3.65/0.53        | 	3.89/1.20	        | 3.89/1.19         |
| max_total_num_tokens                        | 98696             | 82258*4            | 82258*8          |

**Performance Comparison**:

```shell
python -m sglang.bench_one_batch_server --model None --base-url http://localhost:8188 --batch-size {bs} --input-len {input_seq} --output-len 1024
```

| input len | batch size | tp8 latency | output throughput | dp4 latency | output throughput | dp8 latency | output throughput |
|-----------|------------|-------------|-------------------|-------------|-------------------|-------------|-------------------|
| 256       | 1          | 14.16       | 72.31             | 16.63       | 61.59             | 16.84       | 60.80             |
| 256       | 4          | 19.23       | 212.98            | 20.53       | 199.55            | 20.82       | 196.75            |
| 256       | 8          | 22.81       | 359.21            | 24.72       | 331.33            | 23.74       | 345.02            |
| 256       | 16         | 27.13       | 603.92            | 29.47       | 555.90            | 28.76       | 569.68            |
| 256       | 32         | 34.04       | 962.55            | 35.94       | 911.62            | 35.19       | 931.11            |
| 256       | 48         | 40.10       | 1225.70           | 40.21       | 1222.45           | 39.65       | 1239.79           |
| 256       | 64         | 67.45       | 971.64            | **43.91**   | **1492.39**       | 44.49       | 1473.02           |
| 256       | 96         | 79.39       | 1238.24           | **52.35**   | **1877.66**       | 52.69       | 1865.58           |
| 256       | 128        | 113.39      | 1155.93           | **57.36**   | **2285.00**       | 57.60       | 2275.67           |
| 1024      | 1          | 14.48       | 70.73             | 16.84       | 60.82             | 17.17       | 59.64             |
| 1024      | 4          | 18.85       | 217.25            | 20.74       | 197.46            | 21.89       | 187.12            |
| 1024      | 8          | 23.45       | 349.36            | 25.67       | 319.18            | 25.52       | 320.97            |
| 1024      | 16         | 28.34       | 578.11            | 29.66       | 552.47            | 30.88       | 530.57            |
| 1024      | 32         | 37.57       | 872.30            | 38.25       | 856.76            | 38.45       | 852.20            |
| 1024      | 48         | 46.68       | 1053.04           | **43.97**   | **1117.75**       | 44.24       | 1110.92           |
| 1024      | 64         | 76.28       | 859.21            | **49.02**   | **1336.82**       | 49.90       | 1313.24           |
| 1024      | 96         | 93.56       | 1050.74           | **59.77**   | **1644.84**       | 60.78       | 1617.42           |
| 1024      | 128        | 131.59      | 996.06            | **67.76**   | **1934.37**       | 67.93       | 1929.56           |
| 4096      | 1          | 15.29       | 66.97             | 18.09       | 56.61             | 19.16       | 53.45             |
| 4096      | 4          | 21.03       | 194.81            | 22.96       | 178.41            | 24.27       | 168.76            |
| 4096      | 8          | 28.45       | 287.95            | 29.70       | 275.87            | 28.72       | 285.19            |
| 4096      | 16         | 39.68       | 412.88            | **36.95**   | **443.44**        | 37.39       | 438.23            |
| 4096      | 32         | 82.49       | 397.26            | **52.17**   | **628.10**        | 53.22       | 615.65            |
| 4096      | 48         | 124.72      | 394.11            | **66.07**   | **743.90**        | 67.61       | 727.04            |
| 4096      | 64         | 167.71      | 390.77            | **79.40**   | **825.36**        | 79.90       | 820.26            |
| 4096      | 96         | 233.19      | 421.55            | 144.59      | 679.88            | **106.63**  | **921.92**        |
| 4096      | 128        | 317.57      | 412.73            | 170.99      | 766.54            | **132.86**  | **986.54**        |

## Modifications

<!-- Describe the changes made in this PR. -->
Use dp for mla core calculations and tp for others, keeping memory and calculation time of linear in attn.
1. Convert model input from dp to tp using dp_gather to obtain all input_ids.
2. Use all_to_all operators before and after each mla layer for tp and dp conversion.
4. Implement a custom all_to_all for dynamic input/output splitting (split_sizes) based on sglang allreduce IPC, currently limited to single-machine use.
5. Process model output using dp_scatter to obtain results for the specified dp.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
