### PR TITLE
[OAI] patch origin request_id logic

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -198,6 +198,7 @@ class CompletionRequest(BaseModel):
 
     # For request id
     rid: Optional[Union[List[str], str]] = None
+
     @field_validator("max_tokens")
     @classmethod
     def validate_max_tokens_positive(cls, v):

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -196,6 +196,8 @@ class CompletionRequest(BaseModel):
     bootstrap_port: Optional[int] = None
     bootstrap_room: Optional[int] = None
 
+    # For request id
+    rid: Optional[Union[List[str], str]] = None
     @field_validator("max_tokens")
     @classmethod
     def validate_max_tokens_positive(cls, v):
@@ -430,8 +432,8 @@ class ChatCompletionRequest(BaseModel):
     stream_reasoning: bool = True
     chat_template_kwargs: Optional[Dict] = None
 
-    # The request id.
-    rid: Optional[str] = None
+    # For request id
+    rid: Optional[Union[List[str], str]] = None
 
     # For PD disaggregation
     bootstrap_host: Optional[str] = None
@@ -529,7 +531,7 @@ class EmbeddingRequest(BaseModel):
     user: Optional[str] = None
 
     # The request id.
-    rid: Optional[str] = None
+    rid: Optional[Union[List[str], str]] = None
 
 
 class EmbeddingObject(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -95,6 +95,7 @@ class OpenAIServingChat(OpenAIServingBase):
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
             return_hidden_states=request.return_hidden_states,
+            rid=request.rid
         )
 
         return adapted_request, request

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -95,7 +95,7 @@ class OpenAIServingChat(OpenAIServingBase):
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
             return_hidden_states=request.return_hidden_states,
-            rid=request.rid
+            rid=request.rid,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -87,6 +87,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
             return_hidden_states=request.return_hidden_states,
+            rid=request.rid,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/entrypoints/openai/serving_embedding.py
+++ b/python/sglang/srt/entrypoints/openai/serving_embedding.py
@@ -119,6 +119,7 @@ class OpenAIServingEmbedding(OpenAIServingBase):
 
         adapted_request = EmbeddingReqInput(
             **prompt_kwargs,
+            rid=request.rid,
         )
 
         return adapted_request, request

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -324,9 +324,12 @@ class GenerateReqInput:
             self.rid = new_rids
         elif isinstance(self.rid, list):
             if len(self.rid) != num:
-                raise ValueError("The specified rids length mismatch with the batch_size for batch processing.")
+                raise ValueError(
+                    "The specified rids length mismatch with the batch_size for batch processing."
+                )
         else:
             raise ValueError("The rid should be a string or a list of strings.")
+
     def _normalize_logprob_params(self, num):
         """Normalize logprob-related parameters for batch processing."""
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -319,9 +319,14 @@ class GenerateReqInput:
         """Normalize request IDs for batch processing."""
         if self.rid is None:
             self.rid = [uuid.uuid4().hex for _ in range(num)]
-        elif not isinstance(self.rid, list):
-            raise ValueError("The rid should be a list for batch processing.")
-
+        elif isinstance(self.rid, str):
+            new_rids = [f"{self.rid}_{i}" for i in range(num)]
+            self.rid = new_rids
+        elif isinstance(self.rid, list):
+            if len(self.rid) != num:
+                raise ValueError("The specified rids length mismatch with the batch_size for batch processing.")
+        else:
+            raise ValueError("The rid should be a string or a list of strings.")
     def _normalize_logprob_params(self, num):
         """Normalize logprob-related parameters for batch processing."""
 


### PR DESCRIPTION

## Modifications

1.  Add back the logic where the user specifies the request ID originally.
2. When handling is_single=False, the method def _normalize_rid(self, num) generates a list of rids based on the specified rid. 