### PR TITLE
[CPU] [sgl-kernel] set dispatch key of initialize to CatchAll

### DIFF
--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -342,7 +342,6 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   // all reduce
   m.def("initialize(int size, int rank) -> ()");
-  m.impl("initialize", torch::kCPU, &initialize);
   m.def("shm_allreduce(Tensor data, int reduce_op) -> ()");
   m.impl("shm_allreduce", torch::kCPU, &shm_allreduce);
   m.def("shm_allgather(Tensor data, int dim) -> Tensor");
@@ -360,6 +359,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
 TORCH_LIBRARY_IMPL(sgl_kernel, CatchAll, m) {
   m.impl("init_cpu_threads_env", init_cpu_threads_env);
+  m.impl("initialize", &initialize);
 }
 
 REGISTER_EXTENSION(common_ops)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
For the `initialize` OP, there were no tensor arguments to this OP and `torch::kCPU` does not work in this case. We need to use `CatchAll` as mentioned here: https://github.com/sgl-project/sglang/pull/6770#issuecomment-2924075568. 

https://github.com/sgl-project/sglang/pull/7524 has done the same for this OP `init_cpu_threads_env`.

