### PR TITLE
[router] support http2 in router

### DIFF
--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -264,7 +264,7 @@ pub async fn startup(config: ServerConfig) -> std::io::Result<()> {
             // Default handler for unmatched routes.
             .default_service(web::route().to(sink_handler))
     })
-    .bind((config.host, config.port))?
+    .bind_auto_h2c((config.host, config.port))?
     .run()
     .await
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Make the router support http2 and http1.x at the same time, so that the concurrency of the router on single node won't be limited by the available ports.

Thank you for your time on reviewing this pr :)

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
