### PR TITLE
[Fix] Fix a bug for flashmla to run R1 model

### DIFF
--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -241,6 +241,9 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 seq_lens_cpu,
             )
 
+    def get_cuda_graph_seq_len_fill_value(self):
+        return 1024
+
     def forward_decode(
         self,
         q: torch.Tensor,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
When using sglang to run R1 Model by TP = 16, there is a bug for flashmla.
I investigated this issue and found that it causes illegal access to the HMB when the seq_length is zero, leading to a program crash.

So, we should not pass a invalid parameter to flashmla kernel. I chose the number 1024 because it is 2 to the power of 10. Other numbers would also work.



Related PR: https://github.com/sgl-project/sglang/pull/5272
Thanks for @sleepcoo

```
root:/sgl-workspace/pengcuo_work/op_test/FlashMLA# python3 tests/test_flash_mla.py  
b=16, s_q=1, mean_sk=0, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=False
q : torch.Size([16, 1, 16, 576]) torch.bfloat16
blocked_k : torch.Size([0, 64, 1, 576]) torch.bfloat16
block_table : torch.Size([16, 0]) torch.int32
cache_seqlens : torch.Size([16]) torch.int32
cache_seqlens : tensor([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], device='cuda:0',
       dtype=torch.int32)
num_splits : tensor([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16],
       device='cuda:0', dtype=torch.int32)
Traceback (most recent call last):
  File "/mnt/gemininjceph2/geminicephfs/mm-base-plt2/user_pengcuoze/work/op_test/FlashMLA/tests/test_flash_mla.py", line 168, in <module>
    main(torch_dtype)
  File "/mnt/gemininjceph2/geminicephfs/mm-base-plt2/user_pengcuoze/work/op_test/FlashMLA/tests/test_flash_mla.py", line 149, in main
    test_flash_mla(b, s_q, s, h_q, h_kv, d, dv, causal, varlen)
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/mnt/gemininjceph2/geminicephfs/mm-base-plt2/user_pengcuoze/work/op_test/FlashMLA/tests/test_flash_mla.py", line 110, in test_flash_mla
    out_torch, lse_torch = ref_mla()
  File "/mnt/gemininjceph2/geminicephfs/mm-base-plt2/user_pengcuoze/work/op_test/FlashMLA/tests/test_flash_mla.py", line 96, in ref_mla
    end = begin + cache_seqlens[i]
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_device.py", line 104, in __torch_function__
    return func(*args, **kwargs)
RuntimeError: CUDA error: an illegal memory access was encountered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
