### PR TITLE
fix: nixl hang

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -358,7 +358,7 @@ class NixlKVManager(BaseKVManager):
                 room = int(components[0])
                 if components[1] == "kv":
                     chunk_id = int(components[2])
-                    is_last = bool(components[3])
+                    is_last = bool(int(components[3]))
                     self.transfer_statuses[room].received_kvs.add(chunk_id)
                     if is_last:
                         self.transfer_statuses[room].num_kvs_expected = chunk_id + 1


### PR DESCRIPTION
https://github.com/sgl-project/sglang/issues/6320


```python
>>> msg = b'876613880292365106_kv_0_0'
>>> components = msg.decode("ascii").split("_")
>>> bool(components[3])
True
>>> bool(int(components[3]))
False
```