### PR TITLE
[bugfix] add pd router policy validation

### DIFF
--- a/sgl-router/src/config/types.rs
+++ b/sgl-router/src/config/types.rs
@@ -231,16 +231,12 @@ impl RouterConfig {
                     PolicyConfig::PowerOfTwo { .. } => {
                         crate::pd_types::PDSelectionPolicy::PowerOfTwo
                     }
-                    PolicyConfig::CacheAware {
-                        cache_threshold,
-                        balance_abs_threshold,
-                        balance_rel_threshold,
-                        ..
-                    } => crate::pd_types::PDSelectionPolicy::CacheAware {
-                        cache_threshold: *cache_threshold,
-                        balance_abs_threshold: *balance_abs_threshold,
-                        balance_rel_threshold: *balance_rel_threshold,
-                    },
+                    PolicyConfig::CacheAware { .. } => {
+                        return Err(ConfigError::IncompatibleConfig {
+                            reason: "CacheAware policy is not supported in PD disaggregated mode"
+                                .to_string(),
+                        });
+                    }
                     PolicyConfig::RoundRobin => {
                         return Err(ConfigError::IncompatibleConfig {
                             reason: "RoundRobin policy is not supported in PD disaggregated mode"


### PR DESCRIPTION
## Motivation

This PR fixes #7901  by adding validation to prevent the use of cache_aware policy with PD disaggregation mode, which is not supported and causes a  runtime panic.

Previously, when users attempted to run the router with --pd-disaggregation and --policy cache_aware, they would encounter a panic:
 ```
thread '' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.46.1/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
```

## Modifications

  1. Added validation in sgl-router/src/config/validation.rs:
    - Updated validate_compatibility() to check for and reject the combination of CacheAware policy with PrefillDecode mode
    - Added test case test_validate_cache_aware_with_pd_mode to verify the validation works correctly
  2. Updated conversion logic in sgl-router/src/config/types.rs:
    - Modified to_routing_policy_config() to return an error when attempting to convert CacheAware policy in PD mode

  Now users will receive a clear error message during configuration validation:
  Configuration validation failed: CacheAware policy is not supported in PD disaggregated mode

## Checklist

  - [x] Format your code according to the https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit.
  - [x] Add unit tests as outlined in the https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci.
  - [x] Update documentation / docstrings / example tutorials as needed, according to
  https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci.
  - [ ]Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to
  https://docs.sglang.ai/references/benchmark_and_profiling.html and https://docs.sglang.ai/references/accuracy_evaluation.html.
  - [ ]For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a
  co-author when merging the PR.
  - [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.