### PR TITLE
fix: exclude null fields from message serialization

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -308,9 +308,9 @@ class ToolCall(BaseModel):
     def _serialize(self, handler):
         data = handler(self)
         # Remove all None fields
-        for field in ["id", "index"]:
-            if getattr(self, field) is None:
-                data.pop(field, None)
+        for field_name in self.__class__.model_fields:
+            if getattr(self, field_name) is None:
+                data.pop(field_name, None)
         return data
 
 
@@ -473,9 +473,9 @@ class ChatMessage(BaseModel):
     def _serialize(self, handler):
         data = handler(self)
         # Remove all None fields
-        for field in ["tool_calls", "reasoning_content"]:
-            if getattr(self, field) is None:
-                data.pop(field, None)
+        for field_name in self.__class__.model_fields:
+            if getattr(self, field_name) is None:
+                data.pop(field_name, None)
         return data
 
 
@@ -519,9 +519,9 @@ class DeltaMessage(BaseModel):
     def _serialize(self, handler):
         data = handler(self)
         # Remove all None fields
-        for field in ["tool_calls", "reasoning_content", "hidden_states"]:
-            if getattr(self, field) is None:
-                data.pop(field, None)
+        for field_name in self.__class__.model_fields:
+            if getattr(self, field_name) is None:
+                data.pop(field_name, None)
         return data
 
 

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -304,10 +304,19 @@ class ToolCall(BaseModel):
     type: Literal["function"] = "function"
     function: FunctionResponse
 
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        # Remove all None fields
+        for field in ["id", "index"]:
+            if getattr(self, field) is None:
+                data.pop(field, None)
+        return data
+
 
 class ChatCompletionMessageGenericParam(BaseModel):
     role: Literal["system", "assistant", "tool"]
-    content: Union[str, List[ChatCompletionMessageContentTextPart], None]
+    content: Union[str, List[ChatCompletionMessageContentTextPart], None] = None
     tool_call_id: Optional[str] = None
     name: Optional[str] = None
     reasoning_content: Optional[str] = None
@@ -460,6 +469,15 @@ class ChatMessage(BaseModel):
     reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
 
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        # Remove all None fields
+        for field in ["tool_calls", "reasoning_content"]:
+            if getattr(self, field) is None:
+                data.pop(field, None)
+        return data
+
 
 class ChatCompletionResponseChoice(BaseModel):
     index: int
@@ -500,8 +518,10 @@ class DeltaMessage(BaseModel):
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
         data = handler(self)
-        if self.hidden_states is None:
-            data.pop("hidden_states", None)
+        # Remove all None fields
+        for field in ["tool_calls", "reasoning_content", "hidden_states"]:
+            if getattr(self, field) is None:
+                data.pop(field, None)
         return data
 
 

--- a/test/srt/openai_server/basic/test_protocol.py
+++ b/test/srt/openai_server/basic/test_protocol.py
@@ -192,6 +192,63 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.stream_reasoning)
         self.assertEqual(request.chat_template_kwargs, {"custom_param": "value"})
 
+    def test_tool_calls_message_format(self):
+        """Test that tool calls messages are properly handled"""
+        # Test assistant message with tool calls but no content
+        tool_call_message = {
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "arguments": '{"url":"https://example.com"}',
+                    "name": "tool-0_browser_navigate"
+                },
+                "id": "call_123",
+                "type": "function"
+            }]
+        }
+
+        # Test assistant message with both tool calls and content
+        tool_call_with_content_message = {
+            "role": "assistant",
+            "content": "Let me help you with that.",
+            "tool_calls": [{
+                "function": {
+                    "arguments": '{"url":"https://example.com"}',
+                    "name": "tool-0_browser_navigate"
+                },
+                "id": "call_123",
+                "type": "function"
+            }]
+        }
+
+        # Create request with both types of messages
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[
+                {"role": "user", "content": "Navigate to example.com"},
+                tool_call_message,
+                {"role": "tool", "content": "Successfully navigated", "name": "tool-0_browser_navigate"},
+                tool_call_with_content_message
+            ]
+        )
+
+        # Verify the messages were properly parsed
+        self.assertEqual(len(request.messages), 4)
+
+        # Check tool call message without content
+        tool_msg = request.messages[1]
+        self.assertEqual(tool_msg.role, "assistant")
+        self.assertIsNone(tool_msg.content)  # Content should be None
+        self.assertEqual(len(tool_msg.tool_calls), 1)
+        self.assertEqual(tool_msg.tool_calls[0].function.name, "tool-0_browser_navigate")
+
+        # Check tool call message with content
+        tool_content_msg = request.messages[3]
+        self.assertEqual(tool_content_msg.role, "assistant")
+        self.assertEqual(tool_content_msg.content, "Let me help you with that.")
+        self.assertEqual(len(tool_content_msg.tool_calls), 1)
+        self.assertEqual(tool_content_msg.tool_calls[0].function.name, "tool-0_browser_navigate")
+
 
 class TestModelSerialization(unittest.TestCase):
     """Test model serialization with hidden states"""
@@ -236,6 +293,61 @@ class TestModelSerialization(unittest.TestCase):
         data = response.model_dump(exclude_none=True)
         self.assertIn("hidden_states", data["choices"][0])
         self.assertEqual(data["choices"][0]["hidden_states"], [0.1, 0.2, 0.3])
+
+    def test_tool_calls_excluded_when_none(self):
+        """Test that None tool_calls are excluded from serialization"""
+        # Test ChatMessage
+        message = ChatMessage(role="assistant", content="Hello")
+        json_str = message.model_dump_json()
+        self.assertEqual(
+            json_str,
+            '{"role":"assistant","content":"Hello"}'
+        )
+
+        # Test DeltaMessage
+        delta = DeltaMessage(role="assistant", content="Hello")
+        json_str = delta.model_dump_json()
+        self.assertEqual(
+            json_str,
+            '{"role":"assistant","content":"Hello"}'
+        )
+
+    def test_tool_calls_included_when_not_none(self):
+        """Test that non-None tool_calls are included in serialization"""
+        tool_calls = [
+            ToolCall(
+                id="call_123",
+                type="function",
+                function=FunctionResponse(
+                    name="test_function",
+                    arguments='{"test": "value"}'
+                )
+            )
+        ]
+
+        # Test ChatMessage
+        message = ChatMessage(
+            role="assistant",
+            content="Hello",
+            tool_calls=tool_calls
+        )
+        json_str = message.model_dump_json()
+        self.assertEqual(
+            json_str,
+            '{"role":"assistant","content":"Hello","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test_function","arguments":"{\\\"test\\\": \\\"value\\\"}"}}]}'
+        )
+
+        # Test DeltaMessage
+        delta = DeltaMessage(
+            role="assistant",
+            content="Hello",
+            tool_calls=tool_calls
+        )
+        json_str = delta.model_dump_json()
+        self.assertEqual(
+            json_str,
+            '{"role":"assistant","content":"Hello","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test_function","arguments":"{\\\"test\\\": \\\"value\\\"}"}}]}'
+        )
 
 
 class TestValidationEdgeCases(unittest.TestCase):

--- a/test/srt/openai_server/basic/test_protocol.py
+++ b/test/srt/openai_server/basic/test_protocol.py
@@ -197,28 +197,32 @@ class TestChatCompletionRequest(unittest.TestCase):
         # Test assistant message with tool calls but no content
         tool_call_message = {
             "role": "assistant",
-            "tool_calls": [{
-                "function": {
-                    "arguments": '{"url":"https://example.com"}',
-                    "name": "tool-0_browser_navigate"
-                },
-                "id": "call_123",
-                "type": "function"
-            }]
+            "tool_calls": [
+                {
+                    "function": {
+                        "arguments": '{"url":"https://example.com"}',
+                        "name": "tool-0_browser_navigate",
+                    },
+                    "id": "call_123",
+                    "type": "function",
+                }
+            ],
         }
 
         # Test assistant message with both tool calls and content
         tool_call_with_content_message = {
             "role": "assistant",
             "content": "Let me help you with that.",
-            "tool_calls": [{
-                "function": {
-                    "arguments": '{"url":"https://example.com"}',
-                    "name": "tool-0_browser_navigate"
-                },
-                "id": "call_123",
-                "type": "function"
-            }]
+            "tool_calls": [
+                {
+                    "function": {
+                        "arguments": '{"url":"https://example.com"}',
+                        "name": "tool-0_browser_navigate",
+                    },
+                    "id": "call_123",
+                    "type": "function",
+                }
+            ],
         }
 
         # Create request with both types of messages
@@ -227,9 +231,13 @@ class TestChatCompletionRequest(unittest.TestCase):
             messages=[
                 {"role": "user", "content": "Navigate to example.com"},
                 tool_call_message,
-                {"role": "tool", "content": "Successfully navigated", "name": "tool-0_browser_navigate"},
-                tool_call_with_content_message
-            ]
+                {
+                    "role": "tool",
+                    "content": "Successfully navigated",
+                    "name": "tool-0_browser_navigate",
+                },
+                tool_call_with_content_message,
+            ],
         )
 
         # Verify the messages were properly parsed
@@ -240,14 +248,18 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertEqual(tool_msg.role, "assistant")
         self.assertIsNone(tool_msg.content)  # Content should be None
         self.assertEqual(len(tool_msg.tool_calls), 1)
-        self.assertEqual(tool_msg.tool_calls[0].function.name, "tool-0_browser_navigate")
+        self.assertEqual(
+            tool_msg.tool_calls[0].function.name, "tool-0_browser_navigate"
+        )
 
         # Check tool call message with content
         tool_content_msg = request.messages[3]
         self.assertEqual(tool_content_msg.role, "assistant")
         self.assertEqual(tool_content_msg.content, "Let me help you with that.")
         self.assertEqual(len(tool_content_msg.tool_calls), 1)
-        self.assertEqual(tool_content_msg.tool_calls[0].function.name, "tool-0_browser_navigate")
+        self.assertEqual(
+            tool_content_msg.tool_calls[0].function.name, "tool-0_browser_navigate"
+        )
 
 
 class TestModelSerialization(unittest.TestCase):
@@ -299,18 +311,12 @@ class TestModelSerialization(unittest.TestCase):
         # Test ChatMessage
         message = ChatMessage(role="assistant", content="Hello")
         json_str = message.model_dump_json()
-        self.assertEqual(
-            json_str,
-            '{"role":"assistant","content":"Hello"}'
-        )
+        self.assertEqual(json_str, '{"role":"assistant","content":"Hello"}')
 
         # Test DeltaMessage
         delta = DeltaMessage(role="assistant", content="Hello")
         json_str = delta.model_dump_json()
-        self.assertEqual(
-            json_str,
-            '{"role":"assistant","content":"Hello"}'
-        )
+        self.assertEqual(json_str, '{"role":"assistant","content":"Hello"}')
 
     def test_tool_calls_included_when_not_none(self):
         """Test that non-None tool_calls are included in serialization"""
@@ -319,34 +325,25 @@ class TestModelSerialization(unittest.TestCase):
                 id="call_123",
                 type="function",
                 function=FunctionResponse(
-                    name="test_function",
-                    arguments='{"test": "value"}'
-                )
+                    name="test_function", arguments='{"test": "value"}'
+                ),
             )
         ]
 
         # Test ChatMessage
-        message = ChatMessage(
-            role="assistant",
-            content="Hello",
-            tool_calls=tool_calls
-        )
+        message = ChatMessage(role="assistant", content="Hello", tool_calls=tool_calls)
         json_str = message.model_dump_json()
         self.assertEqual(
             json_str,
-            '{"role":"assistant","content":"Hello","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test_function","arguments":"{\\\"test\\\": \\\"value\\\"}"}}]}'
+            '{"role":"assistant","content":"Hello","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test_function","arguments":"{\\"test\\": \\"value\\"}"}}]}',
         )
 
         # Test DeltaMessage
-        delta = DeltaMessage(
-            role="assistant",
-            content="Hello",
-            tool_calls=tool_calls
-        )
+        delta = DeltaMessage(role="assistant", content="Hello", tool_calls=tool_calls)
         json_str = delta.model_dump_json()
         self.assertEqual(
             json_str,
-            '{"role":"assistant","content":"Hello","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test_function","arguments":"{\\\"test\\\": \\\"value\\\"}"}}]}'
+            '{"role":"assistant","content":"Hello","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test_function","arguments":"{\\"test\\": \\"value\\"}"}}]}',
         )
 
 


### PR DESCRIPTION
- Add model_serializer to ChatMessage and DeltaMessage to exclude null fields
- Add model_serializer to ToolCall to exclude null id and index
- Ensure JSON output matches OpenAI API format
- Add tests to verify exact JSON output

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

When serializing messages in the OpenAI API format, the current implementation includes fields with null values in the JSON output. This creates unnecessarily verbose responses and deviates from OpenAI's API format which omits these fields entirely. This is particularly noticeable with tool_calls and reasoning_content fields, where they appear as null in messages that don't use these features.
For example, a simple assistant message currently outputs:
```
{
  "role": "assistant",
  "content": "Hello",
  "tool_calls": null,
  "reasoning_content": null
}
```
When OpenAI would return:
```
{
  "role": "assistant",
  "content": "Hello"
}
```
Modifications

- Added `@model_serializer` to `ChatMessage` / `DeltaMessage` / `ToolCall` class to exclude null fields
- Added new test cases to verify JSON serialization

These changes ensure our API responses match OpenAI's format, improving compatibility for clients that might be sensitive to the presence of null fields.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
