### PR TITLE
[Bugfix] Fix Llama4 gibberish output with long context and CUDA graph

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -263,6 +263,124 @@ def make_local_attention_virtual_batches(
     return seqlens_q_local, cu_seqlens_q_local, seqlens_k_local, block_table_local
 
 
+def make_local_attention_virtual_batches_torch(
+    attn_chunk_size: int,
+    query_start_loc: torch.Tensor,  # 1D, int32 or int64
+    seq_lens: torch.Tensor,  # 1D, int32 or int64
+    block_table: torch.Tensor,  # 2D, int32
+    page_size: int = 0,
+):
+    """
+    Fully vectorized PyTorch version of make_local_attention_virtual_batches.
+    All logic is unchanged from the numpy version.
+    """
+    device = query_start_loc.device
+    dtype = torch.int32
+
+    max_seq_len = seq_lens.max()
+    effective_chunk_size = min(attn_chunk_size, max_seq_len)
+    effective_chunk_size = (effective_chunk_size // page_size) * page_size
+    if effective_chunk_size < page_size:
+        effective_chunk_size = page_size
+    attn_chunk_size = effective_chunk_size
+
+    q_seqlens = query_start_loc[1:] - query_start_loc[:-1]
+    actual_batch_size = seq_lens.shape[0]
+
+    q_tokens_in_first_block = torch.minimum(
+        attn_chunk_size - ((seq_lens - q_seqlens) % attn_chunk_size), q_seqlens
+    ).to(dtype)
+    tokens_in_last_block = attn_chunk_size + (seq_lens % -attn_chunk_size)
+    local_blocks = 1 + (
+        (q_seqlens - q_tokens_in_first_block + attn_chunk_size - 1) // attn_chunk_size
+    )
+
+    # --- Vectorized arange logic ---
+    cu_num_blocks = torch.cumsum(local_blocks, dim=0)
+    virtual_batches = cu_num_blocks[-1].item()
+    # block_offsets = np.repeat(cu_num_blocks - local_blocks, local_blocks)
+    block_offsets = torch.repeat_interleave(cu_num_blocks - local_blocks, local_blocks)
+    # arange = np.arange(virtual_batches, dtype=np.int32) - block_offsets
+    arange = torch.arange(virtual_batches, dtype=dtype, device=device) - block_offsets
+    # rarange = np.repeat(local_blocks, local_blocks) - arange - 1
+    repeated_local_blocks = torch.repeat_interleave(local_blocks, local_blocks)
+    rarange = repeated_local_blocks - arange - 1
+
+    # seqlens_q_local = np.repeat(q_seqlens - q_tokens_in_first_block, local_blocks)
+    seqlens_q_local = torch.repeat_interleave(
+        q_seqlens - q_tokens_in_first_block, local_blocks
+    ).to(dtype)
+    # set the first block since this may be a partial block
+    seqlens_q_local[arange == 0] = q_tokens_in_first_block[
+        torch.arange(actual_batch_size, dtype=dtype, device=device).repeat_interleave(
+            local_blocks
+        )[arange == 0]
+    ]
+    # set the remaining blocks
+    mask = arange > 0
+    seqlens_q_local[mask] = torch.minimum(
+        (seqlens_q_local[mask] - attn_chunk_size * (arange[mask] - 1).to(dtype)).to(
+            dtype
+        ),
+        torch.full_like(seqlens_q_local[mask], attn_chunk_size, dtype=dtype),
+    )
+
+    # cu_seqlens_q_local = np.pad(np.cumsum(seqlens_q_local), (1, 0)).astype(np.int32)
+    cu_seqlens_q_local = torch.cat(
+        [
+            torch.zeros(1, dtype=dtype, device=device),
+            torch.cumsum(seqlens_q_local, dim=0).to(dtype),
+        ]
+    ).to(dtype)
+
+    # seqlens_k_local = np.full(cu_num_blocks[-1], attn_chunk_size, dtype=np.int32)
+    seqlens_k_local = torch.full(
+        (virtual_batches,), attn_chunk_size, dtype=dtype, device=device
+    )
+    # seqlens_k_local[cu_num_blocks - 1] = tokens_in_last_block
+    seqlens_k_local[cu_num_blocks - 1] = tokens_in_last_block
+
+    # k_seqstarts_absolute = np.repeat(seq_lens_np, local_blocks) - (
+    #     rarange * attn_chunk_size + np.repeat(tokens_in_last_block, local_blocks)
+    # )
+    seq_lens_repeated = torch.repeat_interleave(seq_lens, local_blocks)
+    tokens_in_last_block_repeated = torch.repeat_interleave(
+        tokens_in_last_block, local_blocks
+    )
+    k_seqstarts_absolute = seq_lens_repeated - (
+        rarange * attn_chunk_size + tokens_in_last_block_repeated
+    )
+    block_starts = k_seqstarts_absolute // page_size
+
+    # block_table_local = np.repeat(block_table, local_blocks, axis=0)
+    # --- Fully vectorized block_table_local computation ---
+    assert attn_chunk_size % page_size == 0, (
+        f"attn_chunk_size {attn_chunk_size} is not "
+        f"divisible by page_size {page_size}"
+    )
+    pages_per_local_batch = attn_chunk_size // page_size
+
+    block_indices = torch.arange(
+        pages_per_local_batch, dtype=dtype, device=device
+    ).unsqueeze(0).expand(
+        virtual_batches, pages_per_local_batch
+    ) + block_starts.unsqueeze(
+        1
+    )
+    block_indices = block_indices.flatten().clamp(max=block_table.shape[1] - 1)
+
+    batch_indices = torch.repeat_interleave(
+        torch.arange(actual_batch_size, dtype=dtype, device=device),
+        local_blocks * pages_per_local_batch,
+    )
+
+    block_table_local = block_table[batch_indices, block_indices].view(
+        virtual_batches, -1
+    )
+
+    return seqlens_q_local, cu_seqlens_q_local, seqlens_k_local, block_table_local
+
+
 def cdiv(a: int, b: int) -> int:
     """Ceiling division."""
     return -(a // -b)
@@ -918,6 +1036,7 @@ class FlashAttentionBackend(AttentionBackend):
             and local_attn_metadata is not None
             and (hasattr(layer, "use_irope") and layer.use_irope)
         )
+        # print(f"layer: {layer.layer_id}, use_local_attn: {use_local_attn}")
         # We do cascade attention for Draft Decode with topk > 1
         use_cascade_attn = self.topk > 1
 
@@ -1130,6 +1249,26 @@ class FlashAttentionBackend(AttentionBackend):
         to avoid memory allocations.
         """
 
+        # Estimate maximum sizes for local attention metadata
+        max_seq_len = self.max_context_len
+        attn_chunk_size = self.attention_chunk_size if self.attention_chunk_size else 1
+        max_virtual_batches = (
+            max_bs * (max_seq_len + attn_chunk_size - 1) // attn_chunk_size
+            if attn_chunk_size > 0
+            else max_bs
+        )
+        max_blocks_per_seq = (
+            (self.max_context_len + self.attention_chunk_size - 1)
+            // self.attention_chunk_size
+            if self.attention_chunk_size
+            else 1
+        )
+        max_pages_per_block = (
+            (self.attention_chunk_size + self.page_size - 1) // self.page_size
+            if self.page_size
+            else 1
+        )
+
         # This is being used by normal decode and draft decode when topk == 1
         self.decode_cuda_graph_metadata = {
             "cache_seqlens": torch.zeros(max_bs, dtype=torch.int32, device=self.device),
@@ -1153,6 +1292,19 @@ class FlashAttentionBackend(AttentionBackend):
             ),
             "strided_indices": torch.arange(
                 0, self.max_context_len, self.page_size, device=self.device
+            ),
+            # Pre-allocate tensors for local attention metadata
+            "local_query_start_loc": torch.zeros(
+                max_virtual_batches + 1, dtype=torch.int32, device=self.device
+            ),
+            "local_seqused_k": torch.zeros(
+                max_virtual_batches, dtype=torch.int32, device=self.device
+            ),
+            "local_block_table": torch.zeros(
+                max_virtual_batches,
+                max_blocks_per_seq * max_pages_per_block,
+                dtype=torch.int32,
+                device=self.device,
             ),
         }
 
@@ -1407,6 +1559,23 @@ class FlashAttentionBackend(AttentionBackend):
                 )
                 self.decode_cuda_graph_metadata[bs] = metadata
 
+                if self.attention_chunk_size is not None:
+                    metadata.local_attn_metadata = (
+                        FlashAttentionMetadata.LocalAttentionMetadata(
+                            local_query_start_loc=self.decode_cuda_graph_metadata[
+                                "local_query_start_loc"
+                            ],
+                            local_seqused_k=self.decode_cuda_graph_metadata[
+                                "local_seqused_k"
+                            ],
+                            local_block_table=self.decode_cuda_graph_metadata[
+                                "local_block_table"
+                            ],
+                            local_max_query_len=0,
+                            local_max_seq_len=0,
+                        )
+                    )
+
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata.cache_seqlens_int32 = self.target_verify_metadata[
@@ -1574,6 +1743,8 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata_expand.page_table[: cache_loc.shape[0]].copy_(
                         cache_loc[:, :decode_length].contiguous().to(torch.int32)
                     )
+                # Local attention metadata will be handled by the CUDA graph
+                # DO NOT call _init_local_attn_metadata_cuda_graph during replay
             else:
                 metadata = self.decode_cuda_graph_metadata[bs]
                 # Normal Decode
@@ -1599,7 +1770,11 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata.page_table[:, :max_seq_pages].copy_(page_indices)
                 metadata.page_table[:, max_seq_pages:].fill_(0)
 
-            self._init_local_attn_metadata(metadata, device)
+                # Local attention metadata will be handled by the CUDA graph
+                # DO NOT call _init_local_attn_metadata_cuda_graph during replay
+                # self._setup_local_attn_metadata_for_replay(metadata)
+                if self.attention_chunk_size is not None:
+                    self._update_local_attn_metadata_for_replay(metadata, bs)
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
@@ -1741,28 +1916,194 @@ class FlashAttentionBackend(AttentionBackend):
             metadata.local_attn_metadata = None
             return
 
-        cu_seqlens_q_np = cu_seqlens_q.cpu().numpy()
-        seq_lens_np = cache_seqlens_int32.cpu().numpy()
         (
-            seqlens_q_local_np,
-            cu_seqlens_q_local_np,
-            seqlens_k_local_np,
+            seqlens_q_local,
+            cu_seqlens_q_local,
+            seqlens_k_local,
             block_table_local,
-        ) = make_local_attention_virtual_batches(
+        ) = make_local_attention_virtual_batches_torch(
             self.attention_chunk_size,
-            cu_seqlens_q_np,
-            seq_lens_np,
+            cu_seqlens_q,
+            cache_seqlens_int32,
             page_table,
             self.page_size,
         )
+
+        # Get sizes
+        # q_len = cu_seqlens_q_local.shape[0]
+        # k_len = seqlens_k_local.shape[0]
+        # b0, b1 = block_table_local.shape
+
+        # Get the current device ID for debug output
+        device_id = cu_seqlens_q.device.index
+
+        # Only print debug info for device 0 to reduce output clutter
+        debug_print = device_id == 0
+
+        if debug_print:
+            print("=== [No CUDA graph] ===")
+            # Print the input parameters for comparison
+            print(
+                "=== Parameters to make_local_attention_virtual_batches_torch (No CUDA graph) ==="
+            )
+            print(f"attn_chunk_size: {self.attention_chunk_size}")
+            print(f"query_start_loc: {cu_seqlens_q}")
+            print(f"seq_lens: {cache_seqlens_int32}")
+            print(f"page_table shape: {page_table.shape}")
+            if page_table.shape[0] > 0 and page_table.shape[1] > 0:
+                print(f"page_table sample: {page_table[0, :10]}...")
+            print(f"page_size: {self.page_size}")
+
+            # Print the output results
+            print("=== Results (No CUDA graph) ===")
+            print("local_query_start_loc", cu_seqlens_q_local)
+            print("local_seqused_k", seqlens_k_local)
+            print("local_block_table", block_table_local)
+
         local_metadata = FlashAttentionMetadata.LocalAttentionMetadata(
-            local_query_start_loc=torch.from_numpy(cu_seqlens_q_local_np).to(device),
-            local_seqused_k=torch.from_numpy(seqlens_k_local_np).to(device),
+            local_query_start_loc=cu_seqlens_q_local.to(device),
+            local_seqused_k=seqlens_k_local.to(device),
             local_block_table=block_table_local.to(device),
-            local_max_query_len=int(seqlens_q_local_np.max()),
-            local_max_seq_len=int(seqlens_k_local_np.max()),
+            local_max_query_len=int(seqlens_q_local.max().item()),
+            local_max_seq_len=int(seqlens_k_local.max().item()),
         )
         metadata.local_attn_metadata = local_metadata
+
+    def _update_local_attn_metadata_for_replay(
+        self, metadata: FlashAttentionMetadata, bs: int
+    ):
+        """Update preallocated local attention metadata in-place before CUDA graph replay."""
+        # Access preallocated buffers
+        local_q_buf = self.decode_cuda_graph_metadata["local_query_start_loc"]
+        local_k_buf = self.decode_cuda_graph_metadata["local_seqused_k"]
+        local_block_buf = self.decode_cuda_graph_metadata["local_block_table"]
+        cu_seqlens_q = self.decode_cuda_graph_metadata["cu_seqlens_q"]
+
+        # Step 1: recompute seqlens_q from metadata
+        seqlens_q = metadata.cache_seqlens_int32[:bs]
+        page_table = metadata.page_table[:bs, :]
+
+        # In normal decode mode for a single new token, we see query_start_loc as [0, 1]
+        # But in CUDA graph mode, we're getting [0, full_seq_len]
+        # Create a modified version that mimics the normal decode pattern
+        # for the last token only
+
+        # First update the cumulative sequence lengths as before
+        cu_seqlens_q[0] = 0
+        for i in range(bs):
+            cu_seqlens_q[i + 1] = cu_seqlens_q[i] + seqlens_q[i]
+        if cu_seqlens_q.size(0) > bs + 1:
+            cu_seqlens_q[bs + 1 :].fill_(0)
+
+        # Now create a modified version for local attention that only processes the last token
+        # This mimics the normal decode pattern
+        modified_cu_seqlens_q = torch.zeros_like(cu_seqlens_q[: bs + 1])
+        modified_cu_seqlens_q[0] = 0
+        for i in range(bs):
+            modified_cu_seqlens_q[i + 1] = (
+                modified_cu_seqlens_q[i] + 1
+            )  # Only 1 token per sequence
+
+        # Debug print
+        # Get the current device ID for debug output
+        device_id = seqlens_q.device.index
+
+        # Only print debug info for device 0 to reduce output clutter
+        debug_print = device_id == 0
+        if debug_print:
+            print(f">>> DEBUG: replay input metadata (bs={bs})")
+            print(f"Original cu_seqlens_q: {cu_seqlens_q[:bs+1]}")
+            print(f"Modified cu_seqlens_q: {modified_cu_seqlens_q}")
+            print(f"seqlens_q: {seqlens_q}")
+
+            # Print the full parameters being passed to make_local_attention_virtual_batches_torch
+            print(
+                "=== Parameters to make_local_attention_virtual_batches_torch (CUDA graph) ==="
+            )
+            print(f"attn_chunk_size: {self.attention_chunk_size}")
+            print(f"query_start_loc (modified): {modified_cu_seqlens_q}")
+            print(f"seq_lens: {seqlens_q}")
+            print(f"page_table shape: {page_table.shape}")
+            print(f"page_size: {self.page_size}")
+
+        # CRITICAL: Use only the first (bs+1) elements of cu_seqlens_q
+        # This ensures that actual_batch_size in make_local_attention_virtual_batches_torch
+        # will be exactly bs, matching the size of seqlens_q
+
+        # CRITICAL: Slice the page_table to match the actual sequence length
+        # This prevents zeros in the block table due to the pre-allocated page_table being too large
+        max_seq_len = int(seqlens_q.max().item())
+        sliced_page_table = page_table[:, :max_seq_len]
+
+        if debug_print:
+            print(f"Original page_table shape: {page_table.shape}")
+            print(f"Sliced page_table shape: {sliced_page_table.shape}")
+
+        (
+            seqlens_q_local,
+            cu_seqlens_q_local,
+            seqlens_k_local,
+            block_table_local,
+        ) = make_local_attention_virtual_batches_torch(
+            self.attention_chunk_size,
+            modified_cu_seqlens_q,  # Use the modified version that mimics normal decode
+            seqlens_q,
+            sliced_page_table,
+            self.page_size,
+        )
+
+        # Get sizes
+        q_len = cu_seqlens_q_local.shape[0]
+        k_len = seqlens_k_local.shape[0]
+        b0, b1 = block_table_local.shape
+
+        # Sanity check: ensure preallocated buffer is large enough
+        assert (
+            local_q_buf.shape[0] >= q_len
+        ), f"local_query_start_loc too small: {local_q_buf.shape[0]} < {q_len}"
+        assert (
+            local_k_buf.shape[0] >= k_len
+        ), f"local_seqused_k too small: {local_k_buf.shape[0]} < {k_len}"
+        assert (
+            local_block_buf.shape[0] >= b0 and local_block_buf.shape[1] >= b1
+        ), f"local_block_table too small: {local_block_buf.shape} < {(b0, b1)}"
+
+        # In-place updates into preallocated tensors
+        local_q_buf[:q_len].copy_(cu_seqlens_q_local)
+        # Zero out the rest of the buffer to avoid stale data
+        if q_len < local_q_buf.shape[0]:
+            local_q_buf[q_len:].fill_(0)
+
+        local_k_buf[:k_len].copy_(seqlens_k_local)
+        # Zero out the rest of the buffer
+        if k_len < local_k_buf.shape[0]:
+            local_k_buf[k_len:].fill_(0)
+
+        local_block_buf[:b0, :b1].copy_(block_table_local)
+        # Zero out the rest of the buffer
+        if b0 < local_block_buf.shape[0] or b1 < local_block_buf.shape[1]:
+            # Zero out unused rows
+            if b0 < local_block_buf.shape[0]:
+                local_block_buf[b0:, :].fill_(0)
+            # Zero out unused columns in used rows
+            if b1 < local_block_buf.shape[1]:
+                local_block_buf[:b0, b1:].fill_(0)
+
+        if debug_print:
+            print("=== [Replay] Local Attention Metadata ===")
+            print("local_query_start_loc:", local_q_buf[:q_len])
+            print("local_seqused_k:", local_k_buf[:k_len])
+            print("local_block_table:", local_block_buf[:b0, :b1])
+
+        # If metadata.local_attn_metadata already exists, just update its fields
+        if metadata.local_attn_metadata is not None:
+            lam = metadata.local_attn_metadata
+            lam.local_max_query_len = int(seqlens_q_local.max().item())
+            lam.local_max_seq_len = int(seqlens_k_local.max().item())
+
+        assert id(metadata.local_attn_metadata.local_query_start_loc) == id(
+            self.decode_cuda_graph_metadata["local_query_start_loc"]
+        ), "Replay tensor mismatch! You reassigned a new tensor instead of updating in-place."
 
 
 class FlashAttentionMultiStepBackend:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Llama4 is generating gibberish output with long context (larger than 8192) with cuda graph. This PR fixes the issue.

This is because the local attention mechanism wasn't properly handling tensor operations during CUDA graph replay. Specifically:
- In `init_cuda_graph_state`, the relevant tensors for local attention were not being pre-allocated. As a result, the local_attn_metadata was not being used in CUDA graph execution.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

- Consolidate `use_local_attn` check in `forward_decode` and `forward_extend`
- Fixed CUDA graph initialization for local attention:
  - Added pre-allocated tensors in `init_cuda_graph_state` for local attention metadata
  - Initialized these tensors properly in `init_forward_metadata_capture_cuda_graph`
  - Added documentation to clarify that only normal decode CUDA graph is supported for local attention (not speculative decoding)

- Update local attention metadata properly in CUDA graph replay:
  - Properly sliced the page table to match the actual batch size and sequence length
  - Added clear documentation about the purpose of each operation

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
