### PR TITLE
[Fix] fix assert error in disaggregatin decoder

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -332,12 +332,9 @@ class DecodeTransferQueue:
             elif poll == KVPoll.Success:
                 # pop and push it to waiting queue
                 idx = decode_req.metadata_buffer_index
-                assert len(decode_req.req.output_ids) == 0
                 output_id_buffer = self.metadata_buffers[0]
                 # the last dimension is padded by the same values.
                 output_id = output_id_buffer[idx][0].item()
-                assert len(decode_req.req.output_ids) == 0
-                assert decode_req.req.transferred_output_id is None
                 decode_req.req.transferred_output_id = output_id
                 transferred_reqs.append(decode_req)
                 indices_to_remove.add(i)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

I've identified the root cause of this bug(https://github.com/sgl-project/sglang/issues/6133). When the concurrency of the decoder nodes is high, the decoder nodes generate OOM warning logs. At this point, the `_extend_requests_to_queue` function in `scheduler.py` is called. If it determines that the request is on a decoder node, it reinserts the retracted request into the `disagg_decode_prealloc_queue` queue, causing the `output_ids` of the request to become non-empty. Therefore, the related `assert` code needs to be removed.  

An alternative solution is to directly place the `retracted_req` into the `waiting_queue`, but this would trigger another error.
![fix](https://github.com/user-attachments/assets/51c20e5d-dac5-4db7-86ea-8becacbdb437)

![err](https://github.com/user-attachments/assets/4448c724-7ff3-460f-ae58-a262b0326aab)

