### PR TITLE
[Minor] Move torch.compile patch to a better place

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -34,6 +34,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
+from sglang.srt.patch_torch import monkey_patch_torch_compile
 from sglang.srt.utils import get_available_gpu_memory, is_hip
 
 _is_hip = is_hip()
@@ -107,6 +108,8 @@ def set_torch_compile_config():
     torch._dynamo.config.accumulated_cache_size_limit = 1024
     if hasattr(torch._dynamo.config, "cache_size_limit"):
         torch._dynamo.config.cache_size_limit = 1024
+
+    monkey_patch_torch_compile()
 
 
 def get_batch_sizes_to_capture(model_runner: ModelRunner):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -64,10 +64,7 @@ from sglang.srt.model_loader.loader import (
 )
 from sglang.srt.model_loader.utils import set_default_torch_dtype
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.patch_torch import (
-    monkey_patch_torch_compile,
-    monkey_patch_torch_reductions,
-)
+from sglang.srt.patch_torch import monkey_patch_torch_reductions
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -91,8 +88,6 @@ logger = logging.getLogger(__name__)
 
 SGLANG_CI_SMALL_KV_SIZE = os.getenv("SGLANG_CI_SMALL_KV_SIZE", None)
 UNBALANCED_MODEL_LOADING_TIMEOUT_S = 300
-
-monkey_patch_torch_compile()
 
 
 class ModelRunner:


### PR DESCRIPTION
Improve this https://github.com/sgl-project/sglang/pull/5259.
- It is better to not call `monkey_patch_torch_compile` at top level. I moved it under `set_torch_compile_config`. I hope it is not too late.
- Can you also review other torch.compile configs in `set_torch_compile_config`?

cc @zou3519  can you take a look?