### PR TITLE
Implement `RadixTree` `remove_tenant` method

### DIFF
--- a/scripts/playground/router/tree.py
+++ b/scripts/playground/router/tree.py
@@ -1,6 +1,6 @@
 import time
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict
 
 
 class Node:
@@ -231,7 +231,7 @@ class MultiTenantRadixTree:
     def _remove_tenant_recursive(self, node: Node, tenant_id: str) -> bool:
         """
         Recursively remove tenant_id from the subtree rooted at node using post-order traversal.
-        
+
         Args:
             node: The current node in the traversal.
             tenant_id: The identifier of the tenant to remove.
@@ -246,11 +246,7 @@ class MultiTenantRadixTree:
             del node.children[key]
         if tenant_id in node.tenant_last_access_time:
             del node.tenant_last_access_time[tenant_id]
-        if (
-            node != self.root
-            and not node.tenant_last_access_time
-            and not node.children
-        ):
+        if node != self.root and not node.tenant_last_access_time and not node.children:
             return True  # Signal to parent that this node should be pruned
 
         return False

--- a/scripts/playground/router/tree.py
+++ b/scripts/playground/router/tree.py
@@ -237,8 +237,38 @@ class MultiTenantRadixTree:
         Args:
             tenant_id: The identifier of the tenant whose data should be removed
         """
-        # TODO: Implementation needed
-        pass
+        if not self.root:
+            return
+
+        stack = [self.root]
+        visited_nodes = []
+
+        while stack:
+            node = stack.pop()
+            visited_nodes.append(node)
+
+            if tenant_id in node.tenant_last_access_time:
+                del node.tenant_last_access_time[tenant_id]
+
+            for child in node.children.values():
+                stack.append(child)
+
+        for node in reversed(visited_nodes):
+            # Check pruning conditions: Not root, no tenants, no children
+            if (
+                node != self.root
+                and not node.tenant_last_access_time
+                and not node.children
+            ):
+                parent = node.parent
+                if parent:  # Should always be true if node != self.root
+                    key_to_remove = None
+                    for key, child_node in parent.children.items():
+                        if child_node is node:
+                            key_to_remove = key
+                            break
+                    if key_to_remove is not None:
+                        del parent.children[key_to_remove]
 
     def pretty_print(self) -> str:
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
add the missing method, 
> def remove_tenant(self, tenant_id: str) -> None:
        """
        Remove all data associated with a specific tenant from the tree.
        This operation maintains the integrity of the shared tree structure while
        removing only the specified tenant's access information.
        Args:
            tenant_id: The identifier of the tenant whose data should be removed

## Modifications

<!-- Describe the changes made in this PR. -->

Test with `cd scripts/playground/router && python -m unittest test_tree.py`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
