### PR TITLE
Add Triton Fused MoE kernel config for E=16 on B200

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_3_0/E=16,N=1024,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_3_0/E=16,N=1024,device_name=NVIDIA_B200.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Improve the E=16 performance on B200 (`meta-llama/Llama-4-Scout-17B-16E`). I'll follow up with other quants (fp4 first)

The triton version is `triton==3.3.0` (this is what the Blackwell image uses). So I had to add a new folder to match this version

@BBuf Let me know if this is ok 👍 

Here's a table summarizing the performance improvements:

| Metric                      | Previous Value | New Value | Improvement |
|-----------------------------|----------------|-----------|-------------|
| Output Token Throughput     | 1,288.90 tok/s | 1,358.61 tok/s | 5.4%        |
| Request Throughput          | 1.29 req/s     | 1.36 req/s  | 5.4%        |
| TPOT / Inter-Token Latency | 9.67 ms        | 8.97 ms   | 7.2%        |
| End-to-End Latency          | 12408.66 ms            | 11771.30 ms       | 5.1%        |

```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  99.31     
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127329    
Request throughput (req/s):              1.29      
Input token throughput (tok/s):          1288.90   
Output token throughput (tok/s):         1288.90   
Total token throughput (tok/s):          2577.79   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   12408.66  
Median E2E Latency (ms):                 11760.96  
---------------Time to First Token----------------
Mean TTFT (ms):                          2799.20   
Median TTFT (ms):                        2269.24   
P99 TTFT (ms):                           7522.41   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           9.67      
Median ITL (ms):                         9.48      
P95 ITL (ms):                            9.98      
P99 ITL (ms):                            10.27     
Max ITL (ms):                            3187.75   
==================================================
```

After:

```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     128       
Benchmark duration (s):                  94.21     
Total input tokens:                      128000    
Total generated tokens:                  128000    
Total generated tokens (retokenized):    127277    
Request throughput (req/s):              1.36      
Input token throughput (tok/s):          1358.61   
Output token throughput (tok/s):         1358.61   
Total token throughput (tok/s):          2717.22   
Concurrency:                             15.99     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11771.30  
Median E2E Latency (ms):                 10961.09  
---------------Time to First Token----------------
Mean TTFT (ms):                          2859.37   
Median TTFT (ms):                        2225.49   
P99 TTFT (ms):                           8735.10   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           8.97      
Median ITL (ms):                         8.74      
P95 ITL (ms):                            9.25      
P99 ITL (ms):                            9.53      
Max ITL (ms):                            5208.34   
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Add the `python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=16,N=1024,device_name=NVIDIA_B200.json` file.

<!-- Describe the changes made in this PR. -->
