### PR TITLE
support return logprobs for pipeline

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -811,11 +811,14 @@ class Scheduler(
                                     "extend_input_len_per_req": result.extend_input_len_per_req,
                                     "extend_logprob_start_len_per_req": result.extend_logprob_start_len_per_req,
                                 }
-                                | ({
-                                    f"logits_output.{k}": v
-                                    for k, v in result.logits_output.__dict__.items()
-                                } if result.logits_output is not None else {})
-                            )
+                                | (
+                                    {
+                                        f"logits_output.{k}": v
+                                        for k, v in result.logits_output.__dict__.items()
+                                    }
+                                    if result.logits_output is not None
+                                    else {}
+                                )
                             )
                         else:
                             pp_outputs = PPProxyTensors(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -811,10 +811,11 @@ class Scheduler(
                                     "extend_input_len_per_req": result.extend_input_len_per_req,
                                     "extend_logprob_start_len_per_req": result.extend_logprob_start_len_per_req,
                                 }
-                                | {
+                                | ({
                                     f"logits_output.{k}": v
                                     for k, v in result.logits_output.__dict__.items()
-                                }
+                                } if result.logits_output is not None else {})
+                            )
                             )
                         else:
                             pp_outputs = PPProxyTensors(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -804,11 +804,24 @@ class Scheduler(
                             result.next_token_ids,
                             result.bid,
                         )
-                        pp_outputs = PPProxyTensors(
-                            {
-                                "next_token_ids": next_token_ids,
-                            }
-                        )
+                        if self.cur_batch.return_logprob:
+                            pp_outputs = PPProxyTensors(
+                                {
+                                    "next_token_ids": next_token_ids,
+                                    "extend_input_len_per_req": result.extend_input_len_per_req,
+                                    "extend_logprob_start_len_per_req": result.extend_logprob_start_len_per_req,
+                                }
+                                | {
+                                    f"logits_output.{k}": v
+                                    for k, v in result.logits_output.__dict__.items()
+                                }
+                            )
+                        else:
+                            pp_outputs = PPProxyTensors(
+                                {
+                                    "next_token_ids": next_token_ids,
+                                }
+                            )
                         # send the output from the last round to let the next stage worker run post processing
                         self.pp_group.send_tensor_dict(
                             pp_outputs.tensors,
@@ -825,12 +838,25 @@ class Scheduler(
                         )
                     )
                     mbs[next_mb_id].output_ids = next_pp_outputs["next_token_ids"]
+                    logits_output_args = {
+                        k[len("logits_output.") :]: v
+                        for k, v in next_pp_outputs.tensors.items()
+                        if k.startswith("logits_output.")
+                    }
+                    if len(logits_output_args) > 0:
+                        logits_output = LogitsProcessorOutput(**logits_output_args)
+                    else:
+                        logits_output = None
                     output_result = GenerationBatchResult(
-                        logits_output=None,
+                        logits_output=logits_output,
                         pp_hidden_states_proxy_tensors=None,
                         next_token_ids=next_pp_outputs["next_token_ids"],
-                        extend_input_len_per_req=None,
-                        extend_logprob_start_len_per_req=None,
+                        extend_input_len_per_req=next_pp_outputs.tensors.get(
+                            "extend_input_len_per_req", None
+                        ),
+                        extend_logprob_start_len_per_req=next_pp_outputs.tensors.get(
+                            "extend_logprob_start_len_per_req", None
+                        ),
                         bid=bids[next_mb_id],
                         can_run_cuda_graph=result.can_run_cuda_graph,
                     )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
I try to return logprobs with pipeline support and get error:
```
[2025-06-19 19:03:04 PP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 2627, in run_scheduler_process
    scheduler.event_loop_pp()
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 837, in event_loop_pp
    self.process_batch_result(mbs[next_mb_id], output_result)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1733, in process_batch_result
    self.process_batch_result_prefill(batch, result, launch_done)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler_output_processor_mixin.py", line 61, in process_batch_result_prefill
    if logits_output.next_token_logprobs is not None:
AttributeError: 'NoneType' object has no attribute 'next_token_logprobs'
```

## Modifications

<!-- Describe the changes made in this PR. -->
I found some parameters not transferred to peer rank, so I fix it and it works.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
