### PR TITLE
[CPU] fix all_reduce and all_gather

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -441,12 +441,9 @@ class GroupCoordinator:
             return input_
 
         if input_.is_cpu:
-            # TODO: fix the binding of device_group
-            if False:
-                # if cpu_has_amx_support():
-                # TODO: check correctness
+            if cpu_has_amx_support():
                 torch.ops.sgl_kernel.shm_allreduce(
-                    input_, self.device_group, torch.distributed.ReduceOp.SUM
+                    input_, torch.distributed.ReduceOp.SUM
                 )
             else:
                 # fallback when intel amx backend not available
@@ -580,12 +577,8 @@ class GroupCoordinator:
         )
 
         if input_.is_cpu:
-            # TODO: fix the binding of device_group
-            if False:
-                # if cpu_has_amx_support():
-                return torch.ops.sgl_kernel.shm_allgather(
-                    input_, get_tp_group().device_group, dim
-                )
+            if cpu_has_amx_support():
+                return torch.ops.sgl_kernel.shm_allgather(input_, dim)
             else:
                 torch.distributed.all_gather_into_tensor(
                     output_tensor, input_, group=self.device_group

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -578,6 +578,20 @@ class GroupCoordinator:
         output_tensor = torch.empty(
             output_size, dtype=input_.dtype, device=input_.device
         )
+
+        if input_.is_cpu:
+            # TODO: fix the binding of device_group
+            if False:
+                # if cpu_has_amx_support():
+                return torch.ops.sgl_kernel.shm_allgather(
+                    input_, get_tp_group().device_group, dim
+                )
+            else:
+                torch.distributed.all_gather_into_tensor(
+                    output_tensor, input_, group=self.device_group
+                )
+                return output_tensor
+
         # All-gather.
         self.all_gather_into_tensor(output_tensor, input_)
         # Reshape

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -225,7 +225,7 @@ class GroupCoordinator:
         self.device_group = None
         self.cpu_group = None
         self.local_size = get_int_env_var("LOCAL_SIZE", 0)
-  
+
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
                 ranks, backend=torch_distributed_backend

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -225,6 +225,7 @@ class GroupCoordinator:
         self.device_group = None
         self.cpu_group = None
         self.local_size = get_int_env_var("LOCAL_SIZE", 0)
+  
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
                 ranks, backend=torch_distributed_backend

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -40,11 +40,11 @@ import torch.distributed
 from torch.distributed import Backend, ProcessGroup
 
 from sglang.srt.utils import (
-    cpu_has_amx_support,
     direct_register_custom_op,
     get_bool_env_var,
     is_cuda_alike,
     is_npu,
+    is_shm_available,
     supports_custom_op,
 )
 
@@ -441,12 +441,11 @@ class GroupCoordinator:
             return input_
 
         if input_.is_cpu:
-            if cpu_has_amx_support():
+            if is_shm_available(input_.dtype):
                 torch.ops.sgl_kernel.shm_allreduce(
                     input_, torch.distributed.ReduceOp.SUM
                 )
             else:
-                # fallback when intel amx backend not available
                 torch.distributed.all_reduce(input_, group=self.device_group)
             return input_
 
@@ -577,7 +576,7 @@ class GroupCoordinator:
         )
 
         if input_.is_cpu:
-            if cpu_has_amx_support():
+            if is_shm_available(input_.dtype):
                 return torch.ops.sgl_kernel.shm_allgather(input_, dim)
             else:
                 torch.distributed.all_gather_into_tensor(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -223,7 +223,7 @@ class GroupCoordinator:
         self.local_rank = local_rank
         self.device_group = None
         self.cpu_group = None
-
+        self.local_size = int(os.environ.get("LOCAL_SIZE", "0"))
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
                 ranks, backend=torch_distributed_backend
@@ -441,7 +441,7 @@ class GroupCoordinator:
             return input_
 
         if input_.is_cpu:
-            if is_shm_available(input_.dtype):
+            if is_shm_available(input_.dtype, self.world_size, self.local_size):
                 torch.ops.sgl_kernel.shm_allreduce(
                     input_, torch.distributed.ReduceOp.SUM
                 )
@@ -576,7 +576,7 @@ class GroupCoordinator:
         )
 
         if input_.is_cpu:
-            if is_shm_available(input_.dtype):
+            if is_shm_available(input_.dtype, self.world_size, self.local_size):
                 return torch.ops.sgl_kernel.shm_allgather(input_, dim)
             else:
                 torch.distributed.all_gather_into_tensor(

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -42,6 +42,7 @@ from torch.distributed import Backend, ProcessGroup
 from sglang.srt.utils import (
     direct_register_custom_op,
     get_bool_env_var,
+    get_int_env_var,
     is_cuda_alike,
     is_npu,
     is_shm_available,
@@ -223,7 +224,7 @@ class GroupCoordinator:
         self.local_rank = local_rank
         self.device_group = None
         self.cpu_group = None
-        self.local_size = int(os.environ.get("LOCAL_SIZE", "0"))
+        self.local_size = get_int_env_var("LOCAL_SIZE", 0)
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(
                 ranks, backend=torch_distributed_backend

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -506,9 +506,13 @@ class ModelRunner:
                 if _is_cpu_amx_available:
                     # Bind OpenMP threads to CPU cores
                     torch.ops.sgl_kernel.init_cpu_threads_env(self.local_omp_cpuid)
+
+                    # Set local size to hint SGLang to use shared memory based AllReduce
+                    os.environ["LOCAL_SIZE"] = str(self.tp_size)
+                    torch.ops.sgl_kernel.initialize(self.tp_size, self.tp_rank)
                 else:
                     logger.warning(
-                        "init_cpu_threads_env is skipped since intel amx backend is not available"
+                        "init_cpu_threads_env and shared memory based AllReduce is disabled since intel amx backend is not available"
                     )
 
             # Only initialize the distributed environment on the target model worker.

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -2612,3 +2612,7 @@ def get_cpu_ids_by_node():
 
     # ['0,1,2,3', '4,5,6,7', '8,9,10,11', '12,13,14,15', '16,17,18,19', '20,21,22,23']
     return cpu_ids
+
+
+def is_shm_available(dtype):
+    return cpu_has_amx_support() and dtype in [torch.bfloat16, torch.float]

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -2614,5 +2614,10 @@ def get_cpu_ids_by_node():
     return cpu_ids
 
 
-def is_shm_available(dtype):
-    return cpu_has_amx_support() and dtype in [torch.bfloat16, torch.float]
+def is_shm_available(dtype, world_size, local_size):
+    return (
+        cpu_has_amx_support()
+        and dtype in [torch.bfloat16, torch.float]
+        and world_size >= 1
+        and world_size == local_size
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Fix the error of all_reduce and all_gather on CPU
all_reduce:
```
  File "/home/user/sglang/python/sglang/srt/distributed/parallel_state.py", line 418, in all_reduce
    import intel_extension_for_pytorch as ipex
ModuleNotFoundError: No module named 'intel_extension_for_pytorch'
```
I guess the code is directly ported from vllm [here](https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/distributed/parallel_state.py#L367-L368) while SGLang does not have the dependency on ipex.

all_gather:
```
  File "/home/user/sglang/python/sglang/srt/distributed/parallel_state.py", line 496, in all_gather_into_tensor
    torch.ops.sglang.reg_all_gather_into_tensor(
  File "/home/user/miniforge3/envs/sglang-dev/lib/python3.10/site-packages/torch/_ops.py", line 1123, in __call__
    return self._op(*args, **(kwargs or {}))
NotImplementedError: Could not run 'sglang::reg_all_gather_into_tensor' with arguments from the 'CPU' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'sglang::reg_all_gather_into_tensor' is only available for these backends: [CUDA, Meta, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradXLA, AutogradMPS, AutogradXPU, AutogradHPU, AutogradLazy, AutogradMTIA, AutogradMeta, Tracer, AutocastCPU, AutocastXPU, AutocastMPS, AutocastCUDA, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
```


## Modification
- For all_reduce and all_gather, use `torch.ops.sgl_kernel.shm_allreduce` and `torch.ops.sgl_kernel.shm_allgather` for CPU.
- For the `shm_allreduce` and `shm_allgather` OPs, https://github.com/sgl-project/sglang/pull/7486 will remove the `process_group` input parameters  and this PR handles it in python code to fix the below error:
```
RuntimeError: sgl_kernel::shm_allreduce() Expected a value of type '__torch__.torch.classes.c10d.ProcessGroup (of Python compilation unit at: 0)' for argument 'process_group' but instead found type 'ProcessGroup'.
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

