### PR TITLE
chore: change logs from`INFO` to `DEBUG` for dp and add force quit for tokenizer manager

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -175,7 +175,7 @@ class Engine(EngineBase):
         """
         if self.server_args.enable_dp_attention:
             if data_parallel_rank is None:
-                logger.info("data_parallel_rank not provided, using default dispatch")
+                logger.debug("data_parallel_rank not provided, using default dispatch")
             elif data_parallel_rank < 0:
                 raise ValueError("data_parallel_rank must be non-negative")
             elif data_parallel_rank >= self.server_args.dp_size:
@@ -258,7 +258,7 @@ class Engine(EngineBase):
 
         if self.server_args.enable_dp_attention:
             if data_parallel_rank is None:
-                logger.info("data_parallel_rank not provided, using default dispatch")
+                logger.debug("data_parallel_rank not provided, using default dispatch")
             elif data_parallel_rank < 0:
                 raise ValueError("data_parallel_rank must be non-negative")
             elif data_parallel_rank >= self.server_args.dp_size:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1126,10 +1126,10 @@ class TokenizerManager:
         while True:
             remain_num_req = len(self.rid_to_state)
 
-            if self.health_check_failed:
-                # if health check failed, we should exit immediately
+            if self.health_check_failed or os.environ.get("SGL_NO_WAIT_ON_EXIT"):
+                # if health check failed or no wait flag set, exit immediately
                 logger.error(
-                    "Signal SIGTERM received while health check failed. Exiting... remaining number of requests: %d",
+                    "Signal SIGTERM received while health check failed or no wait flag set. Exiting... remaining number of requests: %d",
                     remain_num_req,
                 )
                 break

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1139,7 +1139,7 @@ class TokenizerManager:
         while True:
             remain_num_req = len(self.rid_to_state)
 
-            if self.health_check_failed or os.environ.get("SGL_NO_WAIT_ON_EXIT"):
+            if self.health_check_failed or get_bool_env_var("SGL_NO_WAIT_ON_EXIT"):
                 # if health check failed or no wait flag set, exit immediately
                 logger.error(
                     "Signal SIGTERM received while health check failed or no wait flag set. Exiting... remaining number of requests: %d",

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1139,7 +1139,7 @@ class TokenizerManager:
         while True:
             remain_num_req = len(self.rid_to_state)
 
-            if self.health_check_failed or get_bool_env_var("SGL_NO_WAIT_ON_EXIT"):
+            if self.health_check_failed or get_bool_env_var("SGL_FORCE_SHUTDOWN"):
                 # if health check failed or no wait flag set, exit immediately
                 logger.error(
                     "Signal SIGTERM received while health check failed or no wait flag set. Exiting... remaining number of requests: %d",

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1139,10 +1139,18 @@ class TokenizerManager:
         while True:
             remain_num_req = len(self.rid_to_state)
 
-            if self.health_check_failed or get_bool_env_var("SGL_FORCE_SHUTDOWN"):
-                # if health check failed or no wait flag set, exit immediately
+            if self.health_check_failed:
+                # if health check failed, exit immediately
                 logger.error(
-                    "Signal SIGTERM received while health check failed or no wait flag set. Exiting... remaining number of requests: %d",
+                    "Signal SIGTERM received while health check failed. Exiting... remaining number of requests: %d",
+                    remain_num_req,
+                )
+                break
+
+            elif get_bool_env_var("SGL_FORCE_SHUTDOWN"):
+                # if force shutdown flag set, exit immediately
+                logger.error(
+                    "Signal SIGTERM received while force shutdown flag set. Force exiting... remaining number of requests: %d",
                     remain_num_req,
                 )
                 break


### PR DESCRIPTION
Move some dp attention routing logs to debug. I've also added an env var that will let you quit an SGLang process without waiting for remaining requests. This will help when debugging any hangs during high concurrency benchmarks and shorten iteration loop when the `sgl.Engine` is spawned from another process

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
