### PR TITLE
[FIX] make return type as  EagleVerifyOutput

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -271,7 +271,7 @@ class EagleVerifyInput:
         token_to_kv_pool_allocator: TokenToKVPoolAllocator,
         page_size: int,
         vocab_mask: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> EagleVerifyOutput:
         """
         Verify and find accepted tokens based on logits output and batch
         (which contains spec decoding information).


### PR DESCRIPTION
This function declares to return the torch.tensor type, but actually returns EagleVerifyOutput, which can be very confusing to read.