### PR TITLE
Support dp attention in distributed weights syncing, and gpu remapping

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -987,11 +987,16 @@ class TokenizerManager:
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
-        assert (
-            self.server_args.dp_size == 1
-        ), "dp_size must be 1 for init parameter update group"
-        result = (await self.init_weights_update_group_communicator(obj))[0]
-        return result.success, result.message
+
+        results = await self.init_weights_update_group_communicator(obj)
+        if self.server_args.dp_size == 1:
+            result = results[0]
+            return result.success, result.message
+        else:
+            all_success = all([r.success for r in results])
+            all_message = [r.message for r in results]
+            all_message = " | ".join(all_message)
+            return all_success, all_message
 
     async def update_weights_from_distributed(
         self,
@@ -999,9 +1004,6 @@ class TokenizerManager:
         request: Optional[fastapi.Request] = None,
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
-        assert (
-            self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
-        ), "dp_size must be 1 or dp attention must be enabled for update weights from distributed"
 
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
@@ -1009,8 +1011,15 @@ class TokenizerManager:
         # This means that weight sync
         # cannot run while requests are in progress.
         async with self.model_update_lock.writer_lock:
-            result = (await self.update_weights_from_distributed_communicator(obj))[0]
-            return result.success, result.message
+            results = await self.update_weights_from_distributed_communicator(obj)
+            if self.server_args.dp_size == 1:
+                result = results[0]
+                return result.success, result.message
+            else:
+                all_success = all([r.success for r in results])
+                all_message = [r.message for r in results]
+                all_message = " | ".join(all_message)
+                return all_success, all_message
 
     async def update_weights_from_tensor(
         self,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -66,6 +66,7 @@ class TpModelWorker:
         self.tp_size = server_args.tp_size
         self.tp_rank = tp_rank
         self.pp_rank = pp_rank
+        self.dp_rank = dp_rank
 
         # Init model and tokenizer
         self.model_config = ModelConfig.from_server_args(
@@ -86,6 +87,8 @@ class TpModelWorker:
             tp_size=server_args.tp_size,
             pp_rank=pp_rank,
             pp_size=server_args.pp_size,
+            dp_rank=dp_rank,
+            dp_size=server_args.dp_size,
             nccl_port=nccl_port,
             server_args=server_args,
             is_draft_worker=is_draft_worker,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -779,7 +779,10 @@ class ModelRunner:
         ), "Default torch process group must be initialized"
         assert group_name != "", "Group name cannot be empty"
 
-        rank = rank_offset + self.tp_rank + self.dp_rank * self.tp_size
+        if self.server_args.enable_dp_attention:
+            rank = rank_offset + self.tp_rank
+        else:
+            rank = rank_offset + self.tp_rank + self.dp_rank * self.tp_size
 
         logger.info(
             f"init custom process group: master_address={master_address}, master_port={master_port}, "
@@ -793,6 +796,7 @@ class ModelRunner:
                 world_size=world_size,
                 rank=rank,
                 group_name=group_name,
+                device_id=self.gpu_id,
             )
             return True, "Succeeded to initialize custom process group."
         except Exception as e:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -159,6 +159,8 @@ class ModelRunner:
         tp_size: int,
         pp_rank: int,
         pp_size: int,
+        dp_rank: int,
+        dp_size: int,
         nccl_port: int,
         server_args: ServerArgs,
         is_draft_worker: bool = False,
@@ -179,6 +181,8 @@ class ModelRunner:
         self.pp_rank = pp_rank
         self.pp_size = pp_size
         self.model_config = model_config
+        self.dp_rank = dp_rank
+        self.dp_size = dp_size
         self.dist_port = nccl_port
         self.server_args = server_args
         self.is_draft_worker = is_draft_worker
@@ -775,7 +779,7 @@ class ModelRunner:
         ), "Default torch process group must be initialized"
         assert group_name != "", "Group name cannot be empty"
 
-        rank = rank_offset + self.tp_rank
+        rank = rank_offset + self.tp_rank + self.dp_rank * self.tp_size
 
         logger.info(
             f"init custom process group: master_address={master_address}, master_port={master_port}, "

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1496,6 +1496,7 @@ def init_custom_process_group(
     store=None,
     group_name=None,
     pg_options=None,
+    device_id=-1,
 ):
     from torch.distributed.distributed_c10d import (
         Backend,
@@ -1524,6 +1525,11 @@ def init_custom_process_group(
     if timeout is None:
         timeout = default_pg_timeout
 
+    if device_id >= 0:
+        device_idx = torch.device(f"cuda:{device_id}")
+    else:
+        device_idx = torch.device(f"cuda:{0}")
+
     # backward compatible API
     if store is None:
         rendezvous_iterator = rendezvous(init_method, rank, world_size, timeout=timeout)
@@ -1549,6 +1555,7 @@ def init_custom_process_group(
         group_name=group_name,
         **{pg_options_param_name: pg_options},
         timeout=timeout,
+        device_id=device_idx,
     )
 
     _world.pg_group_ranks[pg] = {i: i for i in range(world_size)}


### PR DESCRIPTION
This PR addresses two issues:

1. The first issue: It enables SgLang to support DP (Data Parallelism) and DP Attention when weights are transmitted via NCCL. This is a necessary feature for running Bailing LLM internally at Ant Group. I believe that the functionality of enabling DPA (Data Parallel Attention) with NCCL weight transfer would also be in demand by other companies.
    
2. The second issue is: When creating an NCCL communication group, failing to specify the device ID for the newly created weight communication group can cause an NCCL error indicating a duplicate GPU.
