### PR TITLE
Fix eplb expert location updater type error

### DIFF
--- a/python/sglang/srt/model_executor/expert_location_updater.py
+++ b/python/sglang/srt/model_executor/expert_location_updater.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ==============================================================================
 import logging
+import datetime
 from typing import Dict, List, Tuple
 
 import torch
@@ -340,7 +341,7 @@ def update_expert_weights_single_layer(
         reqs = torch.distributed.batch_isend_irecv(p2p_ops)
         try:
             for req in reqs:
-                req.wait(timeout=30)
+                req.wait(timeout=datetime.timedelta(seconds=30))
         except RuntimeError:
             logger.error(
                 f"Context: {rank=} {old_physical_to_logical_map=} {new_physical_to_logical_map=} {num_local_physical_experts=} {num_gpu_per_node=}"


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix type error in _execute_p2p_ops function in python/sglang/srt/model_executor/expert_location_updater.py

```
[2025-05-26 07:16:36 DP0 TP0] TpModelWorkerClient hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 118, in forward_thread_func
    self.forward_thread_func_()
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 151, in forward_thread_func_
    self.worker.forward_batch_generation(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 202, in forward_batch_generation
    logits_output, can_run_cuda_graph = self.model_runner.forward(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1190, in forward
    self.eplb_manager.on_forward_pass_end(self.forward_pass_id)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/eplb_manager.py", line 38, in on_forward_pass_end
    self.rebalance()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/eplb_manager.py", line 51, in rebalance
    self._model_runner.update_expert_location(expert_location_metadata)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 603, in update_expert_location
    expert_location_updater.update_expert_location(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/expert_location_updater.py", line 36, in update_expert_location
    _update_expert_weights(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/expert_location_updater.py", line 69, in _update_expert_weights
    update_expert_weights_single_layer(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/expert_location_updater.py", line 371, in update_expert_weights_single_layer
    _entrypoint()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/expert_location_updater.py", line 121, in _entrypoint
    _execute_p2p_ops(p2p_op_infos)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/expert_location_updater.py", line 343, in _execute_p2p_ops
    req.wait(timeout=30)
TypeError: wait(): incompatible function arguments. The following argument types are supported:
    1. (self: torch._C._distributed_c10d.Work, timeout: datetime.timedelta = datetime.timedelta(0)) -> bool

Invoked with: <torch.distributed.distributed_c10d.Work object at 0x7f83484aaeb0>; kwargs: timeout=30
```

## Modifications

<!-- Describe the changes made in this PR. -->

Corrected req.wait(timeout=30) to req.wait(timeout=datetime.timedelta(seconds=30))

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
