### PR TITLE
feat: add load format 'prefetch_auto' for parallel mmap prefetching

### DIFF
--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 class LoadFormat(str, enum.Enum):
     AUTO = "auto"
+    PREFETCH_AUTO = "prefetch_auto"
     PT = "pt"
     SAFETENSORS = "safetensors"
     NPCACHE = "npcache"
@@ -34,6 +35,10 @@ class LoadConfig:
         "auto" will try to load the weights in the safetensors format and
             fall back to the pytorch bin format if safetensors format is
             not available.
+        "prefetch_auto" like "auto" but performs concurrent mmap with
+            MAP_POPULATE to prefetch weight files into the page cache.
+            This helps maximize storage bandwidth and improve model loading
+            performance, especially on systems with high disk I/O capacity.
         "pt" will load the weights in the pytorch bin format.
         "safetensors" will load the weights in the safetensors format.
         "npcache" will load the weights in pytorch format and store

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -455,9 +455,6 @@ def prefetch_weight_files(hf_weights_files: List[str]) -> None:
         rank = torch.distributed.get_rank()
     local_files = hf_weights_files[rank::world_size]
     mmap_files_concurrently(local_files)
-    # synchronize across ranks to ensure all files are prefetched
-    if torch.distributed.is_initialized():
-        torch.distributed.barrier()
 
 def mmap_files_concurrently(hf_weights_files: List[str]) -> None:
     if len(hf_weights_files) == 0:

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -8,6 +8,9 @@ import json
 import logging
 import os
 import tempfile
+import mmap
+import concurrent.futures
+import time
 from collections import defaultdict
 from typing import (
     Any,
@@ -443,6 +446,39 @@ def safetensors_weights_iterator(
         for name, param in result.items():
             yield name, param
 
+def prefetch_weight_files(hf_weights_files: List[str]) -> None:
+    """Prefetch and mmap weight files in parallel for the current distributed rank."""
+    world_size = 1
+    rank = 0
+    if torch.distributed.is_initialized():
+        world_size = torch.distributed.get_world_size()
+        rank = torch.distributed.get_rank()
+    local_files = hf_weights_files[rank::world_size]
+    mmap_files_concurrently(local_files)
+    # synchronize across ranks to ensure all files are prefetched
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+def mmap_files_concurrently(hf_weights_files: List[str]) -> None:
+    if len(hf_weights_files) == 0:
+        return
+    max_workers = min(32, len(hf_weights_files))
+    start_time = time.time()
+    logger.info(f"Mmaping {len(hf_weights_files)} files concurrently")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        list(executor.map(_mmap_single_file, hf_weights_files))
+    logger.info(f"Mmaped {len(hf_weights_files)} files, elapsed time: {time.time() - start_time:.2f}s")
+
+def _mmap_single_file(st_file: str) -> None:
+    with open(st_file, "rb") as f:
+        file_size = os.path.getsize(st_file)
+        mm = mmap.mmap(
+            fileno=f.fileno(),
+            length=file_size,
+            prot=mmap.PROT_READ,
+            flags=mmap.MAP_SHARED | mmap.MAP_POPULATE
+        )
+        mm.close()
 
 def pt_weights_iterator(
     hf_weights_files: List[str],

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -453,6 +453,10 @@ def prefetch_weight_files(hf_weights_files: List[str]) -> None:
     if torch.distributed.is_initialized():
         world_size = torch.distributed.get_world_size()
         rank = torch.distributed.get_rank()
+        device_nums = torch.cuda.device_count()
+        if device_nums < world_size:
+            rank = rank % device_nums
+            world_size = device_nums
     local_files = hf_weights_files[rank::world_size]
     mmap_files_concurrently(local_files)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -593,6 +593,7 @@ class ServerArgs:
             default=ServerArgs.load_format,
             choices=[
                 "auto",
+                "prefetch_auto",
                 "pt",
                 "safetensors",
                 "npcache",
@@ -607,6 +608,10 @@ class ServerArgs:
             '"auto" will try to load the weights in the safetensors format '
             "and fall back to the pytorch bin format if safetensors format "
             "is not available. "
+            '"prefetch_auto" like "auto" but performs concurrent mmap with '
+            "MAP_POPULATE to prefetch weight files into the page cache. "
+            "This helps maximize storage bandwidth and improve model loading "
+            "performance, especially on systems with high disk I/O capacity. "
             '"pt" will load the weights in the pytorch bin format. '
             '"safetensors" will load the weights in the safetensors format. '
             '"npcache" will load the weights in pytorch format and store '


### PR DESCRIPTION


<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The purpose of this PR is to optimize the cold start performance of the inference engine when model weights are already stored on the local disk. The current model loading approach fails to fully utilize available disk bandwidth during initial startup, resulting in suboptimal loading speeds. By implementing a disk bandwidth-optimized loading strategy for cold start scenarios, we can significantly accelerate the engine's initialization process. This improvement will directly enhance Pod scaling efficiency and deployment speed in production environments, enabling faster resource provisioning and workload handling capabilities.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Introduce a new load format 'prefetch_auto' that performs concurrent mmap with MAP_POPULATE to prefetch safetensors files into the page cache. This helps maximize storage bandwidth and improve model loading performance, especially on systems with high disk I/O capacity.

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Test Plan
Our test env:
```
#free -h
              total        used        free      shared  buff/cache   available
Mem:           2.0T         23G        1.3T         92M        640G        1.9T
Swap:            0B          0B          0B
```
lsblk result: 
```
NAME            FSTYPE      LABEL    MOUNTPOINT   SIZE MODEL
nvme0n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme0n1p1     LVM2_member                       3.5T
  └─vgdata-data ext4                 /data       10.5T
nvme3n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme3n1p1     ext4                 /home        3.5T
sdb                                             447.1G SAMSUNG MZ7L3480
├─sdb4          iso9660     config-2             64.8M
├─sdb2          ext4                 /boot          1G
├─sdb3          ext4                 /           58.5G
└─sdb1          vfat                 /boot/efi    512M
nvme2n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme2n1p1     LVM2_member                       3.5T
  └─vgdata-data ext4                 /data       10.5T
nvme1n1                                           3.5T SAMSUNG MZQL23T8HCLS-00B7C
└─nvme1n1p1     LVM2_member                       3.5T
  └─vgdata-data ext4                 /data       10.5T
sda                                             447.1G SAMSUNG MZ7L3480
```
The loaded model is DeepSeek-R1, the weight file size: 642GB. All the weight file is mounted in /data. Three 3.5 TB NVMe Samsung MZQL23T8HCLS-00B7C drives are configured in RAID 0 with LVM, mounted to the /data directory, providing a total storage capacity of 10 TB.

We set the `tp=8` in start command.

## Test Result

Module Loader | Load Time (s) | Peak I/O Bandwidth (GB/s) | Average Bandwidth (GB/s)
-- | -- | -- | --
Default Module Loader | 384 | 5.16| 1.72
Prefetch Auto Module Loader | 96 | 18.75 | 15.28

Time Reduction: The prefetch loader reduces loading time from 384s to 96s (75% improvement).
