### PR TITLE
[PD Disaggregation] Replace the sync batch transfer with async batch transfer in KVCache transfer

### DIFF
--- a/docs/backend/pd_disaggregation.md
+++ b/docs/backend/pd_disaggregation.md
@@ -57,6 +57,8 @@ PD Disaggregation with Mooncake supports the following environment variables for
 | **`SGLANG_DISAGGREGATION_THREAD_POOL_SIZE`** | Controls the total number of worker threads for KVCache transfer operations per TP rank | A dynamic value calculated by `int(0.75 * os.cpu_count()) // 8)`, which is limited to be larger than 4 and less than 12 to ensure efficiency and prevent thread race conditions |
 | **`SGLANG_DISAGGREGATION_QUEUE_SIZE`** | Sets the number of parallel transfer queues. KVCache transfer requests from multiple decode instances will be sharded into these queues so that they can share the threads and the transfer bandwidth at the same time. If it is set to `1`, then we transfer requests one by one according to fcfs strategy | `4` |
 | **`SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT`** | Timeout (seconds) for receiving destination KV indices during request initialization | `120` |
+| **`SGLANG_DISAGGREGATION_LARGE_CHUNK`** | Sets the minimum size threshold to select the KVCache chunk for a parallel transfer in the mooncake connector. | `20480` |
+| **`SGLANG_DISAGGREGATION_ASYNC_TRANSFER_MICRO_BATCH_SIZE`** | Sets the size of a transfer submission unit in the mooncake connector's `batch_transfer_async` | `256` |
 
 #### Decode Server Configuration
 | Variable | Description | Default |

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -279,7 +279,7 @@ class MooncakeKVManager(BaseKVManager):
         
         large_chunks_transfer_futures = [
             executor.submit(
-                self.engine.batch_transfer_async,
+                self.engine.batch_transfer_sync,
                 mooncake_session_id,
                 src_addr_list_large_chunk,
                 dst_addr_list_large_chunk,
@@ -291,7 +291,7 @@ class MooncakeKVManager(BaseKVManager):
         micro_batch_size = max(num_small_chunks // self.thread_pool_size, self.thread_pool_size)
         small_chunks_transfer_futures = [
             executor.submit(
-                self.engine.batch_transfer_async,
+                self.engine.batch_transfer_sync,
                 mooncake_session_id,
                 src_addr_list_small_chunk[i : i + micro_batch_size],
                 dst_addr_list_small_chunk[i : i + micro_batch_size],
@@ -417,7 +417,7 @@ class MooncakeKVManager(BaseKVManager):
         if slice_lens_per_page > get_int_env_var('SGLANG_DISAGGREGATION_LARGE_CHUNK', 20480):
             futures = [
                 executor.submit(
-                    self.engine.batch_transfer_async,
+                    self.engine.batch_transfer_sync,
                     mooncake_session_id,
                     src_addr_list,
                     dst_addr_list,
@@ -428,7 +428,7 @@ class MooncakeKVManager(BaseKVManager):
             micro_batch_size = max(len(length_list) // self.thread_pool_size, self.thread_pool_size)
             futures = [
                 executor.submit(
-                    self.engine.batch_transfer_async,
+                    self.engine.batch_transfer_sync,
                     mooncake_session_id,
                     src_addr_list[i : i + micro_batch_size],
                     dst_addr_list[i : i + micro_batch_size],

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -257,32 +257,48 @@ class MooncakeKVManager(BaseKVManager):
             for layer_id in range(num_layers)
         ]
 
-        # Worker function for processing a single layer
-        def process_layer(src_ptr: int, dst_ptr: int, item_len: int) -> int:
-            src_addr_list = []
-            dst_addr_list = []
-            length_list = []
+        # Group by transfer chunk size
+        src_addr_list_large_chunk, src_addr_list_small_chunk = [], []
+        dst_addr_list_large_chunk, dst_addr_list_small_chunk = [], []
+        length_list_large_chunk, length_list_small_chunk = [], []
+
+        for (src_ptr, dst_ptr, item_len) in layers_params:
             for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
                 src_addr = src_ptr + int(prefill_index[0]) * item_len
                 dst_addr = dst_ptr + int(decode_index[0]) * item_len
                 length = item_len * len(prefill_index)
-                src_addr_list.append(src_addr)
-                dst_addr_list.append(dst_addr)
-                length_list.append(length)
-            return self.engine.batch_transfer_sync(
-                mooncake_session_id, src_addr_list, dst_addr_list, length_list
-            )
-
-        futures = [
+                if length > 20 * 1024:
+                    src_addr_list_large_chunk.append(src_addr)
+                    dst_addr_list_large_chunk.append(dst_addr)
+                    length_list_large_chunk.append(length)
+                else:
+                    src_addr_list_small_chunk.append(src_addr)
+                    dst_addr_list_small_chunk.append(dst_addr)
+                    length_list_small_chunk.append(length)
+        
+        async_futures = [
             executor.submit(
-                process_layer,
-                src_ptr,
-                dst_ptr,
-                item_len,
+                self.engine.batch_transfer_async,
+                mooncake_session_id,
+                src_addr_list_large_chunk,
+                dst_addr_list_large_chunk,
+                length_list_large_chunk,
             )
-            for (src_ptr, dst_ptr, item_len) in layers_params
         ]
 
+        micro_batch_size = min(len(length_list_small_chunk), 256)
+        sync_futures = [
+            executor.submit(
+                self.engine.batch_transfer_sync,
+                mooncake_session_id,
+                src_addr_list_small_chunk[i : i + micro_batch_size],
+                dst_addr_list_small_chunk[i : i + micro_batch_size],
+                length_list_small_chunk[i : i + micro_batch_size],
+            )
+            for i in range (0, len(length_list_small_chunk), micro_batch_size)
+        ]
+
+        futures = list(zip(async_futures, sync_futures))
         for future in concurrent.futures.as_completed(futures):
             status = future.result()
             if status != 0:
@@ -337,7 +353,9 @@ class MooncakeKVManager(BaseKVManager):
             num_heads_to_send = heads_per_decode_rank
             dst_head_offset = 0
 
-        layer_transfer_params = []
+        src_addr_list = []
+        dst_addr_list = []
+        length_list = []
         for layer_id in range(num_layers):
             item_len_of_prefill_rank_page = self.kv_args.kv_item_lens[layer_id]
 
@@ -355,6 +373,9 @@ class MooncakeKVManager(BaseKVManager):
             dst_slice_offset = dst_head_offset * bytes_per_head
             slice_lens_per_page = num_heads_to_send * bytes_per_head
 
+            bytes_per_token_on_prefill = item_len_of_prefill_rank_page // page_size
+            bytes_per_token_on_decode = item_len_of_decode_rank_page // page_size
+
             # Sanity check: The data sub-slice to be sent should fit into the decode instance's page.
             # This means slice_lens_per_page <= item_len_of_decode_rank_page
             if slice_lens_per_page > item_len_of_decode_rank_page:
@@ -364,47 +385,15 @@ class MooncakeKVManager(BaseKVManager):
                     f"target page size ({item_len_of_decode_rank_page})"
                 )
                 return -1
-            layer_transfer_params.append(
-                (
-                    self.kv_args.kv_data_ptrs[layer_id],
-                    dst_kv_ptrs[layer_id],
-                    item_len_of_prefill_rank_page,
-                    item_len_of_decode_rank_page,
-                    src_slice_offset,
-                    dst_slice_offset,
-                    slice_lens_per_page,
-                )
-            )
-
-        def process_layer_tp_aware(layer_params):
-            (
-                src_ptr,
-                dst_ptr,
-                src_item_len,
-                dst_item_len,
-                src_offset,
-                dst_offset,
-                slice_lens_per_page,
-            ) = layer_params
-            src_addr_list = []
-            dst_addr_list = []
-            length_list = []
-
-            # Calculate strides for a single token slot
-            bytes_per_token_on_prefill = src_item_len // page_size
-            bytes_per_token_on_decode = dst_item_len // page_size
 
             for i in range(len(prefill_kv_indices)):
                 prefill_page_idx = int(prefill_kv_indices[i])
                 decode_page_idx = int(dst_kv_indices[i])
 
-                # Get the starting addresses for the current src and dst pages
-                src_page_start_addr = src_ptr + prefill_page_idx * src_item_len
-                dst_page_start_addr = dst_ptr + decode_page_idx * dst_item_len
+                src_page_start_addr = self.kv_args.kv_data_ptrs[layer_id] + prefill_page_idx * item_len_of_prefill_rank_page
+                dst_page_start_addr = dst_kv_ptrs[layer_id] + decode_page_idx * item_len_of_decode_rank_page
 
-                # Iterate through each valid token slot within the current page
                 for token_slot_in_page in range(page_size):
-                    # Calculate the start address of the current token slot
                     src_token_slot_start_addr = (
                         src_page_start_addr
                         + token_slot_in_page * bytes_per_token_on_prefill
@@ -415,29 +404,37 @@ class MooncakeKVManager(BaseKVManager):
                     )
 
                     # Calculate final src and dst addresses by applying head-slice offsets
-                    src_slice_addr = src_token_slot_start_addr + src_offset
-                    dst_slice_addr = dst_token_slot_start_addr + dst_offset
+                    src_slice_addr = src_token_slot_start_addr + src_slice_offset
+                    dst_slice_addr = dst_token_slot_start_addr + dst_slice_offset
 
                     src_addr_list.append(src_slice_addr)
                     dst_addr_list.append(dst_slice_addr)
                     length_list.append(slice_lens_per_page)
 
-                    logger.debug(
-                        f"SYNC: sid={mooncake_session_id}, "
-                        f"src={src_slice_addr}, dst={dst_slice_addr}, len={slice_lens_per_page}"
+        
+        if slice_lens_per_page > 20 * 1024:
+            futures = [
+                executor.submit(
+                    self.engine.batch_transfer_async(
+                        mooncake_session_id,
+                        src_addr_list,
+                        dst_addr_list,
+                        length_list,
                     )
-
-            return self.engine.batch_transfer_sync(
-                mooncake_session_id, src_addr_list, dst_addr_list, length_list
-            )
-
-        futures = [
-            executor.submit(
-                process_layer_tp_aware,
-                layer_params,
-            )
-            for layer_params in layer_transfer_params
-        ]
+                )
+            ]
+        else:
+            micro_batch_size = min(len(length_list), 256)
+            futures = [
+                executor.submit(
+                    self.engine.batch_transfer_sync,
+                    mooncake_session_id,
+                    src_addr_list[i : i + micro_batch_size],
+                    dst_addr_list[i : i + micro_batch_size],
+                    length_list[i : i + micro_batch_size],
+                )
+                for i in range(0, len(length_list), micro_batch_size)
+            ]
 
         for future in concurrent.futures.as_completed(futures):
             status = future.result()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -300,7 +300,7 @@ class MooncakeKVManager(BaseKVManager):
             for i in range (0, num_small_chunks, micro_batch_size)
         ]
 
-        futures = list(zip(async_futures, sync_futures))
+        futures = async_futures + sync_futures
         for future in concurrent.futures.as_completed(futures):
             status = future.result()
             if status != 0:
@@ -417,12 +417,11 @@ class MooncakeKVManager(BaseKVManager):
         if slice_lens_per_page > get_int_env_var('SGLANG_DISAGGREGATION_LARGE_CHUNK', 20480):
             futures = [
                 executor.submit(
-                    self.engine.batch_transfer_async(
-                        mooncake_session_id,
-                        src_addr_list,
-                        dst_addr_list,
-                        length_list,
-                    )
+                    self.engine.batch_transfer_async,
+                    mooncake_session_id,
+                    src_addr_list,
+                    dst_addr_list,
+                    length_list,
                 )
             ]
         else:

--- a/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
@@ -2,6 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import List, Optional
+
 from sglang.srt.utils import get_int_env_var
 
 logger = logging.getLogger(__name__)
@@ -100,17 +101,19 @@ class MooncakeTransferEngine:
     ) -> int:
         """Synchronously transfer data to the specified addresses in batches."""
         try:
-            micro_batch_size = get_int_env_var('SGLANG_DISAGGREGATION_ASYNC_TRANSFER_MICRO_BATCH_SIZE', 256)
+            micro_batch_size = get_int_env_var(
+                "SGLANG_DISAGGREGATION_ASYNC_TRANSFER_MICRO_BATCH_SIZE", 256
+            )
             batch_ids = []
             for i in range(0, len(lengths), micro_batch_size):
                 batch_id = self.engine.batch_transfer_async_write(
                     session_id,
-                    buffers[i: i + micro_batch_size],
-                    peer_buffer_addresses[i: i + micro_batch_size],
-                    lengths[i: i + micro_batch_size]
+                    buffers[i : i + micro_batch_size],
+                    peer_buffer_addresses[i : i + micro_batch_size],
+                    lengths[i : i + micro_batch_size],
                 )
                 batch_ids.append(batch_id)
-            
+
             ret = self.engine.get_batch_transfer_status(batch_ids)
         except Exception:
             ret = -1

--- a/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
@@ -100,39 +100,6 @@ class MooncakeTransferEngine:
     ) -> int:
         """Synchronously transfer data to the specified addresses in batches."""
         try:
-            ret = self.engine.batch_transfer_sync_write(
-                session_id, buffers, peer_buffer_addresses, lengths
-            )
-        except Exception:
-            ret = -1
-            # Inform user to upgrade mooncake-transfer-engine >= 0.3.4.post2
-            if not hasattr(self.engine, "batch_transfer_sync_write"):
-                raise RuntimeError(
-                    "Mooncake's batch transfer requires mooncake-transfer-engine >= 0.3.4.post2. "
-                    "Please upgrade Mooncake by 'pip install mooncake-transfer-engine --upgrade'"
-                )
-
-        if ret < 0:
-            logger.debug(
-                "Failed to batch transfer data. Buffers: %s, Session: %s, Peer addresses: %s",
-                buffers,
-                session_id,
-                peer_buffer_addresses,
-            )
-        return ret
-
-    def batch_transfer_async(
-        self,
-        session_id: str,
-        buffers: List[int],
-        peer_buffer_addresses: List[int],
-        lengths: List[int],
-    ) -> int:
-        """
-        Submits a batch of transfer tasks as micro-batches without immediate result queries. 
-        Results for all micro-batches are queried collectively after submission.
-        """
-        try:
             micro_batch_size = get_int_env_var('SGLANG_DISAGGREGATION_ASYNC_TRANSFER_MICRO_BATCH_SIZE', 256)
             batch_ids = []
             for i in range(0, len(lengths), micro_batch_size):

--- a/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
@@ -128,9 +128,12 @@ class MooncakeTransferEngine:
         peer_buffer_addresses: List[int],
         lengths: List[int],
     ) -> int:
-        """Synchronously transfer data to the specified addresses in batches."""
+        """
+        Submits a batch of transfer tasks as micro-batches without immediate result queries. 
+        Results for all micro-batches are queried collectively after submission.
+        """
         try:
-            micro_batch_size = get_int_env_var('SGLANG_DISAGGREGATION_MICRO_BATCH_SIZE', 256)
+            micro_batch_size = get_int_env_var('SGLANG_DISAGGREGATION_ASYNC_TRANSFER_MICRO_BATCH_SIZE', 256)
             batch_ids = []
             for i in range(0, len(lengths), micro_batch_size):
                 batch_id = self.engine.batch_transfer_async_write(

--- a/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/mooncake/transfer_engine.py
@@ -2,6 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 from typing import List, Optional
+from sglang.srt.utils import get_int_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -129,9 +130,9 @@ class MooncakeTransferEngine:
     ) -> int:
         """Synchronously transfer data to the specified addresses in batches."""
         try:
-            micro_batch_size, batch_size = 256, len(lengths)
+            micro_batch_size = get_int_env_var('SGLANG_DISAGGREGATION_MICRO_BATCH_SIZE', 256)
             batch_ids = []
-            for i in range(0, batch_size, micro_batch_size):
+            for i in range(0, len(lengths), micro_batch_size):
                 batch_id = self.engine.batch_transfer_async_write(
                     session_id,
                     buffers[i: i + micro_batch_size],


### PR DESCRIPTION
## Motivation
This pull request aims to reduce CPU overhead and improve KVCache transfer performance by replacing the `batch_transfer_sync_write` with `batch_transfer_async_write` in the mooncake connector implementation. Building on the findings from [kvcache-ai/Mooncake#564](https://github.com/kvcache-ai/Mooncake/pull/564), it demonstrates that using a single thread with the new `batch_transfer_async` interface can nearly saturate bandwidth. However, for smaller KV chunks (≤ ~20KB), the multi-threaded batch approach performs better (see appendix). Therefore, this PR dynamically scales the number of threads to transfer based on the chunk size to minimize CPU overhead without compromising KVCache transfer performance.

## Modifications
In the Mooncake connector, implement an asynchronous batch transfer interface. Prior to initiating the transfer, aggregate all chunks across all layers. Next, extract the smaller portions and transfer them using the threads in the ThreadPool with `batch_transfer_async`. Finally, delegate the remaining larger portions to be processed by a single thread.

## Evaluation
In local tests (1 prefill nodes + 2 decode nodes, DeepSeek R1 model, 4K context length) with 200*2Gbps RDMA links,
client-side command line 
  ```Python
  python3 -m sglang.bench_serving \
    --backend sglang \
    --dataset-name random \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --num-prompts 500 \
    --random-input $1 \
    --random-output 100 \
    --port 8088 \
    --warmup-requests 16 \
    --max-concurrency 256
  ```
Comparison of transfer performance between current implementation(multi-sync) and my proposal(scale-async)

Metrics explained
  - Latency (ms): average transfer latency of a single request
  - Throughput (GB/s): average transfer throughput of each transfer operation(e.g. `send_kvcache`)
  - Nth-Iteration: running the same command at Nth time without restarting the backend
```txt
====================================================================================================
SUMMARY
====================================================================================================
Test Case            multi-sync(ms) scale-async(ms) multi-sync(GB/s) scale-async(GB/s) Speedup   
----------------------------------------------------------------------------------------------------
4K/1-iteration       67.242           27.972           5.102            15.827         58.40%    
4K/10-iteration      104.254          81.538           3.491            5.396          21.78%    
10K/1-iteration      52.056           42.838           15.644           21.409         17.70%    
10K/5-iteration      70.644           61.808           10.733           14.564         12.50%   
```

## Appendix
Comparison of transfer performance between single thread + batch_transfer_async(single-async) and multi-thread(3 threads) + batch_transfer_async(`multi-async`) when the chunks' sizes of a batch is around tens of KB.
```txt
=========================================================================================
SUMMARY
=========================================================================================
Test Case            multi-async(ms) single-async(ms) multi-async(GB/s) single-async(GB/s) 
----------------------------------------------------------------------------------------
200MB/10000chunks    5.149            5.591            37.935           34.930         
220MB/10000chunks    5.582            5.696            38.492           37.720         
240MB/10000chunks    6.101            5.962            38.419           39.310         
260MB/10000chunks    6.587            6.337            38.549           40.068         
280MB/10000chunks    7.010            6.755            39.005           40.478         
300MB/10000chunks    7.466            7.165            39.239           40.892         
400MB/10000chunks    9.776            9.485            39.959           41.184         
500MB/10000chunks    12.044           11.612           40.541           42.050         
600MB/10000chunks    14.357           13.637           41.083           42.965
```
