### PR TITLE
P/D load balancer forwards profiling requests to instances

### DIFF
--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -210,6 +210,38 @@ async def flush_cache():
     return Response(status_code=200)
 
 
+@app.post("/start_profile")
+async def start_profile():
+    prefill_servers, decode_servers = (
+        load_balancer.prefill_servers,
+        load_balancer.decode_servers,
+    )
+    async with aiohttp.ClientSession() as session:
+        # Create the tasks
+        tasks = []
+        for server in chain(prefill_servers, decode_servers):
+            tasks.append(session.post(f"{server}/start_profile"))
+        for i, response in enumerate(asyncio.as_completed(tasks)):
+            await response
+    return Response(status_code=200)
+
+
+@app.post("/stop_profile")
+async def stop_profile():
+    prefill_servers, decode_servers = (
+        load_balancer.prefill_servers,
+        load_balancer.decode_servers,
+    )
+    async with aiohttp.ClientSession() as session:
+        # Create the tasks
+        tasks = []
+        for server in chain(prefill_servers, decode_servers):
+            tasks.append(session.post(f"{server}/stop_profile"))
+        for i, response in enumerate(asyncio.as_completed(tasks)):
+            await response
+    return Response(status_code=200)
+
+
 @app.get("/get_server_info")
 async def get_server_info():
     prefill_servers, decode_servers = (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2437,6 +2437,7 @@ class Scheduler(
         stage_suffix = f"-{stage.__str__()}" if stage else ""
         logger.info("Stop profiling" + stage_suffix + "...")
         if self.torch_profiler is not None:
+            torch.distributed.barrier(self.tp_cpu_group)
             self.torch_profiler.stop()
             self.torch_profiler.export_chrome_trace(
                 os.path.join(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2437,7 +2437,8 @@ class Scheduler(
         stage_suffix = f"-{stage.__str__()}" if stage else ""
         logger.info("Stop profiling" + stage_suffix + "...")
         if self.torch_profiler is not None:
-            torch.distributed.barrier(self.tp_cpu_group)
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                torch.distributed.barrier(self.attn_tp_cpu_group)
             self.torch_profiler.stop()
             self.torch_profiler.export_chrome_trace(
                 os.path.join(


### PR DESCRIPTION
## Motivation

The `mini_lb` load balancer should forward the `start_profile` and `stop_profile` endpoints to the prefill and decode server instances. This allows the benchmarking tool to initiate profiling when the `--profile` flag is specified.

## Modifications

Adds two POST endpoints `start_profile` and `stop_profile` to the load balancer. The endpoints follow the same pattern as `flush_cache`, iterating over `prefill_servers` and `decode_servers` to forward the request, and await their responses.

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
