### PR TITLE
Enable customized op with pytorch native path and tests llama and phi on Intel GPU 

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -52,6 +52,15 @@ cd ..
 pip install -e "python[all_hip]"
 ```
 
+Note: For Intel GPU, do following instead:
+
+```
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+pip install --upgrade pip
+pip install -e "python[all_xpu]"
+```
+
 ## Method 3: Using docker
 The docker images are available on Docker Hub as [lmsysorg/sglang](https://hub.docker.com/r/lmsysorg/sglang/tags), built from [Dockerfile](https://github.com/sgl-project/sglang/tree/main/docker).
 Replace `<secret>` below with your huggingface hub [token](https://huggingface.co/docs/hub/en/security-tokens).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -79,8 +79,7 @@ srt_hip = [
 
 # xpu is not enabled in public vllm and torch whl,
 # need to follow https://docs.vllm.ai/en/latest/getting_started/xpu-installation.htmlinstall vllm
-#srt_xpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11", "vllm"]
-srt_xpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11"]
+srt_xpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11", "vllm"]
 
 # For Intel Gaudi(device : hpu) follow the installation guide
 # https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -79,6 +79,7 @@ srt_hip = [
 
 # xpu is not enabled in public vllm and torch whl,
 # need to follow https://docs.vllm.ai/en/latest/getting_started/xpu-installation.htmlinstall vllm
+#srt_xpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11", "vllm"]
 srt_xpu = ["sglang[runtime_common]", "outlines>=0.0.44,<=0.1.11"]
 
 # For Intel Gaudi(device : hpu) follow the installation guide

--- a/python/sglang/srt/_custom_ops.py
+++ b/python/sglang/srt/_custom_ops.py
@@ -6,12 +6,15 @@ from typing import List, Tuple
 import torch
 import torch.library
 
-from sglang.srt.utils import get_bool_env_var, is_hip, is_hpu
+from sglang.srt.utils import get_bool_env_var, is_hip, is_hpu, is_xpu
 
 logger = logging.getLogger(__name__)
 use_vllm_custom_allreduce = get_bool_env_var(
     "USE_VLLM_CUSTOM_ALLREDUCE", default="false"
 )
+
+if is_xpu():
+    use_vllm_custom_allreduce = True
 
 if not is_hpu():
     # ROCm does not use vllm custom allreduce

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -21,9 +21,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from sglang.srt.utils import is_cuda_available
+from sglang.srt.utils import is_cuda, is_xpu
 
-_is_cuda = is_cuda_available()
+_is_cuda = is_cuda()
+_is_xpu = is_xpu()
 
 if _is_cuda:
     from sgl_kernel import gelu_and_mul, gelu_tanh_and_mul, silu_and_mul
@@ -167,7 +168,7 @@ def get_act_fn(
     return act_fn
 
 
-if not _is_cuda:
+if not _is_cuda and not _is_xpu:
     logger.info(
         "sgl-kernel is not available on Non-NV platforms. Fallback to other kernel libraries."
     )

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -19,9 +19,10 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
-from sglang.srt.utils import is_cuda_available
+from sglang.srt.utils import is_cuda, is_xpu
 
-_is_cuda = is_cuda_available()
+_is_cuda = is_cuda()
+_is_xpu = is_xpu()
 
 if _is_cuda:
     from sgl_kernel import (
@@ -139,7 +140,7 @@ class Gemma3RMSNorm(nn.Module):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"
 
 
-if not _is_cuda:
+if not _is_cuda and not _is_xpu:
     logger.info(
         "sgl-kernel is not available on Non-NV platforms. Fallback to other kernel libraries."
     )

--- a/python/sglang/srt/layers/quantization/awq.py
+++ b/python/sglang/srt/layers/quantization/awq.py
@@ -3,7 +3,6 @@ import logging
 from typing import Any, Dict, List, Optional
 
 import torch
-from sgl_kernel import awq_dequantize
 
 from sglang.srt.layers.linear import (
     LinearBase,
@@ -12,6 +11,12 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.parameter import GroupQuantScaleParameter, PackedvLLMParameter
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.utils import is_cuda
+
+_is_cuda = is_cuda()
+
+if _is_cuda:
+    from sgl_kernel import awq_dequantize
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1025,6 +1025,7 @@ def get_rope(
     rope_scaling: Optional[Dict[str, Any]] = None,
     dtype: Optional[torch.dtype] = None,
     partial_rotary_factor: float = 1.0,
+    device: Optional[str] = "cuda",
 ) -> RotaryEmbedding:
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -1157,6 +1158,7 @@ def get_rope(
                     "mscale_all_dim",
                 )
             }
+            extra_kwargs["device"] = device
             rotary_emb = DeepseekScalingRotaryEmbedding(
                 head_size,
                 rotary_dim,
@@ -1309,6 +1311,10 @@ def get_rope_wrapper(
     device: Optional[str] = None,
 ):
     if device != "cpu":
+        if device is None:
+            from sglang.srt.managers.schedule_batch import global_server_args_dict
+
+            device = global_server_args_dict["device"]
         return get_rope(
             head_size,
             rotary_dim,
@@ -1318,6 +1324,7 @@ def get_rope_wrapper(
             rope_scaling,
             dtype,
             partial_rotary_factor,
+            device,
         )
 
     return get_rope_cpu(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -58,8 +58,11 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_device_capability,
     is_pin_memory_available,
+    is_xpu,
     set_weight_attrs,
 )
+
+_is_xpu = is_xpu()
 
 
 @contextmanager
@@ -119,7 +122,7 @@ def _get_quantization_config(
         )
         major, minor = get_device_capability()
 
-        if major is not None and minor is not None:
+        if major is not None and minor is not None and not _is_xpu:
             assert 0 <= minor < 10
             capability = major * 10 + minor
             if capability < quant_config.get_min_capability():

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1379,6 +1379,7 @@ def direct_register_custom_op(
     my_lib = target_lib or sglang_lib
     my_lib.define(op_name + schema_str)
     my_lib.impl(op_name, op_func, "CUDA")
+    my_lib.impl(op_name, op_func, "XPU")
     if fake_impl is not None:
         my_lib._register_fake(op_name, fake_impl)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enable SGLang models with pytorch native path on Intel GPU. And we can get correct result by running Llama-3.1-8B-Instruct, and Phi-3.5-mini-instruct.
`
python -m sglang.launch_server.py --model meta-llama/Llama-3.1-8B-Instruct  --trust-remote-code --device xpu --dtype bfloat16/float16

python -m sglang.launch_server.py --model microsoft/Phi-3.5-mini-instruct  --trust-remote-code --device xpu --dtype bfloat16/float16
`
MMLU accuracy evaluation results:
1. For meta-llama/Llama-3.1-8B-Instruct with bfloat16:
subject: abstract_algebra, #q:100, acc: 0.330
subject: anatomy, #q:135, acc: 0.681
subject: astronomy, #q:152, acc: 0.763
subject: business_ethics, #q:100, acc: 0.750
subject: clinical_knowledge, #q:265, acc: 0.747
subject: college_biology, #q:144, acc: 0.812
subject: college_chemistry, #q:100, acc: 0.460
subject: college_computer_science, #q:100, acc: 0.570
subject: college_mathematics, #q:100, acc: 0.410
subject: college_medicine, #q:173, acc: 0.659
Total latency: 54.665
Average accuracy: 0.649

2. For meta-llama/Llama-3.1-8B-Instruct with float16:
subject: abstract_algebra, #q:100, acc: 0.310
subject: anatomy, #q:135, acc: 0.689
subject: astronomy, #q:152, acc: 0.763
subject: business_ethics, #q:100, acc: 0.730
subject: clinical_knowledge, #q:265, acc: 0.747
subject: college_biology, #q:144, acc: 0.819
subject: college_chemistry, #q:100, acc: 0.470
subject: college_computer_science, #q:100, acc: 0.580
subject: college_mathematics, #q:100, acc: 0.440
subject: college_medicine, #q:173, acc: 0.665
Total latency: 54.578
Average accuracy: 0.652

3. For Phi-3.5-mini-instruct  with bfloat16:
subject: abstract_algebra, #q:100, acc: 0.350
subject: anatomy, #q:135, acc: 0.607
subject: astronomy, #q:152, acc: 0.803
subject: business_ethics, #q:100, acc: 0.730
subject: clinical_knowledge, #q:265, acc: 0.762
subject: college_biology, #q:144, acc: 0.875
subject: college_chemistry, #q:100, acc: 0.540
subject: college_computer_science, #q:100, acc: 0.610
subject: college_mathematics, #q:100, acc: 0.390
subject: college_medicine, #q:173, acc: 0.688
Total latency: 54.631
Average accuracy: 0.667

4. For Phi-3.5-mini-instruct  with float16:
subject: abstract_algebra, #q:100, acc: 0.350
subject: anatomy, #q:135, acc: 0.615
subject: astronomy, #q:152, acc: 0.803
subject: business_ethics, #q:100, acc: 0.730
subject: clinical_knowledge, #q:265, acc: 0.762
subject: college_biology, #q:144, acc: 0.868
subject: college_chemistry, #q:100, acc: 0.550
subject: college_computer_science, #q:100, acc: 0.630
subject: college_mathematics, #q:100, acc: 0.420
subject: college_medicine, #q:173, acc: 0.665
Total latency: 60.788
Average accuracy: 0.668



## Modifications

<!-- Describe the changes made in this PR. -->
1. Add native path to fix model broken caused by without sgl-kernel build.
4. Support native path to avoid install special vllm version.
6. Support SGLang models on Intel GPU.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
