### PR TITLE
Fix hicache benchmark script bug - some sampled input_request is []

### DIFF
--- a/benchmark/hicache/data_processing.py
+++ b/benchmark/hicache/data_processing.py
@@ -83,8 +83,9 @@ def common_filter_chat(
                 input_tokens += prompt_len
                 output_tokens += output_len
                 processed.append((prompt, prompt_len, output_len))
-            filtered_dataset.append(processed)
-            l += 1
+            if len(processed) != 0:
+                filtered_dataset.append(processed)
+                l += 1
 
     print(f"#Input tokens: {input_tokens}")
     print(f"#Output tokens: {output_tokens}")


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Issue: https://github.com/sgl-project/sglang/issues/7274

When generating sample dataset from `data_processing.py`, there is a bug where we accidentally add `[]` (None) data into the final sampled dataset. However, such `[]` (None) data should've been filtered out

## Modifications

**Before: hicache/bench_serving.py fails due to "IndexError: list index out of range" **
```
$ python3 bench_serving.py --model /shared/public/elr-models/Qwen/Qwen2-7B/453ed1575b739b5b03ce3758b23befdb0967f40e --backend sglang --dataset-name sharegpt  --enable-multiturn --disable-shuffle
Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=30000, dataset_name='sharegpt', dataset_path='', model='/shared/public/elr-models/Qwen/Qwen2-7B/453ed1575b739b5b03ce3758b23befdb0967f40e', tokenizer=None, chat_template=None, num_prompts=1000, fixed_output_len=None, sharegpt_context_len=None, random_input_len=1024, random_output_len=1024, random_range_ratio=0.0, request_rate=inf, max_concurrency=None, multi=False, request_rate_range='2,34,2', output_file=None, enable_multiturn=True, enable_shared_prefix=False, disable_shuffle=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, max_frames=9223372036854775807)

#Input tokens: 400761
#Output tokens: 800035
Num of shared prefixes or conversations: 1000
Num of total requests: 2933
Starting initial single prompt test run...
Initial test run completed. Starting main benchmark run...
  0%|                                                                                | 0/2933 [00:00<?, ?it/s]
 95%|█████████████████████████████████████████████████████████████████▌   | 2789/2933 [01:00<00:03, 44.42it/s]Traceback (most recent call last):
  File "/home/jobuser/sglang/benchmark/hicache/bench_serving.py", line 1029, in <module>
    run_benchmark(args)
  File "/home/jobuser/sglang/benchmark/hicache/bench_serving.py", line 773, in run_benchmark
    return asyncio.run(
  File "/export/apps/python/3.10/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/export/apps/python/3.10/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/home/jobuser/sglang/benchmark/hicache/bench_serving.py", line 491, in benchmark
    outputs: List[RequestFuncOutput] = await asyncio.gather(*tasks)
  File "/home/jobuser/sglang/benchmark/hicache/bench_serving.py", line 398, in limited_request_func
    return await request_func(
  File "/home/jobuser/sglang/benchmark/hicache/bench_serving.py", line 99, in async_request_openai_completions
    prompt, input_len, max_tokens = request_func_input.prompts[prompt_idx]
IndexError: list index out of range
 95%|█████████████████████████████████████████████████████████████████▋   | 2792/2933 [01:01<00:03, 45.66it/s]
```

**After: hicache/bench_serving.py succeeds **
```
(venv) jobuser [ ~/sglang/benchmark/hicache ]$ python3 bench_serving.py --model /shared/public/elr-models/Qwen/Qwen2-7B/453ed1575b739b5b03ce3758b23befdb0967f40e --backend sglang --dataset-name sharegpt  --enable-multiturn --disable-shuffle | tee ../../output.txt
Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=30000, dataset_name='sharegpt', dataset_path='', model='/shared/public/elr-models/Qwen/Qwen2-7B/453ed1575b739b5b03ce3758b23befdb0967f40e', tokenizer=None, chat_template=None, num_prompts=1000, fixed_output_len=None, sharegpt_context_len=None, random_input_len=1024, random_output_len=1024, random_range_ratio=0.0, request_rate=inf, max_concurrency=None, multi=False, request_rate_range='2,34,2', output_file=None, enable_multiturn=True, enable_shared_prefix=False, disable_shuffle=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, lora_name=None, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, max_frames=9223372036854775807)

#Input tokens: 410086
#Output tokens: 813402
Num of shared prefixes or conversations: 1000
Num of total requests: 2993
Starting initial single prompt test run...
Initial test run completed. Starting main benchmark run...
100%|█████████████████████████████████████████████████████████████████████| 2993/2993 [01:06<00:00, 44.71it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     2993      
Benchmark duration (s):                  66.94     
Total input tokens:                      2070117   
Total generated tokens:                  813402    
Total generated tokens (retokenized):    811432    
Request throughput (req/s):              44.71     
Input token throughput (tok/s):          30926.83  
Output token throughput (tok/s):         12151.94  
Total token throughput (tok/s):          43078.77  
Concurrency:                             550.26    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   12306.09  
Median E2E Latency (ms):                 10252.44  
---------------Time to First Token----------------
Mean TTFT (ms):                          2944.50   
Median TTFT (ms):                        3205.45   
P90 TTFT (ms):                           5766.75   
P99 TTFT (ms):                           6135.17   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.71     
Median TPOT (ms):                        23.84     
P90 TPOT (ms):                           79.74     
P99 TPOT (ms):                           232.71    
---------------Inter-token Latency----------------
Mean ITL (ms):                           49.55     
Median ITL (ms):                         28.55     
P90 ITL (ms):                            77.00     
P99 ITL (ms):                            483.96    
==================================================
```
## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
