### PR TITLE
Online Rotations in SGLang

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -9,7 +9,6 @@ USER root
 
 WORKDIR /sgl-workspace
 ARG BUILD_TYPE=all
-ARG SGL_REPO="https://github.com/sgl-project/sglang"
 ENV SGL_DEFAULT="main"
 ARG SGL_BRANCH=${SGL_DEFAULT}
 
@@ -20,8 +19,8 @@ ARG TRITON_COMMIT="improve_fa_decode_3.0.0"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT="v0.1.1"
 
-RUN git clone ${SGL_REPO} \
-    && cd sglang \
+COPY . /sgl-workspace/sglang
+RUN cd sglang \
     && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
          echo "Using ${SGL_DEFAULT}, default branch."; \
        else \

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,5 +1,5 @@
 # Usage (to build SGLang ROCm docker image):
-#   docker build --build-arg SGL_BRANCH=v0.4.6.post1 -t v0.4.6.post1-rocm630 -f Dockerfile.rocm .
+#   docker build --build-arg SGL_BRANCH=v0.4.6.post2 -t v0.4.6.post2-rocm630 -f Dockerfile.rocm .
 
 # default base image
 ARG BASE_IMAGE="rocm/sgl-dev:vllm20250114"
@@ -9,6 +9,7 @@ USER root
 
 WORKDIR /sgl-workspace
 ARG BUILD_TYPE=all
+ARG SGL_REPO="https://github.com/sgl-project/sglang"
 ENV SGL_DEFAULT="main"
 ARG SGL_BRANCH=${SGL_DEFAULT}
 
@@ -19,8 +20,8 @@ ARG TRITON_COMMIT="improve_fa_decode_3.0.0"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT="v0.1.1"
 
-COPY . /sgl-workspace/sglang
-RUN cd sglang \
+RUN git clone ${SGL_REPO} \
+    && cd sglang \
     && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
          echo "Using ${SGL_DEFAULT}, default branch."; \
        else \

--- a/examples/frontend_language/quick_start/local_example_chat_quarot.py
+++ b/examples/frontend_language/quick_start/local_example_chat_quarot.py
@@ -1,0 +1,75 @@
+"""
+Usage:
+python3 local_example_chat.py
+"""
+
+import sglang as sgl
+
+
+@sgl.function
+def multi_turn_question(s, question_1, question_2):
+    s += sgl.user(question_1)
+    s += sgl.assistant(sgl.gen("answer_1", max_tokens=256))
+    s += sgl.user(question_2)
+    s += sgl.assistant(sgl.gen("answer_2", max_tokens=256))
+
+
+def single():
+    state = multi_turn_question.run(
+        question_1="What is the capital of the United States?",
+        question_2="List two local attractions.",
+    )
+
+    for m in state.messages():
+        print(m["role"], ":", m["content"])
+
+    print("\n-- answer_1 --\n", state["answer_1"])
+
+
+def stream():
+    state = multi_turn_question.run(
+        question_1="What is the capital of the United States?",
+        question_2="List two local attractions.",
+        stream=True,
+    )
+
+    for out in state.text_iter():
+        print(out, end="", flush=True)
+    print()
+
+
+def batch():
+    states = multi_turn_question.run_batch(
+        [
+            {
+                "question_1": "What is the capital of the United States?",
+                "question_2": "List two local attractions.",
+            },
+            {
+                "question_1": "What is the capital of France?",
+                "question_2": "What is the population of this city?",
+            },
+        ]
+    )
+
+    for s in states:
+        print(s.messages())
+
+
+if __name__ == "__main__":
+    runtime = sgl.Runtime(model_path="rcorzine/Meta-Llama-3-8B-quark-w8a8-int8")
+    sgl.set_default_backend(runtime)
+
+    # Run a single request
+    print("\n========== single ==========\n")
+    single()
+
+    # Stream output
+    print("\n========== stream ==========\n")
+    stream()
+
+    # Run a batch of requests
+    print("\n========== batch ==========\n")
+    batch()
+
+    runtime.shutdown()

--- a/examples/frontend_language/quick_start/local_example_chat_quarot.py
+++ b/examples/frontend_language/quick_start/local_example_chat_quarot.py
@@ -57,7 +57,7 @@ def batch():
 
 
 if __name__ == "__main__":
-    runtime = sgl.Runtime(model_path="rcorzine/Meta-Llama-3-8B-quark-w8a8-int8")
+    runtime = sgl.Runtime(model_path="amd/Meta-Llama-3-8B-quark-w8a8-int8-quarot")
     sgl.set_default_backend(runtime)
 
     # Run a single request

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -329,7 +329,7 @@ class ModelConfig:
                     self.quantization = quantization_override
                     break
             """
-                    
+
             # Verify quantization configurations.
             if self.quantization is None:
                 self.quantization = quant_method

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -303,6 +303,7 @@ class ModelConfig:
             "w8a8_int8",
             "w8a8_fp8",
             "moe_wna16",
+            "quark",
         ]
         compatible_quantization_methods = {
             "modelopt_fp4": ["modelopt"],
@@ -319,7 +320,6 @@ class ModelConfig:
             quant_method = quant_cfg.get("quant_method", "").lower()
 
             # Detect which checkpoint is it
-            """
             for _, method in QUANTIZATION_METHODS.items():
                 quantization_override = method.override_quantization_method(
                     quant_cfg, self.quantization
@@ -328,7 +328,6 @@ class ModelConfig:
                     quant_method = quantization_override
                     self.quantization = quantization_override
                     break
-            """
 
             # Verify quantization configurations.
             if self.quantization is None:

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -287,6 +287,7 @@ class ModelConfig:
             "compressed-tensors",
             "fbgemm_fp8",
             "w8a8_fp8",
+            "quark",
         ]
         optimized_quantization_methods = [
             "fp8",
@@ -318,6 +319,7 @@ class ModelConfig:
             quant_method = quant_cfg.get("quant_method", "").lower()
 
             # Detect which checkpoint is it
+            """
             for _, method in QUANTIZATION_METHODS.items():
                 quantization_override = method.override_quantization_method(
                     quant_cfg, self.quantization
@@ -326,7 +328,8 @@ class ModelConfig:
                     quant_method = quantization_override
                     self.quantization = quantization_override
                     break
-
+            """
+                    
             # Verify quantization configurations.
             if self.quantization is None:
                 self.quantization = quant_method

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -50,6 +50,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "ModelOptFp8LinearMethod",
     "ModelOptFp4LinearMethod",
     "IPEXAWQLinearMethod",
+    "QuarkLinearMethod",
 ]
 
 

--- a/python/sglang/srt/layers/parameter.py
+++ b/python/sglang/srt/layers/parameter.py
@@ -50,8 +50,8 @@ class BasevLLMParameter(Parameter):
         return self._weight_loader
 
     def _assert_and_load(self, loaded_weight: torch.Tensor):
-        if self.data.numel()==loaded_weight.numel()==1:
-            loaded_weight=loaded_weight.view(self.data.shape)
+        if self.data.numel() == loaded_weight.numel() == 1:
+            loaded_weight = loaded_weight.view(self.data.shape)
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)
 

--- a/python/sglang/srt/layers/parameter.py
+++ b/python/sglang/srt/layers/parameter.py
@@ -50,6 +50,8 @@ class BasevLLMParameter(Parameter):
         return self._weight_loader
 
     def _assert_and_load(self, loaded_weight: torch.Tensor):
+        if self.data.numel()==loaded_weight.numel()==1:
+            loaded_weight=loaded_weight.view(self.data.shape)
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)
 

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -66,6 +66,7 @@ from sglang.srt.layers.quantization.modelopt_quant import (
 from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
 from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
+from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 
 # Base quantization methods that don't depend on vllm
 BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
@@ -77,6 +78,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "w8a8_fp8": W8A8Fp8Config,
     "moe_wna16": MoeWNA16Config,
     "compressed-tensors": CompressedTensorsConfig,
+    "quark" : QuarkConfig,
 }
 
 # VLLM-dependent quantization methods

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -64,9 +64,9 @@ from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp8Config,
 )
 from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
+from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
 from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 
 # Base quantization methods that don't depend on vllm
 BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
@@ -78,7 +78,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "w8a8_fp8": W8A8Fp8Config,
     "moe_wna16": MoeWNA16Config,
     "compressed-tensors": CompressedTensorsConfig,
-    "quark" : QuarkConfig,
+    "quark": QuarkConfig,
 }
 
 # VLLM-dependent quantization methods

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import fnmatch
+import re
+from typing import Any, Dict, List, Optional, cast
+
+import torch
+
+from sglang.srt.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from sglang.srt.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from sglang.srt.layers.quantization.quark.schemes import (
+    QuarkScheme, QuarkW8A8Int8, hadamard_transform_registry)
+from sglang.srt.layers.quantization.quark.utils import (
+    deep_compare, should_ignore_layer)
+from vllm.platforms import current_platform
+
+__all__ = ["QuarkLinearMethod"]
+
+
+class QuarkConfig(QuantizationConfig):
+
+    def __init__(self,
+                 quant_config: Dict[str, Any],
+                 kv_cache_group: Optional[List[str]] = None,
+                 kv_cache_config: Optional[Dict[str, Any]] = None,
+                 pack_method: str = "reorder"):
+        super().__init__()
+        if kv_cache_group is None:
+            kv_cache_group = []
+        self.quant_config = quant_config
+        self.kv_cache_group = kv_cache_group
+        self.kv_cache_config = kv_cache_config
+        self.pack_method = pack_method
+
+    def get_linear_method(self) -> "QuarkLinearMethod":
+        return QuarkLinearMethod(self)
+
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    def get_name(self) -> str:
+        return "quark"
+
+    def get_quant_method(self, layer: torch.nn.Module,
+                         prefix: str) -> Optional["QuantizeMethodBase"]:
+        from vllm.attention.layer import Attention  # Avoid circular import
+
+        # Check if the layer is skipped for quantization.
+        exclude_layers = cast(List[str], self.quant_config.get("exclude"))
+        if should_ignore_layer(prefix,
+                               ignore=exclude_layers,
+                               fused_mapping=self.packed_modules_mapping):
+            return UnquantizedLinearMethod()
+        if isinstance(layer, LinearBase):
+            scheme = self.get_scheme(layer=layer, layer_name=prefix)
+            layer.scheme = scheme
+            return QuarkLinearMethod(self)
+        return None
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "QuarkConfig":
+        export_config = config.get("export")
+        if export_config is None:
+            raise ValueError("The export key should be included in "
+                             "the configurations of Quark quantized model")
+        kv_cache_group = cast(List[str], export_config.get("kv_cache_group"))
+        pack_method = cast(str, export_config.get("pack_method"))
+
+        # In the export model of quark, the quantization configuration
+        # of kv_cache is stored in layer_quant_config. First, it is
+        # judged whether kv_cache_group exists, and then it is judged
+        # whether layer_quant_config has a quantization configuration
+        # that matches kv_cache.
+        if len(kv_cache_group) == 0:
+            kv_cache_config = None
+        else:
+            kv_cache_set = set(kv_cache_group)
+            layer_quant_config = cast(Dict[str, Any],
+                                      config.get("layer_quant_config"))
+            layer_quant_names = list(layer_quant_config.keys())
+            layer_quant_set = set(layer_quant_names)
+
+            if not kv_cache_set.issubset(layer_quant_set):
+                raise ValueError("The Quark quantized model has the "
+                                 "kv_cache_group parameter setting, "
+                                 "but no kv_cache quantization settings "
+                                 "were found in the quantization "
+                                 "configuration.")
+
+            q_configs = [
+                cast(Dict[str, Any], layer_quant_config.get(name))
+                for name in kv_cache_group
+            ]
+            if not all(
+                    deep_compare(q_config, q_configs[0])
+                    for q_config in q_configs):
+                raise ValueError(
+                    "The quantization method used for kv_cache should "
+                    "be the same, but the quantization method for the "
+                    "kv_cache layer in the config is different.")
+            kv_cache_config = q_configs[0].get("output_tensors")
+            if kv_cache_config is None:
+                raise ValueError(
+                    "The kv_cache quantization configuration is empty.")
+
+            # Since we have already set kv_cache quantization configurations,
+            # we will remove the quantization configuration for the
+            # output_tensors corresponding to the kv_cache layer.
+            for q_config in q_configs:
+                q_config["output_tensors"] = None
+
+        return cls(quant_config=config,
+                   kv_cache_group=kv_cache_group,
+                   kv_cache_config=kv_cache_config,
+                   pack_method=pack_method)
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return []
+
+    def _check_scheme_supported(self,
+                                min_capability: int,
+                                error: bool = True) -> bool:
+        capability_tuple = current_platform.get_device_capability()
+
+        if capability_tuple is not None:
+            capability = capability_tuple.to_int()
+            supported = capability >= min_capability
+            if error and not supported:
+                raise RuntimeError(
+                    "Quantization scheme is not supported for ",
+                    f"the current GPU. Min capability: {min_capability}. ",
+                    f"Current capability: {capability}.")
+            return supported
+        else:
+            return False
+
+    def _is_fp8_w8a8(self, weight_quant: Optional[Dict[str, Any]],
+                     input_quant: Optional[Dict[str, Any]]) -> bool:
+        # Confirm weights and input quantized.
+        if weight_quant is None or input_quant is None:
+            return False
+
+        # Confirm weight scheme is supported
+        is_fp8_dtype = (weight_quant.get("dtype") == "fp8_e4m3"
+                        and input_quant.get("dtype") == "fp8_e4m3")
+        is_static_weight = not weight_quant.get("is_dynamic")
+        is_per_tensor_or_channel_weight = (weight_quant.get("qscheme")
+                                           in ["per_tensor", "per_channel"])
+
+        if not (is_fp8_dtype and is_static_weight
+                and is_per_tensor_or_channel_weight):
+            return False
+
+        # Dynamic quantization is always supported if weights supported.
+        if input_quant.get("is_dynamic"):
+            return True
+
+        # Confirm activation scheme is supported.
+        is_per_tensor_activation = (input_quant.get("qscheme") == "per_tensor")
+        return is_per_tensor_activation
+
+    def _is_static_tensor_w8a8(self, weight_quant: Optional[Dict[str, Any]],
+                               input_quant: Optional[Dict[str, Any]]) -> bool:
+        # Confirm weights and input quantized.
+        if weight_quant is None or input_quant is None:
+            return False
+
+        is_int8_dtype = (weight_quant.get("dtype") == "int8"
+                         and input_quant.get("dtype") == "int8")
+
+        is_tensor = (weight_quant.get("qscheme")
+                     in ["per_tensor", "per_channel"]
+                     and input_quant.get("qscheme") == "per_tensor")
+
+        is_static = (not weight_quant.get("is_dynamic")
+                     and not input_quant.get("is_dynamic"))
+
+        is_weight_symmetric = (weight_quant.get("symmetric") is True)
+
+        # Both symmetric and asymmetric input quantization supported.
+        # Only symmetric weight quantization supported.
+        return is_int8_dtype and is_tensor and is_weight_symmetric and is_static
+
+    def _find_matched_config(self, layer_name: str,
+                    module: torch.nn.Module) -> Dict[str, Any]:
+
+        proj_name = layer_name.split(".")[-1]
+        if proj_name in self.packed_modules_mapping:
+            shard_proj_names = self.packed_modules_mapping[proj_name]
+
+            # Convert fused_name --> [shard_names]
+            shard_names = [
+                layer_name.replace(proj_name, shard_proj_name)
+                for shard_proj_name in shard_proj_names
+            ]
+            shard_configs = [
+                self._find_matched_config(shard_name, module)
+                for shard_name in shard_names
+            ]
+            if not all(
+                    deep_compare(q_config, shard_configs[0])
+                    for q_config in shard_configs):
+                raise ValueError(
+                    f"Found a different quantization configuration for "
+                    f"{shard_proj_names} in {layer_name}. vLLM "
+                    "requires all to use the same scheme.")
+            rv = shard_configs[0]
+        else:
+            layer_quant_config = cast(
+                Dict[str, Any], self.quant_config.get("layer_quant_config"))
+            for name_pattern in layer_quant_config:
+                if fnmatch.fnmatch(layer_name, name_pattern):
+                    return layer_quant_config[name_pattern]
+
+            layer_type = cast(str, type(module))
+            layer_type_quant_config = cast(
+                Dict[str, Any],
+                self.quant_config.get("layer_type_quant_config"))
+            if layer_type in layer_type_quant_config:
+                return layer_type_quant_config[layer_type]
+
+            global_quant_config = cast(
+                Dict[str, Any], self.quant_config.get("global_quant_config"))
+            rv = global_quant_config
+
+        if "online_rotations" in self.quant_config:
+            rot_info = next((value for key, value in self.quant_config['online_rotations'].items() if layer_name.endswith(key)), None)
+            rv['online_rotations']=rot_info
+            
+        return rv
+
+    def _get_scheme_from_config(self, config: Dict[str, Any]) -> "QuarkScheme":
+        if config.get("output_tensors") or config.get("bias"):
+            raise NotImplementedError(
+                "Currently, Quark models with output_tensors "
+                "and bias quantized are not supported")
+        weight_config = cast(Dict[str, Any], config.get("weight"))
+        input_config = cast(Dict[str, Any], config.get("input_tensors"))
+        
+        """for QuaRot and other techniques that involve online rotations"""
+        online_rotation_config = cast(Dict[str, Any], config.get("online_rotations"))
+        if online_rotation_config:
+            func_name,func_args=online_rotation_config['func_name'],online_rotation_config['func_args']
+            if func_name in hadamard_transform_registry:
+                func_name=hadamard_transform_registry[func_name]
+                online_rotation_method=func_name,func_args
+            else:
+                raise ValueError("hadamard rotation func_name is not found in registry")
+        else:
+            online_rotation_method = None
+
+
+        """
+        in this version, fp8 is not implemented yet
+        """
+        if self._is_static_tensor_w8a8(weight_config, input_config):
+            weight_qscheme = cast(str, weight_config.get("qscheme"))
+            return QuarkW8A8Int8(qscheme=weight_qscheme,
+                                is_static_input_scheme=True,
+                                input_symmetric=input_config.get("symmetric"),
+                                online_rotation_method=online_rotation_method)
+
+        raise NotImplementedError("No quark compatible scheme was found. "
+                                f"Weight config: {weight_config}, "
+                                f"Input config: {input_config}")
+
+    def get_scheme(self, layer: torch.nn.Module,
+                   layer_name: str) -> "QuarkScheme":
+
+        layer_quant_config = self._find_matched_config(layer_name, layer)
+
+        # Find the quant_scheme
+        scheme = self._get_scheme_from_config(layer_quant_config)
+        # Raise error if device does not support the scheme
+        # (e.g. fp8 needs ada lovelace)
+        self._check_scheme_supported(scheme.get_min_capability())
+
+        return scheme
+
+    def get_cache_scale(self, name: str) -> Optional[str]:
+        """
+        Check whether the param name matches the format for k/v cache scales
+        in quark. If this is the case, return its equivalent param name 
+        expected by vLLM
+
+        :param name: param name
+        :return: matching param name for KV cache scale in vLLM
+        """
+        if self.kv_cache_group is None or len(self.kv_cache_group) == 0:
+            return None
+
+        kv_proj_names = [
+            re.split(r"[*.]", kv_cache)[-1] for kv_cache in self.kv_cache_group
+        ]
+        if name.endswith(".output_scale"):
+            if len(kv_proj_names) == 1 and kv_proj_names[0] in name:
+                kv_output_scale_name = "." + kv_proj_names[0] + ".output_scale"
+                return name.replace(kv_output_scale_name, ".attn.k_scale")
+
+            elif len(kv_proj_names) == 2:
+                for kv_proj_name in kv_proj_names:
+                    if kv_proj_name in name and kv_proj_name == "k_proj":
+                        return name.replace(".k_proj.output_scale",
+                                            ".attn.k_scale")
+                    elif kv_proj_name in name and kv_proj_name == "v_proj":
+                        return name.replace(".v_proj.output_scale",
+                                            ".attn.v_scale")
+
+        # If no matches, return None
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+
+class QuarkLinearMethod(LinearMethodBase):
+
+    def __init__(self, quantization_config: QuarkConfig):
+        self.quantization_config = quantization_config
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.scheme.process_weights_after_loading(layer)
+
+    def create_weights(self, layer: torch.nn.Module,
+                       input_size_per_partition: int,
+                       output_partition_sizes: List[int], input_size: int,
+                       output_size: int, params_dtype: torch.dtype,
+                       **extra_weight_attrs):
+        """
+        Use the CompressedTensorsScheme associated with each layer to create
+        the necessary parameters for the layer. See LinearMethodBase for param
+        details
+        """
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        layer.scheme.create_weights(
+            layer=layer,
+            input_size=input_size,
+            input_size_per_partition=input_size_per_partition,
+            output_partition_sizes=output_partition_sizes,
+            output_size=output_size,
+            params_dtype=params_dtype,
+            weight_loader=weight_loader)
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None):
+        """
+        Use the output of create_weights and the CompressedTensorsScheme
+        associated with the layer to apply the forward pass with the
+        layer input.  See LinearMethodBase for param details
+
+        """
+        scheme = layer.scheme
+        if scheme is None:
+            raise ValueError("A scheme must be defined for each layer")
+        return scheme.apply_weights(layer, x, bias=bias)

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -50,6 +50,10 @@ class QuarkConfig(QuantizationConfig):
         return [torch.float16, torch.bfloat16]
 
     @classmethod
+    def override_quantization_method(cls, x, y):
+        return None
+
+    @classmethod
     def get_min_capability(cls) -> int:
         return 70
 

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, Dict, List, Optional, cast
 
 import torch
+from vllm.platforms import current_platform
 
 from sglang.srt.layers.linear import (
     LinearBase,
@@ -16,21 +17,24 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.quark.schemes import (
-    QuarkScheme, QuarkW8A8Int8, hadamard_transform_registry)
-from sglang.srt.layers.quantization.quark.utils import (
-    deep_compare, should_ignore_layer)
-from vllm.platforms import current_platform
+    QuarkScheme,
+    QuarkW8A8Int8,
+    hadamard_transform_registry,
+)
+from sglang.srt.layers.quantization.quark.utils import deep_compare, should_ignore_layer
 
 __all__ = ["QuarkLinearMethod"]
 
 
 class QuarkConfig(QuantizationConfig):
 
-    def __init__(self,
-                 quant_config: Dict[str, Any],
-                 kv_cache_group: Optional[List[str]] = None,
-                 kv_cache_config: Optional[Dict[str, Any]] = None,
-                 pack_method: str = "reorder"):
+    def __init__(
+        self,
+        quant_config: Dict[str, Any],
+        kv_cache_group: Optional[List[str]] = None,
+        kv_cache_config: Optional[Dict[str, Any]] = None,
+        pack_method: str = "reorder",
+    ):
         super().__init__()
         if kv_cache_group is None:
             kv_cache_group = []
@@ -52,15 +56,16 @@ class QuarkConfig(QuantizationConfig):
     def get_name(self) -> str:
         return "quark"
 
-    def get_quant_method(self, layer: torch.nn.Module,
-                         prefix: str) -> Optional["QuantizeMethodBase"]:
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional["QuantizeMethodBase"]:
         from vllm.attention.layer import Attention  # Avoid circular import
 
         # Check if the layer is skipped for quantization.
         exclude_layers = cast(List[str], self.quant_config.get("exclude"))
-        if should_ignore_layer(prefix,
-                               ignore=exclude_layers,
-                               fused_mapping=self.packed_modules_mapping):
+        if should_ignore_layer(
+            prefix, ignore=exclude_layers, fused_mapping=self.packed_modules_mapping
+        ):
             return UnquantizedLinearMethod()
         if isinstance(layer, LinearBase):
             scheme = self.get_scheme(layer=layer, layer_name=prefix)
@@ -72,8 +77,10 @@ class QuarkConfig(QuantizationConfig):
     def from_config(cls, config: Dict[str, Any]) -> "QuarkConfig":
         export_config = config.get("export")
         if export_config is None:
-            raise ValueError("The export key should be included in "
-                             "the configurations of Quark quantized model")
+            raise ValueError(
+                "The export key should be included in "
+                "the configurations of Quark quantized model"
+            )
         kv_cache_group = cast(List[str], export_config.get("kv_cache_group"))
         pack_method = cast(str, export_config.get("pack_method"))
 
@@ -86,33 +93,32 @@ class QuarkConfig(QuantizationConfig):
             kv_cache_config = None
         else:
             kv_cache_set = set(kv_cache_group)
-            layer_quant_config = cast(Dict[str, Any],
-                                      config.get("layer_quant_config"))
+            layer_quant_config = cast(Dict[str, Any], config.get("layer_quant_config"))
             layer_quant_names = list(layer_quant_config.keys())
             layer_quant_set = set(layer_quant_names)
 
             if not kv_cache_set.issubset(layer_quant_set):
-                raise ValueError("The Quark quantized model has the "
-                                 "kv_cache_group parameter setting, "
-                                 "but no kv_cache quantization settings "
-                                 "were found in the quantization "
-                                 "configuration.")
+                raise ValueError(
+                    "The Quark quantized model has the "
+                    "kv_cache_group parameter setting, "
+                    "but no kv_cache quantization settings "
+                    "were found in the quantization "
+                    "configuration."
+                )
 
             q_configs = [
                 cast(Dict[str, Any], layer_quant_config.get(name))
                 for name in kv_cache_group
             ]
-            if not all(
-                    deep_compare(q_config, q_configs[0])
-                    for q_config in q_configs):
+            if not all(deep_compare(q_config, q_configs[0]) for q_config in q_configs):
                 raise ValueError(
                     "The quantization method used for kv_cache should "
                     "be the same, but the quantization method for the "
-                    "kv_cache layer in the config is different.")
+                    "kv_cache layer in the config is different."
+                )
             kv_cache_config = q_configs[0].get("output_tensors")
             if kv_cache_config is None:
-                raise ValueError(
-                    "The kv_cache quantization configuration is empty.")
+                raise ValueError("The kv_cache quantization configuration is empty.")
 
             # Since we have already set kv_cache quantization configurations,
             # we will remove the quantization configuration for the
@@ -120,18 +126,18 @@ class QuarkConfig(QuantizationConfig):
             for q_config in q_configs:
                 q_config["output_tensors"] = None
 
-        return cls(quant_config=config,
-                   kv_cache_group=kv_cache_group,
-                   kv_cache_config=kv_cache_config,
-                   pack_method=pack_method)
+        return cls(
+            quant_config=config,
+            kv_cache_group=kv_cache_group,
+            kv_cache_config=kv_cache_config,
+            pack_method=pack_method,
+        )
 
     @classmethod
     def get_config_filenames(cls) -> List[str]:
         return []
 
-    def _check_scheme_supported(self,
-                                min_capability: int,
-                                error: bool = True) -> bool:
+    def _check_scheme_supported(self, min_capability: int, error: bool = True) -> bool:
         capability_tuple = current_platform.get_device_capability()
 
         if capability_tuple is not None:
@@ -141,26 +147,33 @@ class QuarkConfig(QuantizationConfig):
                 raise RuntimeError(
                     "Quantization scheme is not supported for ",
                     f"the current GPU. Min capability: {min_capability}. ",
-                    f"Current capability: {capability}.")
+                    f"Current capability: {capability}.",
+                )
             return supported
         else:
             return False
 
-    def _is_fp8_w8a8(self, weight_quant: Optional[Dict[str, Any]],
-                     input_quant: Optional[Dict[str, Any]]) -> bool:
+    def _is_fp8_w8a8(
+        self,
+        weight_quant: Optional[Dict[str, Any]],
+        input_quant: Optional[Dict[str, Any]],
+    ) -> bool:
         # Confirm weights and input quantized.
         if weight_quant is None or input_quant is None:
             return False
 
         # Confirm weight scheme is supported
-        is_fp8_dtype = (weight_quant.get("dtype") == "fp8_e4m3"
-                        and input_quant.get("dtype") == "fp8_e4m3")
+        is_fp8_dtype = (
+            weight_quant.get("dtype") == "fp8_e4m3"
+            and input_quant.get("dtype") == "fp8_e4m3"
+        )
         is_static_weight = not weight_quant.get("is_dynamic")
-        is_per_tensor_or_channel_weight = (weight_quant.get("qscheme")
-                                           in ["per_tensor", "per_channel"])
+        is_per_tensor_or_channel_weight = weight_quant.get("qscheme") in [
+            "per_tensor",
+            "per_channel",
+        ]
 
-        if not (is_fp8_dtype and is_static_weight
-                and is_per_tensor_or_channel_weight):
+        if not (is_fp8_dtype and is_static_weight and is_per_tensor_or_channel_weight):
             return False
 
         # Dynamic quantization is always supported if weights supported.
@@ -168,33 +181,40 @@ class QuarkConfig(QuantizationConfig):
             return True
 
         # Confirm activation scheme is supported.
-        is_per_tensor_activation = (input_quant.get("qscheme") == "per_tensor")
+        is_per_tensor_activation = input_quant.get("qscheme") == "per_tensor"
         return is_per_tensor_activation
 
-    def _is_static_tensor_w8a8(self, weight_quant: Optional[Dict[str, Any]],
-                               input_quant: Optional[Dict[str, Any]]) -> bool:
+    def _is_static_tensor_w8a8(
+        self,
+        weight_quant: Optional[Dict[str, Any]],
+        input_quant: Optional[Dict[str, Any]],
+    ) -> bool:
         # Confirm weights and input quantized.
         if weight_quant is None or input_quant is None:
             return False
 
-        is_int8_dtype = (weight_quant.get("dtype") == "int8"
-                         and input_quant.get("dtype") == "int8")
+        is_int8_dtype = (
+            weight_quant.get("dtype") == "int8" and input_quant.get("dtype") == "int8"
+        )
 
-        is_tensor = (weight_quant.get("qscheme")
-                     in ["per_tensor", "per_channel"]
-                     and input_quant.get("qscheme") == "per_tensor")
+        is_tensor = (
+            weight_quant.get("qscheme") in ["per_tensor", "per_channel"]
+            and input_quant.get("qscheme") == "per_tensor"
+        )
 
-        is_static = (not weight_quant.get("is_dynamic")
-                     and not input_quant.get("is_dynamic"))
+        is_static = not weight_quant.get("is_dynamic") and not input_quant.get(
+            "is_dynamic"
+        )
 
-        is_weight_symmetric = (weight_quant.get("symmetric") is True)
+        is_weight_symmetric = weight_quant.get("symmetric") is True
 
         # Both symmetric and asymmetric input quantization supported.
         # Only symmetric weight quantization supported.
         return is_int8_dtype and is_tensor and is_weight_symmetric and is_static
 
-    def _find_matched_config(self, layer_name: str,
-                    module: torch.nn.Module) -> Dict[str, Any]:
+    def _find_matched_config(
+        self, layer_name: str, module: torch.nn.Module
+    ) -> Dict[str, Any]:
 
         proj_name = layer_name.split(".")[-1]
         if proj_name in self.packed_modules_mapping:
@@ -210,74 +230,90 @@ class QuarkConfig(QuantizationConfig):
                 for shard_name in shard_names
             ]
             if not all(
-                    deep_compare(q_config, shard_configs[0])
-                    for q_config in shard_configs):
+                deep_compare(q_config, shard_configs[0]) for q_config in shard_configs
+            ):
                 raise ValueError(
                     f"Found a different quantization configuration for "
                     f"{shard_proj_names} in {layer_name}. vLLM "
-                    "requires all to use the same scheme.")
+                    "requires all to use the same scheme."
+                )
             rv = shard_configs[0]
         else:
             layer_quant_config = cast(
-                Dict[str, Any], self.quant_config.get("layer_quant_config"))
+                Dict[str, Any], self.quant_config.get("layer_quant_config")
+            )
             for name_pattern in layer_quant_config:
                 if fnmatch.fnmatch(layer_name, name_pattern):
                     return layer_quant_config[name_pattern]
 
             layer_type = cast(str, type(module))
             layer_type_quant_config = cast(
-                Dict[str, Any],
-                self.quant_config.get("layer_type_quant_config"))
+                Dict[str, Any], self.quant_config.get("layer_type_quant_config")
+            )
             if layer_type in layer_type_quant_config:
                 return layer_type_quant_config[layer_type]
 
             global_quant_config = cast(
-                Dict[str, Any], self.quant_config.get("global_quant_config"))
+                Dict[str, Any], self.quant_config.get("global_quant_config")
+            )
             rv = global_quant_config
 
         if "online_rotations" in self.quant_config:
-            rot_info = next((value for key, value in self.quant_config['online_rotations'].items() if layer_name.endswith(key)), None)
-            rv['online_rotations']=rot_info
-            
+            rot_info = next(
+                (
+                    value
+                    for key, value in self.quant_config["online_rotations"].items()
+                    if layer_name.endswith(key)
+                ),
+                None,
+            )
+            rv["online_rotations"] = rot_info
+
         return rv
 
     def _get_scheme_from_config(self, config: Dict[str, Any]) -> "QuarkScheme":
         if config.get("output_tensors") or config.get("bias"):
             raise NotImplementedError(
                 "Currently, Quark models with output_tensors "
-                "and bias quantized are not supported")
+                "and bias quantized are not supported"
+            )
         weight_config = cast(Dict[str, Any], config.get("weight"))
         input_config = cast(Dict[str, Any], config.get("input_tensors"))
-        
+
         """for QuaRot and other techniques that involve online rotations"""
         online_rotation_config = cast(Dict[str, Any], config.get("online_rotations"))
         if online_rotation_config:
-            func_name,func_args=online_rotation_config['func_name'],online_rotation_config['func_args']
+            func_name, func_args = (
+                online_rotation_config["func_name"],
+                online_rotation_config["func_args"],
+            )
             if func_name in hadamard_transform_registry:
-                func_name=hadamard_transform_registry[func_name]
-                online_rotation_method=func_name,func_args
+                func_name = hadamard_transform_registry[func_name]
+                online_rotation_method = func_name, func_args
             else:
                 raise ValueError("hadamard rotation func_name is not found in registry")
         else:
             online_rotation_method = None
-
 
         """
         in this version, fp8 is not implemented yet
         """
         if self._is_static_tensor_w8a8(weight_config, input_config):
             weight_qscheme = cast(str, weight_config.get("qscheme"))
-            return QuarkW8A8Int8(qscheme=weight_qscheme,
-                                is_static_input_scheme=True,
-                                input_symmetric=input_config.get("symmetric"),
-                                online_rotation_method=online_rotation_method)
+            return QuarkW8A8Int8(
+                qscheme=weight_qscheme,
+                is_static_input_scheme=True,
+                input_symmetric=input_config.get("symmetric"),
+                online_rotation_method=online_rotation_method,
+            )
 
-        raise NotImplementedError("No quark compatible scheme was found. "
-                                f"Weight config: {weight_config}, "
-                                f"Input config: {input_config}")
+        raise NotImplementedError(
+            "No quark compatible scheme was found. "
+            f"Weight config: {weight_config}, "
+            f"Input config: {input_config}"
+        )
 
-    def get_scheme(self, layer: torch.nn.Module,
-                   layer_name: str) -> "QuarkScheme":
+    def get_scheme(self, layer: torch.nn.Module, layer_name: str) -> "QuarkScheme":
 
         layer_quant_config = self._find_matched_config(layer_name, layer)
 
@@ -292,7 +328,7 @@ class QuarkConfig(QuantizationConfig):
     def get_cache_scale(self, name: str) -> Optional[str]:
         """
         Check whether the param name matches the format for k/v cache scales
-        in quark. If this is the case, return its equivalent param name 
+        in quark. If this is the case, return its equivalent param name
         expected by vLLM
 
         :param name: param name
@@ -312,17 +348,16 @@ class QuarkConfig(QuantizationConfig):
             elif len(kv_proj_names) == 2:
                 for kv_proj_name in kv_proj_names:
                     if kv_proj_name in name and kv_proj_name == "k_proj":
-                        return name.replace(".k_proj.output_scale",
-                                            ".attn.k_scale")
+                        return name.replace(".k_proj.output_scale", ".attn.k_scale")
                     elif kv_proj_name in name and kv_proj_name == "v_proj":
-                        return name.replace(".v_proj.output_scale",
-                                            ".attn.v_scale")
+                        return name.replace(".v_proj.output_scale", ".attn.v_scale")
 
         # If no matches, return None
         return None
 
     def get_scaled_act_names(self) -> List[str]:
         return []
+
 
 class QuarkLinearMethod(LinearMethodBase):
 
@@ -332,11 +367,16 @@ class QuarkLinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.scheme.process_weights_after_loading(layer)
 
-    def create_weights(self, layer: torch.nn.Module,
-                       input_size_per_partition: int,
-                       output_partition_sizes: List[int], input_size: int,
-                       output_size: int, params_dtype: torch.dtype,
-                       **extra_weight_attrs):
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
         """
         Use the CompressedTensorsScheme associated with each layer to create
         the necessary parameters for the layer. See LinearMethodBase for param
@@ -350,12 +390,15 @@ class QuarkLinearMethod(LinearMethodBase):
             output_partition_sizes=output_partition_sizes,
             output_size=output_size,
             params_dtype=params_dtype,
-            weight_loader=weight_loader)
+            weight_loader=weight_loader,
+        )
 
-    def apply(self,
-              layer: torch.nn.Module,
-              x: torch.Tensor,
-              bias: Optional[torch.Tensor] = None):
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ):
         """
         Use the output of create_weights and the CompressedTensorsScheme
         associated with the layer to apply the forward pass with the

--- a/python/sglang/srt/layers/quantization/quark/schemes/__init__.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from .quark_scheme import QuarkScheme
+from .quark_w8a8_int8 import QuarkW8A8Int8
+from .hadamard_transform import hadamard_transform_registry
+from .int8utils import process_weights_after_loading
+
+__all__ = ["QuarkScheme", "QuarkW8A8Int8", "hadamard_transform_registry", "process_weights_after_loading"]

--- a/python/sglang/srt/layers/quantization/quark/schemes/__init__.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/__init__.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from .quark_scheme import QuarkScheme
-from .quark_w8a8_int8 import QuarkW8A8Int8
 from .hadamard_transform import hadamard_transform_registry
 from .int8utils import process_weights_after_loading
+from .quark_scheme import QuarkScheme
+from .quark_w8a8_int8 import QuarkW8A8Int8
 
-__all__ = ["QuarkScheme", "QuarkW8A8Int8", "hadamard_transform_registry", "process_weights_after_loading"]
+__all__ = [
+    "QuarkScheme",
+    "QuarkW8A8Int8",
+    "hadamard_transform_registry",
+    "process_weights_after_loading",
+]

--- a/python/sglang/srt/layers/quantization/quark/schemes/hadamard_transform.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/hadamard_transform.py
@@ -1,5 +1,8 @@
-#from fast_hadamard_transform import (FHT_512,FHT_1024)
-from vllm.model_executor.layers.linear import RowParallelLinear
+# from fast_hadamard_transform import (FHT_512,FHT_1024)
+import sgl_kernel
+import torch
+from torch import nn
+
 from sglang.srt.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -8,145 +11,887 @@ from sglang.srt.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
-from torch import nn
-import torch
+from sglang.srt.layers.linear import RowParallelLinear
 
-import fast_hadamard_transform
+register_FHT = {
+    1024: torch.ops.sgl_kernel.fast_hadamard_transform,
+    512: torch.ops.sgl_kernel.fast_hadamard_transform,
+}
 
-register_FHT = {1024: fast_hadamard_transform.FHT_1024, 512: fast_hadamard_transform.FHT_512}
+hadamard_sizes = {
+    28: torch.FloatTensor(
+        [
+            [
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+            ],
+            [
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+            ],
+            [
+                +1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+            ],
+            [
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+            ],
+            [
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+            ],
+            [
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+            ],
+            [
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+            ],
+            [
+                +1,
+                +1,
+                -1,
+                +1,
+                +1,
+                -1,
+                -1,
+                -1,
+                -1,
+                +1,
+                +1,
+                -1,
+                +1,
+                -1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+                +1,
+                +1,
+                +1,
+                +1,
+                -1,
+                -1,
+                +1,
+                -1,
+                -1,
+            ],
+        ]
+    )
+}
 
-hadamard_sizes={28:torch.FloatTensor([
-    [
-        +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, -1, +1, +1, +1, +1, +1, +1,
-        +1, +1, +1, +1, +1, +1, +1],
-    [
-        +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, -1, +1, -1, +1, +1, -1, -1,
-        -1, -1, +1, +1, -1, +1
-    ],
-    [
-        +1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, -1, +1, -1, +1, +1,
-        -1, -1, -1, -1, +1, +1, -1
-    ],
-    [
-        +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, +1, -1, +1, -1, +1, -1, +1,
-        +1, -1, -1, -1, -1, +1, +1
-    ],
-    [
-        +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, +1, -1, +1, -1, +1, -1,
-        +1, +1, -1, -1, -1, -1, +1
-    ],
-    [
-        +1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, +1, -1, +1, -1, +1,
-        -1, +1, +1, -1, -1, -1, -1
-    ],
-    [
-        +1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, +1, -1, +1, +1, -1, +1, -1,
-        +1, -1, +1, +1, -1, -1, -1
-    ],
-    [
-        +1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, +1, -1, -1, +1, +1, -1, +1,
-        -1, +1, -1, +1, +1, -1, -1
-    ],
-    [
-        +1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, +1, -1, -1, -1, +1, +1, -1,
-        +1, -1, +1, -1, +1, +1, -1
-    ],
-    [
-        +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, +1, -1, -1, -1, -1, +1, +1,
-        -1, +1, -1, +1, -1, +1, +1
-    ],
-    [
-        +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, +1, -1, -1, -1, -1, +1,
-        +1, -1, +1, -1, +1, -1, +1
-    ],
-    [
-        +1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, +1, -1, -1, -1, -1,
-        +1, +1, -1, +1, -1, +1, -1
-    ],
-    [
-        +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, +1, -1, +1, +1, -1, -1, -1,
-        -1, +1, +1, -1, +1, -1, +1
-    ],
-    [
-        +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, +1, -1, +1, +1, -1, -1,
-        -1, -1, +1, +1, -1, +1, -1
-    ],
-    [
-        -1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, -1, -1, -1, -1, -1, -1, -1,
-        -1, -1, -1, -1, -1, -1, -1
-    ],
-    [
-        +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, -1, -1, +1, -1, -1, +1,
-        +1, +1, +1, -1, -1, +1, -1
-    ],
-    [
-        +1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, -1, -1, -1, -1, +1, -1, -1,
-        +1, +1, +1, +1, -1, -1, +1
-    ],
-    [
-        +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, -1, -1, +1, -1,
-        -1, +1, +1, +1, +1, -1, -1
-    ],
-    [
-        +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, -1, -1, +1, -1, -1, -1, +1,
-        -1, -1, +1, +1, +1, +1, -1
-    ],
-    [
-        +1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, -1, -1, -1, +1, -1, -1, -1,
-        +1, -1, -1, +1, +1, +1, +1
-    ],
-    [
-        +1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, -1, -1, +1, -1, -1,
-        -1, +1, -1, -1, +1, +1, +1
-    ],
-    [
-        +1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, +1, +1, -1, -1, +1, -1,
-        -1, -1, +1, -1, -1, +1, +1
-    ],
-    [
-        +1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, +1, +1, +1, -1, -1, +1,
-        -1, -1, -1, +1, -1, -1, +1
-    ],
-    [
-        +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, +1, +1, +1, +1, -1, -1,
-        +1, -1, -1, -1, +1, -1, -1
-    ],
-    [
-        +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, -1, -1, +1, +1, +1, +1, -1,
-        -1, +1, -1, -1, -1, +1, -1
-    ],
-    [
-        +1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, -1, -1, -1, +1, +1, +1, +1,
-        -1, -1, +1, -1, -1, -1, +1
-    ],
-    [
-        +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, -1, -1, +1, +1, +1,
-        +1, -1, -1, +1, -1, -1, -1
-    ],
-    [
-        +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, -1, -1, +1, -1, -1, +1, +1,
-        +1, +1, -1, -1, +1, -1, -1
-    ]])}
 
 class HadamardTransform(nn.Module):
     def __init__(self, layer: RowParallelLinear):
         super().__init__()
-        if hasattr(layer,"weight"):
-            weight = getattr(layer,"weight")
-            if hasattr(weight,"device"):
-                self._device=getattr(weight,"device")
+        if hasattr(layer, "weight"):
+            weight = getattr(layer, "weight")
+            if hasattr(weight, "device"):
+                self._device = getattr(weight, "device")
             else:
-                raise ValueError("cannot initialize hadamard transform: corresponding layer has no device")
-            if hasattr(weight,"dtype"):
-                self._dtype=getattr(weight,"dtype")
+                raise ValueError(
+                    "cannot initialize hadamard transform: corresponding layer has no device"
+                )
+            if hasattr(weight, "dtype"):
+                self._dtype = getattr(weight, "dtype")
             else:
-                raise ValueError("cannot initialize hadamamrd trnasform: corresponding layer has no dtype")
+                raise ValueError(
+                    "cannot initialize hadamamrd trnasform: corresponding layer has no dtype"
+                )
         else:
-            raise ValueError("cannot initialize hadamard transform: corresponding layer has not yet been initialized")
-        self.partition_input_size=layer.input_size_per_partition
-        self.actual_input_size=layer.input_size
+            raise ValueError(
+                "cannot initialize hadamard transform: corresponding layer has not yet been initialized"
+            )
+        self.partition_input_size = layer.input_size_per_partition
+        self.actual_input_size = layer.input_size
 
-def matrix_multiply_via_linear(A,X,m,n):
+
+def matrix_multiply_via_linear(A, X, m, n):
     """
     - m,n are the dimensions of matrix X, and it is assumed that matrix A input dim = m
 
@@ -161,74 +906,81 @@ def matrix_multiply_via_linear(A,X,m,n):
             ...
             og^T
     """
-    X=X.view(-1,m,n)
-    
-    X=X.mT
-    X=X.contiguous()
+    X = X.view(-1, m, n)
 
-    X=X.view(-1,m)
+    X = X.mT
+    X = X.contiguous()
 
-    #import torch.nn.functional as F
-    #X=F.linear(X,self.hadamard_k.weight)
+    X = X.view(-1, m)
 
-    X=A(X)
+    # import torch.nn.functional as F
+    # X=F.linear(X,self.hadamard_k.weight)
 
-    X=X.view(-1,n,m*get_tensor_model_parallel_world_size())
-        
-    rank=get_tensor_model_parallel_rank()
-    start=rank*m
-    end=start+m
-    X=X[:,:,start:end]
+    X = A(X)[0]
 
-    X=X.mT
-    X=X.contiguous()
+    X = X.view(-1, n, m * get_tensor_model_parallel_world_size())
+
+    rank = get_tensor_model_parallel_rank()
+    start = rank * m
+    end = start + m
+    X = X[:, :, start:end]
+
+    X = X.mT
+    X = X.contiguous()
 
     return X
 
+
 class QuaRotR4(HadamardTransform):
-    def __init__(self, layer: RowParallelLinear, size_FHT = None, size_k = None):
+    def __init__(self, layer: RowParallelLinear, size_FHT=None, size_k=None):
         super().__init__(layer)
 
         """
         select the appropriate hadamard matrix, based on the target input size
         """
-        if size_FHT is None and not(size_k is None):
-            if self.actual_input_size//size_k in hadamard_sizes:
-                size_FHT=self.actual_input_size//size_k
+        if size_FHT is None and not (size_k is None):
+            if self.actual_input_size // size_k in hadamard_sizes:
+                size_FHT = self.actual_input_size // size_k
             else:
                 raise ValueError(f"No matching size_FHT for size_k={size_k}")
-        elif size_k is None and not(size_FHT is None):
-            if self.actual_input_size//size_FHT in hadamard_sizes:
-                size_k=self.actual_input_size//size_FHT
+        elif size_k is None and not (size_FHT is None):
+            if self.actual_input_size // size_FHT in hadamard_sizes:
+                size_k = self.actual_input_size // size_FHT
             else:
                 raise ValueError(f"No matching size_k for size_FHT={size_FHT}")
         elif size_k is None and size_FHT is None:
             import itertools
-            for s_FHT,s_k in itertools.product(register_FHT.keys(),hadamard_sizes.keys()):
-                if s_FHT*s_k==self.actual_input_size:
-                    size_FHT,size_k=s_FHT,s_k
+
+            for s_FHT, s_k in itertools.product(
+                register_FHT.keys(), hadamard_sizes.keys()
+            ):
+                if s_FHT * s_k == self.actual_input_size:
+                    size_FHT, size_k = s_FHT, s_k
                     break
             else:
-                raise ValueError(f"No matching size_k and size_FHT found for input size {self.actual_input_size}")
+                raise ValueError(
+                    f"No matching size_k and size_FHT found for input size {self.actual_input_size}"
+                )
         else:
-            if size_k*size_FHT != self.actual_input_size:
-                raise ValueError(f"size_k={size_k} and size_FHT={size_FHT} do not match {self.actual_input_size}")
+            if size_k * size_FHT != self.actual_input_size:
+                raise ValueError(
+                    f"size_k={size_k} and size_FHT={size_FHT} do not match {self.actual_input_size}"
+                )
 
-
-        hadamard_k=hadamard_sizes[size_k].to(self._device).bfloat16()
-        #initialize the RowParallelLinear and load the weights
-        self.hadamard_k=RowParallelLinear(input_size=size_k,
-                                            output_size=size_k,
-                                            bias=False)
+        hadamard_k = hadamard_sizes[size_k].to(self._device).bfloat16()
+        # initialize the RowParallelLinear and load the weights
+        self.hadamard_k = RowParallelLinear(
+            input_size=size_k, output_size=size_k, bias=False
+        )
         self.hadamard_k.to(self._device).bfloat16()
-        self.hadamard_k.weight_loader(self.hadamard_k.weight,hadamard_k)
-        self.k=size_k
-        self.scale=1.0/torch.tensor(self.actual_input_size).sqrt()
-        self.chunk_size=size_FHT
-        self.FHT=register_FHT[size_FHT]
-        
+        self.hadamard_k.weight_loader(self.hadamard_k.weight, hadamard_k)
+        self.k = size_k
+        self.scale = 1.0 / torch.tensor(self.actual_input_size).sqrt()
+        self.chunk_size = size_FHT
+        self.FHT = register_FHT[size_FHT]
+
     def forward(self, X):
-        og_shape=X.shape
+        og_shape = X.shape
 
         """
         - perform FHT - "preprocess the input before the hadamard multiply"
@@ -236,8 +988,8 @@ class QuaRotR4(HadamardTransform):
                 - `tensor.reshape(-1, n)`
         - feed it into the appropriate FHT kernel
         """
-        X=X.view(-1,self.chunk_size)
-        X=self.FHT(X,self.scale)
+        X = X.view(-1, self.chunk_size)
+        X = self.FHT(X, self.scale)
 
         """
         if self.chunk_size>512:
@@ -247,14 +999,20 @@ class QuaRotR4(HadamardTransform):
             X[:,1,:]=Y[:,0,:]-Y[:,1,:]
         """
 
-        if get_tensor_model_parallel_world_size()==1:
-            X=X.view(-1,self.hadamard_k.input_size_per_partition,self.chunk_size)
-            X=self.hadamard_k.weight@X
+        if get_tensor_model_parallel_world_size() == 1:
+            X = X.view(-1, self.hadamard_k.input_size_per_partition, self.chunk_size)
+            X = self.hadamard_k.weight @ X
         else:
-            X=matrix_multiply_via_linear(A=self.hadamard_k,X=X,m=self.hadamard_k.input_size_per_partition,n=self.chunk_size)
+            X = matrix_multiply_via_linear(
+                A=self.hadamard_k,
+                X=X,
+                m=self.hadamard_k.input_size_per_partition,
+                n=self.chunk_size,
+            )
 
-        X=X.view(og_shape)
+        X = X.view(og_shape)
 
         return X
-    
-hadamard_transform_registry = {'quarot_r4': QuaRotR4}
+
+
+hadamard_transform_registry = {"quarot_r4": QuaRotR4}

--- a/python/sglang/srt/layers/quantization/quark/schemes/hadamard_transform.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/hadamard_transform.py
@@ -1,0 +1,260 @@
+#from fast_hadamard_transform import (FHT_512,FHT_1024)
+from vllm.model_executor.layers.linear import RowParallelLinear
+from sglang.srt.distributed import (
+    divide,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    split_tensor_along_last_dim,
+    tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_reduce,
+)
+from torch import nn
+import torch
+
+import fast_hadamard_transform
+
+register_FHT = {1024: fast_hadamard_transform.FHT_1024, 512: fast_hadamard_transform.FHT_512}
+
+hadamard_sizes={28:torch.FloatTensor([
+    [
+        +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, -1, +1, +1, +1, +1, +1, +1,
+        +1, +1, +1, +1, +1, +1, +1],
+    [
+        +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, -1, +1, -1, +1, +1, -1, -1,
+        -1, -1, +1, +1, -1, +1
+    ],
+    [
+        +1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, -1, +1, -1, +1, +1,
+        -1, -1, -1, -1, +1, +1, -1
+    ],
+    [
+        +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, +1, -1, +1, -1, +1, -1, +1,
+        +1, -1, -1, -1, -1, +1, +1
+    ],
+    [
+        +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, +1, -1, +1, -1, +1, -1,
+        +1, +1, -1, -1, -1, -1, +1
+    ],
+    [
+        +1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, +1, -1, +1, -1, +1,
+        -1, +1, +1, -1, -1, -1, -1
+    ],
+    [
+        +1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, -1, +1, -1, +1, +1, -1, +1, -1,
+        +1, -1, +1, +1, -1, -1, -1
+    ],
+    [
+        +1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, -1, +1, -1, -1, +1, +1, -1, +1,
+        -1, +1, -1, +1, +1, -1, -1
+    ],
+    [
+        +1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, -1, +1, -1, -1, -1, +1, +1, -1,
+        +1, -1, +1, -1, +1, +1, -1
+    ],
+    [
+        +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, +1, -1, -1, -1, -1, +1, +1,
+        -1, +1, -1, +1, -1, +1, +1
+    ],
+    [
+        +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, +1, -1, -1, -1, -1, +1,
+        +1, -1, +1, -1, +1, -1, +1
+    ],
+    [
+        +1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, -1, +1, +1, +1, -1, -1, -1, -1,
+        +1, +1, -1, +1, -1, +1, -1
+    ],
+    [
+        +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, +1, -1, +1, +1, -1, -1, -1,
+        -1, +1, +1, -1, +1, -1, +1
+    ],
+    [
+        +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, +1, +1, +1, -1, +1, +1, -1, -1,
+        -1, -1, +1, +1, -1, +1, -1
+    ],
+    [
+        -1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, +1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1
+    ],
+    [
+        +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, -1, -1, +1, -1, -1, +1,
+        +1, +1, +1, -1, -1, +1, -1
+    ],
+    [
+        +1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, -1, -1, -1, -1, +1, -1, -1,
+        +1, +1, +1, +1, -1, -1, +1
+    ],
+    [
+        +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, -1, -1, +1, -1,
+        -1, +1, +1, +1, +1, -1, -1
+    ],
+    [
+        +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, -1, -1, +1, -1, -1, -1, +1,
+        -1, -1, +1, +1, +1, +1, -1
+    ],
+    [
+        +1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, -1, -1, -1, +1, -1, -1, -1,
+        +1, -1, -1, +1, +1, +1, +1
+    ],
+    [
+        +1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, -1, +1, -1, -1, +1, -1, -1,
+        -1, +1, -1, -1, +1, +1, +1
+    ],
+    [
+        +1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, -1, +1, +1, -1, -1, +1, -1,
+        -1, -1, +1, -1, -1, +1, +1
+    ],
+    [
+        +1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, -1, +1, +1, +1, -1, -1, +1,
+        -1, -1, -1, +1, -1, -1, +1
+    ],
+    [
+        +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, +1, -1, +1, +1, +1, +1, -1, -1,
+        +1, -1, -1, -1, +1, -1, -1
+    ],
+    [
+        +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, -1, -1, +1, +1, +1, +1, -1,
+        -1, +1, -1, -1, -1, +1, -1
+    ],
+    [
+        +1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, -1, -1, -1, +1, +1, +1, +1,
+        -1, -1, +1, -1, -1, -1, +1
+    ],
+    [
+        +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, +1, -1, +1, -1, -1, +1, +1, +1,
+        +1, -1, -1, +1, -1, -1, -1
+    ],
+    [
+        +1, +1, -1, +1, +1, -1, -1, -1, -1, +1, +1, -1, +1, -1, -1, -1, +1, -1, -1, +1, +1,
+        +1, +1, -1, -1, +1, -1, -1
+    ]])}
+
+class HadamardTransform(nn.Module):
+    def __init__(self, layer: RowParallelLinear):
+        super().__init__()
+        if hasattr(layer,"weight"):
+            weight = getattr(layer,"weight")
+            if hasattr(weight,"device"):
+                self._device=getattr(weight,"device")
+            else:
+                raise ValueError("cannot initialize hadamard transform: corresponding layer has no device")
+            if hasattr(weight,"dtype"):
+                self._dtype=getattr(weight,"dtype")
+            else:
+                raise ValueError("cannot initialize hadamamrd trnasform: corresponding layer has no dtype")
+        else:
+            raise ValueError("cannot initialize hadamard transform: corresponding layer has not yet been initialized")
+        self.partition_input_size=layer.input_size_per_partition
+        self.actual_input_size=layer.input_size
+
+def matrix_multiply_via_linear(A,X,m,n):
+    """
+    - m,n are the dimensions of matrix X, and it is assumed that matrix A input dim = m
+
+    - perform the hadamard multiply
+        - reshape for matrix multiply
+            - `tensor.reshape(-1,hadamard_k.input_size_per_partition,n)`
+        - transpose along last two dimensions (we get (\*,n,input_size_per_partition)), then make it contiguous
+        - call the row parallel linear layer forward pass
+        - reshape the output to the original shape (is transpose needed of the last dimension?) - output is like:
+            og^T
+            og^T
+            ...
+            og^T
+    """
+    X=X.view(-1,m,n)
+    
+    X=X.mT
+    X=X.contiguous()
+
+    X=X.view(-1,m)
+
+    #import torch.nn.functional as F
+    #X=F.linear(X,self.hadamard_k.weight)
+
+    X=A(X)
+
+    X=X.view(-1,n,m*get_tensor_model_parallel_world_size())
+        
+    rank=get_tensor_model_parallel_rank()
+    start=rank*m
+    end=start+m
+    X=X[:,:,start:end]
+
+    X=X.mT
+    X=X.contiguous()
+
+    return X
+
+class QuaRotR4(HadamardTransform):
+    def __init__(self, layer: RowParallelLinear, size_FHT = None, size_k = None):
+        super().__init__(layer)
+
+        """
+        select the appropriate hadamard matrix, based on the target input size
+        """
+        if size_FHT is None and not(size_k is None):
+            if self.actual_input_size//size_k in hadamard_sizes:
+                size_FHT=self.actual_input_size//size_k
+            else:
+                raise ValueError(f"No matching size_FHT for size_k={size_k}")
+        elif size_k is None and not(size_FHT is None):
+            if self.actual_input_size//size_FHT in hadamard_sizes:
+                size_k=self.actual_input_size//size_FHT
+            else:
+                raise ValueError(f"No matching size_k for size_FHT={size_FHT}")
+        elif size_k is None and size_FHT is None:
+            import itertools
+            for s_FHT,s_k in itertools.product(register_FHT.keys(),hadamard_sizes.keys()):
+                if s_FHT*s_k==self.actual_input_size:
+                    size_FHT,size_k=s_FHT,s_k
+                    break
+            else:
+                raise ValueError(f"No matching size_k and size_FHT found for input size {self.actual_input_size}")
+        else:
+            if size_k*size_FHT != self.actual_input_size:
+                raise ValueError(f"size_k={size_k} and size_FHT={size_FHT} do not match {self.actual_input_size}")
+
+
+        hadamard_k=hadamard_sizes[size_k].to(self._device).bfloat16()
+        #initialize the RowParallelLinear and load the weights
+        self.hadamard_k=RowParallelLinear(input_size=size_k,
+                                            output_size=size_k,
+                                            bias=False)
+        self.hadamard_k.to(self._device).bfloat16()
+        self.hadamard_k.weight_loader(self.hadamard_k.weight,hadamard_k)
+        self.k=size_k
+        self.scale=1.0/torch.tensor(self.actual_input_size).sqrt()
+        self.chunk_size=size_FHT
+        self.FHT=register_FHT[size_FHT]
+        
+    def forward(self, X):
+        og_shape=X.shape
+
+        """
+        - perform FHT - "preprocess the input before the hadamard multiply"
+            - reshape the input tensor to groups of 512 for the 8B, 1024 for the 70B:
+                - `tensor.reshape(-1, n)`
+        - feed it into the appropriate FHT kernel
+        """
+        X=X.view(-1,self.chunk_size)
+        X=self.FHT(X,self.scale)
+
+        """
+        if self.chunk_size>512:
+            Y=X.clone().view(-1,2,512)
+            X=X.view(-1,2,512)
+            X[:,0,:]=Y[:,0,:]+Y[:,1,:]
+            X[:,1,:]=Y[:,0,:]-Y[:,1,:]
+        """
+
+        if get_tensor_model_parallel_world_size()==1:
+            X=X.view(-1,self.hadamard_k.input_size_per_partition,self.chunk_size)
+            X=self.hadamard_k.weight@X
+        else:
+            X=matrix_multiply_via_linear(A=self.hadamard_k,X=X,m=self.hadamard_k.input_size_per_partition,n=self.chunk_size)
+
+        X=X.view(og_shape)
+
+        return X
+    
+hadamard_transform_registry = {'quarot_r4': QuaRotR4}

--- a/python/sglang/srt/layers/quantization/quark/schemes/int8utils.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/int8utils.py
@@ -1,0 +1,93 @@
+from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+    convert_to_channelwise)
+
+import torch
+
+def process_weights_after_loading(layer):
+
+    w_q_name = "weight"
+    w_s_name = "weight_scale"
+    i_s_name = "input_scale"
+    i_zp_name = "input_zero_point"
+    azp_adj_name = "azp_adj"                    
+
+    print("before_rep:",layer.weight.shape)
+    # WEIGHT
+    # Cutlass kernels need transposed weight.
+    weight = getattr(layer, w_q_name)
+    replace_parameter(
+        layer, w_q_name,
+        torch.nn.Parameter(weight.t().data, requires_grad=False))
+    print("after_rep:",layer.weight.shape)
+
+
+    # WEIGHT SCALE
+    # Cutlass kernels support only per-tensor and per-channel.
+    # If we have a fused module (QKV, MLP) with per tensor scales (thus N
+    # scales being passed to the kernel), convert to the per-channel case.
+    is_fused_module = len(layer.logical_widths) > 1
+    weight_scale = getattr(layer, w_s_name)
+    #if is_fused_module and not False:
+    weight_scale = convert_to_channelwise(weight_scale,
+                                                layer.logical_widths)
+    replace_parameter(
+        layer, w_s_name,
+        torch.nn.Parameter(weight_scale.data.view(-1,1), requires_grad=False))
+
+    # INPUT SCALE
+    if True:
+        input_scale = getattr(layer, i_s_name)
+
+        if True:
+            replace_parameter(
+                layer, i_s_name,
+                torch.nn.Parameter(torch.full((1,1),input_scale.max(),dtype=torch.float32,device=layer.weight.device), requires_grad=False))
+            setattr(layer, i_zp_name, None)
+        else:
+            input_zero_point = getattr(layer, i_zp_name)
+
+            # reconstruct the ranges
+            int8_traits = torch.iinfo(torch.int8)
+            azps = input_zero_point.to(dtype=torch.int32)
+            range_max = (input_scale * (int8_traits.max - azps)).max()
+            range_min = (input_scale * (int8_traits.min - azps)).min()
+
+            scale = (range_max - range_min) / (int8_traits.max -
+                                                int8_traits.min)
+            replace_parameter(
+                layer, i_s_name,
+                torch.nn.Parameter(scale, requires_grad=False))
+
+            # AZP loaded as int8 but used as int32
+            azp = (int8_traits.min -
+                    range_min / scale).to(dtype=torch.int32)
+            replace_parameter(layer, i_zp_name,
+                                torch.nn.Parameter(azp, requires_grad=False))
+
+    else:
+        setattr(layer, i_s_name, None)
+        setattr(layer, i_zp_name, None)
+
+    # azp_adj is the AZP adjustment term, used to account for weights.
+    # It does not depend on scales or azp, so it is the same for
+    # static and dynamic quantization.
+    # For more details, see csrc/quantization/cutlass_w8a8/Epilogues.md
+    # https://github.com/vllm-project/vllm/blob/8d59dbb00044a588cab96bcdc028006ed922eb06/csrc/quantization/cutlass_w8a8/Epilogues.md
+    if not True:
+        weight = getattr(layer, w_q_name)
+        azp_adj = weight.sum(dim=0, keepdim=True, dtype=torch.int32)
+        if True:
+            # cutlass_w8a8 requires azp to be folded into azp_adj
+            # in the per-tensor case
+            azp_adj = getattr(layer, i_zp_name) * azp_adj
+        setattr(layer, azp_adj_name,
+                torch.nn.Parameter(azp_adj, requires_grad=False))
+    else:
+        setattr(layer, azp_adj_name, None)
+
+def scaled_int8_quant(x, i_s, i_zp, symmetric):
+    pass
+
+def cutlass_scaled_mm(x_q, w_q, scale_a, scale_b, out_dtype, bias):
+    pass

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_scheme.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_scheme.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+
+__all__ = ["QuarkScheme"]
+
+
+class QuarkScheme(ABC):
+    """
+    Abstract class used to describe the weight creation and forward pass 
+    of different quantization schemes supported by Quark.
+    """
+
+    @classmethod
+    @abstractmethod
+    def get_min_capability(cls) -> int:
+        """
+        Get minimum device capability.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_weights(self, *args, **kwargs):
+        """
+        Weight creation for the particular scheme. Inputs to this function 
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_weights(self, layer: torch.nn.Module, x: torch.Tensor,
+                      bias: Optional[torch.Tensor]):
+        """
+        Run the forward pass for the particular scheme. This is where 
+        scheme-specific dequant/quant steps/kernels should be applied.
+
+        :param layer: torch.nn.Module with the registered weights and 
+            other parameters relevant to the particular scheme. 
+        :param x: input to the layer
+        :param bias: bias parameter
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer: torch.nn.Module):
+        """
+        Called after weight loading is complete for any cleanup that
+        needs to occur.
+        """
+        raise NotImplementedError

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_scheme.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_scheme.py
@@ -10,7 +10,7 @@ __all__ = ["QuarkScheme"]
 
 class QuarkScheme(ABC):
     """
-    Abstract class used to describe the weight creation and forward pass 
+    Abstract class used to describe the weight creation and forward pass
     of different quantization schemes supported by Quark.
     """
 
@@ -25,20 +25,21 @@ class QuarkScheme(ABC):
     @abstractmethod
     def create_weights(self, *args, **kwargs):
         """
-        Weight creation for the particular scheme. Inputs to this function 
+        Weight creation for the particular scheme. Inputs to this function
 
         """
         raise NotImplementedError
 
     @abstractmethod
-    def apply_weights(self, layer: torch.nn.Module, x: torch.Tensor,
-                      bias: Optional[torch.Tensor]):
+    def apply_weights(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
+    ):
         """
-        Run the forward pass for the particular scheme. This is where 
+        Run the forward pass for the particular scheme. This is where
         scheme-specific dequant/quant steps/kernels should be applied.
 
-        :param layer: torch.nn.Module with the registered weights and 
-            other parameters relevant to the particular scheme. 
+        :param layer: torch.nn.Module with the registered weights and
+            other parameters relevant to the particular scheme.
         :param x: input to the layer
         :param bias: bias parameter
 

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w8a8_int8.py
@@ -3,19 +3,20 @@
 from typing import Callable, List, Optional, Set
 
 import torch
-
 from vllm import _custom_ops as ops
-
 from vllm.logger import init_logger
+
 """
 from vllm.model_executor.layers.quantization.kernels.scaled_mm import (
     ScaledMMLinearLayerConfig, choose_scaled_mm_linear_kernel)
 """
+from sglang.srt.layers.parameter import (
+    BasevLLMParameter,
+    ChannelQuantScaleParameter,
+    ModelWeightParameter,
+    PerTensorScaleParameter,
+)
 from sglang.srt.layers.quantization.quark.schemes import QuarkScheme
-from sglang.srt.layers.parameter  import (BasevLLMParameter,
-                                           ChannelQuantScaleParameter,
-                                           ModelWeightParameter,
-                                           PerTensorScaleParameter)
 
 logger = init_logger(__name__)
 
@@ -23,28 +24,38 @@ logger = init_logger(__name__)
 class QuarkW8A8Int8(QuarkScheme):
     _kernel_backends_being_used: Set[str] = set()
 
-    def __init__(self, qscheme: str, is_static_input_scheme: Optional[bool],
-            input_symmetric: Optional[bool], online_rotation_method: Optional[Callable]):
+    def __init__(
+        self,
+        qscheme: str,
+        is_static_input_scheme: Optional[bool],
+        input_symmetric: Optional[bool],
+        online_rotation_method: Optional[Callable],
+    ):
         self.qscheme = qscheme
         self.is_static_input_scheme = is_static_input_scheme
         self.input_symmetric = input_symmetric
         self.online_rotation_method = online_rotation_method
-        #Lazy Import
-        from sglang.srt.layers.quantization.quark.schemes import process_weights_after_loading as pwal
-        self.pwal=pwal
+        # Lazy Import
+        from sglang.srt.layers.quantization.quark.schemes import (
+            process_weights_after_loading as pwal,
+        )
+
+        self.pwal = pwal
 
     @classmethod
     def get_min_capability(cls) -> int:
         # turing and up
         return 75
 
-    def create_weights(self, layer: torch.nn.Module,
-                       output_partition_sizes: List[int],
-                       input_size_per_partition: int,
-                       params_dtype: torch.dtype, weight_loader: Callable,
-                       **kwargs):
-
-        #print("output_partition_sizes: ",sum(output_partition_sizes),len(output_partition_sizes))
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_partition_sizes: List[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs
+    ):
 
         layer.logical_widths = output_partition_sizes
         self.logical_widths = output_partition_sizes
@@ -62,40 +73,39 @@ class QuarkW8A8Int8(QuarkScheme):
             logger.info("Using %s for QuarkW8A8Int8", kernel_type.__name__)
             self._kernel_backends_being_used.add(kernel_type.__name__)
         """
-            
+
         # WEIGHT
-        weight = ModelWeightParameter(data=torch.empty(
-            sum(output_partition_sizes),
-            input_size_per_partition,
-            dtype=torch.int8),
-                                      input_dim=1,
-                                      output_dim=0,
-                                      weight_loader=weight_loader)
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                sum(output_partition_sizes), input_size_per_partition, dtype=torch.int8
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
 
         layer.register_parameter("weight", weight)
 
         # WEIGHT SCALE
         if self.qscheme == "per_channel":
             weight_scale = ChannelQuantScaleParameter(
-                data=torch.empty((sum(output_partition_sizes), 1),
-                                 dtype=torch.float32),
+                data=torch.empty((sum(output_partition_sizes), 1), dtype=torch.float32),
                 output_dim=0,
-                weight_loader=weight_loader)
+                weight_loader=weight_loader,
+            )
         else:
             assert self.qscheme == "per_tensor"
-            #print("per_tensor?",len(output_partition_sizes))
-            weight_scale = PerTensorScaleParameter(data=torch.empty(
-                len(output_partition_sizes), dtype=torch.float32),
-                                                   weight_loader=weight_loader)
+            weight_scale = PerTensorScaleParameter(
+                data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+                weight_loader=weight_loader,
+            )
         layer.register_parameter("weight_scale", weight_scale)
-
-        #print("before processing: ",layer.weight_scale.shape)
 
         # INPUT SCALE
         if self.is_static_input_scheme:
-            input_scale = BasevLLMParameter(data=torch.empty(
-                1, dtype=torch.float32),
-                                            weight_loader=weight_loader)
+            input_scale = BasevLLMParameter(
+                data=torch.empty(1, dtype=torch.float32), weight_loader=weight_loader
+            )
             layer.register_parameter("input_scale", input_scale)
 
             if not self.input_symmetric:
@@ -103,8 +113,8 @@ class QuarkW8A8Int8(QuarkScheme):
                 # as the weights
                 # AZP loaded as int8 but used as int32
                 input_zero_point = BasevLLMParameter(
-                    data=torch.empty(1, dtype=torch.int8),
-                    weight_loader=weight_loader)
+                    data=torch.empty(1, dtype=torch.int8), weight_loader=weight_loader
+                )
                 layer.register_parameter("input_zero_point", input_zero_point)
 
         """
@@ -115,55 +125,32 @@ class QuarkW8A8Int8(QuarkScheme):
                                   i_zp_param_name="input_zero_point",
                                   azp_adj_param_name="azp_adj")
         """
-                                  
+
         if self.online_rotation_method:
-            func_name,func_args=self.online_rotation_method
-            self.online_rotation_method_callable=func_name(layer,*func_args)
+            func_name, func_args = self.online_rotation_method
+            self.online_rotation_method_callable = func_name(layer, *func_args)
 
     # Checkpoints are serialized in quark format, which is
     # different from the format the kernel may want. Handle repacking here.
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        print("before processing: ",layer.weight_scale.shape)
-        print("before processing: ",layer.weight_scale)
         self.pwal(layer)
-        #self.kernel.process_weights_after_loading(layer)
-        #print("after processing: ",layer.weight_scale.shape)
-        #print("after processing: ",layer.weight_scale)
 
-    def apply_weights(self, layer: torch.nn.Module, x: torch.Tensor,
-        bias: Optional[torch.Tensor]) -> torch.Tensor:
-
-        #raise ValueError("wrong")
-
-        #print("A, x : ",layer.weight.shape,x.shape)
+    def apply_weights(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: Optional[torch.Tensor]
+    ) -> torch.Tensor:
 
         if self.online_rotation_method:
 
-            x=self.online_rotation_method_callable(x)
-            
-        #return self.kernel.apply_weights(layer, x, bias)
+            x = self.online_rotation_method_callable(x)
 
         """begin - replace kernel.apply_weights"""
 
-        #x_q=(x/layer.input_scale).to(torch.int8)
-        #x_q_uq=x_q.bfloat16()
-
-        #w_uq = (layer.weight.bfloat16().T).contiguous()
-
-        #y=torch.nn.functional.linear(x_q_uq,w_uq)
-        #print(y.shape)
-        #print(layer.weight_scale.shape)
-        #y=y*layer.weight_scale.squeeze()
-
-        i_s=layer.input_scale
-        #print(x.dtype)
-        #print(i_s.dtype)
+        i_s = layer.input_scale
         x_q, x_s, x_zp = ops.scaled_int8_quant(x, i_s, None, symmetric=True)
-        w_q=layer.weight
-        w_s=layer.weight_scale
-        return ops.cutlass_scaled_mm(x_q, w_q, scale_a=x_s, scale_b=w_s, out_dtype=x.dtype, bias=None)
-
+        w_q = layer.weight
+        w_s = layer.weight_scale
+        return ops.cutlass_scaled_mm(
+            x_q, w_q, scale_a=x_s, scale_b=w_s, out_dtype=x.dtype, bias=None
+        )
 
         """end - replace kernel.apply_weights"""
-
-        return y.bfloat16()

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w8a8_int8.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, List, Optional, Set
+
+import torch
+
+from vllm import _custom_ops as ops
+
+from vllm.logger import init_logger
+"""
+from vllm.model_executor.layers.quantization.kernels.scaled_mm import (
+    ScaledMMLinearLayerConfig, choose_scaled_mm_linear_kernel)
+"""
+from sglang.srt.layers.quantization.quark.schemes import QuarkScheme
+from sglang.srt.layers.parameter  import (BasevLLMParameter,
+                                           ChannelQuantScaleParameter,
+                                           ModelWeightParameter,
+                                           PerTensorScaleParameter)
+
+logger = init_logger(__name__)
+
+
+class QuarkW8A8Int8(QuarkScheme):
+    _kernel_backends_being_used: Set[str] = set()
+
+    def __init__(self, qscheme: str, is_static_input_scheme: Optional[bool],
+            input_symmetric: Optional[bool], online_rotation_method: Optional[Callable]):
+        self.qscheme = qscheme
+        self.is_static_input_scheme = is_static_input_scheme
+        self.input_symmetric = input_symmetric
+        self.online_rotation_method = online_rotation_method
+        #Lazy Import
+        from sglang.srt.layers.quantization.quark.schemes import process_weights_after_loading as pwal
+        self.pwal=pwal
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # turing and up
+        return 75
+
+    def create_weights(self, layer: torch.nn.Module,
+                       output_partition_sizes: List[int],
+                       input_size_per_partition: int,
+                       params_dtype: torch.dtype, weight_loader: Callable,
+                       **kwargs):
+
+        #print("output_partition_sizes: ",sum(output_partition_sizes),len(output_partition_sizes))
+
+        layer.logical_widths = output_partition_sizes
+        self.logical_widths = output_partition_sizes
+
+        """
+        scaled_mm_linear_kernel_config = ScaledMMLinearLayerConfig(
+            is_channelwise=(self.qscheme == "per_channel"),
+            is_static_input_scheme=(self.is_static_input_scheme is True),
+            input_symmetric=(self.input_symmetric is True))
+
+        kernel_type = choose_scaled_mm_linear_kernel(
+            scaled_mm_linear_kernel_config)
+
+        if kernel_type.__name__ not in self._kernel_backends_being_used:
+            logger.info("Using %s for QuarkW8A8Int8", kernel_type.__name__)
+            self._kernel_backends_being_used.add(kernel_type.__name__)
+        """
+            
+        # WEIGHT
+        weight = ModelWeightParameter(data=torch.empty(
+            sum(output_partition_sizes),
+            input_size_per_partition,
+            dtype=torch.int8),
+                                      input_dim=1,
+                                      output_dim=0,
+                                      weight_loader=weight_loader)
+
+        layer.register_parameter("weight", weight)
+
+        # WEIGHT SCALE
+        if self.qscheme == "per_channel":
+            weight_scale = ChannelQuantScaleParameter(
+                data=torch.empty((sum(output_partition_sizes), 1),
+                                 dtype=torch.float32),
+                output_dim=0,
+                weight_loader=weight_loader)
+        else:
+            assert self.qscheme == "per_tensor"
+            #print("per_tensor?",len(output_partition_sizes))
+            weight_scale = PerTensorScaleParameter(data=torch.empty(
+                len(output_partition_sizes), dtype=torch.float32),
+                                                   weight_loader=weight_loader)
+        layer.register_parameter("weight_scale", weight_scale)
+
+        #print("before processing: ",layer.weight_scale.shape)
+
+        # INPUT SCALE
+        if self.is_static_input_scheme:
+            input_scale = BasevLLMParameter(data=torch.empty(
+                1, dtype=torch.float32),
+                                            weight_loader=weight_loader)
+            layer.register_parameter("input_scale", input_scale)
+
+            if not self.input_symmetric:
+                # Note: quark stores the zp using the same dtype
+                # as the weights
+                # AZP loaded as int8 but used as int32
+                input_zero_point = BasevLLMParameter(
+                    data=torch.empty(1, dtype=torch.int8),
+                    weight_loader=weight_loader)
+                layer.register_parameter("input_zero_point", input_zero_point)
+
+        """
+        self.kernel = kernel_type(c=scaled_mm_linear_kernel_config,
+                                  w_q_param_name="weight",
+                                  w_s_param_name="weight_scale",
+                                  i_s_param_name="input_scale",
+                                  i_zp_param_name="input_zero_point",
+                                  azp_adj_param_name="azp_adj")
+        """
+                                  
+        if self.online_rotation_method:
+            func_name,func_args=self.online_rotation_method
+            self.online_rotation_method_callable=func_name(layer,*func_args)
+
+    # Checkpoints are serialized in quark format, which is
+    # different from the format the kernel may want. Handle repacking here.
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        print("before processing: ",layer.weight_scale.shape)
+        print("before processing: ",layer.weight_scale)
+        self.pwal(layer)
+        #self.kernel.process_weights_after_loading(layer)
+        #print("after processing: ",layer.weight_scale.shape)
+        #print("after processing: ",layer.weight_scale)
+
+    def apply_weights(self, layer: torch.nn.Module, x: torch.Tensor,
+        bias: Optional[torch.Tensor]) -> torch.Tensor:
+
+        #raise ValueError("wrong")
+
+        #print("A, x : ",layer.weight.shape,x.shape)
+
+        if self.online_rotation_method:
+
+            x=self.online_rotation_method_callable(x)
+            
+        #return self.kernel.apply_weights(layer, x, bias)
+
+        """begin - replace kernel.apply_weights"""
+
+        #x_q=(x/layer.input_scale).to(torch.int8)
+        #x_q_uq=x_q.bfloat16()
+
+        #w_uq = (layer.weight.bfloat16().T).contiguous()
+
+        #y=torch.nn.functional.linear(x_q_uq,w_uq)
+        #print(y.shape)
+        #print(layer.weight_scale.shape)
+        #y=y*layer.weight_scale.squeeze()
+
+        i_s=layer.input_scale
+        #print(x.dtype)
+        #print(i_s.dtype)
+        x_q, x_s, x_zp = ops.scaled_int8_quant(x, i_s, None, symmetric=True)
+        w_q=layer.weight
+        w_s=layer.weight_scale
+        return ops.cutlass_scaled_mm(x_q, w_q, scale_a=x_s, scale_b=w_s, out_dtype=x.dtype, bias=None)
+
+
+        """end - replace kernel.apply_weights"""
+
+        return y.bfloat16()

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+from types import MappingProxyType
+from typing import Any, Iterable, List, Mapping, Optional
+
+
+def deep_compare(dict1: Any, dict2: Any) -> bool:
+    if type(dict1) is not type(dict2):
+        return False
+    if isinstance(dict1, dict):
+        if dict1.keys() != dict2.keys():
+            return False
+        return all(deep_compare(dict1[k], dict2[k]) for k in dict1)
+    elif isinstance(dict1, list):
+        return set(dict1) == set(dict2)
+    else:
+        return dict1 == dict2
+
+
+def should_ignore_layer(
+    layer_name: Optional[str],
+    ignore: Iterable[str],
+    fused_mapping: Mapping[str, List[str]] = MappingProxyType({})
+) -> bool:
+    if layer_name is None:
+        return False
+
+    # layer_name = model.layers.0.self_attn.qkv_proj
+    # proj_name = qkv_proj
+    proj_name = layer_name.split(".")[-1]
+
+    # Fused layers like gate_up_proj or qkv_proj will not be fused
+    # in the safetensors checkpoint. So, we convert the name
+    # from the fused version to unfused + check to make sure that
+    # each shard of the fused layer has the same scheme.
+    if proj_name in fused_mapping:
+        shard_proj_names = fused_mapping[proj_name]
+
+        # Convert fused_name --> [shard_names]
+        shard_names = [
+            layer_name.replace(proj_name, shard_proj_name)
+            for shard_proj_name in shard_proj_names
+        ]
+
+        # Layer should be ignored if shards are ignored.
+        should_ignore_layer = None
+        for shard_name in shard_names:
+            should_ignore_shard = check_equal_or_regex_match(
+                layer_name=shard_name, targets=ignore)
+
+            # If shard_idx=0, set layer ignore to match shard.
+            if should_ignore_layer is None:
+                should_ignore_layer = should_ignore_shard
+
+            # If shard_idx=1+ confirm scheme matches prior shards.
+            elif should_ignore_shard != should_ignore_layer:
+                raise ValueError(f"Found a different quantization schemes for "
+                                 f"{shard_proj_names} in {layer_name}. vLLM "
+                                 "requires all to use the same scheme.")
+
+    # Unfused layers like down_proj and o_proj will match
+    # the safetensors checkpoint already.
+    else:
+        should_ignore_layer = check_equal_or_regex_match(layer_name=layer_name,
+                                                         targets=ignore)
+
+    assert should_ignore_layer is not None
+    return should_ignore_layer
+
+
+def check_equal_or_regex_match(layer_name: str,
+                               targets: Iterable[str]) -> bool:
+    """
+    Checks whether a layer_name is exactly equal or a regex match for 
+    if target starts with 're:' to any target in list.
+    """
+    for target in targets:
+        if _is_equal_or_regex_match(layer_name, target):
+            return True
+    return False
+
+
+def _is_equal_or_regex_match(value: str,
+                             target: str,
+                             check_contains: bool = False) -> bool:
+    """
+    Checks whether a value is exactly equal or a regex match for target
+    if target starts with 're:'. If check_contains is set to True,
+    additionally checks if the target string is contained within the value.
+    """
+
+    if target.startswith("re:"):
+        pattern = target[3:]
+        if re.match(pattern, value):
+            return True
+    elif check_contains:
+        if target.lower() in value.lower():
+            return True
+    elif target == value:
+        return True
+    return False

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -21,7 +21,7 @@ def deep_compare(dict1: Any, dict2: Any) -> bool:
 def should_ignore_layer(
     layer_name: Optional[str],
     ignore: Iterable[str],
-    fused_mapping: Mapping[str, List[str]] = MappingProxyType({})
+    fused_mapping: Mapping[str, List[str]] = MappingProxyType({}),
 ) -> bool:
     if layer_name is None:
         return False
@@ -47,7 +47,8 @@ def should_ignore_layer(
         should_ignore_layer = None
         for shard_name in shard_names:
             should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore)
+                layer_name=shard_name, targets=ignore
+            )
 
             # If shard_idx=0, set layer ignore to match shard.
             if should_ignore_layer is None:
@@ -55,24 +56,26 @@ def should_ignore_layer(
 
             # If shard_idx=1+ confirm scheme matches prior shards.
             elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(f"Found a different quantization schemes for "
-                                 f"{shard_proj_names} in {layer_name}. vLLM "
-                                 "requires all to use the same scheme.")
+                raise ValueError(
+                    f"Found a different quantization schemes for "
+                    f"{shard_proj_names} in {layer_name}. vLLM "
+                    "requires all to use the same scheme."
+                )
 
     # Unfused layers like down_proj and o_proj will match
     # the safetensors checkpoint already.
     else:
-        should_ignore_layer = check_equal_or_regex_match(layer_name=layer_name,
-                                                         targets=ignore)
+        should_ignore_layer = check_equal_or_regex_match(
+            layer_name=layer_name, targets=ignore
+        )
 
     assert should_ignore_layer is not None
     return should_ignore_layer
 
 
-def check_equal_or_regex_match(layer_name: str,
-                               targets: Iterable[str]) -> bool:
+def check_equal_or_regex_match(layer_name: str, targets: Iterable[str]) -> bool:
     """
-    Checks whether a layer_name is exactly equal or a regex match for 
+    Checks whether a layer_name is exactly equal or a regex match for
     if target starts with 're:' to any target in list.
     """
     for target in targets:
@@ -81,9 +84,9 @@ def check_equal_or_regex_match(layer_name: str,
     return False
 
 
-def _is_equal_or_regex_match(value: str,
-                             target: str,
-                             check_contains: bool = False) -> bool:
+def _is_equal_or_regex_match(
+    value: str, target: str, check_contains: bool = False
+) -> bool:
     """
     Checks whether a value is exactly equal or a regex match for target
     if target starts with 're:'. If check_contains is set to True,

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -491,6 +491,14 @@ class LlamaForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
+
+            #QuaRot - temporary
+            if "zero_point" in name:
+                continue
+
+            if ".module" in name:
+                name=name.replace(".module","")
+
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -492,13 +492,6 @@ class LlamaForCausalLM(nn.Module):
 
         for name, loaded_weight in weights:
 
-            #QuaRot - temporary
-            if "zero_point" in name:
-                continue
-
-            if ".module" in name:
-                name=name.replace(".module","")
-
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:

--- a/sgl-kernel/csrc/fht/FHT.cu
+++ b/sgl-kernel/csrc/fht/FHT.cu
@@ -1,0 +1,191 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <hip/hip_bf16.h>
+#include <torch/all.h>
+
+#include <cmath>
+#include <vector>
+
+#include "FHT.h"
+#include "fast_hadamard_transform_common.h"
+
+using input_t = __hip_bfloat16;
+
+#define CHECK_SHAPE(x, ...) \
+  TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
+
+void set_hadamard_params(
+    HadamardParamsBase& params,
+    // sizes
+    const size_t batch,
+    const size_t dim,
+    const size_t multiple,
+    // device pointers
+    const at::Tensor x,
+    const at::Tensor out,
+    float scale) {
+  // Reset the parameters
+  memset(&params, 0, sizeof(params));
+
+  params.batch = batch;
+  params.dim = dim;
+  params.log_N = int(ceil(std::log2(dim / multiple)));
+
+  // Set the pointers and strides.
+  params.x_ptr = x.data_ptr();
+  params.out_ptr = out.data_ptr();
+  // All stride are in elements, not bytes.
+  params.x_batch_stride = x.stride(0);
+  params.out_batch_stride = out.stride(0);
+
+  params.scale = scale;
+}
+
+template <int kNThreads_, int kLogN_, typename input_t_>
+struct fast_hadamard_transform_kernel_traits {
+  using input_t = input_t_;
+  static constexpr int kNThreads = kNThreads_;
+  static constexpr int kLogN = kLogN_;
+  static constexpr int N = 1 << kLogN;
+  static constexpr int kNBytes = sizeof(input_t);
+  static_assert(kNBytes == 2 || kNBytes == 4);
+  static constexpr int kNElts = kLogN == 9 ? 8 : 16;  // kNBytes == 4 ? 4 : 8;
+  // It's possible that we need to do 2 rounds of exchange if input_t is 16 bits
+  // (since then we'd have 8 values of float, and each round we can exchange 4
+  // floats).
+  static constexpr int kNExchangePerVec = sizeof(float) / sizeof(input_t);
+  using vec_t = typename BytesToType<kNBytes * kNElts>::Type;
+  static constexpr int kNChunks = N / (kNElts * kNThreads);
+  // We don't want to use more than 32 KB of shared memory.
+  static constexpr int kSmemExchangeSize = N * 4;  // std::min(N * 4, 32 *
+                                                   // 1024);
+  static constexpr int kNExchangeRounds = N * 4 / kSmemExchangeSize;
+  static_assert(kNExchangeRounds * kSmemExchangeSize == N * 4);
+  static constexpr int kSmemSize = kSmemExchangeSize;
+};
+
+template <typename Ktraits>
+__global__ __launch_bounds__(Ktraits::kNThreads) void fast_hadamard_transform_kernel(HadamardParamsBase params) {
+  constexpr int kNThreads = Ktraits::kNThreads;
+  constexpr int kNElts = Ktraits::kNElts;
+  constexpr int kNExchangePerVec = Ktraits::kNExchangePerVec;
+  constexpr int kNExchangeRounds = Ktraits::kNExchangeRounds;
+  constexpr int kNChunks = Ktraits::kNChunks;
+  using input_t = typename Ktraits::input_t;
+  using vec_t = typename Ktraits::vec_t;
+
+  constexpr int kLogNElts = cilog2(Ktraits::kNElts);
+  static_assert(1 << kLogNElts == kNElts, "kNElts must be a power of 2");
+  constexpr int kWarpSize = 64;  // std::min(kNThreads, 32);
+  constexpr int kLogWarpSize = cilog2(kWarpSize);
+  static_assert(1 << kLogWarpSize == kWarpSize, "Warp size must be a power of 2");
+  constexpr int kNWarps = kNThreads / kWarpSize;
+  constexpr int kLogNWarps = cilog2(kNWarps);
+  static_assert(1 << kLogNWarps == kNWarps, "kNWarps must be a power of 2");
+  constexpr int kLoadsPerExchange = Ktraits::kSmemExchangeSize / (sizeof(vec_t) * kNThreads);
+  static_assert(
+      kLoadsPerExchange * sizeof(vec_t) * kNThreads == Ktraits::kSmemExchangeSize,
+      "kSmemExchangeSize should be a power of 2");
+  static_assert(kNExchangeRounds * kLoadsPerExchange * sizeof(vec_t) == kNChunks * kNElts * sizeof(float));
+
+  constexpr int kChunksPerExchange = Ktraits::kSmemExchangeSize / (sizeof(vec_t) * kNExchangePerVec * kNThreads);
+  static_assert(kChunksPerExchange * sizeof(vec_t) * kNExchangePerVec * kNThreads == Ktraits::kSmemExchangeSize);
+  constexpr int kNExchanges = kNChunks / kChunksPerExchange;
+  static_assert(kNExchanges * kChunksPerExchange == kNChunks);
+
+  // Shared memory.
+  extern __shared__ char smem_[];
+  vec_t* smem_exchange = reinterpret_cast<vec_t*>(smem_);
+
+  const int batch_id = blockIdx.x;
+  input_t* x = reinterpret_cast<input_t*>(params.x_ptr) + batch_id * params.x_batch_stride;
+  input_t* out = reinterpret_cast<input_t*>(params.out_ptr) + batch_id * params.out_batch_stride;
+
+  float x_vals[kNChunks][kNElts];
+  load_input<kNChunks, kNElts, input_t>(x, x_vals, params.dim);
+
+  hadamard_mult_thread<kLogNElts, kNChunks>(x_vals);
+  hadamard_mult_warp<kWarpSize, kLogWarpSize, 0, kNChunks, kNElts>(x_vals);  //<- this is the problem - works for
+                                                                             //<5,0,2,8> but not for <5,0,28,4>
+
+  if constexpr (kNWarps > 1) {
+    exchange_smem_pre<kNChunks, kChunksPerExchange, kNElts, kWarpSize, kNWarps, true, vec_t>(x_vals, smem_exchange);
+    hadamard_mult_warp<kWarpSize, kLogNWarps, 0, kNChunks, kNElts>(x_vals);
+    exchange_smem_pre<kNChunks, kChunksPerExchange, kNElts, kWarpSize, kNWarps, false, vec_t>(x_vals, smem_exchange);
+  }
+
+  if constexpr (kNChunks > 1) {
+    float x_vals_transposed[kNElts][kNChunks];
+#pragma unroll
+    for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        x_vals_transposed[i][c] = x_vals[c][i];
+      }
+    }
+
+    if constexpr (kNChunks == 28) {
+      hadamard_mult_thread_chunk_28<kNElts>(x_vals_transposed);
+    } else {
+      constexpr int kLogNChunks = cilog2(kNChunks);
+      static_assert(1 << kLogNChunks == kNChunks, "kNChunks must be a power of 2");
+      hadamard_mult_thread<kLogNChunks, kNElts>(x_vals_transposed);
+    }
+
+#pragma unroll
+    for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+      for (int i = 0; i < kNElts; ++i) {
+        x_vals[c][i] = x_vals_transposed[i][c];
+      }
+    }
+  }
+
+  store_output<kNChunks, kNElts, input_t>(out, x_vals, params.dim, params.scale);
+}
+
+template <int kNThreads, int kLogN, typename input_t>
+void fast_hadamard_transform_launch(HadamardParamsBase& params, cudaStream_t stream) {
+  using Ktraits = fast_hadamard_transform_kernel_traits<kNThreads, kLogN, input_t>;
+  constexpr int kSmemSize = Ktraits::kSmemSize;
+
+  dim3 grid(params.batch);
+  auto kernel = &fast_hadamard_transform_kernel<Ktraits>;
+  kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+at::Tensor fast_hadamard_transform(at::Tensor& x, double scale) {
+  // NOTE: reshape and get batch_size
+  const auto shapes_og = x.sizes();
+  const int dim_og = x.size(-1);
+  x = x.reshape({-1, dim_og});
+  if (x.stride(-1) != 1) {
+    x = x.contiguous();
+  }
+  const auto sizes = x.sizes();
+  const int batch_size = sizes[0];
+
+  // NOTE: mystery checks
+  CHECK_SHAPE(x, batch_size, dim_og);
+  TORCH_CHECK(x.stride(1) == 1);
+
+  // NOTE: get dim
+  const int dim = x.size(1);
+
+  // NOTE: get output tensor
+  at::Tensor out = torch::empty_like(x);
+
+  // NOTE: construct params
+  HadamardParamsBase params;
+  set_hadamard_params(params, batch_size, dim, 1, x, out, static_cast<float>(scale));
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  if (dim_og == 512) {
+    fast_hadamard_transform_launch<64, 9, input_t>(params, stream);
+  } else if (dim_og == 1024) {
+    fast_hadamard_transform_launch<64, 10, input_t>(params, stream);
+  }
+
+  return out.reshape(shapes_og);
+}

--- a/sgl-kernel/csrc/fht/FHT.h
+++ b/sgl-kernel/csrc/fht/FHT.h
@@ -1,0 +1,34 @@
+/******************************************************************************
+ * Copyright (c) 2023, Tri Dao.
+ ******************************************************************************/
+
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct HadamardParamsBase {
+  using index_t = int64_t;
+
+  int batch, dim, log_N;
+
+  index_t x_batch_stride;
+  index_t out_batch_stride;
+
+  float scale;
+
+  // Common data pointers.
+  void* __restrict__ x_ptr;
+  void* __restrict__ out_ptr;
+
+  // Print method
+  void print() const {
+    std::cout << "batch: " << batch << std::endl;
+    std::cout << "dim: " << dim << std::endl;
+    std::cout << "log_N: " << log_N << std::endl;
+    std::cout << "x_batch_stride: " << x_batch_stride << std::endl;
+    std::cout << "out_batch_stride: " << out_batch_stride << std::endl;
+    std::cout << "scale: " << scale << std::endl;
+    std::cout << "x_ptr: " << x_ptr << std::endl;
+    std::cout << "out_ptr: " << out_ptr << std::endl;
+  }
+};

--- a/sgl-kernel/csrc/fht/fast_hadamard_transform_common.h
+++ b/sgl-kernel/csrc/fht/fast_hadamard_transform_common.h
@@ -1,0 +1,192 @@
+/******************************************************************************
+ * Copyright (c) 2023, Tri Dao.
+ ******************************************************************************/
+
+#pragma once
+
+#define HIP_ENABLE_WARP_SYNC_BUILTINS
+
+#include <ATen/ATen.h>
+#include <ATen/ScalarType.h>
+#include <hip/amd_detail/amd_warp_functions.h>
+#include <hip/hip_runtime.h>
+
+#define FULL_MASK 0xffffffff
+
+const unsigned long long AllThreads = ~0;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct uint8 {
+  uint4 u;
+  uint4 v;
+};
+
+template <int BYTES>
+struct BytesToType {};
+
+template <>
+struct BytesToType<32> {
+  using Type = uint8;
+  static_assert(sizeof(Type) == 32);
+};
+
+template <>
+struct BytesToType<16> {
+  using Type = uint4;
+  static_assert(sizeof(Type) == 16);
+};
+
+template <>
+struct BytesToType<8> {
+  using Type = uint64_t;
+  static_assert(sizeof(Type) == 8);
+};
+
+template <>
+struct BytesToType<4> {
+  using Type = uint32_t;
+  static_assert(sizeof(Type) == 4);
+};
+
+template <>
+struct BytesToType<2> {
+  using Type = uint16_t;
+  static_assert(sizeof(Type) == 2);
+};
+
+template <>
+struct BytesToType<1> {
+  using Type = uint8_t;
+  static_assert(sizeof(Type) == 1);
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// https://stackoverflow.com/questions/35311711/whats-the-right-way-to-compute-integral-base-2-logarithms-at-compile-time
+constexpr int cilog2(int val) {
+  return val > 0 ? 1 + cilog2(val >> 1) : -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int kLogN, int kNChunks>
+__device__ __forceinline__ void hadamard_mult_thread(float x[kNChunks][1 << kLogN]) {
+  constexpr int N = 1 << kLogN;
+#pragma unroll
+  for (int i = 0; i < kLogN; ++i) {
+    const int stride = 1 << i;
+#pragma unroll
+    for (int j = 0; j < N / 2; ++j) {
+      const int lo = j & (stride - 1);
+      const int idx = (j - lo) * 2 + lo;
+#pragma unroll
+      for (int c = 0; c < kNChunks; ++c) {
+        const float a = x[c][idx];
+        const float b = x[c][idx + stride];
+        x[c][idx] = a + b;
+        x[c][idx + stride] = a - b;
+      }
+    }
+  }
+}
+
+template <int N, int kLogWarpSize, int kStepStart, int kNChunks, int kNItems>
+__device__ __forceinline__ void hadamard_mult_warp(float x[kNChunks][kNItems]) {
+  // constexpr int N = 1 << kLogWarpSize;
+  int lane_id = threadIdx.x % N;
+#pragma unroll
+  for (int step = kStepStart; step < kLogWarpSize; ++step) {
+    const int lane_mask = 1 << step;
+    const float sign = (lane_id & lane_mask) ? -1.f : 1.f;
+#pragma unroll
+    for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+      for (int i = 0; i < kNItems; ++i) {
+        int srcLane = lane_id ^ lane_mask;
+        float x_val_other = __shfl(x[c][i], srcLane);  // source lane = current_lane XOR lane_mask
+        // float x_val_other = __shfl_xor_sync(FULL_MASK, x[c][i], lane_mask);
+        x[c][i] = sign * x[c][i] + x_val_other;
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int kNChunks, int kNElts, typename input_t>
+inline __device__ void load_input(input_t* x, float x_vals[kNChunks][kNElts], int dim) {
+  using vec_t = typename BytesToType<sizeof(input_t) * kNElts>::Type;
+  input_t x_vals_load[kNChunks][kNElts] = {0};
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+    if ((c * blockDim.x + threadIdx.x) * kNElts < dim) {
+      reinterpret_cast<vec_t*>(x_vals_load)[c] = reinterpret_cast<const vec_t*>(x)[c * blockDim.x + threadIdx.x];
+    }
+  }
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+    for (int i = 0; i < kNElts; ++i) {
+      x_vals[c][i] = float(x_vals_load[c][i]);
+    }
+  }
+}
+
+template <int kNChunks, int kNElts, typename output_t>
+inline __device__ void store_output(output_t* out, float out_vals[kNChunks][kNElts], int dim, float scale = 1.f) {
+  using vec_t = typename BytesToType<sizeof(output_t) * kNElts>::Type;
+  output_t out_vals_store[kNChunks][kNElts];
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+#pragma unroll
+    for (int i = 0; i < kNElts; ++i) {
+      out_vals_store[c][i] = out_vals[c][i] * scale;
+    }
+  }
+#pragma unroll
+  for (int c = 0; c < kNChunks; ++c) {
+    if ((c * blockDim.x + threadIdx.x) * kNElts < dim) {
+      reinterpret_cast<vec_t*>(out)[c * blockDim.x + threadIdx.x] = reinterpret_cast<const vec_t*>(out_vals_store)[c];
+    }
+  }
+}
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Pre=true means the exchange before the hadamard_mult_warp, Pre=false means
+// after.
+template <int kNChunks, int kChunksPerExchange, int kNElts, int kWarpSize, int kNWarps, bool Pre, typename vec_t>
+inline __device__ void exchange_smem_pre(float x_vals[kNChunks][kNElts], vec_t* smem) {
+  constexpr int kNThreads = kWarpSize * kNWarps;
+  constexpr int kNExchangePerVec = kNElts / (sizeof(vec_t) / sizeof(float));
+  const int warp_id = threadIdx.x / kWarpSize;
+  const int lane_id = threadIdx.x % kWarpSize;
+  const int row_t = threadIdx.x % kNWarps;
+  const int col_t = threadIdx.x / kNWarps;
+// We use the XOR swizzle trick (new_col = col ^ row) to avoid / reduce smem
+// bank conflicts.
+#pragma unroll
+  for (int c0 = 0; c0 < kNChunks / kChunksPerExchange; ++c0) {
+    __syncthreads();
+#pragma unroll
+    for (int c1 = 0; c1 < kChunksPerExchange; ++c1) {
+#pragma unroll
+      for (int r = 0; r < kNExchangePerVec; ++r) {
+        smem
+            [(c1 * kNExchangePerVec + r) * kNThreads +
+             (Pre ? warp_id * kWarpSize + lane_id ^ warp_id : row_t * kWarpSize + col_t ^ row_t)] =
+                reinterpret_cast<vec_t*>(x_vals[c0 * kChunksPerExchange + c1])[r];
+      }
+    }
+    __syncthreads();
+#pragma unroll
+    for (int c1 = 0; c1 < kChunksPerExchange; ++c1) {
+#pragma unroll
+      for (int r = 0; r < kNExchangePerVec; ++r) {
+        reinterpret_cast<vec_t*>(x_vals[c0 * kChunksPerExchange + c1])[r] = smem
+            [(c1 * kNExchangePerVec + r) * kNThreads +
+             (Pre ? row_t * kWarpSize + col_t ^ row_t : warp_id * kWarpSize + lane_id ^ warp_id)];
+      }
+    }
+  }
+}

--- a/sgl-kernel/csrc/torch_extension_rocm.cc
+++ b/sgl-kernel/csrc/torch_extension_rocm.cc
@@ -81,6 +81,12 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
       "Tensor! tree_mask, Tensor! positions, Tensor! retrive_index, Tensor! retrive_next_token, "
       "Tensor! retrive_next_sibling, int topk, int depth, int draft_token_num) -> ()");
   m.impl("build_tree_kernel_efficient", torch::kCUDA, &build_tree_kernel_efficient);
+
+  /*
+   * From csrc/fht
+   */
+  m.def("fast_hadamard_transform(Tensor x, float scale) -> Tensor");
+  m.impl("fast_hadamard_transform", torch::kCUDA, &fast_hadamard_transform);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -55,6 +55,7 @@ fptr_t init_custom_ar(
 void all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out);
 void all_reduce_unreg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& reg_buffer, torch::Tensor& out);
 void dispose(fptr_t _fa);
+at::Tensor fast_hadamard_transform(at::Tensor& x, double scale);
 int64_t meta_size();
 void register_buffer(
     fptr_t _fa, torch::Tensor& t, const std::vector<std::string>& handles, const std::vector<int64_t>& offsets);
@@ -68,6 +69,7 @@ torch::Tensor get_meta_buffer_ipc_handle(torch::Tensor& inp);
 fptr_t
 init_custom_ar(const std::vector<fptr_t>& fake_ipc_ptrs, torch::Tensor& rank_data, int64_t rank, bool full_nvlink);
 void dispose(fptr_t _fa);
+at::Tensor fast_hadamard_transform(at::Tensor& x, double scale);
 int64_t meta_size();
 void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out, fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes);
 std::tuple<std::vector<int64_t>, std::vector<int64_t>> get_graph_buffer_ipc_meta(fptr_t _fa);

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -41,6 +41,7 @@ sources = [
     "csrc/moe/moe_topk_softmax_kernels.cu",
     "csrc/torch_extension_rocm.cc",
     "csrc/speculative/eagle_utils.cu",
+    "csrc/fht/FHT.cu",
 ]
 
 cxx_flags = ["-O3"]

--- a/test/srt/test_online_rotation.py
+++ b/test/srt/test_online_rotation.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test the Hadamard Transform used in online rotations for outlier reduction.
+
+Run `pytest tests/quantization/test_online_rotation.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+import ray
+import torch
+
+import sglang.srt.distributed.parallel_state as parallel_state
+import sglang.srt.layers.quantization.quark.schemes as schemes
+from sglang.srt.utils import get_open_port
+
+init_distributed_environment = parallel_state.init_distributed_environment
+ensure_model_parallel_initialized = parallel_state.ensure_model_parallel_initialized
+hadamard_transform = schemes.hadamard_transform
+hadamard_sizes = hadamard_transform.hadamard_sizes
+hadamard_transform_registry = hadamard_transform.hadamard_transform_registry
+
+
+def multi_process_parallel(
+    world_size: int,
+    cls: Any,
+    test_target: Any,
+) -> None:
+
+    # Using ray helps debugging the error when it failed
+    # as compared to multiprocessing.
+    # NOTE: We need to set working_dir for distributed tests,
+    # otherwise we may get import errors on ray workers
+
+    ray.init(log_to_driver=True)
+
+    distributed_init_port = get_open_port()
+    refs = []
+    for rank in range(world_size):
+        refs.append(test_target.remote(cls, world_size, 1, rank, distributed_init_port))
+    ray.get(refs)
+
+    ray.shutdown()
+
+
+def init_test_distributed_environment(
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+    local_rank: int = -1,
+) -> None:
+    distributed_init_method = f"tcp://localhost:{distributed_init_port}"
+    init_distributed_environment(
+        world_size=pp_size * tp_size,
+        rank=rank,
+        distributed_init_method=distributed_init_method,
+        local_rank=local_rank,
+    )
+    ensure_model_parallel_initialized(tp_size, pp_size)
+
+
+@ray.remote(num_gpus=1, max_calls=1)
+def test_quarot_r4(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    pp_size: int,
+    rank: int,
+    distributed_init_port: str,
+):
+    # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
+    # so that each worker can see all the GPUs
+    # they will be able to set the device to the correct GPU
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+
+    hadamard_transform = hadamard_transform_registry["quarot_r4"]
+    from types import SimpleNamespace
+
+    input_size = 14336
+    dummylayer = SimpleNamespace(
+        weight=torch.Tensor([0]).to(device).bfloat16(),
+        input_size_per_partition=input_size // tp_size,
+        input_size=input_size,
+    )
+    rotation_function = hadamard_transform(layer=dummylayer)
+    """TP: Perform rotation function on activation shard - bfloat16"""
+    activation = torch.ones(2, input_size, device=device).bfloat16()
+    isye = input_size // tp_size
+    activation_shard = activation[:, rank * (isye) : (rank + 1) * (isye)]
+    activation_shard = activation_shard.contiguous().to(device)
+    rotated_activation_shard = rotation_function(activation_shard)
+    """Uniproc: Perform rotation function on entire activation - bfloat16"""
+    activation = torch.ones(2, input_size, device=device).bfloat16()
+    og_shape = activation.shape
+    X = activation.view(-1, rotation_function.chunk_size)
+    X = rotation_function.FHT(X, rotation_function.scale)
+    print(X)
+    X = X.view(
+        -1, rotation_function.hadamard_k.input_size, rotation_function.chunk_size
+    )
+    X = hadamard_sizes[rotation_function.k].to(device).bfloat16() @ X
+    X = X.view(og_shape)
+    X_shard = X[
+        :, rank * (input_size // tp_size) : (rank + 1) * (input_size // tp_size)
+    ]
+    """Validate the Tensor Parallel output against the Uniprocessor output"""
+    # rotated_activation_shard=rotated_activation_shard[0:64,:]
+    # X_shard=X_shard[0:64,:]
+    print("Comparing:")
+    if rank == 0:
+        print("Tensor Comparison")
+        print(rotated_activation_shard)
+        print(rotated_activation_shard.shape)
+        print(X_shard)
+        print(X_shard.shape)
+    torch.testing.assert_close(rotated_activation_shard, X_shard)
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="Need at least 2 GPUs to run the test."
+)
+@pytest.mark.parametrize("tp_size", [2])
+@pytest.mark.parametrize("test_target", [test_quarot_r4])
+def test_hadamard_transform_tensor_parallel(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    test_target: Callable[..., Any],
+):
+    multi_process_parallel(tp_size, monkeypatch, test_target)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

On modern GPUs, dedicated int8 matrix-matrix multiplication hardware is prevalent, making int8 quantization of weights and activations necessary. A core limitation of quantizing weights and activations in int8 is the fact that outliers in the activations cannot be represented in the range [-128, 128] of int8. The QuaRot algorithm introduces online rotations to the activations to reduce outliers, enabling improved accuracy in int8 quantization that is close to the unquantized model.

***This work aims to bring efficient int8 quantization with improved accuracy to production by adding support for serving QuaRot models in popular inference framework SGLang.*** It supports configurability for a variety of state of the art LLMs including Llama 3 8B and 70B. This work adapts the Fast Hadamard Transform kernel from the Dao AI Lab for ROCm for efficient online rotations. For model weight quantization, it utilizes the AMD Quark framework, with its existing implementation of the QuaRot algorithm.

The perplexity of int8 quantized weights and activations drops significantly; for example Llama 3 8B drops from 210.0 to 7.1. This is all achieved with minimal performance overhead; with the online rotations incurring less than 10% end to end latency increase compared to the standard int8 quantization. This feature is fully available, ready to be used "out of the box" SGLang for Llama 8B and 70B int8 quantized models, and can be configured for additional models.

## Modifications

- `int8utils.py
	- `process_weights_after_loading` 
		- what it does: does additional processing of the weights after they are loaded from the safetensors - this involves converting them into a format compatible with the scaled matrix multiplication kernels
		- justification: because an implementation existed in mainline vLLM, but not the vLLM distribution that SGLang is built off of
	- updated code: [[_int8utils.py_]]
- `local_example_chat.py
	- simply swap out the model path, in my case I am using `rcorzine/Meta-Llama-3-8B-quark-w8a8-int8`
- `model_config.py
	- need to add quark as an option inside `rocm_supported_quantization`
	- inside `_verify_quantization`, need to remove the part "Detect which checkpoint is it" which attempts to override the quantization method
- `linear.py
	- need to add `"QuarkLinearMethod"` into `WEIGHT_LOADER_V2_SUPPORTED`
- `parameter.py
	- in the specific case where a scalar is loaded, but the expected shape is a multidimensional single element tensor, reshape it (use .view)
- `__init__.py
	- add `"quark" : QuarkConfig` to `BASE_QUANTIZATION_METHODS`
	- (this is the one inside srt/layers/quantization)
- `__init__.py
	- make a new module for quark - inside `srt/layers/quantization/quark/__init__.py`
- `quark.py
	- from vLLM, adapted to SGLang: [[_quark.py_]]
- `utils.py
	- from vLLM, adapted to SGLang: [[_utils.py_]]
- `__init__.py
	- from vLLM, adapted to SGLang: [[___init__.py_]]
- `hadamard_transform.py
	- from vLLM, adapted to SGLang: [[_hadamard_transform.py_]]
- `quark_scheme.py`
	- from vLLM, adapted to SGLang: [[_quark_scheme.py_]]
- `quark_w8a8_int8.py`
	- from vLLM, adapted to SGlang: [[_quark_w8a8_int8.py_]]
- `llama.py`
	- in this case, what is needed is, during the weight loading, to just fix the zero point issue and fix the name if it has the nested module included

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
