### PR TITLE
Fix broadcast use cuda device lead to memory capacity unbalanced

### DIFF
--- a/python/sglang/srt/entrypoints/verl_engine.py
+++ b/python/sglang/srt/entrypoints/verl_engine.py
@@ -118,6 +118,7 @@ class VerlEngine:
             rank=self._tp_rank,
             dist_group=self._device_mesh_cpu.get_group(),
             src=self._device_mesh_cpu.mesh[0].item(),
+            force_cpu_device=False,
         )
 
         return output

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -846,9 +846,12 @@ def broadcast_pyobj(
     rank: int,
     dist_group: Optional[torch.distributed.ProcessGroup] = None,
     src: int = 0,
+    force_cpu_device: bool = True,
 ):
     """Broadcast inputs from rank=0 to all other ranks with torch.dist backend."""
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(
+        "cuda" if torch.cuda.is_available() and not force_cpu_device else "cpu"
+    )
 
     if rank == 0:
         if len(data) == 0:


### PR DESCRIPTION
## Motivation

Ref: https://github.com/sgl-project/sglang/pull/5322

When using NextN in DeepSeek V3/R1, the following issues may occur:

```
[2025-04-15 04:23:49 TP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2063, in run_scheduler_process
    scheduler = Scheduler(server_args, port_args, gpu_id, tp_rank, dp_rank)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 271, in __init__
    self.draft_worker = EAGLEWorker(
  File "/sgl-workspace/sglang/python/sglang/srt/speculative/eagle_worker.py", line 113, in __init__
    super().__init__(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 75, in __init__
    self.model_runner = ModelRunner(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 182, in __init__
    min_per_gpu_memory = self.init_torch_distributed()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 380, in init_torch_distributed
    raise ValueError(
ValueError: The memory capacity is unbalanced. Some GPUs may be occupied by other processes. min_per_gpu_memory=8.8841552734375, local_gpu_memory=11.901611328125, local_gpu_memory * 0.9=10.7114501953125
```

## Modifications

Add the `force_cpu_device` parameter in the `broadcast_pyobj` method. When using Verl Engine, select the specific Device according to the actual situation. Other situations remain the same as before.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
