### PR TITLE
fix: conv template matching func misnamed

### DIFF
--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -54,7 +54,7 @@ class ChatTemplate:
 
 
 chat_template_registry: Dict[str, ChatTemplate] = {}
-matching_function_registry: List[Callable] = []
+matching_function_registry: Dict[str, Callable] = {}
 
 
 def register_chat_template(template):
@@ -62,7 +62,10 @@ def register_chat_template(template):
 
 
 def register_chat_template_matching_function(func):
-    matching_function_registry.append(func)
+    assert (
+        func.__name__ not in matching_function_registry
+    ), f"template matching function `{func.__name__}` already exists in registry"
+    matching_function_registry[func.__name__] = func
 
 
 def get_chat_template(name):
@@ -70,7 +73,7 @@ def get_chat_template(name):
 
 
 def get_chat_template_by_model_path(model_path):
-    for matching_func in matching_function_registry:
+    for _, matching_func in matching_function_registry.items():
         template = matching_func(model_path)
         if template is not None:
             return template

--- a/python/sglang/srt/conversation.py
+++ b/python/sglang/srt/conversation.py
@@ -418,7 +418,7 @@ class Conversation:
 
 # A global registry for all conversation templates
 chat_templates: Dict[str, Conversation] = {}
-matching_function_registry: List[Callable] = []
+matching_function_registry: Dict[str, Callable] = {}
 
 
 def register_conv_template(template: Conversation, override: bool = False):
@@ -431,12 +431,16 @@ def register_conv_template(template: Conversation, override: bool = False):
     chat_templates[template.name] = template
 
 
-def register_conv_template_matching_function(func):
-    matching_function_registry.append(func)
+def register_conv_template_matching_function(func, override: bool = False):
+    if not override:
+        assert (
+            func.__name__ not in matching_function_registry
+        ), f"template matching function `{func.__name__}` already exists in registry"
+    matching_function_registry[func.__name__] = func
 
 
-def get_conv_template_by_model_path(model_path):
-    for matching_func in matching_function_registry:
+def get_conv_template_by_model_path(model_path: str) -> Optional[str]:
+    for _, matching_func in matching_function_registry.items():
         conv_name = matching_func(model_path)
         if conv_name is not None:
             return conv_name

--- a/python/sglang/srt/conversation.py
+++ b/python/sglang/srt/conversation.py
@@ -853,7 +853,7 @@ register_conv_template(
 
 
 @register_conv_template_matching_function
-def match_deepseek_janus_pro(model_path: str):
+def match_llama3_vision(model_path: str):
     if (
         "llama" in model_path.lower()
         and "3.2" in model_path.lower()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

A conversation template matching function isn't named correctly. Although the program logic is still correct, it is best to avoid confusion.

## Modifications


## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
