### PR TITLE
[fix]Update unitest for fp8_blockwise_scaled_grouped_mm kernel

### DIFF
--- a/sgl-kernel/tests/test_fp8_blockwise_moe.py
+++ b/sgl-kernel/tests/test_fp8_blockwise_moe.py
@@ -1,8 +1,8 @@
 import random
-
 import pytest
 import torch
 from sgl_kernel import fp8_blockwise_scaled_grouped_mm
+from typing import Tuple
 
 
 def cdiv(a: int, b: int) -> int:
@@ -17,6 +17,43 @@ def to_fp8(tensor: torch.Tensor) -> torch.Tensor:
     finfo = torch.finfo(torch.float8_e4m3fn)
     return torch.round(tensor.clamp(min=finfo.min, max=finfo.max)).to(
         dtype=torch.float8_e4m3fn
+    )
+
+# Copy from: https://github.com/deepseek-ai/DeepGEMM/blob/main/deep_gemm/utils.py
+def calc_diff(x, y):
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return 1 - sim
+
+
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def per_token_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    pad_size = (128 - (n % 128)) % 128
+    x = torch.nn.functional.pad(x, (0, pad_size), value=0) if pad_size > 0 else x
+    x_view = x.view(m, -1, 128)
+    x_amax = x_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
+    fp8_data = (x_view * (448.0 / x_amax.unsqueeze(2))).to(torch.float8_e4m3fn)
+    return fp8_data.view(m, n + pad_size)[:, :n], (x_amax / 448.0).view(m, -1)
+
+
+def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    x_padded = torch.zeros(
+        (ceil_div(m, 128) * 128, ceil_div(n, 128) * 128), dtype=x.dtype, device=x.device
+    )
+    x_padded[:m, :n] = x
+    x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
+    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
+    x_scaled = (x_view * (448.0 / x_amax)).to(torch.float8_e4m3fn)
+    return x_scaled.view_as(x_padded)[:m, :n].contiguous(), (x_amax / 448.0).view(
+        x_view.size(0), x_view.size(2)
     )
 
 
@@ -55,7 +92,7 @@ def is_sm100_supported(device=None) -> bool:
 
 def is_sm90_supported(device=None) -> bool:
     return (torch.cuda.get_device_capability(device)[0] == 9) and (
-        torch.version.cuda >= "12.8"
+        torch.version.cuda >= "12.3"
     )
 
 
@@ -66,13 +103,11 @@ def is_sm90_supported(device=None) -> bool:
 @pytest.mark.parametrize("num_experts", [8, 16])
 @pytest.mark.parametrize("out_dtype", [torch.half, torch.bfloat16])
 def test_fp8_blockwise_scaled_grouped_mm(num_experts, out_dtype):
+    cc = torch.cuda.get_device_capability(None)[0]
     device = "cuda"
     alignment = 16
     n_g = alignment * random.randint(1, 5) * 128
     k_g = alignment * random.randint(1, 5) * 128
-
-    scale_a_group_shape = (1, 128)
-    scale_b_group_shape = (128, 128)
 
     expert_offsets = torch.zeros((num_experts + 1), device=device, dtype=torch.int32)
     problem_sizes = torch.zeros((num_experts, 3), device=device, dtype=torch.int32)
@@ -90,20 +125,17 @@ def test_fp8_blockwise_scaled_grouped_mm(num_experts, out_dtype):
         expert_offsets[g + 1] = expert_offsets[g] + m_g
         problem_sizes[g][:] = torch.tensor([m_g, n_g, k_g], device=device)
 
-        a_g = to_fp8(torch.randn((m_g, k_g), device=device))
-        b_g = to_fp8(torch.randn((n_g, k_g), device=device).t())
+        a = torch.randn((m_g, k_g), device=device, dtype=out_dtype)      # (M, K):(K, 1)
+        b = torch.randn((n_g, k_g), device=device, dtype=out_dtype).t()  # (K, N):(1, K)
+
+        a_g, a_scale = per_token_cast_to_fp8(a) # ag -- (M, K):(K, 1), a_scale() -- (M, k):(k, 1)
+        b_g, b_scale = per_block_cast_to_fp8(b) # bg -- (K, N):(N, 1), b_scale() -- (k, n):(n, 1)
         a_tensors.append(a_g)
         b_tensors.append(b_g)
-
-        scale_a_shape = scale_shape(a_g.shape, scale_a_group_shape)
-        scale_b_shape = scale_shape(b_g.shape, scale_b_group_shape)
-
-        a_scales_tensors.append(torch.randn(scale_a_shape, device=device) * 0.001)
-        b_scales_tensors.append(torch.randn(scale_b_shape, device=device) * 0.001)
-
-        baseline = baseline_scaled_mm(
-            a_g, b_g, a_scales_tensors[-1], b_scales_tensors[-1], out_dtype
-        )
+        a_scales_tensors.append(a_scale)
+        b_scales_tensors.append(b_scale)
+        
+        baseline = torch.mm(a, b)
         baseline_tensors.append(baseline)
 
     a_stack = torch.empty(
@@ -114,21 +146,35 @@ def test_fp8_blockwise_scaled_grouped_mm(num_experts, out_dtype):
     )
 
     for g in range(num_experts):
-        a_stack[expert_offsets[g] : expert_offsets[g + 1]] = a_tensors[g]
-        b_stack[g] = b_tensors[g].t()
-    b_stack = b_stack.transpose(1, 2)
+        # Matrix A is Row-Major.
+        a_stack[expert_offsets[g] : expert_offsets[g + 1]] = a_tensors[g]   # a_stack[expert_offsets[g] : expert_offsets[g + 1]] -- (M, K):(K, 1)
+        b_stack[g] = b_tensors[g].t()   # b_stack[g] -- (N, K):(K, 1)
+    b_stack = b_stack.transpose(1, 2)   # Transpose Matrix B to Column-Major.
 
     a_scale_stack = torch.empty(
-        (expert_offsets[-1], k_g // 128), device=device, dtype=torch.float32
+        (expert_offsets[-1] * (k_g // 128)), device=device, dtype=torch.float32
     )
     b_scale_stack = torch.empty(
-        (num_experts, n_g // 128, k_g // 128), device=device, dtype=torch.float32
+        (num_experts, k_g // 128, n_g // 128), device=device, dtype=torch.float32
     )
 
     for g in range(num_experts):
-        a_scale_stack[expert_offsets[g] : expert_offsets[g + 1]] = a_scales_tensors[g]
-        b_scale_stack[g] = b_scales_tensors[g].t()
-    b_scale_stack = b_scale_stack.transpose(1, 2)
+        if cc == 9:
+            # For SM90, we need MN-Major scale factor
+            # a_scales_tensors[g] -- (M, k):(k, 1)
+            # a_scales_tensors[g].t().contiguous() -- (k, M):(M, 1)
+            a_scale_stack[expert_offsets[g] * (k_g // 128) : expert_offsets[g + 1] * (k_g // 128)] = \
+                a_scales_tensors[g].t().contiguous().view(-1)
+            b_scale_stack[g] = b_scales_tensors[g]  # b_scale_stack[g] -- (k, n):(n, 1)
+        elif cc == 10:
+            # For SM100, we need K-Major scale factor
+            # a_scales_tensors[g] -- (M, k):(k, 1)
+            a_scale_stack[expert_offsets[g] * (k_g // 128) : expert_offsets[g + 1] * (k_g // 128)] = \
+                a_scales_tensors[g].view(-1)
+            b_scale_stack[g] = b_scales_tensors[g]  # b_scale_stack[g] -- (k, n):(n, 1), we need transpose & contiguous later
+    a_scale_stack = a_scale_stack.view(expert_offsets[-1], k_g // 128)
+    if cc == 10:
+        b_scale_stack = b_scale_stack.transpose(1, 2).contiguous()
 
     c_out = torch.empty((expert_offsets[-1], n_g), device=device, dtype=out_dtype)
     a_strides = torch.full(
@@ -168,9 +214,9 @@ def test_fp8_blockwise_scaled_grouped_mm(num_experts, out_dtype):
     for g in range(num_experts):
         baseline = baseline_tensors[g]
         actual = c_out[expert_offsets[g] : expert_offsets[g + 1]]
-        torch.testing.assert_close(actual, baseline, rtol=1e-2, atol=1e-3)
-        print(f"num_experts={num_experts}, out_dtype={out_dtype}: OK")
-
+        diff = calc_diff(actual, baseline)
+        assert diff < 0.001
+        print(f"num_experts={num_experts}, out_dtype={out_dtype}, diff={diff:.5f}: OK")
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/sgl-kernel/tests/test_fp8_blockwise_moe.py
+++ b/sgl-kernel/tests/test_fp8_blockwise_moe.py
@@ -216,7 +216,7 @@ def test_fp8_blockwise_scaled_grouped_mm(num_experts, out_dtype):
         actual = c_out[expert_offsets[g] : expert_offsets[g + 1]]
         diff = calc_diff(actual, baseline)
         assert diff < 0.001
-        print(f"num_experts={num_experts}, out_dtype={out_dtype}, diff={diff:.5f}: OK")
+        print(f"cc={cc}0 num_experts={num_experts}, out_dtype={out_dtype}, diff={diff:.5f}: OK")
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Follow https://github.com/sgl-project/sglang/pull/7278, https://github.com/sgl-project/sglang/pull/7782
Setting the correct **scale factor layout** for the fp8_blockwise_scaled_grouped_mm kernel can be confusing. In this PR, we updated the **unit test** of fp8_blockwise_scaled_grouped_mm to show an e2e example using the fp8_blockwise_scaled_grouped_mm kernel.

Whether it is SM100 or SM90, the input matrix A must be Row-Major, the input matrix B must be Column-Major, and the output matrix is ​​Row-Major.

For SM90, CUTLASS only supports the scale factor layout of MN-Major, so SFA and SFB must follow the following format:

- The Shape of SFA is **(m, k)** and the Stride is **(1, m)**
- The Shape of SFB is **(n, k)** and the Stride is **(1, n)**

For SM100, CUTLASS supports both MN-Major and K-Major, but since the scale factor layout is hardcoded as K-Major in the code, the fp8_blockwise_scaled_grouped_mm kernel only supports the following format:

- The Shape of SFA is **(m, k)** and the Stride is **(k, 1)**
- The Shape of SFB is **(n, k)** and the Stride is **(k, 1)**

For the accuracy test method, the traditional allclose cannot adapt to the fp8_blockwise_scaled_grouped_mm kernel, so we align the accuracy test method with [DeepGEMM](https://github.com/deepseek-ai/DeepEP). Thanks @LyricZhao @MARD1NO @Alcanderian a lot.

We have conducted extensive experiments on the Hopper & Blackwell architecture, and the accuracy results are in line with expectations:
Hopper:
<img width="3840" height="2112" alt="image" src="https://github.com/user-attachments/assets/10669cb4-3d00-4b97-b53e-a8c260511989" />

Blackwell:
<img width="3840" height="2112" alt="image" src="https://github.com/user-attachments/assets/6bca9885-aaab-4b42-811e-f5b47169e5e8" />

We hope this PR can help you adapt the fp8_blockwise_scaled_grouped_mm kernel to your business scenarios.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Assist developers to adapt the fp8_blockwise_scaled_grouped_mm kernel based on CUTLASS.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
sgl-kernel/tests/test_fp8_blockwise_moe.py
<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
<img width="3840" height="2112" alt="image" src="https://github.com/user-attachments/assets/b4c52971-58ba-47d5-bb3d-10f9713df900" />

- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html)--**Blackwell**
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
