### PR TITLE
[CI] Disabled deepep tests temporarily because it takes too much time.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -89,6 +89,25 @@ jobs:
           cd test/srt
           python3 run_suite.py --suite per-commit-2-gpu
 
+  unittest-test-backend-8-gpu:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false
+    needs: [unit-test-frontend, unit-test-backend-1-gpu, unit-test-backend-2-gpu]
+    runs-on: 8-gpu-runner
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci_install_dependency.sh
+
+      - name: Run test
+        timeout-minutes: 25
+        run: |
+          cd test/srt
+          python3 run_suite.py --suite per-commit-8-gpu
+
   performance-test-1-gpu-part-1:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') &&
         github.event.pull_request.draft == false
@@ -252,35 +271,12 @@ jobs:
           cd test/srt
           python3 test_moe_eval_accuracy_large.py
 
-  large-scale-test-8-gpu:
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false
-    needs: [
-      unit-test-frontend, unit-test-backend-1-gpu, unit-test-backend-2-gpu,
-      performance-test-1-gpu-part-1, performance-test-1-gpu-part-2, performance-test-2-gpu,
-      accuracy-test-1-gpu, accuracy-test-2-gpu,
-    ]
-    runs-on: 8-gpu-runner
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci_install_dependency_8_gpu.sh
-
-      - name: Run test
-        timeout-minutes: 25
-        run: |
-          cd test/srt
-          python3 run_suite.py --suite per-commit-8-gpu
-
   finish:
     if: always()
     needs: [
-      unit-test-frontend, unit-test-backend-1-gpu, unit-test-backend-2-gpu,
+      unit-test-frontend, unit-test-backend-1-gpu, unit-test-backend-2-gpu, unittest-test-backend-8-gpu,
       performance-test-1-gpu-part-1, performance-test-1-gpu-part-2, performance-test-2-gpu,
-      accuracy-test-1-gpu, accuracy-test-2-gpu, large-scale-test-8-gpu,
+      accuracy-test-1-gpu, accuracy-test-2-gpu,
     ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -103,7 +103,7 @@ jobs:
           bash scripts/ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 25
+        timeout-minutes: 20
         run: |
           cd test/srt
           python3 run_suite.py --suite per-commit-8-gpu

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -96,9 +96,11 @@ suites = {
         TestFile("test_verl_engine.py", 64),
     ],
     "per-commit-8-gpu": [
-        TestFile("test_deepep_intranode.py", 50),
-        TestFile("test_deepep_low_latency.py", 50),
-        TestFile("test_moe_deepep_eval_accuracy_large.py", 250),
+        # Disabled deepep tests temporarily because it takes too much time.
+        # TODO: re-enable them after reducing the test time with compilation cache and smaller models.
+        # TestFile("test_deepep_intranode.py", 50),
+        # TestFile("test_deepep_low_latency.py", 50),
+        # TestFile("test_moe_deepep_eval_accuracy_large.py", 250),
         TestFile("test_local_attn.py", 250),
         TestFile("test_full_deepseek_v3.py", 250),
         TestFile("test_pp_single_node.py", 150),


### PR DESCRIPTION
We can re-enable them after doing the following enhancements.

1. Do not compile from scratch every time. Utilize the compilation cache.
2. Use a smaller model `lmsys/sglang-ci-dsv3-test` for most tests
3. Call `scripts/ci_install_dependency.sh` in `scripts/ci_install_dependency_8_gpu.sh` to reduce code duplication.

The final goal is to run the 8-gpu test within 15 mins.