### PR TITLE
[Bug] add flashinfer bool check for fusedmoe in Qwen moe models

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -138,7 +138,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         expert_type = get_moe_impl_class()
         if expert_type is FusedMoE:
             extra_args = {
-                "enable_deepep_moe": global_server_args_dict["enable_deepep_moe"],
+                "enable_flashinfer_moe": global_server_args_dict["enable_flashinfer_moe"],
             }
 
         self.experts = expert_type(

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -100,17 +100,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                 f"the number of experts {config.num_experts}."
             )
 
-        extra_args = {}
-
-        expert_type = get_moe_impl_class()
-        if expert_type is FusedMoE:
-            extra_args = {
-                "enable_flashinfer_moe": global_server_args_dict[
-                    "enable_flashinfer_moe"
-                ],
-            }
-
-        self.experts = expert_type(
+        self.experts = get_moe_impl_class()(
             num_experts=config.num_experts
             + global_server_args_dict["ep_num_redundant_experts"],
             top_k=config.num_experts_per_tok,
@@ -125,7 +115,15 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                 if global_server_args_dict["enable_deepep_moe"]
                 else {}
             ),
-            **extra_args,
+            # Additional args for FusedMoE
+            **(
+                dict(
+                    enable_flashinfer_moe=True,
+                    enable_ep_moe=global_server_args_dict["enable_ep_moe"],
+                )
+                if global_server_args_dict["enable_flashinfer_moe"]
+                else {}
+            ),
         )
 
         self.gate = ReplicatedLinear(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->
## Motivation

The current Qwen MoE models (`qwen2_moe.py` and `qwen3_moe.py`) do not pass the `enable_flashinfer_moe` flag, causing `FuseMoE` to default to `enable_flashinfer_moe=False`.

## Modifications

Added checks to ensure the `enable_flashinfer_moe` flag is correctly passed to the `FuseMoE` initializer.

