### PR TITLE
[DeepEP] Eliminate unnecessary DP cudagraph padding

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -189,7 +189,7 @@ class CudaGraphRunner:
         self.tp_size = model_runner.server_args.tp_size
         self.dp_size = model_runner.server_args.dp_size
         self.enable_deepep_moe = model_runner.server_args.enable_deepep_moe
-        self.moe_dense_fullly_dp = (
+        self.moe_dense_fully_dp = (
             model_runner.server_args.enable_deepep_moe
             and model_runner.server_args.moe_dense_tp_size == 1
         )
@@ -306,7 +306,7 @@ class CudaGraphRunner:
 
     def can_run(self, forward_batch: ForwardBatch):
         if self.enable_dp_attention or self.enable_sp_layernorm:
-            reducer = max if self.moe_dense_fullly_dp else sum
+            reducer = max if self.moe_dense_fully_dp else sum
             # DeepEP MoE layers uses a fixed shape with masking instead of gather tokens from DP ranks.
             total_global_tokens = reducer(forward_batch.global_num_tokens_cpu)
 
@@ -491,7 +491,7 @@ class CudaGraphRunner:
 
         # Pad
         if self.enable_dp_attention or self.enable_sp_layernorm:
-            reducer = max if self.moe_dense_fullly_dp else sum
+            reducer = max if self.moe_dense_fully_dp else sum
             # DeepEP MoE layers uses a fixed shape with masking instead of gather tokens from DP ranks.
             index = bisect.bisect_left(
                 self.capture_bs, reducer(forward_batch.global_num_tokens_cpu)


### PR DESCRIPTION
## Motivation

In DP attention, the batch size of the CUDA graph is expanded to the sum of batches across all DP ranks to enable `all_gather` global tokens before MLP fwd. Since decoding is memory-bound, this padding does not introduce significant performance overhead. Under DeepEP, the padded tokens from each DP rank participate in dispatch/combine operations, resulting in a DP times increase in communication costs.  

DeepEP's MoE computation adopts a fixed shape with masking instead of gathering tokens from all DP ranks, so padding batch size  to the global tokens is actually unnecessary.

Before this fix:
![image](https://github.com/user-attachments/assets/a9c1675c-b134-47a8-8223-ad76966a6a33)

After this fix:
![image](https://github.com/user-attachments/assets/c95567d9-4c5a-49f5-8706-3c6b5d1ac2d7)

With H20, EP16,120 batch decoding with cudagraph, the combine time has been reduced by 10 times, and TPOT has decreased from 300ms to ~100ms.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
