### PR TITLE
fix: Fix "AttributeError: 'MHATokenToKVPoolHost' object has no attribute 'start_layer'"

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -952,7 +952,7 @@ class MHATokenToKVPoolHost(HostKVCache):
         return self.kv_buffer[:, :, indices]
 
     def get_flat_data_by_layer(self, indices, layer_id):
-        return self.kv_buffer[:, layer_id - self.start_layer, indices]
+        return self.kv_buffer[:, layer_id - self.device_pool.start_layer, indices]
 
     def assign_flat_data(self, indices, flat_data):
         self.kv_buffer[:, :, indices] = flat_data
@@ -977,19 +977,19 @@ class MHATokenToKVPoolHost(HostKVCache):
         for i in range(len(device_indices_cpu)):
             h_index = host_indices[i * self.page_size]
             d_index = device_indices_cpu[i]
-            device_pool.k_buffer[layer_id - self.start_layer][
+            device_pool.k_buffer[layer_id - self.device_pool.start_layer][
                 d_index : d_index + self.page_size
             ].copy_(
                 self.kv_buffer[
-                    0, layer_id - self.start_layer, h_index : h_index + self.page_size
+                    0, layer_id - self.device_pool.start_layer, h_index : h_index + self.page_size
                 ],
                 non_blocking=True,
             )
-            device_pool.v_buffer[layer_id - self.start_layer][
+            device_pool.v_buffer[layer_id - self.device_pool.start_layer][
                 d_index : d_index + self.page_size
             ].copy_(
                 self.kv_buffer[
-                    1, layer_id - self.start_layer, h_index : h_index + self.page_size
+                    1, layer_id - self.device_pool.start_layer, h_index : h_index + self.page_size
                 ],
                 non_blocking=True,
             )
@@ -1045,7 +1045,7 @@ class MLATokenToKVPoolHost(HostKVCache):
         return self.kv_buffer[:, indices]
 
     def get_flat_data_by_layer(self, indices, layer_id):
-        return self.kv_buffer[layer_id - self.start_layer, indices]
+        return self.kv_buffer[layer_id - self.device_pool.start_layer, indices]
 
     def assign_flat_data(self, indices, flat_data):
         self.kv_buffer[:, indices] = flat_data
@@ -1066,11 +1066,11 @@ class MLATokenToKVPoolHost(HostKVCache):
         for i in range(len(device_indices_cpu)):
             h_index = host_indices[i * self.page_size]
             d_index = device_indices_cpu[i]
-            device_pool.kv_buffer[layer_id - self.start_layer][
+            device_pool.kv_buffer[layer_id - self.device_pool.start_layer][
                 d_index : d_index + self.page_size
             ].copy_(
                 self.kv_buffer[
-                    layer_id - self.start_layer, h_index : h_index + self.page_size
+                    layer_id - self.device_pool.start_layer, h_index : h_index + self.page_size
                 ],
                 non_blocking=True,
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix issue #6005 (AttributeError: 'MHATokenToKVPoolHost' object has no attribute 'start_layer' when using --enable-hierarchical-cache).

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Replaced instances of `self.start_layer` with `self.device_pool.start_layer` in both MLA and MHA `TokenToKVPoolHost` classes (`memory_controller.py`).

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
