### PR TITLE
Elementwise fused rmsnorm, fix triton error on ROCm

### DIFF
--- a/python/sglang/srt/layers/elementwise.py
+++ b/python/sglang/srt/layers/elementwise.py
@@ -4,6 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
+
 fused_softcap_autotune = triton.autotune(
     configs=[
         triton.Config(kwargs={"BLOCK_SIZE": 128}, num_warps=4),
@@ -190,11 +194,14 @@ def fused_dual_residual_rmsnorm(x, residual, weight1, weight2, eps, autotune=Fal
             output, mid, x, residual, weight1, weight2, eps=eps, hidden_dim=hidden_dim
         )
     else:
+        num_warps = max(
+            min(triton.next_power_of_2(triton.cdiv(hidden_dim, 256)), 32), 4
+        )
+        if _is_hip:
+            num_warps = 16
         config = {
             "BLOCK_SIZE": triton.next_power_of_2(hidden_dim),
-            "num_warps": max(
-                min(triton.next_power_of_2(triton.cdiv(hidden_dim, 256)), 32), 4
-            ),
+            "num_warps": num_warps,
         }
 
         fused_dual_residual_rmsnorm_kernel[(bs,)](
@@ -250,11 +257,12 @@ def fused_rmsnorm(x, weight, eps, autotune=False, inplace=False):
     else:
         output = torch.empty_like(x)
     bs, hidden_dim = x.shape
+    num_warps = max(min(triton.next_power_of_2(triton.cdiv(hidden_dim, 256)), 32), 4)
+    if _is_hip:
+        num_warps = 16
     config = {
         "BLOCK_SIZE": triton.next_power_of_2(hidden_dim),
-        "num_warps": max(
-            min(triton.next_power_of_2(triton.cdiv(hidden_dim, 256)), 32), 4
-        ),
+        "num_warps": num_warps,
     }
 
     fused_rmsnorm_kernel[(bs,)](


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

Obsoleted by #5147 

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix the triton error on ROCm.

Done by the co-authors:

`Co-authored-by: David Hou`

## Modifications

As it is. Fix error below:
```
  File "/sgl-workspace/sglang/python/sglang/srt/layers/elementwise.py", line 260, in fused_rmsnorm
    fused_rmsnorm_kernel[(bs,)](
  File "/sgl-workspace/sglang/python/sglang/srt/models/grok.py", line 371, in forward
    fused_rmsnorm(
  File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 330, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
Traceback (most recent call last):
RuntimeError: Triton Error [HIP]:  Code: 1, Messsage: invalid argument
```
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
