### PR TITLE
refactor(tool call): Fix BaseFormatDetector tool_index issue and refactor `parse_streaming_increment`

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -130,7 +130,6 @@ class BaseFormatDetector(ABC):
         flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
 
         try:
-            # Parse the current tool call directly without building arrays
             try:
                 start_idx = (
                     len(self.bot_token)

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -36,6 +36,7 @@ class BaseFormatDetector(ABC):
         )  # map what has been streamed for each tool so far to a list
         self.bot_token = ""
         self.eot_token = ""
+        self.tool_call_separator = "; "
 
     def parse_base_json(self, action: Any, tools: List[Tool]) -> List[ToolCallItem]:
         tool_indices = {
@@ -227,7 +228,9 @@ class BaseFormatDetector(ABC):
                         )  # Save the ID of the tool that's completing
 
                         # Only remove the processed portion, keep unprocessed content
-                        self._buffer = current_text[start_idx + end_idx :]
+                        self._buffer = current_text[
+                            start_idx + end_idx + len(self.tool_call_separator) :
+                        ]
 
                         if self.current_tool_id < len(self.prev_tool_call_arr):
                             self.prev_tool_call_arr[self.current_tool_id].clear()

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -106,6 +106,7 @@ class BaseFormatDetector(ABC):
         # Append new text to buffer
         self._buffer += new_text
         current_text = self._buffer
+
         if not (self.bot_token in current_text or current_text.startswith("{")):
             # Only clear buffer if we're sure no tool call is starting
             if not self._ends_with_partial_token(self._buffer, self.bot_token):
@@ -127,93 +128,66 @@ class BaseFormatDetector(ABC):
             }
 
         flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
+
         try:
-            tool_call_arr = []
-            is_complete = []
+            # Parse the current tool call directly without building arrays
             try:
                 start_idx = (
                     len(self.bot_token)
                     if current_text.startswith(self.bot_token)
                     else 0
                 )
-                while start_idx < len(current_text):
-                    (obj, end_idx) = _partial_json_loads(
-                        current_text[start_idx:], flags
-                    )
-                    is_complete.append(
-                        _is_complete_json(current_text[start_idx : start_idx + end_idx])
-                    )
-                    start_idx += end_idx + len("; ")
 
-                    # Validate tool name if present
-                    if "name" in obj and obj["name"] not in self._tool_indices:
-                        # Invalid tool name - reset state
-                        self._buffer = ""
-                        self.current_tool_id = -1
-                        self.current_tool_name_sent = False
-                        if self.streamed_args_for_tool:
-                            self.streamed_args_for_tool.pop()
-                        return StreamingParseResult()
+                if start_idx >= len(current_text):
+                    return StreamingParseResult()
 
-                    # Handle parameters/arguments consistency
-                    if "parameters" in obj:
-                        assert (
-                            "arguments" not in obj
-                        ), "model generated both parameters and arguments"
-                        obj["arguments"] = obj["parameters"]
-                    tool_call_arr.append(obj)
+                (obj, end_idx) = _partial_json_loads(current_text[start_idx:], flags)
+
+                is_current_complete = _is_complete_json(
+                    current_text[start_idx : start_idx + end_idx]
+                )
+
+                # Validate tool name if present
+                if "name" in obj and obj["name"] not in self._tool_indices:
+                    # Invalid tool name - reset state
+                    self._buffer = ""
+                    self.current_tool_id = -1
+                    self.current_tool_name_sent = False
+                    if self.streamed_args_for_tool:
+                        self.streamed_args_for_tool.pop()
+                    return StreamingParseResult()
+
+                # Handle parameters/arguments consistency
+                # NOTE: we assume here that the obj is always partial of a single tool call
+                if "parameters" in obj:
+                    assert (
+                        "arguments" not in obj
+                    ), "model generated both parameters and arguments"
+                    obj["arguments"] = obj["parameters"]
+
+                current_tool_call = obj
 
             except MalformedJSON:
                 return StreamingParseResult()
 
-            if len(tool_call_arr) == 0:
+            if not current_tool_call:
                 return StreamingParseResult()
 
-            current_tool_call: Dict = (
-                tool_call_arr[self.current_tool_id] if len(tool_call_arr) > 0 else {}
-            )
-
-            # Case 1:Handle new tool discovered in array
-            # This happens when we discover a new tool call in the JSON array that we haven't processed yet
-            # Example: Previously had [{"name": "tool1", ...}], now we have [{"name": "tool1", ...}, {"name": "tool2", ...}]
-            if len(tool_call_arr) > 0 and len(tool_call_arr) > self.current_tool_id + 1:
-                # Before switching to the new tool, we need to finish streaming any remaining arguments
-                # from the previous tool (if there was one)
-                if self.current_tool_id >= 0:
-                    cur_arguments = current_tool_call.get("arguments")
-                    if cur_arguments:
-                        cur_args_json = json.dumps(cur_arguments)
-                        sent = len(self.streamed_args_for_tool[self.current_tool_id])
-                        argument_diff = cur_args_json[sent:]
-
-                        res = StreamingParseResult(
-                            calls=[
-                                ToolCallItem(
-                                    tool_index=self.current_tool_id,
-                                    name="",
-                                    parameters=argument_diff,
-                                )
-                            ],
-                        )
-                        # Track what we've sent for this tool
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += argument_diff
-                    else:
-                        res = StreamingParseResult()
-                else:
-                    res = StreamingParseResult()
-
-                self.current_tool_id = len(tool_call_arr) - 1
-                self.current_tool_name_sent = False
-                self.streamed_args_for_tool.append("")
-                return res
-
-            # Case 2: Handle tool name streaming
+            # Case 1: Handle tool name streaming
             # This happens when we encounter a tool but haven't sent its name yet
-            elif not self.current_tool_name_sent:
+            if not self.current_tool_name_sent:
                 function_name = current_tool_call.get("name")
+
                 if function_name and function_name in self._tool_indices:
+                    # If this is a new tool (current_tool_id was -1), initialize it
+                    if self.current_tool_id == -1:
+                        self.current_tool_id = 0
+                        self.streamed_args_for_tool.append("")
+                    # If this is a subsequent tool, ensure streamed_args_for_tool is large enough
+                    elif self.current_tool_id >= len(self.streamed_args_for_tool):
+                        while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                            self.streamed_args_for_tool.append("")
+
                     # Send the tool name with empty parameters
                     res = StreamingParseResult(
                         calls=[
@@ -228,7 +202,7 @@ class BaseFormatDetector(ABC):
                 else:
                     res = StreamingParseResult()
 
-            # Case 3:Handle streaming arguments
+            # Case 2: Handle streaming arguments
             # This happens when we've already sent the tool name and now need to stream arguments incrementally
             else:
                 cur_arguments = current_tool_call.get("arguments")
@@ -238,19 +212,29 @@ class BaseFormatDetector(ABC):
                     # Calculate how much of the arguments we've already streamed
                     sent = len(self.streamed_args_for_tool[self.current_tool_id])
                     cur_args_json = json.dumps(cur_arguments)
-                    prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
-                        "arguments"
-                    )
+                    prev_arguments = None
+                    if self.current_tool_id < len(self.prev_tool_call_arr):
+                        prev_arguments = self.prev_tool_call_arr[
+                            self.current_tool_id
+                        ].get("arguments")
 
                     argument_diff = None
 
                     # If the current tool's JSON is complete, send all remaining arguments
-                    if is_complete[self.current_tool_id]:
+                    if is_current_complete:
                         argument_diff = cur_args_json[sent:]
+                        completing_tool_id = (
+                            self.current_tool_id
+                        )  # Save the ID of the tool that's completing
+
+                        # Clear buffer when tool completes
                         self._buffer = ""
-                        self.prev_tool_call_arr[self.current_tool_id].clear()
+
+                        if self.current_tool_id < len(self.prev_tool_call_arr):
+                            self.prev_tool_call_arr[self.current_tool_id].clear()
                         self.current_tool_name_sent = False
                         self.streamed_args_for_tool[self.current_tool_id] = ""
+                        self.current_tool_id += 1
 
                     # If the tool is still being parsed, send incremental changes
                     elif prev_arguments:
@@ -261,20 +245,32 @@ class BaseFormatDetector(ABC):
 
                     # Send the argument diff if there's something new
                     if argument_diff is not None:
+                        # Use the correct tool_index: completing_tool_id for completed tools, current_tool_id for ongoing
+                        tool_index_to_use = (
+                            completing_tool_id
+                            if is_current_complete
+                            else self.current_tool_id
+                        )
                         res = StreamingParseResult(
                             calls=[
                                 ToolCallItem(
-                                    tool_index=self.current_tool_id,
+                                    tool_index=tool_index_to_use,
                                     parameters=argument_diff,
                                 )
                             ],
                         )
-                        if not is_complete[self.current_tool_id]:
+                        if not is_current_complete:
                             self.streamed_args_for_tool[
                                 self.current_tool_id
                             ] += argument_diff
 
-            self.prev_tool_call_arr = tool_call_arr
+            # Update prev_tool_call_arr with current state
+            if self.current_tool_id >= 0:
+                # Ensure prev_tool_call_arr is large enough
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                self.prev_tool_call_arr[self.current_tool_id] = current_tool_call
+
             return res
 
         except Exception as e:

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -103,17 +103,9 @@ class BaseFormatDetector(ABC):
 
         For incompatible formats, detectors should override this method with custom logic.
         """
-        print(f"==============parse_streaming_increment================='")
-        print(f"DEBUG: parse_streaming_increment called with new_text='{new_text}'")
-        print(
-            f"DEBUG: current_tool_id={self.current_tool_id}, current_tool_name_sent={self.current_tool_name_sent}"
-        )
-        print(f"DEBUG: buffer before='{self._buffer}'")
-
         # Append new text to buffer
         self._buffer += new_text
         current_text = self._buffer
-        print(f"DEBUG: buffer after='{current_text}'")
 
         if not (self.bot_token in current_text or current_text.startswith("{")):
             # Only clear buffer if we're sure no tool call is starting
@@ -122,11 +114,9 @@ class BaseFormatDetector(ABC):
                 self._buffer = ""
                 if self.eot_token in normal_text:
                     normal_text = normal_text.replace(self.eot_token, "")
-                print(f"DEBUG: returning normal_text='{normal_text}'")
                 return StreamingParseResult(normal_text=normal_text)
             else:
                 # Might be partial bot_token, keep buffering
-                print(f"DEBUG: partial bot_token detected, keep buffering")
                 return StreamingParseResult()
 
         # Build tool indices if not already built
@@ -136,7 +126,6 @@ class BaseFormatDetector(ABC):
                 for i, tool in enumerate(tools)
                 if tool.function and tool.function.name
             }
-            print(f"DEBUG: built tool_indices={self._tool_indices}")
 
         flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
 
@@ -148,31 +137,19 @@ class BaseFormatDetector(ABC):
                     if current_text.startswith(self.bot_token)
                     else 0
                 )
-                print(f"DEBUG: start_idx={start_idx}")
 
                 if start_idx >= len(current_text):
-                    print(
-                        f"DEBUG: start_idx >= len(current_text), returning empty result"
-                    )
                     return StreamingParseResult()
 
-                print(
-                    f"DEBUG: parsing from start_idx={start_idx}, text='{current_text[start_idx:]}'"
-                )
                 (obj, end_idx) = _partial_json_loads(current_text[start_idx:], flags)
-                print(
-                    f"DEBUG: _partial_json_loads returned obj={obj}, end_idx={end_idx}"
-                )
 
                 is_current_complete = _is_complete_json(
                     current_text[start_idx : start_idx + end_idx]
                 )
-                print(f"DEBUG: is_current_complete={is_current_complete}")
 
                 # Validate tool name if present
                 if "name" in obj and obj["name"] not in self._tool_indices:
                     # Invalid tool name - reset state
-                    print(f"DEBUG: invalid tool name '{obj['name']}', resetting state")
                     self._buffer = ""
                     self.current_tool_id = -1
                     self.current_tool_name_sent = False
@@ -189,38 +166,27 @@ class BaseFormatDetector(ABC):
                     obj["arguments"] = obj["parameters"]
 
                 current_tool_call = obj
-                print(f"DEBUG: current_tool_call={current_tool_call}")
 
             except MalformedJSON:
-                print(f"DEBUG: MalformedJSON exception, returning empty result")
                 return StreamingParseResult()
 
             if not current_tool_call:
-                print(f"DEBUG: current_tool_call is empty, returning empty result")
                 return StreamingParseResult()
 
             # Case 1: Handle tool name streaming
             # This happens when we encounter a tool but haven't sent its name yet
             if not self.current_tool_name_sent:
-                print(f"DEBUG: Case 1 - tool name streaming")
                 function_name = current_tool_call.get("name")
-                print(f"DEBUG: Case 1 - function_name='{function_name}'")
 
                 if function_name and function_name in self._tool_indices:
                     # If this is a new tool (current_tool_id was -1), initialize it
                     if self.current_tool_id == -1:
                         self.current_tool_id = 0
                         self.streamed_args_for_tool.append("")
-                        print(
-                            f"DEBUG: Case 1 - initialized first tool, current_tool_id={self.current_tool_id}"
-                        )
                     # If this is a subsequent tool, ensure streamed_args_for_tool is large enough
                     elif self.current_tool_id >= len(self.streamed_args_for_tool):
                         while len(self.streamed_args_for_tool) <= self.current_tool_id:
                             self.streamed_args_for_tool.append("")
-                        print(
-                            f"DEBUG: Case 1 - initialized tool {self.current_tool_id}, streamed_args_for_tool length now {len(self.streamed_args_for_tool)}"
-                        )
 
                     # Send the tool name with empty parameters
                     res = StreamingParseResult(
@@ -233,20 +199,14 @@ class BaseFormatDetector(ABC):
                         ],
                     )
                     self.current_tool_name_sent = True
-                    print(
-                        f"DEBUG: Case 1 - sent tool name '{function_name}' with tool_index={self.current_tool_id}"
-                    )
                 else:
                     res = StreamingParseResult()
-                    print(f"DEBUG: Case 1 - function name not valid or not found")
 
             # Case 2: Handle streaming arguments
             # This happens when we've already sent the tool name and now need to stream arguments incrementally
             else:
-                print(f"DEBUG: Case 2 - streaming arguments")
                 cur_arguments = current_tool_call.get("arguments")
                 res = StreamingParseResult()
-                print(f"DEBUG: Case 2 - cur_arguments={cur_arguments}")
 
                 if cur_arguments:
                     # Calculate how much of the arguments we've already streamed
@@ -257,9 +217,6 @@ class BaseFormatDetector(ABC):
                         prev_arguments = self.prev_tool_call_arr[
                             self.current_tool_id
                         ].get("arguments")
-                    print(
-                        f"DEBUG: Case 2 - sent={sent}, cur_args_json='{cur_args_json}', prev_arguments={prev_arguments}"
-                    )
 
                     argument_diff = None
 
@@ -272,16 +229,12 @@ class BaseFormatDetector(ABC):
 
                         # Clear buffer when tool completes
                         self._buffer = ""
-                        print(f"DEBUG: Case 2 - cleared buffer, tool complete")
 
                         if self.current_tool_id < len(self.prev_tool_call_arr):
                             self.prev_tool_call_arr[self.current_tool_id].clear()
                         self.current_tool_name_sent = False
                         self.streamed_args_for_tool[self.current_tool_id] = ""
                         self.current_tool_id += 1
-                        print(
-                            f"DEBUG: Case 2 - tool complete, argument_diff='{argument_diff}', completing_tool_id={completing_tool_id}, new current_tool_id={self.current_tool_id}"
-                        )
 
                     # If the tool is still being parsed, send incremental changes
                     elif prev_arguments:
@@ -289,9 +242,6 @@ class BaseFormatDetector(ABC):
                         if cur_args_json != prev_args_json:
                             prefix = _find_common_prefix(prev_args_json, cur_args_json)
                             argument_diff = prefix[sent:]
-                        print(
-                            f"DEBUG: Case 2 - incremental, argument_diff='{argument_diff}'"
-                        )
 
                     # Send the argument diff if there's something new
                     if argument_diff is not None:
@@ -313,9 +263,6 @@ class BaseFormatDetector(ABC):
                             self.streamed_args_for_tool[
                                 self.current_tool_id
                             ] += argument_diff
-                        print(
-                            f"DEBUG: Case 2 - sending argument_diff='{argument_diff}' with tool_index={tool_index_to_use}"
-                        )
 
             # Update prev_tool_call_arr with current state
             if self.current_tool_id >= 0:
@@ -324,12 +271,9 @@ class BaseFormatDetector(ABC):
                     self.prev_tool_call_arr.append({})
                 self.prev_tool_call_arr[self.current_tool_id] = current_tool_call
 
-            print(f"DEBUG: updated prev_tool_call_arr={self.prev_tool_call_arr}")
-            print(f"DEBUG: returning res={res}")
             return res
 
         except Exception as e:
-            print(f"DEBUG: Exception in parse_streaming_increment: {e}")
             logger.error(f"Error in parse_streaming_increment: {e}")
             return StreamingParseResult()
 

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -226,8 +226,8 @@ class BaseFormatDetector(ABC):
                             self.current_tool_id
                         )  # Save the ID of the tool that's completing
 
-                        # Clear buffer when tool completes
-                        self._buffer = ""
+                        # Only remove the processed portion, keep unprocessed content
+                        self._buffer = current_text[start_idx + end_idx :]
 
                         if self.current_tool_id < len(self.prev_tool_call_arr):
                             self.prev_tool_call_arr[self.current_tool_id].clear()

--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -24,6 +24,11 @@ class Llama32Detector(BaseFormatDetector):
     def __init__(self):
         super().__init__()
         self.bot_token = "<|python_tag|>"
+        # NOTE: technically Llama3.2 doesn't support well with parallel tool calls
+        # They need specific prompt engineering to support parallel tool calls
+        # Here we use ';' as the separator, which might have compatibility issues
+        # if users define to use a different separator in their prompt
+        self.tool_call_separator = ";"
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a Llama 3.2 format tool call."""
@@ -42,7 +47,11 @@ class Llama32Detector(BaseFormatDetector):
             normal_text, action_text = "", text
 
         # Split by semicolon and process each part
-        json_parts = [part.strip() for part in action_text.split(";") if part.strip()]
+        json_parts = [
+            part.strip()
+            for part in action_text.split(self.tool_call_separator)
+            if part.strip()
+        ]
         all_actions = []
         for part in json_parts:
             try:
@@ -70,5 +79,5 @@ class Llama32Detector(BaseFormatDetector):
         return EBNFComposer.build_ebnf(
             tools,
             function_format="json",
-            tool_call_separator=",",
+            tool_call_separator=self.tool_call_separator,
         )

--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -30,6 +30,7 @@ class MistralDetector(BaseFormatDetector):
         self.bot_token = "[TOOL_CALLS] ["
         self.eot_token = "]"
         self.tool_call_regex = re.compile(r"\[{.*}\]", re.DOTALL)
+        self.tool_call_separator = ", "
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a Mistral format tool call."""
@@ -126,5 +127,5 @@ class MistralDetector(BaseFormatDetector):
             sequence_start_token=self.bot_token,
             sequence_end_token=self.eot_token,
             function_format="json",
-            tool_call_separator=", ",
+            tool_call_separator=self.tool_call_separator,
         )

--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -29,6 +29,7 @@ class Qwen25Detector(BaseFormatDetector):
         super().__init__()
         self.bot_token = "<tool_call>\n"
         self.eot_token = "\n</tool_call>"
+        self.tool_call_separator = "\n"
         self._normal_text_buffer = ""  # Buffer for handling partial end tokens
 
     def has_tool_call(self, text: str) -> bool:

--- a/python/sglang/srt/function_call/qwen25_detector.py
+++ b/python/sglang/srt/function_call/qwen25_detector.py
@@ -104,7 +104,6 @@ class Qwen25Detector(BaseFormatDetector):
         return result
 
     def structure_info(self) -> _GetInfoFunc:
-        # TODO: Update the begin and end tokens with '\n' if necessary
         return lambda name: StructureInfo(
             begin='<tool_call>\n{"name":"' + name + '", "arguments":',
             end="}\n</tool_call>",

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -18,6 +18,23 @@ def _find_common_prefix(s1: str, s2: str) -> str:
 
 
 def _partial_json_loads(input_str: str, flags: Allow) -> Tuple[Any, int]:
+    """
+    Parse incomplete or partial JSON strings commonly encountered during streaming.
+    
+    Args:
+        input_str (str): The potentially incomplete JSON string to parse.
+        flags (Allow): Bitwise flags controlling what types of partial data are allowed.
+            Common flags include:
+            - Allow.STR: Allow partial strings (e.g., '"hello wo' -> 'hello wo')
+            - Allow.OBJ: Allow partial objects (e.g., '{"key":' -> {'key': None})
+            - Allow.ARR: Allow partial arrays (e.g., '[1, 2,' -> [1, 2])
+            - Allow.ALL: Allow all types of partial data
+    
+    Returns:
+        Tuple[Any, int]: A tuple containing:
+            - parsed_object: The Python object parsed from the JSON
+            - consumed_length: Number of characters consumed from input_str
+    """
     try:
         return (partial_json_parser.loads(input_str, flags), len(input_str))
     except JSONDecodeError as e:

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -20,7 +20,7 @@ def _find_common_prefix(s1: str, s2: str) -> str:
 def _partial_json_loads(input_str: str, flags: Allow) -> Tuple[Any, int]:
     """
     Parse incomplete or partial JSON strings commonly encountered during streaming.
-    
+
     Args:
         input_str (str): The potentially incomplete JSON string to parse.
         flags (Allow): Bitwise flags controlling what types of partial data are allowed.
@@ -29,7 +29,7 @@ def _partial_json_loads(input_str: str, flags: Allow) -> Tuple[Any, int]:
             - Allow.OBJ: Allow partial objects (e.g., '{"key":' -> {'key': None})
             - Allow.ARR: Allow partial arrays (e.g., '[1, 2,' -> [1, 2])
             - Allow.ALL: Allow all types of partial data
-    
+
     Returns:
         Tuple[Any, int]: A tuple containing:
             - parsed_object: The Python object parsed from the JSON

--- a/python/sglang/srt/openai_api/adapter.py
+++ b/python/sglang/srt/openai_api/adapter.py
@@ -1327,7 +1327,6 @@ def v1_chat_generate_response(
                     tool_calls = [
                         ToolCall(
                             id=f"call_{base64.urlsafe_b64encode(uuid.uuid4().bytes).rstrip(b'=').decode()}",
-                            index=call_info.tool_index,
                             function=FunctionResponse(
                                 name=call_info.name, arguments=call_info.parameters
                             ),

--- a/test/srt/test_function_call_parser.py
+++ b/test/srt/test_function_call_parser.py
@@ -689,10 +689,9 @@ class TestBaseFormatDetector(unittest.TestCase):
         tourist_calls = [
             call for call in result.calls if call.name == "get_tourist_attractions"
         ]
-        if tourist_calls:
-            self.assertEqual(
-                tourist_calls[0].tool_index, 1, "Second tool should have tool_index=1"
-            )
+        self.assertEqual(
+            tourist_calls[0].tool_index, 1, "Second tool should have tool_index=1"
+        )
 
     def test_tool_name_streaming_with_correct_index(self):
         """Test that tool names are streamed with correct tool_index values."""
@@ -715,7 +714,7 @@ class TestBaseFormatDetector(unittest.TestCase):
         )
 
         # Start second tool
-        self.detector.parse_streaming_increment("<tool_call>", self.tools)
+        self.detector.parse_streaming_increment(", ", self.tools)
         result2 = self.detector.parse_streaming_increment(
             '{"name": "get_tourist_attractions", ', self.tools
         )

--- a/test/srt/test_function_call_parser.py
+++ b/test/srt/test_function_call_parser.py
@@ -3,6 +3,7 @@ import unittest
 
 from xgrammar import GrammarCompiler, TokenizerInfo
 
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
 from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.mistral_detector import MistralDetector
@@ -514,6 +515,239 @@ class TestEBNFGeneration(unittest.TestCase):
             self.assertIsNotNone(ctx, "EBNF should be valid and compile successfully")
         except RuntimeError as e:
             self.fail(f"Failed to compile EBNF: {e}")
+
+
+class TestBaseFormatDetector(unittest.TestCase):
+    """Test buffer management and sequential tool index assignment in BaseFormatDetector."""
+
+    def setUp(self):
+        """Set up test detector and tools."""
+
+        # Create a concrete implementation of BaseFormatDetector for testing
+        class TestFormatDetector(BaseFormatDetector):
+            def __init__(self):
+                super().__init__()
+                self.bot_token = "<tool_call>"
+                self.eot_token = "</tool_call>"
+
+            def detect_and_parse(self, text, tools):
+                # Not used in streaming tests
+                pass
+
+            def has_tool_call(self, text):
+                return "<tool_call>" in text
+
+            def structure_info(self):
+                # Not used in streaming tests
+                pass
+
+            def build_ebnf(self, tools):
+                # Not used in streaming tests
+                pass
+
+        self.detector = TestFormatDetector()
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "City name",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_tourist_attractions",
+                    description="Get tourist attractions",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "description": "City name",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+        ]
+
+    def test_sequential_tool_index_assignment(self):
+        """Test that multiple tool calls get sequential tool_index values (0, 1, 2, ...)."""
+        # Simulate streaming chunks for two consecutive tool calls
+        chunks = [
+            "<tool_call>",
+            '{"name": "get_weather", ',
+            '"arguments": {"city": "Paris"}}',
+            ", ",
+            '{"name": "get_tourist_attractions", ',
+            '"arguments": {"city": "London"}}',
+            "</tool_call>",
+        ]
+
+        tool_indices_seen = []
+
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+
+            if result.calls:
+                for call in result.calls:
+                    if call.tool_index is not None:
+                        tool_indices_seen.append(call.tool_index)
+
+        # Verify we got sequential tool indices
+        unique_indices = sorted(set(tool_indices_seen))
+        self.assertEqual(
+            unique_indices,
+            [0, 1],
+            f"Expected sequential tool indices [0, 1], got {unique_indices}",
+        )
+
+    def test_buffer_content_preservation(self):
+        """Test that buffer correctly preserves unprocessed content when tool completes."""
+        # Test simpler scenario: tool completion followed by new tool start
+        chunks = [
+            "<tool_call>",
+            '{"name": "get_weather", ',
+            '"arguments": {"city": "Paris"}}',
+            ", ",
+            '{"name": "get_tourist_attractions", ',
+            '"arguments": {"city": "London"}} </tool_call>',
+        ]
+
+        tool_calls_seen = []
+
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+            if result.calls:
+                for call in result.calls:
+                    if (
+                        call.name
+                    ):  # Only count calls with names (not just parameter updates)
+                        tool_calls_seen.append(call.name)
+
+        # Should see both tool names
+        self.assertIn("get_weather", tool_calls_seen, "Should process first tool")
+        self.assertIn(
+            "get_tourist_attractions", tool_calls_seen, "Should process second tool"
+        )
+
+    def test_current_tool_id_increment_on_completion(self):
+        """Test that current_tool_id increments when a tool completes."""
+        # Initial state
+        self.assertEqual(
+            self.detector.current_tool_id, -1, "Should start with current_tool_id=-1"
+        )
+
+        # Process first tool completely
+        chunks = [
+            "<tool_call>",
+            '{"name": "get_weather", ',
+        ]
+
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, self.tools)
+
+        self.assertEqual(
+            self.detector.current_tool_id, 0, "current_tool_id should be 0"
+        )
+        self.assertEqual(
+            result.calls[0].name, "get_weather", "The first tool should be get_weather"
+        )
+        self.assertEqual(
+            result.calls[0].tool_index, 0, "The first tool index should be 0"
+        )
+
+        # Complete second tool name - this should show that current_tool_id is now 1
+        result = self.detector.parse_streaming_increment(
+            '"arguments": {"city": "Paris"}}, {"name": "get_', self.tools
+        )
+        self.assertEqual(result.calls[0].parameters, '{"city": "Paris"}')
+
+        self.assertEqual(
+            self.detector.current_tool_id,
+            1,
+            "current_tool_id should be 1 after first tool completes and second tool starts",
+        )
+
+        result = self.detector.parse_streaming_increment(
+            'tourist_attractions", ', self.tools
+        )
+
+        # Second tool should have tool_index=1
+        tourist_calls = [
+            call for call in result.calls if call.name == "get_tourist_attractions"
+        ]
+        if tourist_calls:
+            self.assertEqual(
+                tourist_calls[0].tool_index, 1, "Second tool should have tool_index=1"
+            )
+
+    def test_tool_name_streaming_with_correct_index(self):
+        """Test that tool names are streamed with correct tool_index values."""
+        # Process first tool
+        self.detector.parse_streaming_increment("<tool_call>", self.tools)
+        result1 = self.detector.parse_streaming_increment(
+            '{"name": "get_weather", ', self.tools
+        )
+
+        # First tool name should have tool_index=0
+        weather_calls = [call for call in result1.calls if call.name == "get_weather"]
+        self.assertEqual(len(weather_calls), 1, "Should have one weather call")
+        self.assertEqual(
+            weather_calls[0].tool_index, 0, "First tool should have tool_index=0"
+        )
+
+        # Complete first tool
+        self.detector.parse_streaming_increment(
+            '"arguments": {"city": "Paris"}}', self.tools
+        )
+
+        # Start second tool
+        self.detector.parse_streaming_increment("<tool_call>", self.tools)
+        result2 = self.detector.parse_streaming_increment(
+            '{"name": "get_tourist_attractions", ', self.tools
+        )
+
+        # Second tool name should have tool_index=1
+        tourist_calls = [
+            call for call in result2.calls if call.name == "get_tourist_attractions"
+        ]
+        self.assertEqual(
+            len(tourist_calls), 1, "Should have one tourist attractions call"
+        )
+        self.assertEqual(
+            tourist_calls[0].tool_index, 1, "Second tool should have tool_index=1"
+        )
+
+    def test_buffer_reset_on_invalid_tool(self):
+        """Test that buffer and state are reset when an invalid tool name is encountered."""
+        # Start fresh with an invalid tool name from the beginning
+        result = self.detector.parse_streaming_increment(
+            '<tool_call>{"name": "invalid_tool", ', self.tools
+        )
+
+        # Should return empty result and reset state
+        self.assertEqual(result.calls, [], "Should return no calls for invalid tool")
+        self.assertEqual(
+            self.detector.current_tool_id,
+            -1,
+            "current_tool_id should remain -1 for invalid tool",
+        )
+        self.assertEqual(
+            self.detector._buffer, "", "Buffer should be cleared for invalid tool"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
1. Fix #6310 
2. Non-stream function call response in OpenAI doesn't have index. We should remove that. See: https://platform.openai.com/docs/api-reference/chat/object
3. Refactor `parse_streaming_increment` in `BaseFormatDetector`

The current  `parse_streaming_increment` in `BaseFormatDetector` has some issues:

### The Original Problem

1. For a single tool call in streaming, the first tool_index should be 0, but it was assigned as the index of the function in the tools list passed by user's request.

2. When there were multiple tool calls, the tool_index was always 0 instead of being sequential (0, 1, 2, etc.). This was because:
- `self.current_tool_id = len(tool_call_arr) - 1` jumped directly to the last tool in the current `tool_call_arr`, which is reinitialized as [] every time of the function call. But the current_tool_id should be the index of the tool processed in the `calls` list
- Complex array handling logic caused state inconsistencies in the entire function

### Refactor Details

1. Removed tool_call_arr and is_complete arrays

**Why:**
- The array `tool_call_arr` was being **rebuilt from scratch** on every streaming increment, but `self.current_tool_id` update based on `len(tool_call_arr)`. 
- This caused state inconsistencies because previous state was lost
- The logic was overly complex and hard to maintain
- They seemed to be designed for a different use case (single JSON array with multiple tools). However, based on the following content, it then assumes the obj is never a list but a dictionary:
https://github.com/sgl-project/sglang/blob/bdb962d75581faa8d472fbbc8b05987c27df6a88/python/sglang/srt/function_call/base_format_detector.py#L158-L164

**Why it won't affect us:**
- We're focusing on the common case where obj is always a single tool object (dict)
- Each tool call is processed independently
- We don't need to track multiple tools in a single parsing call

2. Removed the Entire `Case 1: Handle new tool discovered in array` Section

**Why we removed Case 1:**
Case 1 was unreachable in the original case, because
- `tool_call_array = [obj]` always has length 1 (single tool object)
- So `1 > current_tool_id + 1` is only true when current_tool_id = -1 (initialization) , but the initialization can be easily handled in Case 2.

**Why it won't affect us:**
- Tool switching now happens naturally when each tool completes in Case 2
- Each tool call is processed in separate streaming sessions
- We don't need complex logic to detect "new tools in an array"

3. Proper State Management
- Ensured `streamed_args_for_tool` is properly sized for each new tool, as it is used in `adapter.py` (Not sure the reason yet)
- Added bounds checking for prev_tool_call_arr access
- Correct tool_index assignment using the right ID for completing vs. ongoing tools

4. The Flow Now Works Like This
- Tool 1 starts: `current_tool_id = 0`, sends tool name with tool_index=0
- Tool 1 completes: `current_tool_id` increments to 1, buffer clears
- Tool 2 starts: Uses `current_tool_id = 1`, sends tool name with tool_index=1
- Tool 2 completes: `current_tool_id` increments to 2, and so on...

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

- Simplify parsing logic by removing `tool_call_arr` and `is_complete` arrays 
- Add proper current_tool_id increment when tool completes (original `Case 3: Handle streaming arguments` with is_complete=True)
- Ensure correct `tool_index` assignment before incrementing `current_tool_id`
- Remove index in non-stream tool call in `adapter.py`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
