### PR TITLE
 [Feature][ROCM] add online int4_fp8_moe quant feature

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -317,6 +317,7 @@ class ModelConfig:
             "compressed-tensors",
             "fbgemm_fp8",
             "w8a8_fp8",
+            "quark_int4fp8_moe",
         ]
         optimized_quantization_methods = [
             "fp8",

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -50,6 +50,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "ModelOptFp8LinearMethod",
     "ModelOptFp4LinearMethod",
     "IPEXAWQLinearMethod",
+    "QuarkInt4Fp8LinearMethod",
 ]
 
 

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -66,6 +66,7 @@ from sglang.srt.layers.quantization.modelopt_quant import (
 from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
 from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
+from sglang.srt.layers.quantization.quark_w4a8_int4fp8 import QuarkInt4Fp8Config
 
 # Base quantization methods that don't depend on vllm
 BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
@@ -77,6 +78,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "w8a8_fp8": W8A8Fp8Config,
     "moe_wna16": MoeWNA16Config,
     "compressed-tensors": CompressedTensorsConfig,
+    "quark_int4fp8_moe": QuarkInt4Fp8Config,
 }
 
 # VLLM-dependent quantization methods

--- a/python/sglang/srt/layers/quantization/quark_w4a8_int4fp8.py
+++ b/python/sglang/srt/layers/quantization/quark_w4a8_int4fp8.py
@@ -1,0 +1,524 @@
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+
+from torch.nn.parameter import Parameter
+
+try:
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
+        apply_fp8_marlin_linear,
+        prepare_fp8_layer_for_marlin,
+    )
+
+    MARLIN_FP8_AVAILABLE = True
+except ImportError:
+    MARLIN_FP8_AVAILABLE = False
+
+    def dummy_func(*args, **kwargs):
+        raise ImportError(
+            "marlin FP8 requires some operators from vllm. Please install vllm."
+        )
+
+    apply_fp8_marlin_linear = prepare_fp8_layer_for_marlin = dummy_func
+
+from sglang.srt.distributed import get_tensor_model_parallel_world_size
+from sglang.srt.layers.linear import LinearMethodBase
+from sglang.srt.layers.parameter import ChannelQuantScaleParameter, ModelWeightParameter, PerTensorScaleParameter
+from sglang.srt.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+
+from sglang.srt.layers.quantization.fp8_kernel import (
+    per_token_group_quant_fp8,
+    scaled_fp8_quant,
+)
+
+from sglang.srt.layers.quantization.fp8_utils import (
+    apply_fp8_linear,
+    cutlass_fp8_supported,
+    normalize_e4m3fn_to_e4m3fnuz,
+)
+
+from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+    all_close_1d,
+    convert_to_channelwise,
+    per_tensor_dequantize,
+    requantize_with_max_scale,
+)
+from sglang.srt.utils import (
+    get_bool_env_var,
+    is_hip,
+    is_cuda,
+    permute_weight,
+    print_warning_once,
+    set_weight_attrs,
+)
+
+ACTIVATION_SCHEMES = ["static", "dynamic"]
+
+_is_hip = is_hip()
+_is_cuda = is_cuda()
+
+
+if is_cuda:
+    from sgl_kernel import int8_scaled_mm
+
+if _is_hip:
+    from aiter import ActivationType, QuantType
+    from aiter.fused_moe_bf16_asm import asm_moe, ck_moe_2stages
+    from aiter.ops.shuffle import shuffle_weight
+
+if not _is_cuda:
+    from vllm._custom_ops import scaled_fp8_quant
+
+logger = logging.getLogger(__name__)
+
+
+class QuarkInt4Fp8Config(QuantizationConfig):
+    """Config class for Quark Quantization.
+
+    - Weight: static, per-channel, symmetric
+    - Activation: dynamic, per-token, symmetric
+    """
+
+    def __init__(self,
+        is_checkpoint_fp8_serialized: bool = False,
+        activation_scheme: str = "dynamic",
+        ignored_layers: Optional[List[str]] = None,
+        weight_block_size: List[int] = None,):
+        self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
+        if activation_scheme not in ACTIVATION_SCHEMES:
+            raise ValueError(f"Unsupported activation scheme {activation_scheme}")
+        self.activation_scheme = activation_scheme
+        self.ignored_layers = ignored_layers or []
+        if weight_block_size is not None:
+            if not is_checkpoint_fp8_serialized:
+                raise ValueError(
+                    f"The block-wise quantization only supports fp8-serialized checkpoint for now."
+                )
+            if len(weight_block_size) != 2:
+                raise ValueError(
+                    f"The quantization block size of weight must have 2 dimensions, but got {len(weight_block_size)} dimensions."
+                )
+            if activation_scheme != "dynamic":
+                raise ValueError(
+                    f"The block-wise quantization only supports dynamic activation scheme for now, but got {activation_scheme} activation scheme."
+                )
+        self.weight_block_size = weight_block_size
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    @classmethod
+    def get_name(self) -> str:
+        return "w4a8_int4fp8"
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "QuarkInt4Fp8Config":
+        quant_method = cls.get_from_keys(config, ["quant_method"])
+        activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
+        ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
+        weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
+        return cls(
+            activation_scheme=activation_scheme,
+            ignored_layers=ignored_layers,
+            weight_block_size=weight_block_size,
+        )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> Optional["QuantizeMethodBase"]:
+        from sglang.srt.layers.linear import LinearBase
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+
+        if isinstance(layer, LinearBase):
+            return QuarkInt4Fp8LinearMethod(self)
+        elif isinstance(layer, FusedMoE):
+            return QuarkInt4Fp8MoEMethod(self)
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+
+
+class QuarkInt4Fp8LinearMethod(LinearMethodBase):
+
+    def __init__(self, quantization_config: QuarkInt4Fp8Config):
+        self.cutlass_fp8_supported = cutlass_fp8_supported()
+        self.quant_config = quantization_config
+
+        # For GPUs that lack FP8 hardware support, we can leverage the Marlin
+        # kernel for fast weight-only FP8 quantization
+        self.use_marlin = (
+            get_bool_env_var("SGLANG_FORCE_FP8_MARLIN") and MARLIN_FP8_AVAILABLE
+        )
+        # Disable marlin for ROCm
+        if _is_hip:
+            self.use_marlin = False
+
+        self.block_quant = self.quant_config.weight_block_size is not None
+        if self.block_quant:
+            # Marlin doesn't support block-wise fp8
+            self.use_marlin = False
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+
+        layer.weight = torch.nn.Parameter(layer.weight.data, requires_grad=False)
+
+        layer.weight_scale = torch.nn.Parameter(
+            layer.weight_scale.data, requires_grad=False
+        )
+        if self.quant_config.activation_scheme == "static":
+            layer.input_scale = torch.nn.Parameter(
+                layer.input_scale.data, requires_grad=False
+            )
+
+        # cutlass sgl-kernel and marlin only support per-channel scale
+        if self.cutlass_fp8_supported or self.use_marlin:
+            weight = layer.weight
+            weight_scale = convert_to_channelwise(
+                layer.weight_scale, layer.logical_widths
+            )
+        else:
+            # Dequant -> Quant with max scale so we can run per tensor.
+            weight = layer.weight
+            weight_scale = layer.weight_scale
+            # If ROCm, normalize the weights and scales to e4m3fnuz
+            if _is_hip:
+                weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                    weight=weight,
+                    weight_scale=weight_scale,
+                    input_scale=layer.input_scale,
+                )
+                if input_scale is not None:
+                    layer.input_scale = Parameter(input_scale, requires_grad=False)
+
+            weight_scale, weight = requantize_with_max_scale(
+                weight=weight,
+                weight_scale=weight_scale,
+                logical_widths=layer.logical_widths,
+            )
+
+        # Update layer with new values.
+        layer.weight = Parameter(weight.t(), requires_grad=False)
+        layer.weight_scale = Parameter(weight_scale, requires_grad=False)
+        if self.quant_config.activation_scheme == "static":
+            layer.input_scale = Parameter(
+                layer.input_scale.max(), requires_grad=False
+            )
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs
+    ):
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        tp_size = get_tensor_model_parallel_world_size()
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        scale[:] = torch.finfo(torch.float32).min
+        layer.register_parameter("weight_scale", scale)
+
+        layer.register_parameter("input_scale", None)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ):  
+        return apply_fp8_linear(
+            input=x,
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            input_scale=layer.input_scale,
+            bias=bias,
+            cutlass_fp8_supported=self.cutlass_fp8_supported,
+            use_per_token_if_dynamic=False
+        )
+
+
+class QuarkInt4Fp8MoEMethod:
+    """MoE method for INT8.
+    Supports loading INT8 checkpoints with static weight scale and
+    dynamic/static activation scale.
+    Also supports loading quantized FP16/BF16 model checkpoints with dynamic
+    activation scaling. The weight scaling factor will be initialized after
+    the model weights are loaded.
+    Args:
+        quant_config: The quantization config.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoEMethodBase
+
+        if not hasattr(cls, "_initialized"):
+            original_init = cls.__init__
+            new_cls = type(
+                cls.__name__,
+                (FusedMoEMethodBase,),
+                {
+                    "__init__": original_init,
+                    **{k: v for k, v in cls.__dict__.items() if k != "__dict__"},
+                },
+            )
+            obj = super(new_cls, new_cls).__new__(new_cls)
+            obj.__init__(*args, **kwargs)
+            return obj
+        return super().__new__(cls)
+
+    def __init__(self, quant_config):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
+
+        tp_size = get_tensor_model_parallel_world_size()
+
+        params_dtype = torch.uint32
+        # WEIGHTS
+        # INT4 MoE weight - INT32 packed
+        w13_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts,
+                2 * intermediate_size,
+                hidden_size // 8,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        w2_weight = torch.nn.Parameter(
+            torch.empty(
+                num_experts, hidden_size, intermediate_size // 8, dtype=params_dtype
+            ),
+            requires_grad=False,
+        )
+        layer.register_parameter("w13_weight", w13_weight)
+        set_weight_attrs(w13_weight, extra_weight_attrs)
+
+        layer.register_parameter("w2_weight", w2_weight)
+        set_weight_attrs(w2_weight, extra_weight_attrs)
+
+
+        # Allocate 2 scales for w1 and w3 respectively.
+        # They will be combined to a single scale after weight loading.
+        w13_weight_scale = torch.nn.Parameter(
+            torch.ones(num_experts, 2, dtype=torch.float32), requires_grad=False
+        )
+        w2_weight_scale = torch.nn.Parameter(
+            torch.ones(num_experts, dtype=torch.float32), requires_grad=False
+        )
+        layer.register_parameter("w13_weight_scale", w13_weight_scale)
+        layer.register_parameter("w2_weight_scale", w2_weight_scale)
+
+        if (
+            _is_hip
+        ):  # and get_bool_env_var("CK_MOE"): TODO: add check back after triton kernel
+            # ROCm - using column scaling, duplicate scaling numbers in case per tensor scaling
+            w13_weight_scale1 = torch.nn.Parameter(
+                torch.ones(num_experts, 2 * intermediate_size, dtype=torch.float32),
+                requires_grad=False,
+            )
+            w2_weight_scale1 = torch.nn.Parameter(
+                torch.ones(num_experts, hidden_size, dtype=torch.float32),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight_scale1", w13_weight_scale1)
+            layer.register_parameter("w2_weight_scale1", w2_weight_scale1)
+
+        extra_weight_attrs.update(
+            {"quant_method": FusedMoeWeightScaleSupported.TENSOR.value}
+        )
+
+        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+
+        # Add the quantization method used (per tensor/grouped/channel)
+        # to ensure the weight scales are loaded in properly
+        extra_weight_attrs.update(
+            {"quant_method": FusedMoeWeightScaleSupported.CHANNEL.value}
+        )
+
+        set_weight_attrs(w13_weight_scale1, extra_weight_attrs)
+        set_weight_attrs(w2_weight_scale1, extra_weight_attrs)
+
+        w13_input_scale = None
+        layer.register_parameter("w13_input_scale", w13_input_scale)
+
+        w2_input_scale = None
+        layer.register_parameter("w2_input_scale", w2_input_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if _is_hip: 
+            layer.w13_weight_scale1 *= 0.5
+            layer.w2_weight_scale1 *= 0.5
+
+            layer.w13_weight_scale *= 2.0
+            layer.w2_weight_scale *= 2.0
+
+
+        # TODO: and use_aiter_moe: add after triton kernel added
+        # INT4-FP8 (INT4 MoE Weight, FP8 Compute)
+        # Weight Permutation
+        layer.w13_weight = torch.nn.Parameter(
+            shuffle_weight(layer.w13_weight.data, (16, 16)),
+            requires_grad=False,
+        )
+        torch.cuda.empty_cache()
+        layer.w2_weight = torch.nn.Parameter(
+            shuffle_weight(layer.w2_weight.data, (16, 16)),
+            requires_grad=False,
+        )
+        torch.cuda.empty_cache()
+
+        # INT4-FP8 : offset INT4 w13_weight_scale1 to single w13_weight_scale
+        # Fp8 moe kernel needs single fp8 w13_weight_scale for w13 per expert.
+        # We won't do requant each expert's fp8 weight (not direct available),
+        # instead we adjust half of INT4 w13_weight_scale1 numbers
+        assert layer.w13_weight_scale is not None
+        shard_size = layer.intermediate_size_per_partition
+        max_w13_scales = layer.w13_weight_scale.max(dim=1).values
+        for expert_id in range(layer.num_experts):
+            start = 0
+            max_w13_scale_fp8 = max_w13_scales[expert_id]
+            for shard_id in range(2):
+                if layer.w13_weight_scale[expert_id][shard_id] != max_w13_scale_fp8:
+                    int4_rescale = (
+                        layer.w13_weight_scale[expert_id][shard_id] / max_w13_scale_fp8
+                    )
+                    layer.w13_weight_scale1[expert_id][
+                        start : start + shard_size
+                    ] *= int4_rescale
+                start += shard_size
+
+        layer.w13_weight_scale = torch.nn.Parameter(max_w13_scales, requires_grad=False)
+
+        # special hack to asm_moe, which takes (weight_scale1 * weight_scale) as post GEMM scaling
+        # optimal design - shall apply per-column weight_scale1 before GEMM, and weight_scale post
+        for expert_id in range(layer.num_experts):
+            layer.w13_weight_scale1[expert_id] *= max_w13_scales[expert_id]
+            layer.w2_weight_scale1[expert_id] *= layer.w2_weight_scale[expert_id]
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        top_k: int,
+        renormalize: bool,
+        use_grouped_topk: bool,
+        topk_group: Optional[int] = None,
+        num_expert_group: Optional[int] = None,
+        custom_routing_function: Optional[Callable] = None,
+        correction_bias: Optional[torch.Tensor] = None,
+        activation: str = "silu",
+        apply_router_weight_on_input: bool = False,
+        inplace: bool = True,
+        no_combine: bool = False,
+        routed_scaling_factor: Optional[float] = None,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.moe.fused_moe_triton.fused_moe import fused_experts
+        from sglang.srt.layers.moe.topk import select_experts
+
+        topk_weights, topk_ids = select_experts(
+            hidden_states=x,
+            router_logits=router_logits,
+            use_grouped_topk=use_grouped_topk,
+            top_k=top_k,
+            renormalize=renormalize,
+            topk_group=topk_group,
+            num_expert_group=num_expert_group,
+            custom_routing_function=custom_routing_function,
+            correction_bias=correction_bias,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+
+        if _is_hip:
+            # TODO: add triton kernel and add check get_bool_env_var("CK_MOE")
+            assert not no_combine, f"{no_combine=} is not supported."
+            return ck_moe_2stages(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights,
+                topk_ids,
+                QuantType.per_Token,
+                layer.w13_weight_scale1,
+                layer.w2_weight_scale1,
+                activation=(
+                    ActivationType.Silu if activation == "silu" else ActivationType.Gelu
+                ),
+            )
+
+        # Expert fusion with FP8 quantization
+        return fused_experts(
+            x,
+            layer.w13_weight,
+            layer.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=inplace and not no_combine,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            use_fp8_w8a8=True,
+            w1_scale=(
+                layer.w13_weight_scale_inv
+                if self.block_quant
+                else layer.w13_weight_scale
+            ),
+            w2_scale=(
+                layer.w2_weight_scale_inv if self.block_quant else layer.w2_weight_scale
+            ),
+            a1_scale=layer.w13_input_scale,
+            a2_scale=layer.w2_input_scale,
+            block_shape=self.quant_config.weight_block_size,
+            no_combine=no_combine,
+        )

--- a/python/sglang/srt/layers/quark_utils.py
+++ b/python/sglang/srt/layers/quark_utils.py
@@ -1,0 +1,104 @@
+"""
+Common utilities for quark.
+"""
+
+import logging
+from tqdm.auto import tqdm
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def apply_quark_quant_config_to_model(model_config, quark_config):
+    if quark_config == "" or quark_config is None or hasattr(model_config.hf_config, 'quantization_config'):
+        return
+    elif "int4fp8_moe" in quark_config:
+        quantization_config = {
+            "quant_method": "quark_int4fp8_moe",  # int4-fp8
+            "activation_scheme": "dynamic",
+            "weight_scheme": {
+                "bits": 4,
+                "group": "column",
+                "sym": True
+            },
+        }
+        model_config.hf_config.update({"quantization_config": quantization_config})
+        model_config._verify_quantization()
+    else:
+        raise ValueError(f"Unexpected config: {quark_config}")
+    
+
+def online_quant(model_config, weights_dict):
+    if model_config.quantization == 'quark_int4fp8_moe':
+
+        def quantize_fp8_scale_tensorwise(w):
+            FP8_MAX = 448.0
+            scale = w.abs().amax().float() / FP8_MAX
+            scaled = (w / scale).clamp(-FP8_MAX, FP8_MAX).to(torch.float8_e4m3fn)
+            return scaled, scale
+
+
+        def quantize_int4_scale_columnwise(w):
+            S4_MAX = 7
+            w_flat = w.reshape(-1, w.shape[-1]).float()
+            scale = w_flat.abs().amax(axis=-1) / S4_MAX
+            scaled = torch.round(w_flat / scale[:, None]).to(torch.int8).clamp(-S4_MAX, S4_MAX)
+            return scaled.reshape(w.shape), scale.reshape(w.shape[:-1])
+
+
+        def pack(to_pack: torch.Tensor, reorder: bool = True) -> torch.Tensor:
+            if to_pack.ndim > 2:
+                raise ValueError("Pack: Only supports tensors with dimensions not greater than 2.")
+
+            if reorder:
+                order_map = [0, 2, 4, 6, 1, 3, 5, 7]
+            else:
+                order_map = [0, 1, 2, 3, 4, 5, 6, 7]
+            pack_num = 8
+            if to_pack.ndim == 2:
+                packed = torch.zeros(to_pack.shape[0], to_pack.shape[1] // pack_num, dtype=torch.int32, device=to_pack.device)
+                new_c = to_pack.shape[1] // pack_num
+                for c in range(new_c):
+                    for i in range(pack_num):
+                        # Use -3 as an example, high_position is 11111111,cause bit_or generate errors, so we can't use int4 directly
+                        packed_col = to_pack[:, c * pack_num + order_map[i]].to(torch.int32)
+                        packed_col = packed_col & 0x0F
+                        packed[:, c] = torch.bitwise_or(packed[:, c], torch.bitwise_left_shift(packed_col, i * 4))
+            elif to_pack.ndim == 0:
+                packed = to_pack.to(torch.int32)
+            else:
+                packed = torch.zeros(to_pack.shape[0] // pack_num, dtype=torch.int32, device=to_pack.device)
+                new_c = to_pack.shape[0] // pack_num
+                for c in range(new_c):
+                    for i in range(pack_num):
+                        # Use -3 as an example, high_position is 11111111,cause bit_or generate errors, so we can't use int4 directly
+                        packed_col = to_pack[c * pack_num + order_map[i]]
+                        packed_col = packed_col & 0x0F
+                        packed[c] = torch.bitwise_or(packed[c], torch.bitwise_left_shift(packed_col, i * 4))
+
+            return packed
+
+        def quark_quant_weights(weights_dict):
+            for name, loaded_weight in tqdm(weights_dict, desc="Quark Online Quantizating "):
+                if "w1.weight" in name or "w2.weight" in name or "w3.weight" in name: 
+                    fp8_w, fp8_scale = quantize_fp8_scale_tensorwise(loaded_weight)
+                    int4_w, int4_scale = quantize_int4_scale_columnwise(loaded_weight)
+
+                    int4_w = pack(int4_w)
+                    int4_scale /= fp8_scale
+
+                    yield name, int4_w  
+                    yield name + "_scale", fp8_scale
+                    yield name + "_scale1", int4_scale
+                elif "proj.weight" in name:
+                    fp8_w, fp8_scale = quantize_fp8_scale_tensorwise(loaded_weight)
+
+                    yield name, fp8_w  
+                    yield name + "_scale", fp8_scale
+                else:
+                    yield name, loaded_weight  
+
+        weights_dict = quark_quant_weights(weights_dict)
+    return weights_dict
+        
+

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -84,6 +84,7 @@ global_server_args_dict = {
     "sampling_backend": ServerArgs.sampling_backend,
     "speculative_accept_threshold_acc": ServerArgs.speculative_accept_threshold_acc,
     "speculative_accept_threshold_single": ServerArgs.speculative_accept_threshold_single,
+    "quark_config": ServerArgs.quark_config,
     "torchao_config": ServerArgs.torchao_config,
     "triton_attention_reduce_in_fp32": ServerArgs.triton_attention_reduce_in_fp32,
 }

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.quantization.deep_gemm import (
     update_deep_gemm_config,
 )
 from sglang.srt.layers.sampler import Sampler
+from sglang.srt.layers.quark_utils import apply_quark_quant_config_to_model
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
 from sglang.srt.lora.lora_manager import LoRAManager
 from sglang.srt.managers.schedule_batch import global_server_args_dict
@@ -168,6 +169,7 @@ class ModelRunner:
                 "moe_dense_tp_size": server_args.moe_dense_tp_size,
                 "n_share_experts_fusion": server_args.n_share_experts_fusion,
                 "triton_attention_reduce_in_fp32": server_args.triton_attention_reduce_in_fp32,
+                "quark_config": server_args.quark_config,
                 "torchao_config": server_args.torchao_config,
                 "sampling_backend": server_args.sampling_backend,
                 "speculative_accept_threshold_single": server_args.speculative_accept_threshold_single,
@@ -200,6 +202,10 @@ class ModelRunner:
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(
             enable=self.server_args.enable_memory_saver
         )
+
+        apply_quark_quant_config_to_model(
+            self.model_config, global_server_args_dict["quark_config"])
+
 
         # Load the model
         self.sampler = Sampler()

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -35,6 +35,7 @@ from sglang.srt.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from sglang.srt.layers.quark_utils import online_quant
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_loader.utils import (
     get_model_architecture,
@@ -375,13 +376,14 @@ class DefaultModelLoader(BaseModelLoader):
                 )
 
             self.load_weights_and_postprocess(
-                model, self._get_all_weights(model_config, model), target_device
+                model, model_config, self._get_all_weights(model_config, model), target_device
             )
 
         return model.eval()
 
     @staticmethod
-    def load_weights_and_postprocess(model, weights, target_device):
+    def load_weights_and_postprocess(model, model_config, weights, target_device):
+        weights = online_quant(model_config, weights)
         model.load_weights(weights)
 
         for _, module in model.named_modules():

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -25,7 +25,7 @@ def get_model_architecture(model_config: ModelConfig) -> Tuple[Type[nn.Module], 
     architectures = getattr(model_config.hf_config, "architectures", [])
     # Special handling for quantized Mixtral.
     # FIXME(woosuk): This is a temporary hack.
-    mixtral_supported = ["fp8", "compressed-tensors", "gptq_marlin", "awq_marlin"]
+    mixtral_supported = ["fp8", "compressed-tensors", "gptq_marlin", "awq_marlin", "quark_int4fp8_moe"]
 
     if (
         model_config.quantization is not None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -167,6 +167,7 @@ class ServerArgs:
     torch_compile_max_bs: int = 32
     cuda_graph_max_bs: Optional[int] = None
     cuda_graph_bs: Optional[List[int]] = None
+    quark_config: str = ""
     torchao_config: str = ""
     enable_nan_detection: bool = False
     enable_p2p_check: bool = False
@@ -1093,6 +1094,12 @@ class ServerArgs:
             type=int,
             nargs="+",
             help="Set the list of batch sizes for cuda graph.",
+        )
+        parser.add_argument(
+            "--quark-config",
+            type=str,
+            default=ServerArgs.quark_config,
+            help="Optimize the model with quark. Experimental feature. Current choices are: int4fp8_moe",
         )
         parser.add_argument(
             "--torchao-config",


### PR DESCRIPTION
Quark int4_fp8_moe on the fly quant.

In this PR, we support on the fly quantization of int4_fp8_moe using quark. 

`python bench_one_batch.py --model-path /model/mistralai/Mixtral-8x7B-Instruct-v0.1 --correct --quark-config int4fp8_moe `

