### PR TITLE
docs: remove the use of Downward API for LWS_WORKER_INDEX

### DIFF
--- a/docs/references/deploy_on_k8s.md
+++ b/docs/references/deploy_on_k8s.md
@@ -14,7 +14,7 @@ Here we take the deployment of DeepSeek-R1 as an example.
 
 1. At least two Kubernetes nodes, each with two H20 systems and eight GPUs, are required.
 
-2. Make sure your K8S cluster has LWS correctly installed. If it hasn't been set up yet, please follow the [installation instructions](https://github.com/kubernetes-sigs/lws/blob/main/site/content/en/docs/installation/_index.md).
+2. Make sure your K8S cluster has LWS correctly installed. If it hasn't been set up yet, please follow the [installation instructions](https://github.com/kubernetes-sigs/lws/blob/main/site/content/en/docs/installation/_index.md). **Note:** For LWS versions ≤0.5.x, you must use the Downward API to obtain `LWS_WORKER_INDEX`, as native support for this feature was introduced in v0.6.0.
 
 ## Basic example
 
@@ -95,10 +95,6 @@ spec:
             env:
               - name: NCCL_IB_GID_INDEX
                 value: "3"
-              - name: LWS_WORKER_INDEX
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['leaderworkerset.sigs.k8s.io/worker-index']
             command:
               - python3
               - -m
@@ -164,10 +160,6 @@ spec:
             env:
             - name: NCCL_IB_GID_INDEX
               value: "3"
-            - name: LWS_WORKER_INDEX
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.labels['leaderworkerset.sigs.k8s.io/worker-index']
             command:
               - python3
               - -m


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Since the LWS v0.6.0 release:  https://github.com/kubernetes-sigs/lws/releases/tag/v0.6.0 ,
It supports the environment variable `LWS_WORKER_INDEX` by default, and does not need "Downward API" to access it.

Following https://github.com/kubernetes-sigs/lws/issues/427#issuecomment-2749422683 , the sglang's docs need to update :-)

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Remove the use of Downward API for `LWS_WORKER_INDEX` since it's injected by LWS automatically since v0.6.0.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
