### PR TITLE
needed imports to support vllm's compressed_tensors quantized models

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -45,10 +45,14 @@ from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 try:
 
     from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
-    W4A16SPARSE24_SUPPORTED_BITS, WNA16_SUPPORTED_BITS, CompressedTensors24,
-    CompressedTensorsW4A16Sparse24,
-    CompressedTensorsW8A8Int8,
-    CompressedTensorsW8A16Fp8, CompressedTensorsWNA16)
+        W4A16SPARSE24_SUPPORTED_BITS,
+        WNA16_SUPPORTED_BITS,
+        CompressedTensors24,
+        CompressedTensorsW4A16Sparse24,
+        CompressedTensorsW8A8Int8,
+        CompressedTensorsW8A16Fp8,
+        CompressedTensorsWNA16,
+    )
 
     VLLM_AVAILABLE = True
 except ImportError:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -42,6 +42,18 @@ from sglang.srt.layers.quantization.compressed_tensors.utils import (
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 
+try:
+
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    W4A16SPARSE24_SUPPORTED_BITS, WNA16_SUPPORTED_BITS, CompressedTensors24,
+    CompressedTensorsW4A16Sparse24,
+    CompressedTensorsW8A8Int8,
+    CompressedTensorsW8A16Fp8, CompressedTensorsWNA16)
+
+    VLLM_AVAILABLE = True
+except ImportError:
+    VLLM_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["CompressedTensorsLinearMethod"]


### PR DESCRIPTION

Needed imports to support vllm's compressed_tensors quantized models.

compressed_tensors_moe.py, probably needs similar imports.