### PR TITLE
Fix v1_chat_generate_request to allow for None content

### DIFF
--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -972,6 +972,10 @@ def v1_chat_generate_request(
                         openai_compatible_messages.append(
                             {"role": message.role, "content": message.content}
                         )
+                    elif message.content is None:
+                        openai_compatible_messages.append(
+                            {"role": message.role}
+                        )
                     else:
                         content_list = message.dict()["content"]
                         for content in content_list:

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -973,9 +973,7 @@ def v1_chat_generate_request(
                             {"role": message.role, "content": message.content}
                         )
                     elif message.content is None:
-                        openai_compatible_messages.append(
-                            {"role": message.role}
-                        )
+                        openai_compatible_messages.append({"role": message.role})
                     else:
                         content_list = message.dict()["content"]
                         for content in content_list:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Related to #5452. 
Allow content field to be None, as per OpenAI types: https://github.com/openai/openai-python/blob/05810dd4088b6dbfc4194d7b0bea03eec236c83a/src/openai/types/chat/chat_completion_assistant_message_param.py#L46C67-L47C1

This fixes issues when running agentic-workflow related use of SGLang, where the assistant's output may be fed back into /v1/chat/completions as is without modification. For example, in the following flow:

LLM attempts tool call i.e. content is None and tool_calls is a valid list
LLM's response is fed back into messages in ChatCompletionRequest without modification
It will currently fail on the request generation step since a non-string typed content is automatically assumed to be a list, even though content can be None, even though the OpenAI spec allows this. This change fixes this issue.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
