### PR TITLE
feat: update experiment_runner

### DIFF
--- a/test/srt/configs/llama_405b.yaml
+++ b/test/srt/configs/llama_405b.yaml
@@ -1,0 +1,28 @@
+tasks:
+  - name: sglang-8192-1024-concurrency1
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 1 --num-prompts 5 --output-file llama_405b_results.jsonl
+
+  - name: sglang-8192-1024-concurrency2
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 2 --num-prompts 10 --output-file llama_405b_results.jsonl
+
+  - name: sglang-8192-1024-concurrency4
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 4 --num-prompts 20 --output-file llama_405b_results.jsonl
+
+  - name: sglang-8192-1024-concurrency8
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 8 --num-prompts 32 --output-file llama_405b_results.jsonl
+
+  - name: sglang-8192-1024-concurrency16
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 16 --num-prompts 48 --output-file llama_405b_results.jsonl
+
+  - name: sglang-8192-1024-concurrency24
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 24 --num-prompts 72 --output-file llama_405b_results.jsonl
+
+  - name: sglang-8192-1024-concurrency32
+    server_cmd: python3 -m sglang.launch_server --model nvidia/Llama-3.1-405B-Instruct-FP8 --tp 8
+    client_cmd: python3 -m sglang.bench_serving --random-range-ratio 1 --random-input-len 8192 --random-output-len 1024 --max-concurrency 32 --num-prompts 96 --output-file llama_405b_results.jsonl

--- a/test/srt/experiment_runner.py
+++ b/test/srt/experiment_runner.py
@@ -317,6 +317,11 @@ def format_results(results: List[TaskResult]) -> str:
     return "\n".join(output)
 
 
+def get_bool_env_var(name: str, default: str = "false") -> bool:
+    value = os.getenv(name, default)
+    return value.lower() in ("true", "1")
+
+
 def write_in_github_step_summary(results: List[TaskResult]):
     """Write formatted results to GitHub step summary."""
     if not os.environ.get("GITHUB_STEP_SUMMARY"):
@@ -349,7 +354,8 @@ def main():
             result = runner.run_task(config)
             results.append(result)
 
-        write_in_github_step_summary(results)
+        if get_bool_env_var("SGLANG_IS_IN_CI"):
+            write_in_github_step_summary(results)
     except Exception as e:
         logger.error(f"Error: {e}")
         raise

--- a/test/srt/parse_results.py
+++ b/test/srt/parse_results.py
@@ -1,0 +1,46 @@
+import json
+import pandas as pd
+import argparse
+import os
+from tabulate import tabulate
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description="Parse JSONL benchmark and summarize.")
+parser.add_argument("input_file", type=str, help="Path to input JSONL file")
+args = parser.parse_args()
+
+input_file = args.input_file
+base_name = os.path.splitext(os.path.basename(input_file))[0]
+output_file = f"{base_name}_summary.csv"
+
+fields = [
+    "max_concurrency",
+    "output_throughput",
+    "mean_ttft_ms",
+    "median_ttft_ms",
+    "p99_ttft_ms",
+    "mean_tpot_ms",
+    "median_tpot_ms",
+    "p99_tpot_ms",
+]
+
+# Read JSONL and parse
+results = []
+with open(input_file, "r") as f:
+    for line in f:
+        data = json.loads(line)
+        row = {field: data.get(field, None) for field in fields}
+        max_conc = data.get("max_concurrency")
+        out_tp = data.get("output_throughput")
+        row["per_user_throughput"] = out_tp / max_conc if max_conc else None
+        results.append(row)
+
+# Convert to DataFrame
+df = pd.DataFrame(results)
+
+# Save to CSV
+df.to_csv(output_file, index=False)
+print(f"\nSaved summary to: {output_file}\n")
+
+# Print ASCII table
+print(tabulate(df, headers="keys", tablefmt="grid", floatfmt=".3f"))


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

For models with large weights like Llama 3.1 405B, DeepSeek V3, and Qwen 3, we typically use max concurrency to manage batch size in load testing. During production deployment, this is usually controlled by the upper-level LB. It's important to consider latency and throughput per user at various batch sizes to determine how many users an instance can support.

```bash
# simple example with B200 (not optimized yet)
python3 test/srt/experiment_runner.py --config test/srt/configs/llama_405b.yaml
python3 test/srt/parse_results.py llama_405b_results.jsonl
```

```
Saved summary to: llama_405b_results_summary.csv

+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |              24.101 |        278.285 |          278.324 |       322.245 |         40.449 |           40.364 |        40.773 |                24.101 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |             2.000 |              45.206 |        887.750 |          318.452 |      3109.857 |         39.752 |           40.005 |        47.451 |                22.603 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |             4.000 |              65.530 |        526.299 |          286.991 |      3148.939 |         49.539 |           43.545 |       143.727 |                16.382 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  3 |             8.000 |             138.106 |        662.395 |          321.294 |      3847.821 |         44.514 |           39.358 |       141.036 |                17.263 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  4 |            16.000 |             128.978 |       1061.184 |          287.944 |      3928.394 |         44.852 |           42.679 |        84.700 |                 8.061 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  5 |            24.000 |             178.506 |       1306.952 |          280.354 |      4148.658 |         49.733 |           47.022 |       118.682 |                 7.438 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  6 |            32.000 |             262.929 |        915.923 |          323.104 |      4566.466 |        106.594 |           55.072 |      1316.176 |                 8.217 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
