### PR TITLE
Integrates `cudnn_batch_prefill_with_kv_cache` into flashinfer attention backend

### DIFF
--- a/docs/backend/server_arguments.md
+++ b/docs/backend/server_arguments.md
@@ -249,7 +249,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--hicache-size` | The size of host KV cache memory pool in gigabytes, which will override the hicache_ratio if set. | 0 |
 | `--hicache-write-policy` | The write policy of hierarchical cache. | write_through_selective |
 | `--flashinfer-mla-disable-ragged` | Not using ragged prefill wrapper when running flashinfer mla. | False |
-| `--flashinfer-mla-use-cudnn` | Not using cudnn for prefill when running flashinfer mla. | False |
+| `--flashinfer-use-cudnn` | Not using cudnn for prefill when running flashinfer mla. | False |
 | `--disable-shared-experts-fusion` | Disable shared experts fusion optimization for deepseek v3/r1. | False |
 | `--disable-chunked-prefix-cache` | Disable chunked prefix cache feature for deepseek, which should save overhead for short sequences. | False |
 | `--disable-fast-image-processor` | Adopt base image processor instead of fast image processor. | False |

--- a/docs/backend/server_arguments.md
+++ b/docs/backend/server_arguments.md
@@ -249,6 +249,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--hicache-size` | The size of host KV cache memory pool in gigabytes, which will override the hicache_ratio if set. | 0 |
 | `--hicache-write-policy` | The write policy of hierarchical cache. | write_through_selective |
 | `--flashinfer-mla-disable-ragged` | Not using ragged prefill wrapper when running flashinfer mla. | False |
+| `--flashinfer-mla-use-cudnn` | Not using cudnn for prefill when running flashinfer mla. | False |
 | `--disable-shared-experts-fusion` | Disable shared experts fusion optimization for deepseek v3/r1. | False |
 | `--disable-chunked-prefix-cache` | Disable chunked prefix cache feature for deepseek, which should save overhead for short sequences. | False |
 | `--disable-fast-image-processor` | Adopt base image processor instead of fast image processor. | False |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,7 +58,7 @@ srt = [
     "torchvision==0.22.1",
     "cuda-python",
     "einops",
-    "flashinfer_python==0.2.7.post1",
+    "flashinfer_python==0.2.8rc1",
 ]
 
 blackwell = [
@@ -69,7 +69,7 @@ blackwell = [
     "torchvision==0.22.1",
     "cuda-python",
     "einops",
-    "flashinfer_python==0.2.7.post1",
+    "flashinfer_python==0.2.8rc1",
 ]
 
 # HIP (Heterogeneous-computing Interface for Portability) for AMD

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -642,7 +642,7 @@ def _set_envs_and_config(server_args: ServerArgs):
     if server_args.attention_backend == "flashinfer":
         assert_pkg_version(
             "flashinfer_python",
-            "0.2.7.post1",
+            "0.2.8rc1",
             "Please uninstall the old version and "
             "reinstall the latest version by following the instructions "
             "at https://docs.flashinfer.ai/installation.html.",

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -511,7 +511,7 @@ class FlashInferAttnBackend(AttentionBackend):
                 return o, lse
 
             if self.forward_metadata.extend_no_prefix:
-                if global_server_args_dict["flashinfer_mla_use_cudnn"]:
+                if global_server_args_dict["flashinfer_use_cudnn"]:
                     o, _ = _cudnn_prefill()
                 else:
                     o = self.prefill_wrapper_ragged.forward(
@@ -523,7 +523,7 @@ class FlashInferAttnBackend(AttentionBackend):
                         logits_soft_cap=logits_soft_cap,
                     )
             else:
-                if global_server_args_dict["flashinfer_mla_use_cudnn"]:
+                if global_server_args_dict["flashinfer_use_cudnn"]:
                     o1, s1 = _cudnn_prefill()
                 else:
                     o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -26,6 +26,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.layers.utils import is_sm100_supported
+from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
 from sglang.srt.utils import is_flashinfer_available, next_power_of_2
@@ -41,6 +42,7 @@ if is_flashinfer_available():
         BatchPrefillWithRaggedKVCacheWrapper,
     )
     from flashinfer.cascade import merge_state
+    from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
     from flashinfer.decode import _get_range_buf, get_seq_lens
 
 
@@ -485,25 +487,53 @@ class FlashInferAttnBackend(AttentionBackend):
                 v_scale=layer.v_scale,
             )
         else:
-            if self.forward_metadata.extend_no_prefix:
-                o = self.prefill_wrapper_ragged.forward(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                    v.view(-1, layer.tp_v_head_num, layer.head_dim),
-                    causal=True,
-                    sm_scale=layer.scaling,
-                    logits_soft_cap=logits_soft_cap,
-                )
 
-            else:
-                o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
-                    q.view(-1, layer.tp_q_head_num, layer.head_dim),
-                    k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                    v.view(-1, layer.tp_v_head_num, layer.head_dim),
+            def _cudnn_prefill():
+                qo_lengths = forward_batch.seq_lens - forward_batch.extend_prefix_lens
+                kv_lengths = forward_batch.extend_prefix_lens
+                max_token_per_sequence = int(qo_lengths.max().item())
+                max_sequence_kv = int(kv_lengths.max().item())
+
+                o, lse = cudnn_batch_prefill_with_kv_cache(
+                    q=q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                    k_cache=k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                    v_cache=v.view(-1, layer.tp_k_head_num, layer.v_head_dim),
+                    scale=layer.scaling,
+                    workspace_buffer=self.workspace_buffer.to(torch.int8),
+                    max_token_per_sequence=max_token_per_sequence,
+                    max_sequence_kv=max_sequence_kv,
+                    actual_seq_lens_q=qo_lengths.cpu().int(),
+                    actual_seq_lens_kv=kv_lengths.cpu().int(),
                     causal=True,
-                    sm_scale=layer.scaling,
-                    logits_soft_cap=logits_soft_cap,
+                    return_lse=True,
+                    is_cuda_graph_compatible=False,
                 )
+                return o, lse
+
+            if self.forward_metadata.extend_no_prefix:
+                if global_server_args_dict["flashinfer_mla_use_cudnn"]:
+                    o, _ = _cudnn_prefill()
+                else:
+                    o = self.prefill_wrapper_ragged.forward(
+                        q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                        v.view(-1, layer.tp_v_head_num, layer.head_dim),
+                        causal=True,
+                        sm_scale=layer.scaling,
+                        logits_soft_cap=logits_soft_cap,
+                    )
+            else:
+                if global_server_args_dict["flashinfer_mla_use_cudnn"]:
+                    o1, s1 = _cudnn_prefill()
+                else:
+                    o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
+                        q.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                        v.view(-1, layer.tp_v_head_num, layer.head_dim),
+                        causal=True,
+                        sm_scale=layer.scaling,
+                        logits_soft_cap=logits_soft_cap,
+                    )
                 o2, s2 = prefill_wrapper_paged.forward_return_lse(
                     q.view(-1, layer.tp_q_head_num, layer.head_dim),
                     forward_batch.token_to_kv_pool.get_kv_buffer(layer.layer_id),

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -417,7 +417,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 max_token_per_sequence = int(qo_lengths.max().item())
                 max_sequence_kv = int(kv_lengths.max().item())
 
-                o, lse = cudnn_batch_prefill_with_kv_cache(
+                o, _ = cudnn_batch_prefill_with_kv_cache(
                     q=qall,
                     k_cache=k.view(-1, layer.tp_k_head_num, layer.head_dim),
                     v_cache=v.view(-1, layer.tp_k_head_num, layer.v_head_dim),

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """
 Support attention backend for flashinfer MLA.
 The flashinfer_mla_disable_ragged flag controls whether to use ragged prefill wrapper and defaults to be false.
+The flashinfer_mla_use_cudnn flag controls whether to use cudnn_batch_prefill_with_kv_cache and defaults to be false.
 When it's set to false, all wrappers are BatchMLAPaged wrapper.
 When it's set to true, the backend uses BatchRagged and BatchMLAPaged wrapper for prefilling,
 and uses BatchMLAPaged wrapper for decoding.
@@ -44,6 +45,7 @@ if is_flashinfer_available():
         BatchMLAPagedAttentionWrapper,
         BatchPrefillWithRaggedKVCacheWrapper,
     )
+    from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
 
 
 @dataclass
@@ -408,35 +410,36 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             if k_rope is not None:
                 k = torch.cat([k, k_rope], dim=-1)
-            from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
 
-            qo_lengths = forward_batch.seq_lens - forward_batch.extend_prefix_lens
-            kv_lengths = forward_batch.extend_prefix_lens
-            max_token_per_sequence = int(qo_lengths.max().item())
-            max_sequence_kv = int(kv_lengths.max().item())
+            if global_server_args_dict["flashinfer_mla_use_cudnn"]:
+                qo_lengths = forward_batch.seq_lens - forward_batch.extend_prefix_lens
+                kv_lengths = forward_batch.extend_prefix_lens
+                max_token_per_sequence = int(qo_lengths.max().item())
+                max_sequence_kv = int(kv_lengths.max().item())
 
-            o, lse = cudnn_batch_prefill_with_kv_cache(
-                q=qall,
-                k_cache=k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                v_cache=v.view(-1, layer.tp_k_head_num, layer.v_head_dim),
-                scale=layer.scaling,
-                workspace_buffer=self.workspace_buffer.to(torch.int8),
-                max_token_per_sequence=max_token_per_sequence,
-                max_sequence_kv=max_sequence_kv,
-                actual_seq_lens_q=qo_lengths.cpu().int(),
-                actual_seq_lens_kv=kv_lengths.cpu().int(),
-                causal=True,
-                return_lse=True,
-                is_cuda_graph_compatible=False,
-            )
-            # o = self.prefill_wrapper_ragged.forward(
-            #     qall,
-            #     k.view(-1, layer.tp_k_head_num, layer.head_dim),
-            #     v.view(-1, layer.tp_k_head_num, layer.v_head_dim),
-            #     causal=True,
-            #     sm_scale=layer.scaling,
-            #     logits_soft_cap=logits_soft_cap,
-            # )
+                o, lse = cudnn_batch_prefill_with_kv_cache(
+                    q=qall,
+                    k_cache=k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                    v_cache=v.view(-1, layer.tp_k_head_num, layer.v_head_dim),
+                    scale=layer.scaling,
+                    workspace_buffer=self.workspace_buffer.to(torch.int8),
+                    max_token_per_sequence=max_token_per_sequence,
+                    max_sequence_kv=max_sequence_kv,
+                    actual_seq_lens_q=qo_lengths.cpu().int(),
+                    actual_seq_lens_kv=kv_lengths.cpu().int(),
+                    causal=True,
+                    return_lse=True,
+                    is_cuda_graph_compatible=False,
+                )
+            else:
+                o = self.prefill_wrapper_ragged.forward(
+                    qall,
+                    k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                    v.view(-1, layer.tp_k_head_num, layer.v_head_dim),
+                    causal=True,
+                    sm_scale=layer.scaling,
+                    logits_soft_cap=logits_soft_cap,
+                )
         else:
             # mla paged prefill
             k_buf = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id).to(

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """
 Support attention backend for flashinfer MLA.
 The flashinfer_mla_disable_ragged flag controls whether to use ragged prefill wrapper and defaults to be false.
-The flashinfer_mla_use_cudnn flag controls whether to use cudnn_batch_prefill_with_kv_cache and defaults to be false.
+The flashinfer_use_cudnn flag controls whether to use cudnn_batch_prefill_with_kv_cache and defaults to be false.
 When it's set to false, all wrappers are BatchMLAPaged wrapper.
 When it's set to true, the backend uses BatchRagged and BatchMLAPaged wrapper for prefilling,
 and uses BatchMLAPaged wrapper for decoding.
@@ -411,7 +411,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             if k_rope is not None:
                 k = torch.cat([k, k_rope], dim=-1)
 
-            if global_server_args_dict["flashinfer_mla_use_cudnn"]:
+            if global_server_args_dict["flashinfer_use_cudnn"]:
                 qo_lengths = forward_batch.seq_lens - forward_batch.extend_prefix_lens
                 kv_lengths = forward_batch.extend_prefix_lens
                 max_token_per_sequence = int(qo_lengths.max().item())

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -92,7 +92,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "ep_num_redundant_experts",
     "enable_nan_detection",
     "flashinfer_mla_disable_ragged",
-    "flashinfer_mla_use_cudnn",
+    "flashinfer_use_cudnn",
     "max_micro_batch_size",
     "disable_shared_experts_fusion",
     "sampling_backend",

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -92,6 +92,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "ep_num_redundant_experts",
     "enable_nan_detection",
     "flashinfer_mla_disable_ragged",
+    "flashinfer_mla_use_cudnn",
     "max_micro_batch_size",
     "disable_shared_experts_fusion",
     "sampling_backend",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -219,7 +219,7 @@ class ServerArgs:
     hicache_write_policy: str = "write_through_selective"
     hicache_io_backend: str = ""
     flashinfer_mla_disable_ragged: bool = False
-    flashinfer_mla_use_cudnn: bool = False
+    flashinfer_use_cudnn: bool = False
     disable_shared_experts_fusion: bool = False
     disable_chunked_prefix_cache: bool = False
     disable_fast_image_processor: bool = False
@@ -1546,7 +1546,7 @@ class ServerArgs:
             help="Not using ragged prefill wrapper when running flashinfer mla",
         )
         parser.add_argument(
-            "--flashinfer-mla-use-cudnn",
+            "--flashinfer-use-cudnn",
             action="store_true",
             help="Not using cudnn for prefill when running flashinfer mla",
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -219,6 +219,7 @@ class ServerArgs:
     hicache_write_policy: str = "write_through_selective"
     hicache_io_backend: str = ""
     flashinfer_mla_disable_ragged: bool = False
+    flashinfer_mla_use_cudnn: bool = False
     disable_shared_experts_fusion: bool = False
     disable_chunked_prefix_cache: bool = False
     disable_fast_image_processor: bool = False
@@ -1543,6 +1544,11 @@ class ServerArgs:
             "--flashinfer-mla-disable-ragged",
             action="store_true",
             help="Not using ragged prefill wrapper when running flashinfer mla",
+        )
+        parser.add_argument(
+            "--flashinfer-mla-use-cudnn",
+            action="store_true",
+            help="Not using cudnn for prefill when running flashinfer mla",
         )
         parser.add_argument(
             "--disable-shared-experts-fusion",


### PR DESCRIPTION
## Motivation

`cudnn_batch_prefill_with_kv_cache` has comparable performance to flashinfer's cutlass fmha backend. When we upgrade SM architectures in the future, flashinfer's cutlass fmha backend will need to be upgraded as well. `cudnn_batch_prefill_with_kv_cache` provides an alternative path to that, so potentially might have faster OOB support on newer architectures.

## Modifications
- The `self.prefill_wrapper_ragged.forward` path now has a conditional for using 
`cudnn_batch_prefill_with_kv_cache`. Note that this API needs actual seq_lens and max_token_per_sequence/max_sequence_kv. These values are calculated in this PR.
- Re eagle decoding path: both of the times when spec_info is passed: `forward_batch.forward_mode.is_draft_extend()` or , use_ragged=False. So deducing that we don't need this change for the eagle decoding path.
- Re cuda graph path: from `init_forward_metadata_capture_cuda_graph`, looks like only `BatchMLAPagedAttentionWrapper` is supported. So also deducing that there is no cuda graph concern.

## Current benchmark (b200)
### Commands
#### server
```
python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-R1 --tp 8 --trust-remote-code --attention-backend flashinfer
```
#### bench_serving
```
python3 -m sglang.bench_serving --backend sglang --model deepseek-ai/DeepSeek-R1 --num-prompts 1100 --dataset-name random --random-input-len 1000 --random-output-len 1000 --random-range-ratio 1
```
#### gsm8k
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
```
### Before this PR:
#### bench_serving
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     1100      
Benchmark duration (s):                  237.93    
Total input tokens:                      1100000   
Total generated tokens:                  1100000   
Total generated tokens (retokenized):    1096353   
Request throughput (req/s):              4.62      
Input token throughput (tok/s):          4623.22   
Output token throughput (tok/s):         4623.22   
Total token throughput (tok/s):          9246.44   
Concurrency:                             737.42    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   159502.78 
Median E2E Latency (ms):                 189982.99 
---------------Time to First Token----------------
Mean TTFT (ms):                          71906.42  
Median TTFT (ms):                        103493.21 
P99 TTFT (ms):                           193623.28 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           87.69     
Median ITL (ms):                         74.01     
P95 ITL (ms):                            82.42     
P99 ITL (ms):                            85.01     
Max ITL (ms):                            115465.03
```

#### gsm8k
```
Accuracy: 0.953
Invalid: 0.000
Latency: 28.837 s
Output throughput: 4677.320 token/s
```

### After this PR:
#### bench_serving
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     1100      
Benchmark duration (s):                  237.88    
Total input tokens:                      1100000   
Total generated tokens:                  1100000   
Total generated tokens (retokenized):    1096650   
Request throughput (req/s):              4.62      
Input token throughput (tok/s):          4624.11   
Output token throughput (tok/s):         4624.11   
Total token throughput (tok/s):          9248.22   
Concurrency:                             736.15    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   159198.67 
Median E2E Latency (ms):                 189620.53 
---------------Time to First Token----------------
Mean TTFT (ms):                          71526.57  
Median TTFT (ms):                        103125.81 
P99 TTFT (ms):                           193251.81 
---------------Inter-Token Latency----------------
Mean ITL (ms):                           87.76     
Median ITL (ms):                         73.99     
P95 ITL (ms):                            82.62     
P99 ITL (ms):                            85.34     
Max ITL (ms):                            115467.72 
==================================================
```

#### gsm8k
```
Accuracy: 0.961
Invalid: 0.000
Latency: 27.770 s
Output throughput: 4843.031 token/s
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
