### PR TITLE
Put `_normalize_rid` before other normalization in `io_struct`

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -226,11 +226,11 @@ class GenerateReqInput:
 
         # Expand input based on type
         self._expand_inputs(num)
+        self._normalize_rid(num)
         self._normalize_lora_paths(num)
         self._normalize_image_data(num)
         self._normalize_audio_data(num)
         self._normalize_sampling_params(num)
-        self._normalize_rid(num)
         self._normalize_logprob_params(num)
         self._normalize_custom_logit_processor(num)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
When we send the following payload to a multimodal model, such as llama-3.2-11b-vision-instruct, the server will return a 400 but also failed abort request:

**Payload:**

```python
 payload = {
    "model": "sgl-model",
    "messages": [
        {
            "role": "user",
            "content": [
            {"type": "text", "text": "Hello, can you tell me something interesting about Harry Potter?"},
            ]
        }
    ],
    "max_tokens": 30,
    "temperature": 0.0,
    "top_p": 0.75,
    "top_k": -1,
    "stream": True,
    "stream_options": {
                "include_usage": True,
            },
    "ignore_eos": False,
    # "rid": "a-xfrjoiwejfioewngrinel",
    "n": 2,
    }
```

**Response:**

```
b'data: {"error": {"object": "error", "message": "The length of image_data should be equal to the batch size.", "type": "BadRequestError", "param": null, "code": 400}}'
```

**Server log:**
![Screenshot 2025-06-19 at 11 11 33 AM](https://github.com/user-attachments/assets/26c755e5-7b0b-456c-9b92-30ea64c2cd28)

**RCA:**

1. `The length of image_data should be equal to the batch size.` comes from this line: https://github.com/sgl-project/sglang/blob/e30ef368abd3be9293838e133d33715a7515a99e/python/sglang/srt/openai_api/adapter.py#L1182-L1185  The default `image_data` will be [], but we set `request.n=2`, this makes io_struct call: https://github.com/sgl-project/sglang/blob/e30ef368abd3be9293838e133d33715a7515a99e/python/sglang/srt/managers/io_struct.py#L274-L278 As a result, empty list causes a 400

2. The server log error comes from `_normalize_rid` is called after `_normalize_image_data`. As a result, `obj.rid` in https://github.com/sgl-project/sglang/blob/e30ef368abd3be9293838e133d33715a7515a99e/python/sglang/srt/managers/tokenizer_manager.py#L1096-L1097 is None. Hence the error.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Since there are no strong documentation regarding why `_normalize_rid` can't be put at the top of `_normalize_batch_inputs`. This PR puts it before other normalizaiton so `abort_request` can be handled properly.


<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
