### PR TITLE
Fix set kv cache multi-stream

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -374,9 +374,9 @@ class MHATokenToKVPool(KVCache):
             # Overlap the copy of K and V cache for small batch size
             current_stream = self.device_module.current_stream()
             self.alt_stream.wait_stream(current_stream)
+            self.k_buffer[layer_id - self.start_layer][loc] = cache_k
             with self.device_module.stream(self.alt_stream):
-                self.k_buffer[layer_id - self.start_layer][loc] = cache_k
-            self.v_buffer[layer_id - self.start_layer][loc] = cache_v
+                self.v_buffer[layer_id - self.start_layer][loc] = cache_v
             current_stream.wait_stream(self.alt_stream)
         else:
             self.k_buffer[layer_id - self.start_layer][loc] = cache_k


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

In the original order, many additional streams are created, which may introduce overhead. In the new order, the alternate stream is reused.

### Performance
```bash
python3 -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --tp 1 --disable-radix
python3 -m sglang.bench_one_batch_server --model None --base-url http://0.0.0.0:30000 --batch-size 1 --input-len 512 --output-len 512

# main branch
batch size: 1
latency: 3.50 s
output throughput: 146.21 token/s
(input + output) throughput: 292.42 token/s

# this PR
batch size: 1
latency: 3.50 s
output throughput: 146.44 token/s
(input + output) throughput: 292.89 token/s
```

### Profile
main branch:
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/66dce2d4-86b1-4086-a3a7-d3cf5b97addc" />

this PR:
<img width="1102" alt="image" src="https://github.com/user-attachments/assets/c95f151f-613b-4dae-8d8b-95bd900531e1" />

