### PR TITLE
[AMD] switch to custom allreduce regardless of MSCCL setting on ROCm

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -296,7 +296,6 @@ class CustomAllreduce:
                 self.meta, self.rank_data, handles, offsets, rank, self.full_nvlink
             )
             self.register_buffer(self.buffer)
-            self.MSCCL = os.getenv("RCCL_MSCCL_ENABLE", "1") == "1"
 
         self.disabled = False
 
@@ -430,13 +429,7 @@ class CustomAllreduce:
 
         if _is_hip:
             if self.full_nvlink:
-                if self.world_size == 8:
-                    if self.MSCCL:
-                        return False
-                    else:
-                        return inp_size < self.max_size
-                else:
-                    return inp_size < self.max_size
+                return inp_size < self.max_size
             return False
 
         return False


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
To simplify the logic of allreduce code path for message sizes < 16MB on ROCm.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

@HaiShaw 