### PR TITLE
Overlap qk norm with two streams

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -712,7 +712,7 @@ class DeepseekV2AttentionMLA(nn.Module):
             k_nope = latent_cache[..., : self.kv_lora_rank]
 
             # overlap qk norm
-            if torch.cuda.is_current_stream_capturing():
+            if self.alt_stream is not None and torch.cuda.is_current_stream_capturing():
                 current_stream = torch.cuda.current_stream()
                 self.alt_stream.wait_stream(current_stream)
                 q = self.q_a_layernorm(q)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Overlap qk rms norm with two streams in cuda graph.

### Accuracy
```
Accuracy: 0.944
Invalid: 0.000
Latency: 139.713 s
Output throughput: 1033.580 token/s
```
### Performance
main branch:
```
batch size: 1
latency: 6.60 s
output throughput: 77.61 token/s
(input + output) throughput: 155.22 token/s

batch size: 32
latency: 12.69 s
output throughput: 1291.49 token/s
(input + output) throughput: 2582.98 token/s

batch size: 64
latency: 14.97 s
output throughput: 2188.51 token/s
(input + output) throughput: 4377.03 token/s

batch size: 160
latency: 21.24 s
output throughput: 3856.39 token/s
(input + output) throughput: 7712.77 token/s
```
this PR:
```
batch size: 1
latency: 6.57 s
output throughput: 77.91 token/s
(input + output) throughput: 155.82 token/s

batch size: 32
latency: 11.89 s
output throughput: 1377.47 token/s
(input + output) throughput: 2754.95 token/s

batch size: 64
latency: 14.64 s
output throughput: 2238.02 token/s
(input + output) throughput: 4476.03 token/s

batch size: 160
latency: 20.79 s
output throughput: 3941.00 token/s
(input + output) throughput: 7882.01 token/s
```

### Profile
main branch:
<img width="688" alt="image" src="https://github.com/user-attachments/assets/0e81b3fa-62ba-4736-a0ad-7c7e43c64c89" />

this PR:
<img width="656" alt="image" src="https://github.com/user-attachments/assets/a13da0fa-9fa9-42d5-a4b0-a54d57d066cf" />

23.9μm -> 21.5μm

