### PR TITLE
Fix for fp8 quantization failure of qwen 2.5 VL 7B model.

### DIFF
--- a/sgl-kernel/csrc/gemm/per_token_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/per_token_quant_fp8.cu
@@ -19,21 +19,42 @@ __global__ void per_token_quant_fp8_kernel(
   const int tid = threadIdx.x;
   const int block_dim = blockDim.x;
 
-  const T* token_input = input + token_idx * hidden_dim;
-  FP8_TYPE* token_output = output_q + token_idx * hidden_dim;
+  const T* token_input_base = input + token_idx * hidden_dim;
+  FP8_TYPE* token_output_base = output_q + token_idx * hidden_dim;
 
   float max_value = 0.0f;
-
-  // We want to store 128 bits of data at a time. 16 = 128 / 8 bits
-  // Load is already vectorized, so 16 elements work for T.
   const uint32_t VEC_SIZE = 16;
   using vec_t = flashinfer::vec_t<T, VEC_SIZE>;
-  const int32_t num_vec_elems = hidden_dim / VEC_SIZE;
+  const uint32_t FP8_BYTES_PER_VECTOR = VEC_SIZE * sizeof(FP8_TYPE);
+  const uint32_t ALIGNMENT_BYTES_OUTPUT = FP8_BYTES_PER_VECTOR;
 
-  // Find max using vectorized loads
-  for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
+  // --- Step 1: Find Max Value ---
+  size_t token_input_base_addr = reinterpret_cast<size_t>(token_input_base);
+  int prologue_elements_count = 0;
+
+  if (token_input_base_addr % ALIGNMENT_BYTES_OUTPUT != 0) {
+    prologue_elements_count = (ALIGNMENT_BYTES_OUTPUT - (token_input_base_addr % ALIGNMENT_BYTES_OUTPUT)) / sizeof(T);
+  }
+  // Ensure we don't go beyond hidden_dim if hidden_dim is very small
+  prologue_elements_count = min((int64_t)prologue_elements_count, hidden_dim);
+
+  // Scalar loop for the initial (unaligned) prologue
+  for (int32_t i = tid; i < prologue_elements_count; i += block_dim) {
+    float val = static_cast<float>(token_input_base[i]);
+    max_value = fmaxf(max_value, fabsf(val));
+  }
+
+  // Calculate remaining elements after the prologue
+  const int64_t remaining_elements = hidden_dim - prologue_elements_count;
+  const int32_t num_full_vecs = remaining_elements / VEC_SIZE;
+  const int32_t num_tail_elems = remaining_elements % VEC_SIZE;
+
+  const T* token_input_aligned_start = token_input_base + prologue_elements_count;
+
+  // Vectorized loop for the aligned main part
+  for (int32_t i = tid; i < num_full_vecs; i += block_dim) {
     vec_t input_vec;
-    input_vec.cast_load(token_input + i * VEC_SIZE);
+    input_vec.cast_load(token_input_aligned_start + i * VEC_SIZE);
 
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
@@ -42,21 +63,67 @@ __global__ void per_token_quant_fp8_kernel(
     }
   }
 
+  // Scalar loop for the final (unaligned) tail elements
+  if (num_tail_elems > 0) {
+    const int32_t tail_start_idx = prologue_elements_count + num_full_vecs * VEC_SIZE;
+    for (int32_t i = tail_start_idx + tid; i < hidden_dim; i += block_dim) {
+      float val = static_cast<float>(token_input_base[i]);
+      max_value = fmaxf(max_value, fabsf(val));
+    }
+  }
+
+  // Reduce max_value across threads in the block
   max_value = blockReduceMax(max_value);
 
   __shared__ float scale;
   if (tid == 0) {
-    scale = max_value / FP8_E4M3_MAX;
+    scale = (max_value == 0.0f) ? 1.0f : max_value / FP8_E4M3_MAX;
     output_s[token_idx] = scale;
   }
   __syncthreads();
 
   const float scale_inv = 1.0f / scale;
 
-  // Quantize using vectorized loads
-  for (int32_t i = tid; i < num_vec_elems; i += block_dim) {
+  // --- Step 2: Quantize Values ---
+
+  // Calculate the first address in the output row that IS aligned to ALIGNMENT_BYTES_OUTPUT (16 bytes)
+  size_t token_output_base_addr = reinterpret_cast<size_t>(token_output_base);
+  int prologue_output_elements_count = 0;
+
+  if (token_output_base_addr % ALIGNMENT_BYTES_OUTPUT != 0) {
+    prologue_output_elements_count =
+        (ALIGNMENT_BYTES_OUTPUT - (token_output_base_addr % ALIGNMENT_BYTES_OUTPUT)) / sizeof(FP8_TYPE);
+  }
+  prologue_output_elements_count = min((int64_t)prologue_output_elements_count, hidden_dim);
+
+  // Scalar loop for the initial (unaligned) output prologue
+  for (int32_t i = tid; i < prologue_output_elements_count; i += block_dim) {
+    float val = fmaxf(fminf(static_cast<float>(token_input_base[i]) * scale_inv, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#ifndef USE_ROCM
+    token_output_base[i] = static_cast<FP8_TYPE>(val);
+#else
+    token_output_base[i] = c10::Float8_e4m3fnuz(
+        __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+        c10::Float8_e4m3fnuz::from_bits());
+#endif
+  }
+
+  // Calculate remaining elements for aligned part and tail for output
+  const int64_t remaining_output_elements = hidden_dim - prologue_output_elements_count;
+  const int32_t num_full_vecs_output = remaining_output_elements / VEC_SIZE;
+  const int32_t num_tail_elems_output = remaining_output_elements % VEC_SIZE;
+
+  const T* token_input_for_aligned_output = token_input_base + prologue_output_elements_count;
+  FP8_TYPE* token_output_aligned_start = token_output_base + prologue_output_elements_count;
+
+  assert(
+      reinterpret_cast<size_t>(token_input_for_aligned_output) % ALIGNMENT_BYTES_OUTPUT == 0 &&
+      "Input address must be 16-byte aligned.");
+
+  // Vectorized loop for the aligned main part (output)
+  for (int32_t i = tid; i < num_full_vecs_output; i += block_dim) {
     vec_t input_vec;
-    input_vec.cast_load(token_input + i * VEC_SIZE);
+    input_vec.cast_load(token_input_for_aligned_output + i * VEC_SIZE);
 
     FP8_TYPE output_arr[VEC_SIZE];
 #pragma unroll
@@ -70,8 +137,22 @@ __global__ void per_token_quant_fp8_kernel(
           c10::Float8_e4m3fnuz::from_bits());
 #endif
     }
+    *(reinterpret_cast<uint4*>(token_output_aligned_start + i * VEC_SIZE)) = *(reinterpret_cast<uint4*>(output_arr));
+  }
 
-    *(uint4*)(token_output + i * VEC_SIZE) = *(uint4*)output_arr;
+  // Scalar loop for the final (unaligned) output tail elements
+  if (num_tail_elems_output > 0) {
+    const int32_t tail_output_start_idx = prologue_output_elements_count + num_full_vecs_output * VEC_SIZE;
+    for (int32_t i = tail_output_start_idx + tid; i < hidden_dim; i += block_dim) {
+      float val = fmaxf(fminf(static_cast<float>(token_input_base[i]) * scale_inv, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#ifndef USE_ROCM
+      token_output_base[i] = static_cast<FP8_TYPE>(val);
+#else
+      token_output_base[i] = c10::Float8_e4m3fnuz(
+          __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+          c10::Float8_e4m3fnuz::from_bits());
+#endif
+    }
   }
 }
 
@@ -83,8 +164,6 @@ void sgl_per_token_quant_fp8(torch::Tensor input, torch::Tensor output_q, torch:
   const auto input_sizes = input.sizes();
   const int64_t num_tokens = input_sizes[0];
   const int64_t hidden_dim = input_sizes[1];
-
-  TORCH_CHECK(hidden_dim % 16 == 0, "Hidden dimension must be divisible by 16, but got ", hidden_dim);
 
   const int block_size = 256;
   const int num_blocks = num_tokens;

--- a/sgl-kernel/tests/test_fp8_gemm.py
+++ b/sgl-kernel/tests/test_fp8_gemm.py
@@ -37,8 +37,8 @@ def _test_accuracy_once(M, N, K, with_bias, out_dtype, device):
 
 
 @pytest.mark.parametrize("M", [1, 128, 512, 1024, 4096])
-@pytest.mark.parametrize("N", [16, 128, 512, 1024, 4096])
-@pytest.mark.parametrize("K", [512, 1024, 4096, 8192, 16384])
+@pytest.mark.parametrize("N", [16, 128, 512, 1024, 3420, 4096])
+@pytest.mark.parametrize("K", [512, 1024, 3420, 4096, 8192, 16384])
 @pytest.mark.parametrize("with_bias", [True, False])
 @pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
 def test_accuracy(M, N, K, with_bias, out_dtype):

--- a/sgl-kernel/tests/test_per_token_quant_fp8.py
+++ b/sgl-kernel/tests/test_per_token_quant_fp8.py
@@ -36,7 +36,7 @@ def sglang_per_token_quant_fp8(
 
 @pytest.mark.parametrize(
     "num_tokens,hidden_dim",
-    list(itertools.product([128, 256, 512], [512, 2048, 4096])),
+    list(itertools.product([128, 256, 512], [512, 2048, 3420, 4096])),
 )
 def test_per_token_quant_compare_implementations(
     num_tokens: int,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix this bug https://github.com/sgl-project/sglang/issues/6828 of qwen 2.5 VL 7B where fp8 quantization was reported to fail in the visual model part.

## Modifications

As written in the commit message, two modifications are performed.
1. Make `per_token_quant_fp8.cu` work with non-16-aligned hidden dim. I split the non-aligned hidden dim into 3 parts, the prologue part, the aligned part, and the tail part, since the address may start from a non-128-bit aligned address.
2. Make `fp8_gemm_kernel` work with non-16-aligned K and N supposing the mat mul is `[M, K] x [K, N]`. The extension of N is unlikely to trigger perf regression as we can just initialize the output matrix to be larger but aligned and return a view. The unaligned K is the problematic part (hidden dim 3420 in case of qwen2.5 VL 7B visual LLM). In this PR, the solution is to initialize two empty matrices whose K is aligned and perform two additional copies from the original `mat_a` and `mat_b` respectively. I don't know where this is appropriate, as it slows down the inference and requires double the memory. Two other options are available as I stated in the commit message:
a. Initialize the weight matrix directly to have a 16-aligned (3424 in this case) hidden dim with zero padding.
b. Disable quantization for the vision model part of qwen 2.5 VL. 

Feedback is welcome. Thanks!

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
