### PR TITLE
fix silent fault in benchmark generation

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -511,6 +511,7 @@ async def async_request_sglang_generate(
         st = time.perf_counter()
         most_recent_timestamp = st
         last_output_len = 0
+        success = True
         try:
             async with session.post(
                 url=api_url, json=payload, headers=headers
@@ -527,6 +528,11 @@ async def async_request_sglang_generate(
                             pass
                         else:
                             data = json.loads(chunk)
+
+                            if "error" in data:
+                                output.error = data["error"]["message"]
+                                success = False
+                                break
 
                             # NOTE: Some completion API might have a last
                             # usage summary response without a token so we
@@ -553,11 +559,11 @@ async def async_request_sglang_generate(
 
                                 most_recent_timestamp = timestamp
                                 last_output_len = output_len
-
-                    output.generated_text = generated_text
-                    output.success = True
-                    output.latency = latency
-                    output.output_len = output_len
+                    if success:
+                        output.generated_text = generated_text
+                        output.success = True
+                        output.latency = latency
+                        output.output_len = output_len
                 else:
                     output.error = response.reason or ""
                     output.success = False


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

In `bench_serving.py` the stream generation api may return error. Such error isn't handled correctly and would silently corrupt the final metrics like `mean_ttft`.

e.g. `mean_ttft` would be zero and no error would be raised by `bench_serving.py` when the following error occurs.
```
Error: The input (128038 tokens) is longer than the model's context length (40960 tokens).
```

## Modifications

<!-- Describe the changes made in this PR. -->

Handle error in server's response.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
