### PR TITLE
[feature] Add start step profile argument in /start_profile

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -418,6 +418,7 @@ async def start_profile_async(obj: Optional[ProfileReqInput] = None):
 
     await _global_state.tokenizer_manager.start_profile(
         output_dir=obj.output_dir,
+        start_step=obj.start_step,
         num_steps=obj.num_steps,
         activities=obj.activities,
         with_stack=obj.with_stack,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -905,6 +905,7 @@ class ProfileReqInput:
     # If set, it profile as many as this number of steps.
     # If it is set, profiling is automatically stopped after this step, and
     # the caller doesn't need to run stop_profile.
+    start_step: Optional[int] = None
     num_steps: Optional[int] = None
     activities: Optional[List[str]] = None
     profile_by_stage: bool = False
@@ -932,6 +933,7 @@ class ExpertDistributionReqOutput:
 class ProfileReq:
     type: ProfileReqType
     output_dir: Optional[str] = None
+    start_step: Optional[int] = None
     num_steps: Optional[int] = None
     activities: Optional[List[str]] = None
     profile_by_stage: bool = False

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2402,6 +2402,7 @@ class Scheduler(
             else:
                 self.init_profile(
                     recv_req.output_dir,
+                    recv_req.start_step,
                     recv_req.num_steps,
                     recv_req.activities,
                     recv_req.with_stack,
@@ -2416,6 +2417,7 @@ class Scheduler(
     def init_profile(
         self,
         output_dir: Optional[str],
+        start_step: Optional[int],
         num_steps: Optional[int],
         activities: Optional[List[str]],
         with_stack: Optional[bool],

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1312,7 +1312,7 @@ class Scheduler(
 
         num_new_seq = len(can_run_list)
         f = (
-            f"Prefill batch. Prefill step: {self.forward_ct}, "
+            f"Prefill batch. "
             f"#new-seq: {num_new_seq}, "
             f"#new-token: {adder.log_input_tokens}, "
             f"#cached-token: {adder.log_hit_tokens}, "
@@ -1370,7 +1370,7 @@ class Scheduler(
                 gap_latency / self.server_args.decode_log_interval
             )
 
-        msg = f"Decode batch. step: {self.forward_ct}, " f"#running-req: {num_running_reqs}, " f"{usage_msg}"
+        msg = f"Decode batch. " f"#running-req: {num_running_reqs}, " f"{usage_msg}"
 
         if self.spec_algorithm.is_none():
             spec_accept_length = 0
@@ -2539,10 +2539,7 @@ class Scheduler(
     def stop_profile(
         self, stage: Optional[ForwardMode] = None
     ) -> ProfileReqOutput | None:
-        logger.info("Stop profiling()")
-
         if not self.profile_in_progress:
-            logger.info("Stop profiling() - Profile not in progress")
             return ProfileReqOutput(
                 success=False,
                 message="Profiling is not in progress. Call /start_profile first.",
@@ -2627,10 +2624,6 @@ class Scheduler(
             else:
                 raise RuntimeError(f"unsupported profile stage: {batch.forward_mode}")
         else:
-            if self.profiler_target_forward_ct:
-                logger.info(
-                    f"[check profiler] profiler_target_forward_ct: {self.profiler_target_forward_ct}, forward_ct: {self.forward_ct}, stop_profile: {self.profiler_target_forward_ct <= self.forward_ct}",
-                )
             # Check profiler
             if (
                 self.profiler_target_forward_ct

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1312,7 +1312,7 @@ class Scheduler(
 
         num_new_seq = len(can_run_list)
         f = (
-            f"Prefill batch. "
+            f"Prefill batch. Prefill step: {self.forward_ct}, "
             f"#new-seq: {num_new_seq}, "
             f"#new-token: {adder.log_input_tokens}, "
             f"#cached-token: {adder.log_hit_tokens}, "
@@ -1370,7 +1370,7 @@ class Scheduler(
                 gap_latency / self.server_args.decode_log_interval
             )
 
-        msg = f"Decode batch. " f"#running-req: {num_running_reqs}, " f"{usage_msg}"
+        msg = f"Decode batch. step: {self.forward_ct}, " f"#running-req: {num_running_reqs}, " f"{usage_msg}"
 
         if self.spec_algorithm.is_none():
             spec_accept_length = 0
@@ -2539,7 +2539,10 @@ class Scheduler(
     def stop_profile(
         self, stage: Optional[ForwardMode] = None
     ) -> ProfileReqOutput | None:
+        logger.info("Stop profiling()")
+
         if not self.profile_in_progress:
+            logger.info("Stop profiling() - Profile not in progress")
             return ProfileReqOutput(
                 success=False,
                 message="Profiling is not in progress. Call /start_profile first.",
@@ -2624,6 +2627,10 @@ class Scheduler(
             else:
                 raise RuntimeError(f"unsupported profile stage: {batch.forward_mode}")
         else:
+            if self.profiler_target_forward_ct:
+                logger.info(
+                    f"[check profiler] profiler_target_forward_ct: {self.profiler_target_forward_ct}, forward_ct: {self.forward_ct}, stop_profile: {self.profiler_target_forward_ct <= self.forward_ct}",
+                )
             # Check profiler
             if (
                 self.profiler_target_forward_ct

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2459,7 +2459,9 @@ class Scheduler(
                 self.profiler_prefill_ct = 0
                 self.profiler_decode_ct = 0
             elif start_step:
-                self.profiler_target_forward_ct = self.profiler_start_forward_ct + num_steps
+                self.profiler_target_forward_ct = (
+                    self.profiler_start_forward_ct + num_steps
+                )
             else:
                 self.profiler_target_forward_ct = self.forward_ct + num_steps
             # The caller will be notified when reaching profiler_target_forward_ct
@@ -2635,7 +2637,6 @@ class Scheduler(
                 and self.profiler_start_forward_ct == self.forward_ct
             ):
                 self.start_profile()
-
 
     def expert_distribution_handle(self, recv_req: ExpertDistributionReq):
         if recv_req == ExpertDistributionReq.START_RECORD:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -863,6 +863,7 @@ class TokenizerManager:
     async def start_profile(
         self,
         output_dir: Optional[str] = None,
+        start_step: Optional[int] = None,
         num_steps: Optional[int] = None,
         activities: Optional[List[str]] = None,
         with_stack: Optional[bool] = None,
@@ -875,6 +876,7 @@ class TokenizerManager:
         req = ProfileReq(
             type=ProfileReqType.START_PROFILE,
             output_dir=output_dir,
+            start_step=start_step,
             num_steps=num_steps,
             activities=activities,
             with_stack=with_stack,

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -87,6 +87,7 @@ suites = {
         TestFile("test_skip_tokenizer_init.py", 117),
         TestFile("test_srt_engine.py", 261),
         TestFile("test_srt_endpoint.py", 130),
+        TestFile("test_start_profile.py", 60),
         TestFile("test_torch_compile.py", 76),
         TestFile("test_torch_compile_moe.py", 172),
         TestFile("test_torch_native_attention_backend.py", 123),

--- a/test/srt/test_start_profile.py
+++ b/test/srt/test_start_profile.py
@@ -1,0 +1,115 @@
+"""
+Usage:
+python3 -m unittest test_srt_engine.TestSRTEngine.test_4_sync_async_stream_combination
+"""
+
+import os
+import shutil
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+OUTPUT_DIR = "./profiler_dir"
+
+
+class TestStartProfile(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def setUp(self):
+        self._clear_profile_dir()
+
+    def test_start_profile_1(self):
+        """Test /start_profile with start_step and num_steps argument. This have to be the first test for start_step to work"""
+        response = self._start_profile(start_step="15", num_steps=5)
+
+        self._post_request()
+
+        self._check_non_empty_profile_dir()
+
+    def test_start_profile_2(self):
+        """Test /start_profile with no argument"""
+        response = self._start_profile()
+
+        self._post_request()
+
+        # Before /stop_profile, the profile directory should be empty
+        self._check_empty_profile_dir()
+
+        # Post /stop_profile and check the profile directory is non-empty
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/stop_profile",
+        )
+        self._check_non_empty_profile_dir()
+
+    def test_start_profile_3(self):
+        """Test /start_profile with num_steps argument"""
+        response = self._start_profile(num_steps=5)
+
+        self._post_request()
+
+        self._check_non_empty_profile_dir()
+
+    def _start_profile(self, **kwargs):
+        """Start profiling with optional parameters."""
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/start_profile",
+            json=kwargs if kwargs else None,
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def _post_request(self):
+        response = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 32,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def _clear_profile_dir(self):
+        if os.path.isdir(OUTPUT_DIR):
+            # Remove the directory and all its contents
+            shutil.rmtree(OUTPUT_DIR)
+
+    def _check_non_empty_profile_dir(self):
+        self.assertTrue(os.path.isdir(OUTPUT_DIR), "Output directory does not exist.")
+        self.assertNotEqual(
+            len(os.listdir(OUTPUT_DIR)), 0, "Output directory is empty!"
+        )
+
+    def _check_empty_profile_dir(self):
+        if os.path.isdir(OUTPUT_DIR):
+            self.assertEqual(
+                len(os.listdir(OUTPUT_DIR)), 0, "Output directory is non-empty!"
+            )
+
+
+if __name__ == "__main__":
+    os.environ["SGLANG_TORCH_PROFILER_DIR"] = OUTPUT_DIR
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently, there is no easy to control at which step do we start the profiling.
This PR adds the `start_step` argument to the `/start_profile` API, which provides user with the ability to explicitly control profiling at specific range of steps.

## Modifications

* Fix `profile_in_progress` not being set when only using `CUDA_PROFILER`
* Add `start_step` argument in /`start_profile`, pipe the argument through from `http_server.py` to`scheduler.py`

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
