### PR TITLE
Fix: ensure tensors used in dist.broadcast are created on the correct…

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -847,31 +847,34 @@ def broadcast_pyobj(
     src: int = 0,
 ):
     """Broadcast inputs from rank=0 to all other ranks with torch.dist backend."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[broadcast_pyobj] rank={rank}, device={device}")
 
     if rank == 0:
         if len(data) == 0:
-            tensor_size = torch.tensor([0], dtype=torch.long)
+            tensor_size = torch.tensor([0], dtype=torch.long, device=device)
             dist.broadcast(tensor_size, src=src, group=dist_group)
         else:
             serialized_data = pickle.dumps(data)
             size = len(serialized_data)
+
             tensor_data = torch.ByteTensor(
                 np.frombuffer(serialized_data, dtype=np.uint8)
-            )
-            tensor_size = torch.tensor([size], dtype=torch.long)
+            ).to(device)
+            tensor_size = torch.tensor([size], dtype=torch.long, device=device)
 
             dist.broadcast(tensor_size, src=src, group=dist_group)
             dist.broadcast(tensor_data, src=src, group=dist_group)
         return data
     else:
-        tensor_size = torch.tensor([0], dtype=torch.long)
+        tensor_size = torch.tensor([0], dtype=torch.long, device=device)
         dist.broadcast(tensor_size, src=src, group=dist_group)
         size = tensor_size.item()
 
         if size == 0:
             return []
 
-        tensor_data = torch.empty(size, dtype=torch.uint8)
+        tensor_data = torch.empty(size, dtype=torch.uint8, device=device)
         dist.broadcast(tensor_data, src=src, group=dist_group)
 
         serialized_data = bytes(tensor_data.cpu().numpy())


### PR DESCRIPTION
… device to match NCCL backend

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When using Verl + SGLang with NCCL backend, tensors passed to dist.broadcast must be created on the correct device. Previously, CPU tensors caused "No backend type associated with device type cpu" errors. This commit fixes the issue by explicitly placing tensors on CUDA devices during worker initialization.


## Modifications
```
(WorkerDict pid=120611)   tensor_data = torch.ByteTensor(
Error executing job with overrides: ['algorithm.adv_estimator=grpo', 'data.train_files=/root/data/geo3k/train.parquet', 'data.val_files=/root/data/geo3k/test.parquet', 'data.train_batch_size=512', 'data.max_prompt_length=1024', 'data.max_response_length=2048', 'data.filter_overlong_prompts=True', 'data.truncation=error', 'data.image_key=images', 'actor_rollout_ref.model.path=Qwen/Qwen2.5-VL-7B-Instruct', 'actor_rollout_ref.actor.optim.lr=1e-6', 'actor_rollout_ref.model.use_remove_padding=True', 'actor_rollout_ref.actor.ppo_mini_batch_size=128', 'actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=10', 'actor_rollout_ref.actor.use_kl_loss=True', 'actor_rollout_ref.actor.kl_loss_coef=0.01', 'actor_rollout_ref.actor.kl_loss_type=low_var_kl', 'actor_rollout_ref.actor.entropy_coeff=0', 'actor_rollout_ref.model.enable_gradient_checkpointing=True', 'actor_rollout_ref.actor.fsdp_config.param_offload=False', 'actor_rollout_ref.actor.fsdp_config.optimizer_offload=False', 'actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=20', 'actor_rollout_ref.rollout.tensor_model_parallel_size=2', 'actor_rollout_ref.rollout.name=sglang', 'actor_rollout_ref.rollout.gpu_memory_utilization=0.6', 'actor_rollout_ref.rollout.enable_chunked_prefill=False', 'actor_rollout_ref.rollout.enforce_eager=False', 'actor_rollout_ref.rollout.free_cache_engine=False', 'actor_rollout_ref.rollout.n=5', 'actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=20', 'actor_rollout_ref.ref.fsdp_config.param_offload=True', 'algorithm.use_kl_in_reward=False', 'trainer.critic_warmup=0', 'trainer.logger=[console,wandb]', 'trainer.project_name=verl_grpo_example_geo3k', 'trainer.experiment_name=qwen2_5_vl_7b_function_rm', 'trainer.n_gpus_per_node=4', 'trainer.nnodes=1', 'trainer.save_freq=-1', 'trainer.test_freq=5', 'trainer.total_epochs=15']
Traceback (most recent call last):
  File "/sgl-workspace/verl/verl/trainer/main_ppo.py", line 59, in main
    run_ppo(config)
  File "/sgl-workspace/verl/verl/trainer/main_ppo.py", line 77, in run_ppo
    ray.get(runner.run.remote(config))
  File "/usr/local/lib/python3.10/dist-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/ray/_private/worker.py", line 2771, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
  File "/usr/local/lib/python3.10/dist-packages/ray/_private/worker.py", line 919, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(RuntimeError): ray::TaskRunner.run() (pid=117812, ip=172.17.0.9, actor_id=c477df2a5226bf779c08f63802000000, repr=<main_ppo.TaskRunner object at 0x7f3d229b3490>)
  File "/sgl-workspace/verl/verl/trainer/main_ppo.py", line 193, in run
    trainer.init_workers()
  File "/sgl-workspace/verl/verl/trainer/ppo/ray_trainer.py", line 675, in init_workers
    self.actor_rollout_wg.init_model()
  File "/sgl-workspace/verl/verl/single_controller/ray/base.py", line 43, in func
    output = ray.get(output)
ray.exceptions.RayTaskError(RuntimeError): ray::WorkerDict.actor_rollout_init_model() (pid=120612, ip=172.17.0.9, actor_id=d0d6d98d6c375bdcee508c3402000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7f4266b5c550>)
  File "/sgl-workspace/verl/verl/single_controller/ray/base.py", line 439, in func
    return getattr(self.worker_dict[key], name)(*args, **kwargs)
  File "/sgl-workspace/verl/verl/single_controller/base/decorator.py", line 409, in inner
    return func(*args, **kwargs)
  File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 419, in init_model
    self.rollout, self.rollout_sharding_manager = self._build_rollout(
  File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 356, in _build_rollout
    rollout = SGLangRollout(actor_module=self.config.model.path,
  File "/sgl-workspace/verl/verl/workers/rollout/sglang_rollout/sglang_rollout.py", line 152, in __init__
    [ip, port_args] = broadcast_pyobj([ip, port_args],
  File "/sgl-workspace/sglang/python/sglang/srt/utils.py", line 868, in broadcast_pyobj
    dist.broadcast(tensor_size, src=src, group=dist_group)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 2726, in broadcast
    work = group.broadcast([tensor], opts)
RuntimeError: No backend type associated with device type cpu

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
(TaskRunner pid=117812) Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::WorkerDict.actor_rollout_init_model() (pid=120611, ip=172.17.0.9, actor_id=2ad8c206fdde32cf5d2ce42702000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7f4cddad4550>)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/single_controller/ray/base.py", line 439, in func
(TaskRunner pid=117812)     return getattr(self.worker_dict[key], name)(*args, **kwargs)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/single_controller/base/decorator.py", line 409, in inner
(TaskRunner pid=117812)     return func(*args, **kwargs)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 419, in init_model
(TaskRunner pid=117812)     self.rollout, self.rollout_sharding_manager = self._build_rollout(
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 356, in _build_rollout
(TaskRunner pid=117812)     rollout = SGLangRollout(actor_module=self.config.model.path,
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/rollout/sglang_rollout/sglang_rollout.py", line 152, in __init__
(TaskRunner pid=117812)     [ip, port_args] = broadcast_pyobj([ip, port_args],
(TaskRunner pid=117812)   File "/sgl-workspace/sglang/python/sglang/srt/utils.py", line 863, in broadcast_pyobj
(TaskRunner pid=117812)     dist.broadcast(tensor_size, src=src, group=dist_group)
(TaskRunner pid=117812)   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
(TaskRunner pid=117812)     return func(*args, **kwargs)
(TaskRunner pid=117812)   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 2726, in broadcast
(TaskRunner pid=117812)     work = group.broadcast([tensor], opts)
(TaskRunner pid=117812) RuntimeError: No backend type associated with device type cpu
(TaskRunner pid=117812) Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::WorkerDict.actor_rollout_init_model() (pid=120610, ip=172.17.0.9, actor_id=855ef73378252246770120ca02000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7fa3f42b0580>)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/single_controller/ray/base.py", line 439, in func
(TaskRunner pid=117812)     return getattr(self.worker_dict[key], name)(*args, **kwargs)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/single_controller/base/decorator.py", line 409, in inner
(TaskRunner pid=117812)     return func(*args, **kwargs)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 419, in init_model
(TaskRunner pid=117812)     self.rollout, self.rollout_sharding_manager = self._build_rollout(
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 356, in _build_rollout
(TaskRunner pid=117812)     rollout = SGLangRollout(actor_module=self.config.model.path,
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/rollout/sglang_rollout/sglang_rollout.py", line 152, in __init__
(TaskRunner pid=117812)     [ip, port_args] = broadcast_pyobj([ip, port_args],
(TaskRunner pid=117812)   File "/sgl-workspace/sglang/python/sglang/srt/utils.py", line 868, in broadcast_pyobj
(TaskRunner pid=117812)     dist.broadcast(tensor_size, src=src, group=dist_group)
(TaskRunner pid=117812)   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
(TaskRunner pid=117812)     return func(*args, **kwargs)
(TaskRunner pid=117812)   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 2726, in broadcast
(TaskRunner pid=117812)     work = group.broadcast([tensor], opts)
(TaskRunner pid=117812) RuntimeError: No backend type associated with device type cpu
(TaskRunner pid=117812) Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): ray::WorkerDict.actor_rollout_init_model() (pid=119756, ip=172.17.0.9, actor_id=aa3b80baae1a336680998be402000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7ed20d7597e0>)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/single_controller/ray/base.py", line 439, in func
(TaskRunner pid=117812)     return getattr(self.worker_dict[key], name)(*args, **kwargs)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/single_controller/base/decorator.py", line 409, in inner
(TaskRunner pid=117812)     return func(*args, **kwargs)
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 419, in init_model
(TaskRunner pid=117812)     self.rollout, self.rollout_sharding_manager = self._build_rollout(
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/fsdp_workers.py", line 356, in _build_rollout
(TaskRunner pid=117812)     rollout = SGLangRollout(actor_module=self.config.model.path,
(TaskRunner pid=117812)   File "/sgl-workspace/verl/verl/workers/rollout/sglang_rollout/sglang_rollout.py", line 152, in __init__
(TaskRunner pid=117812)     [ip, port_args] = broadcast_pyobj([ip, port_args],
(TaskRunner pid=117812)   File "/sgl-workspace/sglang/python/sglang/srt/utils.py", line 863, in broadcast_pyobj
(TaskRunner pid=117812)     dist.broadcast(tensor_size, src=src, group=dist_group)
(TaskRunner pid=117812)   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
(TaskRunner pid=117812)     return func(*args, **kwargs)
(TaskRunner pid=117812)   File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 2726, in broadcast
(TaskRunner pid=117812)     work = group.broadcast([tensor], opts)
(TaskRunner pid=117812) RuntimeError: No backend type associated with device type cpu
(WorkerDict pid=119756) Total steps: 60, num_warmup_steps: 0 [repeated 3x across cluster]
(WorkerDict pid=119756) Actor use_remove_padding=True [repeated 2x across cluster]
(WorkerDict pid=119756) /sgl-workspace/sglang/python/sglang/srt/utils.py:858: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)
(WorkerDict pid=119756)   tensor_data = torch.ByteTensor(
```

During the verl + sglang worker initialization phase,
sglang/python/sglang/srt/utils py/broadcast_pyobj L861 code in this operation:
```
tensor_size = torch.tensor([size], dtype=torch.long)
dist.broadcast(tensor_size, src=src, group=dist_group)
```

But here we are creating CPU tensor, but using a distributed group based on GPU backend, by default:

The GPU uses NCCL
The CPU uses GLOO

The default  worker runs on the GPU, but the broadcast torch.ByteTensor() is a CPU tensor, resulting in:
"No backend type associated with device type cpu"
The initial distributed broadcast uses tensor on the CPU, but the default distributed backend only registers the NCCL for GPU communication, resulting in broadcast errors.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
