### PR TITLE
[Feat] optimize Qwen3 on H20 by hybrid Attention Backend

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -211,9 +211,13 @@ class CudaGraphRunner:
         # Attention backend
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.num_tokens_per_bs
-        self.model_runner.decode_attn_backend.init_cuda_graph_state(self.max_num_token)
+        if self.model_runner.decode_attn_backend is None:
+            self.decode_attn_backend = self.model_runner.attn_backend
+        else:
+            self.decode_attn_backend = self.model_runner.decode_attn_backend
+        self.decode_attn_backend.init_cuda_graph_state(self.max_num_token)
         self.seq_len_fill_value = (
-            self.model_runner.decode_attn_backend.get_cuda_graph_seq_len_fill_value()
+            self.decode_attn_backend.get_cuda_graph_seq_len_fill_value()
         )
         # FIXME(lsyin): leave it here for now, I don't know whether it is necessary
         self.encoder_len_fill_value = 0
@@ -445,7 +449,7 @@ class CudaGraphRunner:
             seq_lens=seq_lens,
             req_to_token_pool=self.model_runner.req_to_token_pool,
             token_to_kv_pool=self.model_runner.token_to_kv_pool,
-            attn_backend=self.model_runner.decode_attn_backend,
+            attn_backend=self.decode_attn_backend,
             out_cache_loc=out_cache_loc,
             seq_lens_sum=seq_lens.sum(),
             encoder_lens=encoder_lens,
@@ -464,7 +468,7 @@ class CudaGraphRunner:
             self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
         # Attention backend
-        self.model_runner.decode_attn_backend.init_forward_metadata_capture_cuda_graph(
+        self.decode_attn_backend.init_forward_metadata_capture_cuda_graph(
             bs,
             num_tokens,
             req_pool_indices,
@@ -574,7 +578,7 @@ class CudaGraphRunner:
             self.hidden_states[:raw_num_token] = forward_batch.spec_info.hidden_states
 
         # Attention backend
-        self.model_runner.decode_attn_backend.init_forward_metadata_replay_cuda_graph(
+        self.decode_attn_backend.init_forward_metadata_replay_cuda_graph(
             bs,
             self.req_pool_indices,
             self.seq_lens,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -211,9 +211,9 @@ class CudaGraphRunner:
         # Attention backend
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.num_tokens_per_bs
-        self.model_runner.attn_backend.init_cuda_graph_state(self.max_num_token)
+        self.model_runner.decode_attn_backend.init_cuda_graph_state(self.max_num_token)
         self.seq_len_fill_value = (
-            self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
+            self.model_runner.decode_attn_backend.get_cuda_graph_seq_len_fill_value()
         )
         # FIXME(lsyin): leave it here for now, I don't know whether it is necessary
         self.encoder_len_fill_value = 0
@@ -445,7 +445,7 @@ class CudaGraphRunner:
             seq_lens=seq_lens,
             req_to_token_pool=self.model_runner.req_to_token_pool,
             token_to_kv_pool=self.model_runner.token_to_kv_pool,
-            attn_backend=self.model_runner.attn_backend,
+            attn_backend=self.model_runner.decode_attn_backend,
             out_cache_loc=out_cache_loc,
             seq_lens_sum=seq_lens.sum(),
             encoder_lens=encoder_lens,
@@ -464,7 +464,7 @@ class CudaGraphRunner:
             self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
         # Attention backend
-        self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
+        self.model_runner.decode_attn_backend.init_forward_metadata_capture_cuda_graph(
             bs,
             num_tokens,
             req_pool_indices,
@@ -574,7 +574,7 @@ class CudaGraphRunner:
             self.hidden_states[:raw_num_token] = forward_batch.spec_info.hidden_states
 
         # Attention backend
-        self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
+        self.model_runner.decode_attn_backend.init_forward_metadata_replay_cuda_graph(
             bs,
             self.req_pool_indices,
             self.seq_lens,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -143,6 +143,7 @@ class ModelRunner:
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.use_mla_backend = self.model_config.attention_arch == AttentionArch.MLA
         self.attention_chunk_size = model_config.attention_chunk_size
+        self.decode_attn_backend = None
 
         # Model-specific adjustment
         self.model_specific_adjustment()
@@ -977,7 +978,7 @@ class ModelRunner:
             raise ValueError(
                 f"Invalid attention backend: {self.server_args.attention_backend}"
             )
-        if not self.use_mla_backend:
+        if self.server_args.enable_flashinfer_attention_decode:
             from sglang.srt.layers.attention.flashinfer_backend import (
                     FlashInferAttnBackend,
                 )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -980,8 +980,9 @@ class ModelRunner:
             )
         if self.server_args.enable_flashinfer_attention_decode:
             from sglang.srt.layers.attention.flashinfer_backend import (
-                    FlashInferAttnBackend,
-                )
+                FlashInferAttnBackend,
+            )
+
             self.decode_attn_backend = FlashInferAttnBackend(self)
 
     def init_double_sparsity_channel_config(self, selected_channel):
@@ -1042,12 +1043,18 @@ class ModelRunner:
             forward_batch.attn_backend = self.decode_attn_backend
             self.decode_attn_backend.init_forward_metadata(forward_batch)
             return self.model.forward(
-                forward_batch.input_ids, forward_batch.positions, forward_batch, **kwargs
+                forward_batch.input_ids,
+                forward_batch.positions,
+                forward_batch,
+                **kwargs,
             )
         else:
             self.attn_backend.init_forward_metadata(forward_batch)
             return self.model.forward(
-                forward_batch.input_ids, forward_batch.positions, forward_batch, **kwargs
+                forward_batch.input_ids,
+                forward_batch.positions,
+                forward_batch,
+                **kwargs,
             )
 
     def forward_extend(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -127,6 +127,7 @@ class ServerArgs:
 
     # Kernel backend
     attention_backend: Optional[str] = None
+    enable_flashinfer_attention_decode: bool = False
     sampling_backend: Optional[str] = None
     grammar_backend: Optional[str] = None
 
@@ -872,6 +873,11 @@ class ServerArgs:
             ],
             default=ServerArgs.attention_backend,
             help="Choose the kernels for attention layers.",
+        )
+        parser.add_argument(
+            "--enable-flashinfer-attention-decode",
+            action="store_true",
+            help="Use flashinfer attention backend for decode, it's only suggested for Qwen3-series in H20.",
         )
         parser.add_argument(
             "--sampling-backend",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

### FA3 decode performance is significantly lower than flashinfer on H20
#5630 
https://github.com/Dao-AILab/flash-attention/issues/1572

I have profiled the Qwen3-235B-A22B performance on H20(tp8) as follows.
```
SGLANG_TORCH_PROFILER_DIR=/data/sglang_profilers/QWEN3_tp8_32_3500_25_96G python3 -m sglang.bench_offline_throughput --model-path /data/models/Qwen3-235B-A22B --dataset-path /data/datasets/ShareGPT_V3_unfiltered_cleaned_split.json --dataset-name random --num-prompts 32 --random-input-len 3500 --random-output-len 25 --random-range-ratio 1 --tp-size 8 --trust-remote-code --disable-radix-cache --mem-fraction-static 0.9 --profile --reasoning-parser qwen3 --attention-backend {fa3, flashinfer}
```
#### Prefill
* FA3: 554us
![image](https://github.com/user-attachments/assets/02e74053-53ca-4623-a9ef-413c285e4e18)

* flashinfer: 722us
![image](https://github.com/user-attachments/assets/fc136590-7eec-4fd7-a84b-f43996fd5aaf)


#### Decode
* FA3: 98us
![image](https://github.com/user-attachments/assets/26a84a35-77a5-4ca9-9d72-cb704564a7d7)

* flashinfer: 35us
![image](https://github.com/user-attachments/assets/1123efa3-eef5-4c14-8715-31a74b72c61a)


The results indicate that FA3 decode performance is lower than flashinfer on H20, but FA3 prefill performance is higher than flashinfer on H20.

## Modifications

Use fa3 for prefill and flashinfer for decode on H20 for Qwen3 models. To enhance compatibility, server_arg `--enable-flashinfer-attention-decode` is introduced to determine whether enforce flashinfer as attention backend during the decoding phase, while the prefill phase retains the original `--attention-backend` configuration. By default, this argument is disabled and both prefill and decode phases utilize the backend specified by `--attention-backend` as before.

<!-- Describe the changes made in this PR. -->

## Evaluation

### Summary

* sglang 0.4.6.post2
* H20-96GB
* CUDA 12.4.131
* pytorch 2.6.0+cu124

#### Throughput(input + output tokens/s)
  |   |   | FA3(default) | Flashinfer | Hybrid(fa3 for P and flashinfer for D)
-- | -- | -- | -- | -- | --
Qwen3-235B-A22B | TP=8 | QPS=32, input/output=3500/1500 | 2875.43 | 3466.48 | 3534.57
Qwen3-235B-A22B | TP=8 | QPS=32, input/output=8192/200 | 10438.92 | 10275.08 | 10793.59
Qwen3-30B-A3B | TP=1 | QPS=32, input/output=3500/1500 | 3048.44 | 4249.24 | 4305.04
Qwen3-32B | TP=1 | QPS=4, input/output=3500/1500 | 228.47 | 249.49 | 249.88

### Qwen3-235B-A22B' records as an example
#### comands
```
### server
# FA3 (default)
python3 -m sglang.launch_server --model /data/models/Qwen3-235B-A22B --tp 8 --reasoning-parser qwen3 --port 8080

# Flashinfer
python3 -m sglang.launch_server --model /data/models/Qwen3-235B-A22B --tp 8 --reasoning-parser qwen3 --port 8080 --attention-backend flashinfer

# Hybrid (FA3 for prefill and Flashinfer for decode)
python3 -m sglang.launch_server --model /data/models/Qwen3-235B-A22B --tp 8 --reasoning-parser qwen3 --port 8080 --enable-flashinfer-attention-decode

### client
python3 -m sglang.bench_serving --backend sglang \
            --dataset-name random \
            --dataset-path /data/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
            --random-input-len 3500 \
            --random-output-len 1500 \
            --random-range-ratio 1 \
            --request-rate 32 \
            --max-concurrency 32 \
            --num-prompts 128 \
            --host 0.0.0.0 --port 8080
```
#### results
* FA3(default)
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    32.0      
Max reqeuest concurrency:                32        
Successful requests:                     128       
Benchmark duration (s):                  222.58    
Total input tokens:                      448000    
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191973    
Request throughput (req/s):              0.58      
Input token throughput (tok/s):          2012.80   
Output token throughput (tok/s):         862.63    
Total token throughput (tok/s):          2875.43   
Concurrency:                             31.95     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   55551.83  
Median E2E Latency (ms):                 55102.26  
---------------Time to First Token----------------
Mean TTFT (ms):                          4597.17   
Median TTFT (ms):                        4514.20   
P99 TTFT (ms):                           8477.12   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           33.99     
Median ITL (ms):                         31.61     
P95 ITL (ms):                            33.84     
P99 ITL (ms):                            34.42     
Max ITL (ms):                            7467.86   
==================================================
```
* Flashinfer
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    32.0      
Max reqeuest concurrency:                32        
Successful requests:                     128       
Benchmark duration (s):                  184.63    
Total input tokens:                      448000    
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191985    
Request throughput (req/s):              0.69      
Input token throughput (tok/s):          2426.54   
Output token throughput (tok/s):         1039.95   
Total token throughput (tok/s):          3466.48   
Concurrency:                             31.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   46065.23  
Median E2E Latency (ms):                 46034.10  
---------------Time to First Token----------------
Mean TTFT (ms):                          4825.35   
Median TTFT (ms):                        4708.10   
P99 TTFT (ms):                           9092.60   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           27.51     
Median ITL (ms):                         24.82     
P95 ITL (ms):                            26.18     
P99 ITL (ms):                            26.53     
Max ITL (ms):                            9292.85   
==================================================
```
* Hybrid
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    32.0      
Max reqeuest concurrency:                32        
Successful requests:                     128       
Benchmark duration (s):                  181.07    
Total input tokens:                      448000    
Total generated tokens:                  192000    
Total generated tokens (retokenized):    191987    
Request throughput (req/s):              0.71      
Input token throughput (tok/s):          2474.20   
Output token throughput (tok/s):         1060.37   
Total token throughput (tok/s):          3534.57   
Concurrency:                             31.94     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   45176.10  
Median E2E Latency (ms):                 45040.04  
---------------Time to First Token----------------
Mean TTFT (ms):                          4495.42   
Median TTFT (ms):                        4383.04   
P99 TTFT (ms):                           8057.08   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           27.14     
Median ITL (ms):                         24.54     
P95 ITL (ms):                            25.84     
P99 ITL (ms):                            26.23     
Max ITL (ms):                            8783.36   
==================================================
```

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
