### PR TITLE
Perormance: Enable cuda graph for dp idle batch

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1814,11 +1814,6 @@ class Scheduler(
         else:
             can_cuda_graph = 0
 
-        if not spec_algorithm.is_none():
-            # TODO(sang): Support cuda graph when idle batch is there.
-            if local_batch is None or local_batch.forward_mode.is_idle():
-                can_cuda_graph = 0
-
         is_extend_in_batch = (
             local_batch.forward_mode.is_extend() if local_batch else False
         )

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -680,7 +680,7 @@ class CudaGraphRunner:
                 bs=bs,
                 num_token_non_padded=len(forward_batch.input_ids),
             )
-        if forward_batch.forward_mode.is_idle():
+        if forward_batch.forward_mode.is_idle() and forward_batch.spec_info is not None:
             forward_batch.spec_info.custom_mask = self.custom_mask
         # Attention backend
         self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -306,27 +306,29 @@ class CudaGraphRunner:
                 self.encoder_lens = None
 
             if self.require_gathered_buffer:
+                self.gathered_buffer = torch.zeros(
+                    (
+                        self.max_num_token,
+                        self.model_runner.model_config.hidden_size,
+                    ),
+                    dtype=self.model_runner.dtype,
+                )
                 if self.require_mlp_tp_gather:
-                    self.gathered_buffer = torch.zeros(
-                        (
-                            self.max_bs * self.dp_size * self.num_tokens_per_bs,
-                            self.model_runner.model_config.hidden_size,
-                        ),
-                        dtype=self.model_runner.dtype,
-                    )
                     self.global_num_tokens_gpu = torch.zeros(
                         (self.dp_size,), dtype=torch.int32
                     )
                 else:
                     assert self.require_attn_tp_gather
-                    self.gathered_buffer = torch.zeros(
-                        (
-                            self.max_bs * self.num_tokens_per_bs,
-                            self.model_runner.model_config.hidden_size,
-                        ),
-                        dtype=self.model_runner.dtype,
-                    )
                     self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+
+            self.custom_mask = torch.ones(
+                (
+                    (self.seq_lens.sum().item() + self.max_num_token)
+                    * self.num_tokens_per_bs
+                ),
+                dtype=torch.bool,
+                device="cuda",
+            )
 
         # Capture
         try:
@@ -674,11 +676,12 @@ class CudaGraphRunner:
             self.num_token_non_padded.copy_(forward_batch.num_token_non_padded)
         if self.enable_two_batch_overlap:
             self.tbo_plugin.replay_prepare(
-                forward_mode=forward_batch.forward_mode,
+                forward_mode=self.capture_forward_mode,
                 bs=bs,
                 num_token_non_padded=len(forward_batch.input_ids),
             )
-
+        if forward_batch.forward_mode.is_idle():
+            forward_batch.spec_info.custom_mask = self.custom_mask
         # Attention backend
         self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
             bs,
@@ -686,7 +689,7 @@ class CudaGraphRunner:
             self.seq_lens[:bs],
             forward_batch.seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value,
             self.encoder_lens[:bs] if self.is_encoder_decoder else None,
-            forward_batch.forward_mode,
+            self.capture_forward_mode,
             forward_batch.spec_info,
             seq_lens_cpu=self.seq_lens_cpu[:bs],
         )
@@ -736,11 +739,7 @@ class CudaGraphRunner:
             else:
                 spec_info = EagleVerifyInput(
                     draft_token=None,
-                    custom_mask=torch.ones(
-                        (num_tokens * self.model_runner.model_config.context_len),
-                        dtype=torch.bool,
-                        device="cuda",
-                    ),
+                    custom_mask=self.custom_mask,
                     positions=None,
                     retrive_index=None,
                     retrive_next_token=None,

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -88,6 +88,7 @@ class EagleDraftInput:
     def create_idle_input(
         cls,
         device: torch.device,
+        dtype: torch.dtype,
         hidden_size: int,
         topk: int,
         capture_hidden_mode: CaptureHiddenMode,
@@ -95,11 +96,15 @@ class EagleDraftInput:
         return cls(
             verified_id=None,
             hidden_states=torch.empty(
-                (0, hidden_size), device=device, dtype=torch.float32
+                (0, hidden_size),
+                device=device,
+                dtype=dtype,
             ),
             topk_p=torch.empty((0, topk), device=device, dtype=torch.float32),
             topk_index=torch.empty((0, topk), device=device, dtype=torch.int64),
             capture_hidden_mode=capture_hidden_mode,
+            accept_length=torch.empty((0,), device=device, dtype=torch.int32),
+            accept_length_cpu=[],
         )
 
     def prepare_extend_after_decode(
@@ -333,6 +338,7 @@ class EagleVerifyInput:
             return EagleVerifyOutput(
                 draft_input=EagleDraftInput.create_idle_input(
                     device=batch.device,
+                    dtype=batch.model_config.dtype,
                     hidden_size=batch.model_config.hidden_size,
                     topk=self.topk,
                     capture_hidden_mode=CaptureHiddenMode.LAST,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -322,13 +322,11 @@ class EAGLEWorker(TpModelWorker):
             logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
                 self.verify(batch, spec_info)
             )
-            need_forward, can_run_draft_extend_cuda_graph = (
-                self.check_forward_draft_extend_after_decode(batch)
-            )
-            if need_forward:
+
+            if self.check_forward_draft_extend_after_decode(batch):
                 with self.draft_tp_context(self.draft_model_runner.tp_group):
                     self.forward_draft_extend_after_decode(
-                        batch, can_run_draft_extend_cuda_graph
+                        batch,
                     )
             return (
                 logits_output,
@@ -344,7 +342,7 @@ class EAGLEWorker(TpModelWorker):
             and batch.spec_info.verified_id.shape[0] > 0
         )
         if not self.server_args.enable_dp_attention:
-            return local_need_forward, True
+            return local_need_forward
 
         global_need_forward = torch.tensor(
             [
@@ -357,10 +355,7 @@ class EAGLEWorker(TpModelWorker):
         )
         global_need_forward_cnt = global_need_forward[0].item()
         need_forward = global_need_forward_cnt > 0
-        can_run_draft_extend_cuda_graph = (
-            global_need_forward_cnt == get_tensor_model_parallel_world_size()
-        )
-        return need_forward, can_run_draft_extend_cuda_graph
+        return need_forward
 
     def forward_target_extend(
         self, batch: ScheduleBatch
@@ -497,6 +492,7 @@ class EAGLEWorker(TpModelWorker):
     def _draft_preprocess_idle(self, batch: ScheduleBatch):
         batch.spec_info = EagleDraftInput.create_idle_input(
             device=self.device,
+            dtype=self.model_config.dtype,
             hidden_size=self.model_config.hidden_size,
             topk=self.topk,
             capture_hidden_mode=CaptureHiddenMode.LAST,
@@ -815,15 +811,12 @@ class EAGLEWorker(TpModelWorker):
         assert forward_batch.spec_info is batch.spec_info
         self.capture_for_decode(logits_output, forward_batch.spec_info)
 
-    def forward_draft_extend_after_decode(
-        self, batch: ScheduleBatch, can_run_draft_extend_cuda_graph: bool
-    ):
+    def forward_draft_extend_after_decode(self, batch: ScheduleBatch):
         # Backup fields that will be modified in-place
         seq_lens_backup = batch.seq_lens.clone()
         req_pool_indices_backup = batch.req_pool_indices
         accept_length_backup = batch.spec_info.accept_length
         return_logprob_backup = batch.return_logprob
-
         input_is_idle = batch.forward_mode.is_idle()
         if not input_is_idle:
             # Prepare metadata
@@ -835,13 +828,18 @@ class EAGLEWorker(TpModelWorker):
             else:
                 batch = batch.copy()
                 batch.prepare_for_idle()
+                hidden_size = (
+                    self.model_config.hidden_size * 3
+                    if self.speculative_algorithm.is_eagle3()
+                    else self.model_config.hidden_size
+                )
                 batch.spec_info = EagleDraftInput.create_idle_input(
                     device=self.device,
-                    hidden_size=self.model_config.hidden_size,
+                    dtype=self.model_config.dtype,
+                    hidden_size=hidden_size,
                     topk=self.topk,
                     capture_hidden_mode=CaptureHiddenMode.LAST,
                 )
-
         batch.return_hidden_states = False
         model_worker_batch = batch.get_model_worker_batch()
         model_worker_batch.spec_num_draft_tokens = self.speculative_num_draft_tokens
@@ -856,8 +854,7 @@ class EAGLEWorker(TpModelWorker):
 
         # Run
         can_cuda_graph = (
-            can_run_draft_extend_cuda_graph
-            and self.cuda_graph_runner_for_draft_extend
+            self.cuda_graph_runner_for_draft_extend
             and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
         )
         if can_cuda_graph:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently, #6081 does not enable CUDA graphs when some DP ranks are idle input. 
The goal of this pull request is to support CUDA graph execution even when some DP ranks are idle, thereby improving performance.


## Modifications

<!-- Describe the changes made in this PR. -->


## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## performance
### server launch comands
with --disable-radix , tp-size=16, dp-size = 16.
1. with mtp
```
#2 h20 nodes 
 python3 -m sglang.launch_server --model-path /sgl-workspace//DeepSeek-V3-0324 --disable-overlap-schedule --disable-radix --tp 16 --dist-init-addr 29.226.50.190:20000 --host 0.0.0.0 --port 30000 --nnodes 2 --node-rank  ${RANK}  --trust-remote-code --enable-dp-attention --dp-size 16 --disable-custom-all-reduce --mem-fraction-static 0.60 --cuda-graph-max-bs 256 --enable-metrics --speculative-algo NEXTN --speculative-draft /sgl-workspace/SGLang/DeepSeek-V3-0324-NextN --max-running-requests 256 --chunked-prefill-size 16384 --speculative-num-steps 2 --speculative-eagle-topk 4 --speculative-num-draft-tokens 4 --watchdog-timeout 120
```
2. without mtp
```
# 2 h20 nodes
 python3 -m sglang.launch_server --model-path /sgl-workspace//DeepSeek-V3-0324 --disable-overlap-schedule --disable-radix --tp 16 --dist-init-addr 29.226.50.190:20000 --host 0.0.0.0 --port 30000 --nnodes 2 --node-rank ${RANK}  --trust-remote-code --enable-dp-attention --dp-size 16 --disable-custom-all-reduce --mem-fraction-static 0.60 --cuda-graph-max-bs 256 --enable-metrics  --max-running-requests 256 --chunked-prefill-size 16384  --watchdog-timeout 120
```

### test method
1. Use the GSM8K datasets
2. Testing steps:  First flush_cache, then call sglang.test.few_shot_gsm8k.run_eval to evaluate performance, num_shots=5,max_new_tokens=512.

### results
-  num_questions 500
<img width="802" alt="image" src="https://github.com/user-attachments/assets/3fe4bb5b-0542-47ce-af7d-151f358710c3" />

- num_questions  : 200
<img width="812" alt="image" src="https://github.com/user-attachments/assets/1aeefd50-ce0f-4394-a4a5-7d783180076c" />