### PR TITLE
Bug fix & refactor: correctly guard torch.compile related methods under is_torch_compile_enabled flag

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -15,12 +15,6 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import torch
 
-if os.environ["SGLANG_ENABLE_TORCH_COMPILE"] == "1":
-    import logging
-
-    torch._logging.set_logs(dynamo=logging.ERROR)
-    torch._dynamo.config.suppress_errors = True
-
 from sglang.global_config import global_config
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
@@ -28,7 +22,17 @@ from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.utils import is_sm100_supported
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
-from sglang.srt.utils import is_flashinfer_available, next_power_of_2
+from sglang.srt.utils import (
+    is_flashinfer_available,
+    is_torch_compile_enabled,
+    next_power_of_2,
+)
+
+if is_torch_compile_enabled():
+    import logging
+
+    torch._logging.set_logs(dynamo=logging.ERROR)
+    torch._dynamo.config.suppress_errors = True
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -16,12 +16,6 @@ from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import torch
 
-if os.environ["SGLANG_ENABLE_TORCH_COMPILE"] == "1":
-    import logging
-
-    torch._logging.set_logs(dynamo=logging.ERROR)
-    torch._dynamo.config.suppress_errors = True
-
 from sglang.global_config import global_config
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.flashinfer_backend import (
@@ -32,7 +26,17 @@ from sglang.srt.layers.utils import is_sm100_supported
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
-from sglang.srt.utils import is_flashinfer_available, next_power_of_2
+from sglang.srt.utils import (
+    is_flashinfer_available,
+    is_torch_compile_enabled,
+    next_power_of_2,
+)
+
+if is_torch_compile_enabled():
+    import logging
+
+    torch._logging.set_logs(dynamo=logging.ERROR)
+    torch._dynamo.config.suppress_errors = True
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -32,6 +32,7 @@ from sglang.srt.utils import (
     is_cpu,
     is_cuda,
     is_hip,
+    is_torch_compile_enabled,
     next_power_of_2,
 )
 
@@ -1486,7 +1487,7 @@ def moe_sum_reduce_triton(
     return
 
 
-@torch.compile
+@torch.compile(disable=not is_torch_compile_enabled())
 def moe_sum_reduce_torch_compile(x, out, routed_scaling_factor):
     torch.sum(x, dim=1, out=out)
     out.mul_(routed_scaling_factor)

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -35,6 +35,7 @@ from sglang.srt.utils import (
     is_cpu,
     is_cuda,
     is_hip,
+    is_torch_compile_enabled,
 )
 
 _is_cuda = is_cuda()
@@ -127,7 +128,9 @@ def fused_topk(
     )
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@torch.compile(
+    dynamic=True, backend=get_compiler_backend(), disable=not is_torch_compile_enabled()
+)
 def _fused_topk_postprocess(
     topk_weights,
     topk_ids,
@@ -143,7 +146,9 @@ def _fused_topk_postprocess(
 
 
 # This is used by the Deepseek V2/V3/R1 series models
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@torch.compile(
+    dynamic=True, backend=get_compiler_backend(), disable=not is_torch_compile_enabled()
+)
 def grouped_topk_gpu(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -304,7 +309,9 @@ def _mask_topk_ids_padded_region(
     topk_ids[indices >= num_token_non_padded, :] = -1
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@torch.compile(
+    dynamic=True, backend=get_compiler_backend(), disable=not is_torch_compile_enabled()
+)
 def _biased_grouped_topk_postprocess(
     topk_ids, expert_location_dispatch_info, num_token_non_padded
 ):

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -32,6 +32,7 @@ from sglang.srt.utils import (
     is_cuda,
     is_flashinfer_available,
     is_hip,
+    is_torch_compile_enabled,
 )
 
 _is_hip = is_hip()
@@ -525,7 +526,7 @@ def apply_fp8_linear(
     # We also don't pad when using torch.compile,
     # as it breaks with dynamic shapes.
     if pad_output is None:
-        pad_output = not get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE")
+        pad_output = not is_torch_compile_enabled()
     output_padding = 17 if pad_output else None
 
     # View input as 2D matrix for fp8 methods

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -15,6 +15,7 @@ from sglang.srt.utils import (
     is_cuda,
     is_hip,
     is_npu,
+    is_torch_compile_enabled,
 )
 
 _is_cuda = is_cuda()
@@ -175,7 +176,7 @@ class RotaryEmbedding(CustomOp):
         """A PyTorch-npu implementation of forward()."""
         import os
 
-        if get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE"):
+        if is_torch_compile_enabled():
             return self.forward_native(positions, query, key, offsets)
         else:
             rotary_mode = "half"

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -174,7 +174,6 @@ class RotaryEmbedding(CustomOp):
         offsets: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """A PyTorch-npu implementation of forward()."""
-        import os
 
         if is_torch_compile_enabled():
             return self.forward_native(positions, query, key, offsets)

--- a/python/sglang/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sglang/srt/managers/tp_worker_overlap_thread.py
@@ -35,13 +35,19 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.schedule_batch import ModelWorkerBatch
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import DynamicGradMode, get_compiler_backend
+from sglang.srt.utils import (
+    DynamicGradMode,
+    get_compiler_backend,
+    is_torch_compile_enabled,
+)
 from sglang.utils import get_exception_traceback
 
 logger = logging.getLogger(__name__)
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@torch.compile(
+    dynamic=True, backend=get_compiler_backend(), disable=not is_torch_compile_enabled()
+)
 def resolve_future_token_ids(input_ids, future_token_ids_map):
     input_ids[:] = torch.where(
         input_ids < 0,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -39,7 +39,12 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
-from sglang.srt.utils import flatten_nested_list, get_compiler_backend, support_triton
+from sglang.srt.utils import (
+    flatten_nested_list,
+    get_compiler_backend,
+    is_torch_compile_enabled,
+    support_triton,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -739,7 +744,9 @@ def compute_position_torch(
     return positions.to(torch.int64), extend_start_loc
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@torch.compile(
+    dynamic=True, backend=get_compiler_backend(), disable=not is_torch_compile_enabled()
+)
 def clamp_position(seq_lens):
     return torch.clamp((seq_lens - 1), min=0).to(torch.int64)
 

--- a/python/sglang/srt/models/commandr.py
+++ b/python/sglang/srt/models/commandr.py
@@ -65,10 +65,15 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
-from sglang.srt.utils import add_prefix, get_compiler_backend, set_weight_attrs
+from sglang.srt.utils import (
+    add_prefix,
+    get_compiler_backend,
+    is_torch_compile_enabled,
+    set_weight_attrs,
+)
 
 
-@torch.compile(backend=get_compiler_backend())
+@torch.compile(backend=get_compiler_backend(), disable=not is_torch_compile_enabled())
 def layer_norm_func(hidden_states, weight, variance_epsilon):
     input_dtype = hidden_states.dtype
     hidden_states = hidden_states.to(torch.float32)

--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -57,6 +57,7 @@ from sglang.srt.utils import (
     fast_topk,
     get_compiler_backend,
     is_cuda,
+    is_torch_compile_enabled,
     make_layers,
 )
 
@@ -67,7 +68,11 @@ logger = logging.getLogger(__name__)
 
 class Llama4MoE(nn.Module):
 
-    @torch.compile(dynamic=True, backend=get_compiler_backend())
+    @torch.compile(
+        dynamic=True,
+        backend=get_compiler_backend(),
+        disable=not is_torch_compile_enabled(),
+    )
     @staticmethod
     def custom_routing_function(
         hidden_states: torch.Tensor,
@@ -295,7 +300,11 @@ class Llama4Attention(nn.Module):
         attn_scale = torch.log(floor + 1.0) * self.attn_scale + 1.0
         return attn_scale.unsqueeze(-1)
 
-    @torch.compile(dynamic=True, backend=get_compiler_backend())
+    @torch.compile(
+        dynamic=True,
+        backend=get_compiler_backend(),
+        disable=not is_torch_compile_enabled(),
+    )
     def _mul_attn_scale(self, positions, q):
         attn_scale = self._get_attn_scale(positions)
         return (q * attn_scale).to(q.dtype)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -21,6 +21,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.speculative.eagle_utils import EagleDraftInput
 from sglang.srt.utils import (
+    is_torch_compile_enabled,
     require_attn_tp_gather,
     require_gathered_buffer,
     require_mlp_sync,
@@ -42,7 +43,6 @@ class EAGLEDraftCudaGraphRunner:
         self.model_runner = model_runner = eagle_worker.model_runner
         self.graphs = {}
         self.output_buffers = {}
-        self.enable_torch_compile = model_runner.server_args.enable_torch_compile
         self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
         self.is_encoder_decoder = model_runner.model_config.is_encoder_decoder
         self.require_gathered_buffer = require_gathered_buffer(model_runner.server_args)
@@ -75,7 +75,7 @@ class EAGLEDraftCudaGraphRunner:
             (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
         )
 
-        if self.enable_torch_compile:
+        if is_torch_compile_enabled():
             set_torch_compile_config()
 
         # Graph inputs

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -22,6 +22,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.speculative.eagle_utils import EagleDraftInput, fast_topk
 from sglang.srt.utils import (
+    is_torch_compile_enabled,
     require_attn_tp_gather,
     require_gathered_buffer,
     require_mlp_sync,
@@ -39,7 +40,6 @@ class EAGLEDraftExtendCudaGraphRunner:
         self.model_runner = model_runner = eagle_worker.model_runner
         self.graphs = {}
         self.output_buffers = {}
-        self.enable_torch_compile = model_runner.server_args.enable_torch_compile
         self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
         self.require_gathered_buffer = require_gathered_buffer(model_runner.server_args)
         self.require_mlp_tp_gather = require_mlp_tp_gather(model_runner.server_args)
@@ -70,7 +70,7 @@ class EAGLEDraftExtendCudaGraphRunner:
             (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
         )
 
-        if self.enable_torch_compile:
+        if is_torch_compile_enabled():
             set_torch_compile_config()
 
         # Graph inputs

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -23,7 +23,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
-from sglang.srt.utils import is_cuda, is_hip, next_power_of_2
+from sglang.srt.utils import is_cuda, is_hip, is_torch_compile_enabled, next_power_of_2
 
 logger = logging.getLogger(__name__)
 
@@ -964,7 +964,7 @@ def get_target_cache_loc(
     )
 
 
-@torch.compile(dynamic=True)
+@torch.compile(dynamic=True, disable=not is_torch_compile_enabled())
 def get_src_tgt_cache_loc(
     seq_lens: torch.Tensor,
     out_cache_loc: torch.Tensor,
@@ -1014,7 +1014,7 @@ def filter_finished_cache_loc_kernel(
     )
 
 
-@torch.compile(dynamic=True)
+@torch.compile(dynamic=True, disable=not is_torch_compile_enabled())
 def create_accept_length_filter(
     accept_length: torch.Tensor,
     unfinished_index_device: torch.Tensor,
@@ -1028,7 +1028,7 @@ def create_accept_length_filter(
     return accept_length_filter
 
 
-@torch.compile(dynamic=True)
+@torch.compile(dynamic=True, disable=not is_torch_compile_enabled())
 def select_top_k_tokens(
     i: int,
     topk_p: torch.Tensor,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -48,6 +48,7 @@ from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
     is_cuda,
+    is_torch_compile_enabled,
     next_power_of_2,
 )
 
@@ -914,7 +915,7 @@ def load_token_map(token_map_path: str) -> List[int]:
     return torch.tensor(hot_token_id, dtype=torch.int64)
 
 
-@torch.compile(dynamic=True)
+@torch.compile(dynamic=True, disable=not is_torch_compile_enabled())
 def get_last_loc_large_page_size_top_k_1(
     req_to_token: torch.Tensor,
     req_pool_indices: torch.Tensor,
@@ -931,7 +932,7 @@ def get_last_loc_large_page_size_top_k_1(
     return prefix_lens, seq_lens, last_loc
 
 
-@torch.compile(dynamic=True)
+@torch.compile(dynamic=True, disable=not is_torch_compile_enabled())
 def get_last_loc_large_page_size_large_top_k(
     req_to_token: torch.Tensor,
     req_pool_indices: torch.Tensor,

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -183,6 +183,10 @@ def is_flashinfer_available():
     return importlib.util.find_spec("flashinfer") is not None and is_cuda()
 
 
+def is_torch_compile_enabled() -> bool:
+    return get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE")
+
+
 _ENABLE_TORCH_INFERENCE_MODE = get_bool_env_var(
     "SGLANG_ENABLE_TORCH_INFERENCE_MODE", "false"
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
**From the [sglang wiki](https://docs.sglang.ai/references/environment_variables.html#performance-tuning), `--enable-torch-compile` is a experimental feature and `torch.compile` should be enabled only if `SGLANG_ENABLE_TORCH_COMPILE env var` is true. However, many code logics do not respect `SGLANG_ENABLE_TORCH_COMPILE` but enable torch.compile anyways.**

<img width="818" alt="image" src="https://github.com/user-attachments/assets/56825a1f-acd5-497c-a138-3a4d6acecfd3" />
<img width="842" alt="image" src="https://github.com/user-attachments/assets/ebd7d881-c8fb-41e9-971a-dadc7bc00ba4" />

## Modifications

* Add `is_torch_compile_enabled()` method into `python/sglang/srt/utils.py` which returns true if `SGLANG_ENABLE_TORCH_COMPILE env var` is set to 1/True as per [sglang wiki](https://docs.sglang.ai/references/environment_variables.html#performance-tuning) & [sglang server_args.py](https://github.com/sgl-project/sglang/blob/7248272ccc211c89ce01c584873413a686964a0f/python/sglang/srt/server_args.py#L539)
* Guard all the `torch.compile` related methods under `is_torch_compile_enabled` flag

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
