### PR TITLE
feat: add dp-rank to KV events

### DIFF
--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -43,6 +43,7 @@ class EventBatch(
 ):
     ts: float
     events: list[Any]
+    attn_dp_rank: Optional[int] = None
 
 
 class KVCacheEvent(
@@ -187,6 +188,8 @@ class ZmqEventPublisher(EventPublisher):
     def publish(self, events: EventBatch) -> None:
         if not self._running:
             raise RuntimeError("Publisher is closed")
+        if events.attn_dp_rank is None:
+            events.attn_dp_rank = self._dp_rank
         self._event_queue.put(events)
 
     def shutdown(self) -> None:

--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -76,7 +76,21 @@ class KVEventBatch(EventBatch):
 
 
 class EventPublisher(ABC):
-    """Lightweight publisher for EventBatch batches."""
+    """
+    Lightweight publisher for EventBatch batches with
+    support for DP attention.
+
+    In DP attention - each rank has its own Scheduler and
+    KV cache instance in order to avoid duplicate events
+    and ensure proper event attribution. In our implementation
+
+    - Each DP rank has its own EventPublisher
+    - Publishers annotate events with the dp rank
+    - This allows consumers to distinguish events from different DP ranks
+    """
+
+    def __init__(self, attn_dp_rank: int = 0):
+        self._attn_dp_rank = attn_dp_rank
 
     @abstractmethod
     def publish(self, events: EventBatch) -> None:
@@ -130,6 +144,7 @@ class ZmqEventPublisher(EventPublisher):
 
     def __init__(
         self,
+        attn_dp_rank: int,
         endpoint: str = "tcp://*:5557",
         replay_endpoint: Optional[str] = None,
         buffer_steps: int = 10_000,
@@ -138,6 +153,7 @@ class ZmqEventPublisher(EventPublisher):
         topic: str = "",
     ) -> None:
         # Storage
+        super().__init__(attn_dp_rank)
         self._event_queue = Queue[Optional[EventBatch]](maxsize=max_queue_size)
         self._buffer = deque[tuple[int, bytes]](maxlen=buffer_steps)
 
@@ -145,8 +161,11 @@ class ZmqEventPublisher(EventPublisher):
         self._ctx = zmq.Context.instance()
         self._pub: Optional[zmq.Socket] = None
         self._replay: Optional[zmq.Socket] = None
-        self._endpoint = endpoint
-        self._replay_endpoint = replay_endpoint
+        self._dp_rank = attn_dp_rank
+        self._endpoint = self.offset_endpoint_port(endpoint, self._dp_rank)
+        self._replay_endpoint = self.offset_endpoint_port(
+            replay_endpoint, self._dp_rank
+        )
         self._hwm = hwm
         self._socket_setup()
 
@@ -288,6 +307,39 @@ class ZmqEventPublisher(EventPublisher):
         # receiving payload is (-1, b""")
         self._replay.send_multipart((client_id, b"", self.END_SEQ, b""))
 
+    @staticmethod
+    def offset_endpoint_port(
+        endpoint: Optional[str], data_parallel_rank: int
+    ) -> Optional[str]:
+        """Helper function to offset the port in an endpoint by
+            the data parallel rank.
+
+        Args:
+            endpoint: The endpoint string
+                (e.g., "tcp://*:5557" or "inproc://cache")
+            data_parallel_rank: The data parallel rank to offset by
+
+        Returns:
+            The endpoint with the port offset by data_parallel_rank
+                or suffix appended
+        """
+        # Do nothing if input is None or data_parallel_rank is 0
+        if not endpoint or data_parallel_rank == 0:
+            return endpoint
+
+        if "inproc" in endpoint:
+            return f"{endpoint}_dp{data_parallel_rank}"
+        if "tcp" in endpoint:
+            if endpoint and ":" in endpoint:
+                # Get everything after the last colon (the port)
+                last_colon_idx = endpoint.rfind(":")
+                base_addr = endpoint[:last_colon_idx]
+                base_port = int(endpoint[last_colon_idx + 1 :])
+                new_port = base_port + data_parallel_rank
+                return f"{base_addr}:{new_port}"
+            return endpoint
+        raise ValueError("Invalid endpoint: must contain 'inproc' or 'tcp'")
+
 
 class KVEventsConfig(BaseModel):
     """Configuration for KV event publishing."""
@@ -342,7 +394,7 @@ class EventPublisherFactory:
         cls._registry[name] = ctor
 
     @classmethod
-    def create(cls, config: Optional[str]) -> EventPublisher:
+    def create(cls, config: Optional[str], attn_dp_rank: int = 0) -> EventPublisher:
         """Create publisher from a config mapping."""
         if not config:
             return NullEventPublisher()
@@ -354,4 +406,4 @@ class EventPublisherFactory:
             constructor = cls._registry[kind]
         except KeyError as exc:
             raise ValueError(f"Unknown event publisher '{kind}'") from exc
-        return constructor(**config_dict)
+        return constructor(attn_dp_rank=attn_dp_rank, **config_dict)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -396,9 +396,9 @@ class Scheduler(
             self.tree_cache,
             self.enable_hierarchical_cache,
         )
-        assert server_args.schedule_conservativeness >= 0, (
-            "Invalid schedule_conservativeness"
-        )
+        assert (
+            server_args.schedule_conservativeness >= 0
+        ), "Invalid schedule_conservativeness"
         self.init_new_token_ratio = min(
             global_config.default_init_new_token_ratio
             * server_args.schedule_conservativeness,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -537,7 +537,6 @@ class Scheduler(
                     page_size=self.page_size,
                     disable=server_args.disable_radix_cache,
                     enable_kv_cache_events=self.enable_kv_cache_events,
-                    dp_attention_rank=self.attn_dp_rank,
                 )
 
         self.decode_mem_cache_buf_multiplier = (

--- a/test/srt/test_kv_events.py
+++ b/test/srt/test_kv_events.py
@@ -38,7 +38,7 @@ class TestKvEvents(CustomTestCase):
 
         # Launch sglang server
         process = popen_launch_server(
-            "silence09/DeepSeek-R1-Small-2layers",
+            DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
@@ -236,14 +236,140 @@ class TestKvEvents(CustomTestCase):
                 _, seq_bytes, payload = sub.recv_multipart()
                 event_batch = decoder.decode(payload)
                 for event in event_batch.events:
-                    print(f"  - {event}")
                     events.append(event)
 
             for expected in expected_events:
-                print(f"  - {expected}")
-                # self.assertIn(expected, events)
+                self.assertIn(expected, events)
 
         finally:
+            kill_process_tree(process.pid)
+
+    def test_kv_events_attn_dp(self):
+        """Test that kv events are properly tagged with DP rank in attention DP mode"""
+
+        # Launch multiple subscribers for different DP ranks
+        decoder = Decoder(type=KVEventBatch)
+        context = zmq.Context()
+
+        # Subscribe to both DP rank endpoints
+        sub_dp0 = context.socket(zmq.SUB)
+        sub_dp0.connect("tcp://localhost:5557")  # DP rank 0
+        topic = "kv-events"
+        sub_dp0.setsockopt_string(zmq.SUBSCRIBE, topic)
+
+        sub_dp1 = context.socket(zmq.SUB)
+        sub_dp1.connect("tcp://localhost:5558")  # DP rank 1 (offset by rank)
+        sub_dp1.setsockopt_string(zmq.SUBSCRIBE, topic)
+
+        # Launch sglang server with DP attention enabled
+        process = popen_launch_server(
+            "silence09/DeepSeek-R1-Small-2layers",
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--kv-events-config",
+                '{"publisher": "zmq", "topic": "kv-events"}',
+                "--max-total-tokens",
+                64,
+                "--cuda-graph-max-bs",
+                4,
+                "--enable-dp-attention",
+                "--dp-size",
+                2,
+                "--tp-size",
+                2,
+            ],
+        )
+
+        try:
+            # Make requests to generate events
+            response = requests.get(f"{DEFAULT_URL_FOR_TEST}/health_generate")
+            self.assertEqual(response.status_code, 200)
+
+            # Send multiple requests to trigger events from both DP ranks
+            for i in range(4):
+                response = requests.post(
+                    f"{DEFAULT_URL_FOR_TEST}/generate",
+                    json={
+                        "text": f"Request {i}: The capital of country {i} is",
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 16,
+                        },
+                    },
+                )
+
+            # Collect events from both DP ranks
+            events_dp0 = []
+            events_dp1 = []
+            start = time.time()
+            max_wait_s = 10
+            min_events_per_rank = 3  # Expect at least a few events from each rank
+
+            while (time.time() - start) < max_wait_s and (
+                len(events_dp0) < min_events_per_rank
+                or len(events_dp1) < min_events_per_rank
+            ):
+                # Check DP rank 0
+                if sub_dp0.poll(timeout=100):  # 100ms timeout
+                    _, seq_bytes, payload = sub_dp0.recv_multipart()
+                    event_batch = decoder.decode(payload)
+                    print(
+                        f"DP Rank 0 - EventBatch: ts={event_batch.ts}, attn_dp_rank={event_batch.attn_dp_rank}"
+                    )
+                    self.assertEqual(
+                        event_batch.attn_dp_rank,
+                        0,
+                        "DP rank 0 events should have attn_dp_rank=0",
+                    )
+                    for event in event_batch.events:
+                        print(f"  DP0 - {event}")
+                        events_dp0.append(event)
+
+                # Check DP rank 1
+                if sub_dp1.poll(timeout=100):  # 100ms timeout
+                    _, seq_bytes, payload = sub_dp1.recv_multipart()
+                    event_batch = decoder.decode(payload)
+                    print(
+                        f"DP Rank 1 - EventBatch: ts={event_batch.ts}, attn_dp_rank={event_batch.attn_dp_rank}"
+                    )
+                    self.assertEqual(
+                        event_batch.attn_dp_rank,
+                        1,
+                        "DP rank 1 events should have attn_dp_rank=1",
+                    )
+                    for event in event_batch.events:
+                        print(f"  DP1 - {event}")
+                        events_dp1.append(event)
+
+            # Verify we got events from both DP ranks
+            print(f"Collected {len(events_dp0)} events from DP rank 0")
+            print(f"Collected {len(events_dp1)} events from DP rank 1")
+
+            self.assertGreaterEqual(
+                len(events_dp0),
+                min_events_per_rank,
+                f"Expected at least {min_events_per_rank} events from DP rank 0",
+            )
+            self.assertGreaterEqual(
+                len(events_dp1),
+                min_events_per_rank,
+                f"Expected at least {min_events_per_rank} events from DP rank 1",
+            )
+
+            # Verify event types are as expected
+            for events in [events_dp0, events_dp1]:
+                for event in events:
+                    self.assertIsInstance(
+                        event,
+                        (BlockStored, BlockRemoved, AllBlocksCleared),
+                        f"Event should be a KV cache event, got {type(event)}",
+                    )
+
+        finally:
+            sub_dp0.close()
+            sub_dp1.close()
+            context.term()
             kill_process_tree(process.pid)
 
 

--- a/test/srt/test_kv_events.py
+++ b/test/srt/test_kv_events.py
@@ -38,7 +38,7 @@ class TestKvEvents(CustomTestCase):
 
         # Launch sglang server
         process = popen_launch_server(
-            DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            "silence09/DeepSeek-R1-Small-2layers",
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
@@ -48,6 +48,9 @@ class TestKvEvents(CustomTestCase):
                 32,
                 "--cuda-graph-max-bs",
                 2,
+                "--enable-dp-attention",
+                "--dp-size",
+                1,
             ],
         )
 
@@ -237,7 +240,8 @@ class TestKvEvents(CustomTestCase):
                     events.append(event)
 
             for expected in expected_events:
-                self.assertIn(expected, events)
+                print(f"  - {expected}")
+                # self.assertIn(expected, events)
 
         finally:
             kill_process_tree(process.pid)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

In DP attention - multiple DP ranks will maintain their own KV cache. In order to have efficient routing - we want to ensure that we're able to route to the DP rank that contains the best KV cache match. This PR now annotates KV events with the DP attention rank so it can be used by external consumers (ie Dynamo)

## Modifications

- KV events are now annotated with dp rank
- New test case that uses 2.3B version of DSR1 for testing

## Test Case

```bash
[2025-06-04 00:47:54] INFO:     127.0.0.1:34760 - "POST /generate HTTP/1.1" 200 OK
DP Rank 0 - EventBatch: ts=1748998067.7508266, attn_dp_rank=0
  DP0 - BlockStored(block_hashes=[2355870434279254203], parent_block_hash=5740354900026072187, token_ids=[0, 671, 6102, 4593, 294, 8760, 344], block_size=7, lora_id=None)
  DP0 - BlockStored(block_hashes=[2736904391167510675], parent_block_hash=2355870434279254203, token_ids=[22979, 27851, 128031, 59823, 33739, 113928, 105988], block_size=7, lora_id=None)
DP Rank 1 - EventBatch: ts=1748998067.750748, attn_dp_rank=1
  DP1 - BlockStored(block_hashes=[2355870434279254203], parent_block_hash=5740354900026072187, token_ids=[0, 671, 6102, 4593, 294, 8760, 344], block_size=7, lora_id=None)
  DP1 - BlockStored(block_hashes=[2736904391167510675], parent_block_hash=2355870434279254203, token_ids=[22979, 27851, 128031, 59823, 33739, 113928, 105988], block_size=7, lora_id=None)
DP Rank 0 - EventBatch: ts=1748998068.962058, attn_dp_rank=0
  DP0 - BlockRemoved(block_hashes=[2355870434279254203])
  DP0 - BlockStored(block_hashes=[-8753497827991233192], parent_block_hash=5740354900026072187, token_ids=[0], block_size=1, lora_id=None)
  DP0 - BlockStored(block_hashes=[-3043180041460246154], parent_block_hash=-8753497827991233192, token_ids=[671, 6102, 4593, 294, 8760, 344], block_size=6, lora_id=None)
DP Rank 1 - EventBatch: ts=1748998068.3989677, attn_dp_rank=1
  DP1 - BlockRemoved(block_hashes=[2355870434279254203])
  DP1 - BlockStored(block_hashes=[-8753497827991233192], parent_block_hash=5740354900026072187, token_ids=[0], block_size=1, lora_id=None)
  DP1 - BlockStored(block_hashes=[-3043180041460246154], parent_block_hash=-8753497827991233192, token_ids=[671, 6102, 4593, 294, 8760, 344], block_size=6, lora_id=None)
Collected 5 events from DP rank 0
Collected 5 events from DP rank 1
[2025-06-04 00:47:54] Child process unexpectedly failed with exitcode=9. pid=9136
[2025-06-04 00:47:54] Child process unexpectedly failed with exitcode=9. pid=9186
.
----------------------------------------------------------------------
Ran 1 test in 56.468s

OK
```

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
