### PR TITLE
[Feature] Support Flashinfer fmha on Blackwell

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -29,6 +29,7 @@ from sglang.srt.layers.attention.flashinfer_backend import (
     create_flashinfer_kv_indices_triton,
 )
 from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.utils import is_sm100_supported
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
@@ -108,8 +109,11 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         else:
             self.q_indptr_decode = q_indptr_decode_buf
 
+        fmha_backend = "auto"
+        if is_sm100_supported():
+            fmha_backend = "cutlass"
         self.prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
-            self.workspace_buffer, "NHD"
+            self.workspace_buffer, "NHD", backend=fmha_backend
         )
 
         if not self.skip_prefill:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -52,7 +52,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     cutlass_fp8_supported,
     dispatch_w8a8_block_fp8_linear,
     input_to_float8,
-    is_sm100_supported,
     normalize_e4m3fn_to_e4m3fnuz,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -63,6 +62,7 @@ from sglang.srt.layers.quantization.utils import (
     per_tensor_dequantize,
     requantize_with_max_scale,
 )
+from sglang.srt.layers.utils import is_sm100_supported
 from sglang.srt.utils import (
     get_bool_env_var,
     is_cuda,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Optional, Tuple
 import torch
 
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+from sglang.srt.layers.utils import is_sm100_supported
 
 try:
     from vllm import _custom_ops as ops
@@ -81,12 +82,6 @@ def cutlass_fp8_supported():
     elif major == 8 and minor == 9:
         return cuda_version >= (12, 4)
     return False
-
-
-def is_sm100_supported(device=None) -> bool:
-    return (torch.cuda.get_device_capability(device)[0] == 10) and (
-        torch.version.cuda >= "12.8"
-    )
 
 
 def normalize_e4m3fn_to_e4m3fnuz(

--- a/python/sglang/srt/layers/utils.py
+++ b/python/sglang/srt/layers/utils.py
@@ -33,3 +33,9 @@ class PPMissingLayer(torch.nn.Identity):
         """
         input = args[0] if args else next(iter(kwargs.values()))
         return (input,) if self.return_tuple else input
+
+
+def is_sm100_supported(device=None) -> bool:
+    return (torch.cuda.get_device_capability(device)[0] == 10) and (
+        torch.version.cuda >= "12.8"
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Support Flashinfer's FMHA on Blackwell.
https://github.com/sgl-project/sglang/issues/5855
https://github.com/flashinfer-ai/flashinfer/pull/1039
Flashinfer needs to be pulled from latest github main and installed from source.
Adding `--disable-radix` is needed for Deepseek models to use fmha.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
Use `is_sm100_supported()` to decide whether use "cutlass" as fmha backend.
Move is_sm100_supported() to layers dir level.
Close #6906
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Accuracy Results
1. Llama-3.1-8B-Instruct
```
python3 -m sglang.launch_server --model meta-llama/Llama-3.1-8B-Instruct --trust-remote --attention-backend flashinfer
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
```
```
Accuracy: 0.797
Invalid: 0.000
Latency: 16.580 s
Output throughput: 8042.298 token/s
```
2. Deepseek
```
python3 -m sglang.launch_server --model-path /dev/shm/DeepSeek-V3-0324/ --tp 8 --trust-remote --attention-backend flashinfer --disable-radix
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
```
```
Accuracy: 0.941
Invalid: 0.000
Latency: 124.990 s
Output throughput: 1142.425 token/s
```
## Profile Results
With Triton backend:
`python3 -m sglang.bench_one_batch --model-path /dev/shm/DeepSeek-V3-0324 --tp 8 --trust-remote-code --attention-backend triton --batch 16 --input-len 1024 --output-len 2 --profile`
![Screenshot 2025-06-06 at 13 59 36](https://github.com/user-attachments/assets/91f4e2ae-25cc-4ea6-acf4-123ba44c4a1f)
With Flashinfer backend and fmha:
`python3 -m sglang.bench_one_batch --model-path /dev/shm/DeepSeek-V3-0324 --tp 8 --trust-remote-code --attention-backend flashinfer --disable-radix-cache --batch 16 --input-len 1024 --output-len 2 --profile`
``
![Screenshot 2025-06-06 at 14 00 14](https://github.com/user-attachments/assets/741baa7a-51a9-484c-b822-62ff44c99235)



## Benchmark Results
Flashinfer (with cutlass backend):
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  214.35    
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127383    
Request throughput (req/s):              0.60      
Input token throughput (tok/s):          597.16    
Output token throughput (tok/s):         597.16    
Total token throughput (tok/s):          1194.31   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   26784.38  
Median E2E Latency (ms):                 26046.30  
---------------Time to First Token----------------
Mean TTFT (ms):                          1459.04   
Median TTFT (ms):                        782.75    
P99 TTFT (ms):                           4256.96   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.49     
Median ITL (ms):                         25.29     
P95 ITL (ms):                            25.74     
P99 ITL (ms):                            26.57     
Max ITL (ms):                            2334.88   
==================================================
```
Flashinfer (without cutlass backend):
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  211.57    
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127324    
Request throughput (req/s):              0.61      
Input token throughput (tok/s):          605.01    
Output token throughput (tok/s):         605.01    
Total token throughput (tok/s):          1210.03   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   26435.22  
Median E2E Latency (ms):                 26002.80  
---------------Time to First Token----------------
Mean TTFT (ms):                          1140.16   
Median TTFT (ms):                        770.49    
P99 TTFT (ms):                           4188.27   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.46     
Median ITL (ms):                         25.26     
P95 ITL (ms):                            25.74     
P99 ITL (ms):                            26.47     
Max ITL (ms):                            2203.56   
==================================================
```
Triton:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  228.98    
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127376    
Request throughput (req/s):              0.56      
Input token throughput (tok/s):          559.01    
Output token throughput (tok/s):         559.01    
Total token throughput (tok/s):          1118.02   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   28611.00  
Median E2E Latency (ms):                 28187.49  
---------------Time to First Token----------------
Mean TTFT (ms):                          1323.01   
Median TTFT (ms):                        984.89    
P99 TTFT (ms):                           4376.39   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           27.47     
Median ITL (ms):                         27.24     
P95 ITL (ms):                            28.20     
P99 ITL (ms):                            28.75     
Max ITL (ms):                            3818.41   
==================================================
```
Commands:
`python3 -m sglang.launch_server --model-path /dev/shm/DeepSeek-V3-0324/ --tp 8 --trust-remote   --attention-backend flashinfer --disable-radix`
`python3 -m sglang.launch_server --model-path /dev/shm/DeepSeek-V3-0324/ --tp 8 --trust-remote --attention-backend triton`
with
`python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 1000 --random-output-len 1000 --random-range-ratio 1 --num-prompts 128 --max-concurrency 16`

