### PR TITLE
support remote prefill with etcd and nats

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -5,8 +5,8 @@ import numpy as np
 import numpy.typing as npt
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.server_args import ServerArgs
-
 
 class KVArgs:
     engine_rank: int
@@ -38,6 +38,7 @@ class BaseKVManager(ABC):
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
         is_mla_backend: Optional[bool] = False,
+        is_remote_prefill: Optional[bool] = False,
     ): ...
 
 
@@ -88,7 +89,7 @@ class BaseKVReceiver(ABC):
     ): ...
 
     @abstractmethod
-    def init(self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
+    def init(self, req: Req, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
         """
         Notify the prefill server about the kv indices and aux index
         """

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -35,9 +35,11 @@ class CommonKVManager(BaseKVManager):
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
         is_mla_backend: Optional[bool] = False,
+        is_remote_prefill: Optional[bool] = False,
     ):
         self.kv_args = args
         self.is_mla_backend = is_mla_backend
+        self.is_remote_prefill = is_remote_prefill
         self.disaggregation_mode = disaggregation_mode
         # for p/d multi node infer
         self.bootstrap_port = server_args.disaggregation_bootstrap_port
@@ -51,6 +53,12 @@ class CommonKVManager(BaseKVManager):
             )
 
         self.rank_port = get_free_port()
+        self.rank_ip = get_local_ip_by_remote()
+        self.engine_rank = args.engine_rank
+
+        if self.is_remote_prefill:
+            return
+
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self._register_to_bootstrap()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -11,6 +11,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVArgs,
     KVPoll,
 )
+from sglang.srt.managers.schedule_batch import Req
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ class FakeKVReceiver(BaseKVReceiver):
             logger.info("FakeKVReceiver poll success")
             return KVPoll.Success
 
-    def init(self, kv_indices: list[int], aux_index: Optional[int] = None):
+    def init(self, req: Req, kv_indices: list[int], aux_index: Optional[int] = None):
         self.has_init = True
         logger.info(
             f"FakeKVReceiver init with kv_indices: {kv_indices}, aux_index: {aux_index}"

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -12,7 +12,7 @@ import threading
 import time
 from collections import defaultdict
 from functools import cache
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -41,6 +41,10 @@ from sglang.srt.utils import (
     get_ip,
     get_local_ip_by_remote,
 )
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +132,7 @@ class MooncakeKVManager(BaseKVManager):
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
         is_mla_backend: Optional[bool] = False,
+        is_remote_prefill: Optional[bool] = False,
     ):
         self.kv_args = args
         self.engine = MooncakeTransferEngine(
@@ -136,6 +141,7 @@ class MooncakeKVManager(BaseKVManager):
             ib_device=self.kv_args.ib_device,
         )
         self.is_mla_backend = is_mla_backend
+        self.is_remote_prefill = False # TODO: remote prefill doesn't support mooncake for now
         self.disaggregation_mode = disaggregation_mode
         # for p/d multi node infer
         self.bootstrap_port = server_args.disaggregation_bootstrap_port
@@ -955,7 +961,7 @@ class MooncakeKVReceiver(BaseKVReceiver):
                 cls._socket_locks[endpoint] = threading.Lock()
             return cls._socket_cache[endpoint], cls._socket_locks[endpoint]
 
-    def init(self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
+    def init(self, req: Req, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
         for bootstrap_info in self.bootstrap_infos:
             self.prefill_server_url = (
                 f"{bootstrap_info['rank_ip']}:{bootstrap_info['rank_port']}"

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import dataclasses
 import logging
+import pickle
 import queue
 import socket
 import struct
@@ -26,10 +28,13 @@ from sglang.srt.disaggregation.common.conn import (
 )
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
+    RemotePrefillReq,
     group_concurrent_contiguous,
 )
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import get_local_ip_by_remote
+from sglang.srt.utils import get_local_ip_by_remote, broadcast_pyobj
+
+from sglang.srt.managers.schedule_batch import Req
 
 logger = logging.getLogger(__name__)
 
@@ -96,8 +101,10 @@ class NixlKVManager(CommonKVManager):
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
         is_mla_backend: Optional[bool] = False,
+        is_remote_prefill: Optional[bool] = False,
     ):
-        super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        super().__init__(args, disaggregation_mode, server_args,
+                         is_mla_backend, is_remote_prefill)
         try:
             from nixl._api import nixl_agent
         except ImportError as e:
@@ -109,6 +116,64 @@ class NixlKVManager(CommonKVManager):
         self.agent = nixl_agent(str(uuid.uuid4()))
         self.server_socket = zmq.Context().socket(zmq.PULL)
         self.register_buffer_to_engine()
+
+        if self.is_remote_prefill:
+            from os import environ
+            import etcd3
+            import json
+            import base64
+            import hashlib
+
+            etcd_endpoint = environ.get("ETCD_ENDPOINT", "127.0.0.1:2379")
+            self.model_name_hash = hashlib.sha256(server_args.served_model_name.encode('utf-8')) \
+                .hexdigest()[:8]
+            self.etcd_client = etcd3.client(host=etcd_endpoint.split(":")[0],
+                                            port=int(etcd_endpoint.split(":")[1]))
+            # register to etcd
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                self.request_status = {}
+                self.transfer_infos: Dict[int, TransferInfo] = {}
+                self.peer_names: Dict[str, str] = {}
+            elif self.disaggregation_mode == DisaggregationMode.DECODE:
+                self.transfer_statuses: Dict[int, TransferStatus] = defaultdict(
+                    TransferStatus
+                )
+                # broadcast engine_id to all ranks only in decode
+                engine_id = None
+                if self.engine_rank == 0:
+                    engine_id = hashlib.sha256(uuid.uuid4().bytes).hexdigest()[:8]
+                    broadcast_pyobj([engine_id], self.engine_rank, None, 0, False)
+                    logger.debug(f"Rank {self.engine_rank} broadcasted engine_id: {engine_id}")
+                else:
+                    engine_id = broadcast_pyobj([], self.engine_rank, None, 0, False)[0]
+                    logger.debug(f"Rank {self.engine_rank} received engine_id: {engine_id}")
+                self.engine_id = engine_id
+
+                agent_metadata = base64.b64encode(self.agent.get_agent_metadata()).decode('ascii')
+                if self.engine_rank == 0:
+                    self.etcd_client.put(
+                        f"/decode/{self.model_name_hash}/{self.engine_id}",
+                        json.dumps({
+                            "tp_size": self.tp_size,
+                            "dp_size": self.dp_size,
+                        })
+                    )
+                self.etcd_client.put(
+                    f"/decode/{self.model_name_hash}/{self.engine_id}/{self.engine_rank}",
+                    json.dumps({
+                        "agent_metadata": agent_metadata,
+                        "agent_name": self.agent.name,
+                        "kv_data_ptrs": self.kv_args.kv_data_ptrs,
+                        "aux_data_ptrs": self.kv_args.aux_data_ptrs,
+                        "gpu_id": self.kv_args.gpu_id,
+                    })
+                )
+                logger.debug(f"Register key: /decode/{self.model_name_hash}/{self.engine_id}/{self.engine_rank} to ETCD")
+            else:
+                raise ValueError(
+                    f"Unsupported DisaggregationMode: {self.disaggregation_mode}"
+                )
+            return
 
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.request_status = {}
@@ -409,9 +474,75 @@ class NixlKVReceiver(CommonKVReceiver):
         bootstrap_room: Optional[int] = None,
     ):
         self.started_transfer = False
+        self.is_remote_prefill = mgr.is_remote_prefill
+        if self.is_remote_prefill:
+            # if remote prefill, don't get boostrap info from prefill server
+
+            self.kv_mgr = mgr
+            self.bootstrap_room = bootstrap_room
+            self.send_to_queue_loop = asyncio.new_event_loop()
+            self._start_send_to_queue_thread(self.send_to_queue_loop)
+            return
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
 
-    def init(self, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
+    def _start_send_to_queue_thread(self, event_loop):
+        """Start a thread to send requests to the queue."""
+        if self.kv_mgr.engine_rank != 0:
+            return
+
+        def start_async_loop(loop):
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        threading.Thread(target=start_async_loop, args=(event_loop,)).start()
+
+    def _send_to_queue(self, req: Req, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
+        if self.kv_mgr.engine_rank != 0:
+            logger.debug(f"rank {self.kv_mgr.engine_rank} start to transfer")
+            self.started_transfer = True
+            return
+
+        queue_name = f"{self.kv_mgr.model_name_hash}"
+        kv_indices = base64.b64encode(kv_indices.tobytes()).decode("ascii")
+
+        remote_prefill_req = RemotePrefillReq(
+            rid=req.rid,
+            origin_input_text="",
+            origin_input_ids=req.origin_input_ids,
+            sampling_params=req.sampling_params,
+            kv_indices=kv_indices,
+            rank_ip=self.kv_mgr.rank_ip,
+            rank_port=self.kv_mgr.rank_port,
+            engine_rank=self.kv_mgr.engine_rank,
+            aux_index=aux_index,
+            bootstrap_room=self.bootstrap_room,
+            engine_id=self.kv_mgr.engine_id
+        )
+
+        remote_prefill_req_data = pickle.dumps(remote_prefill_req)
+
+        async def send_to_nats():
+            import nats
+            from os import environ
+
+            logger.debug(f"Send request and kv indices to queue: {queue_name} with len: {len(remote_prefill_req_data)} and boostrap room: {req.bootstrap_room}")
+            nats_endpoint = environ.get("NATS_ENDPOINT", "nats://127.0.0.1:4222")
+            nats_client = await nats.connect(nats_endpoint)
+
+            await nats_client.publish(
+                queue_name,
+                remote_prefill_req_data
+            )
+
+        asyncio.run_coroutine_threadsafe(send_to_nats(), self.send_to_queue_loop)
+        logger.debug(f"Send request to queue succeed!")
+        self.started_transfer = True
+
+    def init(self, req: Req, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
+        if self.is_remote_prefill:
+            self._send_to_queue(req, kv_indices, aux_index)
+            return
+
         for bootstrap_info in self.bootstrap_infos:
             self.prefill_server_url = (
                 f"{bootstrap_info['rank_ip']}:{bootstrap_info['rank_port']}"

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -166,6 +166,8 @@ class NixlKVManager(CommonKVManager):
                         "kv_data_ptrs": self.kv_args.kv_data_ptrs,
                         "aux_data_ptrs": self.kv_args.aux_data_ptrs,
                         "gpu_id": self.kv_args.gpu_id,
+                        "tp_size": self.tp_size,
+                        "dp_size": self.dp_size,
                     })
                 )
                 logger.debug(f"Register key: /decode/{self.model_name_hash}/{self.engine_id}/{self.engine_rank} to ETCD")
@@ -487,7 +489,8 @@ class NixlKVReceiver(CommonKVReceiver):
 
     def _start_send_to_queue_thread(self, event_loop):
         """Start a thread to send requests to the queue."""
-        if self.kv_mgr.engine_rank != 0:
+        per_dp_tp_rank = self.kv_mgr.tp_size // self.kv_mgr.dp_size
+        if self.kv_mgr.engine_rank % per_dp_tp_rank != 0:
             return
 
         def start_async_loop(loop):
@@ -497,7 +500,9 @@ class NixlKVReceiver(CommonKVReceiver):
         threading.Thread(target=start_async_loop, args=(event_loop,)).start()
 
     def _send_to_queue(self, req: Req, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
-        if self.kv_mgr.engine_rank != 0:
+        # only send the request to the queue if the engine rank per dp rank is 0
+        per_dp_tp_rank = self.kv_mgr.tp_size // self.kv_mgr.dp_size
+        if self.kv_mgr.engine_rank % per_dp_tp_rank != 0:
             logger.debug(f"rank {self.kv_mgr.engine_rank} start to transfer")
             self.started_transfer = True
             return
@@ -528,15 +533,25 @@ class NixlKVReceiver(CommonKVReceiver):
             logger.debug(f"Send request and kv indices to queue: {queue_name} with len: {len(remote_prefill_req_data)} and boostrap room: {req.bootstrap_room}")
             nats_endpoint = environ.get("NATS_ENDPOINT", "nats://127.0.0.1:4222")
             nats_client = await nats.connect(nats_endpoint)
+            js = nats_client.jetstream()
+            await js.add_stream(
+                name=queue_name,
+                subjects=[queue_name],
+                max_age=60 * 60 * 24,  # 1 day
+                max_bytes=1024 * 1024 * 1024,  # 1 GB
+                max_msgs=1000000,  # 1 million messages
+            )
 
-            await nats_client.publish(
+            ark = await js.publish(
                 queue_name,
                 remote_prefill_req_data
             )
 
+            self.started_transfer = True
+            logger.debug(f"Published request to NATS with ark: {ark}")
+
         asyncio.run_coroutine_threadsafe(send_to_nats(), self.send_to_queue_loop)
         logger.debug(f"Send request to queue succeed!")
-        self.started_transfer = True
 
     def init(self, req: Req, kv_indices: npt.NDArray[np.int64], aux_index: Optional[int] = None):
         if self.is_remote_prefill:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -454,6 +454,10 @@ class SchedulerDisaggregationPrefillMixin:
                 req.metadata_buffer_index
             )
 
+        # Don't send the remote prefill request to detokenizer
+        if self.is_remote_prefill:
+            done_reqs = [req for req in done_reqs if not req.is_remote_prefill]
+
         # Stream requests which have finished transfer
         self.stream_output(
             done_reqs,
@@ -523,8 +527,6 @@ class SchedulerDisaggregationPrefillMixin:
         import numpy as np
         from .nixl.conn import NixlKVSender, TransferInfo
         import json
-        from os import environ
-        import etcd3
 
         req = Req(rid = remote_prefill_req.rid,
                 origin_input_text=remote_prefill_req.origin_input_text,
@@ -532,7 +534,8 @@ class SchedulerDisaggregationPrefillMixin:
                 sampling_params=remote_prefill_req.sampling_params,
                 bootstrap_room=remote_prefill_req.bootstrap_room,
                 bootstrap_host=remote_prefill_req.rank_ip,
-                bootstrap_port=remote_prefill_req.rank_port)
+                bootstrap_port=remote_prefill_req.rank_port,
+                is_remote_prefill=True)
 
         bootstrap_room = req.bootstrap_room
         engine_id = remote_prefill_req.engine_id

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -19,15 +19,18 @@ Life cycle of a request in the prefill server
 
 from __future__ import annotations
 
+import asyncio
+import base64
 import logging
+import pickle
 import threading
-from collections import deque
+from collections import deque, defaultdict
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Dict
 
 import torch
 
-from sglang.srt.disaggregation.base import BaseKVManager, KVArgs, KVPoll
+from sglang.srt.disaggregation.base import BaseKVManager, BaseKVSender, KVArgs, KVPoll
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     FakeBootstrapHost,
@@ -35,6 +38,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    RemotePrefillReq,
     get_kv_class,
     is_mla_backend,
     kv_to_page_indices,
@@ -54,6 +58,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+REQ_KV_SENDR_MAP: Dict[str:BaseKVSender] = defaultdict()
 
 class PrefillBootstrapQueue:
     """
@@ -72,6 +77,7 @@ class PrefillBootstrapQueue:
         gloo_group: ProcessGroup,
         transfer_backend: TransferBackend,
         scheduler: Scheduler,
+        is_remote_prefill: bool = False,
     ):
         self.token_to_kv_pool = token_to_kv_pool
         self.draft_token_to_kv_pool = draft_token_to_kv_pool
@@ -88,6 +94,7 @@ class PrefillBootstrapQueue:
         self.queue: List[Req] = []
         self.gloo_group = gloo_group
         self.bootstrap_port = bootstrap_port
+        self.is_remote_prefill = is_remote_prefill
 
     def store_prefill_results(self, idx: int, token_id: int):
         assert token_id >= 0, f"token_id: {token_id} is negative"
@@ -136,7 +143,8 @@ class PrefillBootstrapQueue:
             kv_sender_class = get_kv_class(TransferBackend.FAKE, KVClassType.SENDER)
         else:
             kv_sender_class = get_kv_class(self.transfer_backend, KVClassType.SENDER)
-        req.disagg_kv_sender = kv_sender_class(
+
+        REQ_KV_SENDR_MAP[req.rid] = kv_sender_class(
             mgr=self.kv_manager,
             bootstrap_addr=f"{req.bootstrap_host}:{self.bootstrap_port}",
             bootstrap_room=req.bootstrap_room,
@@ -163,7 +171,7 @@ class PrefillBootstrapQueue:
             return []
 
         polls = poll_and_all_reduce(
-            [req.disagg_kv_sender for req in self.queue], self.gloo_group
+            [REQ_KV_SENDR_MAP[req.rid] for req in self.queue], self.gloo_group
         )
 
         for i, (req, poll) in enumerate(zip(self.queue, polls)):
@@ -172,7 +180,7 @@ class PrefillBootstrapQueue:
             elif poll == KVPoll.Failed:
                 error_message = f"Prefill bootstrap failed for request rank={self.tp_rank} {req.rid=} {req.bootstrap_room=}"
                 try:
-                    req.disagg_kv_sender.failure_exception()
+                    REQ_KV_SENDR_MAP[req.rid].failure_exception()
                 except Exception as e:
                     error_message += f" with exception {e}"
                 logger.error(error_message)
@@ -193,7 +201,7 @@ class PrefillBootstrapQueue:
             )
             assert req.metadata_buffer_index is not None
             num_pages = kv_to_page_num(num_kv_indices, self.token_to_kv_pool.page_size)
-            req.disagg_kv_sender.init(num_pages, req.metadata_buffer_index)
+            REQ_KV_SENDR_MAP[req.rid].init(num_pages, req.metadata_buffer_index)
 
             bootstrapped_reqs.append(req)
             indices_to_remove.add(i)
@@ -213,6 +221,10 @@ class SchedulerDisaggregationPrefillMixin:
     @torch.no_grad()
     def event_loop_normal_disagg_prefill(self: Scheduler):
         """A normal scheduler loop for prefill worker in disaggregation mode."""
+
+        # only start the queue thread on rank 0
+        if self.is_remote_prefill and self.tp_rank == 0:
+            self._start_queue_thread()
 
         while True:
             recv_reqs = self.recv_requests()
@@ -251,6 +263,8 @@ class SchedulerDisaggregationPrefillMixin:
     @torch.no_grad()
     def event_loop_overlap_disagg_prefill(self: Scheduler):
         self.result_queue = deque()
+        if self.is_remote_prefill:
+            self._start_queue_thread()
 
         while True:
             recv_reqs = self.recv_requests()
@@ -299,6 +313,7 @@ class SchedulerDisaggregationPrefillMixin:
             # HACK (byronhsu): reset the batch_is_full flag because we never enter update_running_batch which resets it
             # Otherwise, it hangs under high concurrency
             self.running_batch.batch_is_full = False
+
 
     def process_batch_result_disagg_prefill(
         self: Scheduler,
@@ -404,7 +419,7 @@ class SchedulerDisaggregationPrefillMixin:
         done_reqs = []
 
         polls = poll_and_all_reduce(
-            [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
+            [REQ_KV_SENDR_MAP[req.rid] for req in self.disagg_prefill_inflight_queue],
             self.attn_tp_cpu_group,
         )
 
@@ -417,13 +432,13 @@ class SchedulerDisaggregationPrefillMixin:
                 self.tree_cache.cache_finished_req(req)  # unlock the tree
                 req.finished_reason = FINISH_LENGTH(length=0)
                 # FIXME: clean up req's data in transfer engine
-                if hasattr(req.disagg_kv_sender, "clear"):
-                    req.disagg_kv_sender.clear()
+                if hasattr(REQ_KV_SENDR_MAP[req.rid], "clear"):
+                    REQ_KV_SENDR_MAP[req.rid].clear()
                 done_reqs.append(req)
             elif poll == KVPoll.Failed:
                 error_message = f"Prefill transfer failed for request rank={self.tp_rank} {req.rid=} {req.bootstrap_room=}"
                 try:
-                    req.disagg_kv_sender.failure_exception()
+                    REQ_KV_SENDR_MAP[req.rid].failure_exception()
                 except Exception as e:
                     error_message += f" with exception {e}"
                 logger.warning(error_message)
@@ -434,6 +449,7 @@ class SchedulerDisaggregationPrefillMixin:
                 done_reqs.append(req)
 
         for req in done_reqs:
+            del REQ_KV_SENDR_MAP[req.rid]
             self.disagg_prefill_bootstrap_queue.req_to_metadata_buffer_idx_allocator.free(
                 req.metadata_buffer_index
             )
@@ -501,4 +517,85 @@ class SchedulerDisaggregationPrefillMixin:
                 f"Skip sending kv chunk for request {req.rid=} {req.bootstrap_room=} because page_indices is empty"
             )
             return
-        req.disagg_kv_sender.send(page_indices)
+        REQ_KV_SENDR_MAP[req.rid].send(page_indices)
+
+    def handle_remote_prefill_req(self: Scheduler, remote_prefill_req: RemotePrefillReq):
+        import numpy as np
+        from .nixl.conn import NixlKVSender, TransferInfo
+        import json
+        from os import environ
+        import etcd3
+
+        req = Req(rid = remote_prefill_req.rid,
+                origin_input_text=remote_prefill_req.origin_input_text,
+                origin_input_ids=remote_prefill_req.origin_input_ids,
+                sampling_params=remote_prefill_req.sampling_params,
+                bootstrap_room=remote_prefill_req.bootstrap_room,
+                bootstrap_host=remote_prefill_req.rank_ip,
+                bootstrap_port=remote_prefill_req.rank_port)
+
+        bootstrap_room = req.bootstrap_room
+        engine_id = remote_prefill_req.engine_id
+        self.disagg_prefill_bootstrap_queue.add(req)
+        kv_sender = REQ_KV_SENDR_MAP[req.rid]
+        kv_indices = base64.b64decode(remote_prefill_req.kv_indices)
+        remote_agent_key = f"{engine_id}_{self.tp_rank}"
+
+        if self.remote_agent_map.get(remote_agent_key) is None:
+            # only load on first time
+            data = self.etcd_client.get(f"/decode/{self.model_name_hash}/{engine_id}/{self.tp_rank}")
+            agent_info = json.loads(data[0])
+            agent_info["agent_metadata"] = base64.b64decode(agent_info["agent_metadata"])
+            self.remote_agent_map[remote_agent_key] = agent_info
+
+        agent_info = self.remote_agent_map.get(remote_agent_key)
+        assert agent_info is not None, "Invalid remote agent"
+
+        agent_name = agent_info["agent_name"]
+
+        logger.debug(f"rank {self.tp_rank} with agent name: {agent_name}")
+        if isinstance(kv_sender, NixlKVSender):
+            kv_mgr = kv_sender.kv_mgr
+            if bootstrap_room not in kv_mgr.transfer_infos:
+                kv_mgr.transfer_infos[bootstrap_room] = {}
+                kv_mgr.transfer_infos[bootstrap_room][agent_name] = TransferInfo(
+                    room =remote_prefill_req.bootstrap_room,
+                    endpoint=remote_prefill_req.rank_ip,
+                    dst_port=remote_prefill_req.rank_port,
+                    agent_metadata= agent_info["agent_metadata"],
+                    agent_name=agent_name,
+                    dst_kv_ptrs=agent_info["kv_data_ptrs"],
+                    dst_kv_indices= np.frombuffer(kv_indices, dtype=np.int64),
+                    dst_aux_ptrs=agent_info["aux_data_ptrs"],
+                    dst_aux_index=remote_prefill_req.aux_index,
+                    dst_gpu_id=agent_info["gpu_id"],
+                    required_dst_info_num=0,
+                )
+            kv_mgr.update_status(bootstrap_room, KVPoll.WaitingForInput)
+
+    def _start_queue_thread(self: Scheduler):
+        """Start a thread to send requests to the queue."""
+
+        def start_async_loop(loop):
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        event_loop = asyncio.new_event_loop()
+        threading.Thread(target=start_async_loop, args=(event_loop,)).start()
+
+        queue_name = f"{self.model_name_hash}"
+
+        async def recv_from_nats():
+            import nats
+
+            nats_client = await nats.connect(self.nats_endpoint)
+
+            sub = await nats_client.subscribe(queue_name)
+            while True:
+                msg = await sub.next_msg(timeout=None)
+                remote_prefill_req: RemotePrefillReq = pickle.loads(msg.data)
+                logger.debug(f"Recv request {remote_prefill_req.rid} and bootstrap room: {remote_prefill_req.bootstrap_room}.")
+                self.remote_prefill_reqs.append(remote_prefill_req)
+
+        asyncio.run_coroutine_threadsafe(recv_from_nats(), event_loop)
+        logger.debug(f"Start thread to recv queue succeed!")

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -253,6 +253,9 @@ class DataParallelController:
                 self.workers
             )
         else:
+            if req.bootstrap_room is None:
+                import random
+                req.bootstrap_room = random.randint(0, 2**63 - 1)
             self.workers[req.bootstrap_room % len(self.workers)].send_pyobj(req)
 
     def shortest_queue_scheduler(self, input_requests):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -442,6 +442,7 @@ class Req:
         bootstrap_host: Optional[str] = None,
         bootstrap_port: Optional[int] = None,
         bootstrap_room: Optional[int] = None,
+        is_remote_prefill: bool = False,
     ):
         # Input and output info
         self.rid = rid
@@ -594,6 +595,7 @@ class Req:
         self.bootstrap_host: str = bootstrap_host
         self.bootstrap_port: Optional[int] = bootstrap_port
         self.bootstrap_room: Optional[int] = bootstrap_room
+        self.is_remote_prefill = is_remote_prefill
 
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -48,7 +48,6 @@ import triton.language as tl
 from sglang.global_config import global_config
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.constrained.base_grammar_backend import BaseGrammarObject
-from sglang.srt.disaggregation.base import BaseKVSender
 from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
     ScheduleBatchDisaggregationDecodeMixin,
 )
@@ -595,7 +594,6 @@ class Req:
         self.bootstrap_host: str = bootstrap_host
         self.bootstrap_port: Optional[int] = bootstrap_port
         self.bootstrap_room: Optional[int] = bootstrap_room
-        self.disagg_kv_sender: Optional[BaseKVSender] = None
 
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -670,6 +670,7 @@ class Scheduler(
             self.etcd_client = etcd3.client(host=etcd_endpoint.split(":")[0],
                                         port=int(etcd_endpoint.split(":")[1]))
             self.remote_agent_map = {}
+            self.remote_engine_configs = {}
             self.nats_endpoint = environ.get("NATS_ENDPOINT", "nats://127.0.0.1:4222")
 
     @DynamicGradMode()
@@ -882,14 +883,14 @@ class Scheduler(
                     req
                     for req in recv_reqs
                     if isinstance(
-                        req, (TokenizedGenerateReqInput, TokenizedEmbeddingReqInput)
+                        req, (TokenizedGenerateReqInput, RemotePrefillReq, TokenizedEmbeddingReqInput)
                     )
                 ]
                 control_reqs = [
                     req
                     for req in recv_reqs
                     if not isinstance(
-                        req, (TokenizedGenerateReqInput, TokenizedEmbeddingReqInput)
+                        req, (TokenizedGenerateReqInput, RemotePrefillReq, TokenizedEmbeddingReqInput)
                     )
                 ]
             else:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -16,6 +16,7 @@
 import faulthandler
 import logging
 import os
+import random
 import signal
 import sys
 import threading
@@ -23,6 +24,7 @@ import time
 from collections import defaultdict, deque
 from concurrent import futures
 from dataclasses import dataclass
+import hashlib
 from http import HTTPStatus
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple, Union
@@ -54,6 +56,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    RemotePrefillReq,
     prepare_abort,
 )
 from sglang.srt.distributed import get_pp_group, get_world_group
@@ -449,6 +452,7 @@ class Scheduler(
             [
                 (TokenizedGenerateReqInput, self.handle_generate_request),
                 (TokenizedEmbeddingReqInput, self.handle_embedding_request),
+                (RemotePrefillReq, self.handle_remote_prefill_req),
                 (FlushCacheReqInput, self.flush_cache_wrapped),
                 (AbortReq, self.abort_request),
                 (OpenSessionReqInput, self.open_session),
@@ -577,6 +581,10 @@ class Scheduler(
         self.transfer_backend = TransferBackend(
             self.server_args.disaggregation_transfer_backend
         )
+        self.is_remote_prefill = self.server_args.enable_remote_prefill
+        self.model_name_hash = hashlib.sha256(self.server_args.served_model_name.encode('utf-8')) \
+                .hexdigest()[:8]
+        self.remote_prefill_reqs = []
 
         if (
             self.disaggregation_mode == DisaggregationMode.DECODE
@@ -594,6 +602,7 @@ class Scheduler(
                 metadata_buffers=self.disagg_metadata_buffers,
                 scheduler=self,
                 tree_cache=self.tree_cache,
+                is_remote_prefill=self.is_remote_prefill,
             )
 
             # The decode requests pending for pre-allocation
@@ -615,12 +624,15 @@ class Scheduler(
                 tp_size=self.tp_size,
                 bootstrap_port=self.server_args.disaggregation_bootstrap_port,
                 transfer_backend=self.transfer_backend,
+                is_remote_prefill=self.is_remote_prefill,
             )
 
             # Metric for pre-allocation
             self.num_tokens_pre_allocated = 0
 
-        elif self.disaggregation_mode == DisaggregationMode.PREFILL:
+        elif (
+            self.disaggregation_mode == DisaggregationMode.PREFILL
+        ):
             # *2 for the headroom.
             buffer_size = self.max_running_requests * 2
             req_to_metadata_buffer_idx_allocator = ReqToMetadataIdxAllocator(
@@ -643,9 +655,22 @@ class Scheduler(
                 gloo_group=self.attn_tp_cpu_group,
                 transfer_backend=self.transfer_backend,
                 scheduler=self,
+                is_remote_prefill=self.is_remote_prefill,
             )
             # The prefill requests that are in the middle of kv sending
             self.disagg_prefill_inflight_queue: List[Req] = []
+
+        if self.is_remote_prefill:
+            from os import environ
+            import etcd3
+            import nats
+
+            # connect to etcd
+            etcd_endpoint = environ.get("ETCD_ENDPOINT", "127.0.0.1:2379")
+            self.etcd_client = etcd3.client(host=etcd_endpoint.split(":")[0],
+                                        port=int(etcd_endpoint.split(":")[1]))
+            self.remote_agent_map = {}
+            self.nats_endpoint = environ.get("NATS_ENDPOINT", "nats://127.0.0.1:4222")
 
     @DynamicGradMode()
     def event_loop_normal(self):
@@ -833,6 +858,9 @@ class Scheduler(
                     except zmq.ZMQError:
                         break
                     recv_reqs.append(recv_rpc)
+
+                while len(self.remote_prefill_reqs) > 0:
+                    recv_reqs.append(self.remote_prefill_reqs.pop(-1))
             else:
                 recv_reqs = None
         else:
@@ -928,6 +956,9 @@ class Scheduler(
             if recv_req.bootstrap_port is None:
                 # Use default bootstrap port
                 recv_req.bootstrap_port = self.server_args.disaggregation_bootstrap_port
+
+            if recv_req.bootstrap_room is None and self.is_remote_prefill:
+                recv_req.bootstrap_room = random.randint(0, 2**63 - 1)
 
             req = Req(
                 recv_req.rid,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -223,6 +223,7 @@ class ServerArgs:
     disaggregation_transfer_backend: str = "mooncake"
     disaggregation_ib_device: Optional[str] = None
     pdlb_url: Optional[str] = None
+    enable_remote_prefill: bool = False
 
     def __post_init__(self):
         # Expert parallelism
@@ -1466,6 +1467,11 @@ class ServerArgs:
             type=str,
             default=None,
             help="The URL of the PD disaggregation load balancer. If set, the prefill/decode server will register with the load balancer.",
+        )
+        parser.add_argument(
+            "--enable-remote-prefill",
+            action="store_true",
+            help="Enable remote prefill",
         )
 
         parser.add_argument(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

- Relate to RFC #6925 
- Support remote prefill with etcd and nats
- No additional LB required
- Increase the availability and scaling process with PD disaggregation

## Modifications

1. update the disaggregation workflow and add enable_remote_prefill flag
2. currently only support same TP for prefill and decode 

## Features to support

- Remote prefill on large DP EP architecture 
- Conditional remote prefill base on input tokens
- Optional Etcd and Nats
- Dynamo example

## Testing

1.  start etcd
2. start nats
3. start prefill and decode

```bash

ETCD_ENDPOINT="127.0.0.1:2379" NATS_ENDPOINT="nats://127.0.0.1:4222"
CUDA_VISIBLE_DEVICES=4,5 python3 -m sglang.launch_server --model-path /data/models/Qwen3-32B-FP8 --port 8081 --host 0.0.0.0 --tp-size 2  --trust-remote-code --disaggregation-mode prefill --disaggregation-ib-device "mlx5_3" --page-size 64 --chunked-prefill-size 393216  --disable-radix-cache --disaggregation-transfer-backend nixl --disable-overlap-schedule --attention-backend fa3 --log-level debug --enable-remote-prefill

ETCD_ENDPOINT="127.0.0.1:2379" NATS_ENDPOINT="nats://127.0.0.1:4222"
CUDA_VISIBLE_DEVICES=6,7 python3 -m sglang.launch_server --model-path /data/models/Qwen3-32B-FP8 --port 8080 --host 0.0.0.0 --tp-size 2 --trust-remote-code --disaggregation-mode decode --disaggregation-ib-device "mlx5_3" --page-size 64 --chunked-prefill-size 393216  --disable-radix-cache --disaggregation-transfer-backend nixl --disable-overlap-schedule --cuda-graph-bs 1 2 4 6 8 10 16 --attention-backend fa3 --log-level debug --enable-remote-prefill 
```

4. run test request

```bash
curl http://localhost:8080/v1/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "/data/models/Qwen3-32B-FP8",
        "prompt": "San Francisco is a",
        "max_tokens": 100,
        "temperature": 0,
        "bootstrap_room": 100
    }'
```

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
