### PR TITLE
[Fix]: fix assert errors in high-concurrency scenarios during PD.

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -699,6 +699,8 @@ class Req:
         self.is_chunked = 0
         self.req_pool_idx = None
         self.already_computed = 0
+        self.output_ids = []
+        self.transferred_output_id = None
 
     def offload_kv_cache(self, req_to_token_pool, token_to_kv_pool_allocator):
         token_indices = req_to_token_pool.req_to_token[


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.


### BUG Reproduction
In disaggregatin PD high-concurrency scenarios, the decoder node may encounter assertion errors，as mentioned in this issue https://github.com/sgl-project/sglang/issues/6133.
![image (3)](https://github.com/user-attachments/assets/c08a4bfc-586f-40a5-8b91-c967312c9b92)


### Root Cause Analysis
Logs show `Decode out of memory happened.` The call stack is as follows:
```
scheduler.py::update_running_batch()
       # Selects requests to evict KV cache based on current VRAM
    -> schedule_batch.py::retract_decode()
           # Clears metadata of selected requests
        -> schedule_batch.py::reset_for_retract()
               # Re-adds requests to disagg_decode_prealloc_queue
            -> scheduler.py::_extend_requests_to_queue()
```
When handling retracted requests, the system must recompute the KV cache through prefill operations after eviction. However, an incomplete metadata cleanup in schedule_batch.py::reset_for_retract() led to assertion failures during KV cache transfer operations.
