### PR TITLE
[WIP] adapt trtllm fp blockscale kernel

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -196,6 +196,8 @@ set(SOURCES
     "csrc/gemm/per_tensor_quant_fp8.cu"
     "csrc/gemm/per_token_group_quant_8bit.cu"
     "csrc/gemm/per_token_quant_fp8.cu"
+    "csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_runner.cu"
+    "csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm.cu"
     "csrc/moe/moe_align_kernel.cu"
     "csrc/moe/moe_fused_gate.cu"
     "csrc/moe/moe_topk_softmax_kernels.cu"

--- a/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm.cu
+++ b/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm.cu
@@ -1,0 +1,359 @@
+// Adapted from https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/thop/fp8BlockScalingGemm.cpp
+/*
+ * Copyright (c) 2020-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/EmptyTensor.h>
+
+#include <optional>
+
+#include "trt_fp8_blockscale_gemm_runner.cuh"
+#include "utils.h"
+
+using namespace tensorrt_llm::kernels::fp8_blockscale_gemm;
+using namespace tensorrt_llm::kernels;
+
+using Fp8BlockScaleGemmRunnerPtr = std::unique_ptr<CutlassFp8BlockScaleGemmRunnerInterface>;
+
+namespace {
+void check_input_dtypes(torch::Tensor const& mat, torch::Tensor const& matScale) {
+  TORCH_CHECK(
+      mat.scalar_type() == at::ScalarType::Float8_e4m3fn,
+      "Matrix dtype must be FP8 (the matrix will be dequantized on the fly).");
+
+  CHECK_CUDA_INPUT(matScale);
+  CHECK_CUDA_TYPE(matScale, torch::ScalarType::Float);
+}
+
+#define DISPATCH_SCALAR_TYPE(scalar_type, ...)               \
+  if (scalar_type == at::ScalarType::BFloat16) {             \
+    using DataType = __nv_bfloat16;                          \
+    __VA_ARGS__();                                           \
+  } else if (scalar_type == at::ScalarType::Float8_e4m3fn) { \
+    using DataType = __nv_fp8_e4m3;                          \
+    __VA_ARGS__();                                           \
+  } else {                                                   \
+    TORCH_CHECK(false);                                      \
+  }
+
+Fp8BlockScaleGemmRunnerPtr get_gemm_runner(at::ScalarType dtype_a, at::ScalarType dtype_b) {
+  Fp8BlockScaleGemmRunnerPtr result;
+
+  DISPATCH_SCALAR_TYPE(dtype_a, [&] {
+    using ADtypeStatic = DataType;
+    DISPATCH_SCALAR_TYPE(dtype_b, [&] {
+      using BDtypeStatic = DataType;
+      result = std::make_unique<CutlassFp8BlockScaleGemmRunner<ADtypeStatic, BDtypeStatic, __nv_bfloat16>>();
+    })
+  })
+
+  return result;
+}
+
+}  // namespace
+
+torch::Tensor fp8_block_scaling_gemm_hopper(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale) {
+  check_input_dtypes(mat1, mat1Scale);
+  check_input_dtypes(mat2, mat2Scale);
+
+  TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix");
+  TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
+  TORCH_CHECK(
+      mat1.sizes()[1] == mat2.sizes()[1],
+      "mat1 and mat2 shapes cannot be multiplied (",
+      mat1.sizes()[0],
+      "x",
+      mat1.sizes()[1],
+      " and ",
+      mat2.sizes()[0],
+      "x",
+      mat2.sizes()[1],
+      ")");
+
+  auto const m = mat1.sizes()[0];
+  auto const n = mat2.sizes()[0];
+  auto const k = mat1.sizes()[1];
+  TORCH_CHECK(k % 16 == 0, "K must be a multiple of 16, (K=", k, ")");
+  TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
+
+  at::Tensor out = at::detail::empty_cuda({m, n}, at::ScalarType::BFloat16, mat1.device(), std::nullopt);
+
+  auto gemm_runner = get_gemm_runner(mat1.scalar_type(), mat2.scalar_type());
+
+  auto stream = at::cuda::getCurrentCUDAStream(mat1.get_device());
+
+  float const* mat1ScalePtr = mat1Scale.data_ptr<float>();
+  float const* mat2ScalePtr = mat2Scale.data_ptr<float>();
+
+  gemm_runner->gemm(
+      reinterpret_cast<__nv_fp8_e4m3*>(mat1.data_ptr()),
+      k,
+      reinterpret_cast<__nv_fp8_e4m3*>(mat2.data_ptr()),
+      k,
+      reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),
+      n,
+      m,
+      n,
+      k,
+      mat1ScalePtr,
+      mat2ScalePtr,
+      stream);
+
+  return out;
+}
+
+torch::Tensor trt_fp8_block_scaling_gemm(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale) {
+  auto const sm = getSMVersion();
+  switch (sm) {
+    case 90:
+      return fp8_block_scaling_gemm_hopper(mat1, mat2, mat1Scale, mat2Scale);
+    default:
+      TORCH_CHECK(false, "Unsupported SM version for FP8 block scaling GEMM");
+  }
+}
+
+torch::Tensor fp8_block_scaling_moe_gemm_hopper(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale,
+    torch::Tensor const& token_offset) {
+  TORCH_CHECK(mat1.scalar_type() == at::ScalarType::Float8_e4m3fn, "Matrix dtype must be FP8.");
+  TORCH_CHECK(mat2.scalar_type() == at::ScalarType::Float8_e4m3fn, "Matrix dtype must be FP8.");
+  TORCH_CHECK(mat1Scale.scalar_type() == at::ScalarType::Float, "Scale dtype must be FP32.");
+  TORCH_CHECK(mat2Scale.scalar_type() == at::ScalarType::Float, "Scale dtype must be FP32.");
+  TORCH_CHECK(token_offset.scalar_type() == at::ScalarType::Long, "Token offset dtype must be INT64.");
+
+  TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix of shape (m_total, k)");
+  TORCH_CHECK(mat2.dim() == 3, "mat2 must be a matrix of shape (num_problems, n, k)");
+  TORCH_CHECK(mat1.sizes()[1] == mat2.sizes()[2], "mat1 and mat2 shapes cannot be multiplied");
+
+  auto const m_total = mat1.sizes()[0];
+  auto const num_problems = mat2.sizes()[0];
+  auto const n = mat2.sizes()[1];
+  auto const k = mat2.sizes()[2];
+  TORCH_CHECK(k % 16 == 0, "K must be a multiple of 16, (K=", k, ")");
+  TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
+
+  at::Tensor out = at::detail::empty_cuda({m_total, n}, at::ScalarType::BFloat16, mat1.device(), std::nullopt);
+
+  auto gemm_runner = get_gemm_runner(mat1.scalar_type(), mat2.scalar_type());
+
+  auto stream = at::cuda::getCurrentCUDAStream(mat1.get_device());
+
+  float const* mat1ScalePtr = mat1Scale.data_ptr<float>();
+  float const* mat2ScalePtr = mat2Scale.data_ptr<float>();
+
+  auto workspace_size = static_cast<int64_t>(gemm_runner->getWorkspaceSizeBase(m_total, n, k, num_problems));
+  auto workspace = at::detail::empty_cuda({workspace_size}, at::ScalarType::Byte, mat1.device(), std::nullopt);
+  void* workspace_ptr = workspace.data_ptr();
+  gemm_runner->configureWorkspace(static_cast<char*>(workspace_ptr));
+  gemm_runner->moeGemm(
+      out.data_ptr(),
+      mat1.data_ptr(),
+      mat2.data_ptr(),
+      static_cast<int64_t*>(token_offset.data_ptr()),
+      num_problems,
+      n,
+      k,
+      stream,
+      mat1ScalePtr,
+      mat2ScalePtr);
+
+  return out;
+}
+
+torch::Tensor trt_fp8_block_scaling_moe_gemm(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale,
+    torch::Tensor const& token_offset) {
+  auto const sm = getSMVersion();
+  switch (sm) {
+    case 90:
+      return fp8_block_scaling_moe_gemm_hopper(mat1, mat2, mat1Scale, mat2Scale, token_offset);
+    default:
+      TORCH_CHECK(false, "Unsupported SM version for FP8 block scaling MoEGEMM");
+  }
+}
+
+// All inputs are k-major
+torch::Tensor trt_fp8_block_scaling_bmm_out(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale,
+    torch::Tensor& out) {
+  check_input_dtypes(mat1, mat1Scale);
+  check_input_dtypes(mat2, mat2Scale);
+
+  TORCH_CHECK(mat1.dim() == 3, "mat1 must be a batched matrix");
+  TORCH_CHECK(mat2.dim() == 3, "mat2 must be a batched matrix");
+  TORCH_CHECK(
+      mat1.sizes()[0] == mat2.sizes()[0],
+      "mat1 and mat2 batch dim must be the same but got",
+      mat1.sizes()[0],
+      ", and ",
+      mat2.sizes()[0]);
+  TORCH_CHECK(
+      mat1.sizes()[2] == mat2.sizes()[2],
+      "mat1 and mat2 k dim must be the same but got",
+      mat1.sizes()[2],
+      ", and ",
+      mat2.sizes()[2]);
+
+  // mat1 could be strided due to padding
+
+  auto const b = mat1.sizes()[0];
+  auto const m = mat1.sizes()[1];
+  auto const n = mat2.sizes()[1];
+  auto const k = mat1.sizes()[2];
+  TORCH_CHECK(k % 16 == 0, "K must be a multiple of 16, (K=", k, ")");
+  TORCH_CHECK(n % 16 == 0, "N must be a multiple of 16, (N=", n, ")");
+
+  CHECK_CUDA_INPUT(out);
+  CHECK_CUDA_TYPE(out, at::ScalarType::BFloat16);
+  auto const& out_shape = out.sizes();
+  TORCH_CHECK(
+      out_shape[0] == b && out_shape[1] == m && out_shape[2] == n,
+      "out shape must be (",
+      b,
+      ", ",
+      m,
+      ", ",
+      n,
+      "), but got (",
+      out_shape[0],
+      ", ",
+      out_shape[1],
+      ", ",
+      out_shape[2],
+      ").");
+
+  auto gemm_runner = get_gemm_runner(mat1.scalar_type(), mat2.scalar_type());
+
+  auto stream = at::cuda::getCurrentCUDAStream(mat1.get_device());
+
+  float* mat1ScalePtr = mat1Scale.data_ptr<float>();
+  float* mat2ScalePtr = mat2Scale.data_ptr<float>();
+
+  auto* out_ptr = reinterpret_cast<__nv_bfloat16*>(out.data_ptr());
+  auto* mat1_ptr = reinterpret_cast<__nv_fp8_e4m3*>(mat1.data_ptr());
+  auto* mat2_ptr = reinterpret_cast<__nv_fp8_e4m3*>(mat2.data_ptr());
+
+  TORCH_CHECK(out.strides()[2] == 1, "The last stride of out must be 1, not ", out.strides()[2]);
+  TORCH_CHECK(mat1.strides()[2] == 1, "The last stride of mat1 must be 1, not ", mat1.strides()[2]);
+  TORCH_CHECK(mat2.strides()[2] == 1, "The last stride of mat2 must be 1, not ", mat2.strides()[2]);
+
+  auto const strideD = out.strides()[0];  // m * n
+  auto const ldd = out.strides()[1];      // n
+
+  auto const strideA = mat1.strides()[0];
+  auto const lda = mat1.strides()[1];
+
+  auto const strideB = mat2.strides()[0];
+  auto const ldb = mat2.strides()[1];
+
+  // mat1Scale is a 1D tensor which doesn't carry any stride information
+  auto const strideScalesA = ((m + 4 - 1) / 4 * 4) * ((k + 128 - 1) / 128);
+
+  gemm_runner->strideBatchGemm(
+      out_ptr,
+      ldd,
+      strideD,
+      mat1_ptr,
+      lda,
+      strideA,
+      mat2_ptr,
+      ldb,
+      strideB,
+      b,
+      m,
+      n,
+      k,
+      stream,
+      mat1ScalePtr,
+      strideScalesA,
+      mat2ScalePtr);
+
+  return out;
+}
+
+// All inputs are k-major
+torch::Tensor trt_fp8_block_scaling_bmm(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale,
+    std::optional<c10::ScalarType> out_dtype) {
+  auto const b = mat1.sizes()[0];
+  auto const m = mat1.sizes()[1];
+  auto const n = mat2.sizes()[1];
+
+  auto const dtype = out_dtype.value_or(at::ScalarType::BFloat16);
+
+  at::Tensor out = at::detail::empty_cuda({b, m, n}, dtype, mat1.device(), std::nullopt);
+  return trt_fp8_block_scaling_bmm_out(mat1, mat2, mat1Scale, mat2Scale, out);
+}
+
+std::tuple<at::Tensor, at::Tensor> trt_per_token_1x128_quant_fp8_kernel(at::Tensor const& self) {
+  CHECK_CUDA_INPUT(self);
+
+  TORCH_CHECK(self.scalar_type() == at::ScalarType::BFloat16, "Input matrix dtype must be BF16.");
+  TORCH_CHECK(self.dim() == 2, "input must be a matrix");
+
+  auto const m = self.sizes()[0];
+  auto const n = self.sizes()[1];
+
+  TORCH_CHECK(m <= std::numeric_limits<int32_t>::max(), "M must be within int32");
+  TORCH_CHECK(n <= std::numeric_limits<int32_t>::max(), "N must be within int32");
+
+  // required by the sm90 fp8_block_scaling gemm kernel
+  TORCH_CHECK(n % 16 == 0, "self.sizes()[1] must be a multiple of 16, but got ", n);
+
+  auto mGemmRunner = CutlassFp8BlockScaleGemmRunner<__nv_bfloat16, __nv_fp8_e4m3, __nv_bfloat16>();
+
+  auto const m_padded = (m + 4 - 1) / 4 * 4;
+
+  // row major, add padding required by the sm90 fp8_block_scaling gemm kernel
+  at::Tensor valueE4M3 =
+      at::detail::empty_cuda({m_padded, n}, at::ScalarType::Float8_e4m3fn, self.device(), /* stride */ std::nullopt);
+  int64_t scaleSizeInBytes = mGemmRunner.getActScaleSize(m, n);  // 128-byte aligned
+  int64_t elementSize = scaleSizeInBytes / torch::elementSize(torch::ScalarType::Float);
+
+  // col major
+  at::Tensor scaleFP8SF = at::detail::empty_cuda(
+      {elementSize}, torch::ScalarType::Float, self.device(), /* stride */ std::nullopt);  // 1D tensor
+
+  __nv_fp8_e4m3* act_buffer = reinterpret_cast<__nv_fp8_e4m3*>(valueE4M3.data_ptr());
+  float* act_scale_buffer = reinterpret_cast<float*>(scaleFP8SF.data_ptr());
+
+  auto stream = at::cuda::getCurrentCUDAStream(self.get_device());
+
+  mGemmRunner.fp8CS1x128(
+      act_buffer, act_scale_buffer, reinterpret_cast<__nv_bfloat16 const*>(self.data_ptr()), n, m, stream);
+
+  // Post-process the scale tensor for sm100 gemm/moe kernel
+  return {valueE4M3.slice(0, 0, m), scaleFP8SF};
+}

--- a/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_kernel.cuh
+++ b/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_kernel.cuh
@@ -1,0 +1,1809 @@
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm_kernel.cuh
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cutlass/arch/barrier.h>
+#include <cutlass/arch/reg_reconfig.h>
+
+#include <array>
+#include <cstdint>
+#include <cub/cub.cuh>
+#include <cute/arch/cluster_sm90.hpp>
+#include <cute/arch/copy_sm90_desc.hpp>
+#include <cute/arch/copy_sm90_tma.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "trt_fp8_blockscale_mma_utils.cuh"
+#include "trt_fp8_blockscale_tma_utils.cuh"
+#include "utils.h"
+
+namespace kernel_utils {
+
+inline void find_divisor(uint32_t& mul, uint32_t& shr, int x) {
+  auto find_log_2 = [](int x, bool round_up = false) {
+    auto clz = [](int x) {
+      for (int i = 31; i >= 0; --i) {
+        if ((1 << i) & x) {
+          return 31 - i;
+        }
+      }
+      return 32;
+    };
+
+    int a = 31 - clz(x);
+    if (round_up) {
+      a += (x & (x - 1)) ? 1 : 0;
+    }
+    return a;
+  };
+
+  assert(x != 0);
+  if (x == 1) {
+    // If dividing by 1, reduced math doesn't work because mul_coeff would need
+    // to be 2^32, which doesn't fit into unsigned int.  the div() routine
+    // handles this special case separately.
+    mul = 0;
+    shr = 0;
+  } else {
+    // To express the division N/D in terms of a multiplication, what we first
+    // imagine is simply N*(1/D).  However, 1/D will always evaluate to 0 (for
+    // D>1), so we need another way.  There's nothing that says we have to use
+    // exactly the fraction 1/D; instead it could be any X/Y that reduces to 1/D
+    // (i.e., Y=X*D), or at least to "close enough" to it.  If we pick Y that is
+    // a power of two, then the N*(X/Y) can be N*X followed by a right-shift by
+    // some amount. The power of two we should pick should be at least 2^32,
+    // because in the div() routine we'll use umulhi(), which returns only the
+    // upper 32 bits -- this being equivalent to a right-shift by 32.  But we
+    // might want a higher power of two for better accuracy depending on the
+    // magnitude of the denominator. Once we've picked Y, then X [our mul_coeff
+    // value] is simply Y/D, rounding up, and we save shift_coeff as whatever
+    // further shift we have to do beyond what the umulhi() implies.
+    uint32_t p = 31 + find_log_2(x, true);
+    uint32_t m = (uint32_t)(((1ull << p) + (uint32_t)x - 1) / (uint32_t)x);
+
+    mul = m;
+    shr = p - 32;
+  }
+}
+
+__device__ __forceinline__ void fast_divmod(uint32_t& div, uint32_t& mod, int x, int y, uint32_t mul, uint32_t shr) {
+  if (y == 1) {
+    div = x;
+    mod = 0;
+  } else {
+    div = __umulhi((uint32_t)x, mul) >> shr;
+    mod = x - div * y;
+  }
+}
+
+template <typename T>
+__inline__ __device__ T warpReduceSum(T val) {
+  constexpr uint32_t FINAL_MASK = 0xffffffff;
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val = max(val, __shfl_xor_sync(FINAL_MASK, val, mask, 32));
+  return val;
+}
+
+template <>
+__inline__ __device__ __nv_bfloat16 warpReduceSum(__nv_bfloat16 val) {
+  constexpr uint32_t FINAL_MASK = 0xffffffff;
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val = __hmax(val, __shfl_xor_sync(FINAL_MASK, val, mask, 32));
+  return val;
+}
+
+__inline__ __device__ uint32_t elect_one_sync([[maybe_unused]] int lane_id) {
+  uint32_t pred = 0;
+#if __CUDA_ARCH__ >= 900
+  uint32_t laneid = 0;
+  asm volatile(
+      "\n\
+     {\n\
+         .reg .b32 %rx;\n\
+         .reg .pred %px;\n\
+         elect.sync %rx|%px, %2;\n\
+         @%px mov.s32 %1, 1;\n\
+         mov.s32 %0, %rx;\n\
+     }\n\
+   "
+      : "+r"(laneid), "+r"(pred)
+      : "r"(0xFFFFFFFF));
+#else
+  return lane_id == 0;
+#endif
+  return pred;
+}
+
+}  // namespace kernel_utils
+
+namespace tensorrt_llm::kernels::fp8_blockscale_gemm {
+
+template <typename T>
+__device__ __host__ constexpr T div_up(T a, int b) {
+  return (a + b - 1) / b;
+}
+
+using TileShape = std::tuple<uint32_t, uint32_t, uint32_t>;
+enum class Layout { RowMajor, ColMajor };
+enum class ScaleType { PerTensor, PerBlock, PerChannel, PerSubChannel };
+
+template <int TILE_M, int TILE_N>
+struct GroupedGemmProblemVisitor {
+  struct Input {
+    int64_t const* problem_m_offsets;
+    int64_t const* problem_m_padded_offsets;
+  };
+
+  static __host__ __device__ dim3 grid_dim(int shape_m, int shape_n, int num_problems) {
+    return dim3(div_up(shape_m, TILE_M), div_up(shape_n, TILE_N), num_problems);
+  }
+
+  static __device__ int tile_m_idx() {
+    return blockIdx.x;
+  }
+
+  static __device__ int tile_n_idx() {
+    return blockIdx.y;
+  }
+
+  static __device__ int problem_idx() {
+    return blockIdx.z;
+  }
+
+  static __device__ int m_offset(Input const& input) {
+    int problem_idx_ = problem_idx();
+    return input.problem_m_offsets[problem_idx_];
+  }
+
+  static __device__ int m_padded_offset(Input const& input) {
+    int problem_idx_ = problem_idx();
+    return input.problem_m_padded_offsets[problem_idx_];
+  }
+
+  static __device__ int n_offset(Input const& input) {
+    int problem_idx_ = problem_idx();
+    return problem_idx_ * TILE_N * gridDim.y;
+  }
+
+  static __device__ int m_boundary(Input const& input) {
+    int problem_idx_ = problem_idx();
+    return input.problem_m_offsets[problem_idx_ + 1] - input.problem_m_offsets[problem_idx_];
+  }
+};
+
+template <int TILE_M, int TILE_N>
+struct PlainGemmProblemVisitor {
+  struct Input {
+    int shape_m;
+  };
+
+  static __host__ __device__ dim3 grid_dim(int shape_m, int shape_n) {
+    return dim3(div_up(shape_m, TILE_M), div_up(shape_n, TILE_N));
+  }
+
+  static __device__ int tile_m_idx() {
+    return blockIdx.x;
+  }
+
+  static __device__ int tile_n_idx() {
+    return blockIdx.y;
+  }
+
+  static __device__ int problem_idx() {
+    return 0;
+  }
+
+  static __device__ int m_offset(Input const& input) {
+    return 0;
+  }
+
+  static __device__ int n_offset(Input const& input) {
+    return 0;
+  }
+
+  static __device__ int m_boundary(Input const& input) {
+    return input.shape_m;
+  }
+};
+
+template <int TILE_M, int TILE_N>
+struct StridedBatchedGemmProblemVisitor {
+  struct Input {
+    int shape_m;
+    int ld_a;
+    int stride_a;
+    int ld_b;
+    int stride_b;
+    int stride_d;
+    int stride_scales_a;
+    // stride_a % ld_a must be 0
+    // stride_b % ld_b must be 0
+  };
+
+  static __host__ __device__ dim3 grid_dim(int shape_m, int shape_n, int num_problems) {
+    return dim3(div_up(shape_m, TILE_M), div_up(shape_n, TILE_N), num_problems);
+  }
+
+  static __device__ int tile_m_idx() {
+    return blockIdx.x;
+  }
+
+  static __device__ int tile_n_idx() {
+    return blockIdx.y;
+  }
+
+  static __device__ int problem_idx() {
+    return blockIdx.z;
+  }
+
+  static __device__ int m_offset(Input const& input) {
+    int problem_idx_ = problem_idx();
+    return input.stride_a / input.ld_a * problem_idx_;
+  }
+
+  static __device__ int n_offset(Input const& input) {
+    int problem_idx_ = problem_idx();
+    return input.stride_b / input.ld_b * problem_idx_;
+  }
+
+  static __device__ int m_boundary(Input const& input) {
+    return input.shape_m;
+  }
+};
+
+namespace cde = cuda::device::experimental;
+
+template <
+    typename ProblemVisitor,
+    typename ElementA,
+    typename ElementB,
+    typename ElementD,
+    Layout LayoutD,
+    typename WGMMA_OP,
+    int TILE_M,
+    int TILE_N,
+    int TILE_K,
+    int NUM_STAGES,
+    bool IsPersistentKernel = false>
+__global__ void __launch_bounds__(TILE_M == 64 ? 256 : 384, 1) cooperative_1x128_by_128x128_fp8_gemm_kernel(
+    ElementD* gmem_d,
+    int ld_d,
+    float const* scales_b,
+    typename ProblemVisitor::Input problem_input,
+    int shape_n,
+    int shape_k,
+    __grid_constant__ const CUtensorMap tensor_map_a,
+    __grid_constant__ const CUtensorMap tensor_map_b,
+    __grid_constant__ const CUtensorMap tensor_map_scales_a,
+    int guessed_m) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  static_assert(sizeof(ElementA) == 1 && sizeof(ElementB) == 1);
+  static_assert(TILE_K == 128);
+  constexpr int ScaleGranMA = 1;
+  constexpr int ScaleGranKA = 128;
+  constexpr int ScaleGranNB = 128;
+  constexpr int ScaleGranKB = 128;
+  static_assert(TILE_K % ScaleGranKA == 0);
+
+  static constexpr int SMEM_A_SIZE_PER_STAGE = TILE_M * TILE_K * sizeof(ElementA);
+  static constexpr int SMEM_B_SIZE_PER_STAGE = TILE_N * TILE_K * sizeof(ElementB);
+  static constexpr int SMEM_SCALES_A_SIZE_PER_STAGE =
+      div_up(TILE_M, ScaleGranMA) * div_up(TILE_K, ScaleGranKA) * sizeof(float);
+  static constexpr bool IS_UNIFORM_SCALE_B = ScaleGranNB % TILE_N == 0;
+
+  constexpr int BLOCK_SIZE = TILE_M == 64 ? 256 : 384;
+  constexpr int TMA_ISSUE_INTERVAL = 1;
+  using Barrier = cuda::barrier<cuda::thread_scope_block>;
+
+  int tile_m_idx = ProblemVisitor::tile_m_idx();
+  int m_boundary = ProblemVisitor::m_boundary(problem_input);
+  if (tile_m_idx * TILE_M >= m_boundary) return;
+
+  int tile_n_idx = ProblemVisitor::tile_n_idx();
+  int problem_idx = ProblemVisitor::problem_idx();
+  int problem_m_offset = ProblemVisitor::m_offset(problem_input);
+  int problem_m_padded_offset = 0;
+  if constexpr (std::is_same_v<ProblemVisitor, GroupedGemmProblemVisitor<TILE_M, TILE_N>>) {
+    problem_m_padded_offset = ProblemVisitor::m_padded_offset(problem_input);
+  }
+  int problem_n_offset = ProblemVisitor::n_offset(problem_input);
+
+  int scales_b_ld = ScaleGranKB != 0 ? div_up(shape_k, ScaleGranKB) : 1;
+  scales_b += problem_idx * div_up(shape_n, ScaleGranNB) * scales_b_ld;
+
+  int iters_in_former_scales_b = TILE_N / 8;  // assuming divisible
+  if constexpr (ScaleGranNB != 0) {
+    scales_b += ((tile_n_idx * TILE_N) / ScaleGranNB) * scales_b_ld;
+    iters_in_former_scales_b =
+        min(TILE_N, ScaleGranNB - (tile_n_idx * TILE_N) % ScaleGranNB) / 8;  // assuming divisible
+  }
+
+  // Align to 1024 byte for swizzle-128B
+  extern __shared__ __align__(1024) uint8_t smem_buffer[];
+  ElementA* smem_a[NUM_STAGES];
+  ElementB* smem_b[NUM_STAGES];
+  float* smem_scales_a[NUM_STAGES];
+
+  Barrier* full_bars[NUM_STAGES];
+  // NUM_EMPTY_BARS must be a const expression, otherwise it will cost too many registers.
+  constexpr int NUM_EMPTY_BARS = div_up(NUM_STAGES, TMA_ISSUE_INTERVAL);
+  Barrier* empty_bars[NUM_EMPTY_BARS];
+
+  float* smem_scales_b;
+
+  for (int i = 0; i < NUM_STAGES; i++) {
+    smem_a[i] = reinterpret_cast<ElementA*>(smem_buffer + i * SMEM_A_SIZE_PER_STAGE);
+    smem_b[i] =
+        reinterpret_cast<ElementB*>(smem_buffer + NUM_STAGES * SMEM_A_SIZE_PER_STAGE + i * SMEM_B_SIZE_PER_STAGE);
+    smem_scales_a[i] = reinterpret_cast<float*>(
+        smem_buffer + NUM_STAGES * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE) + i * SMEM_SCALES_A_SIZE_PER_STAGE);
+    full_bars[i] = reinterpret_cast<Barrier*>(
+        smem_buffer + NUM_STAGES * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SCALES_A_SIZE_PER_STAGE) +
+        i * sizeof(Barrier));
+  }
+  for (int i = 0; i < NUM_EMPTY_BARS; i++) {
+    empty_bars[i] = i ? empty_bars[i - 1] + 1 : full_bars[NUM_STAGES - 1] + 1;
+  }
+  smem_scales_b = reinterpret_cast<float*>(empty_bars[NUM_EMPTY_BARS - 1] + 1);
+
+  int lane_predicate = cute::elect_one_sync();
+  if (threadIdx.x < 32 && lane_predicate == 1) {
+    cute::prefetch_tma_descriptor(reinterpret_cast<cute::TmaDescriptor const*>(&tensor_map_a));
+    cute::prefetch_tma_descriptor(reinterpret_cast<cute::TmaDescriptor const*>(&tensor_map_b));
+    cute::prefetch_tma_descriptor(reinterpret_cast<cute::TmaDescriptor const*>(&tensor_map_scales_a));
+
+    for (int i = 0; i < NUM_STAGES; i++) {
+      init(full_bars[i], 1);
+    }
+    for (int i = 0; i < NUM_EMPTY_BARS; i++) {
+      init(empty_bars[i], BLOCK_SIZE - 128);
+    }
+    cutlass::arch::fence_view_async_shared();
+  }
+  int math_wg_idx = __shfl_sync(0xffffffff, threadIdx.x / 128 - 1, 0);
+
+  float scale_b_r, scale_b_r_second_part;
+  if constexpr (ScaleGranKB != 0) {
+    int end_index = !IS_UNIFORM_SCALE_B && iters_in_former_scales_b < TILE_N / 8 ? scales_b_ld * 2 : scales_b_ld;
+#pragma unroll
+    for (int i = threadIdx.x; i < end_index; i += BLOCK_SIZE) {
+      float gmem_scale_b = __ldg(scales_b + i);
+      asm volatile("st.shared.f32 [%0], %1;" ::"l"(smem_scales_b + i), "f"(gmem_scale_b));
+    }
+  } else {
+    scale_b_r = scales_b[0];
+  }
+
+  __syncthreads();
+
+  while (true) {
+    constexpr int NUM_ACCUMS = WGMMA_OP::NUM_ACCUM;
+    float accum[NUM_ACCUMS] = {0};
+    float final_accum[NUM_ACCUMS] = {0};
+    constexpr int K_PER_ITER = NUM_STAGES * TILE_K;
+
+    if (threadIdx.x < 128) {
+      for (int k_iter = 0; k_iter < div_up(shape_k, K_PER_ITER); k_iter++) {
+        auto copy_func = [&](Barrier& empty_bar, int stage_range_start, int stage_range_end) {
+          empty_bar.wait_parity(k_iter + 1 & 1);
+          for (int i = stage_range_start; i < stage_range_end; i++) {
+            auto& bar = *full_bars[i];
+            int k_idx = k_iter * K_PER_ITER + i * TILE_K;
+            cde::cp_async_bulk_tensor_2d_global_to_shared(
+                smem_a[i], &tensor_map_a, k_idx, tile_m_idx * TILE_M + problem_m_offset, bar);
+            cde::cp_async_bulk_tensor_2d_global_to_shared(
+                smem_b[i], &tensor_map_b, k_idx, tile_n_idx * TILE_N + problem_n_offset, bar);
+            if constexpr (std::is_same_v<ProblemVisitor, StridedBatchedGemmProblemVisitor<TILE_M, TILE_N>>) {
+              int scale_y_offset =
+                  problem_idx * (problem_input.stride_scales_a / (div_up(problem_input.shape_m, 4) * 4));
+              // The scales has been aligned to 16 bytes
+              cde::cp_async_bulk_tensor_2d_global_to_shared(
+                  smem_scales_a[i],
+                  &tensor_map_scales_a,
+                  (tile_m_idx * TILE_M) / ScaleGranMA,
+                  scale_y_offset + k_idx / ScaleGranKA,
+                  bar);
+            } else {
+              // The scales has been aligned to 16 bytes
+              cde::cp_async_bulk_tensor_2d_global_to_shared(
+                  smem_scales_a[i],
+                  &tensor_map_scales_a,
+                  (problem_m_padded_offset + tile_m_idx * TILE_M) / ScaleGranMA,
+                  k_idx / ScaleGranKA,
+                  bar);
+            }
+          }
+          for (int i = stage_range_start; i < stage_range_end; i++) {
+            auto no_use = mbarrier_arrive_1_expect_tx_cta(
+                full_bars[i], SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SCALES_A_SIZE_PER_STAGE);
+          }
+        };
+        if (threadIdx.x == 0) {
+          int num_stages = div_up((shape_k - k_iter * K_PER_ITER), TILE_K);
+          for (int i = 0; i < NUM_EMPTY_BARS; i++) {
+            int range_start = i * TMA_ISSUE_INTERVAL;
+            int range_end = (i + 1) * TMA_ISSUE_INTERVAL;
+            range_end = range_end > NUM_STAGES ? NUM_STAGES : range_end;
+            range_end = range_end > num_stages ? num_stages : range_end;
+            copy_func(*empty_bars[i], range_start, range_end);
+          }
+        }
+      }
+    } else {
+      int thr_id_in_wg = threadIdx.x % 128;
+      int base_r = thr_id_in_wg / 32 * 16 + thr_id_in_wg % 32 / 4;
+      int r_0 = base_r + math_wg_idx * WGMMA_OP::M;
+      int r_1 = base_r + math_wg_idx * WGMMA_OP::M + 8;
+
+      struct DivisibleK {};
+
+      struct NotDivisibleK {};
+
+      auto mma_func = [&](int k_iter, auto type) {
+        constexpr bool K_IS_DIVISIBLE = std::is_same_v<decltype(type), DivisibleK> ? true : false;
+        int num_stages;
+        if constexpr (K_IS_DIVISIBLE) {
+          num_stages = NUM_STAGES;
+        } else {
+          num_stages = div_up(shape_k % K_PER_ITER, TILE_K);
+          num_stages = !num_stages ? NUM_STAGES : num_stages;
+        }
+
+#pragma unroll
+        for (int s = 0; s < num_stages; s++) {
+          if constexpr (ScaleGranKB != 0) {
+            asm volatile("ld.shared.f32 %0, [%1];" : "=f"(scale_b_r) : "l"(smem_scales_b));
+            if (!IS_UNIFORM_SCALE_B && iters_in_former_scales_b < TILE_N / 8) {
+              asm volatile("ld.shared.f32 %0, [%1];" : "=f"(scale_b_r_second_part) : "l"(smem_scales_b + scales_b_ld));
+            }
+            smem_scales_b++;
+          }
+          (*full_bars[s]).wait_parity(k_iter & 1);
+          for (int _ = 0; _ < NUM_ACCUMS; _++) {
+            warpgroup_fence_operand(accum[_]);
+          }
+          warpgroup_arrive();
+          for (int k = 0; k < TILE_K / WGMMA_OP::K; k++) {
+            auto desc_a = make_smem_desc(smem_a[s] + math_wg_idx * WGMMA_OP::M * TILE_K + k * WGMMA_OP::K, 1);
+            auto desc_b = make_smem_desc(smem_b[s] + k * WGMMA_OP::K, 1);
+            WGMMA_OP::wgmma(desc_a, desc_b, accum, k);
+          }
+          warpgroup_commit_batch();
+          for (int _ = 0; _ < NUM_ACCUMS; _++) {
+            warpgroup_fence_operand(accum[_]);
+          }
+          warpgroup_wait<0>();
+
+          float scale_0 = smem_scales_a[s][r_0] * scale_b_r;
+          float scale_1 = smem_scales_a[s][r_1] * scale_b_r;
+
+          bool cross_0 = tile_m_idx * TILE_M + r_0 >= m_boundary;
+          bool cross_1 = tile_m_idx * TILE_M + r_1 >= m_boundary;
+
+          if (cross_0) {
+            scale_0 = 0;
+          }
+          if (cross_1) {
+            scale_1 = 0;
+          }
+
+          if constexpr (K_IS_DIVISIBLE) {
+            if (s % TMA_ISSUE_INTERVAL == TMA_ISSUE_INTERVAL - 1 || s == NUM_STAGES - 1) {
+              int tma_group_idx = s / TMA_ISSUE_INTERVAL;
+              auto no_use = (*empty_bars[tma_group_idx]).arrive();
+            }
+          }
+
+          float scale_0_second_part = smem_scales_a[s][r_0] * scale_b_r_second_part;
+          float scale_1_second_part = smem_scales_a[s][r_1] * scale_b_r_second_part;
+
+          if (!IS_UNIFORM_SCALE_B && iters_in_former_scales_b < TILE_N / 8) {
+            for (int i = 0; i < iters_in_former_scales_b; i++) {
+              final_accum[i * 4 + 0] += scale_0 * accum[i * 4];
+              final_accum[i * 4 + 1] += scale_0 * accum[i * 4 + 1];
+            }
+            for (int i = 0; i < iters_in_former_scales_b; i++) {
+              final_accum[i * 4 + 2] += scale_1 * accum[i * 4 + 2];
+              final_accum[i * 4 + 3] += scale_1 * accum[i * 4 + 3];
+            }
+
+            for (int i = iters_in_former_scales_b; i < WGMMA_OP::NUM_ACCUM / 4; i++) {
+              final_accum[i * 4 + 0] += scale_0_second_part * accum[i * 4];
+              final_accum[i * 4 + 1] += scale_0_second_part * accum[i * 4 + 1];
+            }
+            for (int i = iters_in_former_scales_b; i < WGMMA_OP::NUM_ACCUM / 4; i++) {
+              final_accum[i * 4 + 2] += scale_1_second_part * accum[i * 4 + 2];
+              final_accum[i * 4 + 3] += scale_1_second_part * accum[i * 4 + 3];
+            }
+          } else {
+            for (int i = 0; i < WGMMA_OP::NUM_ACCUM / 4; i++) {
+              final_accum[i * 4 + 0] += scale_0 * accum[i * 4];
+              final_accum[i * 4 + 1] += scale_0 * accum[i * 4 + 1];
+            }
+            for (int i = 0; i < WGMMA_OP::NUM_ACCUM / 4; i++) {
+              final_accum[i * 4 + 2] += scale_1 * accum[i * 4 + 2];
+              final_accum[i * 4 + 3] += scale_1 * accum[i * 4 + 3];
+            }
+          }
+        }
+      };
+
+      int num_iterations = div_up(shape_k, K_PER_ITER);
+      for (int k_iter = 0; k_iter < num_iterations - 1; k_iter++) {
+        mma_func(k_iter, DivisibleK{});
+      }
+      mma_func(num_iterations - 1, NotDivisibleK{});
+    }
+
+    if constexpr (LayoutD == Layout::RowMajor) {
+      __syncthreads();
+      ElementD* smem_c = reinterpret_cast<ElementD*>(smem_buffer);
+      constexpr int SMEM_C_PADDING = 8;
+
+      if (threadIdx.x >= 128) {
+        int thr_id_in_wg = threadIdx.x % 128;
+        int base_r = thr_id_in_wg / 32 * 16 + thr_id_in_wg % 32 / 4;
+        int base_c = thr_id_in_wg % 4 * 2;
+        int r_0 = base_r;
+        int r_1 = base_r + 8;
+        int c_0 = base_c;
+
+        for (int i = 0; i < WGMMA_OP::NUM_ACCUM / 4; i++) {
+          int c_1 = c_0 + 1;
+          smem_c[(r_0 + math_wg_idx * WGMMA_OP::M) * (TILE_N + SMEM_C_PADDING) + c_0] =
+              static_cast<ElementD>(final_accum[i * 4]);
+          smem_c[(r_0 + math_wg_idx * WGMMA_OP::M) * (TILE_N + SMEM_C_PADDING) + c_1] =
+              static_cast<ElementD>(final_accum[i * 4 + 1]);
+          smem_c[(r_1 + math_wg_idx * WGMMA_OP::M) * (TILE_N + SMEM_C_PADDING) + c_0] =
+              static_cast<ElementD>(final_accum[i * 4 + 2]);
+          smem_c[(r_1 + math_wg_idx * WGMMA_OP::M) * (TILE_N + SMEM_C_PADDING) + c_1] =
+              static_cast<ElementD>(final_accum[i * 4 + 3]);
+          c_0 += 8;
+        }
+      }
+      __syncthreads();
+      ElementD* gmem_d_this_block;
+      if constexpr (std::is_same_v<ProblemVisitor, StridedBatchedGemmProblemVisitor<TILE_M, TILE_N>>) {
+        gmem_d_this_block = gmem_d + problem_idx * problem_input.stride_d + (tile_m_idx * TILE_M) * ld_d;
+      } else {
+        gmem_d_this_block = gmem_d + (problem_m_offset + tile_m_idx * TILE_M) * ld_d;
+      }
+      int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+      int lane_idx = threadIdx.x % 32;
+      constexpr int int4_per_tile_line = TILE_N * sizeof(ElementD) / sizeof(int4);
+      // assert(shape_n * sizeof(ElementD) % sizeof(int4) == 0)
+      int int4_per_global_line = shape_n * sizeof(ElementD) / sizeof(int4);
+      constexpr int num_lines = TILE_M;
+      constexpr int num_warps = BLOCK_SIZE / 32;
+      int4* smem_c_int4 = reinterpret_cast<int4*>(smem_c);
+      bool is_last_tile_n = (tile_n_idx + 1) * TILE_N > shape_n;
+      int int4_per_line = is_last_tile_n ? int4_per_global_line % int4_per_tile_line : int4_per_tile_line;
+
+      for (int line_idx = warp_idx; line_idx < num_lines; line_idx += num_warps) {
+        if (tile_m_idx * TILE_M + line_idx >= m_boundary) {
+          break;
+        }
+        for (int elem_idx = lane_idx; elem_idx < int4_per_line; elem_idx += 32) {
+          int4* g_data_addr =
+              reinterpret_cast<int4*>(&gmem_d_this_block[line_idx * ld_d + tile_n_idx * TILE_N]) + elem_idx;
+          int4* s_data_addr =
+              &smem_c_int4
+                  [line_idx * (int4_per_tile_line + SMEM_C_PADDING * sizeof(ElementD) / sizeof(int4)) + elem_idx];
+          *g_data_addr = *s_data_addr;
+        }
+        __syncwarp();
+      }
+    } else if constexpr (LayoutD == Layout::ColMajor) {
+    }
+
+    if constexpr (!IsPersistentKernel) {
+      return;
+    }
+
+    tile_m_idx += guessed_m / TILE_M;
+    if (tile_m_idx * TILE_M >= m_boundary) return;
+
+    if (threadIdx.x < 32 && lane_predicate == 1) {
+      for (int i = 0; i < NUM_STAGES; i++) {
+        full_bars[i]->~Barrier();
+        init(full_bars[i], 1);
+      }
+      for (int i = 0; i < NUM_EMPTY_BARS; i++) {
+        empty_bars[i]->~Barrier();
+        init(empty_bars[i], BLOCK_SIZE - 128);
+      }
+      cutlass::arch::fence_view_async_shared();
+    }
+    __syncthreads();
+    smem_scales_b = reinterpret_cast<float*>(empty_bars[NUM_EMPTY_BARS - 1] + 1);
+  }
+#else
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    printf("This kernel requires SM90a\n");
+    asm volatile("trap;");
+  }
+#endif
+}
+
+template <
+    typename ElementA,
+    Layout LayoutA,
+    typename ElementB,
+    Layout LayoutB,
+    typename ElementD,
+    Layout LayoutD,
+    typename ElementAccumulator,
+    typename ElementCompute,
+    typename ElementScalar,
+    int TILE_M,
+    int TILE_N,
+    int TILE_K,
+    ScaleType ScaleTypeA,
+    ScaleType ScaleTypeB,
+    int ScaleGranMA = 0,
+    int ScaleGranKA = 0,
+    int ScaleGranNB = 0,
+    int ScaleGranKB = 0,
+    int NUM_OF_STAGES = 0>
+class Fp8Gemm {
+ public:
+  static constexpr int MAX_SHAPE_K = 20480;
+
+ private:
+  using Barrier = cuda::barrier<cuda::thread_scope_block>;
+  static constexpr int SMEM_A_SIZE_PER_STAGE = TILE_M * TILE_K * sizeof(ElementA);
+  static constexpr int SMEM_B_SIZE_PER_STAGE = TILE_N * TILE_K * sizeof(ElementB);
+  static constexpr bool IS_UNIFORM_SCALE_B = ScaleGranNB % TILE_N == 0;
+
+ public:
+  static constexpr int get_smem_size(int num_stages, int max_shape_k = MAX_SHAPE_K) {
+    auto smem_size = num_stages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + sizeof(Barrier) + sizeof(Barrier));
+
+    if constexpr (ScaleTypeA == ScaleType::PerSubChannel) {
+      auto scale_smem_size =
+          num_stages * div_up(TILE_M, ScaleGranMA) * div_up(TILE_K, ScaleGranKA) * sizeof(ElementScalar);
+      smem_size += scale_smem_size;
+    }
+    if constexpr (ScaleTypeB != ScaleType::PerTensor) {
+      auto scale_smem_size = (IS_UNIFORM_SCALE_B ? 1 : 2) * div_up(max_shape_k, ScaleGranKB) * sizeof(ElementScalar);
+      smem_size += scale_smem_size;
+    }
+    return smem_size;
+  }
+
+ private:
+  static constexpr int get_num_stages() {
+    constexpr auto sm90_capacity = 232448;
+
+    if constexpr (get_smem_size(8) <= sm90_capacity) return 8;
+    if constexpr (get_smem_size(7) <= sm90_capacity) return 7;
+    if constexpr (get_smem_size(6) <= sm90_capacity) return 6;
+    if constexpr (get_smem_size(5) <= sm90_capacity) return 5;
+    static_assert(get_smem_size(4) <= sm90_capacity, "The required shared memory size is too large");
+    return 4;
+  }
+
+  static constexpr int NUM_STAGES = NUM_OF_STAGES == 0 ? get_num_stages() : NUM_OF_STAGES;
+  static constexpr int BLOCK_SIZE = TILE_M == 64 ? 256 : 384;
+
+ public:
+  Fp8Gemm() {
+    static_assert(!(ScaleTypeA == ScaleType::PerSubChannel && (ScaleGranMA == 0 || ScaleGranKA == 0)));
+    static_assert(TILE_M % ScaleGranMA == 0 && TILE_K % ScaleGranKA == 0);
+  }
+
+  // GroupedGemm
+  static void
+  run(ElementA* gmem_a,
+      ElementB* gmem_b,
+      ElementD* gmem_d,
+      ElementScalar* scales_a,
+      ElementScalar const* scales_b,
+      int num_problems,
+      int64_t const* problem_m_offsets,
+      int shape_n,
+      int shape_k,
+      int max_shape_m,
+      cudaStream_t stream = 0,
+      int guessed_m = TILE_M,
+      int64_t const* problem_m_padded_offsets = nullptr,
+      int max_shape_m_padded = 0) {
+    using ProblemVisitor = GroupedGemmProblemVisitor<TILE_M, TILE_N>;
+    // Need a factory for selecting WGMMA_OP, need to add E5M2 op if needed.
+    using WGMMA_OP = typename Fp8MmaSelector<ElementA, ElementB, TILE_N>::Type;
+#define Kernel                                  \
+  cooperative_1x128_by_128x128_fp8_gemm_kernel< \
+      ProblemVisitor,                           \
+      ElementA,                                 \
+      ElementB,                                 \
+      ElementD,                                 \
+      LayoutD,                                  \
+      WGMMA_OP,                                 \
+      TILE_M,                                   \
+      TILE_N,                                   \
+      TILE_K,                                   \
+      NUM_STAGES,                               \
+      true>
+    assert(shape_n % TILE_N == 0);
+    auto tma_a_desc = make_2d_tma_a_desc(gmem_a, max_shape_m, shape_k);
+    auto tma_b_desc = make_2d_tma_b_desc(gmem_b, shape_k, num_problems * shape_n);
+    auto tma_scales_a_desc = make_2d_tma_scales_a_desc(scales_a, max_shape_m_padded, shape_k);
+    static_assert(TILE_N == WGMMA_OP::N);
+    guessed_m = div_up(guessed_m, TILE_M) * TILE_M;
+    int smem_size = get_smem_size(NUM_STAGES, shape_k);
+    cudaFuncSetAttribute(Kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    typename ProblemVisitor::Input problem_input{problem_m_offsets, problem_m_padded_offsets};
+    auto grid_size = ProblemVisitor::grid_dim(guessed_m, shape_n, num_problems);
+
+    Kernel<<<grid_size, BLOCK_SIZE, smem_size, stream>>>(
+        gmem_d,
+        shape_n,
+        scales_b,
+        problem_input,
+        shape_n,
+        shape_k,
+        tma_a_desc,
+        tma_b_desc,
+        tma_scales_a_desc,
+        guessed_m);
+#undef Kernel
+  }
+
+  // PlainGemm
+  static void
+  run(ElementA* gmem_a,
+      int ld_a,
+      ElementB* gmem_b,
+      int ld_b,
+      ElementD* gmem_d,
+      int ld_d,
+      ElementScalar* scales_a,
+      ElementScalar const* scales_b,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      cudaStream_t stream = 0,
+      int guessed_m = TILE_M) {
+    using ProblemVisitor = PlainGemmProblemVisitor<TILE_M, TILE_N>;
+    // Need a factory for selecting WGMMA_OP, need to add E5M2 op if needed.
+    using WGMMA_OP = typename Fp8MmaSelector<ElementA, ElementB, TILE_N>::Type;
+#define Kernel                                  \
+  cooperative_1x128_by_128x128_fp8_gemm_kernel< \
+      ProblemVisitor,                           \
+      ElementA,                                 \
+      ElementB,                                 \
+      ElementD,                                 \
+      LayoutD,                                  \
+      WGMMA_OP,                                 \
+      TILE_M,                                   \
+      TILE_N,                                   \
+      TILE_K,                                   \
+      NUM_STAGES,                               \
+      true>
+    assert(shape_n % TILE_N == 0);
+    auto tma_a_desc = make_2d_tma_a_desc(gmem_a, shape_m, shape_k, ld_a * sizeof(*gmem_a));
+    auto tma_b_desc = make_2d_tma_b_desc(gmem_b, shape_k, shape_n, ld_b * sizeof(*gmem_b));
+    auto tma_scales_a_desc = make_2d_tma_scales_a_desc(scales_a, div_up(shape_m, 4) * 4, shape_k);
+    static_assert(TILE_N == WGMMA_OP::N);
+    guessed_m = div_up(guessed_m, TILE_M) * TILE_M;
+    int smem_size = get_smem_size(NUM_STAGES, shape_k);
+    cudaFuncSetAttribute(Kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+
+    typename ProblemVisitor::Input problem_input{shape_m};
+    auto grid_size = ProblemVisitor::grid_dim(guessed_m, shape_n);
+
+    Kernel<<<grid_size, BLOCK_SIZE, smem_size, stream>>>(
+        gmem_d, ld_d, scales_b, problem_input, shape_n, shape_k, tma_a_desc, tma_b_desc, tma_scales_a_desc, guessed_m);
+#undef Kernel
+  }
+
+  // StridedBatchedGemm
+  static void
+  run(ElementA* gmem_a,
+      int ld_a,
+      int stride_a,
+      ElementB* gmem_b,
+      int ld_b,
+      int stride_b,
+      ElementD* gmem_d,
+      int ld_d,
+      int stride_d,
+      ElementScalar* scales_a,
+      int stride_scales_a,
+      ElementScalar const* scales_b,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      int num_problems,
+      cudaStream_t stream = 0) {
+    using ProblemVisitor = StridedBatchedGemmProblemVisitor<TILE_M, TILE_N>;
+    // Need a factory for selecting WGMMA_OP, need to add E5M2 op if needed.
+    using WGMMA_OP = typename Fp8MmaSelector<ElementA, ElementB, TILE_N>::Type;
+#define Kernel                                  \
+  cooperative_1x128_by_128x128_fp8_gemm_kernel< \
+      ProblemVisitor,                           \
+      ElementA,                                 \
+      ElementB,                                 \
+      ElementD,                                 \
+      LayoutD,                                  \
+      WGMMA_OP,                                 \
+      TILE_M,                                   \
+      TILE_N,                                   \
+      TILE_K,                                   \
+      NUM_STAGES,                               \
+      true>
+    assert(shape_n % TILE_N == 0);
+    auto tma_a_desc = make_2d_tma_a_desc(gmem_a, shape_m * num_problems, shape_k, ld_a * sizeof(*gmem_a));
+    auto tma_b_desc = make_2d_tma_b_desc(gmem_b, shape_k, shape_n * num_problems, ld_b * sizeof(*gmem_b));
+    auto tma_scales_a_desc = make_2d_tma_scales_a_desc(scales_a, shape_m, shape_k, num_problems);
+    static_assert(TILE_N == WGMMA_OP::N);
+    typename ProblemVisitor::Input problem_input{shape_m, ld_a, stride_a, ld_b, stride_b, stride_d, stride_scales_a};
+
+    int guessed_m = div_up(shape_m, TILE_M) * TILE_M;
+    int smem_size = get_smem_size(NUM_STAGES, shape_k);
+    cudaFuncSetAttribute(Kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    auto grid_size = ProblemVisitor::grid_dim(shape_m, shape_n, num_problems);
+
+    Kernel<<<grid_size, BLOCK_SIZE, smem_size, stream>>>(
+        gmem_d, ld_d, scales_b, problem_input, shape_n, shape_k, tma_a_desc, tma_b_desc, tma_scales_a_desc, guessed_m);
+#undef Kernel
+  }
+
+  template <typename T>
+  static CUtensorMap
+  make_2d_tma_a_desc(T* global_address, uint64_t gmem_rows, uint64_t gmem_cols, uint64_t global_stride_in_bytes = 0) {
+    return make_2d_tma_desc(global_address, LayoutA, gmem_rows, gmem_cols, global_stride_in_bytes, TILE_M, TILE_K);
+  }
+
+  template <typename T>
+  static CUtensorMap
+  make_2d_tma_b_desc(T* global_address, uint64_t gmem_rows, uint64_t gmem_cols, uint64_t global_stride_in_bytes = 0) {
+    return make_2d_tma_desc(global_address, LayoutB, gmem_rows, gmem_cols, global_stride_in_bytes, TILE_K, TILE_N);
+  }
+
+  template <typename T>
+  static CUtensorMap make_2d_tma_scales_a_desc(
+      T* global_address,
+      uint64_t shape_m,
+      uint64_t shape_k,
+      int num_problems = 1,
+      uint64_t global_stride_in_bytes = 0) {
+    static_assert(TILE_M % ScaleGranMA == 0);
+    static_assert(TILE_K % ScaleGranKA == 0);
+
+    constexpr auto tma_alignment_bytes = 16;
+    constexpr auto alignment = tma_alignment_bytes / sizeof(T);
+    static_assert(sizeof(T) * alignment == tma_alignment_bytes);
+
+    shape_m = div_up(shape_m, alignment) * alignment;
+    return make_2d_tma_desc(
+        global_address,
+        Layout::ColMajor,
+        div_up(shape_m, ScaleGranMA),
+        div_up(shape_k, ScaleGranKA) * num_problems,
+        global_stride_in_bytes,
+        TILE_M / ScaleGranMA,
+        TILE_K / ScaleGranKA,
+        CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_NONE);
+  }
+
+  template <typename T>
+  static CUtensorMap make_2d_tma_desc(
+      T* global_address,
+      Layout layout,
+      uint64_t gmem_rows,
+      uint64_t gmem_cols,
+      uint64_t global_stride_in_bytes,
+      int smem_rows,
+      int smem_cols,
+      CUtensorMapSwizzle swizzle_type = CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B,
+      int smem_padding = 0) {
+    if (layout == Layout::RowMajor) {
+      uint64_t gmem_dim[2] = {gmem_cols, gmem_rows};
+      uint32_t smem_dim[2] = {uint32_t(smem_cols), uint32_t(smem_rows)};
+      if (!global_stride_in_bytes) {
+        global_stride_in_bytes = gmem_cols * sizeof(T);
+      }
+      return make_2d_tma_copy_desc(global_address, gmem_dim, global_stride_in_bytes, smem_dim, swizzle_type);
+    } else {
+      uint64_t gmem_dim[2] = {gmem_rows, gmem_cols};
+      uint32_t smem_dim[2] = {uint32_t(smem_rows), uint32_t(smem_cols)};
+
+      if (!global_stride_in_bytes) {
+        global_stride_in_bytes = gmem_rows * sizeof(T);
+      }
+      return make_2d_tma_copy_desc(global_address, gmem_dim, global_stride_in_bytes, smem_dim, swizzle_type);
+    }
+  }
+};
+
+template <typename T>
+__forceinline__ __device__ T find_max_elem_in_warp(T value) {
+  for (int offset = 16; offset > 0; offset /= 2) {
+    value = T(std::max(float(value), __shfl_down_sync(0xFFFFFFFF, float(value), offset)));
+  }
+  value = T(__shfl_sync(0xffffffff, float(value), 0));
+  return value;
+}
+
+template <typename InputType, typename OutputType, typename ScaleType = float>
+__global__ void
+scale_1x128_kernel(OutputType* output, ScaleType* scales, InputType const* const input, int dim_x, int dim_y) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  size_t scales_along_dim_x = div_up(dim_x, 128);
+  size_t scales_along_dim_y = div_up(dim_y, 1);
+  size_t stride_scale_dim_y = div_up(dim_y, 4) * 4;
+
+  for (size_t warp_idx = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
+       warp_idx < scales_along_dim_x * scales_along_dim_y;
+       warp_idx += gridDim.x * blockDim.x / 32) {
+    int scales_idx_y = warp_idx / scales_along_dim_x;
+    int scales_idx_x = warp_idx % scales_along_dim_x;
+
+    InputType const* input_line = input + (size_t)scales_idx_y * dim_x + scales_idx_x * 128;
+    InputType input_amax = InputType(0);
+    int lane_id = threadIdx.x % 32;
+    InputType input_frag[4] = {0};
+
+    for (int i = 0; i < 4; i++) {
+      if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x) {
+        break;
+      } else {
+        input_frag[i] = input_line[lane_id];
+        input_amax = InputType(std::max(float(input_amax), std::fabs(float(input_frag[i]))));
+      }
+      input_line += 32;
+    }
+
+    InputType amax = find_max_elem_in_warp(input_amax);
+    ScaleType scale = amax != InputType(0.f) ? 448.f / ScaleType(amax) : 1.f;
+
+    if (lane_id == 0) {
+      scales[(size_t)scales_idx_x * stride_scale_dim_y + scales_idx_y] = ScaleType(1.f / scale);
+    }
+
+    OutputType* output_line = output + (size_t)scales_idx_y * dim_x + scales_idx_x * 128;
+    for (int i = 0; i < 4; i++) {
+      if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x) {
+        break;
+      } else {
+        ScaleType value = ScaleType(input_frag[i]) * scale;
+        output_line[lane_id] = OutputType(value);
+      }
+      output_line += 32;
+    }
+  }
+#endif
+}
+
+template <int NumThreads>
+__global__ void
+problem_m_padding_kernel(int64_t const* problem_m_offsets, int64_t* problem_m_padded_offsets, int num_problems) {
+  extern __shared__ char shared_memory[];
+  int64_t* smem_problem_m_boundaries = reinterpret_cast<int64_t*>(shared_memory);
+  using BlockScan = cub::BlockScan<int64_t, NumThreads>;
+  using TempStorage = typename BlockScan::TempStorage;
+  TempStorage* smem_temp_storage = reinterpret_cast<TempStorage*>(smem_problem_m_boundaries + num_problems);
+  // problem_m_offsets[0] is omitted because its value is known to be 0
+  for (int i = threadIdx.x; i < num_problems; i += NumThreads) {
+    smem_problem_m_boundaries[i] = problem_m_offsets[i + 1];
+  }
+  __syncthreads();
+  int64_t reduce_offset = 0;
+  int idx_scan = 0;
+  int num_problems_padded = div_up(num_problems, NumThreads) * NumThreads;
+  for (int i = threadIdx.x; i < num_problems_padded; i += NumThreads) {
+    int64_t problem_m_size = 0;
+    if (i < num_problems) {
+      problem_m_size = smem_problem_m_boundaries[i] - (i > 0 ? smem_problem_m_boundaries[i - 1] : 0);
+    }
+    int64_t scan_val = ((problem_m_size + 31) >> 5) << 5;
+    int64_t block_aggregate;
+    // To reduce the use of __syncthreads, TempStorage is not reused
+    BlockScan(smem_temp_storage[idx_scan++]).InclusiveSum(scan_val, scan_val, block_aggregate);
+    if (i < num_problems) {
+      problem_m_padded_offsets[i + 1] = scan_val + reduce_offset;
+    }
+    reduce_offset += block_aggregate;
+  }
+  if (threadIdx.x == 0) {
+    problem_m_padded_offsets[0] = 0;
+  }
+}
+
+template <bool UseBinarySearch, int NumThreads, typename InputType, typename OutputType>
+__global__ void scale_1x128_kernel(
+    OutputType* output,
+    float* scales,
+    InputType const* input,
+    int64_t const* problem_m_offsets,
+    int64_t* problem_m_padded_offsets,
+    int num_problems,
+    int dim_x,
+    int64_t scale_leading_dim,
+    uint32_t scale_dim_x_mul,
+    uint32_t scale_dim_x_shr) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  extern __shared__ char shared_memory[];
+  int64_t* smem_problem_m_boundaries = reinterpret_cast<int64_t*>(shared_memory);
+  int64_t* smem_problem_m_padded_boundaries = smem_problem_m_boundaries + num_problems;
+  using BlockScan = cub::BlockScan<int64_t, NumThreads>;
+  using TempStorage = typename BlockScan::TempStorage;
+  TempStorage* smem_temp_storage = reinterpret_cast<TempStorage*>(smem_problem_m_padded_boundaries + num_problems);
+
+  // problem_m_offsets[0] is omitted because its value is known to be 0
+  for (int i = threadIdx.x; i < num_problems; i += NumThreads) {
+    smem_problem_m_boundaries[i] = problem_m_offsets[i + 1];
+  }
+  __syncthreads();
+  int64_t reduce_offset = 0;
+  int idx_scan = 0;
+  int num_problems_padded = div_up(num_problems, NumThreads) * NumThreads;
+  for (int i = threadIdx.x; i < num_problems_padded; i += NumThreads) {
+    int64_t problem_m_size = 0;
+    if (i < num_problems) {
+      problem_m_size = smem_problem_m_boundaries[i] - (i > 0 ? smem_problem_m_boundaries[i - 1] : 0);
+    }
+    int64_t scan_val = ((problem_m_size + 31) >> 5) << 5;
+    int64_t block_aggregate;
+    // To reduce the use of __syncthreads, TempStorage is not reused
+    BlockScan(smem_temp_storage[idx_scan++]).InclusiveSum(scan_val, scan_val, block_aggregate);
+    if (i < num_problems) {
+      smem_problem_m_padded_boundaries[i] = scan_val + reduce_offset;
+    }
+    reduce_offset += block_aggregate;
+  }
+  __syncthreads();
+  if (blockIdx.x == 0) {
+    for (int i = threadIdx.x; i < num_problems; i += NumThreads) {
+      problem_m_padded_offsets[i + 1] = smem_problem_m_padded_boundaries[i];
+    }
+    if (threadIdx.x == 0) {
+      problem_m_padded_offsets[0] = 0;
+    }
+  }
+
+  size_t scales_along_dim_x = div_up(dim_x, 128);
+  size_t scales_along_dim_y = smem_problem_m_boundaries[num_problems - 1];
+  size_t total_scales = scales_along_dim_x * scales_along_dim_y;
+
+  int problem_idx = 0;
+  int64_t padded_offset = 0;
+  int64_t boundary_left, boundary_right;
+  if constexpr (UseBinarySearch) {
+    boundary_left = smem_problem_m_boundaries[0];
+    boundary_right = scales_along_dim_y;
+  } else {
+    boundary_left = 0;
+    boundary_right = smem_problem_m_boundaries[0];
+  }
+
+  for (size_t warp_idx = (threadIdx.x + blockIdx.x * NumThreads) / 32; warp_idx < total_scales;
+       warp_idx += (NumThreads * gridDim.x) / 32) {
+    uint32_t scales_idx_y;  // = warp_idx / scales_along_dim_x;
+    uint32_t scales_idx_x;  // = warp_idx % scales_along_dim_x;
+    kernel_utils::fast_divmod(
+        scales_idx_y, scales_idx_x, warp_idx, scales_along_dim_x, scale_dim_x_mul, scale_dim_x_shr);
+
+    if constexpr (UseBinarySearch) {
+      int idx_right = num_problems - 1;
+      int64_t val_right = boundary_right;
+      if (scales_idx_y >= boundary_left) {
+        while (problem_idx + 1 < idx_right) {
+          int idx_mid = (problem_idx + idx_right) >> 1;
+          int64_t val_mid = smem_problem_m_boundaries[idx_mid];
+          if (scales_idx_y < val_mid) {
+            idx_right = idx_mid;
+            val_right = val_mid;
+          } else {
+            problem_idx = idx_mid;
+            boundary_left = val_mid;
+          }
+        }
+        padded_offset = smem_problem_m_padded_boundaries[problem_idx] - boundary_left;
+        boundary_left = val_right;
+      }
+    } else {
+      if (boundary_right <= scales_idx_y) {
+        while (problem_idx < num_problems - 1) {
+          boundary_left = boundary_right;
+          boundary_right = smem_problem_m_boundaries[++problem_idx];
+          if (scales_idx_y < boundary_right) {
+            break;
+          }
+        }
+        padded_offset = smem_problem_m_padded_boundaries[problem_idx - 1] - boundary_left;
+      }
+    }
+
+    auto warp_offset = (size_t)scales_idx_y * dim_x + scales_idx_x * 128;
+    InputType const* input_line = input + warp_offset;
+    OutputType* output_line = output + warp_offset;
+    auto& scale_output = scales[(size_t)scales_idx_x * scale_leading_dim + scales_idx_y + padded_offset];
+
+    int lane_id = threadIdx.x % 32;
+    InputType input_frag[4];
+
+    for (int i = 0; i < 4; i++) {
+      input_frag[i] = (scales_idx_x * 128 + i * 32 + lane_id < dim_x) ? input_line[lane_id] : InputType(0);
+      input_line += 32;
+    }
+
+    InputType amax = kernel_utils::warpReduceSum(
+        max(max(fabs(float(input_frag[0])), fabs(float(input_frag[1]))),
+            max(fabs(float(input_frag[2])), fabs(float(input_frag[3])))));
+
+    // Half seems to be slower, probably because we need float values below
+    // anyway. InputType amax = kernel_utils::warpReduceSum(
+    //     __hmax(__hmax(__habs(input_frag[0]), __habs(input_frag[1])),
+    //         __hmax(__habs(input_frag[2]), __habs(input_frag[3]))));
+
+    float scale = amax != InputType(0.f) ? 448.f / float(amax) : 1.f;
+
+    if (kernel_utils::elect_one_sync(lane_id)) {
+      scale_output = float(1.f / scale);
+    }
+
+    for (int i = 0; i < 4; i++) {
+      float value = float(input_frag[i]) * scale;
+      if (scales_idx_x * 128 + i * 32 + lane_id < dim_x) {
+        output_line[lane_id] = OutputType(value);
+      }
+      output_line += 32;
+    }
+  }
+#endif
+}
+
+// input: [dim_y, dim_h, dim_x]
+// output: [dim_h, dim_y, dim_x], cs[dim_h, dim_x/128, padding(dim_y)]
+template <typename InputType, typename OutputType, typename ScaleType = float>
+__global__ void scale_1x128_reshape_kernel(
+    OutputType* output,
+    ScaleType* scales,
+    InputType const* const input,
+    int dim_x,
+    int dim_h,
+    int dim_y,
+    int stride_x) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  size_t scales_along_dim_x = div_up(dim_x, 128);
+  size_t scales_along_dim_y = div_up(dim_y, 1);
+  size_t scales_along_dim_h = div_up(dim_h, 1);
+  size_t stride_scale_dim_y = div_up(dim_y, 4) * 4;
+
+  for (size_t warp_idx = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
+       warp_idx < scales_along_dim_x * scales_along_dim_y * scales_along_dim_h;
+       warp_idx += gridDim.x * blockDim.x / 32) {
+    int scales_idx_y = warp_idx / (scales_along_dim_x * scales_along_dim_h);
+    int scales_idx_h = (warp_idx % (scales_along_dim_x * scales_along_dim_h)) / scales_along_dim_x;
+    int scales_idx_x = warp_idx % scales_along_dim_x;
+
+    InputType const* input_line =
+        input + (size_t)scales_idx_y * stride_x * dim_h + (size_t)scales_idx_h * stride_x + scales_idx_x * 128;
+    InputType input_amax = InputType(0);
+    int lane_id = threadIdx.x % 32;
+    InputType input_frag[4] = {0};
+
+    for (int i = 0; i < 4; i++) {
+      if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x) {
+        break;
+      } else {
+        input_frag[i] = input_line[lane_id];
+        input_amax = InputType(std::max(float(input_amax), std::fabs(float(input_frag[i]))));
+      }
+      input_line += 32;
+    }
+
+    InputType amax = find_max_elem_in_warp(input_amax);
+    ScaleType scale = amax != InputType(0.f) ? 448.f / ScaleType(amax) : 1.f;
+
+    if (lane_id == 0) {
+      scales
+          [(size_t)scales_idx_h * scales_along_dim_x * stride_scale_dim_y + (size_t)scales_idx_x * stride_scale_dim_y +
+           scales_idx_y] = ScaleType(1.f / scale);
+    }
+
+    OutputType* output_line =
+        output + (size_t)scales_idx_h * dim_y * dim_x + (size_t)scales_idx_y * dim_x + scales_idx_x * 128;
+    for (int i = 0; i < 4; i++) {
+      if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x) {
+        break;
+      } else {
+        ScaleType value = ScaleType(input_frag[i]) * scale;
+        output_line[lane_id] = OutputType(value);
+      }
+      output_line += 32;
+    }
+  }
+#endif
+}
+
+template <typename InputType, typename OutputType, typename ScaleType = float>
+__global__ void
+scale_128x128_kernel(OutputType* output, ScaleType* scales, InputType const* const input, int dim_x, int dim_y) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  int scales_along_dim_x = div_up(dim_x, 128);
+  int scales_along_dim_y = div_up(dim_y, 128);
+
+  for (int warp_idx = (blockIdx.x * blockDim.x + threadIdx.x) / 32; warp_idx < scales_along_dim_x * scales_along_dim_y;
+       warp_idx += gridDim.x * blockDim.x / 32) {
+    int scales_idx_y = warp_idx / scales_along_dim_x;
+    int scales_idx_x = warp_idx % scales_along_dim_x;
+
+    InputType const* input_line = input + scales_idx_y * 128 * dim_x + scales_idx_x * 128;
+    InputType input_amax = InputType(0);
+    int lane_id = threadIdx.x % 32;
+
+    for (int i = 0; i < 128; i++) {
+      if (scales_idx_y * 128 + i >= dim_y) {
+        break;
+      }
+      InputType const* input_d = input_line;
+
+      for (int j = 0; j < 4; j++) {
+        if (scales_idx_x * 128 + i * 32 + lane_id >= dim_x) {
+          break;
+        } else {
+          input_amax = InputType(std::max(float(input_amax), std::fabs(float(input_d[lane_id]))));
+        }
+        input_d += 32;
+      }
+      input_line += dim_x;
+    }
+
+    InputType amax = find_max_elem_in_warp(input_amax);
+    ScaleType scale = amax != InputType(0.f) ? 448.f / ScaleType(amax) : 1.f;
+
+    if (lane_id == 0) {
+      scales[scales_idx_y * scales_along_dim_x + scales_idx_x] = ScaleType(1.f / scale);
+    }
+
+    input_line = input + scales_idx_y * 128 * dim_x + scales_idx_x * 128;
+    OutputType* output_line = output + scales_idx_y * 128 * dim_x + scales_idx_x * 128;
+
+    for (int i = 0; i < 128; i++) {
+      if (scales_idx_y * 128 + i >= dim_y) {
+        break;
+      }
+      InputType const* input_d = input_line;
+      OutputType* output_d = output_line;
+
+      for (int j = 0; j < 4; j++) {
+        if (scales_idx_x * 128 + j * 32 + lane_id >= dim_x) {
+          break;
+        } else {
+          output_d[lane_id] = OutputType(ScaleType(input_d[lane_id]) * scale);
+        }
+        input_d += 32;
+        output_d += 32;
+      }
+
+      input_line += dim_x;
+      output_line += dim_x;
+    }
+  }
+#endif
+}
+
+template <typename OutputType>
+__global__ void fill_kernel(OutputType* output, size_t num_elems, float value) {
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_elems; idx += gridDim.x * blockDim.x) {
+    output[idx] = OutputType(value);
+  }
+}
+
+template <typename InputType, typename OutputType>
+__global__ void convert_kernel(OutputType* output, InputType const* const input, size_t num_elems) {
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_elems; idx += gridDim.x * blockDim.x) {
+    float value = float(input[idx]);
+    if (std::isnan(value)) {
+      output[idx] = OutputType(448);
+    } else {
+      output[idx] = OutputType(value);
+    }
+  }
+}
+
+static int kNumDeviceSMs = -1;
+
+void fp8_1x128_cs(
+    __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream) {
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+  scale_1x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(mat_quant, scales, mat, shape_x, shape_y);
+}
+
+void fp8_1x128_cs_reshape(
+    __nv_fp8_e4m3* mat_quant,
+    float* scales,
+    __nv_bfloat16 const* mat,
+    int shape_x,
+    int shape_h,
+    int shape_y,
+    int stride_x,
+    cudaStream_t stream) {
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+  scale_1x128_reshape_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(
+      mat_quant, scales, mat, shape_x, shape_h, shape_y, stride_x);
+}
+
+void fp8_128x128_cs(
+    __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream) {
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+  convert_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(mat_quant, mat, shape_x * shape_y);
+  fill_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(scales, div_up(shape_x, 128) * div_up(shape_y, 128), 1);
+}
+
+void gemm_dispatch_old(
+    void* mat_a,
+    int ld_a,
+    void* mat_b,
+    int ld_b,
+    void* mat_d,
+    int ld_d,
+    float* scales_a,
+    float* scales_b,
+    int shape_m,
+    int shape_n,
+    int shape_k,
+    cudaStream_t stream) {
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+  auto get_status = [=](int tile_n) -> std::pair<int, int> {
+    int num_blocks = div_up(shape_n, tile_n);
+    int num_waves = div_up(num_blocks, kNumDeviceSMs);
+    return {num_waves, num_blocks % kNumDeviceSMs};
+  };
+
+  auto compare = [=](int tile_n, int old_block_n) -> bool {
+    if (old_block_n == 0) return true;
+
+    auto status = get_status(tile_n);
+    auto old_status = get_status(old_block_n);
+    if (status.first != old_status.first) return status.first < old_status.first;
+    if (status.first == 1) return status.second > old_status.second;
+    return tile_n > old_block_n;
+  };
+
+  int best_tile_m = shape_m <= 64 ? 64 : 128, best_block_n = 0;
+  for (auto const& tile_n : {32, 64, 128})
+    if (compare(tile_n, best_block_n)) best_block_n = tile_n;
+
+#define DISPATCH_BLOCK_SIZE(TILE_M, TILE_N)      \
+  {                                              \
+    using GemmType = Fp8Gemm<                    \
+        __nv_fp8_e4m3,                           \
+        Layout::RowMajor,                        \
+        __nv_fp8_e4m3,                           \
+        Layout::ColMajor,                        \
+        __nv_bfloat16,                           \
+        Layout::RowMajor,                        \
+        float,                                   \
+        float,                                   \
+        float,                                   \
+        TILE_M,                                  \
+        TILE_N,                                  \
+        128,                                     \
+        ScaleType::PerSubChannel,                \
+        ScaleType::PerBlock,                     \
+        1,                                       \
+        128,                                     \
+        128,                                     \
+        128>;                                    \
+    GemmType::run(                               \
+        reinterpret_cast<__nv_fp8_e4m3*>(mat_a), \
+        ld_a,                                    \
+        reinterpret_cast<__nv_fp8_e4m3*>(mat_b), \
+        ld_b,                                    \
+        reinterpret_cast<__nv_bfloat16*>(mat_d), \
+        ld_d,                                    \
+        scales_a,                                \
+        scales_b,                                \
+        shape_m,                                 \
+        shape_n,                                 \
+        shape_k,                                 \
+        stream                                   \
+                                                 \
+    );                                           \
+  }                                              \
+  break
+
+#define DISPATCH_BLOCK_SIZE_M(TILE_N)     \
+  {                                       \
+    switch (best_tile_m) {                \
+      case 64:                            \
+        DISPATCH_BLOCK_SIZE(64, TILE_N);  \
+      case 128:                           \
+        DISPATCH_BLOCK_SIZE(128, TILE_N); \
+    }                                     \
+  }                                       \
+  break
+
+  switch (best_block_n) {
+    case 16:
+      DISPATCH_BLOCK_SIZE_M(16);
+    case 32:
+      DISPATCH_BLOCK_SIZE_M(32);
+    case 64:
+      DISPATCH_BLOCK_SIZE_M(64);
+    case 128:
+      DISPATCH_BLOCK_SIZE_M(128);
+  }
+#undef DISPATCH_BLOCK_SIZE
+#undef DISPATCH_BLOCK_SIZE_M
+}
+
+void gemm_dispatch_old(
+    void* mat_a,
+    void* mat_b,
+    void* mat_d,
+    float* scales_a,
+    float* scales_b,
+    int num_problems,
+    int64_t const* problem_m_offsets,
+    int max_shape_m,
+    int shape_n,
+    int shape_k,
+    cudaStream_t stream) {
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+  auto get_status = [=](int tile_n) -> std::pair<int, int> {
+    int num_blocks = div_up(shape_n, tile_n);
+    int num_waves = div_up(num_blocks, kNumDeviceSMs);
+    return {num_waves, num_blocks % kNumDeviceSMs};
+  };
+
+  auto compare = [=](int tile_n, int old_block_n) -> bool {
+    if (old_block_n == 0) return true;
+
+    auto status = get_status(tile_n), old_status = get_status(old_block_n);
+    if (status.first != old_status.first) return status.first < old_status.first;
+    if (status.first == 1) return status.second > old_status.second;
+    return tile_n > old_block_n;
+  };
+
+  int shape_m = 128;
+  int best_tile_m = shape_m <= 64 ? 64 : 128, best_block_n = 0;
+  for (auto const& tile_n : {64, 128})
+    if (compare(tile_n, best_block_n)) best_block_n = tile_n;
+
+#define DISPATCH_BLOCK_SIZE(TILE_M, TILE_N)      \
+  {                                              \
+    using GemmType = Fp8Gemm<                    \
+        __nv_fp8_e4m3,                           \
+        Layout::RowMajor,                        \
+        __nv_fp8_e4m3,                           \
+        Layout::ColMajor,                        \
+        __nv_bfloat16,                           \
+        Layout::RowMajor,                        \
+        float,                                   \
+        float,                                   \
+        float,                                   \
+        TILE_M,                                  \
+        TILE_N,                                  \
+        128,                                     \
+        ScaleType::PerSubChannel,                \
+        ScaleType::PerBlock,                     \
+        1,                                       \
+        128,                                     \
+        128,                                     \
+        128>;                                    \
+    GemmType::run(                               \
+        reinterpret_cast<__nv_fp8_e4m3*>(mat_a), \
+        reinterpret_cast<__nv_fp8_e4m3*>(mat_b), \
+        reinterpret_cast<__nv_bfloat16*>(mat_d), \
+        scales_a,                                \
+        scales_b,                                \
+        num_problems,                            \
+        problem_m_offsets,                       \
+        shape_n,                                 \
+        shape_k,                                 \
+        max_shape_m,                             \
+        stream                                   \
+                                                 \
+    );                                           \
+  }                                              \
+  break
+
+#define DISPATCH_BLOCK_SIZE_M(TILE_N)     \
+  {                                       \
+    switch (best_tile_m) {                \
+      case 64:                            \
+        DISPATCH_BLOCK_SIZE(64, TILE_N);  \
+      case 128:                           \
+        DISPATCH_BLOCK_SIZE(128, TILE_N); \
+    }                                     \
+  }                                       \
+  break
+
+  switch (best_block_n) {
+    case 16:
+      DISPATCH_BLOCK_SIZE_M(16);
+    case 32:
+      DISPATCH_BLOCK_SIZE_M(32);
+    case 64:
+      DISPATCH_BLOCK_SIZE_M(64);
+    case 128:
+      DISPATCH_BLOCK_SIZE_M(128);
+  }
+#undef DISPATCH_BLOCK_SIZE
+#undef DISPATCH_BLOCK_SIZE_M
+}
+
+void fp8_gemm_run(
+    __nv_fp8_e4m3* mat_a,
+    int ld_a,
+    __nv_fp8_e4m3* mat_b,
+    int ld_b,
+    __nv_bfloat16* mat_d,
+    int ld_d,
+    uint32_t shape_m,
+    uint32_t shape_n,
+    uint32_t shape_k,
+    float* scales_a,
+    float* scales_b,
+    cudaStream_t stream) {
+  if (shape_m == 0) {
+    return;
+  }
+
+  gemm_dispatch_old(
+      mat_a,
+      ld_a,
+      mat_b,
+      ld_b,
+      mat_d,
+      ld_d,
+      scales_a,
+      scales_b,
+      static_cast<int>(shape_m),
+      static_cast<int>(shape_n),
+      static_cast<int>(shape_k),
+      stream);
+}
+
+void fp8_gemm_run(
+    __nv_bfloat16 const* mat_a,
+    __nv_fp8_e4m3* fp8_mat_a,
+    int ld_a,
+    float* scales_a,
+    __nv_bfloat16 const* mat_b,
+    __nv_fp8_e4m3* fp8_mat_b,
+    int ld_b,
+    float* scales_b,
+    __nv_bfloat16* mat_d,
+    int ld_d,
+    uint32_t shape_m,
+    uint32_t shape_n,
+    uint32_t shape_k,
+    cudaStream_t stream,
+    bool internal_quantize_a = true,
+    bool internal_quantize_b = true) {
+  if (shape_m == 0) {
+    return;
+  }
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+
+  if (internal_quantize_a) {
+    scale_1x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(fp8_mat_a, scales_a, mat_a, shape_k, shape_m);
+  }
+  if (internal_quantize_b) {
+    scale_128x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(fp8_mat_b, scales_b, mat_b, shape_k, shape_n);
+  }
+  fp8_gemm_run(fp8_mat_a, ld_a, fp8_mat_b, ld_b, mat_d, ld_d, shape_m, shape_n, shape_k, scales_a, scales_b, stream);
+}
+
+void fp8_grouped_gemm_run(
+    __nv_bfloat16 const* mat_a,
+    __nv_fp8_e4m3* fp8_mat_a,
+    float* scales_a,
+    __nv_bfloat16 const* mat_b,
+    __nv_fp8_e4m3* fp8_mat_b,
+    float* scales_b,
+    __nv_bfloat16* mat_d,
+    int64_t const* problem_m_offsets,
+    int64_t* problem_m_padded_offsets,
+    int num_problems,
+    int64_t expected_m,
+    int64_t max_shape_m,
+    int64_t max_shape_m_padded,
+    int shape_n,
+    int shape_k,
+    cudaStream_t stream,
+    bool internal_quantize_a = true,
+    bool internal_quantize_b = true) {
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+
+  if (internal_quantize_a) {
+    constexpr int NumThreads = 256;
+    int scales_dim_x = div_up(shape_k, 128);
+    uint32_t scale_dim_x_mul, scale_dim_x_shr;
+    kernel_utils::find_divisor(scale_dim_x_mul, scale_dim_x_shr, scales_dim_x);
+
+    using BlockScan = cub::BlockScan<int64_t, NumThreads>;
+    int smem_size =
+        num_problems * sizeof(int64_t) * 2 + div_up(num_problems, NumThreads) * sizeof(BlockScan::TempStorage);
+    int num_blocks = std::min(static_cast<int64_t>(kNumDeviceSMs), div_up(max_shape_m * scales_dim_x, NumThreads / 32));
+    // Binary search is expected to have lower complexity when max_shape_m is small
+    bool use_binary_search =
+        static_cast<double>(max_shape_m) * scales_dim_x / static_cast<double>(NumThreads * num_blocks / 32) <=
+        static_cast<double>(num_problems) / std::log2(static_cast<double>(num_problems));
+    auto kernel = use_binary_search ? scale_1x128_kernel<true, NumThreads, __nv_bfloat16, __nv_fp8_e4m3>
+                                    : scale_1x128_kernel<false, NumThreads, __nv_bfloat16, __nv_fp8_e4m3>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    kernel<<<num_blocks, NumThreads, smem_size, stream>>>(
+        fp8_mat_a,
+        scales_a,
+        mat_a,
+        problem_m_offsets,
+        problem_m_padded_offsets,
+        num_problems,
+        shape_k,
+        max_shape_m_padded,
+        scale_dim_x_mul,
+        scale_dim_x_shr);
+  } else {
+    constexpr int NumThreads = 256;
+    using BlockScan = cub::BlockScan<int64_t, NumThreads>;
+    int smem_size = num_problems * sizeof(int64_t) + div_up(num_problems, NumThreads) * sizeof(BlockScan::TempStorage);
+    auto kernel = problem_m_padding_kernel<NumThreads>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    kernel<<<1, NumThreads, smem_size, stream>>>(problem_m_offsets, problem_m_padded_offsets, num_problems);
+  }
+
+  if (internal_quantize_b) {
+    __nv_fp8_e4m3* fp8_mat_b_tmp = fp8_mat_b;
+    float* scales_b_tmp = scales_b;
+    __nv_bfloat16 const* mat_b_tmp = mat_b;
+
+    for (int i = 0; i < num_problems; i++) {
+      scale_128x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(fp8_mat_b_tmp, scales_b_tmp, mat_b_tmp, shape_k, shape_n);
+      fp8_mat_b_tmp += shape_n * shape_k;
+      mat_b_tmp += shape_n * shape_k;
+      scales_b_tmp += div_up(shape_n, 128) * div_up(shape_k, 128);
+    }
+  }
+  using GemmType = Fp8Gemm<
+      __nv_fp8_e4m3,
+      Layout::RowMajor,
+      __nv_fp8_e4m3,
+      Layout::ColMajor,
+      __nv_bfloat16,
+      Layout::RowMajor,
+      float,
+      float,
+      float,
+      128,
+      64,
+      128,
+      ScaleType::PerSubChannel,
+      ScaleType::PerBlock,
+      1,
+      128,
+      128,
+      128>;
+  GemmType::run(
+      fp8_mat_a,
+      fp8_mat_b,
+      mat_d,
+      scales_a,
+      scales_b,
+      num_problems,
+      problem_m_offsets,
+      shape_n,
+      shape_k,
+      static_cast<int>(max_shape_m),
+      stream,
+      128,
+      problem_m_padded_offsets,
+      static_cast<int>(max_shape_m_padded));
+}
+
+void fp8_stride_batch_gemm_run(
+    __nv_bfloat16 const* mat_a,
+    __nv_fp8_e4m3* fp8_mat_a,
+    float* scales_a,
+    int ld_a,
+    int stride_a,
+    int stride_scales_a,
+    __nv_bfloat16 const* mat_b,
+    __nv_fp8_e4m3* fp8_mat_b,
+    float* scales_b,
+    int ld_b,
+    int stride_b,
+    __nv_bfloat16* mat_d,
+    int ld_d,
+    int stride_d,
+    uint32_t num_problems,
+    uint32_t shape_m,
+    uint32_t shape_n,
+    uint32_t shape_k,
+    cudaStream_t stream,
+    bool internal_quantize_a = true,
+    bool internal_quantize_b = true) {
+  if (shape_m == 0) {
+    return;
+  }
+
+  if (kNumDeviceSMs < 0) {
+    kNumDeviceSMs = getMultiProcessorCount();
+  }
+  if (internal_quantize_a) {
+    scale_1x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(fp8_mat_a, scales_a, mat_a, shape_k, shape_m * num_problems);
+  }
+  if (internal_quantize_b) {
+    scale_128x128_kernel<<<kNumDeviceSMs, 256, 0, stream>>>(
+        fp8_mat_b, scales_b, mat_b, shape_k, shape_n * num_problems);
+  }
+  using GemmType = Fp8Gemm<
+      __nv_fp8_e4m3,
+      Layout::RowMajor,
+      __nv_fp8_e4m3,
+      Layout::ColMajor,
+      __nv_bfloat16,
+      Layout::RowMajor,
+      float,
+      float,
+      float,
+      128,
+      64,
+      128,
+      ScaleType::PerSubChannel,
+      ScaleType::PerBlock,
+      1,
+      128,
+      128,
+      128>;
+  GemmType::run(
+      fp8_mat_a,
+      ld_a,
+      stride_a,
+      fp8_mat_b,
+      ld_b,
+      stride_b,
+      mat_d,
+      ld_d,
+      stride_d,
+      scales_a,
+      stride_scales_a,
+      scales_b,
+      static_cast<int>(shape_m),
+      static_cast<int>(shape_n),
+      static_cast<int>(shape_k),
+      static_cast<int>(num_problems),
+      stream);
+}
+
+}  // namespace tensorrt_llm::kernels::fp8_blockscale_gemm

--- a/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_runner.cu
+++ b/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_runner.cu
@@ -1,0 +1,422 @@
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.cu
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "trt_fp8_blockscale_gemm_kernel.cuh"
+#include "trt_fp8_blockscale_gemm_runner.cuh"
+#include "utils.h"
+
+namespace tensorrt_llm::kernels::fp8_blockscale_gemm {
+
+template <typename ElementA, typename ElementB, typename ElementD>
+CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::CutlassFp8BlockScaleGemmRunner() {}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::~CutlassFp8BlockScaleGemmRunner() {}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::gemm(
+    void* mat_d,
+    void const* mat_a,
+    void const* mat_b,
+    int shape_m,
+    int shape_n,
+    int shape_k,
+    cudaStream_t stream,
+    float const* scales_a,
+    float const* scales_b) {
+  constexpr bool internal_quantize_a = !std::is_same_v<ElementA, __nv_fp8_e4m3>;
+  constexpr bool internal_quantize_b = !std::is_same_v<ElementB, __nv_fp8_e4m3>;
+  __nv_fp8_e4m3* fp8_mat_a;
+  __nv_fp8_e4m3* fp8_mat_b;
+  float* per_token_per_128c_scales;
+  float* per_block_scales;
+
+  auto* ws_ptr = workspace_;
+  if constexpr (internal_quantize_a || internal_quantize_b) {
+    TORCH_CHECK(ws_ptr != nullptr);
+  }
+
+  if constexpr (internal_quantize_a) {
+    fp8_mat_a = reinterpret_cast<__nv_fp8_e4m3*>(ws_ptr);
+    ws_ptr += max_shape_m_4_align_ * shape_k * sizeof(__nv_fp8_e4m3);
+    per_token_per_128c_scales = reinterpret_cast<float*>(ws_ptr);
+    ws_ptr += max_shape_m_4_align_ * div_up(shape_k, 128) * sizeof(float);
+  }
+
+  if constexpr (internal_quantize_b) {
+    fp8_mat_b = reinterpret_cast<__nv_fp8_e4m3*>(ws_ptr);
+    ws_ptr += shape_n * shape_k * sizeof(__nv_fp8_e4m3);
+    per_block_scales = reinterpret_cast<float*>(ws_ptr);
+    ws_ptr += div_up(shape_n, 128) * div_up(shape_k, 128) * sizeof(float);
+  }
+
+#ifdef COMPILE_HOPPER_TMA_GEMMS
+  if constexpr (internal_quantize_a && internal_quantize_b) {
+    fp8_gemm_run(
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a),
+        fp8_mat_a,
+        shape_k,
+        per_token_per_128c_scales,
+        reinterpret_cast<__nv_bfloat16 const*>(mat_b),
+        fp8_mat_b,
+        shape_k,
+        per_block_scales,
+        reinterpret_cast<__nv_bfloat16*>(mat_d),
+        shape_n,
+        shape_m,
+        shape_n,
+        shape_k,
+        stream,
+        internal_quantize_a,
+        internal_quantize_b);
+  }
+
+  if constexpr (internal_quantize_a && !internal_quantize_b) {
+    fp8_gemm_run(
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a),
+        fp8_mat_a,
+        shape_k,
+        per_token_per_128c_scales,
+        nullptr,
+        reinterpret_cast<__nv_fp8_e4m3*>(const_cast<void*>(mat_b)),
+        shape_k,
+        const_cast<float*>(scales_b),
+        reinterpret_cast<__nv_bfloat16*>(mat_d),
+        shape_n,
+        shape_m,
+        shape_n,
+        shape_k,
+        stream,
+        internal_quantize_a,
+        internal_quantize_b);
+  }
+#else   // COMPILE_HOPPER_TMA_GEMMS
+  TORCH_CHECK(false, "fp8 blockscale gemm only support Hopper.");
+#endif  // COMPILE_HOPPER_TMA_GEMMS
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::gemm(
+    __nv_fp8_e4m3 const* mat_a,
+    int ld_a,
+    __nv_fp8_e4m3 const* mat_b,
+    int ld_b,
+    __nv_bfloat16* mat_d,
+    int ld_d,
+    int shape_m,
+    int shape_n,
+    int shape_k,
+    float const* scales_a,
+    float const* scales_b,
+    cudaStream_t stream) {
+  fp8_gemm_run(
+      const_cast<__nv_fp8_e4m3*>(mat_a),
+      ld_a,
+      const_cast<__nv_fp8_e4m3*>(mat_b),
+      ld_b,
+      mat_d,
+      ld_d,
+      shape_m,
+      shape_n,
+      shape_k,
+      const_cast<float*>(scales_a),
+      const_cast<float*>(scales_b),
+      stream);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::moeGemm(
+    void* mat_d,
+    void const* mat_a,
+    void const* mat_b,
+    int64_t const* problem_m_offsets,
+    size_t num_problems,
+    size_t shape_n,
+    size_t shape_k,
+    cudaStream_t stream,
+    float const* scales_a,
+    float const* scales_b) {
+  constexpr bool internal_quantize_a = !std::is_same_v<ElementA, __nv_fp8_e4m3>;
+  constexpr bool internal_quantize_b = !std::is_same_v<ElementB, __nv_fp8_e4m3>;
+
+  __nv_fp8_e4m3* fp8_mat_a;
+  float* per_token_per_128c_scales;
+  __nv_fp8_e4m3* fp8_mat_b;
+  float* per_block_scales;
+  int64_t* problem_m_padded_offsets;
+
+  auto* ws_ptr = workspace_;
+  if constexpr (internal_quantize_a || internal_quantize_b) {
+    TORCH_CHECK(ws_ptr != nullptr);
+  }
+
+  if constexpr (internal_quantize_a) {
+    fp8_mat_a = reinterpret_cast<__nv_fp8_e4m3*>(ws_ptr);
+    ws_ptr += max_shape_m_4_align_ * shape_k * sizeof(__nv_fp8_e4m3);
+    per_token_per_128c_scales = reinterpret_cast<float*>(ws_ptr);
+    ws_ptr += max_shape_m_32_align_padded_ * div_up(shape_k, 128) * sizeof(float);
+  } else {
+    fp8_mat_a = reinterpret_cast<__nv_fp8_e4m3*>(const_cast<void*>(mat_a));
+    per_token_per_128c_scales = const_cast<float*>(scales_a);
+  }
+
+  if constexpr (internal_quantize_b) {
+    fp8_mat_b = reinterpret_cast<__nv_fp8_e4m3*>(ws_ptr);
+    ws_ptr += num_problems * shape_n * shape_k * sizeof(__nv_fp8_e4m3);
+    per_block_scales = reinterpret_cast<float*>(ws_ptr);
+  } else {
+    for (int i = 0; i < num_problems; i++) {
+      fp8_mat_b = reinterpret_cast<__nv_fp8_e4m3*>(const_cast<void*>(mat_b));
+      per_block_scales = const_cast<float*>(scales_b);
+    }
+  }
+
+  problem_m_padded_offsets = reinterpret_cast<int64_t*>(ws_ptr);
+  ws_ptr += (num_problems + 1) * sizeof(int64_t);
+
+#ifdef COMPILE_HOPPER_TMA_GEMMS
+  if constexpr (std::is_same_v<ElementA, __nv_bfloat16> && std::is_same_v<ElementB, __nv_bfloat16>) {
+    fp8_grouped_gemm_run(
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a),
+        fp8_mat_a,
+        per_token_per_128c_scales,
+        reinterpret_cast<__nv_bfloat16 const*>(mat_b),
+        fp8_mat_b,
+        per_block_scales,
+        reinterpret_cast<__nv_bfloat16*>(mat_d),
+        problem_m_offsets,
+        problem_m_padded_offsets,
+        num_problems,
+        expected_m_,
+        max_shape_m_4_align_,
+        max_shape_m_32_align_padded_,
+        shape_n,
+        shape_k,
+        stream,
+        internal_quantize_a,
+        internal_quantize_b);
+  } else if constexpr (std::is_same_v<ElementA, __nv_bfloat16> && std::is_same_v<ElementB, __nv_fp8_e4m3>) {
+    fp8_grouped_gemm_run(
+        reinterpret_cast<__nv_bfloat16 const*>(mat_a),
+        fp8_mat_a,
+        per_token_per_128c_scales,
+        nullptr,
+        fp8_mat_b,
+        per_block_scales,
+        reinterpret_cast<__nv_bfloat16*>(mat_d),
+        problem_m_offsets,
+        problem_m_padded_offsets,
+        num_problems,
+        expected_m_,
+        max_shape_m_4_align_,
+        max_shape_m_32_align_padded_,
+        shape_n,
+        shape_k,
+        stream,
+        internal_quantize_a,
+        internal_quantize_b);
+  } else if constexpr (std::is_same_v<ElementA, __nv_fp8_e4m3> && std::is_same_v<ElementB, __nv_fp8_e4m3>) {
+    fp8_grouped_gemm_run(
+        nullptr,
+        fp8_mat_a,
+        per_token_per_128c_scales,
+        reinterpret_cast<__nv_bfloat16 const*>(mat_b),
+        fp8_mat_b,
+        per_block_scales,
+        reinterpret_cast<__nv_bfloat16*>(mat_d),
+        problem_m_offsets,
+        problem_m_padded_offsets,
+        num_problems,
+        expected_m_,
+        max_shape_m_4_align_,
+        max_shape_m_32_align_padded_,
+        shape_n,
+        shape_k,
+        stream,
+        internal_quantize_a,
+        internal_quantize_b);
+  } else {
+    TORCH_CHECK(false, "fp8 blockscale gemm only support __nv_fp8_e4m3 or bfloat16 as dataType.");
+  }
+#else
+  TORCH_CHECK(false, "fp8 blockscale gemm only support Hopper.");
+#endif
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::strideBatchGemm(
+    __nv_bfloat16* mat_d,
+    int ld_d,
+    int stride_d,
+    __nv_fp8_e4m3* mat_a,
+    int ld_a,
+    int stride_a,
+    __nv_fp8_e4m3* mat_b,
+    int ld_b,
+    int stride_b,
+    int num_problems,
+    int shape_m,
+    int shape_n,
+    int shape_k,
+    cudaStream_t stream,
+    float* scales_a,
+    int stride_scales_a,
+    float* scales_b) {
+  fp8_stride_batch_gemm_run(
+      nullptr,
+      mat_a,
+      scales_a,
+      ld_a,
+      stride_a,
+      stride_scales_a,
+      nullptr,
+      mat_b,
+      scales_b,
+      ld_b,
+      stride_b,
+      mat_d,
+      ld_d,
+      stride_d,
+      num_problems,
+      shape_m,
+      shape_n,
+      shape_k,
+      stream,
+      false,
+      false);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::fp8CS1x128(
+    __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream) {
+  fp8_1x128_cs(mat_quant, scales, mat, shape_x, shape_y, stream);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::fp8CS1x128Reshape(
+    __nv_fp8_e4m3* mat_quant,
+    float* scales,
+    __nv_bfloat16 const* mat,
+    int shape_x,
+    int shape_h,
+    int shape_y,
+    int stride_x,
+    cudaStream_t stream) {
+  fp8_1x128_cs_reshape(mat_quant, scales, mat, shape_x, shape_h, shape_y, stride_x, stream);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+void CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::fp8CS128x128(
+    __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream) {
+  fp8_128x128_cs(mat_quant, scales, mat, shape_x, shape_y, stream);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getWorkspaceSizeBase(
+    size_t max_shape_m, size_t shape_n, size_t shape_k, size_t num_problems) {
+  max_shape_m_4_align_ = std::max(max_shape_m_4_align_, int64_t(div_up(max_shape_m, 4) * 4));
+  if (expected_m_ == 0) {
+    expected_m_ = div_up(max_shape_m_4_align_, num_problems);
+  }
+  max_shape_m_32_align_padded_ = int64_t(div_up(max_shape_m + num_problems * 31, 32) * 32);
+
+  constexpr bool internal_quantize_a = !std::is_same_v<ElementA, __nv_fp8_e4m3>;
+  constexpr bool internal_quantize_b = !std::is_same_v<ElementB, __nv_fp8_e4m3>;
+  size_t total_workspace_size = 0;
+  if constexpr (internal_quantize_a) {
+    // fp8_mat_a
+    total_workspace_size += max_shape_m_4_align_ * shape_k * sizeof(__nv_fp8_e4m3);
+    // scales_a
+    total_workspace_size += max_shape_m_32_align_padded_ * div_up(shape_k, 128) * sizeof(float);
+  }
+
+  if constexpr (internal_quantize_b) {
+    // fp8_mat_b
+    total_workspace_size += num_problems * shape_n * shape_k * sizeof(__nv_fp8_e4m3);
+    // scales_b
+    total_workspace_size += num_problems * div_up(shape_k, 128) * div_up(shape_n, 128) * sizeof(float);
+  }
+
+  total_workspace_size += (num_problems + 1) * sizeof(int64_t);
+
+  return total_workspace_size;
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getWorkspaceSize(
+    size_t shape_m, size_t shape_n, size_t shape_k, size_t top_k, size_t num_problems) {
+  expected_m_ = shape_m;
+  return getWorkspaceSizeBase(shape_m * top_k, shape_n, shape_k, num_problems);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t
+CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getFP8DataSize(int shape_m, int shape_n, bool is_act) {
+  int shape_m_4_align = div_up(shape_m, 4) * 4;
+  constexpr bool internal_quantize_a = !std::is_same_v<ElementA, __nv_fp8_e4m3>;
+  constexpr bool internal_quantize_b = !std::is_same_v<ElementB, __nv_fp8_e4m3>;
+  if (is_act && internal_quantize_a) {
+    return div_up(shape_m_4_align * shape_n * sizeof(__nv_fp8_e4m3), 128) * 128;
+  }
+
+  if ((!is_act) && internal_quantize_b) {
+    return div_up(shape_m * shape_n * sizeof(__nv_fp8_e4m3), 128) * 128;
+  }
+  return 0;
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getActScaleSize(int shape_m, int shape_k) {
+  int shape_m_4_align = div_up(shape_m, 4) * 4;
+  constexpr bool internal_quantize_a = !std::is_same_v<ElementA, __nv_fp8_e4m3>;
+  size_t total_workspace_size = 0;
+  if constexpr (internal_quantize_a) {
+    // scales_a
+    total_workspace_size += div_up(shape_m_4_align * div_up(shape_k, 128) * sizeof(float), 128) * 128;
+  }
+  return total_workspace_size;
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getWeightScaleSize(int shape_n, int shape_k) {
+  constexpr bool internal_quantize_b = !std::is_same_v<ElementB, __nv_fp8_e4m3>;
+  size_t total_workspace_size = 0;
+  if constexpr (internal_quantize_b) {
+    // scales_b
+    total_workspace_size += div_up(div_up(shape_k, 128) * div_up(shape_n, 128) * sizeof(float), 128) * 128;
+  }
+
+  return total_workspace_size;
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getActWorkspaceSize(int shape_m, int shape_k) {
+  return getFP8DataSize(shape_m, shape_k, true) + getActScaleSize(shape_m, shape_k);
+}
+
+template <typename ElementA, typename ElementB, typename ElementD>
+size_t CutlassFp8BlockScaleGemmRunner<ElementA, ElementB, ElementD>::getWeightWorkspaceSize(int shape_n, int shape_k) {
+  return getFP8DataSize(shape_n, shape_k, false) + getWeightScaleSize(shape_n, shape_k);
+}
+
+template class CutlassFp8BlockScaleGemmRunner<__nv_bfloat16, __nv_bfloat16, __nv_bfloat16>;
+template class CutlassFp8BlockScaleGemmRunner<__nv_bfloat16, __nv_fp8_e4m3, __nv_bfloat16>;
+template class CutlassFp8BlockScaleGemmRunner<__nv_fp8_e4m3, __nv_bfloat16, __nv_bfloat16>;
+template class CutlassFp8BlockScaleGemmRunner<__nv_fp8_e4m3, __nv_fp8_e4m3, __nv_bfloat16>;
+
+}  // namespace tensorrt_llm::kernels::fp8_blockscale_gemm

--- a/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_runner.cuh
+++ b/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_gemm_runner.cuh
@@ -1,0 +1,228 @@
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cuda_fp8.h>
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+#include <vector>
+
+// non-persistent-cooperative GEMM
+namespace tensorrt_llm::kernels::fp8_blockscale_gemm {
+
+class CutlassFp8BlockScaleGemmRunnerInterface {
+ public:
+  CutlassFp8BlockScaleGemmRunnerInterface() {}
+
+  virtual ~CutlassFp8BlockScaleGemmRunnerInterface() {}
+
+  virtual void gemm(
+      void* mat_d,
+      void const* mat_a,
+      void const* mat_b,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      cudaStream_t stream,
+      float const* scales_a = nullptr,
+      float const* scales_b = nullptr) = 0;
+
+  virtual void gemm(
+      __nv_fp8_e4m3 const* mat_a,
+      int ld_a,
+      __nv_fp8_e4m3 const* mat_b,
+      int ld_b,
+      __nv_bfloat16* mat_d,
+      int ld_d,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      float const* scales_a,
+      float const* scales_b,
+      cudaStream_t stream) = 0;
+
+  virtual void moeGemm(
+      void* mat_d,
+      void const* mat_a,
+      void const* mat_b,
+      int64_t const* problem_m_offsets,
+      size_t num_problems,
+      size_t shape_n,
+      size_t shape_k,
+      cudaStream_t stream,
+      float const* scales_a = nullptr,
+      float const* scales_b = nullptr) = 0;
+
+  virtual void strideBatchGemm(
+      __nv_bfloat16* mat_d,
+      int ld_d,
+      int stride_d,
+      __nv_fp8_e4m3* mat_a,
+      int ld_a,
+      int stride_a,
+      __nv_fp8_e4m3* mat_b,
+      int ld_b,
+      int stride_b,
+      int num_problems,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      cudaStream_t stream,
+      float* scales_a,
+      int stride_scales_a,
+      float* scales_b) = 0;
+
+  virtual void fp8CS1x128(
+      __nv_fp8_e4m3* mat_quant,
+      float* scales,
+      __nv_bfloat16 const* mat,
+      int shape_x,
+      int shape_y,
+      cudaStream_t stream) = 0;
+  virtual void fp8CS1x128Reshape(
+      __nv_fp8_e4m3* mat_quant,
+      float* scales,
+      __nv_bfloat16 const* mat,
+      int shape_x,
+      int shape_h,
+      int shape_y,
+      int stride_x,
+      cudaStream_t stream) = 0;
+  virtual void fp8CS128x128(
+      __nv_fp8_e4m3* mat_quant,
+      float* scales,
+      __nv_bfloat16 const* mat,
+      int shape_x,
+      int shape_y,
+      cudaStream_t stream) = 0;
+  // Returns desired workspace size in bytes.
+  virtual size_t getWorkspaceSizeBase(size_t max_shape_m, size_t shape_n, size_t shape_k, size_t num_problems = 1) = 0;
+  virtual size_t
+  getWorkspaceSize(size_t shape_m, size_t shape_n, size_t shape_k, size_t top_k = 1, size_t num_problems = 1) = 0;
+
+  void configureWorkspace(char* ws_ptr) {
+    workspace_ = ws_ptr;
+  }
+
+  virtual size_t getFP8DataSize(int shape_m, int shape_n, bool is_act) = 0;
+  virtual size_t getActScaleSize(int shape_m, int shape_k) = 0;
+  virtual size_t getWeightScaleSize(int shape_n, int shape_k) = 0;
+  virtual size_t getActWorkspaceSize(int shape_m, int shape_k) = 0;
+  virtual size_t getWeightWorkspaceSize(int shape_n, int shape_k) = 0;
+
+ protected:
+  char* workspace_ = nullptr;
+};
+
+template <typename ElementA, typename ElementB, typename ElementD>
+class CutlassFp8BlockScaleGemmRunner : public CutlassFp8BlockScaleGemmRunnerInterface {
+ public:
+  CutlassFp8BlockScaleGemmRunner();
+  ~CutlassFp8BlockScaleGemmRunner();
+
+  void gemm(
+      void* mat_d,
+      void const* mat_a,
+      void const* mat_b,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      cudaStream_t stream,
+      float const* scales_a = nullptr,
+      float const* scales_b = nullptr) override;
+
+  void gemm(
+      __nv_fp8_e4m3 const* mat_a,
+      int ld_a,
+      __nv_fp8_e4m3 const* mat_b,
+      int ld_b,
+      __nv_bfloat16* mat_d,
+      int ld_d,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      float const* scales_a,
+      float const* scales_b,
+      cudaStream_t stream) override;
+
+  void moeGemm(
+      void* mat_d,
+      void const* mat_a,
+      void const* mat_b,
+      int64_t const* problem_m_offsets,
+      size_t num_problems,
+      size_t shape_n,
+      size_t shape_k,
+      cudaStream_t stream,
+      float const* scales_a = nullptr,
+      float const* scales_b = nullptr) override;
+
+  void strideBatchGemm(
+      __nv_bfloat16* mat_d,
+      int ld_d,
+      int stride_d,
+      __nv_fp8_e4m3* mat_a,
+      int ld_a,
+      int stride_a,
+      __nv_fp8_e4m3* mat_b,
+      int ld_b,
+      int stride_b,
+      int num_problems,
+      int shape_m,
+      int shape_n,
+      int shape_k,
+      cudaStream_t stream,
+      float* scales_a,
+      int stride_scales_a,
+      float* scales_b) override;
+
+  void fp8CS1x128(
+      __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream)
+      override;
+  void fp8CS1x128Reshape(
+      __nv_fp8_e4m3* mat_quant,
+      float* scales,
+      __nv_bfloat16 const* mat,
+      int shape_x,
+      int shape_h,
+      int shape_y,
+      int stride_x,
+      cudaStream_t stream) override;
+  void fp8CS128x128(
+      __nv_fp8_e4m3* mat_quant, float* scales, __nv_bfloat16 const* mat, int shape_x, int shape_y, cudaStream_t stream)
+      override;
+
+  // Returns desired workspace size in bytes.
+  size_t getWorkspaceSizeBase(size_t max_shape_m, size_t shape_n, size_t shape_k, size_t num_problems = 1) override;
+  size_t
+  getWorkspaceSize(size_t shape_m, size_t shape_n, size_t shape_k, size_t top_k = 1, size_t num_problems = 1) override;
+
+  size_t getFP8DataSize(int shape_m, int shape_n, bool is_act) override;
+  size_t getActScaleSize(int shape_m, int shape_k) override;
+  size_t getWeightScaleSize(int shape_n, int shape_k) override;
+  size_t getActWorkspaceSize(int shape_m, int shape_k) override;
+  size_t getWeightWorkspaceSize(int shape_n, int shape_k) override;
+
+ private:
+  int64_t max_shape_m_4_align_ = 0;
+  int64_t max_shape_m_32_align_padded_ = 0;
+  int64_t expected_m_ = 0;
+};
+
+}  // namespace tensorrt_llm::kernels::fp8_blockscale_gemm

--- a/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_mma_utils.cuh
+++ b/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_mma_utils.cuh
@@ -1,0 +1,1598 @@
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_mma_utils.cuh
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cuda.h>
+
+#include <cute/arch/util.hpp>
+
+namespace tensorrt_llm::kernels::fp8_blockscale_gemm {
+
+struct SM90_64x16x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %10, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n16k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7},"
+        " %8,"
+        " %9,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00), "+f"(d01), "+f"(d02), "+f"(d03), "+f"(d04), "+f"(d05), "+f"(d06), "+f"(d07)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(desc_a, desc_b, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 16;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x32x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %18, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n32k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7, "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15},"
+        " %16,"
+        " %17,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 32;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x48x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %26, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n48k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7, "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15, "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23},"
+        " %24,"
+        " %25,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 48;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x56x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      float& d24,
+      float& d25,
+      float& d26,
+      float& d27,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %30, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n56k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27}, "
+        " %28,"
+        " %29,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23),
+          "+f"(d24),
+          "+f"(d25),
+          "+f"(d26),
+          "+f"(d27)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        d[24],
+        d[25],
+        d[26],
+        d[27],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 56;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x64x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      float& d24,
+      float& d25,
+      float& d26,
+      float& d27,
+      float& d28,
+      float& d29,
+      float& d30,
+      float& d31,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %34, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n64k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31}, "
+        " %32,"
+        " %33,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23),
+          "+f"(d24),
+          "+f"(d25),
+          "+f"(d26),
+          "+f"(d27),
+          "+f"(d28),
+          "+f"(d29),
+          "+f"(d30),
+          "+f"(d31)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        d[24],
+        d[25],
+        d[26],
+        d[27],
+        d[28],
+        d[29],
+        d[30],
+        d[31],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 64;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x96x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      float& d24,
+      float& d25,
+      float& d26,
+      float& d27,
+      float& d28,
+      float& d29,
+      float& d30,
+      float& d31,
+      float& d32,
+      float& d33,
+      float& d34,
+      float& d35,
+      float& d36,
+      float& d37,
+      float& d38,
+      float& d39,
+      float& d40,
+      float& d41,
+      float& d42,
+      float& d43,
+      float& d44,
+      float& d45,
+      float& d46,
+      float& d47,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %50, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n96k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47}, "
+        " %48,"
+        " %49,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23),
+          "+f"(d24),
+          "+f"(d25),
+          "+f"(d26),
+          "+f"(d27),
+          "+f"(d28),
+          "+f"(d29),
+          "+f"(d30),
+          "+f"(d31),
+          "+f"(d32),
+          "+f"(d33),
+          "+f"(d34),
+          "+f"(d35),
+          "+f"(d36),
+          "+f"(d37),
+          "+f"(d38),
+          "+f"(d39),
+          "+f"(d40),
+          "+f"(d41),
+          "+f"(d42),
+          "+f"(d43),
+          "+f"(d44),
+          "+f"(d45),
+          "+f"(d46),
+          "+f"(d47)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        d[24],
+        d[25],
+        d[26],
+        d[27],
+        d[28],
+        d[29],
+        d[30],
+        d[31],
+        d[32],
+        d[33],
+        d[34],
+        d[35],
+        d[36],
+        d[37],
+        d[38],
+        d[39],
+        d[40],
+        d[41],
+        d[42],
+        d[43],
+        d[44],
+        d[45],
+        d[46],
+        d[47],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 96;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x112x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      float& d24,
+      float& d25,
+      float& d26,
+      float& d27,
+      float& d28,
+      float& d29,
+      float& d30,
+      float& d31,
+      float& d32,
+      float& d33,
+      float& d34,
+      float& d35,
+      float& d36,
+      float& d37,
+      float& d38,
+      float& d39,
+      float& d40,
+      float& d41,
+      float& d42,
+      float& d43,
+      float& d44,
+      float& d45,
+      float& d46,
+      float& d47,
+      float& d48,
+      float& d49,
+      float& d50,
+      float& d51,
+      float& d52,
+      float& d53,
+      float& d54,
+      float& d55,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %58, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n112k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47,  "
+        " %48,  %49,  %50,  %51,  %52,  %53,  %54,  %55}, "
+        " %56,"
+        " %57,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23),
+          "+f"(d24),
+          "+f"(d25),
+          "+f"(d26),
+          "+f"(d27),
+          "+f"(d28),
+          "+f"(d29),
+          "+f"(d30),
+          "+f"(d31),
+          "+f"(d32),
+          "+f"(d33),
+          "+f"(d34),
+          "+f"(d35),
+          "+f"(d36),
+          "+f"(d37),
+          "+f"(d38),
+          "+f"(d39),
+          "+f"(d40),
+          "+f"(d41),
+          "+f"(d42),
+          "+f"(d43),
+          "+f"(d44),
+          "+f"(d45),
+          "+f"(d46),
+          "+f"(d47),
+          "+f"(d48),
+          "+f"(d49),
+          "+f"(d50),
+          "+f"(d51),
+          "+f"(d52),
+          "+f"(d53),
+          "+f"(d54),
+          "+f"(d55)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        d[24],
+        d[25],
+        d[26],
+        d[27],
+        d[28],
+        d[29],
+        d[30],
+        d[31],
+        d[32],
+        d[33],
+        d[34],
+        d[35],
+        d[36],
+        d[37],
+        d[38],
+        d[39],
+        d[40],
+        d[41],
+        d[42],
+        d[43],
+        d[44],
+        d[45],
+        d[46],
+        d[47],
+        d[48],
+        d[49],
+        d[50],
+        d[51],
+        d[52],
+        d[53],
+        d[54],
+        d[55],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 112;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x128x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      float& d24,
+      float& d25,
+      float& d26,
+      float& d27,
+      float& d28,
+      float& d29,
+      float& d30,
+      float& d31,
+      float& d32,
+      float& d33,
+      float& d34,
+      float& d35,
+      float& d36,
+      float& d37,
+      float& d38,
+      float& d39,
+      float& d40,
+      float& d41,
+      float& d42,
+      float& d43,
+      float& d44,
+      float& d45,
+      float& d46,
+      float& d47,
+      float& d48,
+      float& d49,
+      float& d50,
+      float& d51,
+      float& d52,
+      float& d53,
+      float& d54,
+      float& d55,
+      float& d56,
+      float& d57,
+      float& d58,
+      float& d59,
+      float& d60,
+      float& d61,
+      float& d62,
+      float& d63,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %66, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n128k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47,  "
+        " %48,  %49,  %50,  %51,  %52,  %53,  %54,  %55,  "
+        " %56,  %57,  %58,  %59,  %60,  %61,  %62,  %63}, "
+        " %64,"
+        " %65,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23),
+          "+f"(d24),
+          "+f"(d25),
+          "+f"(d26),
+          "+f"(d27),
+          "+f"(d28),
+          "+f"(d29),
+          "+f"(d30),
+          "+f"(d31),
+          "+f"(d32),
+          "+f"(d33),
+          "+f"(d34),
+          "+f"(d35),
+          "+f"(d36),
+          "+f"(d37),
+          "+f"(d38),
+          "+f"(d39),
+          "+f"(d40),
+          "+f"(d41),
+          "+f"(d42),
+          "+f"(d43),
+          "+f"(d44),
+          "+f"(d45),
+          "+f"(d46),
+          "+f"(d47),
+          "+f"(d48),
+          "+f"(d49),
+          "+f"(d50),
+          "+f"(d51),
+          "+f"(d52),
+          "+f"(d53),
+          "+f"(d54),
+          "+f"(d55),
+          "+f"(d56),
+          "+f"(d57),
+          "+f"(d58),
+          "+f"(d59),
+          "+f"(d60),
+          "+f"(d61),
+          "+f"(d62),
+          "+f"(d63)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        d[24],
+        d[25],
+        d[26],
+        d[27],
+        d[28],
+        d[29],
+        d[30],
+        d[31],
+        d[32],
+        d[33],
+        d[34],
+        d[35],
+        d[36],
+        d[37],
+        d[38],
+        d[39],
+        d[40],
+        d[41],
+        d[42],
+        d[43],
+        d[44],
+        d[45],
+        d[46],
+        d[47],
+        d[48],
+        d[49],
+        d[50],
+        d[51],
+        d[52],
+        d[53],
+        d[54],
+        d[55],
+        d[56],
+        d[57],
+        d[58],
+        d[59],
+        d[60],
+        d[61],
+        d[62],
+        d[63],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 128;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+struct SM90_64x192x32_F32E4M3E4M3_SS {
+  __device__ static void wgmma(
+      uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      float& d00,
+      float& d01,
+      float& d02,
+      float& d03,
+      float& d04,
+      float& d05,
+      float& d06,
+      float& d07,
+      float& d08,
+      float& d09,
+      float& d10,
+      float& d11,
+      float& d12,
+      float& d13,
+      float& d14,
+      float& d15,
+      float& d16,
+      float& d17,
+      float& d18,
+      float& d19,
+      float& d20,
+      float& d21,
+      float& d22,
+      float& d23,
+      float& d24,
+      float& d25,
+      float& d26,
+      float& d27,
+      float& d28,
+      float& d29,
+      float& d30,
+      float& d31,
+      float& d32,
+      float& d33,
+      float& d34,
+      float& d35,
+      float& d36,
+      float& d37,
+      float& d38,
+      float& d39,
+      float& d40,
+      float& d41,
+      float& d42,
+      float& d43,
+      float& d44,
+      float& d45,
+      float& d46,
+      float& d47,
+      float& d48,
+      float& d49,
+      float& d50,
+      float& d51,
+      float& d52,
+      float& d53,
+      float& d54,
+      float& d55,
+      float& d56,
+      float& d57,
+      float& d58,
+      float& d59,
+      float& d60,
+      float& d61,
+      float& d62,
+      float& d63,
+      float& d64,
+      float& d65,
+      float& d66,
+      float& d67,
+      float& d68,
+      float& d69,
+      float& d70,
+      float& d71,
+      float& d72,
+      float& d73,
+      float& d74,
+      float& d75,
+      float& d76,
+      float& d77,
+      float& d78,
+      float& d79,
+      float& d80,
+      float& d81,
+      float& d82,
+      float& d83,
+      float& d84,
+      float& d85,
+      float& d86,
+      float& d87,
+      float& d88,
+      float& d89,
+      float& d90,
+      float& d91,
+      float& d92,
+      float& d93,
+      float& d94,
+      float& d95,
+      bool scale_d) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+    asm volatile(
+        "{\n"
+        ".reg .pred p;\n"
+        "setp.ne.b32 p, %98, 0;\n"
+        "wgmma.mma_async.sync.aligned.m64n192k32.f32.e4m3.e4m3"
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47,  "
+        " %48,  %49,  %50,  %51,  %52,  %53,  %54,  %55,  "
+        " %56,  %57,  %58,  %59,  %60,  %61,  %62,  %63,  "
+        " %64,  %65,  %66,  %67,  %68,  %69,  %70,  %71,  "
+        " %72,  %73,  %74,  %75,  %76,  %77,  %78,  %79,  "
+        " %80,  %81,  %82,  %83,  %84,  %85,  %86,  %87,  "
+        " %88,  %89,  %90,  %91,  %92,  %93,  %94,  %95},  "
+        " %96,"
+        " %97,"
+        " p   , 1,    1;\n"
+        "}\n"
+        : "+f"(d00),
+          "+f"(d01),
+          "+f"(d02),
+          "+f"(d03),
+          "+f"(d04),
+          "+f"(d05),
+          "+f"(d06),
+          "+f"(d07),
+          "+f"(d08),
+          "+f"(d09),
+          "+f"(d10),
+          "+f"(d11),
+          "+f"(d12),
+          "+f"(d13),
+          "+f"(d14),
+          "+f"(d15),
+          "+f"(d16),
+          "+f"(d17),
+          "+f"(d18),
+          "+f"(d19),
+          "+f"(d20),
+          "+f"(d21),
+          "+f"(d22),
+          "+f"(d23),
+          "+f"(d24),
+          "+f"(d25),
+          "+f"(d26),
+          "+f"(d27),
+          "+f"(d28),
+          "+f"(d29),
+          "+f"(d30),
+          "+f"(d31),
+          "+f"(d32),
+          "+f"(d33),
+          "+f"(d34),
+          "+f"(d35),
+          "+f"(d36),
+          "+f"(d37),
+          "+f"(d38),
+          "+f"(d39),
+          "+f"(d40),
+          "+f"(d41),
+          "+f"(d42),
+          "+f"(d43),
+          "+f"(d44),
+          "+f"(d45),
+          "+f"(d46),
+          "+f"(d47),
+          "+f"(d48),
+          "+f"(d49),
+          "+f"(d50),
+          "+f"(d51),
+          "+f"(d52),
+          "+f"(d53),
+          "+f"(d54),
+          "+f"(d55),
+          "+f"(d56),
+          "+f"(d57),
+          "+f"(d58),
+          "+f"(d59),
+          "+f"(d60),
+          "+f"(d61),
+          "+f"(d62),
+          "+f"(d63),
+          "+f"(d64),
+          "+f"(d65),
+          "+f"(d66),
+          "+f"(d67),
+          "+f"(d68),
+          "+f"(d69),
+          "+f"(d70),
+          "+f"(d71),
+          "+f"(d72),
+          "+f"(d73),
+          "+f"(d74),
+          "+f"(d75),
+          "+f"(d76),
+          "+f"(d77),
+          "+f"(d78),
+          "+f"(d79),
+          "+f"(d80),
+          "+f"(d81),
+          "+f"(d82),
+          "+f"(d83),
+          "+f"(d84),
+          "+f"(d85),
+          "+f"(d86),
+          "+f"(d87),
+          "+f"(d88),
+          "+f"(d89),
+          "+f"(d90),
+          "+f"(d91),
+          "+f"(d92),
+          "+f"(d93),
+          "+f"(d94),
+          "+f"(d95)
+        : "l"(desc_a), "l"(desc_b), "r"(int32_t(scale_d)));
+#else
+    CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+  }
+
+  __device__ static void wgmma(uint64_t const& desc_a, uint64_t const& desc_b, float* d, bool scale_d) {
+    wgmma(
+        desc_a,
+        desc_b,
+        d[0],
+        d[1],
+        d[2],
+        d[3],
+        d[4],
+        d[5],
+        d[6],
+        d[7],
+        d[8],
+        d[9],
+        d[10],
+        d[11],
+        d[12],
+        d[13],
+        d[14],
+        d[15],
+        d[16],
+        d[17],
+        d[18],
+        d[19],
+        d[20],
+        d[21],
+        d[22],
+        d[23],
+        d[24],
+        d[25],
+        d[26],
+        d[27],
+        d[28],
+        d[29],
+        d[30],
+        d[31],
+        d[32],
+        d[33],
+        d[34],
+        d[35],
+        d[36],
+        d[37],
+        d[38],
+        d[39],
+        d[40],
+        d[41],
+        d[42],
+        d[43],
+        d[44],
+        d[45],
+        d[46],
+        d[47],
+        d[48],
+        d[49],
+        d[50],
+        d[51],
+        d[52],
+        d[53],
+        d[54],
+        d[55],
+        d[56],
+        d[57],
+        d[58],
+        d[59],
+        d[60],
+        d[61],
+        d[62],
+        d[63],
+        d[64],
+        d[65],
+        d[66],
+        d[67],
+        d[68],
+        d[69],
+        d[70],
+        d[71],
+        d[72],
+        d[73],
+        d[74],
+        d[75],
+        d[76],
+        d[77],
+        d[78],
+        d[79],
+        d[80],
+        d[81],
+        d[82],
+        d[83],
+        d[84],
+        d[85],
+        d[86],
+        d[87],
+        d[88],
+        d[89],
+        d[90],
+        d[91],
+        d[92],
+        d[93],
+        d[94],
+        d[95],
+        scale_d);
+  }
+
+  static constexpr int M = 64;
+  static constexpr int N = 192;
+  static constexpr int K = 32;
+  static constexpr int NUM_ACCUM = M * N / 128;
+};
+
+__device__ void warpgroup_arrive() {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+  asm volatile("wgmma.fence.sync.aligned;\n" ::: "memory");
+#else
+  CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+}
+
+__device__ void warpgroup_commit_batch() {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+  asm volatile("wgmma.commit_group.sync.aligned;\n" ::: "memory");
+#else
+  CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+}
+
+__device__ void warpgroup_fence_operand(float& reg) {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+  asm volatile("" : "+f"(reg)::"memory");
+#else
+  CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+}
+
+template <int N>
+__device__ void warpgroup_wait() {
+#ifdef CUTLASS_ARCH_MMA_SM90A_ENABLED
+  static_assert(N >= 0 && N <= 7, "WGMMA wait: N must be in range [0, 7]");
+  asm volatile("wgmma.wait_group.sync.aligned %0;\n" ::"n"(N) : "memory");
+#else
+  CUTE_INVALID_CONTROL_PATH("wgmma is only available on SM90a");
+#endif
+}
+
+union GmmaDescriptor {
+  __host__ __device__ constexpr GmmaDescriptor() noexcept : desc_(0) {}
+
+  __host__ __device__ constexpr GmmaDescriptor(uint64_t desc) noexcept : desc_(desc) {}
+
+  __host__ __device__ constexpr GmmaDescriptor(GmmaDescriptor const& t) noexcept : desc_(t.desc_) {}
+
+  __host__ __device__ constexpr GmmaDescriptor(GmmaDescriptor&& t) noexcept : desc_(t.desc_) {}
+
+  __host__ __device__ constexpr GmmaDescriptor& operator=(GmmaDescriptor const& t) noexcept {
+    desc_ = t.desc_;
+    return *this;
+  }
+
+  __host__ __device__ constexpr GmmaDescriptor& operator=(GmmaDescriptor&& t) noexcept {
+    desc_ = t.desc_;
+    return *this;
+  }
+
+  uint64_t desc_;
+  uint32_t reg32_[2];
+  uint16_t reg16_[4];
+
+  struct {
+    uint16_t start_address_ : 14, : 2;
+    uint16_t leading_byte_offset_ : 14, : 2;
+    uint16_t stride_byte_offset_ : 14, : 2;
+    uint8_t : 1, base_offset_ : 3, : 4;
+    uint8_t : 6, layout_type_ : 2;
+  } bitfield;
+
+  // Decay to a uint64_t
+  __host__ __device__ constexpr operator uint64_t() const noexcept {
+    return desc_;
+  }
+};
+
+template <class PointerType>
+__device__ GmmaDescriptor
+make_smem_desc(PointerType smem_ptr, int layout_type, int leading_byte_offset = 0, int stride_byte_offset = 1024) {
+  GmmaDescriptor desc;
+  uint32_t uint_ptr = static_cast<uint32_t>(cute::cast_smem_ptr_to_uint(smem_ptr));
+  desc.bitfield.start_address_ = uint_ptr >> 4;
+  desc.bitfield.layout_type_ = layout_type;
+  desc.bitfield.leading_byte_offset_ = leading_byte_offset >> 4;
+  desc.bitfield.stride_byte_offset_ = stride_byte_offset >> 4;
+  desc.bitfield.base_offset_ = 0;
+  return desc;
+}
+
+template <typename ElementA, typename ElementB, int N>
+struct Fp8MmaSelector {
+  static constexpr auto select_type() {
+    if constexpr (std::is_same_v<ElementA, __nv_fp8_e4m3> && std::is_same_v<ElementB, __nv_fp8_e4m3>) {
+      if constexpr (N == 16) {
+        return SM90_64x16x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 32) {
+        return SM90_64x32x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 48) {
+        return SM90_64x48x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 56) {
+        return SM90_64x56x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 64) {
+        return SM90_64x64x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 96) {
+        return SM90_64x96x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 112) {
+        return SM90_64x112x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 128) {
+        return SM90_64x128x32_F32E4M3E4M3_SS();
+      }
+      if constexpr (N == 192) {
+        return SM90_64x192x32_F32E4M3E4M3_SS();
+      }
+    }
+  }
+
+  using Type = decltype(select_type());
+};
+
+}  // namespace tensorrt_llm::kernels::fp8_blockscale_gemm

--- a/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_tma_utils.cuh
+++ b/sgl-kernel/csrc/gemm/trt_gemm/trt_fp8_blockscale_tma_utils.cuh
@@ -1,0 +1,127 @@
+// Adapted from
+// https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_tma_utils.cuh
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cuda.h>
+#include <cudaTypedefs.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <cassert>
+#include <cuda/barrier>
+#include <cute/arch/util.hpp>
+
+namespace tensorrt_llm::kernels::fp8_blockscale_gemm {
+
+template <class T>
+inline CUtensorMapDataType get_CUtensorMapDataType() {
+  if constexpr (std::is_same<T, int8_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  } else if constexpr (std::is_same<T, uint8_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  } else if constexpr (std::is_same<T, __nv_fp8_e4m3>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  } else if constexpr (std::is_same<T, __nv_fp8_e5m2>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  } else if constexpr (std::is_same<T, uint16_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT16;
+  } else if constexpr (std::is_same<T, uint32_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT32;
+  } else if constexpr (std::is_same<T, uint64_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_UINT64;
+  } else if constexpr (std::is_same<T, int32_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_INT32;
+  } else if constexpr (std::is_same<T, int64_t>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_INT64;
+  } else if constexpr (std::is_same<T, __half>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_FLOAT16;
+  } else if constexpr (std::is_same<T, float>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_FLOAT32;
+  } else if constexpr (std::is_same<T, double>::value) {
+    return CU_TENSOR_MAP_DATA_TYPE_FLOAT64;
+  } else {
+    static_assert(sizeof(T) < 0, "Unknown TMA Format!");
+  }
+}
+
+PFN_cuTensorMapEncodeTiled get_cuTensorMapEncodeTiled() {
+  // Get pointer to cuTensorMapEncodeTiled
+  cudaDriverEntryPointQueryResult driver_status;
+  void* cuTensorMapEncodeTiled_ptr = nullptr;
+#if (__CUDACC_VER_MAJOR__ >= 12 && __CUDACC_VER_MINOR__ >= 5)
+  cudaGetDriverEntryPointByVersion(
+      "cuTensorMapEncodeTiled", &cuTensorMapEncodeTiled_ptr, 12000, cudaEnableDefault, &driver_status);
+#else
+  cudaGetDriverEntryPoint("cuTensorMapEncodeTiled", &cuTensorMapEncodeTiled_ptr, cudaEnableDefault, &driver_status);
+#endif
+
+  if (driver_status != cudaDriverEntryPointSuccess) {
+    throw std::runtime_error("driver_status != cudaDriverEntryPointSuccess");
+  }
+
+  return reinterpret_cast<PFN_cuTensorMapEncodeTiled>(cuTensorMapEncodeTiled_ptr);
+}
+
+template <typename data_type>
+CUtensorMap make_2d_tma_copy_desc(
+    data_type* global_address,
+    uint64_t gmem_dim[2],
+    uint64_t stride_in_bytes,
+    uint32_t smem_dim[2],
+    CUtensorMapSwizzle swizzle_type,
+    PFN_cuTensorMapEncodeTiled encode_func = nullptr) {
+  CUtensorMap tensor_map{};
+  constexpr uint32_t rank = 2;
+  uint64_t global_stride[rank - 1] = {stride_in_bytes};
+  uint32_t elem_strides[rank] = {1, 1};
+
+  if (encode_func == nullptr) {
+    encode_func = get_cuTensorMapEncodeTiled();
+  }
+
+  CUresult res = encode_func(
+      &tensor_map,
+      get_CUtensorMapDataType<typename std::remove_cv<data_type>::type>(),
+      rank,
+      global_address,
+      gmem_dim,
+      global_stride,
+      smem_dim,
+      elem_strides,
+      CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+      swizzle_type,
+      CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_NONE,
+      CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+
+  if (int(res) == 1) {
+    std::cout << "check 0: " << int(res) << std::endl;
+    std::cout << gmem_dim[0] << "\t" << gmem_dim[1] << std::endl;
+  }
+  return tensor_map;
+}
+
+__device__ uint64_t mbarrier_arrive_1_expect_tx_cta(void* smem_ptr, uint32_t tx_count) {
+  uint64_t state;
+  asm("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 %0, [%1], %2; // 8. "
+      : "=l"(state)
+      : "r"(static_cast<uint32_t>(cute::cast_smem_ptr_to_uint(smem_ptr))), "r"(tx_count)
+      : "memory");
+  return state;
+}
+
+}  // namespace tensorrt_llm::kernels::fp8_blockscale_gemm

--- a/sgl-kernel/csrc/torch_extension.cc
+++ b/sgl-kernel/csrc/torch_extension.cc
@@ -241,6 +241,23 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
       "    bool?    pack_gqa,"
       "    int      sm_margin) -> Tensor[]");
   m.impl("fwd", torch::kCUDA, make_pytorch_shim(&mha_fwd));
+
+  /*
+   * From TensorRT-LLM fp8 blockwise gemm
+   */
+  m.def("trt_fp8_block_scaling_gemm(Tensor a, Tensor b, Tensor scale_a, Tensor scale_b) -> Tensor");
+  m.impl("trt_fp8_block_scaling_gemm", torch::kCUDA, &trt_fp8_block_scaling_gemm);
+
+  m.def("trt_fp8_block_scaling_bmm(Tensor a, Tensor b, Tensor scale_a, Tensor scale_b, ScalarType? out_dtype)
+        -> Tensor");
+  m.impl("trt_fp8_block_scaling_bmm", torch::kCUDA, &trt_fp8_block_scaling_bmm);
+
+  m.def("trt_fp8_block_scaling_moe_gemm(Tensor a, Tensor b, Tensor scale_a, Tensor scale_b, Tensor token_offset)
+        -> Tensor");
+  m.impl("trt_fp8_block_scaling_moe_gemm", torch::kCUDA, &trt_fp8_block_scaling_moe_gemm);
+
+  m.def("trt_per_token_1x128_quant_fp8_kernel(Tensor a) -> (Tensor, Tensor)");
+  m.impl("trt_per_token_1x128_quant_fp8_kernel", torch::kCUDA, &trt_per_token_1x128_quant_fp8_kernel);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -338,3 +338,25 @@ std::vector<at::Tensor> mha_fwd(
     int num_splits,
     std::optional<bool> pack_gqa_,
     int const sm_margin);
+
+torch::Tensor trt_fp8_block_scaling_gemm(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale);
+
+torch::Tensor trt_fp8_block_scaling_bmm(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale,
+    std::optional<c10::ScalarType> out_dtype);
+
+torch::Tensor trt_fp8_block_scaling_moe_gemm(
+    torch::Tensor const& mat1,
+    torch::Tensor const& mat2,
+    torch::Tensor const& mat1Scale,
+    torch::Tensor const& mat2Scale,
+    torch::Tensor const& token_offset);
+
+std::tuple<at::Tensor, at::Tensor> trt_per_token_1x128_quant_fp8_kernel(at::Tensor const& self);

--- a/sgl-kernel/include/utils.h
+++ b/sgl-kernel/include/utils.h
@@ -231,6 +231,8 @@ struct cuda_error : public std::runtime_error {
   CHECK_IS_CUDA(x);         \
   CHECK_IS_CONTIGUOUS(x)
 
+#define CHECK_CUDA_TYPE(x, st) TORCH_CHECK(x.scalar_type() == st, "Inconsistency of Tensor type: " #x)
+
 inline int getSMVersion() {
   int device{-1};
   CHECK_CUDA_SUCCESS(cudaGetDevice(&device));
@@ -239,6 +241,14 @@ inline int getSMVersion() {
   CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, device));
   CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(&sm_minor, cudaDevAttrComputeCapabilityMinor, device));
   return sm_major * 10 + sm_minor;
+}
+
+inline int getMultiProcessorCount() {
+  int nSM{0};
+  int deviceID{0};
+  CHECK_CUDA_SUCCESS(cudaGetDevice(&deviceID));
+  CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(&nSM, cudaDevAttrMultiProcessorCount, deviceID));
+  return nSM;
 }
 
 // SGLANG_SHFL_XOR_* adapted from https://github.com/vllm-project/vllm/blob/v0.7.3/csrc/cuda_compat.h#L19-L28

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -35,6 +35,10 @@ from sgl_kernel.gemm import (
     sgl_per_token_group_quant_fp8,
     sgl_per_token_group_quant_int8,
     sgl_per_token_quant_fp8,
+    trt_fp8_blockwise_scaled_bmm,
+    trt_fp8_blockwise_scaled_mm,
+    trt_fp8_blockwise_scaled_moe_mm,
+    trt_per_token_1x128_quant_fp8_kernel,
 )
 from sgl_kernel.moe import moe_align_block_size, moe_fused_gate, topk_softmax
 from sgl_kernel.sampling import (

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -217,3 +217,44 @@ def scaled_fp4_quant(
     )
     output_scale = output_scale.view(torch.float8_e4m3fn)
     return output, output_scale
+
+
+def trt_fp8_blockwise_scaled_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    block_scale_a: torch.Tensor,
+    block_scale_b: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.trt_fp8_block_scaling_gemm.default(
+        a, b, block_scale_a, block_scale_b
+    )
+
+
+def trt_fp8_blockwise_scaled_bmm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    block_scale_a: torch.Tensor,
+    block_scale_b: torch.Tensor,
+    out_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.trt_fp8_block_scaling_bmm.default(
+        a, b, block_scale_a, block_scale_b, out_dtype
+    )
+
+
+def trt_fp8_blockwise_scaled_moe_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    block_scale_a: torch.Tensor,
+    block_scale_b: torch.Tensor,
+    token_offset: torch.Tensor,
+):
+    return torch.ops.sgl_kernel.trt_fp8_block_scaling_moe_gemm(
+        a, b, block_scale_a, block_scale_b, token_offset
+    )
+
+
+def trt_per_token_1x128_quant_fp8_kernel(
+    a: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.sgl_kernel.trt_per_token_1x128_quant_fp8_kernel(a)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
adapt fp8 blockwise gemm kernel into sgl-kernel, ref https://github.com/sgl-project/sglang/issues/4776 https://github.com/NVIDIA/TensorRT-LLM/pull/3071, support these ops:
1. trt_fp8_block_scaling_gemm
2. trt_fp8_block_scaling_bmm
3. trt_fp8_block_scaling_moe_gemm
4. trt_per_token_1x128_quant_fp8_kernel


TODO:

1. write benchmark for these ops and do more comparsion with current ops
5. add more tests （moe_gemm/per_token_group_quant）
6. `trt_per_token_1x128_quant_fp8_kernel` result is not the same as `sgl_per_token_group_quant_fp8`, we need find the reason.

## Modifications

## Conclusion
1. `trt_fp8_block_scaling_gemm` gains good performance in small batch size, but performance degrades obviously when batch size grows up
2. `trt_per_token_group_quant` performance is bad in all cases, it is even worse than triton.
3. `trt_fp8_block_scaling_gemm` must be used with `trt_per_token_group_quant` instead of other kernel, since it uses some padding method which is only implemented in `trt_per_token_group_quant`.
4. `trt_per_token_group_quant` current kernel has serveral bugs, but it can be fixed.

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
