### PR TITLE
[kernel optimize] Add benchmark about pre-computed cumsum extend_lens for optimizing write_req_to_token_pool_triton 

### DIFF
--- a/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
+++ b/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
@@ -366,12 +366,12 @@ def get_benchmark():
                 run_optimized, quantiles=quantiles
             )
         elif provider == "triton_cumsum":
-            extend_lens_cumsum = F.pad(
-                torch.cumsum(extend_lens, dim=0), pad=(1, 0), value=0
-            )
 
-            ms, min_ms, max_ms = triton.testing.do_bench(
-                lambda: write_req_to_token_pool_triton_cumsum[(batch_size,)](
+            def run_triton_cumsum():
+                extend_lens_cumsum = F.pad(
+                    torch.cumsum(extend_lens, dim=0), pad=(1, 0), value=0
+                )
+                write_req_to_token_pool_triton_cumsum[(batch_size,)](
                     req_to_token.clone(),
                     req_pool_indices,
                     pre_lens,
@@ -380,7 +380,9 @@ def get_benchmark():
                     out_cache_loc,
                     max_context_len,
                 ),
-                quantiles=quantiles,
+
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                run_triton_cumsum, quantiles=quantiles
             )
 
         return 1000 * ms, 1000 * max_ms, 1000 * min_ms

--- a/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
+++ b/benchmark/kernels/scheduler_batch/benchmark_write_req_to_token_pool_triton.py
@@ -296,7 +296,7 @@ def get_benchmark():
             x_vals=configs,
             line_arg="provider",
             line_vals=["reference", "triton", "triton_optimize", "triton_cumsum"],
-            line_names=["Reference", "Triton", "Triton Optimized", "Triton Cumsum"],
+            line_names=["PyTorch", "Triton", "Triton Optimized", "Triton Cumsum"],
             styles=[("blue", "-"), ("green", "-"), ("red", "-"), ("orange", "-")],
             ylabel="us",
             plot_name="write-req-to-token-pool-performance",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR introduces a new implementation of `write_req_to_token_pool_triton`. In the original version, performance could degrade with large batch sizes due to the repeated computation of `cumsum_start`. In the new implementation, I precompute the cumsum_starts and pass them directly to the kernel, allowing it to access the values without recomputing them. While this adds some overhead from the precomputation step, it helps avoid redundant calculations in the kernel.

As shown in the results below, the performance improvement becomes noticeable when the batch size increases to 128 or 256. This kernel may be an option for workloads with large batch sizes.


## Modifications
1. Added a Triton kernel that uses the precomputed cumulative sum (cumsum) of extended_lens, eliminating the need for repetitive for loop computations in the original kernel.

2. Increased max_batch_size to 256 to evaluate performance under large batch sizes

<!-- Describe the changes made in this PR. -->

## Checklist
A40 Results:
```
Correctness test passed!
write-req-to-token-pool-performance:
    batch_size  extend_len       PyTorch      Triton  Triton Optimized  Triton Cumsum
0          1.0        32.0    159.743994   68.608001         67.616001      68.608001
1          1.0        64.0    158.720002   68.608001         67.584001      68.608001
2          1.0       128.0    158.720002   68.608001         67.584001      68.608001
3          1.0       256.0    157.695994   68.608001         68.608001      68.608001
4          1.0       512.0    158.720002   68.608001         68.608001      68.608001
5          1.0      1024.0    158.720002   68.608001         68.608001      68.608001
6          1.0      2048.0    158.720002   69.632001         68.608001      69.632001
7          1.0      4096.0    158.720002   70.656002         68.608001      71.680002
8          1.0      8192.0    158.720002   73.728003         68.608001      74.752003
9          2.0        32.0    249.855995   68.608001         68.591997      68.608001
10         2.0        64.0    249.855995   68.608001         68.608001      68.608001
11         2.0       128.0    249.855995   68.608001         67.584001      68.608001
12         2.0       256.0    249.855995   68.608001         68.608001      68.608001
13         2.0       512.0    249.855995   68.608001         68.608001      68.608001
14         2.0      1024.0    250.880003   68.608001         68.608001      68.608001
15         2.0      2048.0    250.880003   69.632001         68.608001      69.632001
16         2.0      4096.0    251.392007   71.680002         68.608001      71.680002
17         2.0      8192.0    250.880003   74.752003         68.608001      74.752003
18         4.0        32.0    429.055989   68.608001         68.608001      68.608001
19         4.0        64.0    457.727998   68.608001         68.608001      68.608001
20         4.0       128.0    427.008003   68.608001         68.608001      68.608001
21         4.0       256.0    429.055989   68.608001         68.608001      68.608001
22         4.0       512.0    428.032011   68.608001         68.608001      68.608001
23         4.0      1024.0    429.055989   68.608001         68.608001      68.608001
24         4.0      2048.0    428.032011   69.632001         68.608001      69.632001
25         4.0      4096.0    429.055989   70.656002         68.608001      71.680002
26         4.0      8192.0    430.079997   74.752003         68.608001      74.752003
27         8.0        32.0    786.432028   68.608001         68.608001      68.608001
28         8.0        64.0    785.408020   68.608001         68.608001      68.608001
29         8.0       128.0    784.384012   68.608001         68.608001      68.608001
30         8.0       256.0    783.360004   68.608001         68.608001      68.608001
31         8.0       512.0    784.384012   68.608001         68.608001      68.608001
32         8.0      1024.0    785.408020   68.608001         68.608001      68.608001
33         8.0      2048.0    785.920024   69.632001         68.608001      69.632001
34         8.0      4096.0    784.384012   71.680002         68.608001      71.680002
35         8.0      8192.0    785.408020   74.752003         69.632001      74.752003
36        16.0        32.0   1491.968036   68.608001         68.608001      68.608001
37        16.0        64.0   1495.552063   68.608001         68.608001      68.608001
38        16.0       128.0   1494.016051   68.608001         68.608001      68.608001
39        16.0       256.0   1499.135971   68.608001         68.608001      68.608001
40        16.0       512.0   1497.599959   68.608001         69.632001      68.608001
41        16.0      1024.0   1498.111963   69.632001         68.608001      69.632001
42        16.0      2048.0   1504.256010   69.632001         68.608001      69.632001
43        16.0      4096.0   1497.599959   71.680002         69.632001      71.680002
44        16.0      8192.0   1504.256010   74.752003         69.632001      75.776003
45        32.0        32.0   2921.472073   69.632001         69.632001      68.608001
46        32.0        64.0   2920.448065   69.632001         69.632001      68.608001
47        32.0       128.0   2924.544096   69.632001         69.632001      68.608001
48        32.0       256.0   2922.496080   69.632001         69.632001      68.608001
49        32.0       512.0   2938.879967   69.632001         69.632001      68.608001
50        32.0      1024.0   2924.544096   69.632001         69.632001      69.632001
51        32.0      2048.0   2932.735920   70.656002         69.632001      70.656002
52        32.0      4096.0   2932.735920   72.704002         70.656002      72.704002
53        32.0      8192.0   2937.855959   75.776003         71.680002      75.776003
54        64.0        32.0   5770.751953   70.656002         70.656002      68.608001
55        64.0        64.0   5788.672447   70.656002         70.656002      68.608001
56        64.0       128.0   5780.479908   70.656002         70.656002      68.608001
57        64.0       256.0   5793.791771   70.656002         70.656002      68.608001
58        64.0       512.0   5818.367958   70.656002         70.656002      68.608001
59        64.0      1024.0   5831.679821   71.680002         71.680002      69.632001
60        64.0      2048.0   5839.871883   72.704002         71.680002      70.656002
61        64.0      4096.0   5825.535774   74.752003         72.704002      73.728003
62        64.0      8192.0   5836.800098   78.847997         75.776003      77.823997
63       128.0        32.0  11589.632034   73.728003         73.728003      68.608001
64       128.0        64.0  11572.736740   73.728003         73.728003      68.608001
65       128.0       128.0  11582.976341   73.728003         73.728003      68.608001
66       128.0       256.0  11630.592346   73.728003         73.728003      68.608001
67       128.0       512.0  11756.544113   73.728003         73.728003      69.632001
68       128.0      1024.0  11731.455803   74.752003         74.752003      70.656002
69       128.0      2048.0  11738.624573   75.776003         74.752003      72.704002
70       128.0      4096.0  11726.847649   78.847997         76.800004      76.800004
71       128.0      8192.0  11761.663437   86.015999         82.943998      83.967999
72       256.0        32.0  23445.503235   80.895998         80.895998      68.608001
73       256.0        64.0  23419.902802   80.895998         80.895998      68.608001
74       256.0       128.0  23441.919327   80.895998         80.895998      68.672001
75       256.0       256.0  23376.895905   80.895998         80.895998      69.632001
76       256.0       512.0  24012.287140   80.895998         81.919998      70.656002
77       256.0      1024.0  23968.769073   81.919998         87.040000      71.680002
78       256.0      2048.0  23984.127045   83.967999         82.943998      75.776003
79       256.0      4096.0  23985.153198   89.088000         88.064000      83.967999
80       256.0      8192.0  23936.511993  101.375997        104.447998      99.327996
```

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
