### PR TITLE
[AMD] Fix Llama 4 Scout and Maverick accuracy issues on MI300X

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -186,6 +186,17 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
 
         if _is_hip and get_bool_env_var("SGLANG_AITER_MOE"):
             assert not no_combine, "unsupported"
+            if apply_router_weight_on_input:
+                assert (topk_weights.dim() == 2
+                        ), "`topk_weights` should be in shape (num_tokens, topk)"
+                _, topk = topk_weights.shape
+                assert (
+                    topk == 1
+                ), "Only support topk=1 when `apply_router_weight_on_input` is True"
+                x = x * topk_weights.to(x.dtype)
+                topk_ids = topk_ids.to(torch.int32)
+                topk_weights = torch.ones_like(topk_weights, dtype=torch.float32) # topk_weights must be FP32 (float32)
+
             return ck_moe_2stages(
                 x,
                 layer.w13_weight,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -195,7 +195,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                     topk == 1
                 ), "Only support topk=1 when `apply_router_weight_on_input` is True"
                 x = x * topk_weights.to(x.dtype)
-                topk_ids = topk_ids.to(torch.int32)
                 topk_weights = torch.ones_like(
                     topk_weights, dtype=torch.float32
                 )  # topk_weights must be FP32 (float32)

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -187,15 +187,18 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         if _is_hip and get_bool_env_var("SGLANG_AITER_MOE"):
             assert not no_combine, "unsupported"
             if apply_router_weight_on_input:
-                assert (topk_weights.dim() == 2
-                        ), "`topk_weights` should be in shape (num_tokens, topk)"
+                assert (
+                    topk_weights.dim() == 2
+                ), "`topk_weights` should be in shape (num_tokens, topk)"
                 _, topk = topk_weights.shape
                 assert (
                     topk == 1
                 ), "Only support topk=1 when `apply_router_weight_on_input` is True"
                 x = x * topk_weights.to(x.dtype)
                 topk_ids = topk_ids.to(torch.int32)
-                topk_weights = torch.ones_like(topk_weights, dtype=torch.float32) # topk_weights must be FP32 (float32)
+                topk_weights = torch.ones_like(
+                    topk_weights, dtype=torch.float32
+                )  # topk_weights must be FP32 (float32)
 
             return ck_moe_2stages(
                 x,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix the following models on AMD GPUs.
- meta-llama/Llama-4-Scout-17B-16E-Instruct
- meta-llama/Llama-4-Maverick-17B-128E-Instruct


## Modifications

<!-- Describe the changes made in this PR. -->
- Fix `FusedMoE `with `SGLANG_AITER_MOE=1` path when `apply_router_weight_on_input=True`

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

### Llama-4-Scout-17B-16E-Instruct
```
SGLANG_AITER_MOE=1 python -m sglang.launch_server --model-path meta-llama/Llama-4-Scout-17B-16E-Instruct/ --port 30000 --tp 8 --mem-fraction-static 0.8 --context-length 65536
lm_eval --model local-chat-completions --model_args model=meta-llama/Llama-4-Scout-17B-16E-Instruct/,base_url=http://localhost:30000/v1/chat/completions,num_concurrent=128,timeout=999999,max_gen_toks=2048 --tasks mmlu_pro --batch_size 128 --apply_chat_template --num_fewshot 0
```
### Llama-4-Maverick-17B-128E-Instruct
```
SGLANG_AITER_MOE=1 python -m sglang.launch_server --model-path meta-llama/Llama-4-Maverick-17B-128E-Instruct --port 30000 --tp 8 --mem-fraction-static 0.8 --context-length 65536
lm_eval --model local-chat-completions --model_args model=meta-llama/Llama-4-Maverick-17B-128E-Instruct,base_url=http://localhost:30000/v1/chat/completions,num_concurrent=128,timeout=999999,max_gen_toks=2048 --tasks mmlu_pro --batch_size 128 --apply_chat_template --num_fewshot 0
```

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<p style='margin:0in;margin-left:.375in;font-family:Calibri;font-size:11.0pt'>Ref:
<a
href="https://github.com/sgl-project/sglang/blob/main/docs/references/llama4.md">https://github.com/sgl-project/sglang/blob/main/docs/references/llama4.md</a></p>

<div style='direction:ltr'>


  | Llama-4-Scout-17B-16E-Instruct | Llama-4-Maverick-17B-128E-Instruct
-- | -- | --
Official Benchmark | 74.3 | 80.5
SGLang (8*H100) | 75.2 | 80.7
SGLang (8*MI300X)     (v0.4.6.post2-rocm630 + this PR) | 75.0 | 81.2



</div>

<!--EndFragment-->
</body>

</html>

This PR also resolves this issue: https://github.com/sgl-project/sglang/issues/5402.

CC: @HaiShaw 

