### PR TITLE
[PD] Support CPU fallback for mooncake

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -32,8 +32,8 @@ from sglang.srt.disaggregation.mooncake.transfer_engine import MooncakeTransferE
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     FastQueue,
-    group_concurrent_contiguous,
     check_gdr_support,
+    group_concurrent_contiguous,
 )
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import (

--- a/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
@@ -90,5 +90,18 @@ class MooncakeTransferEngine:
 
         return ret
 
+    def allocate_managed_buffer(self, length: int) -> int:
+        ret = self.engine.allocate_managed_buffer(length)
+        if ret <= 0:
+            logger.error("Allocation Return Error")
+            raise Exception("Allocation Return Error")
+        return ret
+
+    def free_managed_buffer(self, buffer: int, length: int) -> int:
+        return self.engine.free_managed_buffer(buffer, length)
+
+    def get_localhost(self):
+        return self.hostname
+
     def get_session_id(self):
         return self.session_id


### PR DESCRIPTION
## Motivation

Mooncake is now the default transfer engine supporting PD separation for SGLang. One current limitation is that the user's GPU device must support GDR (GPUDirect RDMA) capability. While this provides better performance, it restricts users with older hardware who want to experience the latest SGLang features. To address this, this PR introduces a CPU fallback path to enable Mooncake-based transmission of KVCache when GDR is unavailable.

Typically, one might manually allocate CPU buffers via CUDA for GPU memory copying, but Mooncake has already anticipated this need by providing a dedicated API (allocate_managed_buffer). This PR leverages that API to implement the fallback functionality. Importantly, this enhancement is fully transparent to users. 

Cc @stmatengss @ShangmingCai
## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
