### PR TITLE
[feat]mmprocessor: support minicpm prep pixel values input

### DIFF
--- a/python/sglang/srt/multimodal/processors/minicpm.py
+++ b/python/sglang/srt/multimodal/processors/minicpm.py
@@ -10,6 +10,33 @@ from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
 
+def get_image_token_regex():
+    import re
+    """
+    Generates a regular expression pattern to match two types of image tokens.
+
+    The pattern supports:
+    1. prec placeholder pattern: Tokens with <image_id>,
+        followed by <image> content,
+        and optionally 0+ <slice> elements (each may be followed by newlines).
+    2. raw image pattern: Standalone parenthesized image tokens like (<image>./</image>).
+
+    Returns:
+        re.Pattern: Compiled regular expression object.
+    """
+    # Core components of the patterns
+    image_id = r'<image_id>\d+</image_id>'          # Matches <image_id> with digits (e.g., <image_id>0</image_id>)
+    image_content = r'<image>(?:<unk>)+</image>'    # Matches <image> with one or more <unk> (e.g., <image><unk><unk></image>)
+    slice_content = r'<slice>(?:<unk>)+</slice>'    # Matches <slice> with one or more <unk> (e.g., <slice><unk></slice>)
+    paren_image = r'\(<image>\./</image>\)'         # Matches parenthesized image (e.g., (<image>./</image>))
+
+    # prec pattern: <image_id> + <image> + optional 0+ <slice> (with optional newlines after each slice)
+    prec_pattern = (
+        f'{image_id}{image_content}'                # Mandatory part: image_id + image content
+        f'(?:{slice_content}\\n*)*'                 # Optional part: 0+ slices (each may have 0+ newlines after)
+    )
+    # Combine prec and raw patterns, return compiled regex
+    return re.compile(f'(?:{prec_pattern}|{paren_image})')
 
 # Compatible with both 'O' and 'V'
 class MiniCPMMultimodalProcessor(BaseMultimodalProcessor):
@@ -18,8 +45,30 @@ class MiniCPMMultimodalProcessor(BaseMultimodalProcessor):
     def __init__(self, hf_config, server_args, _processor):
         super().__init__(hf_config, server_args, _processor)
         self.image_token = "(<image>./</image>)"
+        self.image_token_regex = get_image_token_regex()
         self.audio_token = "(<audio>./</audio>)"
         self.video_token = "(<video>./</video>)"
+
+        # Set token IDs for process_and_combine_mm_data
+        tokenizer = _processor.tokenizer
+        self.IM_TOKEN_ID = tokenizer.unk_id
+        self.AUDIO_TOKEN_ID = getattr(tokenizer, "audio_token_id", None)
+
+
+    def process_mm_data(
+        self, input_text, images=None, videos=None, audios=None, **kwargs
+    ):
+        ret = super().process_mm_data(input_text, images, videos, audios, **kwargs)
+        ret['tgt_size'] = ret['tgt_sizes']
+        if ( "audio_features" in ret
+            and (ret["audio_features"] is None
+            or len(ret["audio_features"]) == 0)
+        ):
+            ret.pop('audio_features')
+            ret.pop('audio_feature_lens')
+            ret.pop('audio_bounds')
+            ret.pop('spk_bounds')
+        return ret
 
     async def process_mm_data_async(
         self,
@@ -38,17 +87,12 @@ class MiniCPMMultimodalProcessor(BaseMultimodalProcessor):
             multimodal_tokens=MultimodalSpecialTokens(
                 image_token=self.image_token,
                 video_token=self.video_token,
+                image_token_regex=self.image_token_regex,
                 audio_token=self.audio_token,
             ),
         )
         if base_output is None:
             return None
-
-        res = self.process_mm_data(
-            input_text=base_output.input_text,
-            images=base_output.images,
-            audios=base_output.audios,
-        )
 
         # Collect special token ids
         tokenizer = self._processor.tokenizer
@@ -68,81 +112,45 @@ class MiniCPMMultimodalProcessor(BaseMultimodalProcessor):
         im_start_id = tokenizer.im_start_id
         im_end_id = tokenizer.im_end_id
         im_token_id = tokenizer.unk_id
-        pixel_values = res["pixel_values"]
-        tgt_sizes = res["tgt_sizes"]
+        mm_items, input_ids = self.process_and_combine_mm_data(base_output)
 
-        if not isinstance(pixel_values, (torch.Tensor, list)):
-            raise ValueError(
-                "Incorrect type of pixel values. " f"Got type: {type(pixel_values)}"
-            )
+        for item in mm_items:
+            if item.modality in [Modality.IMAGE, Modality.MULTI_IMAGES]:
+                pixel_values = item.pixel_values
+                tgt_sizes = item.tgt_size
+                if not isinstance(pixel_values, (torch.Tensor, list)):
+                    raise ValueError(
+                        "Incorrect type of pixel values. " f"Got type: {type(pixel_values)}"
+                    )
 
-        if not isinstance(tgt_sizes, (torch.Tensor, list)):
-            raise ValueError(
-                "Incorrect type of target sizes. " f"Got type: {type(tgt_sizes)}"
-            )
+                if not isinstance(tgt_sizes, (torch.Tensor, list)):
+                    raise ValueError(
+                        "Incorrect type of target sizes. " f"Got type: {type(tgt_sizes)}"
+                    )
 
-        if len(pixel_values) != len(tgt_sizes):
-            raise ValueError(
-                "Inconsistent batch lengths, found: "
-                f"{len(pixel_values)} vs. {len(tgt_sizes)}"
-            )
+                if len(pixel_values) != len(tgt_sizes):
+                    raise ValueError(
+                        "Inconsistent batch lengths, found: "
+                        f"{len(pixel_values)} vs. {len(tgt_sizes)}"
+                    )
 
-        pixel_values_flat: List[torch.Tensor] = []
-        tgt_sizes_flat: List[torch.Tensor] = []
-        for pixel_b, tgt_b in zip(pixel_values, tgt_sizes):
-            # per image
-            if len(pixel_b) != len(tgt_b):
-                raise ValueError(
-                    "Inconsistent N lengths, found: " f"{len(pixel_b)} vs {len(tgt_b)}"
-                )
-            for pixel_n, tgt_n in zip(pixel_b, tgt_b):
-                pixel_values_flat += [pixel_n]
-                tgt_sizes_flat += [tgt_n]
+                pixel_values_flat: List[torch.Tensor] = []
+                tgt_sizes_flat: List[torch.Tensor] = []
+                for pixel_b, tgt_b in zip(pixel_values, tgt_sizes):
+                    # per image
+                    if len(pixel_b) != len(tgt_b):
+                        raise ValueError(
+                            "Inconsistent N lengths, found: " f"{len(pixel_b)} vs {len(tgt_b)}"
+                        )
+                    for pixel_n, tgt_n in zip(pixel_b, tgt_b):
+                        pixel_values_flat += [pixel_n]
+                        tgt_sizes_flat += [tgt_n]
 
-        pixel_values = pixel_values_flat
+                item.pixel_values = pixel_values_flat
+                item.tgt_size = tgt_sizes_flat
 
-        items = []
-        input_ids = res["input_ids"].flatten()
-        image_offsets = self.get_mm_items_offset_by_pair(
-            input_ids=input_ids, mm_start_id=im_start_id, mm_end_id=im_end_id
-        )
-        slice_offsets = self.get_mm_items_offset_by_pair(
-            input_ids=input_ids, mm_start_id=slice_start_id, mm_end_id=slice_end_id
-        )
-        image_offsets.extend(slice_offsets)
-        image_offsets = sorted(image_offsets)
-
-        if len(pixel_values) != 0:
-            item = MultimodalDataItem(
-                pixel_values=pixel_values,
-                offsets=image_offsets,
-                tgt_size=tgt_sizes_flat,
-                modality=Modality.IMAGE,
-            )
-            items += [item]
-
-        if (
-            "audio_features" in res
-            and res["audio_features"] is not None
-            and len(res["audio_features"]) != 0
-        ):
-            if audio_start_id is not None and audio_end_id is not None:
-                audio_offsets = self.get_mm_items_offset_by_pair(
-                    input_ids=input_ids,
-                    mm_start_id=audio_start_id,
-                    mm_end_id=audio_end_id,
-                )
-            else:
-                audio_offsets = None
-            item = MultimodalDataItem(
-                audio_features=[res["audio_features"]],
-                audio_feature_lens=res["audio_feature_lens"],
-                offsets=audio_offsets,
-                modality=Modality.AUDIO,
-            )
-            items += [item]
         return {
-            "mm_items": items,
+            "mm_items": mm_items,
             "input_ids": input_ids.tolist(),
             "audio_start_id": audio_start_id,
             "audio_end_id": audio_end_id,

--- a/test/srt/test_vlm_input_format.py
+++ b/test/srt/test_vlm_input_format.py
@@ -215,6 +215,26 @@ class TestKimiVLImageUnderstandsImage(
             image_grid_hws=processor_output["image_grid_hws"],
         )
 
+class TestMiniCPMUnderstandsImage(VLMInputTestBase, unittest.IsolatedAsyncioTestCase):
+    #python test_vlm_input_format.py TestMiniCPMUnderstandsImage
+    model_path = "openbmb/MiniCPM-v-2_6"
+    chat_template = "minicpmv"
+
+    @classmethod
+    def _init_visual(cls):
+        pass
+
+    @unittest.skip("skip")
+    async def test_understands_precomputed_features(self):
+        pass
+
+    def _pixel_values_image_data(self, processor_output):
+        return dict(
+            modality="IMAGE",
+            pixel_values=processor_output["pixel_values"],
+            tgt_size=processor_output["tgt_sizes"]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation
follow the great work of 
https://github.com/sgl-project/sglang/issues/6483
https://github.com/sgl-project/sglang/pull/6543
in this pr, i try to adjust minicpm mmprocessor to support preprocessed pixels values input.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
