### PR TITLE
use `torch.clamp`

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -596,9 +596,12 @@ class FlashInferIndicesUpdaterDecode:
         for wrapper_id in range(2):
             if wrapper_id == 0:
                 # Sliding window attention
-                paged_kernel_lens_tmp = torch.minimum(  # TODO: replace this with clamp
-                    seq_lens,
-                    torch.tensor(self.sliding_window_size + 1),
+                upper_bound = (
+                    1 if not self.sliding_window_size else self.sliding_window_size + 1
+                )
+                paged_kernel_lens_tmp = torch.clamp(
+                    input=seq_lens,
+                    max=upper_bound,
                 )
                 paged_kernel_lens_sum_tmp = paged_kernel_lens_tmp.sum().item()
                 kv_start_idx_tmp = seq_lens - paged_kernel_lens_tmp


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Motivated by the note in code, we should use `torch.clamp` cc @merrymercy  if you could please look.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
https://pytorch.org/docs/stable/generated/torch.clamp.html
## Modifications

<!-- Describe the changes made in this PR. -->
use `torch.clamp` for val
> The `torch.minimum` function calculates the element-wise minimum between the seq_lens tensor and a scalar tensor `self.sliding_window_size + 1`. Now, no value in `paged_kernel_lens_tmp` exceeds `self.sliding_window_size + 1`. Values in `seq_lens` that are already less than or equal to this limit remain unchanged.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
