### PR TITLE
[bugfix] fix runtime dropping panic in editable

### DIFF
--- a/sgl-router/src/lib.rs
+++ b/sgl-router/src/lib.rs
@@ -272,7 +272,12 @@ impl Router {
                 .unwrap_or_else(|| "127.0.0.1".to_string()),
         });
 
-        actix_web::rt::System::new().block_on(async move {
+        // Use tokio runtime instead of actix-web System for better compatibility
+        let runtime = tokio::runtime::Runtime::new()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+
+        // Block on the async startup function
+        runtime.block_on(async move {
             server::startup(server::ServerConfig {
                 host: self.host.clone(),
                 port: self.port,
@@ -286,8 +291,7 @@ impl Router {
                 request_timeout_secs: self.request_timeout_secs,
             })
             .await
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-            Ok(())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
         })
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a PanicException that occurs when using the sgl-router Python bindings in editable/development mode:  

- `pyo3_runtime.PanicException`: Cannot drop a runtime in a context where blocking is not allowed. 
- This happens when a runtime is dropped from within an asynchronous context.

The issue occurred because the router was creating an `actix_web::rt::System` runtime and immediately dropping it when the `start()` method returned. When called from Python in certain async contexts, this caused a panic.


## Modifications

 Replaced `actix_web::rt::System::new().block_on()` with `tokio::runtime::Runtime::new()` and `runtime.block_on()`. This approach:

  - Uses tokio's runtime which handles dropping more gracefully in async contexts
  - Avoids the panic when used in editable mode installations
  - Has no performance impact since tokio is already a dependency
  - Maintains the same blocking behavior expected by the Python bindings

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
