### PR TITLE
Revert "[fix] fix bench_one_batch_server"

### DIFF
--- a/python/sglang/bench_one_batch_server.py
+++ b/python/sglang/bench_one_batch_server.py
@@ -26,8 +26,6 @@ from sglang.srt.entrypoints.http_server import launch_server
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import kill_process_tree
 
-multiprocessing.set_start_method("spawn", force=True)
-
 
 @dataclasses.dataclass
 class BenchArgs:


### PR DESCRIPTION
Reverts sgl-project/sglang#5607 because it sets some global behavior. It breaks some CI tests.