### PR TITLE
bump flashinfer_python to 0.2.4 to fix ci

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,7 +48,7 @@ runtime_common = [
 srt = [
     "sglang[runtime_common]",
     "sgl-kernel==0.0.6",
-    "flashinfer_python==0.2.3",
+    "flashinfer_python==0.2.4",
     "torch==2.5.1",
     "cuda-python",
     "outlines>=0.0.44,<=0.1.11",

--- a/scripts/ci_install_dependency.sh
+++ b/scripts/ci_install_dependency.sh
@@ -14,7 +14,7 @@ pip install -e "python[all]" --find-links https://flashinfer.ai/whl/cu124/torch2
 
 rm -rf /root/.cache/flashinfer
 # Force reinstall flashinfer and torch_memory_saver
-pip install flashinfer_python==0.2.3 --find-links ${FLASHINFER_REPO} --force-reinstall --no-deps
+pip install flashinfer_python==0.2.4 --find-links ${FLASHINFER_REPO} --force-reinstall --no-deps
 pip install sgl-kernel==0.0.6 --force-reinstall
 
 pip install torch_memory_saver


### PR DESCRIPTION
https://flashinfer.ai/whl/cu124/torch2.5/flashinfer-python/

0.2.3 missing.