### PR TITLE
[Fix] Add missing packed_modules_mapping for LlavaForConditionalGeneration

### DIFF
--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -609,6 +609,12 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
     according to config.
     """
 
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "proj": ["o_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"]
+    }
+
     MULTIMODAL_PROJECTOR_TYPE = LlavaMultiModalProjector
 
     @property


### PR DESCRIPTION
## Motivation

This is used in python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py to determine whether a specific packed layer should be ignored for quantization. Without this configuration quantization_config.ignore in config.json is not taken into account.

Fixes loading RedHatAI/Pixtral-Large-Instruct-2411-hf-FP8-dynamic on devices without native FP8 capability. In that model certain small layers (everything in vision tower) are not quantized.

## Modifications

Add missing `packed_modules_mapping` member.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [not needed] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [not needed] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
