### PR TITLE
[CPU] Use weight_packed_linear kernel for linear, MoEGate and lm_head

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -31,6 +31,7 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.utils import (
+    _process_weight_after_loading,
     cpu_has_amx_support,
     prepack_weight_if_needed,
     set_weight_attrs,
@@ -170,15 +171,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
         set_weight_attrs(weight, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # Pack weight for get better performance on CPU
-        layer.weight = torch.nn.Parameter(
-            prepack_weight_if_needed(layer.weight.data),
-            requires_grad=False,
-        )
-
-        self.use_intel_amx_backend = (
-            layer.weight.device == torch.device("cpu") and cpu_has_amx_support()
-        )
+        _process_weight_after_loading(layer, ["weight"])
 
     def apply(
         self,
@@ -187,7 +180,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
-        if self.use_intel_amx_backend:
+        if layer.use_intel_amx_backend:
             return torch.ops.sgl_kernel.weight_packed_linear(
                 x, layer.weight, bias, True  # is_vnni
             )

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -454,11 +454,20 @@ class LogitsProcessor(nn.Module):
             dp_gather_replicate(hidden_states, local_hidden_states, logits_metadata)
 
         if hasattr(lm_head, "weight"):
-            logits = torch.matmul(
-                hidden_states.to(lm_head.weight.dtype), lm_head.weight.T
-            )
+            if lm_head.use_intel_amx_backend:
+                logits = torch.ops.sgl_kernel.weight_packed_linear(
+                    hidden_states.to(lm_head.weight.dtype),
+                    lm_head.weight,
+                    None,  # bias
+                    True,  # is_vnni
+                )
+            else:
+                logits = torch.matmul(
+                    hidden_states.to(lm_head.weight.dtype), lm_head.weight.T
+                )
         else:
             # GGUF models
+            # TODO: use weight_packed_linear for GGUF models
             logits = lm_head.quant_method.apply(lm_head, hidden_states, embedding_bias)
 
         if self.logit_scale is not None:

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -549,6 +549,10 @@ class ParallelLMHead(VocabParallelEmbedding):
             use_presharded_weights=use_presharded_weights,
         )
         self.quant_config = quant_config
+
+        from sglang.srt.utils import PackWeightMethod
+
+        self.quant_method = PackWeightMethod(weight_names=["weight"])
         if bias:
             self.bias = Parameter(
                 torch.empty(self.num_embeddings_per_partition, dtype=params_dtype)


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When CPU has AMX support, replace `F.linear` and `torch.matmul` with `weight_packed_linear` to optimize the performance.

https://github.com/sgl-project/sglang/pull/6408, https://github.com/sgl-project/sglang/pull/6614, https://github.com/sgl-project/sglang/pull/6641 need to be landed first and the current PR will work then.

## Modifications
When CPU has AMX support,
- pack the weight of linear, MoEGate and lm_head
 - Add a `PackWeightMethod` to handle weight packing
- use the `weight_packed_linear` kernel for better performance


<!-- Describe the changes made in this PR. -->


