### PR TITLE
Revert "Support aiter RMSNorm in AMD (#5510)"

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -20,12 +20,9 @@ import torch
 import torch.nn as nn
 
 from sglang.srt.custom_op import CustomOp
-from sglang.srt.utils import is_cuda, is_hip
-
-logger = logging.getLogger(__name__)
+from sglang.srt.utils import is_cuda
 
 _is_cuda = is_cuda()
-_is_hip = is_hip()
 
 if _is_cuda:
     from sgl_kernel import (
@@ -35,20 +32,8 @@ if _is_cuda:
         rmsnorm,
     )
 
-if _is_hip:
 
-    from aiter.ops.rmsnorm import rms_norm, rmsnorm2d_fwd_with_add
-
-    rmsnorm = rms_norm
-
-    def fused_add_rmsnorm(
-        x: torch.Tensor,
-        residual: torch.Tensor,
-        w: torch.Tensor,
-        eps: float,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        rmsnorm2d_fwd_with_add(x, x, residual, residual, w, eps)
-        return x, residual
+logger = logging.getLogger(__name__)
 
 
 class RMSNorm(CustomOp):
@@ -154,7 +139,7 @@ class Gemma3RMSNorm(nn.Module):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"
 
 
-if not (_is_cuda or _is_hip):
+if not _is_cuda:
     logger.info(
         "sgl-kernel is not available on Non-NV platforms. Fallback to other kernel libraries."
     )


### PR DESCRIPTION
This reverts commit 968ef51562d30a97337066738146faafa020e059.

need to add unit test for aiter on AMD GPU.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
