### PR TITLE
add sentencepiece as dependency explicitly

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,6 +41,7 @@ runtime_common = [
     "pybase64",
     "python-multipart",
     "pyzmq>=25.1.2",
+    "sentencepiece",
     "soundfile==0.13.1",
     "scipy",
     "torchao==0.9.0",


### PR DESCRIPTION
## Motivation

`sentencepiece` is a required package for srt at https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/configs/internvl.py#L6 

It was previously installed as a dependent package of `xgrammar==0.1.19`.

Yet after #7866 merged, `sentencepiece` would not be installed for `xgrammar==0.1.20`.


## Modifications

The installation of `sentencepiece` is added in the `.toml` explicitly.