### PR TITLE
fix: import vllm_rotary_embedding error when head_size not in 64, 128, 256, 512

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
+from vllm._custom_ops import rotary_embedding as vllm_rotary_embedding
 
 from sglang.srt.custom_op import CustomOp
 from sglang.srt.utils import is_cuda
@@ -14,8 +15,6 @@ _is_cuda = is_cuda()
 
 if _is_cuda:
     from sgl_kernel import apply_rope_with_cos_sin_cache_inplace
-else:
-    from vllm._custom_ops import rotary_embedding as vllm_rotary_embedding
 
 
 def _rotate_neox(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
[EXAONE-3.5-2.4B-Instruct](https://huggingface.co/LGAI-EXAONE/EXAONE-3.5-2.4B-Instruct), [EXAONE-Deep-2.4B](https://huggingface.co/LGAI-EXAONE/EXAONE-Deep-2.4B) used head_size 80.

We always need to set `--attention-backend triton` and use [vllm_rotary_embedding](https://github.com/sgl-project/sglang/blob/b5be56944b6eb61b44866011f157e8df0e563bd7/python/sglang/srt/layers/rotary_embedding.py#L163).

Ref:
https://github.com/sgl-project/sglang/pull/4064
[import line](https://github.com/sgl-project/sglang/pull/4064/files#diff-280f743de711d3cdcc29f539ac7030135ab46f3b4fc9885a827ec2f6b9bce888R9)
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
Apply unconditional `import vllm_rotary_embedding`

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
