### PR TITLE
[Bugfix](gemma3_mm): handle flatten_batch constraint for multiple images

### DIFF
--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -288,13 +288,22 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
                     "MM inputs where only some items are precomputed."
                 )
             return torch.concat([item.precomputed_features for item in items])
-        pixel_values = torch.stack(
-            flatten_nested_list([item.pixel_values for item in items]), dim=0
-        )
-        pixel_values = pixel_values.to(device=self.vision_tower.device)
-        pixel_values = pixel_values.to(dtype=self.language_model.dtype())
 
-        vision_outputs = self.vision_tower(pixel_values=pixel_values)
+        # Process images one by one to handle flatten_batch=True constraint in vision_tower
+        all_pixel_values = flatten_nested_list([item.pixel_values for item in items])
+        vision_outputs_list = []
+
+        for pixel_value in all_pixel_values:
+            # Add batch dimension for single image processing
+            pixel_value_batch = pixel_value.unsqueeze(0)
+            pixel_value_batch = pixel_value_batch.to(device=self.vision_tower.device)
+            pixel_value_batch = pixel_value_batch.to(dtype=self.language_model.dtype())
+
+            vision_output = self.vision_tower(pixel_values=pixel_value_batch)
+            vision_outputs_list.append(vision_output)
+
+        # Concatenate all vision outputs
+        vision_outputs = torch.cat(vision_outputs_list, dim=0)
         image_features = self.multi_modal_projector(vision_outputs)
         return image_features
 


### PR DESCRIPTION
Process images individually in get_image_feature() to avoid AssertionError when SigLIP vision tower expects batch size = 1.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Current CI TestGemma3itServer is failing.

![Screenshot 2025-05-23 at 6 09 22 PM](https://github.com/user-attachments/assets/fc46a443-7bec-4b63-b129-a289a96ce63e)

The root cause is that when multiple images are processed, the code stacks them into a batch with size > 1, but the SigLIP vision tower (used in Gemma3) has flatten_batch=True which expects batch size 1.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
- Process images individually in `gemma3_mm.get_image_feature()` to avoid AssertionError
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
