### PR TITLE
Fix FA3 DeepSeek prefill performance regression

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -583,13 +583,17 @@ class DeepseekV2AttentionMLA(nn.Module):
                 return AttnForwardMethod.MLA
         elif self.attention_backend == "fa3":
             # Flash Attention: Use MHA with chunked KV cache when prefilling on long sequences.
+            if forward_batch.extend_prefix_lens_cpu is not None:
+                sum_extend_prefix_lens = sum(forward_batch.extend_prefix_lens_cpu)
             if (
                 forward_batch.forward_mode.is_extend()
                 and not self.disable_chunked_prefix_cache
                 and not forward_batch.forward_mode.is_target_verify()
                 and not forward_batch.forward_mode.is_draft_extend()
-                and sum(forward_batch.extend_prefix_lens_cpu)
-                >= self.chunked_prefix_cache_threshold
+                and (
+                    sum_extend_prefix_lens >= self.chunked_prefix_cache_threshold
+                    or sum_extend_prefix_lens == 0
+                )
             ):
                 return AttnForwardMethod.MHA_CHUNKED_KV
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix FA3 DeepSeek prefill performance regression

Significantly boost 20% at context len 1024, the longer context, the more benifitions

cmd: `python3 -m sglang.bench_one_batch --model lmsys/sglang-ci-dsv3-test --batch-size 8 --input-len 1024 --output-len 128 --trust-remote-code`

- before
```
Prefill. latency: 0.32884 s, throughput:  24911.50 token/s
Decode. Batch size: 8, latency: 0.01430 s, throughput:    559.60 token/s
Decode. Batch size: 8, latency: 0.01438 s, throughput:    556.49 token/s
Decode. Batch size: 8, latency: 0.01415 s, throughput:    565.55 token/s
Decode. Batch size: 8, latency: 0.01433 s, throughput:    558.10 token/s
Decode. Batch size: 8, latency: 0.01465 s, throughput:    546.01 token/s
Decode.  median latency: 0.01490 s, median throughput:    536.79 token/s
Total. latency:  2.217 s, throughput:   4156.30 token/s
```

- after

```
Benchmark ...
Prefill. latency: 0.27612 s, throughput:  29668.45 token/s
Decode. Batch size: 8, latency: 0.01418 s, throughput:    564.37 token/s
Decode. Batch size: 8, latency: 0.01412 s, throughput:    566.39 token/s
Decode. Batch size: 8, latency: 0.01405 s, throughput:    569.45 token/s
Decode. Batch size: 8, latency: 0.01408 s, throughput:    568.10 token/s
Decode. Batch size: 8, latency: 0.01437 s, throughput:    556.84 token/s
Decode.  median latency: 0.01411 s, median throughput:    566.95 token/s
Total. latency:  2.071 s, throughput:   4449.77 token/s
```

===================================================

MORE advice: we should consider both context len and prefix len to select MLA or MHA CHUNKED KV. Since they both affect the FLOPS of the core attention

ATTN FLOPS = bh * sq * sk * (dq + dv) * 2
MHA:  128b * context * (context + prefix) * (192 + 128) * 2
MLA: 128b * context * (context + prefix) * (576 + 512) * 2

Extract KV FLOPS: b * prefix * kvlora * (h * dqn) * 2 = bh * prefix * kvlora * dqn * 2 = 128b * prefix * 512 * 128 * 2

Goal: MHA + Extact KV < MLA
1. context * (context + prefix) * 320 * 2 + prefix * 65536 * 2 < context * (context + prefix) * 1088 * 2
2. prefix < 0.01171875 * (context + prefix) * context
3. set C = 0.01171875
4. prefix < C * (context^2 + prefix*context)

We can impl the filter like this? @Fridge003 
`sum(prefix) < C * sum(context^2 + prefix*context)`

Maybe have some mistake, welcome to point out

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
