### PR TITLE
[Feature] reduce tqdm logging

### DIFF
--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -46,6 +46,8 @@ class LoadConfig:
         checkpoints.
     decryption_key_file: If set, decrypts the output files with a password read
         from this file (after PBKDF2).
+    use_tqdm_on_load: Whether to enable tqdm for showing progress bar during
+        loading. Default to True.
     """
 
     load_format: Union[str, LoadFormat] = LoadFormat.AUTO
@@ -53,6 +55,7 @@ class LoadConfig:
     model_loader_extra_config: Optional[Union[str, dict]] = field(default_factory=dict)
     ignore_patterns: Optional[Union[List[str], str]] = None
     decryption_key_file: Optional[str] = None
+    use_tqdm_on_load: bool = True
 
     def __post_init__(self):
         model_loader_extra_config = self.model_loader_extra_config or {}

--- a/python/sglang/srt/connector/s3.py
+++ b/python/sglang/srt/connector/s3.py
@@ -107,7 +107,9 @@ class S3Connector(BaseFileConnector):
             self.client.download_file(bucket_name, file, destination_file)
 
     def weight_iterator(
-        self, rank: int = 0
+        self,
+        rank: int = 0,
+        use_tqdm_on_load: bool = True,
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
         from sglang.srt.model_loader.weight_utils import (
             runai_safetensors_weights_iterator,
@@ -115,7 +117,9 @@ class S3Connector(BaseFileConnector):
 
         # only support safetensor files now
         hf_weights_files = self.glob(allow_pattern=["*.safetensors"])
-        return runai_safetensors_weights_iterator(hf_weights_files)
+        return runai_safetensors_weights_iterator(
+            hf_weights_files, use_tqdm_on_load=use_tqdm_on_load
+        )
 
     def close(self):
         self.client.close()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -411,6 +411,7 @@ class ModelRunner:
         self.load_config = LoadConfig(
             load_format=self.server_args.load_format,
             download_dir=self.server_args.download_dir,
+            use_tqdm_on_load=self.server_args.use_tqdm_on_load,
         )
         if self.server_args.load_format == "gguf":
             monkey_patch_vllm_gguf_config()
@@ -492,7 +493,10 @@ class ModelRunner:
 
         target_device = torch.device(self.device)
         self.model_config.model_path = model_path
-        load_config = LoadConfig(load_format=load_format)
+        load_config = LoadConfig(
+            load_format=load_format,
+            use_tqdm_on_load=self.server_args.use_tqdm_on_load,
+        )
 
         # Only support DefaultModelLoader for now
         loader = get_model_loader(load_config)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -326,11 +326,18 @@ class DefaultModelLoader(BaseModelLoader):
                 self.load_config.download_dir,
                 hf_folder,
                 hf_weights_files,
+                self.load_config.use_tqdm_on_load,
             )
         elif use_safetensors:
-            weights_iterator = safetensors_weights_iterator(hf_weights_files)
+            weights_iterator = safetensors_weights_iterator(
+                hf_weights_files,
+                use_tqdm_on_load=self.load_config.use_tqdm_on_load,
+            )
         else:
-            weights_iterator = pt_weights_iterator(hf_weights_files)
+            weights_iterator = pt_weights_iterator(
+                hf_weights_files,
+                use_tqdm_on_load=self.load_config.use_tqdm_on_load,
+            )
 
         # Apply the prefix.
         return ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
@@ -808,9 +815,15 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
     def _hf_weight_iter(self, hf_weights_files, use_safetensors: bool):
         if use_safetensors:
-            return safetensors_weights_iterator(hf_weights_files)
+            return safetensors_weights_iterator(
+                hf_weights_files,
+                use_tqdm_on_load=self.load_config.use_tqdm_on_load,
+            )
         else:
-            return pt_weights_iterator(hf_weights_files)
+            return pt_weights_iterator(
+                hf_weights_files,
+                use_tqdm_on_load=self.load_config.use_tqdm_on_load,
+            )
 
     def _get_quantized_weights_iterator(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -62,6 +62,7 @@ class ServerArgs:
     completion_template: Optional[str] = None
     is_embedding: bool = False
     revision: Optional[str] = None
+    use_tqdm_on_load: bool = True
 
     # Port for the HTTP server
     host: str = "127.0.0.1"
@@ -466,6 +467,13 @@ class ServerArgs:
             "--trust-remote-code",
             action="store_true",
             help="Whether or not to allow for custom models defined on the Hub in their own modeling files.",
+        )
+        parser.add_argument(
+            "--use-tqdm-on-load",
+            dest="use_tqdm_on_load",
+            action=argparse.BooleanOptionalAction,
+            default=ServerArgs.use_tqdm_on_load,
+            help="Whether to enable/disable progress bar when loading model weights.",
         )
         parser.add_argument(
             "--dtype",


### PR DESCRIPTION
# Motivation

Reduce the logging.

## Modifications

Enables optional tqdm progress bars during model weight loading and CUDA graph capture. via CLI:

`python3 -m sglang.launch_server --model-path ... --no-use-tqdm-on-load`

Defaults to True. Only shows on rank 0 for distributed

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
