### PR TITLE
[Bugfix] Wrong lm_head in Pipeline Parallelism

### DIFF
--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -279,7 +279,9 @@ class LlamaModel(nn.Module):
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
-        if self.pp_group.is_first_rank:
+        if self.pp_group.is_first_rank or (
+            self.pp_group.is_last_rank and config.tie_word_embeddings
+        ):
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,


### PR DESCRIPTION
## Motivation

Some models have `tie_word_embeddings` set to `True`, meaning they reuse the `embed_tokens` layer as the `lm_head`. However, in the current implementation of pipeline parallelism — for example, in `llama.py` — this weight sharing is not properly handled.

```
  if self.pp_group.is_first_rank:
      self.embed_tokens = VocabParallelEmbedding(
          config.vocab_size,
          config.hidden_size,
          quant_config=quant_config,
          prefix=add_prefix("embed_tokens", prefix),
      )
  else:
      self.embed_tokens = PPMissingLayer()
```

It directly uses `first_rank` to determine whether to use the real `embed_tokens` layer or a placeholder, which overlooks the case when `tie_word_embeddings=True`. If I launch a server with such a model — for example, `meta-llama/Llama-3.2-1B-Instruct` — using the command:

    python3 -m sglang.launch_server --model meta-llama/Llama-3.2-1B-Instruct --pp-size 2

it triggers the following bug:

```
 1928, in __getattr__
    raise AttributeError(
AttributeError: 'PPMissingLayer' object has no attribute 'quant_method'
```

the wrong `lm_head` is used, resulting in an error.

## Modifications

I simply added an additional condition to handle this case properly:

    pp_group.is_last_rank and config.tie_word_embeddings

If this change works elegantly, I’d like to apply it to other models as well.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
