### PR TITLE
Support aiter RMSNorm in AMD

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -154,7 +154,7 @@ class Gemma3RMSNorm(nn.Module):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"
 
 
-if not (_is_cuda or is_hip):
+if not (_is_cuda or _is_hip):
     logger.info(
         "sgl-kernel is not available on Non-NV platforms. Fallback to other kernel libraries."
     )

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -11,19 +11,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Fused operators for normalization layers, with ROCm AITer support."""
+"""Fused operators for normalization layers."""
 
 import logging
-import os
 from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
 from sglang.srt.custom_op import CustomOp
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_hip
+
+logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 
 if _is_cuda:
     from sgl_kernel import (
@@ -33,92 +35,20 @@ if _is_cuda:
         rmsnorm,
     )
 
+if _is_hip:
 
-logger = logging.getLogger(__name__)
+    import aiter
 
-# -----------------------------------------------------------------------------
-# ROCm AITer integration -------------------------------------------------------
-# -----------------------------------------------------------------------------
+    rmsnorm = aiter.rms_norm
 
-
-def _is_rocm() -> bool:
-    """Return True when running on ROCm (HIP) runtime."""
-    return hasattr(torch.version, "hip") and torch.version.hip is not None  # type: ignore[attr-defined]
-
-
-def is_rocm_aiter_rmsnorm_enabled() -> bool:  # noqa: N802  (follow existing naming)
-    """Heuristic to decide whether to use AITer kernels on ROCm.
-
-    The behaviour mirrors vLLM's env‑flag logic so existing deployment flags
-    continue to work:
-        * VLLM_ROCM_USE_AITER_RMSNORM=1 enables the specialised RMSNorm kernels.
-        * VLLM_ROCM_USE_AITER=1 must also be set (or the old flag combination
-          used by vLLM).
-    """
-    return _is_rocm() and (
-        os.environ.get("VLLM_ROCM_USE_AITER_RMSNORM", "0") == "1"
-        and os.environ.get("VLLM_ROCM_USE_AITER", "0") == "1"
-    )
-
-# ---- Safe import of AITer ----------------------------------------------------
-
-try:
-    import aiter as _rocm_aiter  # lightweight import, only when available
-
-    def rocm_aiter_rms_norm(  # noqa: N802
-        x: torch.Tensor, weight: torch.Tensor, variance_epsilon: float
-    ) -> torch.Tensor:
-        """Thin wrapper that calls AITer's RMSNorm implementation."""
-        return _rocm_aiter.rms_norm(x, weight, variance_epsilon)  # type: ignore[attr-defined]
-
-    def rocm_aiter_fused_add_rms_norm(  # noqa: N802
+    def fused_add_rmsnorm(
         x: torch.Tensor,
         residual: torch.Tensor,
-        weight: torch.Tensor,
-        variance_epsilon: float,
+        w: torch.Tensor,
+        eps: float,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Fused residual‑add‑plus‑RMSNorm for AITer on ROCm."""
-        _rocm_aiter.rmsnorm2d_fwd_with_add(  # type: ignore[attr-defined]
-            x,          # output tensor (in‑place on *x*)
-            x,          # input tensor
-            residual,   # residual input
-            residual,   # residual output (in‑place)
-            weight,
-            variance_epsilon,
-        )
+        aiter.rmsnorm2d_fwd_with_add(x, x, residual, residual, w, eps)
         return x, residual
-
-except ModuleNotFoundError:
-
-    def rocm_aiter_rms_norm(*args, **kwargs):  # type: ignore[return‑type]
-        raise RuntimeError(
-            "AITer not found. Install ROCm AITer or unset VLLM_ROCM_USE_AITER_RMSNORM.")
-
-    def rocm_aiter_fused_add_rms_norm(*args, **kwargs):  # type: ignore[return‑type]
-        raise RuntimeError(
-            "AITer not found. Install ROCm AITer or unset VLLM_ROCM_USE_AITER_RMSNORM.")
-
-# -----------------------------------------------------------------------------
-#  Helper to pick the fastest kernel at runtime (CUDA / ROCm) ------------------
-# -----------------------------------------------------------------------------
-
-def dispatch_cuda_rmsnorm_func(add_residual: bool):
-    """Return the best available kernel for (fused‑)RMSNorm on the current HW."""
-
-    # Prefer ROCm AITer when explicitly enabled.
-    if add_residual:
-        if is_rocm_aiter_rmsnorm_enabled():
-            return rocm_aiter_fused_add_rms_norm
-        return fused_add_rmsnorm  # type: ignore[name‑defined]
-
-    # No residual path
-    if is_rocm_aiter_rmsnorm_enabled():
-        return rocm_aiter_rms_norm
-    return rmsnorm  # type: ignore[name‑defined]
-
-# -----------------------------------------------------------------------------
-#  Core classes ----------------------------------------------------------------
-# -----------------------------------------------------------------------------
 
 
 class RMSNorm(CustomOp):
@@ -136,12 +66,12 @@ class RMSNorm(CustomOp):
         x: torch.Tensor,
         residual: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        add_residual = residual is not None
-        norm_fn = dispatch_cuda_rmsnorm_func(add_residual)
 
-        if add_residual:
-            return norm_fn(x, residual, self.weight.data, self.variance_epsilon)
-        return norm_fn(x, self.weight.data, self.variance_epsilon)
+        if residual is not None:
+            fused_add_rmsnorm(x, residual, self.weight.data, self.variance_epsilon)
+            return x, residual
+        out = rmsnorm(x, self.weight.data, self.variance_epsilon)
+        return out
 
     def forward_native(
         self,
@@ -222,3 +152,10 @@ class Gemma3RMSNorm(nn.Module):
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"
+
+
+if not (_is_cuda or _is_hip):
+    logger.info(
+        "sgl-kernel is not available on Non-NV platforms. Fallback to other kernel libraries."
+    )
+    from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -37,9 +37,9 @@ if _is_cuda:
 
 if _is_hip:
 
-    import aiter
+    from aiter.ops.rmsnorm import rms_norm, rmsnorm2d_fwd_with_add
 
-    rmsnorm = aiter.rms_norm
+    rmsnorm = rms_norm
 
     def fused_add_rmsnorm(
         x: torch.Tensor,
@@ -47,7 +47,7 @@ if _is_hip:
         w: torch.Tensor,
         eps: float,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        aiter.rmsnorm2d_fwd_with_add(x, x, residual, residual, w, eps)
+        rmsnorm2d_fwd_with_add(x, x, residual, residual, w, eps)
         return x, residual
 
 

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -222,10 +222,3 @@ class Gemma3RMSNorm(nn.Module):
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"
-
-
-if not _is_cuda:
-    logger.info(
-        "sgl-kernel is not available on Non‑NVIDIA platforms. "
-        "Using PyTorch or ROCm AITer kernels where possible."
-    )

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -154,7 +154,7 @@ class Gemma3RMSNorm(nn.Module):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"
 
 
-if not (_is_cuda or _is_hip):
+if not (_is_cuda or is_hip):
     logger.info(
         "sgl-kernel is not available on Non-NV platforms. Fallback to other kernel libraries."
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

https://github.com/sgl-project/sglang/issues/2965
* [ ]  Support GemmaRMSNorm and RMSNorm in AMD.
* [ ]  remove `from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm` in `sglang/python/sglang/srt/layers/layernorm.py`.

Currently, sglang rocm uses vllm's RMSNorm and vllm's RMSNorm uses aiter's RMSNorm.

## Modifications

<!-- Describe the changes made in this PR. -->

Support `rocm_aiter_rms_norm` and `rocm_aiter_fused_add_rms_norm` for AMD ROCm.

Test: `TORCH_COMPILE_DISABLE=1 python3 sglang/test/test_layernorm.py`

test note:
without TORCH_COMPILE_DISABLE=1, it will fail gemma_rmsnorm test.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
