### PR TITLE
Fix OOM When Using Large Context Length

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -824,7 +824,7 @@ class ModelRunner:
             1 - self.mem_fraction_static
         )
         max_num_token = int(rest_memory * (1 << 30) // cell_size)
-        return max_num_token
+        return max_num_token, cell_size
 
     def init_memory_pool(
         self,
@@ -847,7 +847,9 @@ class ModelRunner:
                 f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
             )
 
-        self.max_total_num_tokens = self.profile_max_num_token(total_gpu_memory)
+        self.max_total_num_tokens, cell_size = self.profile_max_num_token(
+            total_gpu_memory
+        )
 
         if max_num_reqs is None:
             max_num_reqs = min(
@@ -894,6 +896,14 @@ class ModelRunner:
                     f"Use the profiled value instead."
                 )
             self.max_total_num_tokens = min(self.max_total_num_tokens, max_total_tokens)
+
+        # modify max_total_num_tokens due to ReqToTokenPool
+        self.max_total_num_tokens -= (
+            (max_num_reqs + 1)
+            * (self.server_args.context_length + 4)
+            * torch._utils._element_size(torch.int32)
+            // cell_size
+        )
 
         self.max_total_num_tokens = (
             self.max_total_num_tokens

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -900,7 +900,7 @@ class ModelRunner:
         # modify max_total_num_tokens due to ReqToTokenPool
         self.max_total_num_tokens -= (
             (max_num_reqs + 1)
-            * (self.server_args.context_length + 4)
+            * (self.model_config.context_len + 4)
             * torch._utils._element_size(torch.int32)
             // cell_size
         )


### PR DESCRIPTION
Enable long context length

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When setting a large context length (e.g., for LLaMA 4), launching the server with:

```
python3 -m sglang.launch_server --model-path meta-llama/Llama-4-Scout-17B-16E-Instruct --port 30002 --tp 8 --context-length 2800000
```

can lead to an out-of-memory (OOM) issue as follows:

```
[2025-05-29 14:59:00] Received sigquit from a child process. It usually means the child failed.
[2025-05-29 14:59:00 TP5] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2344, in run_scheduler_process
    scheduler = Scheduler(server_args, port_args, gpu_id, tp_rank, pp_rank, dp_rank)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 280, in __init__
    self.tp_worker = TpWorkerClass(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 64, in __init__
    self.worker = TpModelWorker(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 78, in __init__
    self.model_runner = ModelRunner(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 233, in __init__
    self.initialize(min_per_gpu_memory)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 300, in initialize
    self.init_memory_pool(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 955, in init_memory_pool
    self.token_to_kv_pool = MHATokenToKVPool(
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 266, in __init__
    self._create_buffers()
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 289, in _create_buffers
    self.v_buffer = [
  File "/sgl-workspace/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 290, in <listcomp>
    torch.zeros(
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 944.00 MiB. GPU 5 has a total capacity of 139.72 GiB of which 824.94 MiB is free. Process 216191 has 138.90 GiB memory in use. Of the allocated memory 136.92 GiB is allocated by PyTorch, and 352.33 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```

The cause is that ReqToTokenPool requires a non-negligible amount of memory, especially when the context length is large. However, this memory overhead is currently not accounted for when computing max_total_num_tokens, which can result in overallocation and subsequent OOM errors during initialization.

## Modifications

This PR reduces max_total_num_tokens based on the memory usage required by ReqToTokenPool

```
self.max_total_num_tokens -= (max_num_reqs + 1) * (self.server_args.context_length + 4) * torch._utils._element_size(torch.int32) // cell_size
```

This helps prevent OOM issues when launching with very large context lengths.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
