### PR TITLE
Add sticky round roubin scheduler

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -167,6 +167,7 @@ class Engine(EngineBase):
         bootstrap_host: Optional[Union[List[str], str]] = None,
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
+        dp_rank: Optional[int] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -188,6 +189,7 @@ class Engine(EngineBase):
             bootstrap_host=bootstrap_host,
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
+            dp_rank=dp_rank,
         )
         loop = asyncio.get_event_loop()
         generator = self.tokenizer_manager.generate_request(obj, None)
@@ -237,6 +239,7 @@ class Engine(EngineBase):
         bootstrap_host: Optional[Union[List[str], str]] = None,
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
+        dp_rank: Optional[int] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -257,6 +260,7 @@ class Engine(EngineBase):
             bootstrap_host=bootstrap_host,
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
+            dp_rank=dp_rank,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -248,9 +248,12 @@ class DataParallelController:
 
     def round_robin_scheduler(self, req: Req):
         if self.server_args.disaggregation_mode == "null":
-            self.workers[self.round_robin_counter].send_pyobj(req)
-            self.round_robin_counter = (self.round_robin_counter + 1) % len(
-                self.workers
+            if req.dp_rank is not None:
+                self.workers[req.dp_rank].send_pyobj(req)
+            else:
+                self.workers[self.round_robin_counter].send_pyobj(req)
+                self.round_robin_counter = (self.round_robin_counter + 1) % len(
+                    self.workers
             )
         else:
             self.workers[req.bootstrap_room % len(self.workers)].send_pyobj(req)

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -234,6 +234,7 @@ class DetokenizerManager:
             output_token_ids_logprobs_val=recv_obj.output_token_ids_logprobs_val,
             output_token_ids_logprobs_idx=recv_obj.output_token_ids_logprobs_idx,
             output_hidden_states=recv_obj.output_hidden_states,
+            dp_ranks=recv_obj.dp_ranks,
         )
 
     def handle_multimodal_decode_req(self, recv_obj: BatchMultimodalDecodeReq):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -98,6 +98,9 @@ class GenerateReqInput:
     # Use the processor's `to_str()` method to generate the serialized string.
     custom_logit_processor: Optional[Union[List[Optional[str]], str]] = None
 
+    # Data parallel rank information for sticky scheduling
+    dp_rank: Optional[int] = None
+
     # Whether to return hidden states
     return_hidden_states: bool = False
 
@@ -456,6 +459,9 @@ class TokenizedGenerateReqInput:
     # Use the processor's `to_str()` method to generate the serialized string.
     custom_logit_processor: Optional[str] = None
 
+    # Data parallel rank information for sticky scheduling
+    dp_rank: Optional[int] = None
+
     # Whether to return hidden states
     return_hidden_states: bool = False
 
@@ -614,6 +620,9 @@ class BatchTokenIDOut:
     # Hidden states
     output_hidden_states: List[List[float]]
 
+    # Data parallel rank information for sticky scheduling
+    dp_ranks: Optional[List[int]] = None
+
 
 @dataclass
 class BatchMultimodalDecodeReq:
@@ -660,6 +669,9 @@ class BatchStrOut:
 
     # Hidden states
     output_hidden_states: List[List[float]]
+
+    # Data parallel rank information for sticky scheduling
+    dp_ranks: Optional[List[int]] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -99,6 +99,7 @@ class GenerateReqInput:
     custom_logit_processor: Optional[Union[List[Optional[str]], str]] = None
 
     # Data parallel rank information for sticky scheduling
+    # Data parallel rank information for sticky scheduling. If set, the request will be routed to this specific DP rank.
     dp_rank: Optional[int] = None
 
     # Whether to return hidden states

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -438,6 +438,7 @@ class Req:
         custom_logit_processor: Optional[str] = None,
         return_hidden_states: bool = False,
         eos_token_ids: Optional[Set[int]] = None,
+        dp_rank: Optional[int] = None,
         bootstrap_host: Optional[str] = None,
         bootstrap_port: Optional[int] = None,
         bootstrap_room: Optional[int] = None,
@@ -607,6 +608,9 @@ class Req:
         # We use `tmp_end_idx` to store the end index of the kv cache to send.
         self.tmp_end_idx: int = -1
         self.metadata_buffer_index: int = -1
+
+        # Data parallel rank information for sticky scheduling
+        self.dp_rank: Optional[int] = dp_rank
 
     @property
     def seqlen(self):

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -461,6 +461,7 @@ class SchedulerOutputProcessorMixin:
         skip_req: Optional[Req] = None,
     ):
         rids = []
+        dp_ranks = []
         finished_reasons: List[BaseFinishReason] = []
 
         decoded_texts = []
@@ -534,6 +535,7 @@ class SchedulerOutputProcessorMixin:
                     req.send_output_token_logprobs_offset
                 )
                 rids.append(req.rid)
+                dp_ranks.append(req.dp_rank)
                 finished_reasons.append(
                     req.finished_reason.to_json() if req.finished_reason else None
                 )
@@ -675,6 +677,7 @@ class SchedulerOutputProcessorMixin:
                     output_token_ids_logprobs_val,
                     output_token_ids_logprobs_idx,
                     output_hidden_states,
+                    dp_ranks,
                 )
             )
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -566,6 +566,7 @@ class TokenizerManager:
                 session_params=session_params,
                 custom_logit_processor=obj.custom_logit_processor,
                 return_hidden_states=obj.return_hidden_states,
+                dp_rank=obj.dp_rank,
             )
         elif isinstance(obj, EmbeddingReqInput):
             tokenized_obj = TokenizedEmbeddingReqInput(
@@ -1146,6 +1147,7 @@ class TokenizerManager:
                 "id": rid,
                 "finish_reason": recv_obj.finished_reasons[i],
                 "prompt_tokens": recv_obj.prompt_tokens[i],
+                "dp_rank": recv_obj.dp_ranks[i] if isinstance(recv_obj, (BatchStrOut, BatchTokenIDOut)) else None,
             }
 
             if getattr(state.obj, "return_logprob", False):

--- a/test/srt/test_sticky_scheduler.py
+++ b/test/srt/test_sticky_scheduler.py
@@ -1,0 +1,77 @@
+import gc
+import unittest
+
+import torch
+
+import sglang as sgl
+from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+
+
+class StickySchedulerTest(unittest.TestCase):
+
+    def init_backend(self, dp, tp):
+        self.dp = dp
+        self.tp = tp
+        self.engine = sgl.Engine(
+            model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            random_seed=42,
+            tp_size=tp,
+            dp_size=dp,
+            disable_cuda_graph=True,
+        )
+
+    def clean_up(self):
+        gc.collect()
+        torch.cuda.empty_cache()
+        self.engine.shutdown()
+
+
+    def test_sticky_round_robin(self):
+        """
+        Tests the round robin with sticky scheduling. If a request desires a certain data parallel rank,
+        it should be sent to the corresponding rank.
+        """
+        self.init_backend(2, 1)
+        # first request
+        print(f"Test: First request sent")
+        resp = self.engine.generate(
+            prompt="What is knock knock?",
+            sampling_params={
+                "max_new_tokens": 0,
+                "temperature": 0.0,
+            }
+        )
+        dp_rank = resp["meta_info"]["dp_rank"]
+        print(f"Test: First request was sent to dp rank: {dp_rank}")
+        assert dp_rank == 0
+
+        # the subsequent request specifies the same dp_rank
+        print(f"Test: Second request sent")
+        resp = self.engine.generate(
+            prompt="What is knock knock and why is it called that?",
+            sampling_params={
+                "max_new_tokens": 1,
+                "temperature": 0.0,
+            },
+            dp_rank=dp_rank
+        )
+        print(f"Test: Second request was sent to dp rank: {resp['meta_info']['dp_rank']}")
+        assert resp["meta_info"]["dp_rank"] == dp_rank
+
+        # another request without specifying dp_rank
+        print(f"Test: Third request sent")
+        resp = self.engine.generate(
+            prompt="Where is LinkedIn's headquarters?",
+            sampling_params={
+                "max_new_tokens": 0,
+                "temperature": 0.0,
+            }
+        )
+        print(f"Test: Third request was sent to dp rank: {resp['meta_info']['dp_rank']}")
+        assert resp["meta_info"]["dp_rank"] == 1
+
+        self.clean_up()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR adds the sticky scheduling for round robin scheduler. That is a generate request can specify which dp rank it desires to be scheduled. If not provided, the default round robin counter is used to determine the dp rank.

The general use case is where for a multi-part prompt at the client side, some parts of the prompt are available but for the rest of them the client must wait for a period of time to be available. In this case the client can send the first parts of the prompt to the engine to cache it as a prefix and send the rest of the prompt to the same dp rank where the cache exists once they are ready.
The particular use case is in a recommendation system where we want to rank a set of items for a user. Recommendation systems consist of two stages: a retrieval stage and a ranking stage. When using Sglang for both stages, the flow (and prompts) look like this:

```bash
(For user i get relevant items) --> +-----------------------+ --> (For user i rank items: item_1, ..., item_N) --> +---------------------+
                                    |   Retrieval Stage     |                                                 |   Ranking Stage     |
                                    +-----------------------+                                                 +---------------------+

```

As it can be seen, the flow is sequential for the same user. However, as an optimization, while the retrieval stage is running, we can send the first part of the prompt for ranking which is `for user i rank items:`  to the ranking stage. Once the retrieval stage is done, we sent the ranking prompt to the same dp rank that the first par the prompt was executed.

The following diagram depicts it:
```bash
(For user i get relevant items) --> +--------------------------+ 
                                    |   Retrieval Stage        |
                                    | returns item_1,...,item_N|
                                    |  for user i              |
                                    +--------------------------+
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |
                                                |                                                                            |
                            (For user i rank items: item_1, ..., item_N)
                            (uses KV cache for the "For user i rank items" part)
                                                |
                                                |  
                                                v                                              
(For user i rank items:) ----------> +-------------------------+
(running in parallel with retrieval) |   Ranking Stage         |
                                     | ranks item_1,...,item_N |
                                     |     for user i          |
                                     +-------------------------+




```
## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
