### PR TITLE
Add some metrics for kvcache

### DIFF
--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -63,3 +63,6 @@ class ChunkCache(BasePrefixCache):
 
     def pretty_print(self):
         return ""
+
+    def total_size(self):
+        return 0

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -156,6 +156,9 @@ class TokenToKVPoolAllocator:
     def available_size(self):
         return len(self.free_slots)
 
+    def total_size(self):
+        return self.size
+
     def get_kvcache(self):
         return self._kvcache
 

--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -190,6 +190,9 @@ class PagedTokenToKVPoolAllocator:
     def available_size(self):
         return len(self.free_pages) * self.page_size
 
+    def total_size(self):
+        return self.size
+
     def get_kvcache(self):
         return self._kvcache
 

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -27,6 +27,11 @@ class SchedulerStats:
     num_queue_reqs: int = 0
     cache_hit_rate: float = 0.0
     spec_accept_length: float = 0.0
+    mempool_size: int = 0
+    mempool_available_size: int = 0
+    tree_cache_size: int = 0
+    tree_cache_evictable_size: int = 0
+    retract_count: int = 0
 
 
 class SchedulerMetricsCollector:
@@ -87,6 +92,41 @@ class SchedulerMetricsCollector:
             multiprocess_mode="mostrecent",
         )
 
+        self.mempool_size = Gauge(
+            name="sglang:mempool_size",
+            documentation="The size of the memory pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.mempool_available_size = Gauge(
+            name="sglang:mempool_available_size",
+            documentation="The available size of the memory pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.tree_cache_size = Gauge(
+            name="sglang:tree_cache_size",
+            documentation="The size of the tree cache.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.tree_cache_evictable_size = Gauge(
+            name="sglang:tree_cache_evictable_size",
+            documentation="The size of the evictable tree cache.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.retract_count = Gauge(
+            name="sglang:retract_count",
+            documentation="The number of retracted requests.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
     def _log_gauge(self, gauge, data: Union[int, float]) -> None:
         # Convenience function for logging to gauge.
         gauge.labels(**self.labels).set(data)
@@ -99,6 +139,11 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.num_queue_reqs, stats.num_queue_reqs)
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
+        self._log_gauge(self.mempool_size, stats.mempool_size)
+        self._log_gauge(self.mempool_available_size, stats.mempool_available_size)
+        self._log_gauge(self.tree_cache_size, stats.tree_cache_size)
+        self._log_gauge(self.tree_cache_evictable_size, stats.tree_cache_evictable_size)
+        self._log_gauge(self.retract_count, stats.retract_count)
         self.last_log_time = time.time()
 
 


### PR DESCRIPTION
## Motivation

Add more metrics for tracking kvcache related information.

## Modifications

The new metrics are:
- mempool_size: the size of the memory pool
- mempool_available_siz: the available size of the memory pool
- tree_cache_size: the size of the tree cache
- tree_cache_evictable_size: the evictable size of the tree cache
- retract_count: the number of retracted requests

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] (Seems no need) Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
