### PR TITLE
xgrammar 0.1.19

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,7 +42,7 @@ runtime_common = [
     "transformers==4.51.1",
     "uvicorn",
     "uvloop",
-    "xgrammar==0.1.17",
+    "xgrammar==0.1.19",
     "blobfile==3.0.0"
 ]
 

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -60,15 +60,22 @@ class XGrammarGrammar(BaseGrammarObject):
 
         # Fix (from vLLM team): postpone the import of apply_token_bitmask_inplace_kernels to the
         # class init site to avoid re-initializing CUDA in forked subprocess.
-        from xgrammar.kernels import apply_token_bitmask_inplace_kernels
+        try:
+            from xgrammar.kernels.apply_token_bitmask_inplace_cuda import (
+                apply_token_bitmask_inplace_cuda,
+            )
+        except ImportError:
+            apply_token_bitmask_inplace_cuda = None
+
+        from xgrammar.kernels.apply_token_bitmask_inplace_cpu import (
+            apply_token_bitmask_inplace_cpu,
+        )
 
         self.use_token_bitmask_triton = get_bool_env_var(
             "SGLANG_TOKEN_BITMASK_TRITON", "false"
         )
-        self.apply_vocab_mask_cuda = apply_token_bitmask_inplace_kernels.get(
-            "cuda", None
-        )
-        self.apply_vocab_mask_cpu = apply_token_bitmask_inplace_kernels.get("cpu", None)
+        self.apply_vocab_mask_cuda = apply_token_bitmask_inplace_cuda
+        self.apply_vocab_mask_cpu = apply_token_bitmask_inplace_cpu
 
     def accept_token(self, token: int):
         assert self.matcher.accept_token(token)


### PR DESCRIPTION
## Motivation

Support xgrammar 0.1.19 which now enforces min/max items for arrays.

## Modifications

Pin to 0.1.19 and update import strategy for bitmask kernels.
