### PR TITLE
[Docker] Upgrading base image from 24.04 to 24.12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG CUDA_VERSION=12.4.1
 
-FROM nvcr.io/nvidia/tritonserver:24.04-py3-min
+FROM nvcr.io/nvidia/tritonserver:24.12-py3-min
 
 ARG BUILD_TYPE=all
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The current docker image uses nvcr.io/nvidia/tritonserver:24.04-py3-min with CUDA 12.4 as the base, then when sglang and torch packages are installed, CUDA version gets reinstalled to 12.6, which can cause errors and increases build time, and is actually pointless. This PR simply safely upgrades the base image version to nvcr.io/nvidia/tritonserver:24.12-py3-min with CUDA 12.6.

https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/rel-25-05.html#rel-25-05
![image](https://github.com/user-attachments/assets/a2e871e6-91a0-4a13-9d88-ad270f423e4d)
