### PR TITLE
Bump xgrammar's version to 0.1.20

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -47,7 +47,7 @@ runtime_common = [
     "timm==1.0.16",
     "uvicorn",
     "uvloop",
-    "xgrammar==0.1.19",
+    "xgrammar==0.1.20",
 ]
 
 srt = [


### PR DESCRIPTION
## 0.1.20 Release Log
Summary
Fix Windows build flags for Torch extensions
Refactor the Parser and FSM libraries for improved maintainability
Expose accept_string and print_internal_states with configurable max recursion depth
**Correct acceptance of certain invalid characters in JSON strings**
Make tiktoken and sentencepiece optional dependencies
Support int64 values in JSON Schema conversion
Add a C++ reflection-based JSON serialization method

## Motivation

Fix https://github.com/sgl-project/sglang/issues/7767

