### PR TITLE
[feat] add small vocab table for eagle qwen2

### DIFF
--- a/python/sglang/srt/models/qwen2_eagle.py
+++ b/python/sglang/srt/models/qwen2_eagle.py
@@ -126,7 +126,7 @@ class Qwen2ForCausalLMEagle(Qwen2ForCausalLM):
             self.lm_head = self.model.embed_tokens
         else:
             self.lm_head = ParallelLMHead(
-                config.vocab_size,
+                getattr(config, "hot_vocab_size", config.vocab_size),
                 config.hidden_size,
                 quant_config=quant_config,
                 prefix=add_prefix("lm_head", prefix),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -429,7 +429,7 @@ class ServerArgs:
                     "Mixed chunked prefill is disabled because of using "
                     "eagle speculative decoding."
                 )
-            
+
             model_arch = get_model_arch(self)
 
             # Auto set draft_model_path DeepSeek-V3/R1

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -423,7 +423,13 @@ class ServerArgs:
                 "Overlap scheduler is disabled because of using "
                 "eagle speculative decoding."
             )
-
+            if self.enable_mixed_chunk:
+                self.enable_mixed_chunk = False
+                logger.warning(
+                    "Mixed chunked prefill is disabled because of using "
+                    "eagle speculative decoding."
+                )
+            
             model_arch = get_model_arch(self)
 
             # Auto set draft_model_path DeepSeek-V3/R1


### PR DESCRIPTION
I am following the original PR [https://github.com/sgl-project/sglang/pull/3822/files ](https://github.com/sgl-project/sglang/pull/3822/files), which introduces the small vocab table and modifies the script for llama models in python/sglang/srt/models/llama_eagle.py, similarly adjusting the code for the qwen2 series of models. This should also resolve the issue I recently opened: [https://github.com/sgl-project/sglang/issues/6863 ](https://github.com/sgl-project/sglang/issues/6863).