### PR TITLE
allow sample of first token on decode side

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -128,6 +128,7 @@ class MooncakeKVManager(BaseKVManager):
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
         is_mla_backend: Optional[bool] = False,
+        skip_sample_on_prefill: bool = False,
     ):
         self.kv_args = args
         self.engine = MooncakeTransferEngine(
@@ -150,6 +151,7 @@ class MooncakeKVManager(BaseKVManager):
         self.request_status: Dict[int, KVPoll] = {}
         self.rank_port = None
         self.server_socket = zmq.Context().socket(zmq.PULL)
+        self.skip_sample_on_prefill = skip_sample_on_prefill
         self.register_buffer_to_engine()
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.transfer_infos: Dict[int, Dict[str, TransferInfo]] = {}

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -297,7 +297,7 @@ class NixlKVManager(CommonKVManager):
                 str(req.room) + "_aux",
                 mem_type=mem_type,
             )
-            handles.append(kv_xfer_handle)
+            handles.append(aux_xfer_handle)
         return handles
 
     def update_transfer_status(self):

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -106,7 +106,6 @@ class MetadataBuffers:
         self.output_token_logprobs_idx = torch.zeros(
             (size, 16), dtype=torch.int32, device="cpu"
         )
-        # TODO: use cuda:0 if logits_only?
         self.output_top_logprobs_val = torch.zeros(
             (size, max_top_logprobs_num), dtype=torch.float32, device="cpu"
         )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -617,6 +617,8 @@ class Req:
         # start_send_idx = len(req.fill_ids)
         self.start_send_idx: int = 0
 
+        self.transferred_logits: Optional[torch.Tensor] = None
+
         # For overlap schedule, we delay the kv transfer until `process_batch_result_disagg_prefill` rather than `process_prefill_chunk` in non-overlap
         # This is because kv is not ready in `process_prefill_chunk`.
         # We use `tmp_end_idx` to store the end index of the kv cache to send.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -692,7 +692,6 @@ class Scheduler(
                 )
                 self.disagg_metadata_buffers = MetadataBuffers(buffer_size)
             else:
-                assert self.model_config.vocab_size > 64
                 self.disagg_metadata_buffers = MetadataBuffers(
                     self.max_running_requests,
                     max_top_logprobs_num=self.model_config.vocab_size,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1297,6 +1297,18 @@ class ModelRunner:
         )
         return next_token_ids
 
+    def forward_batch_sampling(
+        self,
+        logits_output: LogitsProcessorOutput,
+        sampling_info: SamplingBatchInfo,
+    ) -> torch.Tensor:
+
+        self._preprocess_logits(logits_output, sampling_info)
+
+        next_token_ids = self.sampler(logits_output, sampling_info, False, [], [])
+
+        return next_token_ids
+
     @property
     def model_is_mrope(self) -> bool:
         """Detect if the model has "mrope" rope_scaling type.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -233,6 +233,7 @@ class ServerArgs:
     disaggregation_ib_device: Optional[str] = None
     num_reserved_decode_tokens: int = 512  # used for decode kv cache offload in PD
     pdlb_url: Optional[str] = None
+    skip_sample_on_prefill: bool = False
 
     def __post_init__(self):
         # Expert parallelism
@@ -1575,6 +1576,12 @@ class ServerArgs:
             type=str,
             default=None,
             help="The URL of the PD disaggregation load balancer. If set, the prefill/decode server will register with the load balancer.",
+        )
+        parser.add_argument(
+            "--skip-sample-on-prefill",
+            type=bool,
+            default=ServerArgs.skip_sample_on_prefill,
+            help="If true, the first sampling will be done in decode side instead of prefill side. Default is False.",
         )
 
     @classmethod


### PR DESCRIPTION
This PR adds a new option to balance the workload of prefill & decode side when the system is under pressure. 

When the sglang of both prefill and decode are started with the option "--skip-sample-on-prefill True", the prefill side will not try to sample the first token. Instead, the logits of the first token will be sent over to decode side, which will do the sampling. Therefore, when the prefill side is under greater pressure, this option will help shift the load to the decode side a bit.