### PR TITLE
perf: update H20 fused_moe_triton kernel config to get higher throughput during prefilling

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/E=272,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/E=272,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -5,19 +5,19 @@
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
-        "num_stages": 3
+        "num_stages": 4
     },
     "2": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 1,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "4": {
         "BLOCK_SIZE_M": 16,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 1,
         "num_warps": 4,
@@ -33,17 +33,17 @@
     },
     "16": {
         "BLOCK_SIZE_M": 16,
-        "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
         "GROUP_SIZE_M": 64,
         "num_warps": 4,
-        "num_stages": 3
+        "num_stages": 4
     },
     "24": {
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
-        "BLOCK_SIZE_K": 64,
-        "GROUP_SIZE_M": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
         "num_stages": 3
     },
@@ -51,7 +51,7 @@
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 1,
+        "GROUP_SIZE_M": 32,
         "num_warps": 4,
         "num_stages": 3
     },
@@ -83,7 +83,7 @@
         "BLOCK_SIZE_M": 16,
         "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
         "num_stages": 3
     },
@@ -96,50 +96,50 @@
         "num_stages": 3
     },
     "512": {
-        "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
-        "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     },
     "1024": {
         "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 64,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
         "num_stages": 3
     },
     "1536": {
         "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 64,
+        "GROUP_SIZE_M": 32,
         "num_warps": 4,
         "num_stages": 3
     },
     "2048": {
         "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
         "GROUP_SIZE_M": 64,
         "num_warps": 4,
         "num_stages": 3
     },
     "3072": {
-        "BLOCK_SIZE_M": 128,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 32,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
-        "num_stages": 4
+        "num_stages": 3
     },
     "4096": {
         "BLOCK_SIZE_M": 64,
-        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_N": 128,
         "BLOCK_SIZE_K": 128,
-        "GROUP_SIZE_M": 64,
+        "GROUP_SIZE_M": 16,
         "num_warps": 4,
         "num_stages": 3
     }


### PR DESCRIPTION

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
We have provided fused_moe_triton config in PR(https://github.com/sgl-project/sglang/pull/5641) to improve model performance.
However, we found that after using this config, the throughput of the model during **prefilling period** dropped by about 3%.
After careful analysis, we found that the fused_moe_triton using this config will show different performance under different triton versions.
In the environment of triton==3.1.0 and torch==2.5.1, this config will increase the throughput of the model(deepseek-R1-671B) by about 3%; but in the newer environment of triton==3.2.0 and torch==2.6.0, it will bring negative performance improvement.
So we updated the config of the fused_moe_triton kernel to adapt to the newer environment.


## Modifications
Update python/sglang/srt/layers/moe/fused_moe_triton/configs/E=272,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json

## Benchmark
launch server (triton==3.2.0 and torch==2.6.0)
```
SGL_ENABLE_JIT_DEEPGEMM=0 python -u -m sglang.launch_server \
--model-path /sgl-workspace/DeepSeek-R1 \
--nnodes 2 --trust-remote-code  \
--served-model-name deepseek-r1 \
--dist-init-addr 29.226.67.154:5000 \
--node-rank ${NODE_RANK} \
--host 0.0.0.0 --port 8000 \
--tp 16 \
--node-rank ${NODE_RANK} \
--disable-radix-cache   \
--schedule-policy fcfs \
--chunked-prefill-size 32768 \
--max-prefill-tokens 32768 \
--disable-overlap-schedule \
--mem-fraction-static 0.79 \
--attention-backend flashinfer \
--cuda-graph-bs 1 2 4 8 16 32 64 96 128 256 --cuda-graph-max-bs 256
```
### For Prefill Period
TL;DR: Achieve a throughput improvement of about 4-5% after using new config.
```
python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 1 --input-len 2048 --output-len 0
old config:
latency: 0.19 s
output throughput: 0.00 token/s
(input + output) throughput: 10845.82 token/s
new config:
latency: 0.18 s
output throughput: 0.00 token/s
(input + output) throughput: 11309.41 token/s

python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 1 --input-len 4096 --output-len 0
old config:
latency: 0.33 s
output throughput: 0.00 token/s
(input + output) throughput: 12351.59 token/s
new config:
latency: 0.32 s
output throughput: 0.00 token/s
(input + output) throughput: 12812.78 token/s

python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 1 --input-len 8192 --output-len 0
old config:
latency: 0.66 s
output throughput: 0.00 token/s
(input + output) throughput: 12497.38 token/s
new config:
latency: 0.63 s
output throughput: 0.00 token/s
(input + output) throughput: 12956.29 token/s

python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 1 --input-len 16384 --output-len 0
old config:
latency: 1.44 s
output throughput: 0.00 token/s
(input + output) throughput: 11352.01 token/s
new config:
latency: 1.38 s
output throughput: 0.00 token/s
(input + output) throughput: 11845.40 token/s
```

### For Decoding Period
TL;DR: almost no impact.
```
python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 32 --input-len 1 --output-len 512
old config:
latency: 17.74 s
output throughput: 923.81 token/s
(input + output) throughput: 925.62 token/s
new config:
latency: 17.85 s
output throughput: 918.09 token/s
(input + output) throughput: 919.88 token/s

python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 64 --input-len 1 --output-len 512
old config:
latency: 21.19 s
output throughput: 1546.62 token/s
(input + output) throughput: 1549.64 token/s
new config:
latency: 21.23 s
output throughput: 1543.39 token/s
(input + output) throughput: 1546.41 token/s

python3 -m sglang.bench_one_batch_server --model None --skip-warmup \
--base-url http://127.0.0.1:8000 --batch-size 128 --input-len 1 --output-len 512
old config:
latency: 26.03 s
output throughput: 2517.67 token/s
(input + output) throughput: 2522.59 token/s
new config:
latency: 26.00 s
output throughput: 2520.71 token/s
(input + output) throughput: 2525.64 token/s
```

### Mix prefill and decoding period
```
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 4096 --random-output-len 512 \
--random-range-ratio 1 --port 8000 --model /sgl-workspace/DeepSeek-R1

old config:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  48.57     
Total input tokens:                      204800    
Total generated tokens:                  25600     
Total generated tokens (retokenized):    25467     
Request throughput (req/s):              1.03      
Input token throughput (tok/s):          4216.65   
Output token throughput (tok/s):         527.08    
Total token throughput (tok/s):          4743.74   
Concurrency:                             47.91     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   46536.78  
Median E2E Latency (ms):                 46650.29  
---------------Time to First Token----------------
Mean TTFT (ms):                          7731.00   
Median TTFT (ms):                        8370.85   
P99 TTFT (ms):                           12445.46  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           76.28     
Median ITL (ms):                         62.59     
P95 ITL (ms):                            64.05     
P99 ITL (ms):                            65.01     
Max ITL (ms):                            16312.27  
==================================================
new config:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max reqeuest concurrency:                not set   
Successful requests:                     50        
Benchmark duration (s):                  48.39     
Total input tokens:                      204800    
Total generated tokens:                  25600     
Total generated tokens (retokenized):    25446     
Request throughput (req/s):              1.03      
Input token throughput (tok/s):          4232.26   
Output token throughput (tok/s):         529.03    
Total token throughput (tok/s):          4761.30   
Concurrency:                             47.90     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   46358.45  
Median E2E Latency (ms):                 46473.85  
---------------Time to First Token----------------
Mean TTFT (ms):                          7584.68   
Median TTFT (ms):                        8223.41   
P99 TTFT (ms):                           12115.31  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           76.28     
Median ITL (ms):                         63.03     
P95 ITL (ms):                            64.39     
P99 ITL (ms):                            65.44     
Max ITL (ms):                            15981.39  
==================================================
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
