### PR TITLE
fix(internvl): support Qwen2 + Qwen2_5 architectures in LLM config selection

### DIFF
--- a/python/sglang/srt/configs/internvl.py
+++ b/python/sglang/srt/configs/internvl.py
@@ -9,6 +9,7 @@ from transformers import (
     LlamaConfig,
     PretrainedConfig,
     PreTrainedTokenizer,
+    Qwen2Config,
 )
 
 from sglang.utils import logger
@@ -301,9 +302,9 @@ class InternVLChatConfig(PretrainedConfig):
             )
 
         if llm_config is None:
-            llm_config = {"architectures": ["InternLM2ForCausalLM"]}
+            llm_config = {"architectures": ["Qwen2ForCausalLM"]}
             logger.info(
-                "llm_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`)."
+                "llm_config is None. Initializing the Qwen2Config config with default values (`Qwen2Config`)."
             )
 
         self.vision_config = InternVisionConfig(**vision_config)
@@ -311,6 +312,8 @@ class InternVLChatConfig(PretrainedConfig):
             self.llm_config = LlamaConfig(**llm_config)
         elif llm_config.get("architectures")[0] == "InternLM2ForCausalLM":
             self.llm_config = InternLM2Config(**llm_config)
+        elif llm_config.get("architectures")[0] == "Qwen2ForCausalLM":
+            self.llm_config = Qwen2Config(**llm_config)
         else:
             raise ValueError(
                 "Unsupported architecture: {}".format(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

fix(internvl): support Qwen2 architecture in LLM config selection

## Motivation

Previous logic only supported Llama and InternLM2 architectures. 
Added handling for Qwen2Config and set it as the default for internvl3 models. 
This resolves 'Unsupported architecture: Qwen2ForCausalLM' errors when launching internvl3.
Tested locally; launches successfully.


Before, you could not even launch internvl3,

Running ```python -m sglang.launch_server --model-path OpenGVLab/InternVL3-8B --host 0.0.0.0 --port 8000```
Gives:
```
File "/workspace/.venv/lib/python3.11/site-packages/transformers/configuration_utils.py", line 746, in from_dict
    config = cls(**config_dict)
             ^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.11/site-packages/sglang/srt/configs/internvl.py", line 318, in __init__
    raise ValueError(
ValueError: Unsupported architecture: Qwen2ForCausalLM
```

## Modifications

Replaced default llm_config in internvl, added qwen2 backbone. Ran pre-commit.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
