### PR TITLE
[modelopt] automatically inspect if model is ModelOpt quantized and set quantization method

### DIFF
--- a/test/srt/test_eval_fp8_accuracy.py
+++ b/test/srt/test_eval_fp8_accuracy.py
@@ -1,15 +1,11 @@
 import unittest
 from types import SimpleNamespace
 
-import torch
-
 from sglang.srt.utils import kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_FP8_MODEL_NAME_FOR_ACCURACY_TEST,
     DEFAULT_FP8_MODEL_NAME_FOR_DYNAMIC_QUANT_ACCURACY_TEST,
-    DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST,
-    DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST_REVISION,
     DEFAULT_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -106,51 +102,6 @@ class TestEvalFP8DynamicQuantAccuracy(CustomTestCase):
         self._run_test(
             model=DEFAULT_MODEL_NAME_FOR_TEST,
             other_args=[],
-            expected_score=0.64,
-        )
-
-
-class TestEvalFP8ModelOptQuantAccuracy(CustomTestCase):
-
-    def _run_test(self, model, other_args, expected_score):
-        base_url = DEFAULT_URL_FOR_TEST
-        other_args = other_args or []
-
-        process = popen_launch_server(
-            model,
-            base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=other_args,
-        )
-
-        try:
-            args = SimpleNamespace(
-                base_url=base_url,
-                model=model,
-                eval_name="mmlu",
-                num_examples=64,
-                num_threads=32,
-                temperature=0.1,
-            )
-
-            metrics = run_eval(args)
-            self.assertGreaterEqual(metrics["score"], expected_score)
-        finally:
-            kill_process_tree(process.pid)
-
-    @unittest.skipIf(
-        torch.version.hip is not None, "modelopt quantization unsupported on ROCm"
-    )
-    def test_mmlu_offline_only(self):
-        """Test with offline quantization only."""
-        self._run_test(
-            model=DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST,
-            other_args=[
-                "--quantization",
-                "modelopt",
-                "--revision",
-                DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST_REVISION,
-            ],
             expected_score=0.64,
         )
 

--- a/test/srt/test_modelopt.py
+++ b/test/srt/test_modelopt.py
@@ -1,6 +1,8 @@
 import unittest
 from types import SimpleNamespace
+
 import torch
+
 from sglang.srt.utils import kill_process_tree
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
@@ -11,7 +13,6 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
-
 
 
 class TestEvalFP8ModelOptQuantAccuracy(CustomTestCase):

--- a/test/srt/test_modelopt.py
+++ b/test/srt/test_modelopt.py
@@ -1,0 +1,57 @@
+import unittest
+from types import SimpleNamespace
+import torch
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST,
+    DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST_REVISION,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+
+class TestEvalFP8ModelOptQuantAccuracy(CustomTestCase):
+
+    def _run_test(self, model, other_args, expected_score):
+        base_url = DEFAULT_URL_FOR_TEST
+        other_args = other_args or []
+
+        process = popen_launch_server(
+            model,
+            base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+        try:
+            args = SimpleNamespace(
+                base_url=base_url,
+                model=model,
+                eval_name="mmlu",
+                num_examples=64,
+                num_threads=32,
+                temperature=0.1,
+            )
+
+            metrics = run_eval(args)
+            self.assertGreaterEqual(metrics["score"], expected_score)
+        finally:
+            kill_process_tree(process.pid)
+
+    @unittest.skipIf(
+        torch.version.hip is not None, "modelopt quantization unsupported on ROCm"
+    )
+    def test_mmlu_offline_only(self):
+        """Test with offline quantization only."""
+        self._run_test(
+            model=DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST,
+            other_args=[
+                "--revision",
+                DEFAULT_FP8_MODEL_NAME_FOR_MODELOPT_QUANT_ACCURACY_TEST_REVISION,
+            ],
+            expected_score=0.64,
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
currently in order to load modelopt-quantized model, users have to explicitly pass `--quantization modelopt` to server launch command, otherwise server will fail to load model w/
```
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 400, in load_model
    self.model = get_model(
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/__init__.py", line 22, in get_model
    return loader.load_model(
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 370, in load_model
    model.load_weights(self._get_all_weights(model_config, model))
  File "/sgl-workspace/sglang/python/sglang/srt/models/llama.py", line 516, in load_weights
    param = params_dict[name]
KeyError: 'model.layers.0.mlp.gate_up_proj.input_scale'
```
The reason is that `input_scale` param will not be instantiated w/o quantization method specified hence not present in model's `named_parameters(), while the model checkpoint itself does contain this weight.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
1. Inspect if `hf_quant_config.json` is present in the model path / repo. If so, automatically set quant method
2. extract modelopt-related tests to a standalone test file
3. remove `--quantization modelopt` in test
<!-- Describe the changes made in this PR. -->

## Checklist

- [ x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
