### PR TITLE
Use TP=1 for 1P1D test

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -94,6 +94,7 @@ suites = {
         TestFile("test_patch_torch.py", 19),
         TestFile("test_update_weights_from_distributed.py", 103),
         TestFile("test_verl_engine.py", 64),
+        TestFile("test_disaggregation.py", 90),
     ],
     "per-commit-8-gpu": [
         # Disabled deepep tests temporarily because it takes too much time.
@@ -102,7 +103,6 @@ suites = {
         # TestFile("test_deepep_low_latency.py", 50),
         # TestFile("test_moe_deepep_eval_accuracy_large.py", 250),
         TestFile("test_local_attn.py", 250),
-        TestFile("test_disaggregation.py", 90),
         TestFile("test_full_deepseek_v3.py", 250),
         TestFile("test_pp_single_node.py", 150),
     ],

--- a/test/srt/test_disaggregation.py
+++ b/test/srt/test_disaggregation.py
@@ -63,8 +63,6 @@ class TestDisaggregationMooncake(CustomTestCase):
             cls.base_host,
             "--port",
             str(cls.base_port + 100),
-            "--tp",
-            "4",
         ]
         cls.process_prefill = popen_launch_pd_server(
             cls.model,
@@ -83,10 +81,8 @@ class TestDisaggregationMooncake(CustomTestCase):
             cls.base_host,
             "--port",
             str(cls.base_port + 200),
-            "--tp",
-            "4",
             "--base-gpu-id",
-            "4",
+            "1",
         ]
         cls.process_decode = popen_launch_pd_server(
             cls.model,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

8GPU runner is expensive, so use tp=1 to run on 2 gpu runner.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
