### PR TITLE
Revert "[deepep] fix: shared experts are not initialized when shared experts fusion is disabled"

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -183,7 +183,7 @@ class ServerArgs:
     enable_flashmla: bool = False
     flashinfer_mla_disable_ragged: bool = False
     warmups: Optional[str] = None
-    n_share_experts_fusion: int = 0
+    n_share_experts_fusion: Optional[int] = None
     disable_shared_experts_fusion: bool = False
 
     # Debug tensor dumps
@@ -1106,7 +1106,7 @@ class ServerArgs:
         parser.add_argument(
             "--n-share-experts-fusion",
             type=int,
-            default=0,
+            default=None,
             help="The number of shared_experts need to be replica to fuse with normal experts in deepseek v3/r1 "
             "we use tp_size by default.",
         )


### PR DESCRIPTION
Reverts sgl-project/sglang#5072

Set the default value of `n_share_experts_fusion` to None, considering that in DS V3/R1, it automatically uses TP_SIZE to fill in the value of `n_share_experts_fusion` to achieve the effect of being enabled by default. This modification actually disrupts our enabling logic, which is a misunderstanding.

