### PR TITLE
Revert "Use device_id in dist init to reduce NCCL communicator warmup & creation overhead"

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1055,11 +1055,6 @@ def init_distributed_environment(
             world_size=world_size,
             rank=rank,
             timeout=timeout,
-            device_id=torch.device(
-                f"cuda:{torch.cuda.current_device()}"
-                if hasattr(torch, "cuda") and torch.cuda.is_available()
-                else None
-            ),  # Allow NCCL to eagerly init communicator
         )
 
     # set the local rank


### PR DESCRIPTION
Reverts sgl-project/sglang#5728.

It introduces many problems. See the original thread.