### PR TITLE
fix: resolve sglang startup block caused by broadcast_pyobj log flooding

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -849,7 +849,6 @@ def broadcast_pyobj(
 ):
     """Broadcast inputs from rank=0 to all other ranks with torch.dist backend."""
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"[broadcast_pyobj] rank={rank}, device={device}")
 
     if rank == 0:
         if len(data) == 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The log `[broadcast_pyobj] rank=2, device=cuda` introduced in #5322 yesterday causes excessive log flooding, which blocks the initialization of the sglang server.

```
[2025-04-13 14:53:45 TP1] Capture cuda graph end. Time elapsed: 7.81 s. avail mem=6.60 GB. mem usage=1.45 GB.
[2025-04-13 14:53:45 TP1] max_total_num_tokens=6079237, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4097, context_len=32768
[2025-04-13 14:53:45 TP0] max_total_num_tokens=6079237, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4097, context_len=32768
[2025-04-13 14:53:45 TP2] max_total_num_tokens=6079237, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4097, context_len=32768
[2025-04-13 14:53:45 TP3] max_total_num_tokens=6079237, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4097, context_len=32768
[2025-04-13 14:53:46] INFO:     Started server process [216190]
[2025-04-13 14:53:46] INFO:     Waiting for application startup.
[2025-04-13 14:53:46] INFO:     Application startup complete.
[2025-04-13 14:53:46] INFO:     Uvicorn running on http://10.13.3.170:30000 (Press CTRL+C to quit)
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
[broadcast_pyobj] rank=2, device=cuda
...
```

## Modifications

<!-- Describe the changes made in this PR. -->
delete the print

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
