### PR TITLE
add a version check for GGUF, according to the link in checkout

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1204,6 +1204,7 @@ class GGUFModelLoader(BaseModelLoader):
         # only load the gguf module when needed
         try:
             import gguf
+
             from sglang.srt.model_loader.utils import check_gguf_version
 
             check_gguf_version(version=getattr(gguf, "__version__", None))

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1204,8 +1204,9 @@ class GGUFModelLoader(BaseModelLoader):
         # only load the gguf module when needed
         try:
             import gguf
+            from sglang.srt.model_loader.utils import check_gguf_version
 
-            # FIXME: add version check for gguf
+            check_gguf_version(version=getattr(gguf, "__version__", None))
         except ImportError as err:
             raise ImportError(
                 "Please install gguf via `pip install gguf` to use gguf quantizer."

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -39,3 +39,18 @@ def get_model_architecture(model_config: ModelConfig) -> Tuple[Type[nn.Module], 
 
 def get_architecture_class_name(model_config: ModelConfig) -> str:
     return get_model_architecture(model_config)[1]
+
+
+def check_gguf_version(version: str) -> None:
+    """Checks if the installed gguf version is sufficient."""
+    MIN_GGUF_VERSION = "0.10.0"
+
+    installed_version_str = getattr(version, "__version__")
+
+    if installed_version_str < MIN_GGUF_VERSION:
+        raise ImportError(
+            f"Installed gguf version {installed_version_str} is insufficient. "
+            f"SGLang requires gguf>={MIN_GGUF_VERSION}. "
+            f"Please upgrade gguf via `pip install --upgrade gguf`."
+            "You may see the following link to be useful: https://github.com/huggingface/transformers/blob/b6d65e40b256d98d9621707762b94bc8ad83b7a7/src/transformers/modeling_gguf_pytorch_utils.py#L286"
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

add the minimum version of gguf as needed.

## Modifications

<!-- Describe the changes made in this PR. -->
the version SET is based on the link to `transformers` that has a bit more context to the issue.

this is also related, which could also be worth checking out.

lastly we could extract in general utils, but this is optional, until we decide on the approach for VL2.
this is also related, see
https://github.com/sgl-project/sglang/blob/7c99103f4c2a5e92e34bbfc5f3779fe9a447c8ee/python/sglang/srt/configs/deepseekvl2.py#L82
lastly,
one should also check out this for a bit more context:
https://github.com/sgl-project/sglang/issues/4900

Specifically 
> We should sort out the dependencies in pyproject and classify them by vlm, quant, etc. Currently, because we don't pay attention to gguf in our daily test cases, we haven't tested whether gguf works with DeepSeek V3. @ mickqian @ yizhang2077


## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
