### PR TITLE
Use modelopt for fp8 and fp4 by default (#5251)

### DIFF
--- a/docs/backend/quantization.md
+++ b/docs/backend/quantization.md
@@ -66,12 +66,48 @@ model.quantize(calibration_dataset, batch_size=2) # quantize
 model.save(quant_path) # save model
 ```
 
-#### Using [LLM Compressor](https://github.com/vllm-project/llm-compressor/)
+#### Using [ModelOpt](https://github.com/nvidia/modelopt) (Recommended for NVIDIA GPUs)
+
+ModelOpt is now the recommended tool for FP8 and FP4 quantization on NVIDIA GPUs.
 
 ```bash
 # install
-pip install llmcompressor
+pip install nvidia-modelopt[hf,torch]
 ```
+
+Here's an example of how to quantize a model to FP8 using ModelOpt:
+
+```python
+from transformers import AutoTokenizer
+from modelopt.torch.quantization import quantize
+from tensorrt_llm.quantization import QuantConfig
+from tensorrt_llm.modelopt.torch.export import export_hf_checkpoint
+
+
+# Step 1: Load the model's tokenizer
+MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+# Step 2: Configure and apply quantization
+config = QuantConfig(weights_precision="fp8")
+model = quantize(MODEL_ID, config)
+
+# Step 3: Save the quantized model
+SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-ModelOpt"
+model.save_pretrained(SAVE_DIR)
+export_hf_checkpoint(model=model, export_dir=SAVE_DIR,)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+You can then use the quantized model with SGLang:
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path $PWD/Meta-Llama-3-8B-Instruct-FP8-ModelOpt \
+    --port 30000 --host 0.0.0.0
+```
+
+#### Using [LLM Compressor](https://github.com/vllm-project/llm-compressor/) (Deprecated for NVIDIA GPUs)
 
 Here, we take quantize `meta-llama/Meta-Llama-3-8B-Instruct` to `FP8` as an example to elaborate on how to do offline quantization.
 
@@ -121,6 +157,15 @@ python3 -m sglang.launch_server \
     --port 30000 --host 0.0.0.0
 ```
 
+For NVIDIA GPUs, we recommend using `modelopt` quantization method for better performance with FP8 and FP4:
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
+    --quantization modelopt \
+    --port 30000 --host 0.0.0.0
+```
+
 Our team is working on supporting more online quantization methods. SGLang will soon support methods including but not limited to `["awq", "gptq", "marlin", "gptq_marlin", "awq_marlin", "bitsandbytes", "gguf"]`.
 
 SGLang also supports quantization methods based on [torchao](https://github.com/pytorch/ao). You can simply specify `--torchao-config` in the command line to support this feature. For example, if you want to enable `int4wo-128` for model `meta-llama/Meta-Llama-3.1-8B-Instruct`, you can launch the server with the following command:
@@ -147,6 +192,7 @@ python3 -m sglang.launch_server \
 ## Reference
 
 - [GPTQModel](https://github.com/ModelCloud/GPTQModel)
+- [ModelOpt](https://github.com/NVIDIA/TensorRT-Model-Optimizer)
 - [LLM Compressor](https://github.com/vllm-project/llm-compressor/)
 - [Torchao: PyTorch Architecture Optimization](https://github.com/pytorch/ao)
 - [vLLM Quantization](https://docs.vllm.ai/en/latest/quantization/)

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -308,6 +308,11 @@ class ModelConfig:
         if quant_cfg is not None:
             quant_method = quant_cfg.get("quant_method", "").lower()
 
+            # For NVIDIA GPUs, use ModelOpt as default
+            if self.quantization is None and not is_hip():
+                if "fp8" in quant_method:
+                    self.quantization = "modelopt"
+
             # Detect which checkpoint is it
             for _, method in QUANTIZATION_METHODS.items():
                 quantization_override = method.override_quantization_method(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

To use modelopt for fp8 and fp4 by default: https://github.com/sgl-project/sglang/issues/5251

## Modifications

- Uses modelopt as default for fp8
- Adds documentation for quantitization
- Adds test case verifying default

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
