### PR TITLE
Fix DeepSeek torch.compile caching link

### DIFF
--- a/docs/references/deepseek.md
+++ b/docs/references/deepseek.md
@@ -66,7 +66,7 @@ Detailed commands for reference:
 If you encounter errors when starting the server, ensure the weights have finished downloading. It's recommended to download them beforehand or restart multiple times until all weights are downloaded. Please refer to [DeepSeek V3](https://huggingface.co/deepseek-ai/DeepSeek-V3-Base#61-inference-with-deepseek-infer-demo-example-only) official guide to download the weights.
 
 ### Caching `torch.compile`
-The DeepSeek series have huge model weights, it takes some time to compile the model with `torch.compile` for the first time if you have added the flag `--enable-torch-compile`. You can refer [here](https://docs.sglang.ai/backend/hyperparameter_tuning.html#try-advanced-options) to optimize the caching of compilation results, so that the cache can be used to speed up the next startup.
+The DeepSeek series have huge model weights, it takes some time to compile the model with `torch.compile` for the first time if you have added the flag `--enable-torch-compile`. You can refer [here](torch_compile_cache.md) to optimize the caching of compilation results, so that the cache can be used to speed up the next startup.
 
 ### Launch with one node of 8 x H200
 Please refer to [the example](https://github.com/sgl-project/sglang/tree/main/benchmark/deepseek_v3#using-docker-recommended). **Note that Deepseek V3 is already in FP8. So we should not run it with any quantization arguments like `--quantization fp8 --kv-cache-dtype fp8_e5m2`.

--- a/docs/references/torch_compile_cache.md
+++ b/docs/references/torch_compile_cache.md
@@ -3,7 +3,7 @@
 SGLang uses `max-autotune-no-cudagraphs` mode of torch.compile. The auto-tuning can be slow.
 If you want to deploy a model on many different machines, you can ship the torch.compile cache to these machines and skip the compilation steps.
 
-This is based on https://pytorch.org/tutorials/recipes/torch_compile_caching_tutorial.html
+This is based on the [PyTorch compile caching recipe](https://pytorch.org/tutorials/recipes/torch_compile_caching_tutorial.html).
 
 
 1. Generate the cache by setting TORCHINDUCTOR_CACHE_DIR and running the model once.


### PR DESCRIPTION
## Motivation

The reference page for DeepSeek models has a section mentioning using `torch.compile` and recommending caching the results to speed up subsequent boot times. The link for caching details pointed at the general optimizing page that has since been updated to no longer have any details on caching.

## Modifications

This updates the link to point to the dedicated torch compile caching reference page, as well as a slight polish of an upstream link included on that page.

## Checklist

- [ ] (NA) Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] (NA) Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [X] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] (NA) Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] (NA) For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
