### PR TITLE
Do not use FA3 for mistral

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -2089,7 +2089,6 @@ def is_fa3_default_architecture(hf_config):
         "Qwen2ForCausalLM",
         "Llama4ForConditionalGeneration",
         "LlamaForCausalLM",
-        "MistralForCausalLM",
         "Gemma2ForCausalLM",
         "Gemma3ForConditionalGeneration",
         "Qwen3ForCausalLM",


### PR DESCRIPTION
likely an acc regression found in the nightly tests https://github.com/sgl-project/sglang/actions/runs/15090530789/job/42418423641#step:4:3371