### PR TITLE
chore: tune mem fraction static for vlm

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -485,9 +485,10 @@ class ModelRunner:
                     if baseline_complexity_score > 0
                     else 1.0
                 )
+                print(f"{complexity_ratio=}")
 
-                # every time the complexity grows 100%, adjust final factor for 2%
-                sensitivity_scale = 0.02
+                # every time the complexity grows 100%, adjust final factor for 3%
+                sensitivity_scale = 0.03
                 dynamic_adjustment_factor = 1.0 - sensitivity_scale * (
                     complexity_ratio - 1.0
                 )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -486,12 +486,11 @@ class ModelRunner:
                     else 1.0
                 )
 
-                # everytime the complexity grows 100%, adjust final factor for 3%
+                # every time the complexity grows 100%, adjust final factor for 2%
                 sensitivity_scale = 0.02
                 dynamic_adjustment_factor = 1.0 - sensitivity_scale * (
                     complexity_ratio - 1.0
                 )
-                print(f"{dynamic_adjustment_factor=}")
                 dynamic_adjustment_factor = max(
                     0.8, min(1.05, dynamic_adjustment_factor)
                 )
@@ -502,9 +501,6 @@ class ModelRunner:
                 self.mem_fraction_static = (
                     original_server_arg_mem_fraction * final_overall_factor
                 )
-
-                print(f"{vit_hidden_size=}")
-                print(f"{vit_num_layers=}")
 
                 logger.info(
                     f"Multimodal model: Dynamically adjusted --mem-fraction-static "

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -458,63 +458,6 @@ class ModelRunner:
                     f"{self.model_config.hf_config.model_type}"
                 )
 
-            # roughly reduce the mem_fraction_static base on params of Vit
-            original_server_arg_mem_fraction = self.mem_fraction_static
-            # a base mem_fraction_static factor for regular Vit
-            base_mem_fraction_reduction_ratio = 0.95
-            if (
-                hasattr(self.model_config.hf_config, "vision_config")
-                and self.model_config.hf_config.vision_config is not None
-            ):
-                vision_config = self.model_config.hf_config.vision_config
-
-                vit_num_layers = getattr(vision_config, "num_hidden_layers", 24)
-                vit_hidden_size = getattr(vision_config, "hidden_size", 1024)
-
-                # baseline ViT params (ViT-L/14)
-                baseline_vit_layers = 24
-                baseline_vit_hidden_size = 1024
-
-                # weight params count
-                current_complexity_score = vit_num_layers * (vit_hidden_size**2)
-                baseline_complexity_score = baseline_vit_layers * (
-                    baseline_vit_hidden_size**2
-                )
-                complexity_ratio = (
-                    current_complexity_score / baseline_complexity_score
-                    if baseline_complexity_score > 0
-                    else 1.0
-                )
-
-                # every time the complexity grows 100%, adjust final factor for 10%
-                sensitivity_scale = 0.1
-                dynamic_adjustment_factor = 1.0 - sensitivity_scale * (
-                    complexity_ratio - 1.0
-                )
-                dynamic_adjustment_factor = max(
-                    0.8, min(1.05, dynamic_adjustment_factor)
-                )
-
-                final_overall_factor = (
-                    base_mem_fraction_reduction_ratio * dynamic_adjustment_factor
-                )
-                self.mem_fraction_static = (
-                    original_server_arg_mem_fraction * final_overall_factor
-                )
-
-                logger.info(
-                    f"Multimodal model: Dynamically adjusted --mem-fraction-static "
-                    f"from: {original_server_arg_mem_fraction:.3f} to: {self.mem_fraction_static:.3f}."
-                )
-            else:
-                self.mem_fraction_static = (
-                    original_server_arg_mem_fraction * base_mem_fraction_reduction_ratio
-                )
-                logger.info(
-                    f"Multimodal model: No detailed vision_config, fixed adjusted --mem-fraction-static "
-                    f"from: {original_server_arg_mem_fraction:.3f} to: {self.mem_fraction_static:.3f}."
-                )
-
         if not self.use_mla_backend:
             server_args.disable_chunked_prefix_cache = True
         elif self.page_size > 1:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -485,10 +485,9 @@ class ModelRunner:
                     if baseline_complexity_score > 0
                     else 1.0
                 )
-                print(f"{complexity_ratio=}")
 
-                # every time the complexity grows 100%, adjust final factor for 3%
-                sensitivity_scale = 0.03
+                # every time the complexity grows 100%, adjust final factor for 10%
+                sensitivity_scale = 0.1
                 dynamic_adjustment_factor = 1.0 - sensitivity_scale * (
                     complexity_ratio - 1.0
                 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -342,9 +342,9 @@ class ServerArgs:
                 baseline_vit_hidden_size = 1024
 
                 # weight params count
-                current_complexity_score = vit_num_layers * (vit_hidden_size ** 2)
+                current_complexity_score = vit_num_layers * (vit_hidden_size**2)
                 baseline_complexity_score = baseline_vit_layers * (
-                    baseline_vit_hidden_size ** 2
+                    baseline_vit_hidden_size**2
                 )
                 complexity_ratio = (
                     current_complexity_score / baseline_complexity_score
@@ -652,8 +652,8 @@ class ServerArgs:
             default=ServerArgs.tokenizer_mode,
             choices=["auto", "slow"],
             help="Tokenizer mode. 'auto' will use the fast "
-                 "tokenizer if available, and 'slow' will "
-                 "always use the slow tokenizer.",
+            "tokenizer if available, and 'slow' will "
+            "always use the slow tokenizer.",
         )
         parser.add_argument(
             "--skip-tokenizer-init",
@@ -682,27 +682,27 @@ class ServerArgs:
                 "remote",
             ],
             help="The format of the model weights to load. "
-                 '"auto" will try to load the weights in the safetensors format '
-                 "and fall back to the pytorch bin format if safetensors format "
-                 "is not available. "
-                 '"pt" will load the weights in the pytorch bin format. '
-                 '"safetensors" will load the weights in the safetensors format. '
-                 '"npcache" will load the weights in pytorch format and store '
-                 "a numpy cache to speed up the loading. "
-                 '"dummy" will initialize the weights with random values, '
-                 "which is mainly for profiling."
-                 '"gguf" will load the weights in the gguf format. '
-                 '"bitsandbytes" will load the weights using bitsandbytes '
-                 "quantization."
-                 '"layered" loads weights layer by layer so that one can quantize a '
-                 "layer before loading another to make the peak memory envelope "
-                 "smaller.",
+            '"auto" will try to load the weights in the safetensors format '
+            "and fall back to the pytorch bin format if safetensors format "
+            "is not available. "
+            '"pt" will load the weights in the pytorch bin format. '
+            '"safetensors" will load the weights in the safetensors format. '
+            '"npcache" will load the weights in pytorch format and store '
+            "a numpy cache to speed up the loading. "
+            '"dummy" will initialize the weights with random values, '
+            "which is mainly for profiling."
+            '"gguf" will load the weights in the gguf format. '
+            '"bitsandbytes" will load the weights using bitsandbytes '
+            "quantization."
+            '"layered" loads weights layer by layer so that one can quantize a '
+            "layer before loading another to make the peak memory envelope "
+            "smaller.",
         )
         parser.add_argument(
             "--model-loader-extra-config",
             type=str,
             help="Extra config for model loader. "
-                 "This will be passed to the model loader corresponding to the chosen load_format.",
+            "This will be passed to the model loader corresponding to the chosen load_format.",
             default=ServerArgs.model_loader_extra_config,
         )
         parser.add_argument(
@@ -716,13 +716,13 @@ class ServerArgs:
             default=ServerArgs.dtype,
             choices=["auto", "half", "float16", "bfloat16", "float", "float32"],
             help="Data type for model weights and activations.\n\n"
-                 '* "auto" will use FP16 precision for FP32 and FP16 models, and '
-                 "BF16 precision for BF16 models.\n"
-                 '* "half" for FP16. Recommended for AWQ quantization.\n'
-                 '* "float16" is the same as "half".\n'
-                 '* "bfloat16" for a balance between precision and range.\n'
-                 '* "float" is shorthand for FP32 precision.\n'
-                 '* "float32" for FP32 precision.',
+            '* "auto" will use FP16 precision for FP32 and FP16 models, and '
+            "BF16 precision for BF16 models.\n"
+            '* "half" for FP16. Recommended for AWQ quantization.\n'
+            '* "float16" is the same as "half".\n'
+            '* "bfloat16" for a balance between precision and range.\n'
+            '* "float" is shorthand for FP32 precision.\n'
+            '* "float32" for FP32 precision.',
         )
         parser.add_argument(
             "--kv-cache-dtype",
@@ -758,9 +758,9 @@ class ServerArgs:
             type=nullable_str,
             default=None,
             help="Path to the JSON file containing the KV cache "
-                 "scaling factors. This should generally be supplied, when "
-                 "KV cache dtype is FP8. Otherwise, KV cache scaling factors "
-                 "default to 1.0, which may cause accuracy issues. ",
+            "scaling factors. This should generally be supplied, when "
+            "KV cache dtype is FP8. Otherwise, KV cache scaling factors "
+            "default to 1.0, which may cause accuracy issues. ",
         )
         parser.add_argument(
             "--context-length",
@@ -808,20 +808,20 @@ class ServerArgs:
             type=str,
             default=None,
             help="The specific model version to use. It can be a branch "
-                 "name, a tag name, or a commit id. If unspecified, will use "
-                 "the default version.",
+            "name, a tag name, or a commit id. If unspecified, will use "
+            "the default version.",
         )
         parser.add_argument(
             "--impl",
             type=str,
             default=ServerArgs.impl,
             help="Which implementation of the model to use.\n\n"
-                 '* "auto" will try to use the SGLang implementation if it exists '
-                 "and fall back to the Transformers implementation if no SGLang "
-                 "implementation is available.\n"
-                 '* "sglang" will use the SGLang model implementation.\n'
-                 '* "transformers" will use the Transformers model '
-                 "implementation.\n",
+            '* "auto" will try to use the SGLang implementation if it exists '
+            "and fall back to the Transformers implementation if no SGLang "
+            "implementation is available.\n"
+            '* "sglang" will use the SGLang model implementation.\n'
+            '* "transformers" will use the Transformers model '
+            "implementation.\n",
         )
 
         # Memory and scheduling
@@ -842,7 +842,7 @@ class ServerArgs:
             type=int,
             default=ServerArgs.max_total_tokens,
             help="The maximum number of tokens in the memory pool. If not specified, it will be automatically calculated based on the memory usage fraction. "
-                 "This option is typically used for development and debugging purposes.",
+            "This option is typically used for development and debugging purposes.",
         )
         parser.add_argument(
             "--chunked-prefill-size",
@@ -1513,7 +1513,7 @@ class ServerArgs:
             "--triton-attention-reduce-in-fp32",
             action="store_true",
             help="Cast the intermediate attention results to fp32 to avoid possible crashes related to fp16."
-                 "This only affects Triton attention kernels.",
+            "This only affects Triton attention kernels.",
         )
         parser.add_argument(
             "--triton-attention-num-kv-splits",
@@ -1526,8 +1526,8 @@ class ServerArgs:
             type=int,
             default=ServerArgs.num_continuous_decode_steps,
             help="Run multiple continuous decoding steps to reduce scheduling overhead. "
-                 "This can potentially increase throughput but may also increase time-to-first-token latency. "
-                 "The default value is 1, meaning only run one decoding step at a time.",
+            "This can potentially increase throughput but may also increase time-to-first-token latency. "
+            "The default value is 1, meaning only run one decoding step at a time.",
         )
         parser.add_argument(
             "--delete-ckpt-after-loading",
@@ -1603,7 +1603,7 @@ class ServerArgs:
             type=str,
             required=False,
             help="Specify custom warmup functions (csv) to run before server starts eg. --warmups=warmup_name1,warmup_name2 "
-                 "will run the functions `warmup_name1` and `warmup_name2` specified in warmup.py before the server starts listening for requests",
+            "will run the functions `warmup_name1` and `warmup_name2` specified in warmup.py before the server starts listening for requests",
         )
 
         # Debug tensor dumps
@@ -1675,8 +1675,8 @@ class ServerArgs:
             type=str,
             default=ServerArgs.disaggregation_ib_device,
             help="The InfiniBand devices for disaggregation transfer, accepts single device (e.g., --disaggregation-ib-device mlx5_0) "
-                 "or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). "
-                 "Default is None, which triggers automatic device detection when mooncake backend is enabled.",
+            "or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). "
+            "Default is None, which triggers automatic device detection when mooncake backend is enabled.",
         )
         parser.add_argument(
             "--num-reserved-decode-tokens",
@@ -1720,8 +1720,8 @@ class ServerArgs:
 
     def check_server_args(self):
         assert (
-                   self.tp_size * self.pp_size
-               ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
+            self.tp_size * self.pp_size
+        ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
 
         # FIXME pp constraints
         if self.pp_size > 1:

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -30,7 +30,7 @@ class TestQwen2VLServer(TestOpenAIVisionServer):
             api_key=cls.api_key,
             other_args=[
                 "--mem-fraction-static",
-                "0.4",
+                "0.35",
             ],
         )
         cls.base_url += "/v1"
@@ -49,7 +49,7 @@ class TestQwen2_5_VLServer(TestOpenAIVisionServer):
             api_key=cls.api_key,
             other_args=[
                 "--mem-fraction-static",
-                "0.4",
+                "0.35",
             ],
         )
         cls.base_url += "/v1"
@@ -69,7 +69,7 @@ class TestVLMContextLengthIssue(CustomTestCase):
             other_args=[
                 "--context-length",
                 "300",
-                "--mem-fraction-static=0.80",
+                "--mem-fraction-static=0.75",
             ],
         )
         cls.base_url += "/v1"
@@ -141,7 +141,7 @@ class TestMinicpmvServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.4",
+                "0.35",
             ],
         )
         cls.base_url += "/v1"
@@ -175,7 +175,7 @@ class TestMinicpmoServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.7",
+                "0.65",
             ],
         )
         cls.base_url += "/v1"

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -28,10 +28,6 @@ class TestQwen2VLServer(TestOpenAIVisionServer):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
-            other_args=[
-                "--mem-fraction-static",
-                "0.4",
-            ],
         )
         cls.base_url += "/v1"
 
@@ -47,10 +43,6 @@ class TestQwen2_5_VLServer(TestOpenAIVisionServer):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
-            other_args=[
-                "--mem-fraction-static",
-                "0.4",
-            ],
         )
         cls.base_url += "/v1"
 
@@ -140,8 +132,6 @@ class TestMinicpmvServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.4",
             ],
         )
         cls.base_url += "/v1"
@@ -174,8 +164,6 @@ class TestMinicpmoServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.7",
             ],
         )
         cls.base_url += "/v1"

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -28,6 +28,10 @@ class TestQwen2VLServer(TestOpenAIVisionServer):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
+            other_args=[
+                "--mem-fraction-static",
+                "0.5",
+            ],
         )
         cls.base_url += "/v1"
 
@@ -132,6 +136,8 @@ class TestMinicpmvServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.7",
             ],
         )
         cls.base_url += "/v1"

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -47,6 +47,10 @@ class TestQwen2_5_VLServer(TestOpenAIVisionServer):
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
+            other_args=[
+                "--mem-fraction-static",
+                "0.5",
+            ],
         )
         cls.base_url += "/v1"
 

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -164,6 +164,8 @@ class TestMinicpmoServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.7",
             ],
         )
         cls.base_url += "/v1"

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -30,7 +30,7 @@ class TestQwen2VLServer(TestOpenAIVisionServer):
             api_key=cls.api_key,
             other_args=[
                 "--mem-fraction-static",
-                "0.5",
+                "0.4",
             ],
         )
         cls.base_url += "/v1"
@@ -49,7 +49,7 @@ class TestQwen2_5_VLServer(TestOpenAIVisionServer):
             api_key=cls.api_key,
             other_args=[
                 "--mem-fraction-static",
-                "0.5",
+                "0.4",
             ],
         )
         cls.base_url += "/v1"
@@ -141,7 +141,7 @@ class TestMinicpmvServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.7",
+                "0.4",
             ],
         )
         cls.base_url += "/v1"

--- a/test/srt/test_vision_openai_server_b.py
+++ b/test/srt/test_vision_openai_server_b.py
@@ -22,7 +22,7 @@ class TestPixtralServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.73",
+                "0.70",
             ],
         )
         cls.base_url += "/v1"
@@ -44,7 +44,7 @@ class TestMistral3_1Server(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.8",
+                "0.75",
             ],
         )
         cls.base_url += "/v1"
@@ -88,7 +88,7 @@ class TestJanusProServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.4",
+                "0.35",
             ],
         )
         cls.base_url += "/v1"
@@ -140,7 +140,7 @@ class TestGemma3itServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.75",
+                "0.70",
                 "--enable-multimodal",
             ],
         )
@@ -197,7 +197,7 @@ class TestPhi4MMServer(TestOpenAIVisionServer):
             other_args=[
                 "--trust-remote-code",
                 "--mem-fraction-static",
-                "0.75",
+                "0.70",
                 "--disable-radix-cache",
                 "--max-loras-per-batch",
                 "1",

--- a/test/srt/test_vision_openai_server_b.py
+++ b/test/srt/test_vision_openai_server_b.py
@@ -21,6 +21,8 @@ class TestPixtralServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.73",
             ],
         )
         cls.base_url += "/v1"
@@ -41,6 +43,8 @@ class TestMistral3_1Server(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.8",
             ],
         )
         cls.base_url += "/v1"
@@ -83,6 +87,8 @@ class TestJanusProServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.4",
             ],
         )
         cls.base_url += "/v1"
@@ -109,6 +115,8 @@ class TestJanusProServer(TestOpenAIVisionServer):
 #             other_args=[
 #                 "--chat-template",
 #                 "llama-4",
+#                 "--mem-fraction-static",
+#                 "0.8",
 #                 "--tp-size=8",
 #                 "--context-length=8192",
 #             ],
@@ -188,6 +196,8 @@ class TestPhi4MMServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.75",
                 "--disable-radix-cache",
                 "--max-loras-per-batch",
                 "1",

--- a/test/srt/test_vision_openai_server_b.py
+++ b/test/srt/test_vision_openai_server_b.py
@@ -131,6 +131,8 @@ class TestGemma3itServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
+                "--mem-fraction-static",
+                "0.75",
                 "--enable-multimodal",
             ],
         )

--- a/test/srt/test_vision_openai_server_b.py
+++ b/test/srt/test_vision_openai_server_b.py
@@ -21,8 +21,6 @@ class TestPixtralServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.73",
             ],
         )
         cls.base_url += "/v1"
@@ -43,8 +41,6 @@ class TestMistral3_1Server(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.8",
             ],
         )
         cls.base_url += "/v1"
@@ -87,8 +83,6 @@ class TestJanusProServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.4",
             ],
         )
         cls.base_url += "/v1"
@@ -115,8 +109,6 @@ class TestJanusProServer(TestOpenAIVisionServer):
 #             other_args=[
 #                 "--chat-template",
 #                 "llama-4",
-#                 "--mem-fraction-static",
-#                 "0.8",
 #                 "--tp-size=8",
 #                 "--context-length=8192",
 #             ],
@@ -139,8 +131,6 @@ class TestGemma3itServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.70",
                 "--enable-multimodal",
             ],
         )
@@ -196,8 +186,6 @@ class TestPhi4MMServer(TestOpenAIVisionServer):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--mem-fraction-static",
-                "0.75",
                 "--disable-radix-cache",
                 "--max-loras-per-batch",
                 "1",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Currently, the `--mem-fraction-static` from server_args will be multiplied with a fixed factor F(0.9) for multimodal models.

`mem_fraction_static = original_mem_fraction_static * F`

For vlms (or multimodal models), where additional modules (e.g. Vit) are involved, this factor F should be dynamically tuned to further utilize memory for kv-cache, while not causing OOM
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Introduce a naive mechanism for calculating the mentioned factor, based on:
1. mem usage of Vit weights: usually proportional to `hidden_size ** 2`
2. compute complexity of multimodal embeddings: proportional to `seq_len * hidden_size * intermediate_size`
3. mem usage of activations: proportional to `hidden_size`

Hence, our final complexity approximation will be:

$$S_{\text{current}} = L_{\text{ViT,current}} \times (H_{\text{ViT,current}})^2$$

we set ViT-L/14 as baseline Vit，with parameter of：
*   $L_{\text{ViT,baseline}} = 24$ layers
*   $H_{\text{ViT,baseline}} = 1024$


We assume the Vit baseline above requires `--mem-fraction-static` factor of 0.95($F_0$), thus:

$F_{\text{adjusted}} \approx 1 - \left( \frac{S_{\text{current}}}{S_{\text{baseline}}}  - 1 \right) \times C$,

where C is a constant scaling value.

<!-- Describe the changes made in this PR. -->

The real factor of different models:

|                                             | $F$(from original mem-fraction-static) | 
|---------------------------------------------|----------------------------------------|
| Qwen2-VL-7B-Instruct                        | 0.76                                   | 
| Qwen2.5-VL-7B-Instruct                      | 0.76                                   | 
| meta-llama/Llama-3.2-11B-Vision-Instruct    | 0.93                                   | 
| openbmb/MiniCPM-o-2_6                       | 0.94                                   | 
| OpenGVLab/InternVL2_5-2B                    | 0.94                                   | 
| openbmb/MiniCPM-v-2_6                       | 0.94                                   | 
| google/gemma-3-4b-it                        | 0.941                                  | 
| moonshotai/Kimi-VL-A3B-Instruct             | 0.942                                  | 
| microsoft/Phi-4-multimodal-instruct         | 0.95                                   | 
| OpenGVLab/InternVL2_5-2B                    | 0.95                                   | 
| lmms-lab/llava-onevision-qwen2-0.5b-ov      | 0.95                                   | 
| deepseek-ai/deepseek-vl2-small              | 0.95                                   | 
| deepseek-ai/deepseek-vl2-tiny               | 0.95                                   | 
| deepseek-ai/Janus-Pro-7B                    | 0.95                                   | 
| mistral-community/pixtral-12b               | 0.95                                   | 
| unsloth/Mistral-Small-3.1-24B-Instruct-2503 | 0.95                                   | 








## TODO

1. consider dtype
2. consider audio encoder and other multimodal models

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
