### PR TITLE
fix empty_cache error in pt_weights_iterator

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -457,7 +457,6 @@ def pt_weights_iterator(
         state = torch.load(bin_file, map_location="cpu", weights_only=True)
         yield from state.items()
         del state
-        torch.cuda.empty_cache()
 
 
 def get_gguf_extra_tensor_names(


### PR DESCRIPTION
I encountered the following error when training RL with sglang while using a model in `.pt` format. It works fine after removing the `torch.cuda.empty_cache()` in `pt_weights_iterator` function

 
```
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_executor/model_runner.py", line 179, in initialize [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     self.load_model() [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/loader.py", line 370, in load_model [repeated 12x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     self.model = get_model( [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/__init__.py", line 22, in get_model [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     return loader.load_model( [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     model.load_weights(self._get_all_weights(model_config, model)) [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/models/qwen2.py", line 420, in load_weights [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     for name, loaded_weight in weights: [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/loader.py", line 343, in _get_all_weights [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     yield from self._get_weights_iterator(primary_weights) [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/loader.py", line 329, in <genexpr> [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     return ((source.prefix + name, tensor) for (name, tensor) in weights_iterator) [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/weight_utils.py", line 460, in pt_weights_iterator [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     torch.cuda.empty_cache() [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)   File "/usr/local/lib/python3.10/dist-packages/torch/cuda/memory.py", line 192, in empty_cache [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130)     torch._C._cuda_emptyCache() [repeated 6x across cluster]
(WorkerDict pid=443, ip=10.71.253.130) RuntimeError: captures_underway.empty() INTERNAL ASSERT FAILED at "../c10/cuda/CUDACachingAllocator.cpp":2967, please report a bug to PyTorch.  [repeated 6x across cluster]
```

Related issue: https://github.com/volcengine/verl/issues/705
