### PR TITLE
[CI][Router] Fix bench_one_batch_server for pd router test

### DIFF
--- a/.github/workflows/pr-test-pd-router.yml
+++ b/.github/workflows/pr-test-pd-router.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         echo "Installing SGLang with all extras..."
         python3 -m pip --no-cache-dir install -e "python[all]" --break-system-packages
-        python3 -m pip --no-cache-dir install mooncake-transfer-engine==0.3.4.post1
+        python3 -m pip --no-cache-dir install mooncake-transfer-engine==0.3.4.post2
 
     - name: Build and install sgl-router
       run: |

--- a/python/sglang/bench_one_batch_server.py
+++ b/python/sglang/bench_one_batch_server.py
@@ -253,8 +253,11 @@ def run_benchmark(server_args: ServerArgs, bench_args: BenchArgs):
     else:
         proc, base_url = launch_server_process(server_args)
 
-    server_info = requests.get(base_url + "/get_server_info")
-    tokenizer_path = server_info.json()["tokenizer_path"]
+    server_info = requests.get(base_url + "/get_server_info").json()
+    if "tokenizer_path" in server_info:
+        tokenizer_path = server_info["tokenizer_path"]
+    elif "prefill" in server_info:
+        tokenizer_path = server_info["prefill"][0]["tokenizer_path"]
     tokenizer = get_tokenizer(tokenizer_path)
 
     # warmup

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -238,7 +238,6 @@ async def get_server_info():
             "internal_states": all_internal_states,
             "prefill": prefill_infos,
             "decode": decode_infos,
-            "tokenizer_path": prefill_infos[0]["tokenizer_path"],
         }
     else:
         # Fallback with dummy data if no internal states found
@@ -251,7 +250,6 @@ async def get_server_info():
             ],
             "prefill": prefill_infos,
             "decode": decode_infos,
-            "tokenizer_path": prefill_infos[0]["tokenizer_path"],
         }
 
 

--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -238,6 +238,7 @@ async def get_server_info():
             "internal_states": all_internal_states,
             "prefill": prefill_infos,
             "decode": decode_infos,
+            "tokenizer_path": prefill_infos[0]["tokenizer_path"],
         }
     else:
         # Fallback with dummy data if no internal states found
@@ -250,6 +251,7 @@ async def get_server_info():
             ],
             "prefill": prefill_infos,
             "decode": decode_infos,
+            "tokenizer_path": prefill_infos[0]["tokenizer_path"],
         }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
The return JSON of `/get_server_info` endpoint under PD mode is different, which is nested with multiple instances' server info. To make it compatible with bench_one_batch_server, we need to determine whether server_info is nested and "tokenizer_path" is present.

```bash
Run echo "Running benchmark test..."
Running benchmark test...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/keru/action-runner/_work/sglang/sglang/python/sglang/bench_one_batch_server.py", line 396, in <module>
    run_benchmark(server_args, bench_args)
  File "/home/keru/action-runner/_work/sglang/sglang/python/sglang/bench_one_batch_server.py", line 257, in run_benchmark
    tokenizer_path = server_info.json()["tokenizer_path"]
                     ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'tokenizer_path'
Error: Process completed with exit code 1.
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->


<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
