### PR TITLE
Fix sgl-router startup crash

### DIFF
--- a/sgl-router/src/router.rs
+++ b/sgl-router/src/router.rs
@@ -182,7 +182,6 @@ impl Router {
                 // Wait until all workers are healthy for regular modes
                 let worker_urls = worker_urls.clone();
                 std::thread::spawn(move || {
-                    // If the function returns Result<_, String> keep it, otherwise adjust
                     Self::wait_for_healthy_workers(&worker_urls, timeout_secs, interval_secs)
                 })
                 .join()

--- a/sgl-router/src/router.rs
+++ b/sgl-router/src/router.rs
@@ -180,7 +180,13 @@ impl Router {
             }
             _ => {
                 // Wait until all workers are healthy for regular modes
-                Self::wait_for_healthy_workers(&worker_urls, timeout_secs, interval_secs)?;
+                let worker_urls = worker_urls.clone();
+                std::thread::spawn(move || {
+                    // If the function returns Result<_, String> keep it, otherwise adjust
+                    Self::wait_for_healthy_workers(&worker_urls, timeout_secs, interval_secs)
+                })
+                .join()
+                .map_err(|e| format!("Health-check thread panicked: {e:?}"))??;
             }
         }
 

--- a/sgl-router/src/router.rs
+++ b/sgl-router/src/router.rs
@@ -185,7 +185,10 @@ impl Router {
                     Self::wait_for_healthy_workers(&worker_urls, timeout_secs, interval_secs)
                 })
                 .join()
-                .map_err(|e| format!("Health-check thread panicked: {e:?}"))??;
+                .map_err(|e| {
+                    error!("Health-check thread panicked: {:?}", e);
+                    format!("Health-check thread panicked: {e:?}")
+                })??;
             }
         }
 


### PR DESCRIPTION
# Motivation

This fixes a possible crash during startup in some environments that looks like this:

```
2025-06-25 15:01:45  INFO sglang_router_rs::server: src/server.rs:312: 🚧 Initializing Prometheus metrics on 127.0.0.1:29000
2025-06-25 15:01:45  INFO sglang_router_rs::server: src/server.rs:321: 🚧 Initializing router on 0.0.0.0:30000
2025-06-25 15:01:45  INFO sglang_router_rs::server: src/server.rs:322: 🚧 Initializing workers on ["http://10.0.0.1:30000", "http://10.0.0.2:30000", "http://10.0.0.3:30000"]
2025-06-25 15:01:45  INFO sglang_router_rs::server: src/server.rs:323: 🚧 Policy Config: CacheAwareConfig { cache_threshold: 0.5, balance_abs_threshold: 32, balance_rel_threshold: 1.0001, eviction_interval_secs: 60, max_tree_size: 16777216, timeout_secs: 300, interval_secs: 10 }
2025-06-25 15:01:45  INFO sglang_router_rs::server: src/server.rs:324: 🚧 Max payload size: 256 MB
2025-06-25 15:01:45  INFO sglang_router_rs::server: src/server.rs:334: 🚧 Service discovery disabled

thread '<unnamed>' panicked at /home/router/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
```

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

# Modifications

Launch start-up health check in `sgl-router/src/router.rs` in a thread and wait for the thread to join.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.