### PR TITLE
[PD Feature] Support TP16 and Optimize Dynamic Connection Establishment

### DIFF
--- a/python/sglang/srt/disaggregation/conn.py
+++ b/python/sglang/srt/disaggregation/conn.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import random
 import struct
 import threading
 from functools import cache
@@ -11,12 +9,14 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
-import requests
-import zmq
+import zmq, socket
 from aiohttp import web
+import requests
 
 from sglang.srt.disaggregation.transfer_engine.mooncake import MooncakeTransferEngine
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import get_free_port
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,6 @@ def group_concurrent_contiguous(
 
 class KVArgs:
     engine_rank: int
-    tp_size: int
     kv_data_ptrs: list[int]
     kv_data_lens: list[int]
     kv_item_lens: list[int]
@@ -57,6 +56,7 @@ class KVArgs:
     aux_data_lens: list[int]
     aux_item_lens: list[int]
     ib_device: str
+    tp_size: int
 
 
 class KVPoll:
@@ -71,23 +71,32 @@ RequestPoolType = Dict[int, Tuple[npt.NDArray[np.int64], Optional[int]]]
 WaitingPoolType = Dict[
     int, Tuple[str, list[int], npt.NDArray[np.int64], list[int], int]
 ]
-# TODO: To be obsoleted
-# KVSENDER_POLLING_PORT = 17788
-# KVRECEIVER_POLLING_PORT = 27788
+KVSENDER_POLLING_PORT = 17788
+KVRECEIVER_POLLING_PORT = 27788
 
 
 class KVManager:
+    _ctx = zmq.Context()
+    _socket_cache = {}
+    _socket_locks = {}
+    _global_lock = threading.Lock()
+
     # TODO: make it general and support multiple transfer backend before merging
-    def __init__(self, args: KVArgs, disaggregation_mode: DisaggregationMode):
+    def __init__(self, args: KVArgs, disaggregation_mode: DisaggregationMode, server_args: ServerArgs):
         self.engine = MooncakeTransferEngine()
         self.kv_args = args
+        self.server_args = server_args
         self.disaggregation_mode = disaggregation_mode
         self.request_pool: RequestPoolType = {}
         self.request_status: Dict[int, KVPoll] = {}
-        self.connection_pool: Dict[int, str] = {}
-        self.rank_port = None
         self.server_socket = zmq.Context().socket(zmq.PULL)
         self.register_buffer_to_engine()
+        self.rank_port = None
+
+        # TODO: in decode node, this is no need to be called   in the future
+        # For now, prefill mulit-node need use the same prefill addr registerd to bootstrap server
+        self.prefill_addr = self.parse_prefill_addr(server_args)
+
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.waiting_pool: WaitingPoolType = {}
             self.transfer_event = threading.Event()
@@ -110,11 +119,80 @@ class KVManager:
         ):
             self.engine.register(aux_data_ptr, aux_data_len)
 
+    def register_zmq_info_to_bootstrap_server(self, key, value, bootstrap_addr: str = None):
+        """
+        register to the bootstrap server
+        """
+        bootstrap_url = self.parse_bootstrap_addr(self.server_args, bootstrap_addr)
+        respo = requests.put(bootstrap_url, params={"key": key}, json=value)
+        if respo.status_code != 200:
+            raise Exception("error registering zmq info to bootstrap server")
+
+    def parse_prefill_addr(self, args: ServerArgs):
+        port = args.port  # http_server_port
+        dist_init_addr = args.dist_init_addr
+        if dist_init_addr:
+            ip_address = socket.gethostbyname(dist_init_addr.split(":")[0])
+        else:
+            ip_address = self.engine.get_localhost()
+        return f"{ip_address}:{port}"
+
+    def parse_bootstrap_addr(self, args: ServerArgs, bootstrap_addr: str = ""):
+        """
+        parse the bootstrap addr from the server args
+        """
+        scheme = "http://"
+
+        if bootstrap_addr:
+            # for now bootstrap_port is fixed to 8998
+            return f"{scheme}{bootstrap_addr}/kv_route"
+
+        else:
+            port = args.disaggregation_bootstrap_port  # bootstrap_port
+            dist_init_addr = args.dist_init_addr
+            if dist_init_addr:
+                ip_address = socket.gethostbyname(dist_init_addr.split(":")[0])
+            else:
+                ip_address = self.engine.get_localhost()
+            return f"{scheme}{ip_address}:{port}/kv_route"
+
+    @classmethod
+    def _connect(cls, endpoint: str):
+        with cls._global_lock:
+            if endpoint not in cls._socket_cache:
+                sock = cls._ctx.socket(zmq.PUSH)
+                sock.connect(endpoint)
+                cls._socket_cache[endpoint] = sock
+                cls._socket_locks[endpoint] = threading.Lock()
+            return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
+
     @cache
-    def _connect(self, endpoint: str):
-        socket = zmq.Context().socket(zmq.PUSH)
-        socket.connect(endpoint)
-        return socket
+    def query_zmq_rank_addr(self, key, bootstrap_url):
+        resp = requests.get(bootstrap_url, params={"key": key})
+        if resp.status_code != 200:
+            raise Exception("Cant query receiver rank port for key {}, resp status {}".format(key, resp.status_code))
+        ip, port = resp.json()['zmq_ip'], resp.json()['zmq_port']
+        return ip, port
+
+    @cache
+    def get_free_zmq_port(self, key):
+        return get_free_port()
+
+    @cache
+    def get_prefill_register_key(self, prefill_addr: str):
+        key = f'{prefill_addr}_{self.kv_args.tp_size}_{self.kv_args.engine_rank}'
+        return key
+
+    @cache
+    def get_decode_register_key(self, session_id):
+        key = f'{session_id}_{self.kv_args.tp_size}_{self.kv_args.engine_rank}'
+        return key
+
+    @cache
+    def get_pd_meta_key(self):
+        """
+        """
+        return f"{self.engine.session_id}_{self.disaggregation_mode}_{self.kv_args.tp_size}_{self.kv_args.engine_rank}"
 
     def send_kvcache(
         self,
@@ -192,30 +270,40 @@ class KVManager:
         )
         return status
 
-    def sync_status_to_decode_endpoint(self, remote: str, dst_port: int, room: int):
+    def sync_status_to_decode_endpoint(self, remote: str, room: int, mooncake_session_id: str):
         if ":" in remote:
             remote = remote.split(":")[0]
-        self._connect("tcp://" + remote + ":" + str(dst_port)).send_multipart(
-            [
-                str(room).encode("ascii"),
-                str(self.request_status[room]).encode("ascii"),
-            ]
+        query_key = self.get_decode_register_key(mooncake_session_id)
+        bootstrap_addr = self.parse_bootstrap_addr(self.server_args)
+
+        _, receiver_rank_port = self.query_zmq_rank_addr(query_key, bootstrap_addr)
+        sock, lock = self._connect(
+            "tcp://"
+            + remote
+            + ":"
+            + str(receiver_rank_port)
         )
+        with lock:
+            sock.send_multipart(
+                [
+                    str(room).encode("ascii"),
+                    str(self.request_status[room]).encode("ascii"),
+                ]
+            )
 
     def start_prefill_thread(self):
-        self.rank_port = random.randint(20001, 25000)
-        while True:
-            try:
-                self.server_socket.bind("tcp://*:" + str(self.rank_port))
-                break
-            except zmq.ZMQError as e:
-                self.rank_port += 1
+        self.rank_port = self.get_free_zmq_port(self.get_pd_meta_key())
+        # should register to the bootstrap server, now to metadata server
+        self.register_zmq_info_to_bootstrap_server(
+            self.get_prefill_register_key(self.prefill_addr),
+            {"zmq_port": self.rank_port, "zmq_ip": self.engine.get_localhost()}
+        )
+        self.server_socket.bind("tcp://*:" + str(self.rank_port))
 
         def prefill_thread():
             while True:
                 (
                     endpoint,
-                    dst_port,
                     mooncake_session_id,
                     bootstrap_room,
                     dst_ptrs,
@@ -226,18 +314,16 @@ class KVManager:
                 if bootstrap_room.decode("ascii") == "None":
                     continue
                 endpoint = endpoint.decode("ascii")
-                dst_port = dst_port.decode("ascii")
                 mooncake_session_id = mooncake_session_id.decode("ascii")
                 bootstrap_room = int(bootstrap_room.decode("ascii"))
-                dst_ptrs = list(struct.unpack(f"{len(dst_ptrs)//8}Q", dst_ptrs))
+                dst_ptrs = list(struct.unpack(f"{len(dst_ptrs) // 8}Q", dst_ptrs))
                 dst_kv_indices = np.frombuffer(dst_kv_indices, dtype=np.int64)
                 dst_aux_ptrs = list(
-                    struct.unpack(f"{len(dst_aux_ptrs)//8}Q", dst_aux_ptrs)
+                    struct.unpack(f"{len(dst_aux_ptrs) // 8}Q", dst_aux_ptrs)
                 )
                 dst_aux_index = int(dst_aux_index.decode("ascii"))
                 self.waiting_pool[bootstrap_room] = (
                     endpoint,
-                    dst_port,
                     mooncake_session_id,
                     dst_ptrs,
                     dst_kv_indices,
@@ -261,14 +347,13 @@ class KVManager:
                     self.request_status[room] = status
                     (
                         endpoint,
-                        dst_port,
                         mooncake_session_id,
                         dst_ptrs,
                         dst_kv_indices,
                         dst_aux_ptrs,
                         dst_aux_index,
                     ) = self.waiting_pool.pop(room)
-                    self.sync_status_to_decode_endpoint(endpoint, dst_port, room)
+                    self.sync_status_to_decode_endpoint(endpoint, room, mooncake_session_id)
                     (
                         prefill_kv_indices,
                         prefill_aux_index,
@@ -281,7 +366,7 @@ class KVManager:
                     )
                     if ret != 0:
                         status = KVPoll.Failed
-                        self.sync_status_to_decode_endpoint(endpoint, dst_port, room)
+                        self.sync_status_to_decode_endpoint(endpoint, room, mooncake_session_id)
                         continue
                     ret = self.send_aux(
                         mooncake_session_id,
@@ -294,18 +379,13 @@ class KVManager:
                     else:
                         status = KVPoll.Success
                     self.request_status[room] = status
-                    self.sync_status_to_decode_endpoint(endpoint, dst_port, room)
+                    self.sync_status_to_decode_endpoint(endpoint, room, mooncake_session_id)
 
         threading.Thread(target=transfer_thread).start()
 
     def start_decode_thread(self):
-        self.rank_port = random.randint(25001, 30000)
-        while True:
-            try:
-                self.server_socket.bind("tcp://*:" + str(self.rank_port))
-                break
-            except zmq.ZMQError as e:
-                self.rank_port += 1
+        self.rank_port = self.get_free_zmq_port(self.get_pd_meta_key())
+        self.server_socket.bind("tcp://*:" + str(self.rank_port))
 
         def decode_thread():
             while True:
@@ -354,44 +434,10 @@ class KVSender:
         self.bootstrap_room = bootstrap_room
         self.kv_mgr.set_status(bootstrap_room, KVPoll.WaitingForInput)
         self.aux_index = None
-        self.bootstrap_server_url = bootstrap_addr
-
-        self.session_id = self.kv_mgr.get_session_id()
-
-    def _register_to_bootstrap(self):
-        """Register KVSender to bootstrap server via HTTP POST."""
-        url = f"http://{self.bootstrap_server_url}/kv_route"
-        payload = {
-            "identity": self.session_id,
-            "role": "Prefill",
-            "serve_ip": self.bootstrap_server_url.split(":")[0],
-            "serve_port": self.kv_mgr.rank_port,
-            "tp_rank": self.kv_mgr.kv_args.engine_rank,
-            "tp_size": self.kv_mgr.kv_args.tp_size,
-        }
-
-        logger.info(
-            f"Register prefill server port {self.kv_mgr.rank_port} for tp_rank {self.kv_mgr.kv_args.engine_rank}"
-        )
-
-        try:
-            response = requests.put(url, json=payload)
-            if response.status_code == 200:
-                logger.info(f"Prefill successfully registered to bootstrap server.")
-            else:
-                logger.info(
-                    f"Prefill Failed to register to bootstrap server: {response.status_code}, {response.text}"
-                )
-        except Exception as e:
-            logger.info(f"Prefill Failed to register to bootstrap server: {e}")
 
     def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
         self.aux_index = aux_index
         self.num_kv_indices = num_kv_indices
-
-        # Register to bootstrap server
-        logger.info(f"Prefill bootstrap addr {self.bootstrap_server_url}.")
-        self._register_to_bootstrap()
 
     def send(self, kv_indices: npt.NDArray[np.int64]):
         self.kv_mgr.enqueue_request(self.bootstrap_room, kv_indices, self.aux_index)
@@ -404,81 +450,52 @@ class KVSender:
 
 
 class KVReceiver:
+    _ctx = zmq.Context()
+    _socket_cache = {}
+    _socket_locks = {}
+    _global_lock = threading.Lock()
 
     def __init__(
-        self, mgr: KVManager, bootstrap_addr: str, bootstrap_room: Optional[int] = None
+        self, mgr: KVManager, prefill_addr: str, bootstrap_addr: str, bootstrap_room: Optional[int] = None
     ):
         self.bootstrap_room = bootstrap_room
         self.bootstrap_addr = bootstrap_addr
         self.kv_mgr = mgr
+        self.bootstrap_url = self.kv_mgr.parse_bootstrap_addr(mgr.server_args, bootstrap_addr)
+        prefill_ip, sender_rank_port = self.kv_mgr.query_zmq_rank_addr(
+            self.kv_mgr.get_prefill_register_key(prefill_addr), self.bootstrap_url)
+
+        logger.debug(f"KVReceiver init: prefill_addr={prefill_addr}, sender_rank_port={sender_rank_port}")
+        self.prefill_server_url = (
+            prefill_ip
+            + ":"
+            + str(sender_rank_port)
+        )
+        self.register_to_bootstrap(self.prefill_server_url)
+
         self.decode_ip = self.kv_mgr.get_localhost()
         self.session_id = self.kv_mgr.get_session_id()
         self.kv_mgr.set_status(bootstrap_room, KVPoll.WaitingForInput)
-        self.prefill_engine_rank = None
-        self.prefill_tp_size = None
-        self.decode_port = self.kv_mgr.rank_port
-        self.dealer_socket = None
-
-    def _get_prefill_port_from_bootstrap(self, tp_rank: int):
-        """Fetch the prefill server port corresponding to tp_rank from the bootstrap server."""
-        try:
-            url = f"http://{self.bootstrap_addr}/kv_route?tp_rank={tp_rank}"
-            response = requests.get(url)
-            if response.status_code == 200:
-                prefill_serve_port = int(response.text)
-                return prefill_serve_port
-            else:
-                logger.error(
-                    f"Failed to get prefill server port: {response.status_code}, {response.text}"
-                )
-                return None
-        except Exception as e:
-            logger.error(f"Error fetching prefill port from bootstrap: {e}")
-            return None
 
     @cache
-    def _connect_bootstrap(self, endpoint: str):
-        socket = zmq.Context().socket(zmq.DEALER)
-        socket.setsockopt(zmq.IDENTITY, self.session_id)
-        socket.connect(endpoint)
-        return socket
+    def register_to_bootstrap(self, prefill_addr: str) -> None:
+        logger.debug(f"KVReceiver Registering prefill_addr={prefill_addr}")
+        # should register to the bootstrap server, now to metadata server
+        self.kv_mgr.register_zmq_info_to_bootstrap_server(
+            self.kv_mgr.get_decode_register_key(self.kv_mgr.engine.get_session_id()),
+            {"zmq_port": self.kv_mgr.rank_port, "zmq_ip": self.kv_mgr.engine.get_localhost()}, bootstrap_addr=self.bootstrap_addr)
 
-    @cache
-    def _connect(self, endpoint: str):
-        socket = zmq.Context().socket(zmq.PUSH)
-        socket.connect(endpoint)
-        return socket
+    @classmethod
+    def _connect(cls, endpoint: str):
+        with cls._global_lock:
+            if endpoint not in cls._socket_cache:
+                sock = cls._ctx.socket(zmq.PUSH)
+                sock.connect(endpoint)
+                cls._socket_cache[endpoint] = sock
+                cls._socket_locks[endpoint] = threading.Lock()
+            return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
 
     def init(self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
-        prefill_port = None
-        logger.info(f"Decode bootstrap addr {self.bootstrap_addr}.")
-
-        if self.kv_mgr.kv_args.engine_rank not in self.kv_mgr.connection_pool:
-            prefill_port = self._get_prefill_port_from_bootstrap(
-                self.kv_mgr.kv_args.engine_rank
-            )
-            if prefill_port is None:
-                logger.error(
-                    f"Could not fetch prefill server port for tp_rank {self.kv_mgr.kv_args.engine_rank}"
-                )
-            else:
-                self.kv_mgr.connection_pool[self.kv_mgr.kv_args.engine_rank] = (
-                    prefill_port
-                )
-        else:
-            prefill_port = self.kv_mgr.connection_pool[self.kv_mgr.kv_args.engine_rank]
-
-        self.prefill_server_url = f"{self.bootstrap_addr.split(':')[0]}:{prefill_port}"
-
-        if prefill_port is not None:
-            logger.info(
-                f"Fetched prefill server port {prefill_port} for tp_rank {self.kv_mgr.kv_args.engine_rank}"
-            )
-            self.handshake_prefill_server(kv_indices, aux_index)
-
-    def handshake_prefill_server(
-        self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None
-    ):
         self.kv_mgr.enqueue_request(self.bootstrap_room, kv_indices, aux_index)
         packed_kv_data_ptrs = b"".join(
             struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.kv_data_ptrs
@@ -486,18 +503,19 @@ class KVReceiver:
         packed_aux_data_ptrs = b"".join(
             struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.aux_data_ptrs
         )
-        self._connect("tcp://" + self.prefill_server_url).send_multipart(
-            [
-                self.decode_ip.encode("ascii"),
-                str(self.decode_port).encode("ascii"),
-                self.session_id.encode("ascii"),
-                str(self.bootstrap_room).encode("ascii"),
-                packed_kv_data_ptrs,
-                kv_indices.tobytes(),
-                packed_aux_data_ptrs,
-                str(aux_index).encode("ascii"),
-            ]
-        )
+        socket, lock = self._connect("tcp://" + self.prefill_server_url)
+        with lock:
+            socket.send_multipart(
+                [
+                    self.decode_ip.encode("ascii"),
+                    self.session_id.encode("ascii"),
+                    str(self.bootstrap_room).encode("ascii"),
+                    packed_kv_data_ptrs,
+                    kv_indices.tobytes(),
+                    packed_aux_data_ptrs,
+                    str(aux_index).encode("ascii"),
+                ]
+            )
 
     def poll(self) -> KVPoll:
         return self.kv_mgr.check_status(self.bootstrap_room)
@@ -511,15 +529,9 @@ class KVBootstrapServer:
         self.port = port
         self.app = web.Application()
         self.store = dict()
+        self.kv_route_store = dict()
         self.lock = asyncio.Lock()
         self._setup_routes()
-        # prefill_engine_rank -> prefill_serve_port
-        self.prefill_port_table: Dict[int, int] = {}
-
-        self.context = zmq.Context()
-
-        self.prefill_engine_rank = None
-        self.prefill_tp_size = None
 
         # Start bootstrap server
         self.thread = threading.Thread(target=self._run_server, daemon=True)
@@ -529,7 +541,10 @@ class KVBootstrapServer:
         self.thread.start()
 
     def _setup_routes(self):
+        # will deprecate in the future
         self.app.router.add_route("*", "/metadata", self._handle_metadata)
+
+        # only route for bootstrap server
         self.app.router.add_route("*", "/kv_route", self._handle_kv_route)
 
     async def _handle_metadata(self, request: web.Request):
@@ -576,55 +591,47 @@ class KVBootstrapServer:
         )
 
     async def _handle_kv_route(self, request: web.Request):
-        method = request.method
-        if method == "PUT":
-            return await self._handle_kv_route_put(request)
-        elif method == "GET":
-            return await self._handle_kv_route_get(request)
-        else:
-            return web.Response(
-                text="Method not allowed", status=405, content_type="application/json"
-            )
+        key = request.query.get("key", "")
 
-    async def _handle_kv_route_put(self, request: web.Request):
-        data = await request.json()
-        # TODO: validate request
-        # if not data or 'serve_port' not in data or 'tp_size' not in data:
-        #     return web.Response(
-        #         text="Missing information", status=400
-        #     )
-        identity = data["identity"]
-        role = data["role"]
-        serve_ip = data["serve_ip"]
-        serve_port = int(data["serve_port"])  # Assuming serve_port is an integer
-        tp_size = int(data["tp_size"])
-        tp_rank = int(data["tp_rank"])
+        if request.method == "GET":
+            return await self._handle_kv_route_get(key)
+        elif request.method == "PUT":
+            return await self._handle_kv_route_put(key, request)
+        elif request.method == "DELETE":
+            return await self._handle_metadata_delete(key)
+        return web.Response(
+            text="Method not allowed", status=405, content_type="application/json"
+        )
 
-        # Add lock to make sure thread-safe
-        if role == "Prefill":
-            async with self.lock:
-                self.prefill_port_table[tp_rank] = serve_port
-            print(f"Registered Prefill tp_rank: {tp_rank} serve_port: {serve_port}")
-
-        return web.Response(text="OK", status=200)
-
-    async def _handle_kv_route_get(self, request: web.Request):
-        tp_rank = request.query.get("tp_rank")
-        if not tp_rank:
-            return web.Response(text="Missing tp_rank", status=400)
-        try:
-            tp_rank = int(tp_rank)
-        except ValueError:
-            return web.Response(text="tp_rank must be int", status=400)
-
-        # Find corresponding port
+    async def _handle_kv_route_put(self, key, request: web.Request):
+        data = await request.read()
         async with self.lock:
-            prefill_serve_port = self.prefill_port_table.get(tp_rank)
+            self.kv_route_store[key] = data
+        return web.Response(
+            text="kv route info updated", status=200, content_type="application/json"
+        )
 
-        if prefill_serve_port is not None:
-            return web.Response(text=str(prefill_serve_port), status=200)
-        else:
-            return web.Response(text="Not Found", status=404)
+    async def _handle_kv_route_get(self, key):
+        async with self.lock:
+            value = self.kv_route_store.get(key)
+        if value is None:
+            return web.Response(
+                text="metadata not found", status=404, content_type="application/json"
+            )
+        return web.Response(body=value, status=200, content_type="application/json")
+
+    async def _handle_kv_route_delete(self, key):
+        async with self.lock:
+            if key not in self.kv_route_store:
+                return web.Response(
+                    text="metadata not found",
+                    status=404,
+                    content_type="application/json",
+                )
+            del self.kv_route_store[key]
+        return web.Response(
+            text="metadata deleted", status=200, content_type="application/json"
+        )
 
     def _run_server(self):
         try:
@@ -655,4 +662,5 @@ class KVBootstrapServer:
             self.thread.join(timeout=2)
             logger.info("Server thread stopped")
 
-    def poll(self) -> KVPoll: ...
+    def poll(self) -> KVPoll:
+        ...

--- a/python/sglang/srt/disaggregation/conn.py
+++ b/python/sglang/srt/disaggregation/conn.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import random
 import struct
 import threading
 from functools import cache
@@ -9,6 +11,7 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
+import requests
 import zmq
 from aiohttp import web
 
@@ -46,6 +49,7 @@ def group_concurrent_contiguous(
 
 class KVArgs:
     engine_rank: int
+    tp_size: int
     kv_data_ptrs: list[int]
     kv_data_lens: list[int]
     kv_item_lens: list[int]
@@ -67,8 +71,9 @@ RequestPoolType = Dict[int, Tuple[npt.NDArray[np.int64], Optional[int]]]
 WaitingPoolType = Dict[
     int, Tuple[str, list[int], npt.NDArray[np.int64], list[int], int]
 ]
-KVSENDER_POLLING_PORT = 17788
-KVRECEIVER_POLLING_PORT = 27788
+# TODO: To be obsoleted
+# KVSENDER_POLLING_PORT = 17788
+# KVRECEIVER_POLLING_PORT = 27788
 
 
 class KVManager:
@@ -79,6 +84,8 @@ class KVManager:
         self.disaggregation_mode = disaggregation_mode
         self.request_pool: RequestPoolType = {}
         self.request_status: Dict[int, KVPoll] = {}
+        self.connection_pool: Dict[int, str] = {}
+        self.rank_port = None
         self.server_socket = zmq.Context().socket(zmq.PULL)
         self.register_buffer_to_engine()
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -185,15 +192,10 @@ class KVManager:
         )
         return status
 
-    def sync_status_to_decode_endpoint(self, remote: str, room: int):
+    def sync_status_to_decode_endpoint(self, remote: str, dst_port: int, room: int):
         if ":" in remote:
             remote = remote.split(":")[0]
-        self._connect(
-            "tcp://"
-            + remote
-            + ":"
-            + str(KVRECEIVER_POLLING_PORT + self.kv_args.engine_rank)
-        ).send_multipart(
+        self._connect("tcp://" + remote + ":" + str(dst_port)).send_multipart(
             [
                 str(room).encode("ascii"),
                 str(self.request_status[room]).encode("ascii"),
@@ -201,13 +203,19 @@ class KVManager:
         )
 
     def start_prefill_thread(self):
-        sender_rank_port = KVSENDER_POLLING_PORT + self.kv_args.engine_rank
-        self.server_socket.bind("tcp://*:" + str(sender_rank_port))
+        self.rank_port = random.randint(20001, 25000)
+        while True:
+            try:
+                self.server_socket.bind("tcp://*:" + str(self.rank_port))
+                break
+            except zmq.ZMQError as e:
+                self.rank_port += 1
 
         def prefill_thread():
             while True:
                 (
                     endpoint,
+                    dst_port,
                     mooncake_session_id,
                     bootstrap_room,
                     dst_ptrs,
@@ -218,6 +226,7 @@ class KVManager:
                 if bootstrap_room.decode("ascii") == "None":
                     continue
                 endpoint = endpoint.decode("ascii")
+                dst_port = dst_port.decode("ascii")
                 mooncake_session_id = mooncake_session_id.decode("ascii")
                 bootstrap_room = int(bootstrap_room.decode("ascii"))
                 dst_ptrs = list(struct.unpack(f"{len(dst_ptrs)//8}Q", dst_ptrs))
@@ -228,6 +237,7 @@ class KVManager:
                 dst_aux_index = int(dst_aux_index.decode("ascii"))
                 self.waiting_pool[bootstrap_room] = (
                     endpoint,
+                    dst_port,
                     mooncake_session_id,
                     dst_ptrs,
                     dst_kv_indices,
@@ -251,13 +261,14 @@ class KVManager:
                     self.request_status[room] = status
                     (
                         endpoint,
+                        dst_port,
                         mooncake_session_id,
                         dst_ptrs,
                         dst_kv_indices,
                         dst_aux_ptrs,
                         dst_aux_index,
                     ) = self.waiting_pool.pop(room)
-                    self.sync_status_to_decode_endpoint(endpoint, room)
+                    self.sync_status_to_decode_endpoint(endpoint, dst_port, room)
                     (
                         prefill_kv_indices,
                         prefill_aux_index,
@@ -270,7 +281,7 @@ class KVManager:
                     )
                     if ret != 0:
                         status = KVPoll.Failed
-                        self.sync_status_to_decode_endpoint(endpoint, room)
+                        self.sync_status_to_decode_endpoint(endpoint, dst_port, room)
                         continue
                     ret = self.send_aux(
                         mooncake_session_id,
@@ -283,13 +294,18 @@ class KVManager:
                     else:
                         status = KVPoll.Success
                     self.request_status[room] = status
-                    self.sync_status_to_decode_endpoint(endpoint, room)
+                    self.sync_status_to_decode_endpoint(endpoint, dst_port, room)
 
         threading.Thread(target=transfer_thread).start()
 
     def start_decode_thread(self):
-        receiver_rank_port = KVRECEIVER_POLLING_PORT + self.kv_args.engine_rank
-        self.server_socket.bind("tcp://*:" + str(receiver_rank_port))
+        self.rank_port = random.randint(25001, 30000)
+        while True:
+            try:
+                self.server_socket.bind("tcp://*:" + str(self.rank_port))
+                break
+            except zmq.ZMQError as e:
+                self.rank_port += 1
 
         def decode_thread():
             while True:
@@ -338,10 +354,44 @@ class KVSender:
         self.bootstrap_room = bootstrap_room
         self.kv_mgr.set_status(bootstrap_room, KVPoll.WaitingForInput)
         self.aux_index = None
+        self.bootstrap_server_url = bootstrap_addr
+
+        self.session_id = self.kv_mgr.get_session_id()
+
+    def _register_to_bootstrap(self):
+        """Register KVSender to bootstrap server via HTTP POST."""
+        url = f"http://{self.bootstrap_server_url}/kv_route"
+        payload = {
+            "identity": self.session_id,
+            "role": "Prefill",
+            "serve_ip": self.bootstrap_server_url.split(":")[0],
+            "serve_port": self.kv_mgr.rank_port,
+            "tp_rank": self.kv_mgr.kv_args.engine_rank,
+            "tp_size": self.kv_mgr.kv_args.tp_size,
+        }
+
+        logger.info(
+            f"Register prefill server port {self.kv_mgr.rank_port} for tp_rank {self.kv_mgr.kv_args.engine_rank}"
+        )
+
+        try:
+            response = requests.put(url, json=payload)
+            if response.status_code == 200:
+                logger.info(f"Prefill successfully registered to bootstrap server.")
+            else:
+                logger.info(
+                    f"Prefill Failed to register to bootstrap server: {response.status_code}, {response.text}"
+                )
+        except Exception as e:
+            logger.info(f"Prefill Failed to register to bootstrap server: {e}")
 
     def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
         self.aux_index = aux_index
         self.num_kv_indices = num_kv_indices
+
+        # Register to bootstrap server
+        logger.info(f"Prefill bootstrap addr {self.bootstrap_server_url}.")
+        self._register_to_bootstrap()
 
     def send(self, kv_indices: npt.NDArray[np.int64]):
         self.kv_mgr.enqueue_request(self.bootstrap_room, kv_indices, self.aux_index)
@@ -361,14 +411,37 @@ class KVReceiver:
         self.bootstrap_room = bootstrap_room
         self.bootstrap_addr = bootstrap_addr
         self.kv_mgr = mgr
-        self.prefill_server_url = (
-            bootstrap_addr.split(":")[0]
-            + ":"
-            + str(KVSENDER_POLLING_PORT + self.kv_mgr.kv_args.engine_rank)
-        )
         self.decode_ip = self.kv_mgr.get_localhost()
         self.session_id = self.kv_mgr.get_session_id()
         self.kv_mgr.set_status(bootstrap_room, KVPoll.WaitingForInput)
+        self.prefill_engine_rank = None
+        self.prefill_tp_size = None
+        self.decode_port = self.kv_mgr.rank_port
+        self.dealer_socket = None
+
+    def _get_prefill_port_from_bootstrap(self, tp_rank: int):
+        """Fetch the prefill server port corresponding to tp_rank from the bootstrap server."""
+        try:
+            url = f"http://{self.bootstrap_addr}/kv_route?tp_rank={tp_rank}"
+            response = requests.get(url)
+            if response.status_code == 200:
+                prefill_serve_port = int(response.text)
+                return prefill_serve_port
+            else:
+                logger.error(
+                    f"Failed to get prefill server port: {response.status_code}, {response.text}"
+                )
+                return None
+        except Exception as e:
+            logger.error(f"Error fetching prefill port from bootstrap: {e}")
+            return None
+
+    @cache
+    def _connect_bootstrap(self, endpoint: str):
+        socket = zmq.Context().socket(zmq.DEALER)
+        socket.setsockopt(zmq.IDENTITY, self.session_id)
+        socket.connect(endpoint)
+        return socket
 
     @cache
     def _connect(self, endpoint: str):
@@ -377,6 +450,35 @@ class KVReceiver:
         return socket
 
     def init(self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
+        prefill_port = None
+        logger.info(f"Decode bootstrap addr {self.bootstrap_addr}.")
+
+        if self.kv_mgr.kv_args.engine_rank not in self.kv_mgr.connection_pool:
+            prefill_port = self._get_prefill_port_from_bootstrap(
+                self.kv_mgr.kv_args.engine_rank
+            )
+            if prefill_port is None:
+                logger.error(
+                    f"Could not fetch prefill server port for tp_rank {self.kv_mgr.kv_args.engine_rank}"
+                )
+            else:
+                self.kv_mgr.connection_pool[self.kv_mgr.kv_args.engine_rank] = (
+                    prefill_port
+                )
+        else:
+            prefill_port = self.kv_mgr.connection_pool[self.kv_mgr.kv_args.engine_rank]
+
+        self.prefill_server_url = f"{self.bootstrap_addr.split(':')[0]}:{prefill_port}"
+
+        if prefill_port is not None:
+            logger.info(
+                f"Fetched prefill server port {prefill_port} for tp_rank {self.kv_mgr.kv_args.engine_rank}"
+            )
+            self.handshake_prefill_server(kv_indices, aux_index)
+
+    def handshake_prefill_server(
+        self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None
+    ):
         self.kv_mgr.enqueue_request(self.bootstrap_room, kv_indices, aux_index)
         packed_kv_data_ptrs = b"".join(
             struct.pack("Q", ptr) for ptr in self.kv_mgr.kv_args.kv_data_ptrs
@@ -387,6 +489,7 @@ class KVReceiver:
         self._connect("tcp://" + self.prefill_server_url).send_multipart(
             [
                 self.decode_ip.encode("ascii"),
+                str(self.decode_port).encode("ascii"),
                 self.session_id.encode("ascii"),
                 str(self.bootstrap_room).encode("ascii"),
                 packed_kv_data_ptrs,
@@ -410,6 +513,13 @@ class KVBootstrapServer:
         self.store = dict()
         self.lock = asyncio.Lock()
         self._setup_routes()
+        # prefill_engine_rank -> prefill_serve_port
+        self.prefill_port_table: Dict[int, int] = {}
+
+        self.context = zmq.Context()
+
+        self.prefill_engine_rank = None
+        self.prefill_tp_size = None
 
         # Start bootstrap server
         self.thread = threading.Thread(target=self._run_server, daemon=True)
@@ -420,21 +530,22 @@ class KVBootstrapServer:
 
     def _setup_routes(self):
         self.app.router.add_route("*", "/metadata", self._handle_metadata)
+        self.app.router.add_route("*", "/kv_route", self._handle_kv_route)
 
     async def _handle_metadata(self, request: web.Request):
         key = request.query.get("key", "")
 
         if request.method == "GET":
-            return await self._handle_get(key)
+            return await self._handle_metadata_get(key)
         elif request.method == "PUT":
-            return await self._handle_put(key, request)
+            return await self._handle_metadata_put(key, request)
         elif request.method == "DELETE":
-            return await self._handle_delete(key)
+            return await self._handle_metadata_delete(key)
         return web.Response(
             text="Method not allowed", status=405, content_type="application/json"
         )
 
-    async def _handle_get(self, key):
+    async def _handle_metadata_get(self, key):
         async with self.lock:
             value = self.store.get(key)
         if value is None:
@@ -443,7 +554,7 @@ class KVBootstrapServer:
             )
         return web.Response(body=value, status=200, content_type="application/json")
 
-    async def _handle_put(self, key, request):
+    async def _handle_metadata_put(self, key, request):
         data = await request.read()
         async with self.lock:
             self.store[key] = data
@@ -451,7 +562,7 @@ class KVBootstrapServer:
             text="metadata updated", status=200, content_type="application/json"
         )
 
-    async def _handle_delete(self, key):
+    async def _handle_metadata_delete(self, key):
         async with self.lock:
             if key not in self.store:
                 return web.Response(
@@ -463,6 +574,57 @@ class KVBootstrapServer:
         return web.Response(
             text="metadata deleted", status=200, content_type="application/json"
         )
+
+    async def _handle_kv_route(self, request: web.Request):
+        method = request.method
+        if method == "PUT":
+            return await self._handle_kv_route_put(request)
+        elif method == "GET":
+            return await self._handle_kv_route_get(request)
+        else:
+            return web.Response(
+                text="Method not allowed", status=405, content_type="application/json"
+            )
+
+    async def _handle_kv_route_put(self, request: web.Request):
+        data = await request.json()
+        # TODO: validate request
+        # if not data or 'serve_port' not in data or 'tp_size' not in data:
+        #     return web.Response(
+        #         text="Missing information", status=400
+        #     )
+        identity = data["identity"]
+        role = data["role"]
+        serve_ip = data["serve_ip"]
+        serve_port = int(data["serve_port"])  # Assuming serve_port is an integer
+        tp_size = int(data["tp_size"])
+        tp_rank = int(data["tp_rank"])
+
+        # Add lock to make sure thread-safe
+        if role == "Prefill":
+            async with self.lock:
+                self.prefill_port_table[tp_rank] = serve_port
+            print(f"Registered Prefill tp_rank: {tp_rank} serve_port: {serve_port}")
+
+        return web.Response(text="OK", status=200)
+
+    async def _handle_kv_route_get(self, request: web.Request):
+        tp_rank = request.query.get("tp_rank")
+        if not tp_rank:
+            return web.Response(text="Missing tp_rank", status=400)
+        try:
+            tp_rank = int(tp_rank)
+        except ValueError:
+            return web.Response(text="tp_rank must be int", status=400)
+
+        # Find corresponding port
+        async with self.lock:
+            prefill_serve_port = self.prefill_port_table.get(tp_rank)
+
+        if prefill_serve_port is not None:
+            return web.Response(text=str(prefill_serve_port), status=200)
+        else:
+            return web.Response(text="Not Found", status=404)
 
     def _run_server(self):
         try:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -99,6 +99,7 @@ class DecodePreallocQueue:
     def _init_kv_manager(self) -> KVManager:
         kv_args = KVArgs()
         kv_args.engine_rank = self.tp_rank
+        kv_args.tp_size = self.tp_size
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -118,7 +118,7 @@ class DecodePreallocQueue:
             metadata_buffer[0].nbytes for metadata_buffer in self.metadata_buffers
         ]
         kv_args.ib_device = "mock-ib-device"
-        kv_manager = KVManager(kv_args, DisaggregationMode("decode"))
+        kv_manager = KVManager(kv_args, DisaggregationMode("decode"), self.scheduler.server_args)
         return kv_manager
 
     def add(self, req: Req) -> None:
@@ -126,6 +126,7 @@ class DecodePreallocQueue:
 
         kv_receiver = KVReceiver(
             mgr=self.kv_manager,
+            prefill_addr=req.prefill_addr,
             bootstrap_addr=f"{req.bootstrap_host}:{self.bootstrap_port}",
             bootstrap_room=req.bootstrap_room,
         )

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -155,12 +155,15 @@ async def handle_generate_request(request_data: dict):
 
     # Parse and transform prefill_server for bootstrap data
     parsed_url = urllib.parse.urlparse(prefill_server)
+
+    prefill_addr = parsed_url.netloc
     hostname = parsed_url.hostname
     modified_request = request_data.copy()
     modified_request.update(
         {
             "bootstrap_host": hostname,
             "bootstrap_room": random.randint(0, 2**63 - 1),
+            "prefill_addr": f"{prefill_addr}",
         }
     )
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -77,6 +77,7 @@ class PrefillBootstrapQueue:
     def _init_kv_manager(self) -> KVManager:
         kv_args = KVArgs()
         kv_args.engine_rank = self.tp_rank
+        kv_args.tp_size = self.tp_size
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -56,6 +56,7 @@ class PrefillBootstrapQueue:
         tp_size: int,
         bootstrap_port: int,
         gloo_group: ProcessGroup,
+        scheduler: Scheduler,
     ):
         self.token_to_kv_pool = token_to_kv_pool
         self.aux_dtype = aux_dtype
@@ -64,6 +65,7 @@ class PrefillBootstrapQueue:
         self.req_to_metadata_buffer_idx_allocator = req_to_metadata_buffer_idx_allocator
         self.tp_rank = tp_rank
         self.tp_size = tp_size
+        self.scheduler = scheduler
         self.kv_manager = self._init_kv_manager()
         self.queue: List[Req] = []
         self.gloo_group = gloo_group
@@ -97,7 +99,7 @@ class PrefillBootstrapQueue:
             metadata_buffer[0].nbytes for metadata_buffer in self.metadata_buffers
         ]
         kv_args.ib_device = "mock-ib-device"
-        kv_manager = KVManager(kv_args, DisaggregationMode("prefill"))
+        kv_manager = KVManager(kv_args, DisaggregationMode("prefill"), self.scheduler.server_args)
         return kv_manager
 
     def add(self, req: Req) -> None:

--- a/python/sglang/srt/disaggregation/transfer_engine/mooncake.py
+++ b/python/sglang/srt/disaggregation/transfer_engine/mooncake.py
@@ -106,3 +106,6 @@ class MooncakeTransferEngine:
 
     def get_session_id(self):
         return self.session_id
+
+    def get_metadata_server(self):
+        return self.config.metadata_server

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -98,6 +98,7 @@ class GenerateReqInput:
     # For disaggregated inference
     bootstrap_host: Optional[str] = None
     bootstrap_room: Optional[int] = None
+    prefill_addr: Optional[str] = None
 
     def normalize_batch_and_arguments(self):
         """
@@ -442,6 +443,7 @@ class TokenizedGenerateReqInput:
     # For disaggregated inference
     bootstrap_host: Optional[str] = None
     bootstrap_room: Optional[int] = None
+    prefill_addr: Optional[str] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -390,6 +390,7 @@ class Req:
         eos_token_ids: Optional[Set[int]] = None,
         bootstrap_host: Optional[str] = None,
         bootstrap_room: Optional[int] = None,
+        prefill_addr: Optional[str] = None,
     ):
         # Input and output info
         self.rid = rid
@@ -525,6 +526,7 @@ class Req:
         # For disaggregation
         self.bootstrap_host: str = bootstrap_host
         self.bootstrap_room: Optional[int] = bootstrap_room
+        self.prefill_addr: str = prefill_addr
         self.disagg_kv_sender: Optional[KVSender] = None
 
         # used for warmup because we don't have a pair yet when init

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -592,6 +592,7 @@ class Scheduler(
                 tp_size=self.tp_size,
                 bootstrap_port=self.server_args.disaggregation_bootstrap_port,
                 gloo_group=self.tp_worker.get_attention_tp_cpu_group(),
+                scheduler=self,
             )
             # The prefill requests that are in the middle of kv sending
             self.disagg_prefill_infight_queue: List[Req] = []
@@ -838,6 +839,7 @@ class Scheduler(
                 custom_logit_processor=custom_logit_processor,
                 return_hidden_states=recv_req.return_hidden_states,
                 eos_token_ids=self.model_config.hf_eos_token_id,
+                prefill_addr=recv_req.prefill_addr,
                 bootstrap_host=recv_req.bootstrap_host,
                 bootstrap_room=recv_req.bootstrap_room,
             )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -456,6 +456,7 @@ class TokenizerManager:
                 obj.stream,
                 bootstrap_host=obj.bootstrap_host,
                 bootstrap_room=obj.bootstrap_room,
+                prefill_addr=obj.prefill_addr,
                 lora_path=obj.lora_path,
                 input_embeds=input_embeds,
                 session_params=session_params,

--- a/python/sglang/srt/openai_api/protocol.py
+++ b/python/sglang/srt/openai_api/protocol.py
@@ -361,6 +361,10 @@ class ChatCompletionRequest(BaseModel):
     separate_reasoning: bool = True
     stream_reasoning: bool = True
 
+    bootstrap_host: Optional[str] = None
+    bootstrap_room: Optional[int] = None
+    prefill_addr: Optional[str] = None
+
 
 class FunctionResponse(BaseModel):
     """Function response."""

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1870,3 +1870,18 @@ def is_hopper_with_cuda_12_3():
     cuda_version = torch.version.cuda.split(".")
     is_cuda_compatible = int(cuda_version[0]) == 12 and int(cuda_version[1]) >= 3
     return is_hopper and is_cuda_compatible
+
+def get_local_ip_by_remote(addr="8.8.8.8:8888"):
+    """
+    Get Local IP Connecting Remote Addr
+    """
+
+    host, port = addr.split(":")
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect((host, int(port.strip())))  # connecting fake server to get ip host
+        return s.getsockname()[0]
+
+def get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))  # allocated by sys
+        return s.getsockname()[1]


### PR DESCRIPTION
[PD Feature] Support TP16 and Optimize Dynamic Connection Establishment
## Motivation

Currently, Mooncake requires enhancements in handling multi-node `prefill` and `decode` setups. Specifically, it needs to support dynamic connection establishment and work reliably with multi-node TP=16 scenarios.

Thanks the pr:  [5351](https://github.com/sgl-project/sglang/pull/5351) authored by  @yuan-luo

## Modifications

1. Changed the port assignment from static computation to dynamically acquiring available ports.  
2. Enabled the load balancer to forward the `prefill_addr` to both `prefill` and `decode` nodes. This address is now used as a key to register and query the corresponding IP and ZMQ port information.

## Checklist

- [x] Dynamic port assignment implemented  
- [x] `prefill_addr` forwarding and registration logic added  
- [x] Multi-node TP=16 setup tested  
- [ ] Add relevant unit/integration tests  
- [ ] Update documentation if necessary
