### PR TITLE
feat: integrate deepgemm into EPMoE

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -709,39 +709,6 @@ def grouped_gemm_triton(
     return c
 
 
-# @triton.jit
-# def fill_masked_m_triton_kernel(topk_ids, masked_m, num_experts, N, BLOCK_SIZE: tl.constexpr):
-#     expert_id = tl.program_id(0)
-#     masked_m_tensor = 0
-    
-#     for start_off in tl.range(0, N, BLOCK_SIZE):
-#         topk_ids_off = tl.arange(0, BLOCK_SIZE) + start_off
-#         topk_ids_mask = topk_ids_off < N
-#         topk_ids_tensor = tl.load(topk_ids + topk_ids_off, topk_ids_mask, other=num_experts)
-#         masked_m_tensor += tl.sum(tl.where(topk_ids_tensor == expert_id, 1, 0))
-#     tl.store(masked_m + expert_id, masked_m_tensor)
-
-
-# @triton.jit
-# def deepgemm_compute_src2dst_triton_kernel(topk_ids, src2dst, max_m, num_experts, N, BLOCK_SIZE: tl.constexpr):
-#     expert_id = tl.program_id(0)
-#     expert_len = 0
-#     start_dst = max_m * expert_id
-    
-#     for i in tl.range(0, N, BLOCK_SIZE):
-#         off = tl.arange(0, BLOCK_SIZE) + i
-#         mask = off < N
-#         topk_ids_tensor = tl.load(topk_ids + off, mask, other=num_experts)
-#         src2dst_tensor  = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
-#         src2dst_mask    = topk_ids_tensor == expert_id
-#         for j in tl.range(0, BLOCK_SIZE):
-#             if topk_ids_tensor[j] == expert_id:
-#                 src2dst_mask[j] = 1
-#                 src2dst_tensor[j] = start_dst + expert_len
-
-#         tl.store(src2dst + off, src2dst_tensor, src2dst_mask)
-
-
 @triton.jit
 def compute_masked_m_triton_kernel(seg_indptr, masked_m, num_experts, N):
     expert_id = tl.program_id(0)  

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -808,7 +808,7 @@ def fill_gateup_input_triton_kernel(
             
 
 def exp2_upper(num: int) -> int:
-    for i in range(31):
+    for i in range(2, 31):
         value = pow(2, i)
         if num <= value:
             return value

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -812,7 +812,6 @@ def moe_ep_deepgemm_preproess(
         seg_indptr, masked_m, num_experts, reorder_topk_ids.numel()
     )
 
-    # m_max = exp2_upper(torch.max(masked_m).item())
     m_max = exp2_upper(hidden_states.size(0))
     expected_m = (topk_ids.numel() + num_experts - 1) // num_experts
     gateup_input = torch.empty(
@@ -862,19 +861,6 @@ def moe_ep_deepgemm_preproess(
         scale.size(1),
         BLOCK_SIZE=1024,
     )
-
-    # if hidden_states.get_device() == 0:
-    #         print("begin")
-    #         print("src2dst: ", src2dst)
-    #         print("seg_indptr: ", seg_indptr)
-    #         print("m_max:", m_max)
-    #         print("topk_ids: ", topk_ids)
-    #         print("hidden_state: ", hidden_states)
-    # if hidden_states.get_device() == 7:
-    #         print("masked_m:", masked_m[start_expert_id : (end_expert_id+1)])
-    #         print("gateup_input: ", gateup_input[31])
-    #         print("gateup_input_scale: ", gateup_input_scale[31])
-    #         print("topk: ", top_k)
 
     return (
         m_max,

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -709,41 +709,60 @@ def grouped_gemm_triton(
     return c
 
 
-@triton.jit
-def fill_masked_m_triton_kernel(topk_ids, masked_m, num_experts, N, BLOCK_SIZE: tl.constexpr):
-    id = tl.program_id(0)
+# @triton.jit
+# def fill_masked_m_triton_kernel(topk_ids, masked_m, num_experts, N, BLOCK_SIZE: tl.constexpr):
+#     expert_id = tl.program_id(0)
+#     masked_m_tensor = 0
     
-    topk_ids_off = tl.arange(0, BLOCK_SIZE) + id * BLOCK_SIZE
-    topk_ids_mask = topk_ids_off < N
-    topk_ids_tensor = tl.load(topk_ids + topk_ids_off, topk_ids_mask, -1)
-    masked_m_tensor = tl.zeros(num_experts, tl.int32)
+#     for start_off in tl.range(0, N, BLOCK_SIZE):
+#         topk_ids_off = tl.arange(0, BLOCK_SIZE) + start_off
+#         topk_ids_mask = topk_ids_off < N
+#         topk_ids_tensor = tl.load(topk_ids + topk_ids_off, topk_ids_mask, other=num_experts)
+#         masked_m_tensor += tl.sum(tl.where(topk_ids_tensor == expert_id, 1, 0))
+#     tl.store(masked_m + expert_id, masked_m_tensor)
+
+
+# @triton.jit
+# def deepgemm_compute_src2dst_triton_kernel(topk_ids, src2dst, max_m, num_experts, N, BLOCK_SIZE: tl.constexpr):
+#     expert_id = tl.program_id(0)
+#     expert_len = 0
+#     start_dst = max_m * expert_id
     
-    for i in tl.range(BLOCK_SIZE):
-        masked_m_tensor[topk_ids_tensor[i]] += 1
-    
-    for i in tl.range(num_experts):
-        tl.atomic_add(masked_m, masked_m_tensor[i])
+#     for i in tl.range(0, N, BLOCK_SIZE):
+#         off = tl.arange(0, BLOCK_SIZE) + i
+#         mask = off < N
+#         topk_ids_tensor = tl.load(topk_ids + off, mask, other=num_experts)
+#         src2dst_tensor  = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+#         src2dst_mask    = topk_ids_tensor == expert_id
+#         for j in tl.range(0, BLOCK_SIZE):
+#             if topk_ids_tensor[j] == expert_id:
+#                 src2dst_mask[j] = 1
+#                 src2dst_tensor[j] = start_dst + expert_len
+
+#         tl.store(src2dst + off, src2dst_tensor, src2dst_mask)
 
 
 @triton.jit
-def compute_src2dst_triton_kernel(topk_ids, src2dst, max_m, num_experts, BLOCK_SIZE, N):
-    expert_id = tl.program_id(0)
-    expert_len = 0
-    start_dst = max_m * expert_id
-    
-    for i in tl.range(0, N, BLOCK_SIZE):
-        off = tl.arange(0, BLOCK_SIZE) + i * BLOCK_SIZE
-        mask = off < N
-        topk_ids_tensor = tl.load(topk_ids + off, mask, other=num_experts)
-        src2dst_tensor  = tl.zeros(BLOCK_SIZE, dtype=tl.int32)
-        src2dst_mask    = tl.zeros(BLOCK_SIZE, dtype=tl.int16)
-        for j in tl.range(0, BLOCK_SIZE):
-            if topk_ids_tensor[j] == expert_id:
-                src2dst_mask[j] = 1
-                src2dst_tensor[j] = start_dst + expert_len
-                expert_len += 1
-        tl.store(src2dst + off, src2dst_tensor, src2dst_mask)
-            
+def compute_masked_m_triton_kernel(seg_indptr, masked_m, num_experts, N):
+    expert_id = tl.program_id(0)  
+    start = tl.load(seg_indptr + expert_id + 1)
+    end = tl.load(seg_indptr + expert_id + 2, mask = expert_id < (num_experts - 1), other=N)
+    tl.store(masked_m + expert_id, (end - start))
+
+@triton.jit
+def deepgemm_compute_src2dst_triton_kernel(
+    topk_ids, reorder_ids, seg_indptr, src2dst, max_m, num_toks, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    dst_id = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = dst_id < num_toks
+    src_id = tl.load(reorder_ids + dst_id, mask=mask)
+    expert_id = tl.load(topk_ids + src_id, mask=(src_id < num_toks))
+    expert_dst_start = tl.load(seg_indptr + expert_id + 1)
+    expert_dst_offset = dst_id - expert_dst_start
+    dst_id = expert_id * max_m + expert_dst_offset
+    tl.store(src2dst + src_id, dst_id, mask=mask)   
+  
 
 @triton.jit
 def fill_gateup_input_triton_kernel(
@@ -764,7 +783,6 @@ def fill_gateup_input_triton_kernel(
     src_idx = tl.program_id(0)
     src2dst_ptr = src2dst_ptr + src_idx * topk
     topk_ids_ptr = topk_ids_ptr + src_idx * topk
-
     src_ptr = input_ptr + src_idx * hidden_size
     scale_src_ptr = scale_ptr + src_idx * scale_size
     
@@ -778,10 +796,12 @@ def fill_gateup_input_triton_kernel(
                 mask = offset < hidden_size
                 in_data = tl.load(src_ptr + offset, mask=mask)
                 tl.store(dst_ptr + offset, in_data, mask=mask)
-            off = tl.arange(0, scale_size)
-            in_scale = tl.load(scale_src_ptr + off)
             scale_dst_ptr = gateup_input_scale_ptr + dst_idx * scale_size
-            tl.store(scale_dst_ptr + off, in_scale)
+            for start_offset in tl.range(0, scale_size, BLOCK_SIZE):
+                offset = start_offset + tl.arange(0, BLOCK_SIZE)
+                mask = offset < scale_size
+                in_scale = tl.load(scale_src_ptr + offset, mask=mask)
+                tl.store(scale_dst_ptr + offset, in_scale, mask=mask)
             
 
 def moe_ep_deepgemm_preproess(topk_ids: torch.Tensor, 
@@ -792,23 +812,29 @@ def moe_ep_deepgemm_preproess(topk_ids: torch.Tensor,
                               end_expert_id, 
                               block_shape,
                               output_dtype: torch.dtype = torch.float8_e4m3fn,):
+    reorder_topk_ids, reorder_ids = torch.sort(topk_ids.view(-1), stable=True)
+    seg_indptr = torch.zeros(num_experts + 1, device=topk_ids.device, dtype=torch.int64)
     src2dst = torch.empty(topk_ids.numel(), device=topk_ids.device, dtype=torch.int32)
     masked_m = torch.zeros(num_experts, device=topk_ids.device, dtype=torch.int32)
+
+    compute_seg_indptr_triton_kernel[(num_experts,)](
+        reorder_topk_ids, seg_indptr, topk_ids.numel()
+    )
     
     grid = lambda meta: (triton.cdiv(topk_ids.numel(), meta["BLOCK_SIZE"]),)
-    fill_masked_m_triton_kernel[grid](
-        topk_ids, masked_m, num_experts, topk_ids.numel(), BLOCK_SIZE=512)
+    compute_masked_m_triton_kernel[(num_experts, )](
+        seg_indptr, masked_m, num_experts, reorder_topk_ids.numel())
     
     m_max = torch.max(masked_m).item()
-    expected_m = int(topk_ids.shape[0] / num_experts)
+    expected_m = (topk_ids.shape[0] + num_experts - 1) // num_experts
     gateup_input = torch.empty(
         (int(end_expert_id - start_expert_id + 1), m_max, hidden_states.size(1)),
         device=hidden_states.device,
         dtype=output_dtype,
     )
 
-    compute_src2dst_triton_kernel[(num_experts, )](
-        topk_ids, src2dst, m_max, num_experts, 1024, topk_ids.numel())
+    deepgemm_compute_src2dst_triton_kernel[grid](
+        topk_ids, reorder_ids, seg_indptr, src2dst, m_max, topk_ids.numel(), BLOCK_SIZE=256)
 
     if block_shape is not None:
         assert len(block_shape) == 2
@@ -818,7 +844,9 @@ def moe_ep_deepgemm_preproess(topk_ids: torch.Tensor,
         else:
             hidden_states, scale = per_token_group_quant_fp8(hidden_states, block_k)
     
-        gateup_input_scale = torch.empty(gateup_input.size(0), gateup_input.size(1), scale.size(1))
+        gateup_input_scale = torch.empty((gateup_input.size(0), gateup_input.size(1), scale.size(1)),
+                                        device=hidden_states.device,
+                                        dtype=scale.dtype)
 
     fill_gateup_input_triton_kernel[(hidden_states.shape[0],)](hidden_states, scale,
                                     gateup_input,
@@ -831,4 +859,4 @@ def moe_ep_deepgemm_preproess(topk_ids: torch.Tensor,
                                     hidden_states.size(1),
                                     scale.size(1),
                                     BLOCK_SIZE=1024)
-    return m_max, masked_m, expected_m, src2dst, (gateup_input, gateup_input_scale)
+    return m_max, masked_m[start_expert_id : (end_expert_id+1)], expected_m, src2dst, gateup_input, gateup_input_scale

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -41,15 +41,6 @@ from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.utils import DeepEPMode, is_cuda, is_hip, set_weight_attrs, get_bool_env_var
 
-_is_cuda = is_cuda()
-
-if _is_cuda:
-    from sglang.srt.custom_op import scaled_fp8_quant as sgl_scaled_fp8_quant
-else:
-    from vllm import _custom_ops as vllm_ops
-
-logger = logging.getLogger(__name__)
-
 _is_hip = is_hip()
 
 if _is_hip:

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -37,6 +37,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from sglang.srt.layers.quantization.deep_gemm import _ENABLE_JIT_DEEPGEMM
 from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
 from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
@@ -54,8 +55,6 @@ if _is_hip:
     from vllm._custom_ops import scaled_fp8_quant
 
 logger = logging.getLogger(__name__)
-
-epmoe_use_deepgemm = get_bool_env_var("EPMOE_USE_DEEPGEMM")
 
 
 class GroupedGemmRunner(torch.nn.Module):
@@ -222,7 +221,7 @@ class EPMoE(torch.nn.Module):
         )
 
     def forward(self, hidden_states: torch.Tensor, router_logits: torch.Tensor):
-        if use_deep_gemm and epmoe_use_deepgemm:
+        if use_deep_gemm and _ENABLE_JIT_DEEPGEMM:
             return self.forward_deepgemm(hidden_states, router_logits)
         else:
             return self.forward_normal(hidden_states, router_logits)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

For normal EPMoE (no DeepEP),  integrate DeepGEMM as an option. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

1. Add `forward_deepgemm` in EPMoE.  Use env `EPMOE_USE_DEEPGEMM` to enable it.
2. Add some triton kernels for PreRecord and PostRecord of `forward_deepgemm`.

## Evaluation
### Speed
With 2*H20-96G*8 for EP16, enabling EPMOE_USE_DEEPGEMM leads to a 14% throughput gain.
* Disable EPMOE_USE_DEEPGEMM
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    64.0
Max reqeuest concurrency:                64
Successful requests:                     192
Benchmark duration (s):                  280.53
Total input tokens:                      672000
Total generated tokens:                  288000
Total generated tokens (retokenized):    285278
Request throughput (req/s):              0.68
Input token throughput (tok/s):          2395.46
Output token throughput (tok/s):         1026.63
Total token throughput (tok/s):          3422.09
Concurrency:                             53.17
Accept length:                           3.04
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   77682.09
Median E2E Latency (ms):                 79075.32
---------------Time to First Token----------------
Mean TTFT (ms):                          4389.81
Median TTFT (ms):                        758.88
P99 TTFT (ms):                           21329.72
---------------Inter-Token Latency----------------
Mean ITL (ms):                           48.90
Median ITL (ms):                         34.40
P95 ITL (ms):                            121.80
P99 ITL (ms):                            264.88
Max ITL (ms):                            21210.85
==================================================
```

* Enable EPMOE_USE_DEEPGEMM
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    64.0
Max reqeuest concurrency:                64
Successful requests:                     192
Benchmark duration (s):                  246.03
Total input tokens:                      672000
Total generated tokens:                  288000
Total generated tokens (retokenized):    285757
Request throughput (req/s):              0.78
Input token throughput (tok/s):          2731.37
Output token throughput (tok/s):         1170.59
Total token throughput (tok/s):          3901.96
Concurrency:                             58.55
Accept length:                           3.10
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   75031.17
Median E2E Latency (ms):                 75272.64
---------------Time to First Token----------------
Mean TTFT (ms):                          4070.91
Median TTFT (ms):                        597.56
P99 TTFT (ms):                           19711.67
---------------Inter-Token Latency----------------
Mean ITL (ms):                           47.35
Median ITL (ms):                         34.07
P95 ITL (ms):                            118.96
P99 ITL (ms):                            244.79
Max ITL (ms):                            19567.36
==================================================
```

* Launch server commands
```
# node0
GLOO_SOCKET_IFNAME=eth0 NCCL_IB_HCA=mlx5_ NCCL_IB_DISABLE=0 NCCL_SOCKET_IFNAME=eth0 NCCL_IB_GID_INDEX=3 \
NCCL_MIN_NCHANNELS=24 \
NCCL_IB_QPS_PER_CONNECTION=8 \
SGL_ENABLE_JIT_DEEPGEMM=1 \
EPMOE_USE_DEEPGEMM=1 \
python3 -m sglang.launch_server \
--cuda-graph-bs 1 2 4 8 10 16 20 24 28 32 40 44 48 52 56 64 66 68 70 72 74 76 --cuda-graph-max-bs 78 \
--attention-backend fa3 \
--speculative-algo NEXTN --speculative-draft /data/models/DeepSeek-R1-NextN --speculative-num-steps 4 --speculative-eagle-topk 2 --speculative-num-draft-tokens 6 \
--model-path /data/models/DeepSeek-R1/ \
--tp 16 \
--dist-init-addr 192.168.0.7:10240 \
--nnodes 2 --node-rank 0 --trust-remote-code \
--host 0.0.0.0 --port 8000 --enable-ep-moe --max-running-requests 78 --mem-fraction-static 0.75 --disable-chunked-prefix-cache

# node1
GLOO_SOCKET_IFNAME=eth0 NCCL_IB_HCA=mlx5_ NCCL_IB_DISABLE=0 NCCL_SOCKET_IFNAME=eth0 NCCL_IB_GID_INDEX=3 \
NCCL_MIN_NCHANNELS=24 \
NCCL_IB_QPS_PER_CONNECTION=8 \
SGL_ENABLE_JIT_DEEPGEMM=1 \
EPMOE_USE_DEEPGEMM=1 \
python3 -m sglang.launch_server \
--cuda-graph-bs 1 2 4 8 10 16 20 24 28 32 40 44 48 52 56 64 66 68 70 72 74 76 --cuda-graph-max-bs 78 \
--attention-backend fa3 \
--speculative-algo NEXTN --speculative-draft /data/models/DeepSeek-R1-NextN --speculative-num-steps 4 --speculative-eagle-topk 2 --speculative-num-draft-tokens 6 \
--model-path /data/models/DeepSeek-R1/ \
--tp 16 \
--dist-init-addr 192.168.0.7:10240 \
--nnodes 2 --node-rank 1 --trust-remote-code \
--host 0.0.0.0 --port 8000 --enable-ep-moe --max-running-requests 78 --mem-fraction-static 0.75 --disable-chunked-prefix-cache

# client
python3 -m sglang.bench_serving --backend sglang \
            --dataset-name random \
            --dataset-path /data/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
            --random-input-len 3500 \
            --random-output-len 1500 \
            --random-range-ratio 1 \
            --request-rate 74 \
            --max-concurrency 74 \
            --num-prompts 296 \
            --host 0.0.0.0 --port 8000
```


### Accuracy

MMLU test with [mmlu/bench_sglang.py](https://github.com/sgl-project/sglang/blob/main/benchmark/mmlu/bench_sglang.py)
```
100%|██████████████████████████████████████████████████████████████████| 1369/1369 [00:47<00:00, 28.74it/s]
subject: abstract_algebra, #q:100, acc: 0.750
subject: anatomy, #q:135, acc: 0.852
subject: astronomy, #q:152, acc: 0.941
subject: business_ethics, #q:100, acc: 0.880
subject: clinical_knowledge, #q:265, acc: 0.925
subject: college_biology, #q:144, acc: 0.972
subject: college_chemistry, #q:100, acc: 0.630
subject: college_computer_science, #q:100, acc: 0.840
subject: college_mathematics, #q:100, acc: 0.770
subject: college_medicine, #q:173, acc: 0.890
Total latency: 47.643
Average accuracy: 0.865
```

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
