### PR TITLE
apply fused moe gate in ds v3/r1

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -17,11 +17,11 @@ from typing import Callable, Optional
 
 import torch
 import torch.nn.functional as F
+from sgl_kernel import moe_fused_gate
 
 from sglang.srt.managers.expert_distribution import ExpertDistributionRecorder
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.utils import get_compiler_backend, is_cuda, is_hip
-from sgl_kernel import moe_fused_gate
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import math
 import os
 from typing import Callable, Optional
 
@@ -210,6 +211,10 @@ def biased_grouped_topk_impl(
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
+def is_power_of_two(n):
+    return n > 0 and math.log2(n).is_integer()
+
+
 def biased_grouped_topk(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -222,7 +227,7 @@ def biased_grouped_topk(
     n_share_experts_fusion: int = 0,
 ):
     # TODO: moe_fused_gate kernel is not supported for n_share_experts_fusion > 0 now.
-    if n_share_experts_fusion == 0:
+    if n_share_experts_fusion == 0 and is_power_of_two(correction_bias.shape[0]):
         return moe_fused_gate(
             gating_output,
             correction_bias,


### PR DESCRIPTION
## torch profile

```shell
python3 -m sglang.bench_serving --backend sglang --num-prompts 2 --request-rate 1 --port 30001 --flush-cache --warmup-requests 1 --profile
```

### main branch

![图片](https://github.com/user-attachments/assets/6e5d87ca-1090-47da-b05e-1e1124583048)

### pr

![图片](https://github.com/user-attachments/assets/e09ede25-c6c6-4481-8428-30d053c96e4e)

Only one kernel now.

36us->8us.


## fused_moe_gate gsm8k acc test

```shell
SGL_ENABLE_JIT_DEEPGEMM=0 python3 -m sglang.launch_server --model /DeepSeek-V3 --tp 8 --trust-remote-code --port 30001
python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8  --port 30001

100%|█████████████████████████████████████████████████████████████████████████| 1319/1319 [00:54<00:00, 24.24it/s]
Accuracy: 0.950
Invalid: 0.000
Latency: 54.740 s
Output throughput: 2529.836 token/s
```

## fused moe gate performance(in H200)

```shell
SGL_ENABLE_JIT_DEEPGEMM=0 python3 -m sglang.launch_server --model /DeepSeek-V3 --tp 8 --trust-remote-code --port 30001
python3 -m sglang.bench_serving --backend sglang --num-prompts 300 --request-rate 1 --port 30001 --flush-cache --warmup-requests 20
```

|qps|Input token throughput (tok/s)|Output token throughput (tok/s)|Total token throughput (tok/s)|
|---|---|---|---|
|4(main)| 719.99| 456.44| 1176.43|
|4(pr)  | 763.11| 483.77| 1246.88|
|8(main)| 840.96| 533.13| 1374.09|
|8(pr)  | 887.35| 562.54| 1449.89|
|16(main)| 892.55| 565.83| 1458.38|
|16(pr)  | 964.91| 611.70| 1576.61|


- qps=4: 5.9%+
- qps=8: 5.5%+
- qps=16: 8.1%+
