### PR TITLE
Refine pre_reorder_triton_kernel slightly to improve performance

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_ep_pre_reorder_triton.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_ep_pre_reorder_triton.py
@@ -1,0 +1,100 @@
+import argparse
+import itertools
+
+import pandas as pd
+import torch
+import triton
+
+from sglang.srt.layers.moe.ep_moe.kernels import pre_reorder_triton_kernel
+
+
+def benchmark_pre_reorder(batch_size, topk, model_config):
+    hidden_size = model_config["hidden_size"]
+    block_size = model_config["block_size"]
+    expert_range = model_config["expert_range"]
+
+    input_ptr = torch.randn(batch_size, hidden_size, dtype=torch.float16, device="cuda")
+    gateup_input_ptr = torch.zeros(
+        batch_size * topk, hidden_size, dtype=torch.float16, device="cuda"
+    )
+    src2dst_ptr = torch.randint(
+        0, batch_size * topk, (batch_size, topk), dtype=torch.int32, device="cuda"
+    )
+    topk_ids_ptr = torch.randint(
+        expert_range[0],
+        expert_range[1] + 1,
+        (batch_size, topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    a1_scales_ptr = torch.rand(
+        expert_range[1] - expert_range[0] + 1, dtype=torch.float32, device="cuda"
+    )
+
+    input_ptr = input_ptr.view(-1)
+    gateup_input_ptr = gateup_input_ptr.view(-1)
+    src2dst_ptr = src2dst_ptr.view(-1)
+    topk_ids_ptr = topk_ids_ptr.view(-1)
+
+    def run_kernel():
+        pre_reorder_triton_kernel[(batch_size,)](
+            input_ptr,
+            gateup_input_ptr,
+            src2dst_ptr,
+            topk_ids_ptr,
+            a1_scales_ptr,
+            expert_range[0],
+            expert_range[1],
+            topk,
+            hidden_size,
+            block_size,
+        )
+
+    for _ in range(10):
+        run_kernel()
+    torch.cuda.synchronize()
+
+    ms, _, _ = triton.testing.do_bench(run_kernel, quantiles=[0.5, 0.2, 0.8])
+    return ms
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hidden-size", type=int, required=True)
+    parser.add_argument("--block-size", type=int, default=512)
+    args = parser.parse_args()
+
+    model_config = {
+        "hidden_size": args.hidden_size,
+        "block_size": args.block_size,
+        "expert_range": (0, 255),
+    }
+
+    batch_sizes = [64, 128, 256, 512, 640, 768, 1024]
+    topks = [2, 4, 8]
+    configs = list(itertools.product(batch_sizes, topks))
+
+    # Prepare results dict: keys = topk, each row is indexed by batch_size
+    results_dict = {topk: {} for topk in topks}
+
+    for batch_size, topk in configs:
+        ms = benchmark_pre_reorder(batch_size, topk, model_config)
+        results_dict[topk][batch_size] = ms
+
+    # Build dataframe
+    df = pd.DataFrame(
+        {
+            "batch_size": batch_sizes,
+            **{
+                f"TopK={topk}": [results_dict[topk].get(bs, None) for bs in batch_sizes]
+                for topk in topks
+            },
+        }
+    )
+
+    print("\npre-reorder-performance:")
+    print(df.to_string(index=False, float_format="%.6f"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

In ep_moe kernel _pre_reorder_triton_kernel_ and _post_reorder_triton_kernel_, every inner loop recomputes
offset = start_offset + tl.arange(...)

The optimization is to create a constant once:
vec = tl.arange(0, BLOCK_SIZE)
and inside the loop use idx = start_offset + vec

The benefit is one less instruction each iteration. The warp scheduler can vectorize the access pattern.
Per benchmark result the kernel gains 10-15% performance.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
