### PR TITLE
Remove contiguous before Flashinfer groupwise fp8 gemm

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -166,11 +166,13 @@ def flashinfer_gemm_w8a8_block_fp8_linear(
         input_2d, block_size[1], column_major_scales=False
     )
 
-    x_scale_input = x_scale.T.contiguous()
-    weight_scale_input = weight_scale.T.contiguous()
-
     output = gemm_fp8_nt_groupwise(
-        q_input, weight, x_scale_input, weight_scale_input, out_dtype=input_2d.dtype
+        q_input,
+        weight,
+        x_scale,
+        weight_scale,
+        scale_major_mode="K",
+        out_dtype=input_2d.dtype,
     )
 
     if bias is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Follow up of #6479. 
With the update of flashinfer gemm kernel in https://github.com/flashinfer-ai/flashinfer/pull/1102,
the contiguous operation before gemm kernel can be removed.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Accuracy Results
```bash
SGLANG_ENABLE_FLASHINFER_GEMM=1 python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code --attention-backend triton

python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
```

```bash
Accuracy: 0.943
Invalid: 0.000
Latency: 53.125 s
Output throughput: 2696.061 token/s
```

## Profile Results
```bash
SGLANG_ENABLE_FLASHINFER_GEMM=1 python3 -m sglang.bench_one_batch --model-path deepseek-ai/DeepSeek-V3-0324 --tp 8 --trust-remote-code --attention-backend triton --batch 16 --input-len 1024 --output-len 2 --profile
```

Before removing contiguous:
![image](https://github.com/user-attachments/assets/f30b370a-b947-4a20-85c3-9e3f994ec242)

After removing contiguous:
![截屏2025-06-01 18 56 00](https://github.com/user-attachments/assets/76dba203-1dad-4258-840c-a4267deaa032)


## Benchmark Results
```bash
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 1000 --random-output-len 1000 --random-range-ratio 1 --num-prompts 128 --max-concurrency 16
```

Before:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  186.06    
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127307    
Request throughput (req/s):              0.69      
Input token throughput (tok/s):          687.97    
Output token throughput (tok/s):         687.97    
Total token throughput (tok/s):          1375.94   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   23246.34  
Median E2E Latency (ms):                 22506.67  
---------------Time to First Token----------------
Mean TTFT (ms):                          1408.12   
Median TTFT (ms):                        924.91    
P99 TTFT (ms):                           6815.20   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           21.99     
Median ITL (ms):                         21.58     
P95 ITL (ms):                            22.58     
P99 ITL (ms):                            23.35     
Max ITL (ms):                            5320.55   
==================================================
```

After:
```bash
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  176.54    
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127284    
Request throughput (req/s):              0.73      
Input token throughput (tok/s):          725.03    
Output token throughput (tok/s):         725.03    
Total token throughput (tok/s):          1450.06   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   22058.60  
Median E2E Latency (ms):                 21352.31  
---------------Time to First Token----------------
Mean TTFT (ms):                          1602.52   
Median TTFT (ms):                        897.12    
P99 TTFT (ms):                           5025.32   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           20.59     
Median ITL (ms):                         20.41     
P95 ITL (ms):                            21.39     
P99 ITL (ms):                            21.80     
Max ITL (ms):                            3018.27   
==================================================
```