### PR TITLE
Tiny Llama4 type error in constructor

### DIFF
--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -203,7 +203,7 @@ class Llama4Attention(nn.Module):
         super().__init__()
         self.layer_id = layer_id
         self.hidden_size = hidden_size
-        self.use_rope = int((layer_id + 1) % 4 != 0)
+        self.use_rope = (layer_id + 1) % 4 != 0
         self.use_qk_norm = config.use_qk_norm and self.use_rope
 
         attn_tp_rank = get_attention_tp_rank()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix the type error.

<img width="843" alt="Screenshot 2025-05-29 at 6 19 04 PM" src="https://github.com/user-attachments/assets/9624d5bf-2a6f-40da-a801-222b7cc7f1ec" />

self.use_rope doesn't need to be an int


`self.use_rope` should be a boolean because:

1. **It's used as a boolean flag:**
```python
if self.use_rope:  # Natural boolean check
    # do something
```

2. **RadixAttention expects boolean:**
```python
self.attn = RadixAttention(
    # ...
    use_irope=self.use_rope,  # Expected type: bool
)
```

3. **The expression is already boolean:**
```python
# This naturally returns True/False
self.use_rope = (layer_id + 1) % 4 != 0  # bool
```

The `int()` wrapper was unnecessary since the comparison `!= 0` already produces the correct boolean type