### PR TITLE
fix: use fa3 unit test on hopper only

### DIFF
--- a/sgl-kernel/tests/test_flash_attention.py
+++ b/sgl-kernel/tests/test_flash_attention.py
@@ -17,7 +17,7 @@ def is_fa3_supported(device=None) -> bool:
     #  https://docs.nvidia.com/cuda/cuda-c-programming-guide/#shared-memory-8-x
     #  now sgl-kernel only build fa3 for sm90a && cuda >= 12.4
     return (
-        (torch.cuda.get_device_capability(device)[0] >= 9)
+        (torch.cuda.get_device_capability(device)[0] == 9)
         and (torch.version.cuda >= "12.4")
         # or torch.cuda.get_device_capability(device) == (8, 0)
         # or torch.cuda.get_device_capability(device) == (8, 7)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

fix on Blackwell

```
================================================================================= short test summary info =================================================================================
FAILED test_flash_attention.py::test_flash_attn_kvcache[1-128-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[1-339-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[3-1024-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[64-800-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[64-256-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[3-799-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[64-2048-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[16-20000-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[128-128-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[256-512-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
FAILED test_flash_attention.py::test_flash_attn_kvcache[2048-3577-64-False-False-False-None-0.0-False-False-True-False-False-False-mha-dtype0] - RuntimeError: Only Hopper supports different V headdim
=================================================================================== 11 failed in 10.79s ===================================================================================
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
