### PR TITLE
Remove duplicate IO Struct test

### DIFF
--- a/test/srt/test_io_struct.py
+++ b/test/srt/test_io_struct.py
@@ -124,24 +124,6 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         # Ensure that text items are properly duplicated too
         self.assertEqual(req.text, expected_text)
 
-    def test_list_of_lists_with_none_values(self):
-        """Test handling of list of lists with None values."""
-        req = copy.deepcopy(self.base_req)
-        req.image_data = [
-            [None],  # None value
-            ["image.jpg"],  # Single image
-        ]
-
-        req.normalize_batch_and_arguments()
-
-        # Structure should remain the same
-        self.assertEqual(len(req.image_data), 2)
-        self.assertEqual(len(req.image_data[0]), 1)
-        self.assertEqual(len(req.image_data[1]), 1)
-
-        # Check modalities
-        self.assertEqual(req.modalities, [None, "image"])
-
     def test_specific_parallel_n_per_sample(self):
         """Test parallel expansion when different samples have different n values."""
         req = copy.deepcopy(self.base_req)


### PR DESCRIPTION
## Motivation
The `test/srt/test_io_struct.py` test suite contains duplicate `test_list_of_lists_with_none_values` test with same logic.

## Modifications
Removes one of the `test_list_of_lists_with_none_values` tests.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
