### PR TITLE
[FIX] Fix concatenation error in capture_bs when open --disable-cuda-graph-padding and without MTP

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -116,7 +116,7 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner):
     if capture_bs is None:
         if server_args.speculative_algorithm is None:
             if server_args.disable_cuda_graph_padding:
-                capture_bs = list(range(1, 33)) + range(40, 161, 16)
+                capture_bs = list(range(1, 33)) + list(range(40, 161, 16))
             else:
                 capture_bs = [1, 2, 4, 8] + list(range(16, 161, 8))
         else:


### PR DESCRIPTION
# [FIX] Fix concatenation error in capture_bs when open --disable-cuda-graph-padding and without MTP


## Motivation

This PR fixes a `TypeError` that occurs when trying to concatenate a `list` with a `range` object in `cuda_graph_runner.py`. when you use `--disable-cuda-graph-padding` and have no mtp.


## Modifications

The original code:
```python
capture_bs = list(range(1, 33)) + range(40, 161, 16)
```
Modified
```python
capture_bs = list(range(1, 33)) + list(range(40, 161, 16)
```

## Checklist

- [ x ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
