### PR TITLE
feat: realize Tokenizer API, which is a simple wrapper over HuggingFace-style tokenizers.

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -617,7 +617,7 @@ async def tokenize(request: Request):
                 content={"error": "The 'text' field must be a string"},
             )
         
-        tokenizer = _global_state.tokenizer_manager.get_tokenizer()
+        tokenizer = _global_state.tokenizer_manager.tokenizer
         token_ids = tokenizer.encode(text)
         
         return {
@@ -650,8 +650,25 @@ async def detokenize(request: Request):
                     content={"error": "All tokens must be integers"},
                 )
         
-        tokenizer = _global_state.tokenizer_manager.get_tokenizer()
+        tokenizer = _global_state.tokenizer_manager.tokenizer
         text = tokenizer.decode(tokens)
+        
+        # 清理各种可能的特殊标记
+        # 常见的特殊标记列表
+        special_tokens = [
+            "<|begin_of_text|>", "<|endoftext|>", 
+            "<s>", "</s>", "<pad>", 
+            "[CLS]", "[SEP]", "[PAD]", "[MASK]",
+            "<bos>", "<eos>", 
+        ]
+        
+        # 移除所有特殊标记
+        for token in special_tokens:
+            text = text.replace(token, "")
+            
+        # 如果客户端明确要求保留特殊标记，则不进行清理
+        if data.get("keep_special_tokens", False):
+            text = tokenizer.decode(tokens)
         
         return {
             "text": text

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -40,7 +40,7 @@ import uvicorn
 import uvloop
 from fastapi import FastAPI, File, Form, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import ORJSONResponse, Response, StreamingResponse, JSONResponse
+from fastapi.responses import JSONResponse, ORJSONResponse, Response, StreamingResponse
 
 from sglang.srt.entrypoints.engine import _launch_subprocesses
 from sglang.srt.function_call_parser import FunctionCallParser
@@ -616,14 +616,11 @@ async def tokenize(request: Request):
                 status_code=400,
                 content={"error": "The 'text' field must be a string"},
             )
-        
+
         tokenizer = _global_state.tokenizer_manager.tokenizer
         token_ids = tokenizer.encode(text)
-        
-        return {
-            "tokens": token_ids,
-            "count": len(token_ids)
-        }
+
+        return {"tokens": token_ids, "count": len(token_ids)}
     except Exception as e:
         return JSONResponse(
             status_code=500,
@@ -642,37 +639,42 @@ async def detokenize(request: Request):
                 status_code=400,
                 content={"error": "The 'tokens' field must be a list of integers"},
             )
-        
+
         for token in tokens:
             if not isinstance(token, int):
                 return JSONResponse(
                     status_code=400,
                     content={"error": "All tokens must be integers"},
                 )
-        
+
         tokenizer = _global_state.tokenizer_manager.tokenizer
         text = tokenizer.decode(tokens)
-        
+
         # 清理各种可能的特殊标记
         # 常见的特殊标记列表
         special_tokens = [
-            "<|begin_of_text|>", "<|endoftext|>", 
-            "<s>", "</s>", "<pad>", 
-            "[CLS]", "[SEP]", "[PAD]", "[MASK]",
-            "<bos>", "<eos>", 
+            "<|begin_of_text|>",
+            "<|endoftext|>",
+            "<s>",
+            "</s>",
+            "<pad>",
+            "[CLS]",
+            "[SEP]",
+            "[PAD]",
+            "[MASK]",
+            "<bos>",
+            "<eos>",
         ]
-        
+
         # 移除所有特殊标记
         for token in special_tokens:
             text = text.replace(token, "")
-            
+
         # 如果客户端明确要求保留特殊标记，则不进行清理
         if data.get("keep_special_tokens", False):
             text = tokenizer.decode(tokens)
-        
-        return {
-            "text": text
-        }
+
+        return {"text": text}
     except Exception as e:
         return JSONResponse(
             status_code=500,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -650,8 +650,6 @@ async def detokenize(request: Request):
         tokenizer = _global_state.tokenizer_manager.tokenizer
         text = tokenizer.decode(tokens)
 
-        # 清理各种可能的特殊标记
-        # 常见的特殊标记列表
         special_tokens = [
             "<|begin_of_text|>",
             "<|endoftext|>",
@@ -666,11 +664,9 @@ async def detokenize(request: Request):
             "<eos>",
         ]
 
-        # 移除所有特殊标记
         for token in special_tokens:
             text = text.replace(token, "")
 
-        # 如果客户端明确要求保留特殊标记，则不进行清理
         if data.get("keep_special_tokens", False):
             text = tokenizer.decode(tokens)
 

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -280,7 +280,6 @@ async def process_batch(tokenizer_manager, batch_id: str, batch_request: BatchRe
         end_point = batch_storage[batch_id].endpoint
         file_request_list = []
         all_requests = []
-        all_extra_bodies = []
         request_ids = []
         for line_id, line in enumerate(lines):
             request_data = json.loads(line)
@@ -294,29 +293,13 @@ async def process_batch(tokenizer_manager, batch_id: str, batch_request: BatchRe
                 raise ValueError("Streaming requests are not supported in batch mode")
 
             if end_point == "/v1/chat/completions":
-                extra_body_item = {
-                    k: v
-                    for k, v in body.items()
-                    if k not in ChatCompletionRequest.model_fields
-                }
-                request_item = ChatCompletionRequest(
-                    **{
-                        k: v
-                        for k, v in body.items()
-                        if k in ChatCompletionRequest.model_fields
-                    }
-                )
-                all_requests.append(request_item)
-                all_extra_bodies.append(extra_body_item)
+                all_requests.append(ChatCompletionRequest(**body))
             elif end_point == "/v1/completions":
                 all_requests.append(CompletionRequest(**body))
 
         if end_point == "/v1/chat/completions":
             adapted_request, request = v1_chat_generate_request(
-                all_requests,
-                tokenizer_manager,
-                request_ids=request_ids,
-                extra_body=all_extra_bodies,
+                all_requests, tokenizer_manager, request_ids=request_ids
             )
         elif end_point == "/v1/completions":
             adapted_request, request = v1_generate_request(
@@ -732,7 +715,10 @@ def v1_generate_response(
 
 
 async def v1_completions(tokenizer_manager, raw_request: Request):
-    request_json = await raw_request.json()
+    try:
+        request_json = await raw_request.json()
+    except Exception as e:
+        return create_error_response("Invalid request body, error: ", str(e))
     all_requests = [CompletionRequest(**request_json)]
     created = int(time.time())
     adapted_request, request = v1_generate_request(all_requests)
@@ -912,7 +898,6 @@ def v1_chat_generate_request(
     all_requests: List[ChatCompletionRequest],
     tokenizer_manager,
     request_ids: List[str] = None,
-    extra_body: List[Dict] | Dict = None,
 ):
     input_ids = []
     prompts = []
@@ -925,17 +910,10 @@ def v1_chat_generate_request(
     modalities_list = []
     lora_paths = []
 
-    is_batch = isinstance(extra_body, list)
+    # NOTE: with openai API, the prompt's logprobs are always not computed
 
-    for i, request in enumerate(all_requests):
-        # Extract chat_template_kwargs for the current request
-        current_extra_body = extra_body[i] if is_batch and extra_body else extra_body
-        chat_template_kwargs = (
-            current_extra_body.get("chat_template_kwargs", {})
-            if current_extra_body
-            else {}
-        )
-
+    is_multimodal = tokenizer_manager.model_config.is_multimodal
+    for request in all_requests:
         # Prep the data needed for the underlying GenerateReqInput:
         #  - prompt: The full prompt string.
         #  - stop: Custom stop tokens.
@@ -944,6 +922,7 @@ def v1_chat_generate_request(
         #    None skips any image processing in GenerateReqInput.
         strict_tag = None
         prompt = ""
+        prompt_ids = []
         if not isinstance(request.messages, str):
             # Apply chat template and its stop strings.
             tools = None
@@ -964,6 +943,33 @@ def v1_chat_generate_request(
 
             if chat_template_name is None:
                 openai_compatible_messages = []
+                if (
+                    tools
+                    and tokenizer_manager.server_args.tool_call_parser == "deepseekv3"
+                ):
+                    # add function call prompt to deepseekv3
+                    openai_compatible_messages.append(
+                        {
+                            "role": "system",
+                            "content": """You are a helpful Assistant.
+                    ## Tools
+                    ### Function
+                    You have the following functions available:
+                    """
+                            + "".join(
+                                [
+                                    f"""
+                        - `{tool['name']}`:
+                        ```json
+                        {json.dumps(tool)}
+                        ```
+                        """
+                                    for tool in tools
+                                ]
+                            ),
+                        }
+                    )
+
                 for message in request.messages:
                     if isinstance(message.content, str):
                         openai_compatible_messages.append(
@@ -976,9 +982,16 @@ def v1_chat_generate_request(
                                 openai_compatible_messages.append(
                                     {"role": message.role, "content": content["text"]}
                                 )
-                if openai_compatible_messages[-1]["role"] == "assistant":
-                    assistant_prefix = openai_compatible_messages[-1]["content"]
-                    openai_compatible_messages = openai_compatible_messages[:-1]
+                if (
+                    openai_compatible_messages
+                    and openai_compatible_messages[-1]["role"] == "assistant"
+                ):
+                    if request.continue_final_message:
+                        # Remove the final assistant message so its content can be continued.
+                        assistant_prefix = openai_compatible_messages[-1]["content"]
+                        openai_compatible_messages = openai_compatible_messages[:-1]
+                    else:
+                        assistant_prefix = None
                 else:
                     assistant_prefix = None
 
@@ -988,7 +1001,6 @@ def v1_chat_generate_request(
                         tokenize=True,
                         add_generation_prompt=True,
                         tools=tools,
-                        **chat_template_kwargs,
                     )
                 except:
                     #  This except branch will be triggered when the chosen model
@@ -1000,7 +1012,6 @@ def v1_chat_generate_request(
                         tokenize=True,
                         add_generation_prompt=True,
                         tools=tools,
-                        **chat_template_kwargs,
                     )
 
                 if assistant_prefix:
@@ -1011,7 +1022,7 @@ def v1_chat_generate_request(
                     ):
                         encoded = encoded[1:]
                     prompt_ids += encoded
-                if tokenizer_manager.model_config.is_multimodal:
+                if is_multimodal:
                     prompt = tokenizer_manager.tokenizer.decode(prompt_ids)
                 stop = request.stop
                 image_data = None
@@ -1019,7 +1030,33 @@ def v1_chat_generate_request(
                 modalities = []
             else:
                 conv = generate_chat_conv(request, chat_template_name)
-                prompt = conv.get_prompt()
+                # If we should continue the final assistant message, adjust the conversation.
+                if (
+                    request.continue_final_message
+                    and request.messages
+                    and request.messages[-1].role == "assistant"
+                ):
+                    # Remove the auto-added blank assistant turn, if present.
+                    if conv.messages and conv.messages[-1][1] is None:
+                        conv.messages.pop()
+                    # Rebuild the prompt from the conversation.
+                    prompt = conv.get_prompt()
+                    # Strip any trailing stop tokens or separators that indicate end-of-assistant.
+                    if isinstance(conv.stop_str, list):
+                        for stop_token in conv.stop_str:
+                            if prompt.endswith(stop_token):
+                                prompt = prompt[: -len(stop_token)]
+                    elif isinstance(conv.stop_str, str) and prompt.endswith(
+                        conv.stop_str
+                    ):
+                        prompt = prompt[: -len(conv.stop_str)]
+                    if conv.sep and prompt.endswith(conv.sep):
+                        prompt = prompt[: -len(conv.sep)]
+                    if getattr(conv, "sep2", None) and prompt.endswith(conv.sep2):
+                        prompt = prompt[: -len(conv.sep2)]
+                else:
+                    prompt = conv.get_prompt()
+
                 image_data = conv.image_data
                 audio_data = conv.audio_data
                 modalities = conv.modalities
@@ -1030,7 +1067,9 @@ def v1_chat_generate_request(
                         stop.append(request.stop)
                     else:
                         stop.extend(request.stop)
-                prompt_ids = tokenizer_manager.tokenizer.encode(prompt)
+
+                if not is_multimodal:
+                    prompt_ids = tokenizer_manager.tokenizer.encode(prompt)
         else:
             # Use the raw prompt and stop strings if the messages is already a string.
             prompt_ids = request.messages
@@ -1070,6 +1109,8 @@ def v1_chat_generate_request(
             sampling_params["json_schema"] = convert_json_schema_to_str(
                 request.response_format.json_schema.schema_
             )
+        elif request.response_format and request.response_format.type == "json_object":
+            sampling_params["json_schema"] = '{"type": "object"}'
         elif (
             request.response_format and request.response_format.type == "structural_tag"
         ):
@@ -1098,7 +1139,7 @@ def v1_chat_generate_request(
         audio_data_list.append(audio_data)
         modalities_list.append(modalities)
     if len(all_requests) == 1:
-        if tokenizer_manager.model_config.is_multimodal:
+        if is_multimodal:
             # processor will need text input
             prompt_kwargs = {"text": prompts[0]}
         else:
@@ -1137,6 +1178,8 @@ def v1_chat_generate_request(
         rid=request_ids,
         modalities=modalities_list,
         lora_path=lora_paths,
+        bootstrap_host=all_requests[0].bootstrap_host,
+        bootstrap_room=all_requests[0].bootstrap_room,
     )
 
     return adapted_request, all_requests if len(all_requests) > 1 else all_requests[0]
@@ -1211,7 +1254,7 @@ def v1_chat_generate_response(
             tools = request.tools
             separate_reasoning = request.separate_reasoning
 
-        if reasoning_parser and separate_reasoning and enable_thinking:
+        if reasoning_parser and separate_reasoning:
             try:
                 parser = ReasoningParser(
                     model_type=reasoning_parser, stream_reasoning=False
@@ -1339,27 +1382,13 @@ def v1_chat_generate_response(
 async def v1_chat_completions(
     tokenizer_manager, raw_request: Request, cache_report=False
 ):
-    request_json = await raw_request.json()
-    # Extract potential extra_body from the request JSON
-    extra_body = {
-        k: v
-        for k, v in request_json.items()
-        if k not in ChatCompletionRequest.model_fields
-    }
-    all_requests = [
-        ChatCompletionRequest(
-            **{
-                k: v
-                for k, v in request_json.items()
-                if k in ChatCompletionRequest.model_fields
-            }
-        )
-    ]
+    try:
+        request_json = await raw_request.json()
+    except Exception as e:
+        return create_error_response("Invalid request body, error: ", str(e))
+    all_requests = [ChatCompletionRequest(**request_json)]
     created = int(time.time())
-    # Pass extra_body to v1_chat_generate_request
-    adapted_request, request = v1_chat_generate_request(
-        all_requests, tokenizer_manager, extra_body=extra_body
-    )
+    adapted_request, request = v1_chat_generate_request(all_requests, tokenizer_manager)
 
     if adapted_request.stream:
         parser_dict = {}
@@ -1777,7 +1806,10 @@ def v1_embedding_response(ret, model_path, to_file=False):
 
 
 async def v1_embeddings(tokenizer_manager, raw_request: Request):
-    request_json = await raw_request.json()
+    try:
+        request_json = await raw_request.json()
+    except Exception as e:
+        return create_error_response("Invalid request body, error: ", str(e))
     all_requests = [EmbeddingRequest(**request_json)]
     adapted_request, request = v1_embedding_request(all_requests, tokenizer_manager)
 

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -576,10 +576,8 @@ The SmartHome Mini is a compact smart home assistant available in black or white
         assert response.status_code == 200, f"Failed with: {response.text}"
         data = response.json()
         assert "text" in data
-        # 比较时忽略特殊标记和空格差异
         assert data["text"].strip() == text.strip()
 
-        # 测试保留特殊标记的选项
         response = requests.post(
             f"{self.base_url.replace('/v1', '')}/detokenize",
             json={"tokens": tokens, "keep_special_tokens": True},

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -8,9 +8,9 @@ import json
 import re
 import time
 import unittest
-import requests
 
 import openai
+import requests
 
 from sglang.srt.hf_transformers_utils import get_tokenizer
 from sglang.srt.utils import kill_process_tree
@@ -555,8 +555,7 @@ The SmartHome Mini is a compact smart home assistant available in black or white
         # Test /tokenize endpoint
         text = "Hello, world! This is a test of the tokenizer API."
         response = requests.post(
-            f"{self.base_url.replace('/v1', '')}/tokenize",
-            json={"text": text}
+            f"{self.base_url.replace('/v1', '')}/tokenize", json={"text": text}
         )
         assert response.status_code == 200, f"Failed with: {response.text}"
         data = response.json()
@@ -564,44 +563,41 @@ The SmartHome Mini is a compact smart home assistant available in black or white
         assert "count" in data
         assert isinstance(data["tokens"], list)
         assert data["count"] == len(data["tokens"])
-        
+
         # Verify tokens are correct by comparing with local tokenizer
         expected_tokens = self.tokenizer.encode(text)
         assert data["tokens"] == expected_tokens
-        
+
         # Test /detokenize endpoint
         tokens = data["tokens"]
         response = requests.post(
-            f"{self.base_url.replace('/v1', '')}/detokenize",
-            json={"tokens": tokens}
+            f"{self.base_url.replace('/v1', '')}/detokenize", json={"tokens": tokens}
         )
         assert response.status_code == 200, f"Failed with: {response.text}"
         data = response.json()
         assert "text" in data
         # 比较时忽略特殊标记和空格差异
         assert data["text"].strip() == text.strip()
-        
+
         # 测试保留特殊标记的选项
         response = requests.post(
             f"{self.base_url.replace('/v1', '')}/detokenize",
-            json={"tokens": tokens, "keep_special_tokens": True}
+            json={"tokens": tokens, "keep_special_tokens": True},
         )
         assert response.status_code == 200, f"Failed with: {response.text}"
         data_with_special = response.json()
         assert "text" in data_with_special
-        
+
         # Test with empty inputs
         response = requests.post(
-            f"{self.base_url.replace('/v1', '')}/tokenize",
-            json={"text": ""}
+            f"{self.base_url.replace('/v1', '')}/tokenize", json={"text": ""}
         )
         assert response.status_code == 200, f"Failed with: {response.text}"
         empty_tokens = self.tokenizer.encode("")
         assert response.json()["count"] == len(empty_tokens)
-        
+
         response = requests.post(
-            f"{self.base_url.replace('/v1', '')}/detokenize",
-            json={"tokens": []}
+            f"{self.base_url.replace('/v1', '')}/detokenize", json={"tokens": []}
         )
         assert response.status_code == 200, f"Failed with: {response.text}"
         assert response.json()["text"] == ""

--- a/test/srt/test_openai_server.py
+++ b/test/srt/test_openai_server.py
@@ -558,7 +558,7 @@ The SmartHome Mini is a compact smart home assistant available in black or white
             f"{self.base_url.replace('/v1', '')}/tokenize",
             json={"text": text}
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, f"Failed with: {response.text}"
         data = response.json()
         assert "tokens" in data
         assert "count" in data
@@ -575,24 +575,35 @@ The SmartHome Mini is a compact smart home assistant available in black or white
             f"{self.base_url.replace('/v1', '')}/detokenize",
             json={"tokens": tokens}
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, f"Failed with: {response.text}"
         data = response.json()
         assert "text" in data
-        assert data["text"] == text
+        # 比较时忽略特殊标记和空格差异
+        assert data["text"].strip() == text.strip()
+        
+        # 测试保留特殊标记的选项
+        response = requests.post(
+            f"{self.base_url.replace('/v1', '')}/detokenize",
+            json={"tokens": tokens, "keep_special_tokens": True}
+        )
+        assert response.status_code == 200, f"Failed with: {response.text}"
+        data_with_special = response.json()
+        assert "text" in data_with_special
         
         # Test with empty inputs
         response = requests.post(
             f"{self.base_url.replace('/v1', '')}/tokenize",
             json={"text": ""}
         )
-        assert response.status_code == 200
-        assert response.json()["count"] == 0 or response.json()["count"] == len(self.tokenizer.encode(""))
+        assert response.status_code == 200, f"Failed with: {response.text}"
+        empty_tokens = self.tokenizer.encode("")
+        assert response.json()["count"] == len(empty_tokens)
         
         response = requests.post(
             f"{self.base_url.replace('/v1', '')}/detokenize",
             json={"tokens": []}
         )
-        assert response.status_code == 200
+        assert response.status_code == 200, f"Failed with: {response.text}"
         assert response.json()["text"] == ""
 
 

--- a/test/srt/test_tokenizer_api.py
+++ b/test/srt/test_tokenizer_api.py
@@ -1,0 +1,172 @@
+"""
+Test the tokenizer API endpoints.
+
+Run with:
+python3 -m unittest test_tokenizer_api.TestTokenizerAPI
+"""
+
+import json
+import unittest
+import requests
+
+from sglang.srt.hf_transformers_utils import get_tokenizer
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestTokenizerAPI(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        )
+        cls.tokenizer = get_tokenizer(cls.model)
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_tokenize_simple(self):
+        """Test tokenizing a simple string."""
+        text = "Hello, world!"
+        response = requests.post(
+            f"{self.base_url}/tokenize",
+            json={"text": text}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        
+        # Compare with local tokenizer
+        expected_tokens = self.tokenizer.encode(text)
+        
+        self.assertIn("tokens", data)
+        self.assertIsInstance(data["tokens"], list)
+        self.assertEqual(data["tokens"], expected_tokens)
+        
+        self.assertIn("count", data)
+        self.assertEqual(data["count"], len(expected_tokens))
+
+    def test_tokenize_empty(self):
+        """Test tokenizing an empty string."""
+        text = ""
+        response = requests.post(
+            f"{self.base_url}/tokenize",
+            json={"text": text}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        
+        expected_tokens = self.tokenizer.encode(text)
+        
+        self.assertIn("tokens", data)
+        self.assertEqual(data["tokens"], expected_tokens)
+        self.assertEqual(data["count"], len(expected_tokens))
+
+    def test_tokenize_long(self):
+        """Test tokenizing a longer text."""
+        text = "This is a longer text that should be tokenized properly. " * 10
+        response = requests.post(
+            f"{self.base_url}/tokenize",
+            json={"text": text}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        
+        expected_tokens = self.tokenizer.encode(text)
+        
+        self.assertIn("tokens", data)
+        self.assertEqual(data["tokens"], expected_tokens)
+        self.assertEqual(data["count"], len(expected_tokens))
+
+    def test_tokenize_invalid(self):
+        """Test tokenizing with invalid input."""
+        response = requests.post(
+            f"{self.base_url}/tokenize",
+            json={"text": 123}  # Not a string
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_detokenize_simple(self):
+        """Test detokenizing a simple token list."""
+        text = "Hello, world!"
+        tokens = self.tokenizer.encode(text)
+        
+        response = requests.post(
+            f"{self.base_url}/detokenize",
+            json={"tokens": tokens}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        
+        self.assertIn("text", data)
+        self.assertEqual(data["text"], text)
+
+    def test_detokenize_empty(self):
+        """Test detokenizing an empty token list."""
+        tokens = []
+        
+        response = requests.post(
+            f"{self.base_url}/detokenize",
+            json={"tokens": tokens}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        
+        self.assertIn("text", data)
+        self.assertEqual(data["text"], "")
+
+    def test_detokenize_invalid_format(self):
+        """Test detokenizing with invalid input format."""
+        response = requests.post(
+            f"{self.base_url}/detokenize",
+            json={"tokens": "not_a_list"}
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_detokenize_invalid_token(self):
+        """Test detokenizing with invalid token type."""
+        response = requests.post(
+            f"{self.base_url}/detokenize",
+            json={"tokens": [1, 2, "not_an_int", 4]}
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_roundtrip(self):
+        """Test tokenize followed by detokenize roundtrip."""
+        original_text = "This is a test of the tokenizer API roundtrip functionality."
+        
+        # First tokenize
+        tokenize_response = requests.post(
+            f"{self.base_url}/tokenize",
+            json={"text": original_text}
+        )
+        self.assertEqual(tokenize_response.status_code, 200)
+        tokens = tokenize_response.json()["tokens"]
+        
+        # Then detokenize
+        detokenize_response = requests.post(
+            f"{self.base_url}/detokenize",
+            json={"tokens": tokens}
+        )
+        self.assertEqual(detokenize_response.status_code, 200)
+        reconstructed_text = detokenize_response.json()["text"]
+        
+        # Compare original and reconstructed text
+        self.assertEqual(reconstructed_text, original_text)
+
+
+if __name__ == "__main__":
+    unittest.main() 

--- a/test/srt/test_tokenizer_api.py
+++ b/test/srt/test_tokenizer_api.py
@@ -8,10 +8,11 @@ python3 sglang/test/srt/test_tokenizer_api.py
 """
 
 import json
-import unittest
-import requests
-import sys
 import os
+import sys
+import unittest
+
+import requests
 
 # 添加项目根目录到Python路径
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
@@ -48,36 +49,30 @@ class TestTokenizerAPI(CustomTestCase):
     def test_tokenize_simple(self):
         """Test tokenizing a simple string."""
         text = "Hello, world!"
-        response = requests.post(
-            f"{self.base_url}/tokenize",
-            json={"text": text}
-        )
-        
+        response = requests.post(f"{self.base_url}/tokenize", json={"text": text})
+
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        
+
         # Compare with local tokenizer
         expected_tokens = self.tokenizer.encode(text)
-        
+
         self.assertIn("tokens", data)
         self.assertIsInstance(data["tokens"], list)
         self.assertEqual(data["tokens"], expected_tokens)
-        
+
         self.assertIn("count", data)
         self.assertEqual(data["count"], len(expected_tokens))
 
     def test_tokenize_empty(self):
         """Test tokenizing an empty string."""
         text = ""
-        response = requests.post(
-            f"{self.base_url}/tokenize",
-            json={"text": text}
-        )
+        response = requests.post(f"{self.base_url}/tokenize", json={"text": text})
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        
+
         expected_tokens = self.tokenizer.encode(text)
-        
+
         self.assertIn("tokens", data)
         self.assertEqual(data["tokens"], expected_tokens)
         self.assertEqual(data["count"], len(expected_tokens))
@@ -85,15 +80,12 @@ class TestTokenizerAPI(CustomTestCase):
     def test_tokenize_long(self):
         """Test tokenizing a longer text."""
         text = "This is a longer text that should be tokenized properly. " * 10
-        response = requests.post(
-            f"{self.base_url}/tokenize",
-            json={"text": text}
-        )
+        response = requests.post(f"{self.base_url}/tokenize", json={"text": text})
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        
+
         expected_tokens = self.tokenizer.encode(text)
-        
+
         self.assertIn("tokens", data)
         self.assertEqual(data["tokens"], expected_tokens)
         self.assertEqual(data["count"], len(expected_tokens))
@@ -101,8 +93,7 @@ class TestTokenizerAPI(CustomTestCase):
     def test_tokenize_invalid(self):
         """Test tokenizing with invalid input."""
         response = requests.post(
-            f"{self.base_url}/tokenize",
-            json={"text": 123}  # Not a string
+            f"{self.base_url}/tokenize", json={"text": 123}  # Not a string
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
@@ -111,14 +102,11 @@ class TestTokenizerAPI(CustomTestCase):
         """Test detokenizing a simple token list."""
         text = "Hello, world!"
         tokens = self.tokenizer.encode(text)
-        
-        response = requests.post(
-            f"{self.base_url}/detokenize",
-            json={"tokens": tokens}
-        )
+
+        response = requests.post(f"{self.base_url}/detokenize", json={"tokens": tokens})
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        
+
         self.assertIn("text", data)
         # 比较时忽略开头的特殊标记
         self.assertEqual(data["text"].strip(), text.strip())
@@ -126,22 +114,18 @@ class TestTokenizerAPI(CustomTestCase):
     def test_detokenize_empty(self):
         """Test detokenizing an empty token list."""
         tokens = []
-        
-        response = requests.post(
-            f"{self.base_url}/detokenize",
-            json={"tokens": tokens}
-        )
+
+        response = requests.post(f"{self.base_url}/detokenize", json={"tokens": tokens})
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data = response.json()
-        
+
         self.assertIn("text", data)
         self.assertEqual(data["text"], "")
 
     def test_detokenize_invalid_format(self):
         """Test detokenizing with invalid input format."""
         response = requests.post(
-            f"{self.base_url}/detokenize",
-            json={"tokens": "not_a_list"}
+            f"{self.base_url}/detokenize", json={"tokens": "not_a_list"}
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
@@ -149,8 +133,7 @@ class TestTokenizerAPI(CustomTestCase):
     def test_detokenize_invalid_token(self):
         """Test detokenizing with invalid token type."""
         response = requests.post(
-            f"{self.base_url}/detokenize",
-            json={"tokens": [1, 2, "not_an_int", 4]}
+            f"{self.base_url}/detokenize", json={"tokens": [1, 2, "not_an_int", 4]}
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
@@ -160,65 +143,77 @@ class TestTokenizerAPI(CustomTestCase):
         # 先获取一个包含特殊标记的示例
         text = "Hello, world!"
         tokens = self.tokenizer.encode(text)
-        
+
         # 正常情况下，特殊标记会被移除
-        response = requests.post(
-            f"{self.base_url}/detokenize",
-            json={"tokens": tokens}
-        )
+        response = requests.post(f"{self.base_url}/detokenize", json={"tokens": tokens})
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data_without_special = response.json()
-        
+
         # 使用keep_special_tokens=True选项
         response = requests.post(
             f"{self.base_url}/detokenize",
-            json={"tokens": tokens, "keep_special_tokens": True}
+            json={"tokens": tokens, "keep_special_tokens": True},
         )
         self.assertEqual(response.status_code, 200, f"Failed with: {response.text}")
         data_with_special = response.json()
-        
+
         # 对于某些模型，这两者可能会有所不同
         # 这里我们只检查响应格式是否正确
         self.assertIn("text", data_with_special)
         self.assertIsInstance(data_with_special["text"], str)
-        
+
         # 如果模型确实添加了特殊标记，两个结果应该不同
         # 但由于测试可能使用不同的模型，我们只在有区别时断言
         if data_with_special["text"] != data_without_special["text"]:
             # 验证保留特殊标记的版本比不保留的版本更长或包含更多内容
             special_tokens = [
-                "<|begin_of_text|>", "<|endoftext|>", 
-                "<s>", "</s>", "<pad>", 
-                "[CLS]", "[SEP]", "[PAD]", "[MASK]",
-                "<bos>", "<eos>", 
+                "<|begin_of_text|>",
+                "<|endoftext|>",
+                "<s>",
+                "</s>",
+                "<pad>",
+                "[CLS]",
+                "[SEP]",
+                "[PAD]",
+                "[MASK]",
+                "<bos>",
+                "<eos>",
             ]
-            has_special_token = any(token in data_with_special["text"] for token in special_tokens)
-            self.assertTrue(has_special_token, 
-                           f"Expected special tokens in: {data_with_special['text']}")
+            has_special_token = any(
+                token in data_with_special["text"] for token in special_tokens
+            )
+            self.assertTrue(
+                has_special_token,
+                f"Expected special tokens in: {data_with_special['text']}",
+            )
 
     def test_roundtrip(self):
         """Test tokenize followed by detokenize roundtrip."""
         original_text = "This is a test of the tokenizer API roundtrip functionality."
-        
+
         # First tokenize
         tokenize_response = requests.post(
-            f"{self.base_url}/tokenize",
-            json={"text": original_text}
+            f"{self.base_url}/tokenize", json={"text": original_text}
         )
-        self.assertEqual(tokenize_response.status_code, 200, f"Failed with: {tokenize_response.text}")
+        self.assertEqual(
+            tokenize_response.status_code, 200, f"Failed with: {tokenize_response.text}"
+        )
         tokens = tokenize_response.json()["tokens"]
-        
+
         # Then detokenize
         detokenize_response = requests.post(
-            f"{self.base_url}/detokenize",
-            json={"tokens": tokens}
+            f"{self.base_url}/detokenize", json={"tokens": tokens}
         )
-        self.assertEqual(detokenize_response.status_code, 200, f"Failed with: {detokenize_response.text}")
+        self.assertEqual(
+            detokenize_response.status_code,
+            200,
+            f"Failed with: {detokenize_response.text}",
+        )
         reconstructed_text = detokenize_response.json()["text"]
-        
+
         # Compare original and reconstructed text (ignore any special tokens)
         self.assertEqual(reconstructed_text.strip(), original_text.strip())
 
 
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

realize Tokenizer API, which is a simple wrapper over HuggingFace-style tokenizers. https://docs.vllm.ai/en/v0.8.4_a/serving/openai_compatible_server.html#tokenizer-api

## Modifications

```
cd  sglang/test/srt
python3 -m unittest test_tokenizer_api.TestTokenizerAPI
```
output:
```
command=python3 -m sglang.launch_server --model-path meta-llama/Llama-3.2-1B-Instruct --host 127.0.0.1 --port 8000
/usr/local/lib/python3.10/dist-packages/vllm/connections.py:8: RuntimeWarning: Failed to read commit hash:
No module named 'vllm._version'
  from vllm.version import __version__ as VLLM_VERSION
[2025-04-28 05:38:40] server_args=ServerArgs(model_path='meta-llama/Llama-3.2-1B-Instruct', tokenizer_path='meta-llama/Llama-3.2-1B-Instruct', tokenizer_mode='auto', skip_tokenizer_init=False, enable_tokenizer_batch_encode=False, load_format='auto', trust_remote_code=False, dtype='auto', kv_cache_dtype='auto', quantization=None, quantization_param_path=None, context_length=None, device='cuda', served_model_name='meta-llama/Llama-3.2-1B-Instruct', chat_template=None, completion_template=None, is_embedding=False, revision=None, host='127.0.0.1', port=8000, mem_fraction_static=0.8639842241317652, max_running_requests=None, max_total_tokens=None, chunked_prefill_size=8192, max_prefill_tokens=16384, schedule_policy='fcfs', schedule_conservativeness=1.0, cpu_offload_gb=0, page_size=1, tp_size=1, stream_interval=1, stream_output=False, random_seed=106198034, constrained_json_whitespace_pattern=None, watchdog_timeout=300, dist_timeout=None, download_dir=None, base_gpu_id=0, gpu_id_step=1, log_level='info', log_level_http=None, log_requests=False, log_requests_level=0, show_time_cost=False, enable_metrics=False, decode_log_interval=40, api_key=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, dp_size=1, load_balance_method='round_robin', ep_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', lora_paths=None, max_loras_per_batch=8, lora_backend='triton', attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', speculative_algorithm=None, speculative_draft_model_path=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, disable_radix_cache=False, disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_nccl_nvls=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_multimodal=None, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_ep_moe=False, enable_deepep_moe=False, deepep_mode='auto', enable_torch_compile=False, torch_compile_max_bs=32, cuda_graph_max_bs=None, cuda_graph_bs=None, torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, allow_auto_truncate=False, enable_custom_logit_processor=False, tool_call_parser=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through_selective', flashinfer_mla_disable_ragged=False, warmups=None, moe_dense_tp_size=None, n_share_experts_fusion=0, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, debug_tensor_dump_output_folder=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_bootstrap_port=8998, disaggregation_transfer_backend='mooncake', disaggregation_ib_device=None)
/usr/local/lib/python3.10/dist-packages/vllm/connections.py:8: RuntimeWarning: Failed to read commit hash:
No module named 'vllm._version'
  from vllm.version import __version__ as VLLM_VERSION
/usr/local/lib/python3.10/dist-packages/vllm/connections.py:8: RuntimeWarning: Failed to read commit hash:
No module named 'vllm._version'
  from vllm.version import __version__ as VLLM_VERSION
[2025-04-28 05:38:48 TP0] Attention backend not set. Use fa3 backend by default.
[2025-04-28 05:38:48 TP0] Init torch distributed begin.
[rank0]:[W428 05:38:49.898395559 ProcessGroupGloo.cpp:727] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[2025-04-28 05:38:49 TP0] Init torch distributed ends. mem usage=0.00 GB
[2025-04-28 05:38:49 TP0] Load weight begin. avail mem=94.78 GB
[2025-04-28 05:38:50 TP0] Using model weights format ['*.safetensors']
[2025-04-28 05:38:51 TP0] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.72it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.72it/s]

[2025-04-28 05:38:51 TP0] Load weight end. type=LlamaForCausalLM, dtype=torch.bfloat16, avail mem=92.37 GB, mem usage=2.41 GB.
[2025-04-28 05:38:51 TP0] KV Cache is allocated. #tokens: 2604325, K size: 39.74 GB, V size: 39.74 GB
[2025-04-28 05:38:51 TP0] Memory pool end. avail mem=10.78 GB
[2025-04-28 05:38:51 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=10.68 GB
Capturing batches (avail_mem=6.05 GB): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:06<00:00,  5.52it/s]
[2025-04-28 05:38:58 TP0] Capture cuda graph end. Time elapsed: 6.48 s. avail mem=6.04 GB. mem usage=4.64 GB.
[2025-04-28 05:38:58 TP0] max_total_num_tokens=2604325, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4097, context_len=131072
[2025-04-28 05:38:59] INFO:     Started server process [2615992]
[2025-04-28 05:38:59] INFO:     Waiting for application startup.
[2025-04-28 05:38:59] INFO:     Application startup complete.
[2025-04-28 05:38:59] INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
[2025-04-28 05:39:00] INFO:     127.0.0.1:59424 - "GET /get_model_info HTTP/1.1" 200 OK
[2025-04-28 05:39:00 TP0] Prefill batch. #new-seq: 1, #new-token: 7, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0
[2025-04-28 05:39:01] INFO:     127.0.0.1:59428 - "POST /generate HTTP/1.1" 200 OK
[2025-04-28 05:39:01] The server is fired up and ready to roll!
[2025-04-28 05:39:08 TP0] Prefill batch. #new-seq: 1, #new-token: 1, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0
[2025-04-28 05:39:09] INFO:     127.0.0.1:54282 - "GET /health_generate HTTP/1.1" 200 OK
[2025-04-28 05:39:10] INFO:     127.0.0.1:54296 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54300 - "POST /detokenize HTTP/1.1" 400 Bad Request
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54310 - "POST /detokenize HTTP/1.1" 400 Bad Request
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54322 - "POST /detokenize HTTP/1.1" 200 OK
[2025-04-28 05:39:10] INFO:     127.0.0.1:54330 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54336 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54350 - "POST /tokenize HTTP/1.1" 200 OK
[2025-04-28 05:39:10] INFO:     127.0.0.1:54364 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54366 - "POST /tokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54382 - "POST /tokenize HTTP/1.1" 400 Bad Request
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54396 - "POST /tokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] INFO:     127.0.0.1:54406 - "POST /tokenize HTTP/1.1" 200 OK
.[2025-04-28 05:39:10] Child process unexpectedly failed with an exit code 9. pid=2616298

----------------------------------------------------------------------
Ran 10 tests in 34.882s

OK
```

```
python3 test_tokenizer_api.py 
```
output:
```
command=python3 -m sglang.launch_server --model-path meta-llama/Llama-3.2-1B-Instruct --host 127.0.0.1 --port 8000
/usr/local/lib/python3.10/dist-packages/vllm/connections.py:8: RuntimeWarning: Failed to read commit hash:
No module named 'vllm._version'
  from vllm.version import __version__ as VLLM_VERSION
[2025-04-28 05:39:43] server_args=ServerArgs(model_path='meta-llama/Llama-3.2-1B-Instruct', tokenizer_path='meta-llama/Llama-3.2-1B-Instruct', tokenizer_mode='auto', skip_tokenizer_init=False, enable_tokenizer_batch_encode=False, load_format='auto', trust_remote_code=False, dtype='auto', kv_cache_dtype='auto', quantization=None, quantization_param_path=None, context_length=None, device='cuda', served_model_name='meta-llama/Llama-3.2-1B-Instruct', chat_template=None, completion_template=None, is_embedding=False, revision=None, host='127.0.0.1', port=8000, mem_fraction_static=0.8639842241317652, max_running_requests=None, max_total_tokens=None, chunked_prefill_size=8192, max_prefill_tokens=16384, schedule_policy='fcfs', schedule_conservativeness=1.0, cpu_offload_gb=0, page_size=1, tp_size=1, stream_interval=1, stream_output=False, random_seed=711975287, constrained_json_whitespace_pattern=None, watchdog_timeout=300, dist_timeout=None, download_dir=None, base_gpu_id=0, gpu_id_step=1, log_level='info', log_level_http=None, log_requests=False, log_requests_level=0, show_time_cost=False, enable_metrics=False, decode_log_interval=40, api_key=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, dp_size=1, load_balance_method='round_robin', ep_size=1, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', lora_paths=None, max_loras_per_batch=8, lora_backend='triton', attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', speculative_algorithm=None, speculative_draft_model_path=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, disable_radix_cache=False, disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_nccl_nvls=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_multimodal=None, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_ep_moe=False, enable_deepep_moe=False, deepep_mode='auto', enable_torch_compile=False, torch_compile_max_bs=32, cuda_graph_max_bs=None, cuda_graph_bs=None, torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, allow_auto_truncate=False, enable_custom_logit_processor=False, tool_call_parser=None, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through_selective', flashinfer_mla_disable_ragged=False, warmups=None, moe_dense_tp_size=None, n_share_experts_fusion=0, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, debug_tensor_dump_output_folder=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_bootstrap_port=8998, disaggregation_transfer_backend='mooncake', disaggregation_ib_device=None)
/usr/local/lib/python3.10/dist-packages/vllm/connections.py:8: RuntimeWarning: Failed to read commit hash:
No module named 'vllm._version'
  from vllm.version import __version__ as VLLM_VERSION
/usr/local/lib/python3.10/dist-packages/vllm/connections.py:8: RuntimeWarning: Failed to read commit hash:
No module named 'vllm._version'
  from vllm.version import __version__ as VLLM_VERSION
[2025-04-28 05:39:52 TP0] Attention backend not set. Use fa3 backend by default.
[2025-04-28 05:39:52 TP0] Init torch distributed begin.
[rank0]:[W428 05:39:52.206806070 ProcessGroupGloo.cpp:727] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[2025-04-28 05:39:52 TP0] Init torch distributed ends. mem usage=0.00 GB
[2025-04-28 05:39:52 TP0] Load weight begin. avail mem=94.78 GB
[2025-04-28 05:39:54 TP0] Using model weights format ['*.safetensors']
[2025-04-28 05:39:54 TP0] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.73it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.73it/s]

[2025-04-28 05:39:55 TP0] Load weight end. type=LlamaForCausalLM, dtype=torch.bfloat16, avail mem=92.37 GB, mem usage=2.41 GB.
[2025-04-28 05:39:55 TP0] KV Cache is allocated. #tokens: 2604325, K size: 39.74 GB, V size: 39.74 GB
[2025-04-28 05:39:55 TP0] Memory pool end. avail mem=10.78 GB
[2025-04-28 05:39:55 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=10.68 GB
Capturing batches (avail_mem=6.05 GB): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:06<00:00,  5.46it/s]
[2025-04-28 05:40:01 TP0] Capture cuda graph end. Time elapsed: 6.53 s. avail mem=6.04 GB. mem usage=4.64 GB.
[2025-04-28 05:40:02 TP0] max_total_num_tokens=2604325, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4097, context_len=131072
[2025-04-28 05:40:03] INFO:     Started server process [2619481]
[2025-04-28 05:40:03] INFO:     Waiting for application startup.
[2025-04-28 05:40:03] INFO:     Application startup complete.
[2025-04-28 05:40:03] INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
[2025-04-28 05:40:04] INFO:     127.0.0.1:40742 - "GET /get_model_info HTTP/1.1" 200 OK
[2025-04-28 05:40:04 TP0] Prefill batch. #new-seq: 1, #new-token: 7, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0
[2025-04-28 05:40:05] INFO:     127.0.0.1:40756 - "POST /generate HTTP/1.1" 200 OK
[2025-04-28 05:40:05] The server is fired up and ready to roll!
[2025-04-28 05:40:11 TP0] Prefill batch. #new-seq: 1, #new-token: 1, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0
[2025-04-28 05:40:12] INFO:     127.0.0.1:40764 - "GET /health_generate HTTP/1.1" 200 OK
[2025-04-28 05:40:12] INFO:     127.0.0.1:40768 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40776 - "POST /detokenize HTTP/1.1" 400 Bad Request
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40780 - "POST /detokenize HTTP/1.1" 400 Bad Request
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40792 - "POST /detokenize HTTP/1.1" 200 OK
[2025-04-28 05:40:12] INFO:     127.0.0.1:40798 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40806 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40808 - "POST /tokenize HTTP/1.1" 200 OK
[2025-04-28 05:40:12] INFO:     127.0.0.1:40822 - "POST /detokenize HTTP/1.1" 200 OK
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40832 - "POST /tokenize HTTP/1.1" 200 OK
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40844 - "POST /tokenize HTTP/1.1" 400 Bad Request
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40852 - "POST /tokenize HTTP/1.1" 200 OK
.[2025-04-28 05:40:12] INFO:     127.0.0.1:40862 - "POST /tokenize HTTP/1.1" 200 OK
.
----------------------------------------------------------------------
Ran 10 tests in 34.802s

OK
```


## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
