### PR TITLE
[bug] add a length check in sample_sharegpt_requests

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -785,8 +785,11 @@ def sample_sharegpt_requests(
     prompt_suffix: Optional[str] = "",
     apply_chat_template=False,
 ) -> List[DatasetRow]:
-    if fixed_output_len is not None and fixed_output_len < 4:
-        raise ValueError("output_len too small")
+    if fixed_output_len is not None:
+        if fixed_output_len < 4:
+            raise ValueError("output_len too small")
+        if context_len is not None and context_len <= fixed_output_len:
+            raise ValueError("context_len should be greater than output_len")
 
     # Download sharegpt if necessary
     if not is_file_valid_json(dataset_path) and dataset_path == "":


### PR DESCRIPTION
## Motivation

When running

```
python3 -m sglang.bench_serving --backend sglang --dataset-name sharegpt --num-prompts 1 --sharegpt-output-len xxx --sharegpt-context-len yyy
```

if `xxx >= yyy`, the sampled dataset becomes empty, and the following strange error occurs at runtime:

```
Token indices sequence length is longer than the specified maximum sequence length for this model ...
```

Therefore, an additional check should be added to prevent these parameters from being set incorrectly.


## Modifications

Add a length check in function `sample_sharegpt_requests`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
