### PR TITLE
perf: optimize local_block_table memory allocation

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1165,7 +1165,6 @@ class FlashAttentionBackend(AttentionBackend):
             max_virtual_batches = max_bs * (
                 (max_seq_len + attn_chunk_size - 1) // attn_chunk_size
             )
-            max_blocks_per_seq = (max_seq_len + attn_chunk_size - 1) // attn_chunk_size
             max_pages_per_block = (attn_chunk_size + page_size - 1) // page_size
 
             self.decode_cuda_graph_local_attn_metadata = {
@@ -1177,7 +1176,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "local_block_table": torch.zeros(
                     max_virtual_batches,
-                    max_blocks_per_seq * max_pages_per_block,
+                    max_pages_per_block,
                     dtype=torch.int32,
                     device=self.device,
                 ),


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
The current implementation of the local attention mechanism in `FlashAttentionBackend` allocates **significantly** more memory than necessary for the `local_block_table` tensor. This over-allocation becomes particularly problematic for models with large context lengths, leading to unnecessary GPU memory usage.

The current allocation creates a tensor with dimensions `(max_virtual_batches, max_blocks_per_seq * max_pages_per_block)`, but the actual usage in the `make_local_attention_virtual_batches` function only requires dimensions of `(virtual_batches, pages_per_local_batch)`. 

For example, with a context length of 512K and attention chunk size of 8192, the current allocation is 65 times larger than necessary. This is because `max_blocks_per_seq` scales linearly with the context length. As a result, Llama4-Maverick-FP8 on 8*H100 will OOM as it tries to allocate 20.00 GiB.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
- Reduce memory usage for local attention by allocating the tensor local_block_table from `(max_virtual_batches, max_blocks_per_seq * max_pages_per_block)` to `(max_virtual_batches, max_pages_per_block)`

## Evaludation Results
```
sglang git:(chang/llama4-opt) ✗ python3 -m sglang.eval.loogle_eval --api-url=http://127.0.0.1:8080/v1
Running benchmark: 100%|█████████████████████████████████████████████████████| 1101/1101 [00:00<00:00, 84625.50it/s]
Some weights of RobertaModel were not initialized from the model checkpoint at roberta-large and are newly initialized: ['pooler.dense.bias', 'pooler.dense.weight']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
Loading responses: 100%|██████████████████████████████████████████████████████| 1101/1101 [00:00<00:00, 5563.29it/s]
Scoring batches: 100%|██████████████████████████████████████████████████████████████| 18/18 [02:16<00:00,  7.57s/it]
Average BERTScore (F1): 84.40%
```

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
