### PR TITLE
Fix mini_lb for PD with long output: limit chunk size of decode response

### DIFF
--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -22,6 +22,7 @@ AIOHTTP_STREAM_READ_CHUNK_SIZE = (
     1024 * 64
 )  # 64KB, to prevent aiohttp's "Chunk too big" error
 
+
 def setup_logger():
     logger = logging.getLogger("pdlb")
     logger.setLevel(logging.INFO)

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -154,7 +154,7 @@ class MiniLoadBalancer:
                         else:
                             yield chunk
                 else:
-                    async for chunk in decode_response.content.iter_chunked(1024*64):
+                    async for chunk in decode_response.content.iter_chunked(AIOHTTP_STREAM_READ_CHUNK_SIZE):
                         yield chunk
 
         return StreamingResponse(

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -18,6 +18,7 @@ from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 
 from sglang.srt.disaggregation.utils import PDRegistryRequest
 
+AIOHTTP_STREAM_READ_CHUNK_SIZE = 1024 * 64  # 64KB, to prevent aiohttp's "Chunk too big" error
 
 def setup_logger():
     logger = logging.getLogger("pdlb")

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -154,7 +154,7 @@ class MiniLoadBalancer:
                         else:
                             yield chunk
                 else:
-                    async for chunk in decode_response.content:
+                    async for chunk in decode_response.content.iter_chunked(1024*64):
                         yield chunk
 
         return StreamingResponse(

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -155,7 +155,9 @@ class MiniLoadBalancer:
                         else:
                             yield chunk
                 else:
-                    async for chunk in decode_response.content.iter_chunked(AIOHTTP_STREAM_READ_CHUNK_SIZE):
+                    async for chunk in decode_response.content.iter_chunked(
+                        AIOHTTP_STREAM_READ_CHUNK_SIZE
+                    ):
                         yield chunk
 
         return StreamingResponse(

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -18,7 +18,9 @@ from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 
 from sglang.srt.disaggregation.utils import PDRegistryRequest
 
-AIOHTTP_STREAM_READ_CHUNK_SIZE = 1024 * 64  # 64KB, to prevent aiohttp's "Chunk too big" error
+AIOHTTP_STREAM_READ_CHUNK_SIZE = (
+    1024 * 64
+)   # 64KB, to prevent aiohttp's "Chunk too big" error
 
 def setup_logger():
     logger = logging.getLogger("pdlb")

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -20,7 +20,7 @@ from sglang.srt.disaggregation.utils import PDRegistryRequest
 
 AIOHTTP_STREAM_READ_CHUNK_SIZE = (
     1024 * 64
-)   # 64KB, to prevent aiohttp's "Chunk too big" error
+)  # 64KB, to prevent aiohttp's "Chunk too big" error
 
 def setup_logger():
     logger = logging.getLogger("pdlb")


### PR DESCRIPTION

When I deploy a deepep+1p1d service and stress test for short input and long output scenarios, for example: isl-1k/osl-48k scenarios, chunk too big appears. 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.10/dist-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 74, in app
    await response(scope, receive, send)
  File "/usr/local/lib/python3.10/dist-packages/starlette/responses.py", line 262, in __call__
    with collapse_excgroups():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.10/dist-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.10/dist-packages/starlette/responses.py", line 266, in wrap
    await func()
  File "/usr/local/lib/python3.10/dist-packages/starlette/responses.py", line 246, in stream_response
    async for chunk in self.body_iterator:
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/mini_lb.py", line 158, in stream_results
    async for chunk in decode_response.content:
  File "/usr/local/lib/python3.10/dist-packages/aiohttp/streams.py", line 52, in __anext__
    rv = await self.read_func()
  File "/usr/local/lib/python3.10/dist-packages/aiohttp/streams.py", line 352, in readline
    return await self.readuntil()
  File "/usr/local/lib/python3.10/dist-packages/aiohttp/streams.py", line 380, in readuntil
    raise ValueError("Chunk too big")
ValueError: Chunk too big
```
**Main analysis**
aiohttp will read "as much as possible" from the underlying buffer each time. If the data sent by the server is large and has no natural separation (such as no newline or large chunks), aiohttp will continue to read data into the buffer until the end of the stream is encountered or an internal limit is triggered.

aiohttp's StreamReader has a self._low_water(default 64KB) and a self._high_water (default 128KB). When the data read in a single time exceeds this limit, it will throw ValueError: Chunk too big

The call is StreamReader.iter_chunked(n). This method will read only n bytes at most (here 64KB) each time. Even if the server has a large packet, it will force the big data to be cut into pieces (each piece is at most 64KB) and handed over to you.

In this way, the _limit limit will never be triggered, because you can only get 64KB at most each time, which is much less than the default limit of 128KB. After modification, verification is normal

