### PR TITLE
perf: add block-wise int8_w8a8 quantization kernel configs for H20-3e

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -404,7 +404,7 @@ class PrefillAdder:
         else:
             add_req_state(req, insert_sort=True)
 
-        cur_rem_tokens = self.cur_rem_tokens - len(req.origin_input_ids)
+        cur_rem_tokens = self.cur_rem_tokens - req.extend_input_len
         tokens_freed = 0
         for i, (tokens_left, tokens_occupied) in enumerate(self.req_states):
             decode_steps = (


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
add block-wise int8_w8a8 quantization kernel configs for H20-3e

this also fixes the overwriting bug in tuning_block_wise_kernel.py, where multiple tuning processors overwrite the config file, resulting in only the last processor’s results being preserved.
```
python3 benchmark/kernels/quantization/tuning_block_wise_kernel.py  --tp-size 8 --input-type int8
```

**benchmark** 
model: https://huggingface.co/meituan/DeepSeek-R1-Block-INT8

P50 ITL 17.16 -> 15.89
P95 ITL 17.44 -> 16.17

Baseline
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    1000.0    
Max request concurrency:                 1         
Successful requests:                     3         
Benchmark duration (s):                  79.33     
Total input tokens:                      12000     
Total generated tokens:                  4500      
Total generated tokens (retokenized):    4417      
Request throughput (req/s):              0.04      
Input token throughput (tok/s):          151.26    
Output token throughput (tok/s):         56.72     
Total token throughput (tok/s):          207.98    
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   26437.48  
Median E2E Latency (ms):                 26434.00  
---------------Time to First Token----------------
Mean TTFT (ms):                          612.95    
Median TTFT (ms):                        613.50    
P99 TTFT (ms):                           617.90    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           17.23     
Median ITL (ms):                         17.16     
P95 ITL (ms):                            17.44     
P99 ITL (ms):                            17.51     
Max ITL (ms):                            18.01     
==================================================
```

After applying the kernel configurations
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    1000.0    
Max request concurrency:                 1         
Successful requests:                     3         
Benchmark duration (s):                  73.64     
Total input tokens:                      12000     
Total generated tokens:                  4500      
Total generated tokens (retokenized):    4417      
Request throughput (req/s):              0.04      
Input token throughput (tok/s):          162.94    
Output token throughput (tok/s):         61.10     
Total token throughput (tok/s):          224.05    
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   24541.57  
Median E2E Latency (ms):                 24540.16  
---------------Time to First Token----------------
Mean TTFT (ms):                          620.55    
Median TTFT (ms):                        620.65    
P99 TTFT (ms):                           623.47    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           15.96     
Median ITL (ms):                         15.89     
P95 ITL (ms):                            16.17     
P99 ITL (ms):                            16.27     
Max ITL (ms):                            18.23     
==================================================
```


## Modifications

<!-- Describe the changes made in this PR. -->




## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
