### PR TITLE
ci: Fix test_ebnf_generate_all_optional_function_params

### DIFF
--- a/test/srt/test_ebnf_constrained.py
+++ b/test/srt/test_ebnf_constrained.py
@@ -250,17 +250,17 @@ class TestEBNFConstrained(CustomTestCase):
         # Test patterns that should match - flexible ordering of optional parameters
         allowed_patterns = [
             # Empty arguments
-            r'^\{"name":"config_service", "arguments":\{\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{\}\}$',
             # Single optional parameters (any can appear first)
-            r'^\{"name":"config_service", "arguments":\{"theme":"(light|dark)"\}\}$',
-            r'^\{"name":"config_service", "arguments":\{"language":"(en|es|fr)"\}\}$',
-            r'^\{"name":"config_service", "arguments":\{"notifications":(true|false)\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"theme":"(light|dark)"\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"language":"(en|es|fr)"\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"notifications":(true|false)\}\}$',
             # Two optional parameters (in any order)
-            r'^\{"name":"config_service", "arguments":\{"theme":"(light|dark)", "language":"(en|es|fr)"\}\}$',
-            r'^\{"name":"config_service", "arguments":\{"theme":"(light|dark)", "notifications":(true|false)\}\}$',
-            r'^\{"name":"config_service", "arguments":\{"language":"(en|es|fr)", "notifications":(true|false)\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"theme":"(light|dark)",\s*"language":"(en|es|fr)"\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"theme":"(light|dark)",\s*"notifications":(true|false)\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"language":"(en|es|fr)",\s*"notifications":(true|false)\}\}$',
             # All three optional parameters
-            r'^\{"name":"config_service", "arguments":\{"theme":"(light|dark)", "language":"(en|es|fr)", "notifications":(true|false)\}\}$',
+            r'^\{"name":"config_service",\s*"arguments":\{"theme":"(light|dark)",\s*"language":"(en|es|fr)",\s*"notifications":(true|false)\}\}$',
         ]
         prompt = "Configure the service with optional settings:"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
The CI failed [here](https://github.com/sgl-project/sglang/actions/runs/15717655035/job/44291325000) because the output

```
{"name":"config_service", "arguments":{"language":"en","notifications":true}}` failed to match the pattern
```

failed to match the pattern

```
r'^\{"name":"config_service", "arguments":\{"language":"(en|es|fr)", "notifications":(true|false)\}\}$'
```

The problem is spacing. The regex pattern expects a space after the comma:

```
"language":"(en|es|fr)", "notifications":(true|false)
                        ↑ space here
```

But the actual generated JSON has no space after the comma:

```
"language":"en","notifications":true
               ↑ no space here
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
- Add \s* check to allow space / no space in the arguments

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
