### PR TITLE
Tune memory arguments on B200

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -149,6 +149,8 @@ def get_batch_sizes_to_capture(model_runner: ModelRunner):
         gpu_mem = get_device_memory_capacity()
         if gpu_mem is not None and gpu_mem > 96 * 1024:
             capture_bs += list(range(160, 257, 8))
+        if gpu_mem is not None and gpu_mem > 180 * 1000:
+            capture_bs += list(range(256, 528, 16))
 
     if max(capture_bs) > model_runner.req_to_token_pool.size:
         # In some case (e.g., with a small GPU or --max-running-requests), the #max-running-requests

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -258,9 +258,9 @@ class ServerArgs:
                     self.mem_fraction_static = 0.87
                 else:
                     self.mem_fraction_static = 0.88
-            elif gpu_mem is not None and gpu_mem > 180 * 1000:
+            if gpu_mem is not None and gpu_mem > 180 * 1000:
                 self.mem_fraction_static = 0.79
-            if gpu_mem is not None and gpu_mem > 96 * 1024:
+            elif gpu_mem is not None and gpu_mem > 96 * 1024:
                 mem_fraction = self.mem_fraction_static
                 # 15 GB + additional 3GB for cuda graph
                 reserve_mem = 1024 * 18

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -258,6 +258,8 @@ class ServerArgs:
                     self.mem_fraction_static = 0.87
                 else:
                     self.mem_fraction_static = 0.88
+            else:
+                self.mem_fraction_static = 0.88
             if gpu_mem is not None and gpu_mem > 180 * 1000:
                 self.mem_fraction_static = 0.79
             elif gpu_mem is not None and gpu_mem > 96 * 1024:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -258,8 +258,8 @@ class ServerArgs:
                     self.mem_fraction_static = 0.87
                 else:
                     self.mem_fraction_static = 0.88
-            else:
-                self.mem_fraction_static = 0.88
+            elif gpu_mem is not None and gpu_mem > 180 * 1000:
+                self.mem_fraction_static = 0.79
             if gpu_mem is not None and gpu_mem > 96 * 1024:
                 mem_fraction = self.mem_fraction_static
                 # 15 GB + additional 3GB for cuda graph
@@ -274,7 +274,9 @@ class ServerArgs:
 
         # Set chunked prefill size, which depends on the gpu memory capacity
         if self.chunked_prefill_size is None:
-            if gpu_mem is not None and gpu_mem < 25_000:
+            if gpu_mem is not None and gpu_mem > 180_000:
+                self.chunked_prefill_size = 16384
+            elif gpu_mem is not None and gpu_mem < 25_000:
                 self.chunked_prefill_size = 2048
             elif self.disaggregation_mode != "null":
                 self.chunked_prefill_size = 16384


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

B200 machines are equipped with much higher GBM than H200 (144G -> 184G)
Some of the server arguments can be tuned on B200 to improve the performance on large workload:
- mem_fraction_static: set to 0.79
- chunked_prefill_size: set to 16384
- cuda_graph_bs: raise the upper limit to 512 (might be even higher)


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Benchmark
```bash
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code --attention-backend triton

python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 1000 --random-output-len 1000 --random-range-ratio 1 --num-prompts 512
```

Before this PR:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     512       
Benchmark duration (s):                  162.24    
Total input tokens:                      512000    
Total generated tokens:                  512000    
Total generated tokens (retokenized):    509363    
Request throughput (req/s):              3.16      
Input token throughput (tok/s):          3155.83   
Output token throughput (tok/s):         3155.83   
Total token throughput (tok/s):          6311.67   
Concurrency:                             511.56    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   162100.89 
Median E2E Latency (ms):                 162097.24 
---------------Time to First Token----------------
Mean TTFT (ms):                          18879.61  
Median TTFT (ms):                        18489.64  
P99 TTFT (ms):                           38994.77  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           146.69    
Median ITL (ms):                         124.03    
P95 ITL (ms):                            141.53    
P99 ITL (ms):                            318.28    
Max ITL (ms):                            36817.66  
==================================================
```
After PR:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     512       
Benchmark duration (s):                  113.16    
Total input tokens:                      512000    
Total generated tokens:                  512000    
Total generated tokens (retokenized):    509453    
Request throughput (req/s):              4.52      
Input token throughput (tok/s):          4524.40   
Output token throughput (tok/s):         4524.40   
Total token throughput (tok/s):          9048.80   
Concurrency:                             511.39    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   113029.91 
Median E2E Latency (ms):                 113031.22 
---------------Time to First Token----------------
Mean TTFT (ms):                          22055.51  
Median TTFT (ms):                        21278.90  
P99 TTFT (ms):                           36302.20  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           94.21     
Median ITL (ms):                         77.04     
P95 ITL (ms):                            88.73     
P99 ITL (ms):                            252.49    
Max ITL (ms):                            31378.12  
==================================================

```
