### PR TITLE
Ascend attention backend

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -1,51 +1,55 @@
 name: PR Test (Ascend NPU)
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - "python/**"
+      - "scripts/**"
+      - "test/**"
+      - ".github/workflows/pr-test-npu.yml"
   pull_request:
-    types: [ labeled ]
+    branches: [ main ]
+    paths:
+      - "python/**"
+      - "scripts/**"
+      - "test/**"
+      - ".github/workflows/pr-test-npu.yml"
+  workflow_dispatch:
 
-# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
-# declared as "shell: bash -el {0}" on steps that need to be properly activated.
-# It's used to activate ascend-toolkit environment variables.
-defaults:
-  run:
-    shell: bash -el {0}
-
-# only 1 job can runs on static-8-cards
 concurrency:
-  group: static-8-cards
-  cancel-in-progress: false
+  group: pr-test-npu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  basic-test-8-npu:
-    # pr-test will be triggered when tag 'npu-test'
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'npu-test') }}
-    name: Basic 8 cards test
-    runs-on: npu
-
-    container:
-      image: m.daocloud.io/quay.io/ascend/cann:8.1.rc1-910b-ubuntu22.04-py3.10
-      volumes:
-        - /usr/local/dcmi:/usr/local/dcmi
-        - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
-        - /usr/local/Ascend/driver/:/usr/local/Ascend/driver/
-        # Use self-host cache speed up pip and model download
-        - /home/action/.cache:/github/home/.cache/
-      options: >-
-        --device /dev/davinci0
-        --device /dev/davinci1
-        --device /dev/davinci2
-        --device /dev/davinci3
-        --device /dev/davinci4
-        --device /dev/davinci5
-        --device /dev/davinci6
-        --device /dev/davinci7
-        --device /dev/davinci_manager
-        --device /dev/devmm_svm
-        --device /dev/hisi_hdc
+  unit-test-backend-1-npu-ascend:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') &&
+      github.event.pull_request.draft == false  && contains(github.event.pull_request.labels.*.name, 'npu')
+    strategy:
+      fail-fast: false
+    runs-on: self-hosted
     steps:
-      - name: Check npu and CANN info
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run test
+        timeout-minutes: 40
         run: |
-          npu-smi info
-          python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_gsm8k
-          python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_latency
+          python3 run_suite.py --suite per-commit-npu
+
+  finish:
+    if: always()
+    needs: [ unit-test-backend-1-npu-ascend ]
+    runs-on: self-hosted
+    steps:
+      - name: Check all dependent job statuses
+        run: |
+          results=(${{ join(needs.*.result, ' ') }})
+          for result in "${results[@]}"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "Job failed with result: $result"
+              exit 1
+            fi
+          done
+          echo "All jobs completed successfully"
+          exit 0

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -47,5 +47,5 @@ jobs:
       - name: Check npu and CANN info
         run: |
           npu-smi info
-          python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_mmlu
+          python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_gsm8k
           python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_latency

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -1,0 +1,51 @@
+name: PR Test (Ascend NPU)
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
+# declared as "shell: bash -el {0}" on steps that need to be properly activated.
+# It's used to activate ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+# only 1 job can runs on static-8-cards
+concurrency:
+  group: static-8-cards
+  cancel-in-progress: false
+
+jobs:
+  basic-test-8-npu:
+    # pr-test will be triggered when tag 'npu-test'
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'npu-test') }}
+    name: Basic 8 cards test
+    runs-on: npu
+
+    container:
+      image: m.daocloud.io/quay.io/ascend/cann:8.1.rc1-910b-ubuntu22.04-py3.10
+      volumes:
+        - /usr/local/dcmi:/usr/local/dcmi
+        - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
+        - /usr/local/Ascend/driver/:/usr/local/Ascend/driver/
+        # Use self-host cache speed up pip and model download
+        - /home/action/.cache:/github/home/.cache/
+      options: >-
+        --device /dev/davinci0
+        --device /dev/davinci1
+        --device /dev/davinci2
+        --device /dev/davinci3
+        --device /dev/davinci4
+        --device /dev/davinci5
+        --device /dev/davinci6
+        --device /dev/davinci7
+        --device /dev/davinci_manager
+        --device /dev/devmm_svm
+        --device /dev/hisi_hdc
+    steps:
+      - name: Check npu and CANN info
+        run: |
+          npu-smi info
+          python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_mmlu
+          python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_latency

--- a/docs/backend/attention_backend.md
+++ b/docs/backend/attention_backend.md
@@ -9,6 +9,7 @@
 | **Triton**               | ❌                | ✅                 | ✅      | ✅                 | ❌              |
 | **Torch Native**         | ❌                | ❌                 | ❌      | ❌                 | ❌              |
 | **FlashMLA**             | ✅                | ✅                 | ✅      | ❌                 | ❌              |
+| **Ascend**               | ✅                | ❌                 | ❌      | ❌                 | ❌              |
 
 Note: Every kernel backend is compatible with a page size > 1 by specifying an argument such as `--page-size 16`.
 This is because a page size of 16 can be converted to a page size of 1 in the kernel backend.
@@ -45,4 +46,9 @@ python3 -m sglang.launch_server --model meta-llama/Meta-Llama-3.1-8B-Instruct --
 ```bash
 python3 -m sglang.launch_server --tp 8 --model deepseek-ai/DeepSeek-R1 --attention-backend flashmla --trust-remote-code
 python3 -m sglang.launch_server --tp 8 --model deepseek-ai/DeepSeek-R1 --attention-backend flashmla --kv-cache-dtype fp8_e4m3 --trust-remote-code
+```
+
+- Ascend
+```bash
+python3 -m sglang.launch_server --model meta-llama/Meta-Llama-3.1-8B-Instruct --attention-backend ascend
 ```

--- a/python/sglang/srt/layers/attention/ascend_backend.py
+++ b/python/sglang/srt/layers/attention/ascend_backend.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch_npu
+from torch.nn.functional import scaled_dot_product_attention
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+@dataclass
+class ForwardMetadata:
+
+    # calculated map for kv positions [bs * maxseqlen]
+    block_tables: Optional[torch.Tensor] = None
+
+    # seq len inputs
+    extend_seq_lens_cpu_int: Optional[torch.Tensor] = None
+    seq_lens_cpu_int: Optional[torch.Tensor] = None
+
+
+class AscendAttnBackend(AttentionBackend):
+
+    def gen_attention_mask(self, max_seq_len: int, dtype=torch.float16):
+        mask_flag = torch.tril(
+            torch.ones((max_seq_len, max_seq_len), dtype=torch.bool)
+        ).view(max_seq_len, max_seq_len)
+        mask_flag = ~mask_flag
+        if dtype == torch.float16:
+            mask_value = torch.finfo(torch.float32).min
+        else:
+            mask_value = 1
+        self.mask = (
+            torch.masked_fill(
+                torch.zeros(size=(max_seq_len, max_seq_len)), mask_flag, mask_value
+            )
+            .to(dtype)
+            .to(self.device)
+        )
+        self.mask_len = max_seq_len
+
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__()
+        self.forward_metadata = ForwardMetadata()
+        self.device = model_runner.device
+        self.gen_attention_mask(128, model_runner.dtype)
+        self.page_size = model_runner.page_size
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        """Init the metadata for a forward pass."""
+        self.forward_metadata.block_tables = (
+            forward_batch.req_to_token_pool.req_to_token[
+                forward_batch.req_pool_indices, : forward_batch.seq_lens.max()
+            ][:, :: self.page_size]
+            // self.page_size
+        )
+        if forward_batch.extend_seq_lens is not None:
+            self.forward_metadata.extend_seq_lens_cpu_int = (
+                forward_batch.extend_seq_lens.cpu().int()
+            )
+        self.forward_metadata.seq_lens_cpu_int = forward_batch.seq_lens_cpu.int()
+
+    def forward_extend(
+        self,
+        q,
+        k,
+        v,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        if save_kv_cache:
+            forward_batch.token_to_kv_pool.set_kv_buffer(
+                layer, forward_batch.out_cache_loc, k, v
+            )
+
+        k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        v_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
+
+        query = q.view(-1, layer.tp_q_head_num * layer.qk_head_dim)
+        output = torch.empty(
+            (query.shape[0], layer.tp_q_head_num * layer.v_head_dim),
+            dtype=query.dtype,
+            device=query.device,
+        )
+
+        torch_npu._npu_flash_attention_qlens(
+            query=query,
+            key_cache=k_cache,
+            value_cache=v_cache,
+            mask=self.mask,
+            block_table=self.forward_metadata.block_tables,
+            seq_len=self.forward_metadata.extend_seq_lens_cpu_int,
+            context_lens=self.forward_metadata.seq_lens_cpu_int,
+            scale_value=layer.scaling,
+            num_heads=layer.tp_q_head_num,
+            num_kv_heads=layer.tp_k_head_num,
+            out=output,
+        )
+        return output
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        if save_kv_cache:
+            forward_batch.token_to_kv_pool.set_kv_buffer(
+                layer, forward_batch.out_cache_loc, k, v
+            )
+
+        k_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        v_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
+
+        query = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        num_tokens = query.shape[0]
+        output = torch.empty(
+            (num_tokens, layer.tp_q_head_num, layer.v_head_dim),
+            dtype=query.dtype,
+            device=query.device,
+        )
+
+        torch_npu._npu_paged_attention(
+            query=query,
+            key_cache=k_cache,
+            value_cache=v_cache,
+            num_heads=layer.tp_q_head_num,
+            num_kv_heads=layer.tp_k_head_num,
+            scale_value=layer.scaling,
+            block_table=self.forward_metadata.block_tables,
+            context_lens=self.forward_metadata.seq_lens_cpu_int,
+            out=output,
+        )
+        return output.view(num_tokens, layer.tp_q_head_num * layer.v_head_dim)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1672,6 +1672,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
             or global_server_args_dict["attention_backend"] == "flashmla"
             or global_server_args_dict["attention_backend"] == "cutlass_mla"
+            or global_server_args_dict["attention_backend"] == "ascend"
             or global_server_args_dict["enable_two_batch_overlap"]
         ):
             seq_lens_cpu = (
@@ -1874,7 +1875,10 @@ def get_last_loc(
     req_pool_indices_tensor: torch.Tensor,
     prefix_lens_tensor: torch.Tensor,
 ) -> torch.Tensor:
-    if global_server_args_dict["attention_backend"] != "torch_native":
+    if (
+        global_server_args_dict["attention_backend"] != "ascend"
+        and global_server_args_dict["attention_backend"] != "torch_native"
+    ):
         impl = get_last_loc_triton
     else:
         impl = get_last_loc_torch

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -378,6 +378,12 @@ class ServerArgs:
             )
             self.disable_cuda_graph = True
 
+        if self.attention_backend == "ascend":
+            logger.warning(
+                "At this moment Ascend attention backend only supports a page_size of 128, change page_size to 128."
+            )
+            self.page_size = 128
+
         # Choose grammar backend
         if self.grammar_backend is None:
             self.grammar_backend = "xgrammar"
@@ -1106,6 +1112,7 @@ class ServerArgs:
                 "flashmla",
                 "intel_amx",
                 "torch_native",
+                "ascend",
                 "triton",
             ],
             default=ServerArgs.attention_backend,

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -2398,7 +2398,7 @@ def bind_or_assign(target, source):
 
 
 def support_triton(backend: str) -> bool:
-    return backend not in ["torch_native", "intel_amx"]
+    return backend not in ["torch_native", "intel_amx", "ascend"]
 
 
 try:

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -103,6 +103,7 @@ suites = {
         TestFile("test_vision_openai_server_b.py", 556),
         TestFile("test_w8a8_quantization.py", 46),
         TestFile("test_reasoning_parser.py", 5),
+        TestFile("test_ascend_attention_backend.py", 400),
     ],
     "per-commit-amd": [
         TestFile("models/lora/test_lora_backend.py", 99),

--- a/test/srt/test_ascend_attention_backend.py
+++ b/test/srt/test_ascend_attention_backend.py
@@ -1,0 +1,74 @@
+"""
+Usage:
+python3 -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_gsm8k
+"""
+
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    run_bench_offline_throughput,
+)
+
+
+class TestAscendAttnBackend(CustomTestCase):
+    def test_latency(self):
+        output_throughput = run_bench_offline_throughput(
+            DEFAULT_MODEL_NAME_FOR_TEST,
+            [
+                "--attention-backend",
+                "ascend",
+            ],
+        )
+
+        print(f"{output_throughput=}")
+
+        if is_in_ci():
+            self.assertGreater(output_throughput, 18)
+
+    def test_gsm8k(self):
+        model = DEFAULT_MODEL_NAME_FOR_TEST
+        base_url = DEFAULT_URL_FOR_TEST
+        url = urlparse(base_url)
+        process = popen_launch_server(
+            model,
+            base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--attention-backend",
+                "ascend",
+                "--mem-fraction-static",
+                0.8,
+            ],
+        )
+
+        try:
+            args = SimpleNamespace(
+                num_shots=5,
+                data_path=None,
+                num_questions=1319,
+                max_new_tokens=512,
+                parallel=128,
+                host=f"http://{url.hostname}",
+                port=int(url.port),
+            )
+
+            metrics = run_eval_few_shot_gsm8k(args)
+            self.assertGreaterEqual(metrics["accuracy"], 0.62)
+            self.assertLessEqual(metrics["latency"], 150)
+        finally:
+            kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently only `torch_native` backend works for NPU, it has cycle by batch that works slow for bigger batch, in this MR new Ascend Attention backend for NPU device was implemented. It has big performance improvement for big batch size.

## Modifications

New attention backend - `AscendAttnBackend`: support paged attention with page size 128 only
New option for server argument `attention-backend` - "ascend"

`AscendTokenToKVPool` for store KVCache in paged format with npu operation `torch_npu._npu_reshape_and_cache`

`AscendPagedTokenToKVPoolAllocator` for allocate position in KVCache buffer, current paged allocator implemented on triton that does not work on NPU now

Added test for ascend attention backend `test/srt/test_ascend_attention_backend.py`

`self.cuda_graph_mem_usage = 0` in model_runner added for fix bug with showing output result in run_bench_offline_throughput

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Accuracy and performance result
Used model for test: LLama-3.1-8b-Instruct
```
python -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_gsm8k
```
```
Accuracy: 0.755
Invalid: 0.001
Latency: 97.738 s
Output throughput: 1217.759
```

```
python -m unittest test_ascend_attention_backend.TestAscendAttnBackend.test_latency
```
```
====== Offline Throughput Benchmark Result =======
Backend: engine
Successful requests: 1
Benchmark duration (s): 7.43
Total input tokens: 38
Total generated tokens: 235
Last generation throughput (tok/s): 29.52
Request throughput (req/s): 0.13
Input token throughput (tok/s): 5.12
Output token throughput (tok/s): 31.64
Total token throughput (tok/s): 36.76
```

## Pre-commit check
![image](https://github.com/user-attachments/assets/7f07a4ad-171d-445c-ba52-ed144d517409)
