### PR TITLE
Replace assignment (=) with comparison (==) in write() check

### DIFF
--- a/sgl-kernel/csrc/cpu/shm.cpp
+++ b/sgl-kernel/csrc/cpu/shm.cpp
@@ -54,7 +54,7 @@ void shared_open(SharedData* data, const char* name, size_t nbytes) {
 void shared_create(SharedData* data, const char* name, void* bytes, size_t nbytes) {
   int d = shm_open(name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
   if (d != -1) {
-    if (nbytes = write(d, bytes, nbytes)) {
+    if (nbytes == write(d, bytes, nbytes)) {
       shared_open(data, name, nbytes);
     }
   } else {


### PR DESCRIPTION

## Motivation


This PR fixes a critical bug in the `shared_create` function where an assignment operator was used instead of a comparison operator in a conditional statement, causing potential incorrect behavior when creating shared memory segments.


## Modifications

Fixed the conditional statement in `shared_create` function by replacing the assignment operator (`=`) with proper error checking


