### PR TITLE
Fix bench moe fused gate test

### DIFF
--- a/sgl-kernel/benchmark/bench_moe_fused_gate.py
+++ b/sgl-kernel/benchmark/bench_moe_fused_gate.py
@@ -18,6 +18,7 @@ def biased_grouped_topk_org(scores, bias, num_expert_group, topk_group, topk):
         renormalize=True,
         num_expert_group=num_expert_group,
         topk_group=topk_group,
+        routed_scaling_factor=1.0,
     )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
The biased_grouped_topk is changed to assert routed_scaling_factor is not None. But in bench test still use default none which makes test asserted. With the fix, the test case passed.
```
def biased_grouped_topk(
    hidden_states: torch.Tensor,
    gating_output: torch.Tensor,
    correction_bias: torch.Tensor,
    topk: int,
    renormalize: bool,
    num_expert_group: int = 0,
    topk_group: int = 0,
    compiled: bool = True,
    n_share_experts_fusion: int = 0,
    routed_scaling_factor: Optional[float] = None,
    num_token_non_padded: Optional[torch.Tensor] = None,
):
    assert (
        routed_scaling_factor is not None
    ), "routed_scaling_factor is required for biased_grouped_topk"
```
Without the fix:
```
[root@decfee1df170 benchmark]# python bench_moe_fused_gate.py
Traceback (most recent call last):
  File "/home/root/luoyuan.luo/sglang/sgl-kernel/benchmark/bench_moe_fused_gate.py", line 74, in <module>
    benchmark.run(print_data=True)
  File "/opt/conda/lib/python3.10/site-packages/triton/testing.py", line 364, in run
    result_dfs.append(self._run(bench, save_path, show_plots, print_data, **kwargs))
  File "/opt/conda/lib/python3.10/site-packages/triton/testing.py", line 307, in _run
    ret = self.fn(**x_args, **{bench.line_arg: y}, **bench.args, **kwrags)
  File "/home/root/luoyuan.luo/sglang/sgl-kernel/benchmark/bench_moe_fused_gate.py", line 56, in benchmark
    ms, min_ms, max_ms = triton.testing.do_bench(
  File "/opt/conda/lib/python3.10/site-packages/triton/testing.py", line 117, in do_bench
    fn()
  File "/home/root/luoyuan.luo/sglang/sgl-kernel/benchmark/bench_moe_fused_gate.py", line 57, in <lambda>
    lambda: biased_grouped_topk_org(
  File "/home/root/luoyuan.luo/sglang/sgl-kernel/benchmark/bench_moe_fused_gate.py", line 13, in biased_grouped_topk_org
    return biased_grouped_topk(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/moe/topk.py", line 220, in biased_grouped_topk
    routed_scaling_factor is not None
AssertionError: routed_scaling_factor is required for biased_grouped_topk
```
With the fix:
```
[root@decfee1df170 benchmark]# python bench_moe_fused_gate.py 
INFO 05-20 16:59:52 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 05-20 16:59:52 [__init__.py:239] Automatically detected platform cuda.
moe-fused-gate-performance:
   seq_length    Original  SGL Kernel
0      5000.0   31.456001   30.368000
1     10000.0   44.160001   45.536000
2     15000.0   57.055999   57.248000
3     20000.0   68.031996   69.472000
4     25000.0   80.991998   82.240000
5     30000.0   94.016001   94.912000
6     35000.0  106.367998  105.008006
7     40000.0  118.175998  118.111998
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
