### PR TITLE
Fix sampler nan check when calling top_k_top_p_sampling_from_probs

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -105,8 +105,11 @@ class Sampler(nn.Module):
                         sampling_info.top_ks,
                         sampling_info.top_ps,
                         filter_apply_order="joint",
-                        check_nan=self.use_nan_detection,
                     )
+
+                    if self.use_nan_detection:
+                        logger.warning("Detected errors during sampling!")
+                        batch_next_token_ids.zero_()
 
             elif global_server_args_dict["sampling_backend"] == "pytorch":
                 # A slower fallback implementation with torch native operations.

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -112,10 +112,6 @@ class Sampler(nn.Module):
                         check_nan=self.use_nan_detection,
                     )
 
-                    # if self.use_nan_detection and not torch.all(success):
-                    #     logger.warning("Detected errors during sampling!")
-                    #     batch_next_token_ids = torch.zeros_like(batch_next_token_ids)
-
             elif global_server_args_dict["sampling_backend"] == "pytorch":
                 # A slower fallback implementation with torch native operations.
                 batch_next_token_ids = top_k_top_p_min_p_sampling_from_probs_torch(

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -100,19 +100,15 @@ class Sampler(nn.Module):
                         probs, sampling_info.min_ps
                     )
                 else:
-                    try:
-                        batch_next_token_ids = top_k_top_p_sampling_from_probs(
-                            probs,
-                            sampling_info.top_ks,
-                            sampling_info.top_ps,
-                            filter_apply_order="joint",
-                            check_nan=self.use_nan_detection,
-                        )
-                    except ValueError:
-                        logger.warning("Detected errors during sampling!")
-                        batch_next_token_ids = torch.zeros(
-                            probs.size(0), device=probs.device
-                        )
+                    # Check Nan will throw exception, only check when crash_on_warnings is True
+                    check_nan = self.use_nan_detection and crash_on_warnings()
+                    batch_next_token_ids = top_k_top_p_sampling_from_probs(
+                        probs,
+                        sampling_info.top_ks,
+                        sampling_info.top_ps,
+                        filter_apply_order="joint",
+                        check_nan=check_nan,
+                    )
 
             elif global_server_args_dict["sampling_backend"] == "pytorch":
                 # A slower fallback implementation with torch native operations.

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -111,7 +111,7 @@ class Sampler(nn.Module):
                     except ValueError:
                         logger.warning("Detected errors during sampling!")
                         batch_next_token_ids = torch.zeros(
-                            (probs.size(0),), device=probs.device
+                            probs.size(0), device=probs.device
                         )
 
             elif global_server_args_dict["sampling_backend"] == "pytorch":

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -100,16 +100,19 @@ class Sampler(nn.Module):
                         probs, sampling_info.min_ps
                     )
                 else:
-                    batch_next_token_ids = top_k_top_p_sampling_from_probs(
-                        probs,
-                        sampling_info.top_ks,
-                        sampling_info.top_ps,
-                        filter_apply_order="joint",
-                    )
-
-                    if self.use_nan_detection:
+                    try:
+                        batch_next_token_ids = top_k_top_p_sampling_from_probs(
+                            probs,
+                            sampling_info.top_ks,
+                            sampling_info.top_ps,
+                            filter_apply_order="joint",
+                            check_nan=self.use_nan_detection,
+                        )
+                    except ValueError:
                         logger.warning("Detected errors during sampling!")
-                        batch_next_token_ids.zero_()
+                        batch_next_token_ids = torch.zeros(
+                            (probs.size(0),), device=probs.device
+                        )
 
             elif global_server_args_dict["sampling_backend"] == "pytorch":
                 # A slower fallback implementation with torch native operations.

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -103,17 +103,18 @@ class Sampler(nn.Module):
                         probs, uniform_samples, sampling_info.min_ps
                     )
                 else:
-                    batch_next_token_ids, success = top_k_top_p_sampling_from_probs(
+                    batch_next_token_ids = top_k_top_p_sampling_from_probs(
                         probs,
                         uniform_samples,
                         sampling_info.top_ks,
                         sampling_info.top_ps,
                         filter_apply_order="joint",
+                        check_nan=self.use_nan_detection,
                     )
 
-                    if self.use_nan_detection and not torch.all(success):
-                        logger.warning("Detected errors during sampling!")
-                        batch_next_token_ids = torch.zeros_like(batch_next_token_ids)
+                    # if self.use_nan_detection and not torch.all(success):
+                    #     logger.warning("Detected errors during sampling!")
+                    #     batch_next_token_ids = torch.zeros_like(batch_next_token_ids)
 
             elif global_server_args_dict["sampling_backend"] == "pytorch":
                 # A slower fallback implementation with torch native operations.

--- a/sgl-kernel/python/sgl_kernel/sampling.py
+++ b/sgl-kernel/python/sgl_kernel/sampling.py
@@ -225,7 +225,7 @@ def top_k_top_p_sampling_from_probs(
     deterministic: bool = True,
     generator: Optional[torch.Generator] = None,
     check_nan: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     r"""Adapt from https://github.com/flashinfer-ai/flashinfer/flashinfer/sampling.py
     Fused GPU kernel for top-k and top-p sampling from probabilities,
 

--- a/sgl-kernel/python/sgl_kernel/sampling.py
+++ b/sgl-kernel/python/sgl_kernel/sampling.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 from sgl_kernel.utils import _to_tensor_scalar_tuple, get_cuda_stream
@@ -109,7 +109,7 @@ def _top_p_sampling_from_probs_internal(
     top_p_val: float,
     deterministic: bool,
     generator: Optional[torch.Generator],
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     with probs.device as device:
         probs = probs.float()
         maybe_top_p_arr = (
@@ -135,7 +135,7 @@ def top_p_sampling_from_probs(
     deterministic: bool = True,
     generator: Optional[torch.Generator] = None,
     check_nan: bool = False,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     r"""Adapt from https://github.com/flashinfer-ai/flashinfer/flashinfer/sampling.py
     Fused GPU kernel for top-p sampling (nucleus sampling) from probabilities,
     this operator implements GPU-based rejection sampling without explicit sorting.
@@ -194,7 +194,7 @@ def _top_k_top_p_sampling_from_probs_internal(
     top_p_val: float,
     deterministic: bool,
     generator: Optional[torch.Generator],
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     with probs.device as device:
         probs = probs.float()
         maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

~~Remove success tensor that is not returned from top_k_top_p_sampling_from_probs of the latest flash infer api anymore.~~

The current code on main branch will throw variable referenced before assigned error if `self.use_nan_detection` evaluate to true. This PR fixes it.

We don't need to check for success anymore as the PR in flash infer has improved the robustness of the sampling. Now tokens are guaranteed to be generated.
Details in: https://github.com/flashinfer-ai/flashinfer/pull/912

Please refer to flash infer for reference:
https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/sampling.py


## Modifications

Remove successor, pass in check for nan flag, and fix the function signature.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.


## Test Result
No latency regression after the change.

```python3 -m unittest test_bench_one_batch.TestBenchOneBatch.test_bs1```

Before change:
```
Warmup ...
Prefill. latency: 0.33793 s, throughput:    378.77 token/s
Decode.  median latency: 0.00587 s, median throughput:    170.22 token/s
Total. latency:  0.764 s, throughput:    178.08 token/s
Benchmark ...
Prefill. latency: 0.01321 s, throughput:   9686.79 token/s
Decode.  median latency: 0.00580 s, median throughput:    172.50 token/s
Total. latency:  0.054 s, throughput:   2526.44 token/s
```
After change:
```
Warmup ...
Prefill. latency: 0.50365 s, throughput:    254.14 token/s
Decode.  median latency: 0.00589 s, median throughput:    169.79 token/s
Total. latency:  1.031 s, throughput:    131.89 token/s
Benchmark ...
Prefill. latency: 0.01323 s, throughput:   9676.49 token/s
Decode.  median latency: 0.00579 s, median throughput:    172.60 token/s
Total. latency:  0.054 s, throughput:   2527.25 token/s
```