### PR TITLE
[Bug] Fix accidental logger override caused by internVL.

### DIFF
--- a/python/sglang/srt/managers/multimodal_processors/internvl.py
+++ b/python/sglang/srt/managers/multimodal_processors/internvl.py
@@ -3,7 +3,6 @@
 import numpy as np
 import torch
 from decord import VideoReader, cpu
-from numpy.distutils.cpuinfo import cpu
 from PIL import Image
 
 from sglang.srt.managers.multimodal_processors.base_processor import (


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

I noticed that sglang stopped logging info level logs whenever I use multimodal models. E.g. there is no "the server is fired up and ready to roll" when I load any multimodal model:
![image](https://github.com/user-attachments/assets/021471a2-9407-4e6c-a1dc-a82ca229a870)

I debugged a little bit and found out it's introduced in #5350: sglang loads all processors when loading multimodal model, and internvl introduced numpy.distutils which has a known bug (see: https://github.com/numpy/numpy/issues/24213). 
![image](https://github.com/user-attachments/assets/9b3b56b6-a49a-4762-9e5f-f67dfc95c7c1)
![image](https://github.com/user-attachments/assets/9113a836-1e8e-474b-9348-1bab5566ee5c)

Upon further reading, I found out the introduction of this package might have been a bug itself, as the only location where `cpu` is used is actually expecting `decord.cpu` instead of `numpy.distutils.cpuinfo.cpu`, so I removed the line and the logging is working again:
![image](https://github.com/user-attachments/assets/c570b9c0-fe60-490a-9e4b-abb8f27faffe)

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
