### PR TITLE
enable DeepSeek V3 shared_experts_fusion in sm90

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1382,6 +1382,13 @@ class DeepseekV2ForCausalLM(nn.Module):
                 assert (
                     self.n_share_experts_fusion == self.tp_size
                 ), f"Shared experts fusion optimization is enabled in DeepSeek V3/R1, set it to {self.tp_size} can get best optimized performace."
+        elif self.n_share_experts_fusion == 0:
+            if torch.cuda.get_device_capability("cuda") >= (9, 0) and self.config.architectures[0] == "DeepseekV3ForCausalLM" and self.config.n_routed_experts == 256 and (not global_server_args_dict["enable_deepep_moe"]):
+                self.n_share_experts_fusion = self.tp_size
+                global_server_args_dict["n_share_experts_fusion"] = self.tp_size
+                logger.info(
+                    "Deepseek V3/R1 with fp8 can use shared experts fusion optimization when SM version >=90. Shared experts fusion optimization is enabled."
+                )
 
         self.model = DeepseekV2Model(
             config, quant_config, prefix=add_prefix("model", prefix)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1383,7 +1383,12 @@ class DeepseekV2ForCausalLM(nn.Module):
                     self.n_share_experts_fusion == self.tp_size
                 ), f"Shared experts fusion optimization is enabled in DeepSeek V3/R1, set it to {self.tp_size} can get best optimized performace."
         elif self.n_share_experts_fusion == 0:
-            if torch.cuda.get_device_capability("cuda") >= (9, 0) and self.config.architectures[0] == "DeepseekV3ForCausalLM" and self.config.n_routed_experts == 256 and (not global_server_args_dict["enable_deepep_moe"]):
+            if (
+                torch.cuda.get_device_capability("cuda") >= (9, 0)
+                and self.config.architectures[0] == "DeepseekV3ForCausalLM"
+                and self.config.n_routed_experts == 256
+                and (not global_server_args_dict["enable_deepep_moe"])
+            ):
                 self.n_share_experts_fusion = self.tp_size
                 global_server_args_dict["n_share_experts_fusion"] = self.tp_size
                 logger.info(


### PR DESCRIPTION
## H200 Benchmark

I tested the benchmark using the command provided by https://github.com/sgl-project/sglang/issues/5514. To avoid warmup, I turned off deepgemm. Below are the results and detailed test records.

<img width="676" alt="图片" src="https://github.com/user-attachments/assets/617075f5-aea8-432a-b4e0-da33995ab775" />

**The difference in the data set of 5000-1000 was due to fluctuations. I retested it once, and there was no difference compared to before the fusion. The other cases all showed acceleration. The acceleration ratios were 4% (1000-2000), 4.8% (10k-500), and 1.1% (30k-100) respectively** .

The reason for enabling only in SM>=90 is that the fused moe kernel currently only has tuning config for SM>=90. It is more optimal not to fuse in cases where there is no tuning config available, as the routed experts section mostly have tuning.

```shell
# launch server
# SGLang uses FA3 backend by default since v0.4.5.post1
# Use dp 8 for offline use case
SGL_ENABLE_JIT_DEEPGEMM=0 python3 -m sglang.launch_server --model /DeepSeek-V3 --tp 8 --trust-remote-code --enable-dp-attention --dp-size 8

# Random 1k, 2k
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 1000 --random-output-len 2000 --random-range-ratio 1

# Random 5k, 1k
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 5000 --random-output-len 1000 --random-range-ratio 1

# Random 10k, 500
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 10000 --random-output-len 500 --random-range-ratio 1

# Random 30k, 100
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 30000 --random-output-len 100 --random-range-ratio 1
```

- main:

```shell
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=1000, random_output_len=2000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=1000, random_output_len=2000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 50000
#Output tokens: 100000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [01:42<00:00,  2.06s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  102.82    
Total input tokens:                      50000     
Total generated tokens:                  100000    
Total generated tokens (retokenized):    99617     
Request throughput (req/s):              0.49      
Input token throughput (tok/s):          486.29    
Output token throughput (tok/s):         972.59    
Total token throughput (tok/s):          1458.88   
Concurrency:                             48.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   100745.69 
Median E2E Latency (ms):                 100893.77 
---------------Time to First Token----------------
Mean TTFT (ms):                          7594.28   
Median TTFT (ms):                        7941.47   
P99 TTFT (ms):                           14539.46  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           46.78     
Median ITL (ms):                         43.53     
P95 ITL (ms):                            44.90     
P99 ITL (ms):                            45.78     
Max ITL (ms):                            10498.31  
==================================================
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=5000, random_output_len=1000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=5000, random_output_len=1000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 250000
#Output tokens: 50000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [01:02<00:00,  1.24s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  62.14     
Total input tokens:                      250000    
Total generated tokens:                  50000     
Total generated tokens (retokenized):    49680     
Request throughput (req/s):              0.80      
Input token throughput (tok/s):          4023.35   
Output token throughput (tok/s):         804.67    
Total token throughput (tok/s):          4828.02   
Concurrency:                             48.24     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   59951.17  
Median E2E Latency (ms):                 60163.82  
---------------Time to First Token----------------
Mean TTFT (ms):                          7586.02   
Median TTFT (ms):                        7860.50   
P99 TTFT (ms):                           14192.02  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           52.74     
Median ITL (ms):                         44.15     
P95 ITL (ms):                            45.45     
P99 ITL (ms):                            46.78     
Max ITL (ms):                            15878.84  
==================================================
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=10000, random_output_len=500, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=10000, random_output_len=500, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 500000
#Output tokens: 25000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [01:01<00:00,  1.23s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  61.49     
Total input tokens:                      500000    
Total generated tokens:                  25000     
Total generated tokens (retokenized):    24834     
Request throughput (req/s):              0.81      
Input token throughput (tok/s):          8130.91   
Output token throughput (tok/s):         406.55    
Total token throughput (tok/s):          8537.45   
Concurrency:                             48.13     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   59189.02  
Median E2E Latency (ms):                 59461.02  
---------------Time to First Token----------------
Mean TTFT (ms):                          19739.69  
Median TTFT (ms):                        21000.66  
P99 TTFT (ms):                           34741.34  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           79.53     
Median ITL (ms):                         45.14     
P95 ITL (ms):                            46.55     
P99 ITL (ms):                            329.59    
Max ITL (ms):                            33405.55  
==================================================
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=30000, random_output_len=100, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=30000, random_output_len=100, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 1500000
#Output tokens: 5000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [02:20<00:00,  2.81s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  140.30    
Total input tokens:                      1500000   
Total generated tokens:                  5000      
Total generated tokens (retokenized):    4942      
Request throughput (req/s):              0.36      
Input token throughput (tok/s):          10691.14  
Output token throughput (tok/s):         35.64     
Total token throughput (tok/s):          10726.77  
Concurrency:                             48.98     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   137435.07 
Median E2E Latency (ms):                 137591.79 
---------------Time to First Token----------------
Mean TTFT (ms):                          78679.39  
Median TTFT (ms):                        79021.99  
P99 TTFT (ms):                           133442.19 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           599.41    
Median ITL (ms):                         48.44     
P95 ITL (ms):                            611.42    
P99 ITL (ms):                            670.13    
Max ITL (ms):                            114306.41 
==================================================
```

- pr:

```shell
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=1000, random_output_len=2000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=1000, random_output_len=2000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 50000
#Output tokens: 100000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [01:38<00:00,  1.97s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  98.74     
Total input tokens:                      50000     
Total generated tokens:                  100000    
Total generated tokens (retokenized):    99405     
Request throughput (req/s):              0.51      
Input token throughput (tok/s):          506.37    
Output token throughput (tok/s):         1012.73   
Total token throughput (tok/s):          1519.10   
Concurrency:                             48.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   96654.75  
Median E2E Latency (ms):                 96801.45  
---------------Time to First Token----------------
Mean TTFT (ms):                          7234.81   
Median TTFT (ms):                        7390.31   
P99 TTFT (ms):                           12906.70  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           44.98     
Median ITL (ms):                         42.29     
P95 ITL (ms):                            43.76     
P99 ITL (ms):                            44.48     
Max ITL (ms):                            9602.84   
==================================================
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=5000, random_output_len=1000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=5000, random_output_len=1000, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 250000
#Output tokens: 50000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [01:02<00:00,  1.24s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  62.25     
Total input tokens:                      250000    
Total generated tokens:                  50000     
Total generated tokens (retokenized):    49556     
Request throughput (req/s):              0.80      
Input token throughput (tok/s):          4016.14   
Output token throughput (tok/s):         803.23    
Total token throughput (tok/s):          4819.37   
Concurrency:                             48.26     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   60083.20  
Median E2E Latency (ms):                 60279.38  
---------------Time to First Token----------------
Mean TTFT (ms):                          7924.84   
Median TTFT (ms):                        7610.01   
P99 TTFT (ms):                           17311.49  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           52.64     
Median ITL (ms):                         43.16     
P95 ITL (ms):                            44.83     
P99 ITL (ms):                            45.77     
Max ITL (ms):                            17182.98  
==================================================
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=10000, random_output_len=500, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=10000, random_output_len=500, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 500000
#Output tokens: 25000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [00:58<00:00,  1.17s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  58.64     
Total input tokens:                      500000    
Total generated tokens:                  25000     
Total generated tokens (retokenized):    24859     
Request throughput (req/s):              0.85      
Input token throughput (tok/s):          8526.46   
Output token throughput (tok/s):         426.32    
Total token throughput (tok/s):          8952.78   
Concurrency:                             48.06     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   56360.43  
Median E2E Latency (ms):                 56619.03  
---------------Time to First Token----------------
Mean TTFT (ms):                          19303.59  
Median TTFT (ms):                        20385.84  
P99 TTFT (ms):                           34325.18  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           74.63     
Median ITL (ms):                         44.12     
P95 ITL (ms):                            45.90     
P99 ITL (ms):                            329.94    
Max ITL (ms):                            31297.97  
==================================================
benchmark_args=Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=30000, random_output_len=100, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang-oai', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='/DeepSeek-V3', tokenizer=None, num_prompts=50, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=30000, random_output_len=100, random_range_ratio=1.0, request_rate=10.0, max_concurrency=None, output_file=None, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, prompt_suffix='', pd_seperated=False, flush_cache=False, warmup_requests=1, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

#Input tokens: 1500000
#Output tokens: 5000
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████| 50/50 [02:18<00:00,  2.77s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  138.65    
Total input tokens:                      1500000   
Total generated tokens:                  5000      
Total generated tokens (retokenized):    4933      
Request throughput (req/s):              0.36      
Input token throughput (tok/s):          10818.76  
Output token throughput (tok/s):         36.06     
Total token throughput (tok/s):          10854.82      
Concurrency:                             48.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   135833.65 
Median E2E Latency (ms):                 135968.65 
---------------Time to First Token----------------
Mean TTFT (ms):                          80345.12  
Median TTFT (ms):                        79871.67  
P99 TTFT (ms):                           131958.38 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           566.88    
Median ITL (ms):                         47.17     
P95 ITL (ms):                            611.90    
P99 ITL (ms):                            660.63    
Max ITL (ms):                            111567.95 
==================================================
```

