### PR TITLE
Bug Fix: Inconsistent Return Values in MiniCPMV Class

### DIFF
--- a/python/sglang/srt/models/minicpmv.py
+++ b/python/sglang/srt/models/minicpmv.py
@@ -823,15 +823,23 @@ class MiniCPMV:
 
     def __getattr__(self, name):
         if name == "minicpmv":
-            return None
-        return getattr(self.minicpmv, name)
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
+        attr = getattr(self.minicpmv, name)
+
+        if callable(attr):
+            def wrapper(*args, **kwargs):
+                result = attr(*args, **kwargs)
+                if result is self.minicpmv:
+                    return self
+                return result
+            return wrapper
+        else:
+            return attr
 
     def __call__(self, *args, **kwargs):
         return self.minicpmv(*args, **kwargs)
-
-    def eval(self):
-        self.minicpmv.eval()
-        return self
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [

--- a/python/sglang/srt/models/minicpmv.py
+++ b/python/sglang/srt/models/minicpmv.py
@@ -829,6 +829,10 @@ class MiniCPMV:
     def __call__(self, *args, **kwargs):
         return self.minicpmv(*args, **kwargs)
 
+    def eval(self):
+        self.minicpmv.eval()
+        return self
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)


### PR DESCRIPTION
**Bug Fix: Inconsistent Return Values in `MiniCPMV` Class**

**Issue:**
The current implementation of the `MiniCPMV` class has a bug where method calls like `model.eval()` and `model.train()` return `self.minicpmv` instead of `self`. This inconsistency breaks the chain call pattern, as the return value is not the `MiniCPMV` instance itself, leading to unexpected behavior when chaining methods.

**Impact:**

- **Chain Call Inconsistency:** Methods that should return `self` for chain calls instead return the internal `minicpmv` instance, disrupting the expected behavior of method chaining.
- **Unexpected Behavior:** Users may encounter errors or unexpected results when trying to chain methods, as the return value is not the `MiniCPMV` instance.
- **Method Availability:** When `model.eval()` is called, the type of `model` changes, causing subsequent calls to methods like `model.load_weights` to fail, as the method is no longer available. This affects subsequent calls like `update_weights_from_tensor`.

**Scope:**
This bug is specific to the `python/sglang/srt/models/minicpmv.py` file, as it is a proxy class design.

**Proposed Fix:**

- **Quick Fix:** Add a `def eval()` method that calls `forward` to ensure the return value is `self`.
- **Comprehensive Fix:** Modify the `__getattr__` implementation to ensure that methods like `eval()` and `train()` return `self`, maintaining the integrity of the `MiniCPMV` class and providing a more intuitive API for users.

**Minimal Reproducible Code for the Bug:**

```python
from sglang.srt.configs.model_config import ModelConfig
from sglang.srt.model_executor.model_runner import ModelRunner
from sglang.srt.server_args import PortArgs, ServerArgs
import logging
logging.basicConfig(level=logging.INFO)

def load_model(server_args, port_args, tp_rank):
    model_config = ModelConfig.from_server_args(server_args)
    model_runner = ModelRunner(
        model_config=model_config,
        mem_fraction_static=server_args.mem_fraction_static,
        gpu_id=tp_rank,
        tp_rank=tp_rank,
        tp_size=server_args.tp_size,
        pp_rank=0,
        pp_size=1,
        nccl_port=port_args.nccl_port,
        server_args=server_args
    )
    return model_runner

if __name__ == "__main__":
    server_args = ServerArgs(
        model_path="openbmb/MiniCPM-v-2_6",
        trust_remote_code=True,
    )
    port_args = PortArgs.init_new(server_args)

    print("开始加载模型...")
    model_runner = load_model(server_args, port_args, tp_rank=0)
    logging.info(f"after loading,model_runner.model.load_weights={hasattr(model_runner.model, 'load_weights')}")
    assert hasattr(model_runner.model, "load_weights"), "model_runner.model.load_weights got lost"
    print("模型加载完成！")
```


```shell
INFO:sglang.srt.model_executor.model_runner:Capture cuda graph end. Time elapsed: 6.49 s. mem usage=1.86 GB. avail mem=13.55 GB.
INFO:root:after loading,model_runner.model.load_weights=False
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/linaro/workspace/sglang/runs/units/fixcpmv.py", line 32, in <module>
[rank0]:     assert hasattr(model_runner.model, "load_weights"), "model_runner.model.load_weights got lost"
[rank0]: AssertionError: model_runner.model.load_weights got lost
```
