### PR TITLE
[fix] libmlx5.so already in base image

### DIFF
--- a/docker/Dockerfile.deepep
+++ b/docker/Dockerfile.deepep
@@ -40,7 +40,7 @@ RUN dpkg -i gdrcopy_*.deb
 ENV GDRCOPY_HOME=/usr/src/gdrdrv-2.4.4/
 
 # IBGDA dependency
-RUN ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so || true
+RUN ln -sf /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so
 RUN apt-get install -y libfabric-dev
 
 # DeepEP

--- a/docker/Dockerfile.deepep
+++ b/docker/Dockerfile.deepep
@@ -40,7 +40,7 @@ RUN dpkg -i gdrcopy_*.deb
 ENV GDRCOPY_HOME=/usr/src/gdrdrv-2.4.4/
 
 # IBGDA dependency
-RUN ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so || true
 RUN apt-get install -y libfabric-dev
 
 # DeepEP


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
`/usr/lib/x86_64-linux-gnu/libmlx5.so` already in base image, cause build error from `ln -s`
```
root@n199-204-219:/tmp/sglang# docker build --network host --build-arg BASE_IMAGE=lmsysorg/sglang:v0.4.7-cu124 -f docker/Dockerfile.deepep -t d --no-cache .
[+] Building 200.4s (21/35)                                                                                                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile.deepep                                                                                                                                                                                             0.0s
 => => transferring dockerfile: 2.49kB                                                                                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/lmsysorg/sglang:v0.4.7-cu124                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                                                                                                                         0.0s
 => CACHED [ 1/32] FROM docker.io/lmsysorg/sglang:v0.4.7-cu124                                                                                                                                                                                          0.0s
 => [ 2/32] RUN apt-get update && apt-get install -y --no-install-recommends build-essential wget libssl-dev && wget https://github.com/Kitware/CMake/releases/download/v3.27.4/cmake-3.27.4-linux-x86_64.sh && chmod +x cmake-3.27.4-linux-x86_64.sh  40.3s
 => [ 3/32] RUN apt-get update     && apt-get install -y --no-install-recommends         python3         python3-pip     && ln -s /usr/bin/python3 /usr/bin/python                                                                                      3.5s
 => [ 4/32] WORKDIR /tmp                                                                                                                                                                                                                                0.0s
 => [ 5/32] RUN git clone https://github.com/NVIDIA/gdrcopy.git                                                                                                                                                                                         1.1s
 => [ 6/32] WORKDIR /tmp/gdrcopy                                                                                                                                                                                                                        0.0s
 => [ 7/32] RUN git checkout v2.4.4                                                                                                                                                                                                                     0.1s
 => [ 8/32] RUN apt update                                                                                                                                                                                                                              2.3s
 => [ 9/32] RUN apt install -y nvidia-dkms-535                                                                                                                                                                                                         65.3s
 => [10/32] RUN apt install -y build-essential devscripts debhelper fakeroot pkg-config dkms                                                                                                                                                           37.9s
 => [11/32] RUN apt install -y check libsubunit0 libsubunit-dev                                                                                                                                                                                         4.2s
 => [12/32] WORKDIR /tmp/gdrcopy/packages                                                                                                                                                                                                               0.0s
 => [13/32] RUN CUDA=/usr/local/cuda ./build-deb-packages.sh                                                                                                                                                                                           36.9s
 => [14/32] RUN dpkg -i gdrdrv-dkms_*.deb                                                                                                                                                                                                               8.2s
 => [15/32] RUN dpkg -i libgdrapi_*.deb                                                                                                                                                                                                                 0.2s
 => [16/32] RUN dpkg -i gdrcopy-tests_*.deb                                                                                                                                                                                                             0.2s
 => [17/32] RUN dpkg -i gdrcopy_*.deb                                                                                                                                                                                                                   0.1s
 => ERROR [18/32] RUN ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so                                                                                                                                                 0.1s
------
 > [18/32] RUN ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so:
0.055 ln: failed to create symbolic link '/usr/lib/x86_64-linux-gnu/libmlx5.so': File exists
------
Dockerfile.deepep:43
--------------------
  41 |
  42 |     # IBGDA dependency
  43 | >>> RUN ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so
  44 |     RUN apt-get install -y libfabric-dev
  45 |
--------------------
ERROR: failed to solve: process "/bin/sh -c ln -s /usr/lib/x86_64-linux-gnu/libmlx5.so.1 /usr/lib/x86_64-linux-gnu/libmlx5.so" did not complete successfully: exit code: 1
```


```
root@n199-204-219:/tmp/sglang# docker run -it lmsysorg/sglang:v0.4.7-cu124 bash

root@40ea9ed9b1f8:/sgl-workspace# ls /usr/lib/x86_64-linux-gnu/libmlx5.so*
/usr/lib/x86_64-linux-gnu/libmlx5.so  /usr/lib/x86_64-linux-gnu/libmlx5.so.1  /usr/lib/x86_64-linux-gnu/libmlx5.so.1.24.50.0
```

```
root@n199-204-219:/tmp/sglang# docker run -it lmsysorg/sglang:v0.4.6.post5-cu124 bash

root@1ef3b1265109:/sgl-workspace# ls /usr/lib/x86_64-linux-gnu/libmlx5.so*
/usr/lib/x86_64-linux-gnu/libmlx5.so.1  /usr/lib/x86_64-linux-gnu/libmlx5.so.1.22.39.0
```


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

let it pass

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
