### PR TITLE
[PD] Add custom memory pool option to support Mooncake PD with NVLink 

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/memory_pool.py
+++ b/python/sglang/srt/disaggregation/mooncake/memory_pool.py
@@ -30,21 +30,11 @@ class CustomAllocator:
             so_path = os.path.join(base_path, "hook.so")
             if os.path.exists(so_path):
                 return so_path
-        except ImportError:
-            pass
-
-        # Final fallback: load from environment variable
-        try:
-            env_path = os.environ.get("SGLANG_MOONCAKE_ALLOCATOR_SO_PATH")
-            if env_path and os.path.exists(env_path):
-                return env_path
-        except OSError:
-            pass
-
-        raise RuntimeError(
-            "hook.so not found in mooncake package. "
-            "Set SGLANG_MOONCAKE_ALLOCATOR_SO_PATH or install mooncake correctly."
-        )
+        except (ImportError, FileNotFoundError, TypeError):
+            raise ImportError(
+                "hook.so not found in mooncake package. "
+                "SGLANG_MOONCAKE_CUSTOM_MEM_POOL require mooncake-transfer-engine >= 0.3.3.post2."
+            )
 
     @classmethod
     def get_allocator(cls, device: torch.device) -> CUDAPluggableAllocator:

--- a/python/sglang/srt/disaggregation/mooncake/memory_pool.py
+++ b/python/sglang/srt/disaggregation/mooncake/memory_pool.py
@@ -1,0 +1,57 @@
+import os
+import threading
+from importlib import resources
+from typing import Dict, Final, Optional
+
+import torch
+from torch.cuda.memory import CUDAPluggableAllocator
+
+
+class CustomAllocator:
+    _instances: Dict[torch.device, CUDAPluggableAllocator] = {}
+    _lock: Final = threading.Lock()
+
+    @classmethod
+    def _get_so_path(cls) -> str:
+        """Dynamically locate hook.so in the mooncake package installation"""
+        try:
+            # Attempt to locate package resource
+            with resources.path("mooncake", "hook.so") as so_path:
+                if so_path.exists():
+                    return str(so_path)
+        except (ImportError, FileNotFoundError, TypeError):
+            pass
+
+        # Fallback strategy: check in package location via import metadata
+        try:
+            import mooncake
+
+            base_path = os.path.dirname(os.path.abspath(mooncake.__file__))
+            so_path = os.path.join(base_path, "hook.so")
+            if os.path.exists(so_path):
+                return so_path
+        except ImportError:
+            pass
+
+        # Final fallback: load from environment variable
+        try:
+            env_path = os.environ.get("SGLANG_MOONCAKE_ALLOCATOR_SO_PATH")
+            if env_path and os.path.exists(env_path):
+                return env_path
+        except OSError:
+            pass
+
+        raise RuntimeError(
+            "hook.so not found in mooncake package. "
+            "Set SGLANG_MOONCAKE_ALLOCATOR_SO_PATH or install mooncake correctly."
+        )
+
+    @classmethod
+    def get_allocator(cls, device: torch.device) -> CUDAPluggableAllocator:
+        with cls._lock:
+            if device not in cls._instances:
+                so_path = cls._get_so_path()
+                cls._instances[device] = CUDAPluggableAllocator(
+                    so_path, "mc_nvlink_malloc", "mc_nvlink_free"
+                )
+            return cls._instances[device]

--- a/python/sglang/srt/disaggregation/mooncake/memory_pool.py
+++ b/python/sglang/srt/disaggregation/mooncake/memory_pool.py
@@ -7,7 +7,7 @@ import torch
 from torch.cuda.memory import CUDAPluggableAllocator
 
 
-class CustomAllocator:
+class MooncakeNVLinkAllocator:
     _instances: Dict[torch.device, CUDAPluggableAllocator] = {}
     _lock: Final = threading.Lock()
 
@@ -32,7 +32,6 @@ class CustomAllocator:
                 return so_path
         except (ImportError, FileNotFoundError, TypeError):
             raise ImportError(
-                "hook.so not found in mooncake package. "
                 "SGLANG_MOONCAKE_CUSTOM_MEM_POOL require mooncake-transfer-engine >= 0.3.3.post2."
             )
 

--- a/python/sglang/srt/disaggregation/mooncake/memory_pool.py
+++ b/python/sglang/srt/disaggregation/mooncake/memory_pool.py
@@ -7,6 +7,7 @@ import torch
 from torch.cuda.memory import CUDAPluggableAllocator
 
 
+# TODO(shangming): move this class into mooncake's package for more general use cases
 class MooncakeNVLinkAllocator:
     _instances: Dict[torch.device, CUDAPluggableAllocator] = {}
     _lock: Final = threading.Lock()

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -92,12 +92,7 @@ class MetadataBuffers:
         custom_mem_pool: torch.cuda.MemPool = None,
     ):
         self.custom_mem_pool = custom_mem_pool
-
-        self.output_ids = None
-        self.output_token_logprobs_val = None
-        self.output_token_logprobs_idx = None
-        self.output_top_logprobs_val = None
-        self.output_top_logprobs_idx = None
+        device = "cuda" if self.custom_mem_pool else "cpu"
 
         with (
             torch.cuda.use_mem_pool(self.custom_mem_pool)
@@ -108,30 +103,18 @@ class MetadataBuffers:
 
             # We transfer the metadata of first output token to decode
             # The minimal size for RDMA is 64Bytes, so we pad it to > 64Bytes
-            self.output_ids = torch.zeros(
-                (size, 16),
-                dtype=torch.int32,
-                device="cuda" if self.custom_mem_pool else "cpu",
-            )
+            self.output_ids = torch.zeros((size, 16), dtype=torch.int32, device=device)
             self.output_token_logprobs_val = torch.zeros(
-                (size, 16),
-                dtype=torch.float32,
-                device="cuda" if self.custom_mem_pool else "cpu",
+                (size, 16), dtype=torch.float32, device=device
             )
             self.output_token_logprobs_idx = torch.zeros(
-                (size, 16),
-                dtype=torch.int32,
-                device="cuda" if self.custom_mem_pool else "cpu",
+                (size, 16), dtype=torch.int32, device=device
             )
             self.output_top_logprobs_val = torch.zeros(
-                (size, max_top_logprobs_num),
-                dtype=torch.float32,
-                device="cuda" if self.custom_mem_pool else "cpu",
+                (size, max_top_logprobs_num), dtype=torch.float32, device=device
             )
             self.output_top_logprobs_idx = torch.zeros(
-                (size, max_top_logprobs_num),
-                dtype=torch.int32,
-                device="cuda" if self.custom_mem_pool else "cpu",
+                (size, max_top_logprobs_num), dtype=torch.int32, device=device
             )
 
     def get_buf_infos(self):

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -84,24 +84,59 @@ class ReqToMetadataIdxAllocator:
 
 
 class MetadataBuffers:
-    def __init__(self, size: int, max_top_logprobs_num: int = 128):
-        # TODO: abort top_logprobs_num > 128 in PD
+    def __init__(
+        self,
+        size: int,
+        max_top_logprobs_num: int = 128,
+        custom_mem_pool: torch.cuda.MemPool = None,
+    ):
+        self.custom_mem_pool = custom_mem_pool
 
-        # We transfer the metadata of first output token to decode
-        # The minimal size for RDMA is 64Bytes, so we pad it to > 64Bytes
-        self.output_ids = torch.zeros((size, 16), dtype=torch.int32, device="cpu")
-        self.output_token_logprobs_val = torch.zeros(
-            (size, 16), dtype=torch.float32, device="cpu"
-        )
-        self.output_token_logprobs_idx = torch.zeros(
-            (size, 16), dtype=torch.int32, device="cpu"
-        )
-        self.output_top_logprobs_val = torch.zeros(
-            (size, max_top_logprobs_num), dtype=torch.float32, device="cpu"
-        )
-        self.output_top_logprobs_idx = torch.zeros(
-            (size, max_top_logprobs_num), dtype=torch.int32, device="cpu"
-        )
+        if self.custom_mem_pool is not None:
+            self.output_ids = None
+            self.output_token_logprobs_val = None
+            self.output_token_logprobs_idx = None
+            self.output_top_logprobs_val = None
+            self.output_top_logprobs_idx = None
+
+            with torch.cuda.use_mem_pool(self.custom_mem_pool):
+                # TODO: abort top_logprobs_num > 128 in PD
+
+                # We transfer the metadata of first output token to decode
+                # The minimal size for RDMA is 64Bytes, so we pad it to > 64Bytes
+                self.output_ids = torch.zeros(
+                    (size, 16), dtype=torch.int32, device="cuda"
+                )
+                self.output_token_logprobs_val = torch.zeros(
+                    (size, 16), dtype=torch.float32, device="cuda"
+                )
+                self.output_token_logprobs_idx = torch.zeros(
+                    (size, 16), dtype=torch.int32, device="cuda"
+                )
+                self.output_top_logprobs_val = torch.zeros(
+                    (size, max_top_logprobs_num), dtype=torch.float32, device="cuda"
+                )
+                self.output_top_logprobs_idx = torch.zeros(
+                    (size, max_top_logprobs_num), dtype=torch.int32, device="cuda"
+                )
+        else:
+            # TODO: abort top_logprobs_num > 128 in PD
+
+            # We transfer the metadata of first output token to decode
+            # The minimal size for RDMA is 64Bytes, so we pad it to > 64Bytes
+            self.output_ids = torch.zeros((size, 16), dtype=torch.int32, device="cpu")
+            self.output_token_logprobs_val = torch.zeros(
+                (size, 16), dtype=torch.float32, device="cpu"
+            )
+            self.output_token_logprobs_idx = torch.zeros(
+                (size, 16), dtype=torch.int32, device="cpu"
+            )
+            self.output_top_logprobs_val = torch.zeros(
+                (size, max_top_logprobs_num), dtype=torch.float32, device="cpu"
+            )
+            self.output_top_logprobs_idx = torch.zeros(
+                (size, max_top_logprobs_num), dtype=torch.int32, device="cpu"
+            )
 
     def get_buf_infos(self):
         ptrs = [

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -111,27 +111,27 @@ class MetadataBuffers:
             self.output_ids = torch.zeros(
                 (size, 16),
                 dtype=torch.int32,
-                device="cuda" if self.custom_mem_pool is not None else "cpu",
+                device="cuda" if self.custom_mem_pool else "cpu",
             )
             self.output_token_logprobs_val = torch.zeros(
                 (size, 16),
                 dtype=torch.float32,
-                device="cuda" if self.custom_mem_pool is not None else "cpu",
+                device="cuda" if self.custom_mem_pool else "cpu",
             )
             self.output_token_logprobs_idx = torch.zeros(
                 (size, 16),
                 dtype=torch.int32,
-                device="cuda" if self.custom_mem_pool is not None else "cpu",
+                device="cuda" if self.custom_mem_pool else "cpu",
             )
             self.output_top_logprobs_val = torch.zeros(
                 (size, max_top_logprobs_num),
                 dtype=torch.float32,
-                device="cuda" if self.custom_mem_pool is not None else "cpu",
+                device="cuda" if self.custom_mem_pool else "cpu",
             )
             self.output_top_logprobs_idx = torch.zeros(
                 (size, max_top_logprobs_num),
                 dtype=torch.int32,
-                device="cuda" if self.custom_mem_pool is not None else "cpu",
+                device="cuda" if self.custom_mem_pool else "cpu",
             )
 
     def get_buf_infos(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -622,7 +622,10 @@ class Scheduler(
             self.req_to_metadata_buffer_idx_allocator = ReqToMetadataIdxAllocator(
                 buffer_size
             )
-            self.disagg_metadata_buffers = MetadataBuffers(buffer_size)
+            self.disagg_metadata_buffers = MetadataBuffers(
+                buffer_size,
+                custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
+            )
 
             # The decode requests polling kv cache
             self.disagg_decode_transfer_queue = DecodeTransferQueue(
@@ -669,7 +672,10 @@ class Scheduler(
             self.req_to_metadata_buffer_idx_allocator = ReqToMetadataIdxAllocator(
                 buffer_size
             )
-            self.disagg_metadata_buffers = MetadataBuffers(buffer_size)
+            self.disagg_metadata_buffers = MetadataBuffers(
+                buffer_size,
+                custom_mem_pool=self.token_to_kv_pool_allocator.get_kvcache().maybe_get_custom_mem_pool(),
+            )
 
             self.disagg_prefill_bootstrap_queue = PrefillBootstrapQueue(
                 token_to_kv_pool=self.token_to_kv_pool_allocator.get_kvcache(),

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -272,6 +272,7 @@ class MHATokenToKVPool(KVCache):
                 MooncakeNVLinkAllocator,
             )
 
+            # TODO(shangming): abstract custom allocator class for more backends
             allocator = MooncakeNVLinkAllocator.get_allocator(self.device)
             self.custom_mem_pool = torch.cuda.MemPool(allocator.allocator())
         else:
@@ -603,6 +604,7 @@ class MLATokenToKVPool(KVCache):
                 MooncakeNVLinkAllocator,
             )
 
+            # TODO(shangming): abstract custom allocator class for more backends
             allocator = MooncakeNVLinkAllocator.get_allocator(self.device)
             self.custom_mem_pool = torch.cuda.MemPool(allocator.allocator())
         else:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -36,7 +36,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.radix_attention import RadixAttention
-from sglang.srt.utils import debug_timing, is_cuda, next_power_of_2
+from sglang.srt.utils import debug_timing, get_bool_env_var, is_cuda, next_power_of_2
 
 logger = logging.getLogger(__name__)
 
@@ -264,10 +264,8 @@ class MHATokenToKVPool(KVCache):
         self.head_dim = head_dim
 
         # for disagg with nvlink
-        is_custom_mem_pool_enabled = os.environ.get("SGLANG_MOONCAKE_CUSTOM_MEM_POOL")
-        self.enable_custom_mem_pool = (
-            is_custom_mem_pool_enabled is not None
-            and is_custom_mem_pool_enabled.lower() == "true"
+        self.enable_custom_mem_pool = get_bool_env_var(
+            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL", "false"
         )
         if self.enable_custom_mem_pool:
             from sglang.srt.disaggregation.mooncake.memory_pool import (
@@ -294,29 +292,29 @@ class MHATokenToKVPool(KVCache):
 
     def _create_buffers(self):
         with self.memory_saver_adapter.region():
-            # [size, head_num, head_dim] for each layer
-            # The padded slot 0 is used for writing dummy outputs from padded tokens.
-            self.k_buffer = []
-            self.v_buffer = []
-
             with (
                 torch.cuda.use_mem_pool(self.custom_mem_pool)
                 if self.enable_custom_mem_pool
                 else nullcontext()
             ):
-                for _ in range(self.layer_num):
-                    k = torch.zeros(
+                # [size, head_num, head_dim] for each layer
+                # The padded slot 0 is used for writing dummy outputs from padded tokens.
+                self.k_buffer = [
+                    torch.zeros(
                         (self.size + self.page_size, self.head_num, self.head_dim),
                         dtype=self.store_dtype,
                         device=self.device,
                     )
-                    v = torch.zeros(
+                    for _ in range(self.layer_num)
+                ]
+                self.v_buffer = [
+                    torch.zeros(
                         (self.size + self.page_size, self.head_num, self.head_dim),
                         dtype=self.store_dtype,
                         device=self.device,
                     )
-                    self.k_buffer.append(k)
-                    self.v_buffer.append(v)
+                    for _ in range(self.layer_num)
+                ]
 
         self.data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.k_buffer + self.v_buffer],
@@ -597,10 +595,8 @@ class MLATokenToKVPool(KVCache):
         self.qk_rope_head_dim = qk_rope_head_dim
 
         # for disagg with nvlink
-        is_custom_mem_pool_enabled = os.environ.get("SGLANG_MOONCAKE_CUSTOM_MEM_POOL")
-        self.enable_custom_mem_pool = (
-            is_custom_mem_pool_enabled is not None
-            and is_custom_mem_pool_enabled.lower() == "true"
+        self.enable_custom_mem_pool = get_bool_env_var(
+            "SGLANG_MOONCAKE_CUSTOM_MEM_POOL", "false"
         )
         if self.enable_custom_mem_pool:
             from sglang.srt.disaggregation.mooncake.memory_pool import (
@@ -613,21 +609,20 @@ class MLATokenToKVPool(KVCache):
             self.custom_mem_pool = None
 
         with self.memory_saver_adapter.region():
-            # The padded slot 0 is used for writing dummy outputs from padded tokens.
-            self.kv_buffer = []
-
             with (
                 torch.cuda.use_mem_pool(self.custom_mem_pool)
                 if self.custom_mem_pool
                 else nullcontext()
             ):
-                for _ in range(layer_num):
-                    kv = torch.zeros(
+                # The padded slot 0 is used for writing dummy outputs from padded tokens.
+                self.kv_buffer = [
+                    torch.zeros(
                         (size + page_size, 1, kv_lora_rank + qk_rope_head_dim),
                         dtype=self.store_dtype,
                         device=device,
                     )
-                    self.kv_buffer.append(kv)
+                    for _ in range(layer_num)
+                ]
 
         self.layer_transfer_counter = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
This PR adds an env var option: SGLANG_MOONCAKE_CUSTOM_MEM_POOL, if it is set to true, mooncake will initialize the kvcache in a custom memory pool to enable cross-node NVLink transport.

**This feature requires mooncake-transfer-engine >= 0.3.3.post2**

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
