### PR TITLE
[ci] fix ci test fused_moe op

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -75,6 +75,7 @@ suites = {
         TestFile("test_create_kvindices.py", 2),
         TestFile("test_hicache.py", 60),
         TestFile("test_hicache_mla.py", 90),
+        TestFile("test_fused_moe.py", 200),
     ],
     "per-commit-2-gpu": [
         TestFile("models/lora/test_lora_tp.py", 300),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -76,7 +76,7 @@ suites = {
         TestFile("test_create_kvindices.py", 2),
         TestFile("test_hicache.py", 60),
         TestFile("test_hicache_mla.py", 90),
-        TestFile("test_fused_moe.py", 20),
+        TestFile("test_fused_moe.py", 30),
     ],
     "per-commit-2-gpu": [
         TestFile("models/lora/test_lora_tp.py", 300),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -75,7 +75,7 @@ suites = {
         TestFile("test_create_kvindices.py", 2),
         TestFile("test_hicache.py", 60),
         TestFile("test_hicache_mla.py", 90),
-        TestFile("test_fused_moe.py", 200),
+        TestFile("test_fused_moe.py", 20),
     ],
     "per-commit-2-gpu": [
         TestFile("models/lora/test_lora_tp.py", 300),

--- a/test/srt/test_fused_moe.py
+++ b/test/srt/test_fused_moe.py
@@ -83,7 +83,9 @@ class TestFusedMOE(CustomTestCase):
         for i in range(w1_orig.shape[0]):
             mask = topk_ids == i
             if mask.sum():
-                out[mask] = SiluAndMul()(a[mask] @ w1_orig[i].transpose(0, 1)) @ w2_orig[i].transpose(0, 1)
+                out[mask] = SiluAndMul()(
+                    a[mask] @ w1_orig[i].transpose(0, 1)
+                ) @ w2_orig[i].transpose(0, 1)
 
         return (
             out.view(B, -1, w2.shape[1]) * topk_weight.view(B, -1, 1).to(out.dtype)

--- a/test/srt/test_fused_moe.py
+++ b/test/srt/test_fused_moe.py
@@ -3,7 +3,6 @@ import unittest
 import torch
 import torch.nn.functional as F
 from tqdm import tqdm
-from vllm.model_executor.layers.fused_moe import fused_moe as fused_moe_vllm
 
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_moe
@@ -98,21 +97,10 @@ class TestFusedMOE(CustomTestCase):
                 a2_scale=a2_scale,
             )
 
-            vllm_output = fused_moe_vllm(
-                a,
-                w1,
-                w2,
-                score,
-                topk,
-                renormalize=False,
-                use_fp8_w8a8=True,
-                w1_scale=w1_scale,
-                w2_scale=w2_scale,
-                a1_scale=a1_scale,
-                a2_scale=a2_scale,
+            torch_output = self.torch_naive_moe(a, w1, w2, score, topk)
+            torch.testing.assert_close(
+                sglang_output, torch_output, rtol=rtol, atol=atol
             )
-
-            torch.testing.assert_close(sglang_output, vllm_output, rtol=rtol, atol=atol)
 
         else:
             a = self.create_random_cuda_tensor((m, k), dtype)

--- a/test/srt/test_fused_moe.py
+++ b/test/srt/test_fused_moe.py
@@ -44,7 +44,7 @@ class TestFusedMOE(CustomTestCase):
         else:
             return 1e-2, 1e-2  # Default values for other types
 
-    def torch_naive_moe(self, a, w1, w2, score, topk):
+    def torch_naive_moe(self, a, w1, w2, score, topk, w1_scale=None, w2_scale=None, a1_scale=None, a2_scale=None):
         B, D = a.shape
         a = a.view(B, -1, D).repeat(1, topk, 1).reshape(-1, D)
         out = torch.zeros(B * topk, w2.shape[1], dtype=a.dtype, device=a.device)
@@ -52,12 +52,34 @@ class TestFusedMOE(CustomTestCase):
         topk_weight, topk_ids = torch.topk(score, topk)
         topk_weight = topk_weight.view(-1)
         topk_ids = topk_ids.view(-1)
-        for i in range(w1.shape[0]):
-            mask = topk_ids == i
-            if mask.sum():
-                out[mask] = SiluAndMul()(a[mask] @ w1[i].transpose(0, 1)) @ w2[
-                    i
-                ].transpose(0, 1)
+        
+        # Handle FP8 mode
+        if w1.dtype == torch.float8_e4m3fn:
+            # Convert w1 and w2 to the same dtype as a for computation
+            w1_orig = w1.to(a.dtype)
+            w2_orig = w2.to(a.dtype)
+
+            # Apply scaling factors
+            if w1_scale is not None:
+                w1_orig = (w1_orig * w1_scale.view(-1, 1, 1)).to(a.dtype)
+            if w2_scale is not None:
+                w2_orig = (w2_orig * w2_scale.view(-1, 1, 1)).to(a.dtype)
+            if a1_scale is not None:
+                a = (a * a1_scale).to(a.dtype)
+            if a2_scale is not None:
+                a = (a * a2_scale).to(a.dtype)
+
+            for i in range(w1_orig.shape[0]):
+                mask = topk_ids == i
+                if mask.sum():
+                    out[mask] = SiluAndMul()(a[mask] @ w1_orig[i].transpose(0, 1)) @ w2_orig[i].transpose(0, 1).to(a.dtype)
+        else:
+            # Original logic for non-FP8 mode
+            for i in range(w1.shape[0]):
+                mask = topk_ids == i
+                if mask.sum():
+                    out[mask] = SiluAndMul()(a[mask] @ w1[i].transpose(0, 1)) @ w2[i].transpose(0, 1)
+                    
         return (
             out.view(B, -1, w2.shape[1]) * topk_weight.view(B, -1, 1).to(out.dtype)
         ).sum(dim=1)
@@ -97,7 +119,7 @@ class TestFusedMOE(CustomTestCase):
                 a2_scale=a2_scale,
             )
 
-            torch_output = self.torch_naive_moe(a, w1, w2, score, topk)
+            torch_output = self.torch_naive_moe(a, w1, w2, score, topk, w1_scale, w2_scale, a1_scale, a2_scale)
             torch.testing.assert_close(
                 sglang_output, torch_output, rtol=rtol, atol=atol
             )
@@ -115,8 +137,8 @@ class TestFusedMOE(CustomTestCase):
             )
 
     def test_various_configurations(self):
-        m_values = [1, 33, 64, 222, 1024 * 128]
-        n_values = [128, 1024, 2048]
+        m_values = [1, 33, 64, 222]
+        n_values = [128, 1024]
         k_values = [128, 511, 1024]
         dtypes = [torch.float16, torch.bfloat16]
         fp8_modes = [False, True]
@@ -159,6 +181,7 @@ class TestFusedMOE(CustomTestCase):
                                                 dtype,
                                                 use_fp8_w8a8=use_fp8_w8a8,
                                             )
+                                            torch.cuda.empty_cache()
                                         pbar.update(1)
 
 

--- a/test/srt/test_fused_moe.py
+++ b/test/srt/test_fused_moe.py
@@ -65,27 +65,27 @@ class TestFusedMOE(CustomTestCase):
         topk_ids = topk_ids.view(-1)
 
         if w1.dtype == torch.float8_e4m3fn:
-            w1_orig = w1.to(a.dtype)
-            w2_orig = w2.to(a.dtype)
+            w1_compute = w1.to(a.dtype)
+            w2_compute = w2.to(a.dtype)
 
             if w1_scale is not None:
-                w1_orig = (w1_orig * w1_scale.view(-1, 1, 1)).to(a.dtype)
+                w1_compute = (w1_compute * w1_scale.view(-1, 1, 1)).to(a.dtype)
             if w2_scale is not None:
-                w2_orig = (w2_orig * w2_scale.view(-1, 1, 1)).to(a.dtype)
+                w2_compute = (w2_compute * w2_scale.view(-1, 1, 1)).to(a.dtype)
             if a1_scale is not None:
                 a = (a * a1_scale).to(a.dtype)
             if a2_scale is not None:
                 a = (a * a2_scale).to(a.dtype)
         else:
-            w1_orig = w1
-            w2_orig = w2
+            w1_compute = w1
+            w2_compute = w2
 
-        for i in range(w1_orig.shape[0]):
+        for i in range(w1_compute.shape[0]):
             mask = topk_ids == i
             if mask.sum():
                 out[mask] = SiluAndMul()(
-                    a[mask] @ w1_orig[i].transpose(0, 1)
-                ) @ w2_orig[i].transpose(0, 1)
+                    a[mask] @ w1_compute[i].transpose(0, 1)
+                ) @ w2_compute[i].transpose(0, 1)
 
         return (
             out.view(B, -1, w2.shape[1]) * topk_weight.view(B, -1, 1).to(out.dtype)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

I found that the errors related to "failed to run tuning_fused_moe_triton.py" in https://github.com/sgl-project/sglang/issues/4991 are due to a particular commit in the CI that mistakenly deleted test_fused_moe.py. This deletion resulted in a lack of tests to check for potential circular import issues caused by the line `from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_moe`. The test has been added back. Additionally, I simplified the tests by removing the parts related to vllm `fused_moe` , and now it only compares with the naive implementation in torch. .cc @zhyncs 

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
