### PR TITLE
Support precomputed multimodal features for qwen-vl models.

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -47,6 +47,7 @@ from sglang.srt.managers.io_struct import (
     EmbeddingReqInput,
     GenerateReqInput,
     GetWeightsByNameReqInput,
+    ImageDataItem,
     InitWeightsUpdateGroupReqInput,
     ReleaseMemoryOccupationReqInput,
     ResumeMemoryOccupationReqInput,
@@ -150,9 +151,9 @@ class Engine(EngineBase):
         # See also python/sglang/srt/utils.py:load_image for more details.
         image_data: Optional[
             Union[
-                List[List[Union[Image, str]]],
-                List[Union[Image, str]],
-                Union[Image, str],
+                List[List[ImageDataItem]],
+                List[ImageDataItem],
+                ImageDataItem,
             ]
         ] = None,
         return_logprob: Optional[Union[List[bool], bool]] = False,
@@ -221,9 +222,9 @@ class Engine(EngineBase):
         # See also python/sglang/srt/utils.py:load_image for more details.
         image_data: Optional[
             Union[
-                List[List[Union[Image, str]]],
-                List[Union[Image, str]],
-                Union[Image, str],
+                List[List[ImageDataItem]],
+                List[ImageDataItem],
+                ImageDataItem,
             ]
         ] = None,
         return_logprob: Optional[Union[List[bool], bool]] = False,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -40,6 +40,10 @@ class SessionParams:
     replace: Optional[bool] = None
 
 
+AudioDataItem = Union[str, Dict]
+ImageDataItem = Union[Image, str, Dict]
+
+
 @dataclass
 class GenerateReqInput:
     # The input prompt. It can be a single prompt or a batch of prompts.
@@ -55,10 +59,10 @@ class GenerateReqInput:
     # - List of lists of images (multiple images per request)
     # See also python/sglang/srt/utils.py:load_image for more details.
     image_data: Optional[
-        Union[List[List[Union[Image, str]]], List[Union[Image, str]], Union[Image, str]]
+        Union[List[List[ImageDataItem]], List[ImageDataItem], ImageDataItem]
     ] = None
     # The audio input. Like image data, it can be a file name, a url, or base64 encoded string.
-    audio_data: Optional[Union[List[str], str]] = None
+    audio_data: Optional[Union[List[AudioDataItem], AudioDataItem]] = None
     # The sampling_params. See descriptions below.
     sampling_params: Optional[Union[List[Dict], Dict]] = None
     # The request id.

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -368,12 +368,12 @@ def general_mm_embed_routine(
     input_ids: torch.Tensor,
     forward_batch: ForwardBatch,
     language_model: nn.Module,
-    image_data_embedding_func: Optional[Callable[
-        [List[MultimodalDataItem]], torch.Tensor
-    ]] = None,
-    audio_data_embedding_func: Optional[Callable[
-        [List[MultimodalDataItem]], torch.Tensor
-    ]] = None,
+    image_data_embedding_func: Optional[
+        Callable[[List[MultimodalDataItem]], torch.Tensor]
+    ] = None,
+    audio_data_embedding_func: Optional[
+        Callable[[List[MultimodalDataItem]], torch.Tensor]
+    ] = None,
     placeholder_tokens: Optional[dict[Modality, List[int]]] = None,
     **kwargs,
 ) -> torch.Tensor:

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -368,13 +368,13 @@ def general_mm_embed_routine(
     input_ids: torch.Tensor,
     forward_batch: ForwardBatch,
     language_model: nn.Module,
-    image_data_embedding_func: Callable[
+    image_data_embedding_func: Optional[Callable[
         [List[MultimodalDataItem]], torch.Tensor
-    ] = None,
-    audio_data_embedding_func: Callable[
+    ]] = None,
+    audio_data_embedding_func: Optional[Callable[
         [List[MultimodalDataItem]], torch.Tensor
-    ] = None,
-    placeholder_tokens: dict[Modality, List[int]] = None,
+    ]] = None,
+    placeholder_tokens: Optional[dict[Modality, List[int]]] = None,
     **kwargs,
 ) -> torch.Tensor:
     """
@@ -389,7 +389,6 @@ def general_mm_embed_routine(
             forwarded hidden states
 
     """
-
     assert hasattr(language_model, "get_input_embeddings")
     embed_tokens = language_model.get_input_embeddings()
     if (

--- a/python/sglang/srt/managers/multimodal_processors/base_processor.py
+++ b/python/sglang/srt/managers/multimodal_processors/base_processor.py
@@ -186,7 +186,9 @@ class BaseMultimodalProcessor(ABC):
         image_index, audio_index = 0, 0
 
         for text_part in text_parts:
-            if multimodal_tokens.image_token and multimodal_tokens.image_token.match(text_part):
+            if multimodal_tokens.image_token and multimodal_tokens.image_token.match(
+                text_part
+            ):
                 data = image_data[image_index]
                 is_video = isinstance(data, str) and data.startswith("video:")
                 estimated_frames = estimated_frames_list[image_index]
@@ -203,7 +205,9 @@ class BaseMultimodalProcessor(ABC):
                 )
                 task_info.append((Modality.IMAGE, data, frame_count_limit))
                 image_index += 1
-            elif multimodal_tokens.audio_token and multimodal_tokens.audio_token.match(text_part):
+            elif multimodal_tokens.audio_token and multimodal_tokens.audio_token.match(
+                text_part
+            ):
                 data = audio_data[audio_index]
                 futures.append(
                     self.io_executor.submit(
@@ -245,11 +249,13 @@ class BaseMultimodalProcessor(ABC):
         if image_data is None:
             image_data = []
         if isinstance(multimodal_tokens.image_token, int):
-            multimodal_tokens.image_token = re.compile(re.escape(
-                self._processor.tokenizer.convert_ids_to_tokens(
-                    multimodal_tokens.image_token
+            multimodal_tokens.image_token = re.compile(
+                re.escape(
+                    self._processor.tokenizer.convert_ids_to_tokens(
+                        multimodal_tokens.image_token
+                    )
                 )
-            ))
+            )
         else:
             multimodal_tokens.image_token = multimodal_tokens.image_token
         multimodal_tokens_pattern = multimodal_tokens.collect()

--- a/python/sglang/srt/managers/multimodal_processors/qwen_vl.py
+++ b/python/sglang/srt/managers/multimodal_processors/qwen_vl.py
@@ -1,7 +1,7 @@
 import asyncio
 import math
-from typing import Dict, List, Union
 import re
+from typing import Dict, List, Union
 
 import torch
 from PIL import Image
@@ -24,7 +24,9 @@ class Qwen2_5VLImageProcessor(SGLangBaseProcessor):
 
     def __init__(self, hf_config, server_args, _processor):
         super().__init__(hf_config, server_args, _processor)
-        self.IMAGE_TOKEN = re.compile(r"<\|vision_start\|>(?:<\|image_pad\|>)+<\|vision_end\|>")
+        self.IMAGE_TOKEN = re.compile(
+            r"<\|vision_start\|>(?:<\|image_pad\|>)+<\|vision_end\|>"
+        )
         self.IM_START_TOKEN_ID = hf_config.vision_start_token_id
         self.IM_END_TOKEN_ID = hf_config.vision_end_token_id
         self.image_token_id = hf_config.image_token_id
@@ -119,10 +121,12 @@ class Qwen2_5VLImageProcessor(SGLangBaseProcessor):
             return resize_image(image)
 
         using_precomputed_features = base_output.images and any(
-            isinstance(image, MultimodalDataItem) for image in base_output.images)
+            isinstance(image, MultimodalDataItem) for image in base_output.images
+        )
 
         if using_precomputed_features and not all(
-                isinstance(image, MultimodalDataItem) for image in base_output.images):
+            isinstance(image, MultimodalDataItem) for image in base_output.images
+        ):
             raise ValueError("Unsupported mixture of images and precomputed MM data.")
 
         if base_output.images and not using_precomputed_features:
@@ -141,12 +145,18 @@ class Qwen2_5VLImageProcessor(SGLangBaseProcessor):
         if base_output.images:
             if using_precomputed_features:
                 pixel_values = None
-                image_grid_thw = torch.concat([
-                    torch.as_tensor(item.image_grid_thws) for item in base_output.images
-                ])
-                precomputed_features = torch.concat([
-                    torch.as_tensor(item.precomputed_features) for item in base_output.images
-                ])
+                image_grid_thw = torch.concat(
+                    [
+                        torch.as_tensor(item.image_grid_thws)
+                        for item in base_output.images
+                    ]
+                )
+                precomputed_features = torch.concat(
+                    [
+                        torch.as_tensor(item.precomputed_features)
+                        for item in base_output.images
+                    ]
+                )
             else:
                 pixel_values = ret["pixel_values"]
                 image_grid_thw = ret["image_grid_thw"]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -259,27 +259,23 @@ class MultimodalDataItem:
         self.pad_value = self.hash % (1 << 30)
 
     def is_audio(self):
-        return (
-            self.modality == Modality.AUDIO
-        ) and (
-            self.precomputed_features is not None or
-            not MultimodalDataItem.is_empty_list(self.audio_features)
+        return (self.modality == Modality.AUDIO) and (
+            self.precomputed_features is not None
+            or not MultimodalDataItem.is_empty_list(self.audio_features)
         )
 
     def is_image(self):
         return (
             self.modality == Modality.IMAGE or self.modality == Modality.MULTI_IMAGES
         ) and (
-            self.precomputed_features is not None or
-            not MultimodalDataItem.is_empty_list(self.pixel_values)
+            self.precomputed_features is not None
+            or not MultimodalDataItem.is_empty_list(self.pixel_values)
         )
 
     def is_video(self):
-        return (
-            self.modality == Modality.VIDEO
-        ) and (
-            self.precomputed_features is not None or
-            not MultimodalDataItem.is_empty_list(self.pixel_values)
+        return (self.modality == Modality.VIDEO) and (
+            self.precomputed_features is not None
+            or not MultimodalDataItem.is_empty_list(self.pixel_values)
         )
 
     def is_valid(self) -> bool:

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -495,7 +495,9 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         if any(item.precomputed_features is not None for item in items):
             if not all(item.precomputed_features is not None for item in items):
-                raise NotImplementedError("MM inputs where only some items are precomputed.")
+                raise NotImplementedError(
+                    "MM inputs where only some items are precomputed."
+                )
             return torch.concat([item.precomputed_features for item in items])
         # in qwen-vl, last dim is the same
         pixel_values = torch.cat([item.pixel_values for item in items], dim=0).type(

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -493,6 +493,10 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        if any(item.precomputed_features is not None for item in items):
+            if not all(item.precomputed_features is not None for item in items):
+                raise NotImplementedError("MM inputs where only some items are precomputed.")
+            return torch.concat([item.precomputed_features for item in items])
         # in qwen-vl, last dim is the same
         pixel_values = torch.cat([item.pixel_values for item in items], dim=0).type(
             self.visual.dtype

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -488,7 +488,9 @@ class Qwen2VLForConditionalGeneration(nn.Module):
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         if any(item.precomputed_features is not None for item in items):
             if not all(item.precomputed_features is not None for item in items):
-                raise NotImplementedError("MM inputs where only some items are precomputed.")
+                raise NotImplementedError(
+                    "MM inputs where only some items are precomputed."
+                )
             return torch.concat([item.precomputed_features for item in items])
         # in qwen-vl, last dim is the same
         pixel_values = torch.cat([item.pixel_values for item in items], dim=0).type(

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -486,6 +486,10 @@ class Qwen2VLForConditionalGeneration(nn.Module):
         return pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        if any(item.precomputed_features is not None for item in items):
+            if not all(item.precomputed_features is not None for item in items):
+                raise NotImplementedError("MM inputs where only some items are precomputed.")
+            return torch.concat([item.precomputed_features for item in items])
         # in qwen-vl, last dim is the same
         pixel_values = torch.cat([item.pixel_values for item in items], dim=0).type(
             self.visual.dtype


### PR DESCRIPTION
## Motivation

When running a VLM via SGLang, it's useful to be able to supply image embeddings directly. For example maybe you've frozen your vision encoder and want to precompute features, or if you're using the VLM with a custom encoder.

## Modifications

- Support passing pre-expanded image-pad tokens by matching e.g. `<|vision_start|>(<|image_pad|>)+<|vision_end|>`
- Support passing in a dicitonary with e.g.
```
{ "modality": "IMAGE",
   "image_grid_thws": <image_grid_thw>,
   "precomputed_features": <precomputed_features> }
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
