### PR TITLE
Fix IndexError in move_ready_grammar_requests under high concurrency

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1744,6 +1744,10 @@ class Scheduler(
             )
             num_ready_reqs_max, num_abort_reqs_max = tensor.tolist()
 
+            total_needed = num_ready_reqs_max + num_abort_reqs_max
+            if len(self.grammar_queue) < total_needed:
+                return
+            
             for i in range(num_ready_reqs, num_ready_reqs_max):
                 req = self.grammar_queue[i]
                 req.grammar = req.grammar.result()


### PR DESCRIPTION
### What this PR does
This PR fixes a rare but critical bug in `Scheduler.move_ready_grammar_requests()` where
the grammar_queue length could be smaller than `num_ready_reqs_max`, causing an IndexError.

### Why
Under high concurrency (e.g., toolbench dataset, 12 concurrent requests), asynchronous
future completion may cause inconsistent grammar_queue lengths across TP ranks.

### How
This patch adds a length check before accessing grammar_queue to guarantee safe bounds.

### Testing
- Manually tested on Qwen3-32B with toolbench dataset under stress conditions.
- Server remains stable after patch; crash no longer occurs.

### Additional Notes
This change does not affect normal throughput or behavior under standard workloads.

Closes #6229
