### PR TITLE
[CPU] [FP8] set SGLANG_CPU_FP8_CVT_FTZ in CMakeLists.txt

### DIFF
--- a/sgl-kernel/csrc/cpu/CMakeLists.txt
+++ b/sgl-kernel/csrc/cpu/CMakeLists.txt
@@ -58,6 +58,15 @@ endif()
 
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
+if(NOT DEFINED ENV{SGLANG_CPU_FP8_CVT_FTZ})
+    set(ENV{SGLANG_CPU_FP8_CVT_FTZ} "1")
+endif()
+
+if("$ENV{SGLANG_CPU_FP8_CVT_FTZ}" STREQUAL "1")
+    message(STATUS "Enabling macro: SGLANG_CPU_FP8_CVT_FTZ")
+    add_compile_definitions(SGLANG_CPU_FP8_CVT_FTZ)
+endif()
+
 add_compile_options(
     -O3
     -Wno-unknown-pragmas


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
The `SGLANG_CPU_FP8_CVT_FTZ` macro will be used in the cpp kernel code but it's no set in the `CMakeLists.txt`.
Update the `CMakeLists.txt` to set it according to the environment variable `SGLANG_CPU_FP8_CVT_FTZ`. The default value is 1. Users could disable it when building the sgl-kernel via `export SGLANG_CPU_FP8_CVT_FTZ=0`.
https://github.com/sgl-project/sglang/blob/b6b6268ccf1d992cac417b995fd250281c17912a/sgl-kernel/csrc/cpu/vec.h#L101-L107

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->




