### PR TITLE
[PD] Respect sampling_params.max_new_tokens when PD disaggregation is activated

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1162,6 +1162,12 @@ class TokenizerManager:
         for i, rid in enumerate(recv_obj.rids):
             state = self.rid_to_state.get(rid, None)
             if state is None:
+                # Skip the error report caused by early finish when disaggregation is activated
+                if self.disaggregation_mode == DisaggregationMode.DECODE:
+                    finish_reason = recv_obj.finished_reasons[i]
+                    if "type" in finish_reason and finish_reason["type"] == "length":
+                        continue
+
                 logger.error(
                     f"Received output for {rid=} but the state was deleted in TokenizerManager."
                 )


### PR DESCRIPTION

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
This fixes a bug when PD disaggregation is activated and sampling_params.max_new_tokens <= 1

Before:
```
(base) root@iZ2zed0tiwrdk9tucyw2p9Z:~# curl -X POST http://127.0.0.1:8000/generate -H "Content-Type: application/json" -d '{
  "text": "You are a helpful assistant.\n",
  "sampling_params": {
    "temperature": 0,
    "max_new_tokens": 1
  }, "stream": true
}'
data: {"text":"Okay","meta_info":{"id":"05a3d0597bd642c991a293960228482d","finish_reason":null,"prompt_tokens":6,"completion_tokens":1,"cached_tokens":0}}

data: {"text":"Okay,","meta_info":{"id":"05a3d0597bd642c991a293960228482d","finish_reason":{"type":"length","length":1},"prompt_tokens":6,"completion_tokens":2,"cached_tokens":0,"e2e_latency":0.33734869956970215}}

data: [DONE]

(base) root@iZ2zed0tiwrdk9tucyw2p9Z:~# curl -X POST http://127.0.0.1:8000/generate -H "Content-Type: application/json" -d '{
  "text": "You are a helpful assistant.\n",
  "sampling_params": {
    "temperature": 0,
    "max_new_tokens": 1
  }, "stream": false
}'
{"text":"Okay,","meta_info":{"id":"87603e4404c446dc8bc4e3f69a1e6063","finish_reason":{"type":"length","length":1},"prompt_tokens":6,"completion_tokens":2,"cached_tokens":0,"e2e_latency":0.10740494728088379}}
```
The `completion_tokens` don't match the length required in the sampling params or in the finish reason.

After:
```
(base) root@iZ2zed0tiwrdk9tucyw2p9Z:~# curl -X POST http://127.0.0.1:8000/generate -H "Content-Type: application/json" -d '{
  "text": "You are a helpful assistant.\n",
  "sampling_params": {
    "temperature": 0,
    "max_new_tokens": 1
  }, "stream": true 
}'
data: {"text":"Okay","meta_info":{"id":"13d7bc930ff74b65b8048e52527e8aea","finish_reason":{"type":"length","length":1},"prompt_tokens":6,"completion_tokens":1,"cached_tokens":0,"e2e_latency":0.3873429298400879}}

data: [DONE]

(base) root@iZ2zed0tiwrdk9tucyw2p9Z:~# curl -X POST http://127.0.0.1:8000/generate -H "Content-Type: application/json" -d '{
  "text": "You are a helpful assistant.\n",
  "sampling_params": {
    "temperature": 0,
    "max_new_tokens": 1
  }, "stream": false
}'
{"text":"Okay","meta_info":{"id":"c8bbea881e054239b75b9c6431e3e2a4","finish_reason":{"type":"length","length":1},"prompt_tokens":6,"completion_tokens":1,"cached_tokens":0,"e2e_latency":0.18650269508361816}}
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
The reason behind this is that we get the first token ids from the prefill node and return the first two tokens when the decode instance finishes the first forward pass. We didn't want to cause a weird waiting time and introduce a concept of _Time to Second Token_, but we still need to respect the `sampling_params.max_new_tokens`. This fix is simple by skipping the second token in the streaming output. We should not use `req.check_finished()` since it will cause a memory leak when disaggregation PD is on.

CC: @ByronHsu @acelyc111 @fzyzcjy @whybeyoung 
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
