### PR TITLE
Optimize Hopper CUTLASS FP8 Blockwise Grouped GEMM Kernel in Small K Scenario

### DIFF
--- a/sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
+++ b/sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
@@ -61,7 +61,13 @@ void launch_sm90_fp8_blockwise_scaled_group_mm(
 
   using ArchTag = cutlass::arch::Sm90;
   using OperatorClass = cutlass::arch::OpClassTensorOp;
-  using FusionOperation = cutlass::epilogue::fusion::LinearCombination<ElementD, ElementAccumulator>;
+  static constexpr auto RoundStyle = cutlass::FloatRoundStyle::round_to_nearest;
+  using CustomEVTIdentity =  // acc
+    cutlass::epilogue::fusion::Sm90EVT<
+      cutlass::epilogue::fusion::Sm90Compute<
+        cutlass::epilogue::thread::Identity, ElementD, ElementAccumulator, RoundStyle>,
+      cutlass::epilogue::fusion::Sm90AccFetch
+    >;
 
   using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
       ArchTag,
@@ -78,7 +84,7 @@ void launch_sm90_fp8_blockwise_scaled_group_mm(
       LayoutC*,
       AlignmentC,
       typename ScheduleConfig::EpilogueSchedule,
-      FusionOperation>::CollectiveOp;
+      CustomEVTIdentity>::CollectiveOp;
 
   using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
       ArchTag,
@@ -452,7 +458,7 @@ void sm90_fp8_blockwise_group_mm_dispatch_shape(
     const torch::Tensor& problem_sizes,
     const torch::Tensor& expert_offsets,
     const torch::Tensor& workspace) {
-  struct MmaConfig {
+  struct MmaConfig0 {
     using ElementA = cutlass::float_e4m3_t;
     using MmaTileShape = Shape<_64, _128, _128>;
     using ClusterShape = Shape<_2, _1, _1>;
@@ -464,40 +470,86 @@ void sm90_fp8_blockwise_group_mm_dispatch_shape(
     using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
   };
 
+  struct MmaConfig1 {
+    using ElementA = cutlass::float_e4m3_t;
+    using MmaTileShape = Shape<_128, _128, _128>;
+    using ClusterShape = Shape<_1, _2, _1>;
+    using KernelSchedule = cutlass::gemm::KernelPtrArrayTmaWarpSpecializedCooperativeFP8BlockScaledAccum;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecializedCooperative;
+    using ScaleConfig = cutlass::detail::Sm90BlockwiseScaleConfig<1, 128, 128>;
+
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+
   int num_experts = (int)expert_offsets.size(0);
   torch::TensorOptions options_int = torch::TensorOptions().dtype(torch::kInt64).device(a.device());
   torch::Tensor problem_sizes_transpose = torch::empty(num_experts * 3, options_int);
 
-  run_get_group_gemm_starts<MmaConfig::LayoutSFA, MmaConfig::LayoutSFB, MmaConfig::ScaleConfig>(
-      expert_offsets,
-      a_ptrs,
-      b_ptrs,
-      out_ptrs,
-      a_scales_ptrs,
-      b_scales_ptrs,
-      a,
-      b,
-      output,
-      scales_a,
-      scales_b,
-      layout_sfa,
-      layout_sfb,
-      problem_sizes,
-      problem_sizes_transpose);
-  launch_sm90_fp8_blockwise_scaled_group_mm<OutType, MmaConfig, cutlass::layout::RowMajor>(
-      out_ptrs,
-      a_ptrs,
-      b_ptrs,
-      a_scales_ptrs,
-      b_scales_ptrs,
-      stride_a,
-      stride_b,
-      stride_c,
-      layout_sfa,
-      layout_sfb,
-      problem_sizes,
-      expert_offsets,
-      workspace);
+  if (a.size(1) > 128) {
+    run_get_group_gemm_starts<MmaConfig0::LayoutSFA, MmaConfig0::LayoutSFB, MmaConfig0::ScaleConfig>(
+        expert_offsets,
+        a_ptrs,
+        b_ptrs,
+        out_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        a,
+        b,
+        output,
+        scales_a,
+        scales_b,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        problem_sizes_transpose);
+    launch_sm90_fp8_blockwise_scaled_group_mm<OutType, MmaConfig0, cutlass::layout::RowMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        expert_offsets,
+        workspace);
+  } else {
+    // Small K
+    run_get_group_gemm_starts<MmaConfig1::LayoutSFA, MmaConfig1::LayoutSFB, MmaConfig1::ScaleConfig>(
+        expert_offsets,
+        a_ptrs,
+        b_ptrs,
+        out_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        a,
+        b,
+        output,
+        scales_a,
+        scales_b,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        problem_sizes_transpose);
+    launch_sm90_fp8_blockwise_scaled_group_mm<OutType, MmaConfig1, cutlass::layout::RowMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        expert_offsets,
+        workspace);
+  }
 }
 
 /**
@@ -641,7 +693,7 @@ void fp8_blockwise_scaled_grouped_mm(
 #endif
 
 #if defined(CUTLASS_ARCH_MMA_SM90_SUPPORTED) && defined(CUTLASS_ARCH_MMA_MODIFIABLE_TMA_SM90_SUPPORTED)
-  if (sm_version == 90 && a.size(1) > 256) {
+  if (sm_version == 90) {
     if (output.scalar_type() == torch::kBFloat16) {
       sm90_fp8_blockwise_group_mm_dispatch_shape<cutlass::bfloat16_t>(
           output,
@@ -688,7 +740,6 @@ void fp8_blockwise_scaled_grouped_mm(
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(
       can_implement,
-      "No implemented fp8_blockwise_scaled_mm for current compute capability or K size: ",
-      sm_version,
-      a.size(1));
+      "No implemented fp8_blockwise_scaled_mm for current compute capability: ",
+      sm_version);
 }

--- a/sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
+++ b/sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
@@ -63,11 +63,10 @@ void launch_sm90_fp8_blockwise_scaled_group_mm(
   using OperatorClass = cutlass::arch::OpClassTensorOp;
   static constexpr auto RoundStyle = cutlass::FloatRoundStyle::round_to_nearest;
   using CustomEVTIdentity =  // acc
-    cutlass::epilogue::fusion::Sm90EVT<
-      cutlass::epilogue::fusion::Sm90Compute<
-        cutlass::epilogue::thread::Identity, ElementD, ElementAccumulator, RoundStyle>,
-      cutlass::epilogue::fusion::Sm90AccFetch
-    >;
+      cutlass::epilogue::fusion::Sm90EVT<
+          cutlass::epilogue::fusion::
+              Sm90Compute<cutlass::epilogue::thread::Identity, ElementD, ElementAccumulator, RoundStyle>,
+          cutlass::epilogue::fusion::Sm90AccFetch>;
 
   using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
       ArchTag,
@@ -739,7 +738,5 @@ void fp8_blockwise_scaled_grouped_mm(
   }
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(
-      can_implement,
-      "No implemented fp8_blockwise_scaled_mm for current compute capability: ",
-      sm_version);
+      can_implement, "No implemented fp8_blockwise_scaled_mm for current compute capability: ", sm_version);
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Follow https://github.com/sgl-project/sglang/pull/7278
When K in GEMM problem size is small, CUTLASS Kernel shows suboptimal performance. The reason is that when K is small, the execution time of Mainloop is very short and Epilogue is difficult to be overlapped by Mainloop. In CUTLASS, Epilogue performs unnecessary LinearCombination, which further degrades performance.
We compared the nsight-compute profile reports of DeepGEMM and CUTLASS after aligning TileShape. The results showed that in the Small K scenario, the number of FFMA instructions executed by CUTLASS far exceeded that of DeepGEMM. 
![PR示意图](https://github.com/user-attachments/assets/6e8fc23a-3e05-4f6f-8d0c-549add7b67dd)
Therefore, we optimized the unnecessary LinearCombination in Epilogue.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
Only sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu:
+ Use CUTLASS Sm90EVT to define an identity op in Epilogue
+ When K is extremely small, the Cooperative Kernel has better performance, probably because TMA data copying is more efficient. Therefore, the Cooperative Kernel is used when K < 256.

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
Lint done:
![Small_K Code lint](https://github.com/user-attachments/assets/6c96b9cf-0dff-4d45-ad54-7ed965252d7a)
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
Unitest passed:
![单元测试通过](https://github.com/user-attachments/assets/523b5488-a41b-44ac-9840-106cf02f4be1)
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
Before optimization:
![Small_K优化前](https://github.com/user-attachments/assets/43c311bb-abec-4da6-8bb5-646d4072cc6b)
After optimization:
![Small_K分区间优化](https://github.com/user-attachments/assets/0486c933-f115-47cd-b567-b2abae68e93e)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
