### PR TITLE
feat: add "balance" option and implement for "--ep-dispatch-algorithm"

### DIFF
--- a/python/sglang/srt/managers/expert_location_dispatch.py
+++ b/python/sglang/srt/managers/expert_location_dispatch.py
@@ -23,7 +23,7 @@ from sglang.srt.managers.schedule_batch import global_server_args_dict
 
 @dataclass
 class ExpertLocationDispatchInfo:
-    ep_dispatch_algorithm: Literal["static", "random"]
+    ep_dispatch_algorithm: Literal["static", "dynamic", "balance"]
     # (num_logical_experts,)
     partial_logical_to_rank_dispatch_physical_map: Optional[torch.Tensor]
     # (num_logical_experts, X)
@@ -31,6 +31,7 @@ class ExpertLocationDispatchInfo:
     # (num_logical_experts,)
     partial_logical_to_all_physical_map_num_valid: torch.Tensor
     num_physical_experts: int
+    ep_size: int
 
     @classmethod
     def init_new(cls, layer_id: int):
@@ -57,6 +58,7 @@ class ExpertLocationDispatchInfo:
                 layer_id, :
             ],
             num_physical_experts=expert_location_metadata.num_physical_experts,
+            ep_size=expert_location_metadata.ep_size,
         )
 
 
@@ -82,6 +84,8 @@ def topk_ids_logical_to_physical(
         return _topk_ids_logical_to_physical_static(topk_ids, info)
     if info.ep_dispatch_algorithm in ["dynamic", "fake"]:
         return _topk_ids_logical_to_physical_dynamic(topk_ids, info)
+    if info.ep_dispatch_algorithm == "balance":
+        return _topk_ids_logical_to_physical_balance(topk_ids, info)
     raise NotImplementedError(f"Unknown algorithm {info.ep_dispatch_algorithm}")
 
 
@@ -106,3 +110,40 @@ def _topk_ids_logical_to_physical_dynamic(
 
     topk_ids = topk_ids.view(topk_ids_original_shape)
     return topk_ids
+
+
+def _topk_ids_logical_to_physical_balance(
+    topk_ids: torch.Tensor, info: Optional[ExpertLocationDispatchInfo]
+) -> torch.Tensor:
+    from sgl_kernel import balance_topk_ids
+
+    num_topk_ids = topk_ids.numel()
+    num_gpus = info.ep_size
+
+    if num_topk_ids / num_gpus < 2:
+        # When num_topk_ids is small, the additional overhead of workload balance will be higher than the benefits.
+        return _topk_ids_logical_to_physical_dynamic(topk_ids, info)
+
+    num_logical_experts = info.partial_logical_to_all_physical_map.shape[0]
+    num_physical_experts = info.num_physical_experts
+
+    max_workload_after_balance = torch.empty(
+        [1], dtype=torch.int32, device=topk_ids.device
+    )
+    gpu_workloads_balance_mapping = torch.empty(
+        [num_physical_experts // num_logical_experts, num_gpus],
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    new_topk_ids = torch.empty_like(topk_ids)
+    balance_topk_ids(
+        topk_ids,
+        num_gpus,
+        num_logical_experts,
+        num_physical_experts,
+        max_workload_after_balance,
+        gpu_workloads_balance_mapping,
+        new_topk_ids,
+    )
+
+    return new_topk_ids

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -154,7 +154,9 @@ class ServerArgs:
     enable_deepep_moe: bool = False
     deepep_mode: Optional[Literal["auto", "normal", "low_latency"]] = "auto"
     ep_num_redundant_experts: int = 0
-    ep_dispatch_algorithm: Optional[Literal["static", "dynamic", "fake"]] = None
+    ep_dispatch_algorithm: Optional[Literal["static", "dynamic", "fake", "balance"]] = (
+        None
+    )
     init_expert_location: str = "trivial"
     enable_eplb: bool = False
     eplb_algorithm: str = "auto"
@@ -423,6 +425,14 @@ class ServerArgs:
             logger.info(
                 "EPLB is enabled or init_expert_location is provided. ep_dispatch_algorithm is configured."
             )
+
+        if self.ep_dispatch_algorithm == "balance":
+            assert (
+                not self.enable_eplb
+            ), "'--ep-dispatch-algorithm balance' cannot be used with experts rebalance"
+            assert (
+                self.init_expert_location == "trivial"
+            ), "'--ep-dispatch-algorithm balance' cannot be used with non-trivial '--init-expert-location'"
 
         if self.enable_expert_distribution_metrics and (
             self.expert_distribution_recorder_mode is None

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -246,6 +246,7 @@ set(SOURCES
     "csrc/moe/prepare_moe_input.cu"
     "csrc/moe/ep_moe_reorder_kernel.cu"
     "csrc/moe/ep_moe_silu_and_mul_kernel.cu"
+    "csrc/moe/balance_topk_ids.cu"
     "csrc/speculative/eagle_utils.cu"
     "csrc/speculative/speculative_sampling.cu"
     "csrc/speculative/packbit.cu"

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -202,6 +202,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("apply_shuffle_mul_sum(Tensor input, Tensor output, Tensor permutation, Tensor? factors) -> ()");
   m.impl("apply_shuffle_mul_sum", torch::kCUDA, &apply_shuffle_mul_sum);
 
+  m.def(
+      "balance_topk_ids(Tensor topk_ids, int num_gpus, int num_logical_experts, int num_physical_experts, Tensor "
+      "max_workload_after_balance, Tensor gpu_workloads_balance_mapping, Tensor new_topk_ids) -> ()");
+  m.impl("balance_topk_ids", torch::kCUDA, &balance_topk_ids);
+
+
   /*
    * From csrc/speculative
    */

--- a/sgl-kernel/csrc/moe/balance_topk_ids.cu
+++ b/sgl-kernel/csrc/moe/balance_topk_ids.cu
@@ -1,0 +1,414 @@
+#include <assert.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cudaTypedefs.h>
+#include <inttypes.h>
+#include <torch/all.h>
+
+#include <iostream>
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+constexpr int32_t MAX_NUM_GPUS = 64;
+constexpr int32_t MAX_EXPERT_COPIES_MULTIPLE = 8;
+constexpr int32_t GROUP_SIZE = 1024;
+
+__global__ void gpu_workloads_count_kernel(
+    const int32_t* __restrict__ topk_ids,
+    const int32_t num_logical_experts,
+    const int32_t num_gpus,
+    const int32_t num_topk_ids,
+    int32_t* __restrict__ gpu_workloads,                // [num_gpus]
+    int32_t* __restrict__ grouped_gpu_workloads,        // [ceil_div(num_topk_ids/GROUP_SIZE), num_gpus]
+    int32_t* __restrict__ cumsum_grouped_gpu_workloads  // [ceil_div(num_topk_ids/GROUP_SIZE), num_gpus]
+) {
+  __shared__ int32_t smem_grouped_gpu_workloads[MAX_NUM_GPUS];
+
+  const int32_t num_groups = (num_topk_ids + GROUP_SIZE - 1) / GROUP_SIZE;
+  const int32_t num_logical_experts_per_gpu = num_logical_experts / num_gpus;
+  int32_t previous_cumsum_grouped_gpu_workload = 0;
+
+  for (int32_t group_idx = 0; group_idx < num_groups; ++group_idx) {
+    if (threadIdx.x < num_gpus) {
+      smem_grouped_gpu_workloads[threadIdx.x] = 0;
+    }
+    __syncthreads();
+
+    const int32_t global_idx = group_idx * GROUP_SIZE + threadIdx.x;
+
+    if (global_idx < num_topk_ids) {
+      const int32_t topk_id = topk_ids[global_idx];
+      const int32_t gpu_id = topk_id / num_logical_experts_per_gpu;
+      atomicAdd(&smem_grouped_gpu_workloads[gpu_id], 1);
+    }
+
+    __syncthreads();
+    if (threadIdx.x < num_gpus) {
+      int32_t workload = smem_grouped_gpu_workloads[threadIdx.x];
+      grouped_gpu_workloads[group_idx * num_gpus + threadIdx.x] = workload;
+      previous_cumsum_grouped_gpu_workload += workload;
+      cumsum_grouped_gpu_workloads[group_idx * num_gpus + threadIdx.x] = previous_cumsum_grouped_gpu_workload;
+    }
+    __syncthreads();
+  }
+  if (threadIdx.x < num_gpus) {
+    gpu_workloads[threadIdx.x] = previous_cumsum_grouped_gpu_workload;
+  }
+}
+
+__global__ void search_balance_mapping_kernel(
+    const int32_t* __restrict__ gpu_workloads_wo_balance,
+    const int32_t num_gpus,
+    const int32_t num_topk_ids,
+    const int32_t global_search_interval_left,
+    const int32_t global_search_interval_right,
+    const int32_t num_search_iter,
+    const int32_t search_stride,
+    const int32_t expert_copies_multiple,
+    int32_t* __restrict__ max_workload_after_balance,
+    int32_t* __restrict__ gpu_workloads_balance_mapping) {
+  __shared__ int32_t smem_gpu_workloads_wo_balance[MAX_NUM_GPUS];
+  __shared__ int32_t smem_gpu_workloads_balance_mapping[MAX_EXPERT_COPIES_MULTIPLE * MAX_NUM_GPUS];
+  __shared__ int32_t smem_max_workload_after_balance;
+
+  int32_t tid = threadIdx.x;
+
+  if (tid == 0) {
+    smem_max_workload_after_balance = num_topk_ids;
+  }
+
+  if (tid < num_gpus) {
+    smem_gpu_workloads_wo_balance[tid] = gpu_workloads_wo_balance[tid];
+  }
+  __syncthreads();
+
+  // find the gpu_id with the most workload
+  int32_t gpu_id_with_max_workload_wo_balance = 0;
+  int32_t max_workload = 0;
+  // num_gpus is usually very small(<=16)
+  for (int32_t i = 0; i < num_gpus; ++i) {
+    if (smem_gpu_workloads_wo_balance[i] > max_workload) {
+      max_workload = smem_gpu_workloads_wo_balance[i];
+      gpu_id_with_max_workload_wo_balance = i;
+    }
+  }
+
+  const int32_t local_search_interval_left = global_search_interval_left + tid * num_search_iter * search_stride;
+  const int32_t local_search_interval_right =
+      MIN(local_search_interval_left + (num_search_iter - 1) * search_stride, global_search_interval_right);
+
+  int32_t headroom_on_gpus_after_balance[MAX_NUM_GPUS];
+  int32_t i32_max_workload_after_balance = -1;
+
+  for (int32_t capacity = local_search_interval_left; capacity <= local_search_interval_right;
+       capacity += search_stride) {
+    // We first assume that after workload balance, the workload on ANY GPU will not exceed `capacity`,
+    // and then verify whether this assumption is true.
+    for (int32_t gpu_id = 0; gpu_id < num_gpus; ++gpu_id) {
+      headroom_on_gpus_after_balance[gpu_id] = capacity;
+    }
+    int32_t num_balanced_topk_ids = 0;
+
+    for (int32_t i = 0; i < num_gpus; ++i) {
+      // We start with the GPU with most workload and transfer its workload to other GPUs which loaded redundant
+      // experts.
+      int32_t gpu_id = (gpu_id_with_max_workload_wo_balance + i) % num_gpus;
+      // how much workload on current GPU
+      int32_t workload_waiting_for_balance = smem_gpu_workloads_wo_balance[gpu_id];
+      for (int32_t multiple_idx = expert_copies_multiple - 1; multiple_idx >= 0; --multiple_idx) {
+        // the gpu id which we want to transfer workload to
+        const int32_t balance_gpu_id = (gpu_id - multiple_idx + num_gpus) % num_gpus;
+
+        // calculate how many workload balance_gpu_id can actually accept
+        const int32_t headroom = headroom_on_gpus_after_balance[balance_gpu_id];
+        const int32_t num_tokens_actual_accept = MIN(workload_waiting_for_balance, headroom);
+
+        // update the remaining workload and capacity
+        workload_waiting_for_balance -= num_tokens_actual_accept;
+        headroom_on_gpus_after_balance[balance_gpu_id] -= num_tokens_actual_accept;
+        num_balanced_topk_ids += num_tokens_actual_accept;
+      }
+    }
+
+    assert(num_balanced_topk_ids <= num_topk_ids);
+    if (num_balanced_topk_ids == num_topk_ids) {
+      // The previous assumption is valid and current thread has obtained an alternative answer.
+      i32_max_workload_after_balance = capacity;
+      break;
+    }
+  }
+
+  if (i32_max_workload_after_balance != -1) {
+    // write to shared memory and calculate the optimal answer
+    atomicMin(&smem_max_workload_after_balance, i32_max_workload_after_balance);
+  }
+  __syncthreads();
+
+  if (smem_max_workload_after_balance == i32_max_workload_after_balance) {
+    // The current thread has obtained the optimal answer and needs to output the solution to shared memory.
+    for (int32_t gpu_id = 0; gpu_id < num_gpus; ++gpu_id) {
+      headroom_on_gpus_after_balance[gpu_id] = i32_max_workload_after_balance;
+    }
+
+    for (int32_t i = 0; i < num_gpus; ++i) {
+      const int32_t gpu_id = (gpu_id_with_max_workload_wo_balance + i) % num_gpus;
+      int32_t workload_waiting_for_balance = smem_gpu_workloads_wo_balance[gpu_id];
+      for (int32_t multiple_idx = expert_copies_multiple - 1; multiple_idx >= 0; --multiple_idx) {
+        const int32_t balance_gpu_id = (gpu_id - multiple_idx + num_gpus) % num_gpus;
+
+        const int32_t headroom = headroom_on_gpus_after_balance[balance_gpu_id];
+        const int32_t num_tokens_actual_accept = MIN(workload_waiting_for_balance, headroom);
+
+        workload_waiting_for_balance -= num_tokens_actual_accept;
+        headroom_on_gpus_after_balance[balance_gpu_id] -= num_tokens_actual_accept;
+        smem_gpu_workloads_balance_mapping[multiple_idx * MAX_NUM_GPUS + gpu_id] = num_tokens_actual_accept;
+      }
+    }
+  }
+
+  __syncthreads();
+
+  // Write the solution to global memory.
+  if (tid < num_gpus) {
+    for (int32_t i = 0; i < expert_copies_multiple; ++i) {
+      gpu_workloads_balance_mapping[i * num_gpus + tid] = smem_gpu_workloads_balance_mapping[i * MAX_NUM_GPUS + tid];
+    }
+  }
+
+  if (tid == 0) {
+    max_workload_after_balance[0] = smem_max_workload_after_balance;
+  }
+}
+
+void search_balance_mapping(
+    const torch::Tensor& gpu_workloads_wo_balance,  // [num_gpus]
+    const int32_t num_topk_ids,
+    const int32_t expert_copies_multiple,
+    const int32_t num_gpus,
+    torch::Tensor& max_workload_after_balance,    // [1]
+    torch::Tensor& gpu_workloads_balance_mapping  // [expert_copies_multiple, num_gpus]
+) {
+  auto stream = at::cuda::getCurrentCUDAStream(gpu_workloads_wo_balance.device().index());
+  const int32_t search_interval_left = (num_topk_ids + num_gpus - 1) / num_gpus;
+  const int32_t search_interval_right = (num_topk_ids + expert_copies_multiple - 1) / expert_copies_multiple;
+
+  // search_interval_len should <= num_threads * num_search_iter * search_stride
+  const int32_t search_interval_len = search_interval_right - search_interval_left + 1;
+
+  // We set the search precision to 1% of the search_interval_len, and the maximum value is no more than 16.
+  const int32_t search_stride =
+      std::min<int32_t>(std::max<int32_t>(static_cast<int32_t>(search_interval_len / 100), 1), 16);
+
+  unsigned int num_threads = static_cast<unsigned int>(std::max<int32_t>(search_interval_len, num_gpus));
+  num_threads = std::min<unsigned int>(num_threads, 1024);
+  int32_t num_search_iter = (search_interval_len + num_threads * search_stride - 1) / (num_threads * search_stride);
+
+  search_balance_mapping_kernel<<<1, num_threads, 0, stream>>>(
+      static_cast<const int32_t*>(gpu_workloads_wo_balance.data_ptr()),
+      static_cast<int32_t>(num_gpus),
+      num_topk_ids,
+      search_interval_left,
+      search_interval_right,
+      num_search_iter,
+      search_stride,
+      expert_copies_multiple,
+      static_cast<int32_t*>(max_workload_after_balance.data_ptr()),
+      static_cast<int32_t*>(gpu_workloads_balance_mapping.data_ptr()));
+}
+
+__global__ void rewrite_topk_ids_by_balance_mapping_kernel(
+    const int32_t* __restrict__ topk_ids,
+    const int32_t* __restrict__ gpu_workloads_balance_mapping,
+    const int32_t* __restrict__ grouped_gpu_workloads_wo_balance,
+    const int32_t* __restrict__ cumsum_grouped_gpu_workloads_wo_balance,
+    const int32_t num_gpus,
+    const int32_t num_topk_ids,
+    const int32_t num_logical_experts,
+    const int32_t num_physical_experts,
+    int32_t* __restrict__ new_topk_ids) {
+  __shared__ int32_t smem_new_topk_ids[GROUP_SIZE];
+  __shared__ int32_t smem_gpu_workloads_balance_mapping[MAX_EXPERT_COPIES_MULTIPLE * MAX_NUM_GPUS];
+
+  __shared__ int32_t smem_target_multiple_indices[MAX_NUM_GPUS];
+  __shared__ int32_t smem_num_cases_balance_to_multi_gpus;
+  __shared__ int32_t smem_group_gpu_workloads_counter[MAX_NUM_GPUS];
+
+  const int32_t expert_copies_multiple = num_physical_experts / num_logical_experts;
+  const int32_t num_logical_experts_per_gpu = num_logical_experts / num_gpus;
+  const int32_t num_physical_experts_per_gpu = num_physical_experts / num_gpus;
+
+  const int32_t tid = threadIdx.x;
+  const int32_t global_tid = blockIdx.x * GROUP_SIZE + threadIdx.x;
+  const int32_t group_idx = blockIdx.x;
+
+  if (tid == 0) {
+    smem_num_cases_balance_to_multi_gpus = 0;
+  }
+  __syncthreads();
+
+  if (tid < num_gpus) {
+    int32_t workload_balanced_by_previous_groups = 0;
+    if (group_idx != 0) {
+      workload_balanced_by_previous_groups = cumsum_grouped_gpu_workloads_wo_balance[(group_idx - 1) * num_gpus + tid];
+    }
+
+    int32_t group_task = grouped_gpu_workloads_wo_balance[group_idx * num_gpus + tid];
+    bool determined = false;
+
+    // Determine whether the following situation A exists: In this group of workloads,
+    // there is a GPU that wants to distribute its own workload to at least two other GPUs(including itself).
+    // If the situation A exists, we will get smem_num_cases_balance_to_multi_gpus > 0.
+    int32_t num_cases_balance_to_multi_gpus = 0;
+    for (int32_t multiple_idx = expert_copies_multiple - 1; multiple_idx >= 0; --multiple_idx) {
+      int32_t headroom = gpu_workloads_balance_mapping[multiple_idx * num_gpus + tid];
+      const int32_t tmp = MIN(headroom, workload_balanced_by_previous_groups);
+      headroom -= tmp;
+      workload_balanced_by_previous_groups -= tmp;
+      smem_gpu_workloads_balance_mapping[multiple_idx * MAX_NUM_GPUS + tid] = headroom;
+      if (headroom == 0 || determined) {
+        continue;
+      }
+
+      const bool balance_to_exactly_single_gpu = group_task <= headroom;
+      if (balance_to_exactly_single_gpu) {
+        smem_target_multiple_indices[tid] = multiple_idx;
+      } else {
+        num_cases_balance_to_multi_gpus += 1;
+      }
+      determined = true;
+    }
+    if (num_cases_balance_to_multi_gpus > 0) {
+      atomicAdd(&smem_num_cases_balance_to_multi_gpus, 1);
+    }
+  }
+  __syncthreads();
+
+  int32_t logical_expert_id = 0;
+  int32_t gpu_id = 0;
+  int32_t physical_expert_id = 0;
+
+  if (global_tid < num_topk_ids) {
+    logical_expert_id = topk_ids[global_tid];
+    gpu_id = logical_expert_id / num_logical_experts_per_gpu;
+    physical_expert_id = logical_expert_id + gpu_id * (num_physical_experts_per_gpu - num_logical_experts_per_gpu);
+  }
+
+  if (smem_num_cases_balance_to_multi_gpus == 0) {
+    // Happy path:
+    // Situation A does not exist. In the current grouped workload,
+    // all GPUs will send their workloads to the corresponding only GPU.
+    // We can achieve maximum concurrency.
+    if (global_tid < num_topk_ids) {
+      // The token originally dispatched to GPU i will be dispatched to GPU (i-target_multiple_idx)
+      const int32_t target_multiple_idx = smem_target_multiple_indices[gpu_id];
+      int32_t new_topk_id =
+          physical_expert_id - target_multiple_idx * (expert_copies_multiple - 1) * num_logical_experts_per_gpu;
+      new_topk_id = (new_topk_id + num_physical_experts) % num_physical_experts;
+      new_topk_ids[global_tid] = new_topk_id;
+    }
+    return;
+  }
+
+  if (tid < num_gpus) {
+    smem_group_gpu_workloads_counter[tid] = 0;
+  }
+  __syncthreads();
+
+  if (global_tid < num_topk_ids) {
+    for (int32_t query_gpu_id = 0; query_gpu_id < num_gpus; ++query_gpu_id) {
+      if (query_gpu_id != gpu_id) {
+        continue;
+      }
+      // All threads with topk_id belonging to the same gpu will execute to this point
+      // Get a sequence number by atomicAdd, which determines which gpu the token will transfer to
+      const int32_t idx = static_cast<int32_t>(atomicAdd(&smem_group_gpu_workloads_counter[gpu_id], 1));
+      int32_t acc = 0;
+      int32_t multiple_idx = expert_copies_multiple - 1;
+      for (; multiple_idx >= 0; --multiple_idx) {
+        int32_t headroom = smem_gpu_workloads_balance_mapping[multiple_idx * MAX_NUM_GPUS + gpu_id];
+        int32_t next_acc = acc + headroom;
+        if (acc <= idx && idx < next_acc) {
+          break;
+        }
+        acc = next_acc;
+      }
+      // The token originally dispatched to GPU i will be dispatched to GPU (i-target_multiple_idx)
+      int32_t new_topk_id =
+          physical_expert_id - multiple_idx * (expert_copies_multiple - 1) * num_logical_experts_per_gpu;
+      new_topk_id = (new_topk_id + num_physical_experts) % num_physical_experts;
+      smem_new_topk_ids[tid] = new_topk_id;
+    }
+  }
+
+  __syncthreads();
+  if (global_tid < num_topk_ids) {
+    new_topk_ids[global_tid] = smem_new_topk_ids[tid];
+  }
+}
+
+void balance_topk_ids(
+    const torch::Tensor& topk_ids,
+    const int64_t num_gpus,
+    const int64_t num_logical_experts,
+    const int64_t num_physical_experts,
+    torch::Tensor& max_workload_after_balance,     // [1], int32
+    torch::Tensor& gpu_workloads_balance_mapping,  // [num_physical_experts/num_logical_experts, num_gpus], int32
+    torch::Tensor& new_topk_ids) {
+  TORCH_CHECK(num_physical_experts % num_logical_experts == 0);
+  TORCH_CHECK(num_logical_experts % num_gpus == 0);
+  TORCH_CHECK(num_gpus <= MAX_NUM_GPUS);
+  TORCH_CHECK(topk_ids.dtype() == torch::kInt32);
+  TORCH_CHECK(max_workload_after_balance.dtype() == torch::kInt32);
+  TORCH_CHECK(gpu_workloads_balance_mapping.dtype() == torch::kInt32);
+  TORCH_CHECK(new_topk_ids.dtype() == torch::kInt32);
+
+  const int32_t expert_copies_multiple = static_cast<int32_t>(num_physical_experts / num_logical_experts);
+  TORCH_CHECK(expert_copies_multiple <= MAX_EXPERT_COPIES_MULTIPLE);
+
+  auto stream = at::cuda::getCurrentCUDAStream(topk_ids.device().index());
+  const int32_t num_topk_ids = static_cast<int32_t>(topk_ids.numel());
+
+  auto i32_options = torch::TensorOptions().dtype(torch::kInt32).device(topk_ids.device());
+  torch::Tensor gpu_workloads_wo_balance = torch::zeros({num_gpus}, i32_options);
+  int32_t num_groups = (num_topk_ids + GROUP_SIZE - 1) / GROUP_SIZE;
+  torch::Tensor grouped_gpu_workloads_wo_balance =
+      torch::empty({static_cast<int64_t>(num_groups), num_gpus}, i32_options);
+  torch::Tensor cumsum_grouped_gpu_workloads_wo_balance =
+      torch::empty({static_cast<int64_t>(num_groups), num_gpus}, i32_options);
+
+  // gpu_workloads_wo_balance[i] indicates the number of tokens received on each gpu after
+  // dispatching the token without workload balance.
+  // grouped_gpu_workloads_wo_balance: similar to gpu_workloads_wo_balance, but group by GROUP_SIZE.
+  gpu_workloads_count_kernel<<<1, GROUP_SIZE, 0, stream>>>(
+      static_cast<const int32_t*>(topk_ids.data_ptr()),
+      static_cast<int32_t>(num_logical_experts),
+      static_cast<int32_t>(num_gpus),
+      num_topk_ids,
+      static_cast<int32_t*>(gpu_workloads_wo_balance.data_ptr()),
+      static_cast<int32_t*>(grouped_gpu_workloads_wo_balance.data_ptr()),
+      static_cast<int32_t*>(cumsum_grouped_gpu_workloads_wo_balance.data_ptr()));
+
+  // We traverse the entire solution space and search for how many tokens the GPU
+  // with the most loadwork will receive after workload balance (saved in max_workload_after_balance).
+  // Besides, we figure out how to shift some of the workload from the GPUs with more workload
+  // to the GPUs with less workload (saved in gpu_workloads_balance_mapping).
+  // gpu_workloads_balance_mapping[i][j] indicates how much workload will be transferred from gpu j to gpu j-i.
+  search_balance_mapping(
+      gpu_workloads_wo_balance,
+      num_topk_ids,
+      expert_copies_multiple,
+      static_cast<int32_t>(num_gpus),
+      max_workload_after_balance,
+      gpu_workloads_balance_mapping);
+
+  // do workload balance according to gpu_workloads_balance_mapping
+  rewrite_topk_ids_by_balance_mapping_kernel<<<num_groups, GROUP_SIZE, 0, stream>>>(
+      static_cast<const int32_t*>(topk_ids.data_ptr()),
+      static_cast<const int32_t*>(gpu_workloads_balance_mapping.data_ptr()),
+      static_cast<const int32_t*>(grouped_gpu_workloads_wo_balance.data_ptr()),
+      static_cast<const int32_t*>(cumsum_grouped_gpu_workloads_wo_balance.data_ptr()),
+      static_cast<int32_t>(num_gpus),
+      num_topk_ids,
+      static_cast<int32_t>(num_logical_experts),
+      static_cast<int32_t>(num_physical_experts),
+      static_cast<int32_t*>(new_topk_ids.data_ptr()));
+}

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -319,6 +319,14 @@ void scaled_fp4_experts_quant(
     torch::Tensor const& input_offset_by_experts,
     torch::Tensor const& output_scale_offset_by_experts);
 
+void balance_topk_ids(
+    const torch::Tensor& topk_ids,
+    const int64_t num_gpus,
+    const int64_t num_logical_experts,
+    const int64_t num_physical_experts,
+    torch::Tensor& max_workload_after_balance,
+    torch::Tensor& gpu_workloads_balance_mapping,
+    torch::Tensor& new_topk_ids);
 /*
  * From csrc/speculative
  */

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -49,6 +49,7 @@ from sgl_kernel.gemm import (
 from sgl_kernel.grammar import apply_token_bitmask_inplace_cuda
 from sgl_kernel.moe import (
     apply_shuffle_mul_sum,
+    balance_topk_ids,
     cutlass_fp4_group_mm,
     ep_moe_post_reorder,
     ep_moe_pre_reorder,

--- a/sgl-kernel/python/sgl_kernel/moe.py
+++ b/sgl-kernel/python/sgl_kernel/moe.py
@@ -252,3 +252,23 @@ def cutlass_fp4_group_mm(
         params["blockscale_offsets"],
     )
     return c.to(dtype=out_dtype)
+
+
+def balance_topk_ids(
+    topk_ids,
+    num_gpus,
+    num_logical_experts,
+    num_physical_experts,
+    max_workload_after_balance,
+    gpu_workloads_balance_mapping,
+    new_topk_ids,
+):
+    torch.ops.sgl_kernel.balance_topk_ids.default(
+        topk_ids,
+        num_gpus,
+        num_logical_experts,
+        num_physical_experts,
+        max_workload_after_balance,
+        gpu_workloads_balance_mapping,
+        new_topk_ids,
+    )

--- a/sgl-kernel/tests/test_balance_topk_ids.py
+++ b/sgl-kernel/tests/test_balance_topk_ids.py
@@ -1,0 +1,94 @@
+import pytest
+import torch
+from sgl_kernel import balance_topk_ids
+
+
+@pytest.mark.parametrize("num_gpus", [8, 16, 32])
+@pytest.mark.parametrize(
+    "num_logical_experts, num_physical_experts",
+    [(32, 32), (32, 64), (32, 128), (256, 512), (256, 1024)],
+)
+@pytest.mark.parametrize(
+    "input_shape", [(1, 1), (11,), (1024, 8), (377,), (875, 5), (14000, 8)]
+)
+def test_balance_topk_ids(
+    num_gpus, num_logical_experts, num_physical_experts, input_shape
+):
+    assert num_logical_experts >= num_gpus
+    assert num_logical_experts % num_gpus == 0
+    assert num_physical_experts % num_logical_experts == 0
+
+    topk_ids = torch.randint(
+        low=0,
+        high=num_logical_experts,
+        size=input_shape,
+        device="cuda:0",
+        dtype=torch.int32,
+    )
+
+    max_workload_after_balance = torch.empty([1], dtype=torch.int32, device="cuda:0")
+    new_topk_ids = torch.empty_like(topk_ids)
+    gpu_workloads_balance_mapping = torch.empty(
+        [num_physical_experts // num_logical_experts, num_gpus],
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+    balance_topk_ids(
+        topk_ids,
+        num_gpus,
+        num_logical_experts,
+        num_physical_experts,
+        max_workload_after_balance,
+        gpu_workloads_balance_mapping,
+        new_topk_ids,
+    )
+
+    logical_expert_workloads = torch.bincount(
+        topk_ids.flatten(), minlength=num_logical_experts
+    )
+    origin_gpu_workload = logical_expert_workloads.view(num_gpus, -1).sum(1)
+    torch.testing.assert_close(
+        gpu_workloads_balance_mapping.sum(0), origin_gpu_workload
+    )
+
+    num_copy = num_physical_experts // num_logical_experts
+    expectd_new_gpu_workload = torch.zeros(
+        [num_gpus], dtype=torch.int32, device="cuda:0"
+    )
+    for i in range(num_copy):
+        workload = gpu_workloads_balance_mapping[i]
+        workload = torch.roll(workload, shifts=-i)
+        expectd_new_gpu_workload += workload
+
+    new_gpu_workload = (
+        torch.bincount(new_topk_ids.flatten(), minlength=num_physical_experts)
+        .view(num_gpus, -1)
+        .sum(1)
+        .to(torch.int32)
+    )
+
+    assert (
+        new_gpu_workload.max() <= max_workload_after_balance.item()
+    ), f"{new_gpu_workload.max()=}, {max_workload_after_balance.item()=}"
+
+    torch.testing.assert_close(new_gpu_workload, expectd_new_gpu_workload)
+
+    physical_to_logical_map = []
+    num_physical_experts_each_gpu = num_physical_experts // num_gpus
+    num_logical_experts_each_gpu = num_logical_experts // num_gpus
+    for i in range(0, num_gpus):
+        start_idx = i * num_logical_experts_each_gpu
+        for logical_expert_id in range(
+            start_idx, start_idx + num_physical_experts_each_gpu
+        ):
+            physical_to_logical_map.append(logical_expert_id % num_logical_experts)
+
+    physical_to_logical_map = torch.tensor(
+        physical_to_logical_map, dtype=torch.int32, device="cuda:0"
+    )
+    expected_old_topk_ids = physical_to_logical_map[new_topk_ids]
+    torch.testing.assert_close(topk_ids, expected_old_topk_ids)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->



## Motivation

When enabling `--enable-deepep-moe --deepep-mode normal`, I used `nsys` to analyze the performance bottleneck during the prefill stage and found that the expert workloads are highly imbalanced. This imbalance causes uneven workload across GPUs when computing deep GEMM operations, leading to GPUs with lighter workloads waiting at the `cache_notify` kernel for synchronization before proceeding to token combination.

Although `sglang` has introduced features like `--eplb-rebalance-num-iterations` to record expert usage frequency and perform hot updates, this indirect and non-intuitive update mechanism may pose risks in **production environments**. Therefore, I opted to use `--ep-num-redundant-experts` to introduce redundancy among experts to balance the workload on each GPU.

However, I found that the existing `--ep-dispatch-algorithm` does not effectively balance the workload when dispatching tokens. To address this, I designed a new dispatch algorithm that balances the number of tokens dispatched from a single GPU to all GPUs as evenly as possible.

---

## Modifications

- **sgl-kernel**: Added new kernels to implement workload-balanced token dispatching, along with corresponding test cases.
- **sglang**: Added a new `balance` option for `--ep-dispatch-algorithm` and implemented the related logic.

---

### Algorithm main idea

The main latency in DeepEP arises from the large disparity in the number of tokens dispatched to different GPUs. GPUs receiving fewer tokens must wait during the combine phase for those with more tokens to finish their computations.

The key optimization is to leverage redundant experts to dispatch tokens preferentially to GPUs with fewer tokens, thus balancing the workload.

Since collecting `topk_ids` from all GPUs for global workload balancing is difficult, our approach focuses on local balancing per GPU: each GPU analyzes its own `topk_ids` and tries to distribute tokens evenly across other GPUs.

For example, during the prefill stage, we enable --tp-size=16 (i.e., a total of 16 GPUs) and --ep-num-redundant-experts=256. The input prompt contains 16k tokens, and after MLA and scatter operations, each GPU gets 1k tokens.

For GPU0, it needs to dispatch its 1k tokens to GPUs 0-15 according to the `topk_ids``. The question is: how should GPU0 dispatch these tokens so that, from GPU0’s perspective (without considering GPUs 1 to 15), the number of tokens dispatched to GPU 0-15 is as balanced as possible?


Formally, suppose after balancing, the number of tokens processed by each GPU is `x_1, x_2, ..., x_n`. Define `x = max(x_1, x_2, ..., x_n)`. The smaller `x` is, the more balanced the workload. 

However, solving for the exact `x` requires a dynamic programming-like approach with high overhead. Instead, we approximate `x` by searching within a feasible range.

For example, if dispatching 1024 tokens across 16 GPUs, and each expert has 1 redundant copy (1 logical expert load on 2 GPUs), the upper bound of `x` is 1024 / 2 = 512 (all tokens dispatched to only 2 GPUs), and the lower bound is `1024 / 16 = 64` (perfect balance).

We search for an approximate `x'` within this range by incrementing in strides (e.g., start with `x' = 64`, check feasibility; if not feasible, increase `x'` by 16(search stride) and repeat until a feasible solution is found).

Finally, we rewrite the `topk_ids` based on the found `x'` to achieve balanced token dispatch.

## Comparation

baseline launch command:
```
SGL_ENABLE_JIT_DEEPGEMM=1 python -u -m sglang.launch_server \
--model-path /sgl-workspace/DeepSeek-R1 \
--nnodes 2 --trust-remote-code  \
--served-model-name deepseek-r1 \
--dist-init-addr 29.226.64.238:5000 \
--node-rank ${NODE_RANK} \
--host 0.0.0.0 --port 8000 \
--tp 16 \
--node-rank ${NODE_RANK} \
--schedule-policy fcfs \
--chunked-prefill-size 32768 \
--max-prefill-tokens 32768 \
--disable-overlap-schedule \
--mem-fraction-static 0.90 \
--disable-radix-cache  \
--disable-cuda-graph \
--enable-deepep-moe --deepep-mode normal --ep-size 16 \
--ep-num-redundant-experts 256 --ep-dispatch-algorithm static
```
balanced launch command: similar to baseline launch, change `--ep-dispatch-algorithm static` to `--ep-dispatch-algorithm balance`

### Correctness
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 200 --parallel 16 \
--data-path /geminicephfs/mm-base-tfcc/yuethe/projects/test_data/gsm8k.jsonl \
--host http://127.0.0.1 --port 8000

baseline:
Accuracy: 0.965
Invalid: 0.000
Latency: 497.245 s
Output throughput: 40.883 token/s

balanced:
Accuracy: 0.970
Invalid: 0.000
Latency: 483.616 s
Output throughput: 40.997 token/s
```

### benchmark
benchmark on 2x8xH20.

#### prefill stage (6~8% throughput improvement)

prompt len = 14k, 8.4% throughput improvement
```
## set the random seed to 42 before benchmark
python3 -m sglang.bench_one_batch_server --model None --skip-warmup --base-url http://127.0.0.1:8000 --batch-size 1 --input-len 14000 --output-len 1 --model-path /sgl-workspace/DeepSeek-R1

baseline:
#Input tokens: 14000
#Output tokens: 1
input_requests[0].prompt[:10]=[15795, 860, 5390, 13418, 5191, 11964, 11284, 5734, 6265, 466]
batch size: 1
input_len: 14000
output_len: 1
latency: 1.18 s
ttft: 1.18 s
Last generation throughput: 0.00 tok/s
Input throughput: 11827.43 tok/s

balanced:
#Input tokens: 14000
#Output tokens: 1
input_requests[0].prompt[:10]=[15795, 860, 5390, 13418, 5191, 11964, 11284, 5734, 6265, 466]
batch size: 1
input_len: 14000
output_len: 1
latency: 1.09 s
ttft: 1.09 s
Last generation throughput: 0.00 tok/s
Input throughput: 12827.63 tok/s
```


prompt len = 16384, 6.18% throughput improvement
```
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 16384 --random-output-len 0 --random-range-ratio 1 --port 8000 --model /sgl-workspace/DeepSeek-R1 --dataset-path /geminicephfs/mm-base-tfcc/yuethe/projects/tune/ShareGPT_V3_unfiltered_cleaned_split.json

baseline:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     50        
Benchmark duration (s):                  63.65     
Total input tokens:                      819200    
Total generated tokens:                  0         
Total generated tokens (retokenized):    50        
Request throughput (req/s):              0.79      
Input token throughput (tok/s):          12870.77  
Output token throughput (tok/s):         0.00      
Total token throughput (tok/s):          12870.77  
Concurrency:                             25.56     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   32533.92  
Median E2E Latency (ms):                 32922.46  
---------------Time to First Token----------------
Mean TTFT (ms):                          32533.91  
Median TTFT (ms):                        32922.45  
P99 TTFT (ms):                           58941.45  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================

balanced:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     50        
Benchmark duration (s):                  59.94     
Total input tokens:                      819200    
Total generated tokens:                  0         
Total generated tokens (retokenized):    50        
Request throughput (req/s):              0.83      
Input token throughput (tok/s):          13666.92  
Output token throughput (tok/s):         0.00      
Total token throughput (tok/s):          13666.92  
Concurrency:                             25.56     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   30641.85  
Median E2E Latency (ms):                 31194.94  
---------------Time to First Token----------------
Mean TTFT (ms):                          30641.84  
Median TTFT (ms):                        31194.93  
P99 TTFT (ms):                           55243.41  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
```

prompt len = 10240, 6.15% throughput improvement
```
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 10240 --random-output-len 0 --random-range-ratio 1 --port 8000 --model /sgl-workspace/DeepSeek-R1 --dataset-path /geminicephfs/mm-base-tfcc/yuethe/projects/tune/ShareGPT_V3_unfiltered_cleaned_split.json

baseline:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     50        
Benchmark duration (s):                  46.95     
Total input tokens:                      512000    
Total generated tokens:                  0         
Total generated tokens (retokenized):    50        
Request throughput (req/s):              1.06      
Input token throughput (tok/s):          10904.92  
Output token throughput (tok/s):         0.00      
Total token throughput (tok/s):          10904.92  
Concurrency:                             24.71     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   23200.74  
Median E2E Latency (ms):                 23323.82  
---------------Time to First Token----------------
Mean TTFT (ms):                          23200.73  
Median TTFT (ms):                        23323.81  
P99 TTFT (ms):                           42252.33  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================

balanced:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     50        
Benchmark duration (s):                  44.23     
Total input tokens:                      512000    
Total generated tokens:                  0         
Total generated tokens (retokenized):    50        
Request throughput (req/s):              1.13      
Input token throughput (tok/s):          11576.38  
Output token throughput (tok/s):         0.00      
Total token throughput (tok/s):          11576.38  
Concurrency:                             24.39     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   21576.91  
Median E2E Latency (ms):                 21494.61  
---------------Time to First Token----------------
Mean TTFT (ms):                          21576.90  
Median TTFT (ms):                        21494.59  
P99 TTFT (ms):                           39526.78  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
```

prompt len = 4096, 7.4% throughput improvement
```
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 50 --request-rate 10 --dataset-name random --random-input-len 4096 --random-output-len 0 --random-range-ratio 1 --port 8000 --model /sgl-workspace/DeepSeek-R1 --dataset-path /geminicephfs/mm-base-tfcc/yuethe/projects/tune/ShareGPT_V3_unfiltered_cleaned_split.json

baseline
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     50        
Benchmark duration (s):                  14.56     
Total input tokens:                      204800    
Total generated tokens:                  0         
Total generated tokens (retokenized):    50        
Request throughput (req/s):              3.43      
Input token throughput (tok/s):          14065.61  
Output token throughput (tok/s):         0.00      
Total token throughput (tok/s):          14065.61  
Concurrency:                             21.63     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6299.79   
Median E2E Latency (ms):                 6714.27   
---------------Time to First Token----------------
Mean TTFT (ms):                          6299.78   
Median TTFT (ms):                        6714.27   
P99 TTFT (ms):                           10259.76  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
balanced:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     50        
Benchmark duration (s):                  13.56     
Total input tokens:                      204800    
Total generated tokens:                  0         
Total generated tokens (retokenized):    50        
Request throughput (req/s):              3.69      
Input token throughput (tok/s):          15106.92  
Output token throughput (tok/s):         0.00      
Total token throughput (tok/s):          15106.92  
Concurrency:                             21.67     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5876.49   
Median E2E Latency (ms):                 6307.98   
---------------Time to First Token----------------
Mean TTFT (ms):                          5876.48   
Median TTFT (ms):                        6307.97   
P99 TTFT (ms):                           9384.40   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
```

#### decode stage(2.3% throughput reduction)
Note that: 
When the number of tokens is small, the `balance` dispatch algorithm will be downgraded to a `static` dispatch algorithm to avoid the additional overhead brought by the `balance` algorithm.
Actually, `balance` algorithm is not suitable for the decoding stage because the number of tokens that each GPU needs to dispatch in the decoding stage is too small.

Please note that `--deepep-mode normal` is used here, setting `-deepep-mode=auto/low_latency` will cause program errors (both `baseline` and `balance`)
```
python3 -m sglang.bench_serving --backend sglang-oai --num-prompts 64 --request-rate 10 --dataset-name random --random-input-len 1 --random-output-len 256 --random-range-ratio 1 --port 8000 --model /sgl-workspace/DeepSeek-R1 --dataset-path /geminicephfs/mm-base-tfcc/yuethe/projects/tune/ShareGPT_V3_unfiltered_cleaned_split.json

baseline:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  87.53     
Total input tokens:                      64        
Total generated tokens:                  16384     
Total generated tokens (retokenized):    16384     
Request throughput (req/s):              0.73      
Input token throughput (tok/s):          0.73      
Output token throughput (tok/s):         187.18    
Total token throughput (tok/s):          187.91    
Concurrency:                             61.32     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   83866.92  
Median E2E Latency (ms):                 83517.38  
---------------Time to First Token----------------
Mean TTFT (ms):                          1090.81   
Median TTFT (ms):                        1124.44   
P99 TTFT (ms):                           1967.67   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           326.17    
Median ITL (ms):                         296.30    
P95 ITL (ms):                            424.50    
P99 ITL (ms):                            640.93    
Max ITL (ms):                            5364.63   
==================================================
balanced:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    10.0      
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  89.67     
Total input tokens:                      64        
Total generated tokens:                  16384     
Total generated tokens (retokenized):    16384     
Request throughput (req/s):              0.71      
Input token throughput (tok/s):          0.71      
Output token throughput (tok/s):         182.72    
Total token throughput (tok/s):          183.44    
Concurrency:                             61.39     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   86010.38  
Median E2E Latency (ms):                 85660.04  
---------------Time to First Token----------------
Mean TTFT (ms):                          2102.41   
Median TTFT (ms):                        1975.33   
P99 TTFT (ms):                           3602.40   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           330.51    
Median ITL (ms):                         301.62    
P95 ITL (ms):                            418.52    
P99 ITL (ms):                            720.71    
Max ITL (ms):                            6060.71   
==================================================
```

## Algorithm restriction
```
assert num_physical_expert % num_logical_expert == 0
assert num_logical_expert % num_gpu == 0
```
For deepseek-671B (which has 256 routed_experts), `--ep-num-redundant-experts` can only be set to a multiple of 256.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
