### PR TITLE
Fix draft extend ut stability with flush cache

### DIFF
--- a/test/srt/test_eagle_infer.py
+++ b/test/srt/test_eagle_infer.py
@@ -610,6 +610,9 @@ class TestEAGLEDraftExtend(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_one_batch_accept_length(self):
+        resp = requests.get(self.base_url + "/flush_cache")
+        self.assertEqual(resp.status_code, 200)
+
         prompts = [
             "Hello, my name is",
             "The president of the United States is",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

[This test case](https://github.com/sgl-project/sglang/actions/runs/15518311370/job/43688812431#step:4:626) may fail with small probability. The possible reason is that the cache of the warmup request may affect the test result, so add flush cache before test to make it stable.
