### PR TITLE
[PD] MooncakeKVReceiver connect not reuse socket fix

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -133,8 +133,9 @@ class MooncakeKVManager(BaseKVManager):
         ):
             self.engine.register(aux_data_ptr, aux_data_len)
 
+    @classmethod
     @cache
-    def _connect(self, endpoint: str):
+    def _connect(cls, endpoint: str):
         socket = zmq.Context().socket(zmq.PUSH)
         socket.connect(endpoint)
         return socket

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -436,8 +436,9 @@ class MooncakeKVReceiver(BaseKVReceiver):
             logger.error(f"Error fetching prefill info from bootstrap: {e}")
             return None
 
+    @classmethod
     @cache
-    def _connect(self, endpoint: str):
+    def _connect(cls, endpoint: str):
         socket = zmq.Context().socket(zmq.PUSH)
         socket.connect(endpoint)
         return socket


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

We found that the connections between prefill and decode nodes will be always increase leading to the memory being exhausted.


## Modifications

The cache decorator of the _connect does not take effect because it checks endpoint and self at the same time, so it shoule be changed to class method.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
