### PR TITLE
[Fix] Unload lora in HF_Runner if needed

### DIFF
--- a/python/sglang/test/runners.py
+++ b/python/sglang/test/runners.py
@@ -384,10 +384,6 @@ class HFRunner:
                 output_scores=(not output_str_only),
             )
 
-            if lora_paths is not None and lora_paths[i] is not None:
-                # Unload the LoRA model if it is used
-                model.unload()
-
             text = tokenizer.decode(
                 outputs[0][0][len(input_ids[0]) :], skip_special_tokens=True
             )
@@ -426,6 +422,10 @@ class HFRunner:
                         get_token_ids_logprobs(input_logits, token_ids_logprob).tolist()
                     )
                 del input_logits
+
+        if lora_paths is not None and lora_paths[i] is not None:
+            # Unload the LoRA adapter if it is used
+            model.unload()
 
         return ModelOutput(
             output_strs=output_strs,

--- a/python/sglang/test/runners.py
+++ b/python/sglang/test/runners.py
@@ -384,6 +384,10 @@ class HFRunner:
                 output_scores=(not output_str_only),
             )
 
+            if lora_paths is not None and lora_paths[i] is not None:
+                # Unload the LoRA model if it is used
+                model.unload()
+
             text = tokenizer.decode(
                 outputs[0][0][len(input_ids[0]) :], skip_special_tokens=True
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Close #5897
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
Currently, the HF_Runner will still use lora if this lora is previously loaded. To fix this issue, we need to unload the lora after using it.

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
