### PR TITLE
[FIX] fix llmcompressor support

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -281,6 +281,12 @@ class ReplicatedLinear(LinearBase):
             fused_shapes=fused_shapes,
         )
 
+        # if "model.layers.52.self_attn.fused_qkv_a_proj_with_mqa" in prefix:
+        #     from remote_pdb import set_trace
+
+        #     set_trace()
+        #     pass
+
         # All the linear layer supports quant method.
         assert self.quant_method is not None
         self.quant_method.create_weights(

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -218,7 +218,7 @@ class LinearBase(torch.nn.Module):
     ):
         super().__init__()
 
-        # Debug context
+        # for debug prupose
         self.prefix = prefix
 
         # Keep input parameters

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -213,6 +213,8 @@ class LinearBase(torch.nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         fused_parameters: int = 0,
+        fused_rank: int = -1,
+        fused_shapes: tuple = (),
     ):
         super().__init__()
 
@@ -225,6 +227,9 @@ class LinearBase(torch.nn.Module):
         self.skip_bias_add = skip_bias_add
         # Fix to PR#5619, to create fused weight/input scalars with correct size
         self.fused_parameters = fused_parameters
+        # Fix to PR#5619, to apply fused scalars to each shards
+        self.fused_rank = fused_rank
+        self.fused_shapes = fused_shapes
         if params_dtype is None:
             params_dtype = torch.get_default_dtype()
         self.params_dtype = params_dtype
@@ -260,7 +265,9 @@ class ReplicatedLinear(LinearBase):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        fused_parameters: int = None,
+        fused_parameters: int = 0,
+        fused_rank: int = -1,
+        fused_shapes: tuple = (),
     ):
         super().__init__(
             input_size,
@@ -270,6 +277,8 @@ class ReplicatedLinear(LinearBase):
             quant_config,
             prefix=prefix,
             fused_parameters=fused_parameters,
+            fused_rank=fused_rank,
+            fused_shapes=fused_shapes,
         )
 
         # All the linear layer supports quant method.

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -212,21 +212,19 @@ class LinearBase(torch.nn.Module):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        layer_id: int = None,
-        fused_parameters: int=0,
+        fused_parameters: int = 0,
     ):
         super().__init__()
 
+        # Debug context
         self.prefix = prefix
-        self.layer_id = layer_id
 
         # Keep input parameters
         self.input_size = input_size
         self.output_size = output_size
         self.skip_bias_add = skip_bias_add
-        # To create fused weight/input scalars with correct size, a fix to PR#5619
-        self.fused_parameters = None
-        self.fused_parameters= fused_parameters
+        # Fix to PR#5619, to create fused weight/input scalars with correct size
+        self.fused_parameters = fused_parameters
         if params_dtype is None:
             params_dtype = torch.get_default_dtype()
         self.params_dtype = params_dtype
@@ -262,8 +260,7 @@ class ReplicatedLinear(LinearBase):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        layer_id : int = None,
-        fused_parameters : int = None,
+        fused_parameters: int = None,
     ):
         super().__init__(
             input_size,
@@ -271,8 +268,7 @@ class ReplicatedLinear(LinearBase):
             skip_bias_add,
             params_dtype,
             quant_config,
-            prefix=prefix, # DEBUG(yiakwy)
-            layer_id=layer_id, # DEBUG(yiakwy)
+            prefix=prefix,
             fused_parameters=fused_parameters,
         )
 
@@ -308,12 +304,6 @@ class ReplicatedLinear(LinearBase):
         if len(loaded_weight.shape) == 0:
             loaded_weight = loaded_weight.reshape(1)
 
-        if param.size() != loaded_weight.size():
-            from remote_pdb import set_trace
-            set_trace()
-            print("ups")
-            raise Exception("loaded weight should have the same size with pre-allocaed parameters!")
-            pass
         param.data.copy_(loaded_weight)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -227,7 +227,7 @@ class LinearBase(torch.nn.Module):
         self.skip_bias_add = skip_bias_add
         # Fix to PR#5619, to create fused weight/input scalars with correct size
         self.fused_parameters = fused_parameters
-        # Fix to PR#5619, to apply fused scalars to each shards
+        # Fix to PR#5619, to apply fused scalars to each shard
         self.fused_rank = fused_rank
         self.fused_shapes = fused_shapes
         if params_dtype is None:

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -212,13 +212,21 @@ class LinearBase(torch.nn.Module):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        layer_id: int = None,
+        fused_parameters: int=0,
     ):
         super().__init__()
+
+        self.prefix = prefix
+        self.layer_id = layer_id
 
         # Keep input parameters
         self.input_size = input_size
         self.output_size = output_size
         self.skip_bias_add = skip_bias_add
+        # To create fused weight/input scalars with correct size, a fix to PR#5619
+        self.fused_parameters = None
+        self.fused_parameters= fused_parameters
         if params_dtype is None:
             params_dtype = torch.get_default_dtype()
         self.params_dtype = params_dtype
@@ -254,6 +262,8 @@ class ReplicatedLinear(LinearBase):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        layer_id : int = None,
+        fused_parameters : int = None,
     ):
         super().__init__(
             input_size,
@@ -261,7 +271,9 @@ class ReplicatedLinear(LinearBase):
             skip_bias_add,
             params_dtype,
             quant_config,
-            prefix=prefix,
+            prefix=prefix, # DEBUG(yiakwy)
+            layer_id=layer_id, # DEBUG(yiakwy)
+            fused_parameters=fused_parameters,
         )
 
         # All the linear layer supports quant method.
@@ -296,7 +308,12 @@ class ReplicatedLinear(LinearBase):
         if len(loaded_weight.shape) == 0:
             loaded_weight = loaded_weight.reshape(1)
 
-        assert param.size() == loaded_weight.size()
+        if param.size() != loaded_weight.size():
+            from remote_pdb import set_trace
+            set_trace()
+            print("ups")
+            raise Exception("loaded weight should have the same size with pre-allocaed parameters!")
+            pass
         param.data.copy_(loaded_weight)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -281,12 +281,6 @@ class ReplicatedLinear(LinearBase):
             fused_shapes=fused_shapes,
         )
 
-        # if "model.layers.52.self_attn.fused_qkv_a_proj_with_mqa" in prefix:
-        #     from remote_pdb import set_trace
-
-        #     set_trace()
-        #     pass
-
         # All the linear layer supports quant method.
         assert self.quant_method is not None
         self.quant_method.create_weights(

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -683,22 +683,8 @@ def grouped_gemm_triton(
         assert len(block_shape) == 2
         block_n, block_k = block_shape[0], block_shape[1]
 
-        print(
-            f"[grouped_gemm_triton] a : shape={a.shape}, dtype={a.dtype}, scale_a={scale_a}, use_per_token_if_dynamic={use_per_token_if_dynamic}"
-        )
-
         if torch.finfo(a.dtype).bits > 8:
-            try:
-                a, scale_a = per_token_group_quant_fp8(a, block_k)
-            except Exception as e:
-                from remote_pdb import set_trace
-
-                set_trace()
-                pass
-
-            print(
-                f"[grouped_gemm_triton] scale_a : shape={scale_a.shape}, dtype={scale_a.dtype}"
-            )
+            a, scale_a = per_token_group_quant_fp8(a, block_k)
 
             assert triton.cdiv(a.shape[-1], block_k) == scale_a.shape[-1]
             assert triton.cdiv(b.shape[-2], block_n) == scale_b.shape[-2]
@@ -709,8 +695,6 @@ def grouped_gemm_triton(
             assert triton.cdiv(a.shape[-1], block_k) == scale_a.shape[-1]
             assert triton.cdiv(b.shape[-2], block_n) == scale_b.shape[-2]
             assert triton.cdiv(b.shape[-1], block_k) == scale_b.shape[-1]
-
-    print("[grouped_gemm_triton] here!")
 
     # TODO: adjust config or tune kernel
     # Reduce block size to prevent L40 shared memory overflow.
@@ -735,13 +719,6 @@ def grouped_gemm_triton(
     )
 
     if use_fp8_w8a8 and block_shape is None and use_per_token_if_dynamic:
-
-        if scale_a.shape[0] != a.shape[0]:
-            from remote_pdb import set_trace
-
-            set_trace()
-            pass
-
         assert (
             scale_a.shape[0] == a.shape[0]
         ), f"scale_a.shape: {scale_a.shape}, a.shape: {a.shape}"

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -123,21 +123,30 @@ class GroupedGemmRunner(torch.nn.Module):
             )
         else:
             assert weight_column_major == True
-            c = grouped_gemm_triton(
-                a,
-                b,
-                c,
-                batch_size,
-                weight_column_major,
-                seg_indptr,
-                weight_indices,
-                use_fp8_w8a8,
-                scale_a,
-                scale_b,
-                block_shape=block_shape,
-                c_dtype=c_dtype,
-                use_per_token_if_dynamic=self.use_per_token_if_dynamic,
-            )
+
+            try:
+                c = grouped_gemm_triton(
+                    a,
+                    b,
+                    c,
+                    batch_size,
+                    weight_column_major,
+                    seg_indptr,
+                    weight_indices,
+                    use_fp8_w8a8,
+                    scale_a,
+                    scale_b,
+                    block_shape=block_shape,
+                    c_dtype=c_dtype,
+                    # support broadcasting if self.use_per_token_if_dynamic is True
+                    use_per_token_if_dynamic=self.use_per_token_if_dynamic
+                    or block_shape is not None,
+                )
+            except Exception as e:
+                from remote_pdb import set_trace
+
+                set_trace()
+                pass
         return c
 
 
@@ -172,6 +181,9 @@ class EPMoE(torch.nn.Module):
     ):
         super().__init__()
 
+        # for debug prupose
+        self.prefix = prefix
+
         if params_dtype is None:
             params_dtype = torch.get_default_dtype()
 
@@ -205,6 +217,10 @@ class EPMoE(torch.nn.Module):
         self.routed_scaling_factor = routed_scaling_factor
         self.use_per_token_if_dynamic = use_per_token_if_dynamic
 
+        # NOTE(yiakwy) : record original config, later we will use CompressedEPMoEMethod to do the job,
+        # currently we just broadcasting tensor-wise scalars to adapt to deepgemm
+        self.quant_config = quant_config
+
         if quant_config is None:
             self.quant_method: Optional[QuantizeMethodBase] = UnquantizedEPMoEMethod()
             self.use_fp8_w8a8 = False
@@ -216,14 +232,22 @@ class EPMoE(torch.nn.Module):
                 quant_config
             )
             self.use_fp8_w8a8 = True
+
             self.use_block_quant = getattr(self.quant_method, "block_quant", False)
+
             self.block_shape = (
                 self.quant_method.quant_config.weight_block_size
                 if self.use_block_quant
                 else None
             )
             self.fp8_dtype = torch.float8_e4m3fn
-            self.activation_scheme = quant_config.activation_scheme
+            if not hasattr(quant_config, "activation_scheme"):
+                # (yiakwy) : weights static quantized, while input activation should be dynamic quantized
+                self.activation_scheme = "dynamic"
+                # (yiakwy) : will be used inside EPFp8 quantization method
+                setattr(quant_config, "activation_scheme", self.activation_scheme)
+            else:
+                self.activation_scheme = quant_config.activation_scheme
 
         self.quant_method.create_weights(
             layer=self,
@@ -501,6 +525,13 @@ class EPMoE(torch.nn.Module):
             device=hidden_states_device,
             dtype=torch.int64,
         )
+
+        if "model.layers.3.mlp.experts" in self.prefix:
+            from remote_pdb import set_trace
+
+            set_trace()
+            pass
+
         # GroupGemm-0
         gateup_output = self.grouped_gemm_runner(
             a=gateup_input,
@@ -844,7 +875,10 @@ class Fp8EPMoEMethod(Fp8MoEMethod):
 
     def __init__(self, quant_config: Fp8Config):
         self.quant_config = quant_config
-        self.block_quant = self.quant_config.weight_block_size is not None
+        if not hasattr(self.quant_config, "weight_block_size"):
+            self.block_quant = False
+        else:
+            self.block_quant = self.quant_config.weight_block_size is not None
 
     def create_weights(
         self,
@@ -917,6 +951,12 @@ class Fp8EPMoEMethod(Fp8MoEMethod):
                 ),
                 requires_grad=False,
             )
+
+            print("************************************")
+            print(
+                f"[Fp8EPMoEMethod] [block-wise] creating w_13_scale: {w13_weight_scale.shape}"
+            )
+
             w2_weight_scale = torch.nn.Parameter(
                 torch.ones(
                     num_experts_per_partition,
@@ -928,6 +968,7 @@ class Fp8EPMoEMethod(Fp8MoEMethod):
             )
             layer.register_parameter("w13_weight_scale_inv", w13_weight_scale)
             layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
+
             assert self.quant_config.activation_scheme == "dynamic"
         else:
             # WEIGHT_SCALES
@@ -937,6 +978,11 @@ class Fp8EPMoEMethod(Fp8MoEMethod):
                 requires_grad=False,
             )
             layer.register_parameter("w13_weight_scale", w13_weight_scale)
+
+            print("************************************")
+            print(
+                f"[Fp8EPMoEMethod] [tensor-wise] creating w_13_scale: {w13_weight_scale.shape}"
+            )
 
             w2_weight_scale = torch.nn.Parameter(
                 torch.ones(num_experts_per_partition, dtype=torch.float32),
@@ -1208,19 +1254,90 @@ class DeepEPMoE(EPMoE):
                 hidden_states.device, use_flashinfer=False  # TODO: use flashinfer
             )
 
-        if self.activation_scheme == "dynamic" and not self.use_block_quant:
-            max_value = (
-                torch.max(hidden_states)
-                .repeat(self.num_experts_per_partition)
-                .to(torch.float32)
-            )
-            self.w13_input_scale = max_value / torch.finfo(self.fp8_dtype).max
+        # from remote_pdb import set_trace
+        # set_trace()
+
+        if False and self.activation_scheme == "dynamic" and not self.use_block_quant:
+            try:
+                # NOTE (yiakwy) : wrong input_scale shape
+                # max_value = (
+                #     torch.max(hidden_states)
+                #     .repeat(self.num_experts_per_partition)
+                #     .to(torch.float32)
+                # )
+                max_value = (
+                    torch.max(hidden_states)
+                    .repeat(hidden_states.shape[0])
+                    .to(torch.float32)
+                )
+                self.w13_input_scale = max_value / torch.finfo(self.fp8_dtype).max
+            except Exception as e:
+                from remote_pdb import set_trace
+
+                set_trace()
+                pass
         weight_indices_cur_rank = torch.arange(
             0,
             self.num_experts_per_partition,
             device=hidden_states.device,
             dtype=torch.int64,
         )
+
+        # NOTE (yiakwy) : for the moment deepgeem only supports block_scaled_gemm
+        from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+            CompressedTensorsConfig,
+        )
+
+        w13_weight_scale = (
+            self.w13_weight_scale_inv if self.use_block_quant else self.w13_weight_scale
+        )
+        w2_weight_scale = (
+            self.w2_weight_scale_inv if self.use_block_quant else self.w2_weight_scale
+        )
+        block_shape = (
+            self.block_shape if self.block_shape is not None else [128, 128]
+        )  # self.quant_method.quant_config.weight_block_size
+        if isinstance(self.quant_method.quant_config, CompressedTensorsConfig):
+            # from remote_pdb import set_trace
+            # set_trace()
+
+            hidden_size = hidden_states.shape[1]  # 7168
+            intermediate_size = 2048
+
+            block_n, block_k = block_shape
+
+            def ceil_div(a, b):
+                return (a + b - 1) // b
+
+            batch_size = self.num_experts_per_partition
+
+            w1_scale_shard = (
+                self.w13_weight_scale[:, 0]
+                .view(batch_size, 1, 1)
+                .expand(
+                    batch_size,
+                    ceil_div(intermediate_size, block_n),
+                    ceil_div(hidden_size, block_k),
+                )
+            )
+            w3_scale_shard = (
+                self.w13_weight_scale[:, 1]
+                .view(batch_size, 1, 1)
+                .expand(
+                    batch_size,
+                    ceil_div(intermediate_size, block_n),
+                    ceil_div(hidden_size, block_k),
+                )
+            )
+
+            w13_weight_scale = torch.cat([w1_scale_shard, w3_scale_shard], dim=1)
+
+            w2_weight_scale = self.w2_weight_scale.view(batch_size, 1, 1).expand(
+                batch_size,
+                ceil_div(hidden_size, block_k),
+                ceil_div(intermediate_size, block_n),
+            )
+            pass
 
         # GroupGemm-0
         if hidden_states.shape[0] > 0:
@@ -1238,9 +1355,9 @@ class DeepEPMoE(EPMoE):
                 scale_b=(
                     self.w13_weight_scale_inv
                     if self.use_block_quant
-                    else self.w13_weight_scale
+                    else w13_weight_scale
                 ),
-                block_shape=self.block_shape,
+                block_shape=block_shape,
             )
         else:
             gateup_output = torch.empty(
@@ -1292,6 +1409,8 @@ class DeepEPMoE(EPMoE):
             dtype=hidden_states_dtype,
         )
         if down_input.shape[0] > 0:
+            # from remote_pdb import set_trace
+            # set_trace()
             down_output = self.grouped_gemm_runner(
                 a=down_input,
                 b=self.w2_weight,
@@ -1305,9 +1424,9 @@ class DeepEPMoE(EPMoE):
                 scale_b=(
                     self.w2_weight_scale_inv
                     if self.use_block_quant
-                    else self.w2_weight_scale
+                    else w2_weight_scale
                 ),
-                block_shape=self.block_shape,
+                block_shape=block_shape,
             )
         return down_output
 

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -34,6 +34,9 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (  # Note (yiakwy) : `CompressedTensorsMoEMethod`` will be supported soon
+    CompressedTensorsConfig,
+)
 from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8MoEMethod
 from sglang.srt.layers.quantization.fp8_kernel import (
     is_fp8_fnuz,
@@ -174,7 +177,7 @@ class EPMoE(torch.nn.Module):
     ):
         super().__init__()
 
-        # for debug prupose
+        # for debug purpose
         self.prefix = prefix
 
         if params_dtype is None:
@@ -860,9 +863,12 @@ class Fp8EPMoEMethod(Fp8MoEMethod):
         quant_config: The quantization config.
     """
 
-    def __init__(self, quant_config: Fp8Config):
+    def __init__(self, quant_config: Fp8Config | CompressedTensorsConfig):
         self.quant_config = quant_config
-        if not hasattr(self.quant_config, "weight_block_size"):
+        if (
+            not hasattr(self.quant_config, "weight_block_size")
+            and self.quant_config.weight_block_size is not None
+        ):
             self.block_quant = False
         else:
             self.block_quant = self.quant_config.weight_block_size is not None

--- a/python/sglang/srt/layers/parameter.py
+++ b/python/sglang/srt/layers/parameter.py
@@ -50,10 +50,6 @@ class BasevLLMParameter(Parameter):
         return self._weight_loader
 
     def _assert_and_load(self, loaded_weight: torch.Tensor):
-        if self.data.shape != loaded_weight.shape:
-            from remote_pdb import set_trace
-            set_trace()
-
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)
 

--- a/python/sglang/srt/layers/parameter.py
+++ b/python/sglang/srt/layers/parameter.py
@@ -50,6 +50,10 @@ class BasevLLMParameter(Parameter):
         return self._weight_loader
 
     def _assert_and_load(self, loaded_weight: torch.Tensor):
+        if self.data.shape != loaded_weight.shape:
+            from remote_pdb import set_trace
+            set_trace()
+
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -119,6 +119,17 @@ class CompressedTensorsConfig(QuantizationConfig):
         prefix: str,
     ) -> Optional["QuantizeMethodBase"]:
 
+        # (DEBUG) yiakwy : remove
+        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+        from sglang.srt.models.deepseek_v2 import ReplicatedLinear
+
+        if isinstance(layer, ReplicatedLinear) and \
+            hasattr(layer, "prefix") and "fused_qkv_a_proj_with_mqa" in layer.prefix and \
+            hasattr(layer, "layer_id") and layer.layer_id == 52:
+            # from remote_pdb import set_trace
+            # set_trace()
+            pass
+
         # Check if the layer is skipped for quantization.
         # TODO (@robertgshaw2): support module names
         if should_ignore_layer(
@@ -634,6 +645,17 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
         the necessary parameters for the layer. See LinearMethodBase for param
         details
         """
+        
+        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+        from sglang.srt.models.deepseek_v2 import ReplicatedLinear
+
+        if isinstance(layer, ReplicatedLinear) and \
+            hasattr(layer, "prefix") and "fused_qkv_a_proj_with_mqa" in layer.prefix and \
+            hasattr(layer, "layer_id") and layer.layer_id == 52:
+            # from remote_pdb import set_trace
+            # set_trace()
+            pass
+
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.scheme.create_weights(
             layer=layer,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -118,18 +118,6 @@ class CompressedTensorsConfig(QuantizationConfig):
         layer: torch.nn.Module,
         prefix: str,
     ) -> Optional["QuantizeMethodBase"]:
-
-        # (DEBUG) yiakwy : remove
-        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
-        from sglang.srt.models.deepseek_v2 import ReplicatedLinear
-
-        if isinstance(layer, ReplicatedLinear) and \
-            hasattr(layer, "prefix") and "fused_qkv_a_proj_with_mqa" in layer.prefix and \
-            hasattr(layer, "layer_id") and layer.layer_id == 52:
-            # from remote_pdb import set_trace
-            # set_trace()
-            pass
-
         # Check if the layer is skipped for quantization.
         # TODO (@robertgshaw2): support module names
         if should_ignore_layer(
@@ -645,17 +633,6 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
         the necessary parameters for the layer. See LinearMethodBase for param
         details
         """
-        
-        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
-        from sglang.srt.models.deepseek_v2 import ReplicatedLinear
-
-        if isinstance(layer, ReplicatedLinear) and \
-            hasattr(layer, "prefix") and "fused_qkv_a_proj_with_mqa" in layer.prefix and \
-            hasattr(layer, "layer_id") and layer.layer_id == 52:
-            # from remote_pdb import set_trace
-            # set_trace()
-            pass
-
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.scheme.create_weights(
             layer=layer,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -106,7 +106,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.weight_scheme = weight_scheme
 
         # NOTE(yiakwy) : blockScale is not supported now , will be added soon; temp work around is broadcsating tensor-wise scalars
-        # self.weight_block_size = (128, 128)
+        self.weight_block_size = None
 
     def get_linear_method(self) -> "CompressedTensorsLinearMethod":
         return CompressedTensorsLinearMethod(self)

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -85,6 +85,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         kv_cache_scheme: Optional[Dict[str, Any]] = None,
         config: Optional[Dict[str, Any]] = None,
         packed_modules_mapping: Dict[str, List[str]] = {},
+        is_checkpoint_fp8_serialized: bool = False,
+        activation_scheme: str = "dynamic",
+        weight_scheme: str = "static",
     ):
         super().__init__()
         self.ignore = ignore
@@ -96,6 +99,14 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.sparsity_ignore_list = sparsity_ignore_list
         self.config = config
         self.packed_modules_mapping = packed_modules_mapping
+
+        # NOTE(yiakwy) : ref to FP8Config
+        self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
+        self.activation_scheme = activation_scheme
+        self.weight_scheme = weight_scheme
+
+        # NOTE(yiakwy) : blockScale is not supported now , will be added soon; temp work around is broadcsating tensor-wise scalars
+        # self.weight_block_size = (128, 128)
 
     def get_linear_method(self) -> "CompressedTensorsLinearMethod":
         return CompressedTensorsLinearMethod(self)
@@ -146,6 +157,27 @@ class CompressedTensorsConfig(QuantizationConfig):
         )
         packed_modules_mapping = config.get("packed_modules_mapping", {})
 
+        is_checkpoint_fp8_serialized = False
+
+        for _, group in config["config_groups"].items():
+            weight_desc = group["weights"]
+            num_bits_desc = weight_desc["num_bits"]
+
+            if num_bits_desc == 8:
+                is_checkpoint_fp8_serialized = True
+                break
+
+        # (yiakwy) : weights static quantized, while input activation should be dynamic quantized
+        activation_scheme = "dynamic"
+        weight_scheme = "static"
+
+        for _, group in config["config_groups"].items():
+            act_desc = group["input_activations"]
+            weight_desc = group["weights"]
+
+            activation_scheme = "dynamic" if act_desc["dynamic"] else "static"
+            weight_scheme = "dynamic" if weight_desc["dynamic"] else "static"
+
         return cls(
             target_scheme_map=target_scheme_map,
             ignore=ignore,
@@ -154,6 +186,9 @@ class CompressedTensorsConfig(QuantizationConfig):
             sparsity_ignore_list=sparsity_ignore_list,
             config=config,
             packed_modules_mapping=packed_modules_mapping,
+            is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
+            activation_scheme=activation_scheme,
+            weight_scheme=weight_scheme,
         )
 
     @classmethod

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -117,9 +117,7 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
 
             return rectified_weight, rectified_weight_scale
 
-        # if "model.layers.52.self_attn.fused_qkv_a_proj_with_mqa" in layer.prefix:
         if "fused_qkv_a_proj_with_mqa" in layer.prefix:
-            # from remote_pdb import set_trace
 
             # See DeepSeek V2
             assert layer.fused_parameters == 2
@@ -143,8 +141,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
                     [layer.fused_shapes[1]],
                 )
             )
-
-            # set_trace()
 
             # assigned merged weights back
             merged_weight = torch.cat(
@@ -252,12 +248,6 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-
-        # if "model.layers.52.self_attn.fused_qkv_a_proj_with_mqa" in layer.prefix:
-        #     from remote_pdb import set_trace
-
-        #     set_trace()
-        #     pass
 
         # NOTE (fallback to non-fused solution) : concat([input * w[:shard1] * w_shard1_scale, input * w[shart1:shart1+shart2] * w_shard2_scale], dim=1)
         # Will write kernel to improve it later

--- a/python/sglang/srt/layers/quantization/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/quantization/deep_gemm_wrapper/configurer.py
@@ -25,7 +25,12 @@ try:
     from deep_gemm import fp8_gemm_nt
 
     # They have not given a name to this breaking change
-    DEEPGEMM_BLACKWELL = True
+    sm_version = get_device_sm()
+    if sm_version < 90:
+        # deep_gemm.fp8_gemm_nt can also be imported in SM90 chip
+        DEEPGEMM_BLACKWELL = False
+    else:
+        DEEPGEMM_BLACKWELL = True
 except ImportError:
     DEEPGEMM_BLACKWELL = False
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -420,12 +420,6 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-
-        # if "model.layers.52.self_attn.fused_qkv_a_proj_with_mqa" in layer.prefix:
-        #     from remote_pdb import set_trace
-        #     set_trace()
-        #     pass
-
         if self.use_marlin:
             return apply_fp8_marlin_linear(
                 input=x,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -421,6 +421,11 @@ class Fp8LinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
+        # if "model.layers.52.self_attn.fused_qkv_a_proj_with_mqa" in layer.prefix:
+        #     from remote_pdb import set_trace
+        #     set_trace()
+        #     pass
+
         if self.use_marlin:
             return apply_fp8_marlin_linear(
                 input=x,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -476,6 +476,22 @@ def _process_scaled_mm_output(output, input_2d_shape, output_shape):
     return torch.narrow(output, 0, 0, input_2d_shape[0]).view(*output_shape)
 
 
+def _is_column_major(tensor: torch.Tensor):
+    return tensor.stride()[0] == 1 and tensor.stride()[1] > 1
+
+
+def _clone_in_column_major(tensor: torch.Tensor):
+    shape = tensor.shape
+
+    assert len(shape) == 2
+
+    M, N = shape
+    cloned_tensor = torch.empty((N, M), device=tensor.device, dtype=tensor.dtype)
+    cloned_tensor = torch.transpose(cloned_tensor, 0, 1)
+    cloned_tensor[:] = tensor[:]
+    return cloned_tensor
+
+
 def _apply_fallback_scaled_mm(
     qinput,
     weight,
@@ -490,13 +506,26 @@ def _apply_fallback_scaled_mm(
     if TORCH_DEVICE_IDENTITY is None:
         TORCH_DEVICE_IDENTITY = torch.ones(1, dtype=torch.float32, device=weight.device)
 
-    output = torch._scaled_mm(
-        qinput,
-        weight,
-        scale_a=TORCH_DEVICE_IDENTITY,
-        scale_b=TORCH_DEVICE_IDENTITY,
-        out_dtype=torch.float32,
-    )
+    try:
+
+        if not _is_column_major(weight):
+            cloned_weight = _clone_in_column_major(weight)
+        else:
+            cloned_weight = weight
+
+        output = torch._scaled_mm(
+            qinput,
+            cloned_weight,
+            scale_a=TORCH_DEVICE_IDENTITY,
+            scale_b=TORCH_DEVICE_IDENTITY,
+            out_dtype=torch.float32,
+        )
+
+    except Exception as e:
+        from remote_pdb import set_trace
+
+        set_trace()
+        pass
 
     output = _process_scaled_mm_output(output, input_2d_shape, output_shape)
     x_scale = torch.narrow(x_scale, 0, 0, input_2d_shape[0])

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -506,26 +506,18 @@ def _apply_fallback_scaled_mm(
     if TORCH_DEVICE_IDENTITY is None:
         TORCH_DEVICE_IDENTITY = torch.ones(1, dtype=torch.float32, device=weight.device)
 
-    try:
+    if not _is_column_major(weight):
+        cloned_weight = _clone_in_column_major(weight)
+    else:
+        cloned_weight = weight
 
-        if not _is_column_major(weight):
-            cloned_weight = _clone_in_column_major(weight)
-        else:
-            cloned_weight = weight
-
-        output = torch._scaled_mm(
-            qinput,
-            cloned_weight,
-            scale_a=TORCH_DEVICE_IDENTITY,
-            scale_b=TORCH_DEVICE_IDENTITY,
-            out_dtype=torch.float32,
-        )
-
-    except Exception as e:
-        from remote_pdb import set_trace
-
-        set_trace()
-        pass
+    output = torch._scaled_mm(
+        qinput,
+        cloned_weight,
+        scale_a=TORCH_DEVICE_IDENTITY,
+        scale_b=TORCH_DEVICE_IDENTITY,
+        out_dtype=torch.float32,
+    )
 
     output = _process_scaled_mm_output(output, input_2d_shape, output_shape)
     x_scale = torch.narrow(x_scale, 0, 0, input_2d_shape[0])

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -736,20 +736,12 @@ class DeepseekV2AttentionMLA(nn.Module):
 
         # For tensor parallel attention
         if self.q_lora_rank is not None:
-
-            # DEBUG (yiakwy) : remove
-            # if layer_id == 52:
-            #     from remote_pdb import set_trace
-            #     set_trace()
-            #     pass
-
             self.fused_qkv_a_proj_with_mqa = ReplicatedLinear(
                 self.hidden_size,
                 self.q_lora_rank + self.kv_lora_rank + self.qk_rope_head_dim,
                 bias=False,
                 quant_config=quant_config,
                 prefix=add_prefix("fused_qkv_a_proj_with_mqa", prefix),
-                layer_id=layer_id,
                 fused_parameters=2,
             )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -378,10 +378,6 @@ class DeepseekV2MoE(nn.Module):
     def forward(
         self, hidden_states: torch.Tensor, forward_batch: Optional[ForwardBatch] = None
     ) -> torch.Tensor:
-
-        # from remote_pdb import set_trace
-        # set_trace()
-
         if not self._enable_deepep_moe:
             DUAL_STREAM_TOKEN_THRESHOLD = 1024
             if (

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -251,6 +251,9 @@ class DeepseekV2MoE(nn.Module):
         self.layer_id = layer_id
         self.alt_stream = alt_stream
 
+        # for debug purpose
+        self.prefix = prefix
+
         if self.tp_size > config.n_routed_experts:
             raise ValueError(
                 f"Tensor parallel size {self.tp_size} is greater than "
@@ -375,6 +378,10 @@ class DeepseekV2MoE(nn.Module):
     def forward(
         self, hidden_states: torch.Tensor, forward_batch: Optional[ForwardBatch] = None
     ) -> torch.Tensor:
+
+        # from remote_pdb import set_trace
+        # set_trace()
+
         if not self._enable_deepep_moe:
             DUAL_STREAM_TOKEN_THRESHOLD = 1024
             if (
@@ -531,6 +538,7 @@ class DeepseekV2MoE(nn.Module):
                 topk_weights=topk_weights,
                 forward_mode=forward_mode,
             )
+
         final_hidden_states = self.experts(
             hidden_states=hidden_states,
             topk_idx=topk_idx,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -736,12 +736,21 @@ class DeepseekV2AttentionMLA(nn.Module):
 
         # For tensor parallel attention
         if self.q_lora_rank is not None:
+
+            # DEBUG (yiakwy) : remove
+            # if layer_id == 52:
+            #     from remote_pdb import set_trace
+            #     set_trace()
+            #     pass
+
             self.fused_qkv_a_proj_with_mqa = ReplicatedLinear(
                 self.hidden_size,
                 self.q_lora_rank + self.kv_lora_rank + self.qk_rope_head_dim,
                 bias=False,
                 quant_config=quant_config,
                 prefix=add_prefix("fused_qkv_a_proj_with_mqa", prefix),
+                layer_id=layer_id,
+                fused_parameters=2,
             )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -744,12 +744,6 @@ class DeepseekV2AttentionMLA(nn.Module):
 
         # For tensor parallel attention
         if self.q_lora_rank is not None:
-
-            if layer_id == 52:
-                print(
-                    f"[{prefix}.fused_qkv_a_proj_with_mqa] q_lora_rank : {self.q_lora_rank}, latent : {self.kv_lora_rank + self.qk_rope_head_dim}, hidden_size : {hidden_size}"
-                )
-
             self.fused_qkv_a_proj_with_mqa = ReplicatedLinear(
                 self.hidden_size,
                 self.q_lora_rank + self.kv_lora_rank + self.qk_rope_head_dim,

--- a/python/sglang/srt/torch_memory_saver_adapter.py
+++ b/python/sglang/srt/torch_memory_saver_adapter.py
@@ -11,7 +11,13 @@ try:
     import_error = None
 except ImportError as e:
     import_error = e
-    pass
+except AttributeError as e:
+    # NOTE (yiakwy) : the lib torch_memory_saver is not properly tracked
+    if hasattr(torch_memory_saver, "TorchMemorySaver"):
+        _memory_saver = torch_memory_saver.TorchMemorySaver
+        import_error = None
+    else:
+        raise e
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

We use H800x(few hundreds) SupPod in HKUST to carry out DeepSeekV3 alignment tasks by upgrading model to bf16 before training then quantize the model from bf16 to fp8 (full f8 training will be coming soon).

With **llm_compressor** format support since v0.4.4.post2 by [PR#4743](https://github.com/sgl-project/sglang/pull/4743) , we can successfully launch deepseekV3 in 2x8 H800 nodes in v0.4.4.post2 and perform tuning by resolving circular dependencies (see [circular dependency fix](
 https://github.com/sgl-project/sglang/compare/v0.4.4.post2...yiakwy-xpu-ml-framework-team:AMD-sglang-benchmark-fork:v0.4.4.post2_fix_circular_reference?expand=1
) ).

However this support broken after EPMoE and other features merged (mainly with issues from quantizaiton config).

To serve the model with latest P/D DeepEP arch, I just rebase the codes to the latest v0.4.7 (with this fix). This fix can deal with llmpreprosssor quantization format correctly:

- add "compressor_tensor" format support when loading weights
- quick fix to [PR#5619 ](https://github.com/sgl-project/sglang/pull/5619); the pr reduces MLA KV latent parameters , however the corresponding **compressTensor format** does not create tensorwise scalar correctly;
- enable EpMoE ("--dp 2 --enable-dp-attention") when serving model with **compressed_tensors** format by broadcasting offline tuned tensor-wise weight scalar paramters (block-wise compressed-tensor support will come soon!)

**Correctness Issue of PR#5619 when used with compressed tensor format**

Passed correctness test in v0.4.4.post2 
<img width="800" alt="截屏2025-06-18 10 33 01" src="https://github.com/user-attachments/assets/d63e38da-b19c-48b9-bdd0-d74ff1eba5f3" />

Failed to pass test in v0.4.7 after [PR#5619 ](https://github.com/sgl-project/sglang/pull/5619)
<img width="800" alt="截屏2025-06-17 18 36 20" src="https://github.com/user-attachments/assets/94810ccb-83e3-4fa5-a2b9-c3ffa7f9ded8" />

#### Correctness Verification

After the fix, we can serve both deepseek v3 and finetuend model w, w/o compressed tensor format w, w/o enabling EpMoE :

<img width="800" alt="截屏2025-06-26 05 39 06" src="https://github.com/user-attachments/assets/c750eaa2-4751-4de1-af9b-cae18e4e565b" />

###### server

```
if [ $HOSTNAME == "dgx-008" ]; then
    RANK=0
fi 

if [ $HOSTNAME == "dgx-035" ]; then
    RANK=1
fi

LOG_DIR=/workspace/logs
mkdir -p $LOG_DIR

# MAPPED_MODEL_PATH=YOUR_MODEL
# template=YOUR_MODEL/tool_chat_template_deepseekv3.jinja

MAPPED_MODEL_PATH=/root/models/DeepSeek-V3-0324
template=$MAPPED_MODEL_PATH/tool_chat_template_deepseekv3.jinja

MASTER_ADDR="10.33.4.82"
MASTER_PORT=5000

sglang_args=$(echo -m sglang.launch_server \
  --model-path $MAPPED_MODEL_PATH \
  --dist-init-addr $MASTER_ADDR:$MASTER_PORT \
  --nnodes 2 --node-rank $RANK --tp 16 \
  --enable-deepep-moe --deepep-mode normal --disable-cuda-graph \
  --dp 2 --enable-dp-attention \
  --trust-remote-code --host "0.0.0.0" --port 30000 \
  --log-requests --served-model-name DeepSeek-0324 \
  --context-length 65536 --max-running-requests 128 \
  --allow-auto-truncate --tool-call-parser deepseekv3
)

sglang_args=($sglang_args)

SGL_ENABLE_JIT_DEEPGEMM=0 python "${sglang_args[@]}" 2>&1 | tee $LOG_DIR/$RANK.log
```

###### client

```
curl http://localhost:30000/generate   -H "Content-Type: application/json"  -d '{
    "text": "Once upon a time,",
    "sampling_params": {
      "max_new_tokens": 16,
      "temperature": 0
    }
  }'
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

The modificaiton mainly related to two modules:

- Quantization Format
- EPMoE

#### Using Compressed Tensor Format vs FP8 Dynamic

For linear layers,

![DeepSeek FP8 Dynamic Workflow vs Compressed Tensor](https://github.com/user-attachments/assets/5717ede4-8e17-45f0-b745-18d792358fd3)

After fix , we reserve 2 parameters for tensor-wise quantization work-flow to resolve precision issue. 

When `EPMoE` is enabled (with "--enable-deepep-moe --deepep-mode normal" in server side) , currently `Fp8EPMoEMethod` is used block-wise quantization. This assumption broke the current flexible design, hence only compatible quantization format is supported (with block_scales).

By mocking `block_scale_size` or adapting the module with compressed tensor method, we can support model quantized from bf16 using llmcompressor.

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
