### PR TITLE
[PD] Support get local ip from NIC for PD disaggregation

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,6 +27,7 @@ runtime_common = [
     "llguidance>=0.7.11,<0.8.0",
     "modelscope",
     "msgspec",
+    "netifaces",
     "ninja",
     "orjson",
     "packaging",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,6 @@ runtime_common = [
     "llguidance>=0.7.11,<0.8.0",
     "modelscope",
     "msgspec",
-    "netifaces",
     "ninja",
     "orjson",
     "packaging",

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -39,8 +39,7 @@ from sglang.srt.utils import (
     get_free_port,
     get_int_env_var,
     get_ip,
-    get_local_ip_by_nic,
-    get_local_ip_by_remote,
+    get_local_ip_auto,
 )
 
 logger = logging.getLogger(__name__)
@@ -131,12 +130,7 @@ class MooncakeKVManager(BaseKVManager):
         is_mla_backend: Optional[bool] = False,
     ):
         self.kv_args = args
-        interface = os.environ.get("SGLANG_DISAGGREGATION_LOCAL_IP_NIC", None)
-        self.local_ip = (
-            get_local_ip_by_nic(interface)
-            if interface is not None
-            else get_local_ip_by_remote()
-        )
+        self.local_ip = get_local_ip_auto()
         self.engine = MooncakeTransferEngine(
             hostname=self.local_ip,
             gpu_id=self.kv_args.gpu_id,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -35,12 +35,7 @@ from sglang.srt.disaggregation.common.utils import (
 from sglang.srt.disaggregation.mooncake.transfer_engine import MooncakeTransferEngine
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import (
-    get_free_port,
-    get_int_env_var,
-    get_ip,
-    get_local_ip_auto,
-)
+from sglang.srt.utils import get_free_port, get_int_env_var, get_ip, get_local_ip_auto
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -2106,7 +2106,7 @@ def get_free_port():
 
 
 def get_local_ip_auto() -> str:
-    interface = os.environ.get("SGLANG_DISAGGREGATION_LOCAL_IP_NIC", None)
+    interface = os.environ.get("SGLANG_LOCAL_IP_NIC", None)
     return (
         get_local_ip_by_nic(interface)
         if interface is not None
@@ -2119,7 +2119,7 @@ def get_local_ip_by_nic(interface: str) -> str:
         import netifaces
     except ImportError as e:
         raise ImportError(
-            "Environment variable SGLANG_DISAGGREGATION_LOCAL_IP_NIC requires package netifaces, please install it through 'pip install netifaces'"
+            "Environment variable SGLANG_LOCAL_IP_NIC requires package netifaces, please install it through 'pip install netifaces'"
         ) from e
 
     try:

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -2136,7 +2136,7 @@ def get_local_ip_by_nic(interface: str) -> str:
                     return ip.split("%")[0]
     except (ValueError, OSError) as e:
         raise ValueError(
-            "Can not get local ip from NIC. Please verify whether SGLANG_DISAGGREGATION_LOCAL_IP_NIC is set correctly."
+            "Can not get local ip from NIC. Please verify whether SGLANG_LOCAL_IP_NIC is set correctly."
         )
 
     # Fallback


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Add SGLANG_DISAGGREGATION_LOCAL_IP_NIC to support get local ip from NIC interface for PD disaggregation. This util and env var could be useful when deploying PD in k8s env where all instances might share the same IP obtained from get_local_ip_by_remote when the ports are mapped and bound to another local area IP, which might cause trouble for metadata communication.

With this PR, we can manually set the interface that is correct and observed through `ifconfig`.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

CC: @fzyzcjy 
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
