### PR TITLE
Add update tensor spmd test

### DIFF
--- a/test/srt/test_update_weights_from_tensor_spmd.py
+++ b/test/srt/test_update_weights_from_tensor_spmd.py
@@ -1,14 +1,15 @@
 import gc
+import multiprocessing as mp
+import os
 import time
 import unittest
-import multiprocessing as mp
+
 import torch
-import os
 
 import sglang as sgl
-from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST, CustomTestCase
-from sglang.srt.utils import MultiprocessingSerializer
 from sglang.srt.model_executor.model_runner import LocalSerializedTensor
+from sglang.srt.utils import MultiprocessingSerializer
+from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST, CustomTestCase
 
 
 def _preprocess_tensor_for_update_weights(tensor: torch.Tensor):
@@ -19,50 +20,115 @@ def _preprocess_tensor_for_update_weights(tensor: torch.Tensor):
     return tensor
 
 
-
-def worker_process(rank, world_size, tp_size, port, tensor_queue, barrier):
+def worker_process(
+    rank, world_size, tp_size, port, tensor_queue, barrier, batch_update=False
+):
     try:
         torch.cuda.set_device(rank)
         new_tensor = torch.full((16384, 2048), 1.5, device=f"cuda:{rank}")
-        
+
         param_names = [f"model.layers.{i}.mlp.up_proj.weight" for i in range(6, 16)]
-        
+
         if rank == 0:
             # Process 0: Create engine and collect serialized tensors
-            engine = sgl.Engine(model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST, tp_size=tp_size)
-            
-            # Check initial param values  
-            _check_param(engine, param_names[0], [0.0087, -0.0214, -0.0004, 0.0039, 0.0110])
-            
+            engine = sgl.Engine(
+                model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+                tp_size=tp_size,
+                mem_fraction_static=0.2,
+                disable_cuda_graph=True,
+            )
+
+            # Check initial param values
+            _check_param(
+                engine, param_names[0], [0.0087, -0.0214, -0.0004, 0.0039, 0.0110]
+            )
+
             memory_before = torch.cuda.memory_allocated()
-            
-            for param_name in param_names:
-                gathered_tensors = []
-                
-                # Add local tensor
-                local_serialized = MultiprocessingSerializer.serialize(
-                    _preprocess_tensor_for_update_weights(new_tensor)
-                )
-                gathered_tensors.append(local_serialized)
-                
-                # Collect from other ranks via queue
-                for _ in range(1, world_size):
-                    remote_serialized = tensor_queue.get()
-                    gathered_tensors.append(remote_serialized)
-                
-                # Update weights using gathered serialized tensors
-                time_start = time.perf_counter()
+
+            if batch_update:
+                # Batch update: collect all tensors first, then update once
+                print("=== Testing BATCH UPDATE (all 10 layers at once) ===")
+                all_named_tensors = []
+                total_gather_time = 0
+
+                for param_name in param_names:
+                    gather_start = time.perf_counter()
+                    gathered_tensors = []
+
+                    # Add local tensor
+                    local_serialized = MultiprocessingSerializer.serialize(
+                        _preprocess_tensor_for_update_weights(new_tensor)
+                    )
+                    gathered_tensors.append(local_serialized)
+
+                    # Collect from other ranks via queue
+                    for _ in range(1, world_size):
+                        remote_serialized = tensor_queue.get()
+                        gathered_tensors.append(remote_serialized)
+
+                    all_named_tensors.append(
+                        (param_name, LocalSerializedTensor(values=gathered_tensors))
+                    )
+                    total_gather_time += time.perf_counter() - gather_start
+
+                # Single batch update
+                update_start = time.perf_counter()
                 engine.update_weights_from_tensor(
-                    named_tensors=[(param_name, LocalSerializedTensor(values=gathered_tensors))],
-                    flush_cache=(param_name == param_names[-1])
+                    named_tensors=all_named_tensors, flush_cache=True
                 )
-                print(f"Time delta for {param_name}: {time.perf_counter() - time_start:.03f}")
-            
+                update_time = time.perf_counter() - update_start
+
+                print(
+                    f"Batch update - Gather time: {total_gather_time:.03f}s, Update time: {update_time:.03f}s, Total: {total_gather_time + update_time:.03f}s"
+                )
+
+            else:
+                # Sequential update: update one by one
+                print("=== Testing SEQUENTIAL UPDATE (one by one) ===")
+                total_update_time = 0
+                total_gather_time = 0
+
+                for param_name in param_names:
+                    gather_start = time.perf_counter()
+                    gathered_tensors = []
+
+                    # Add local tensor
+                    local_serialized = MultiprocessingSerializer.serialize(
+                        _preprocess_tensor_for_update_weights(new_tensor)
+                    )
+                    gathered_tensors.append(local_serialized)
+
+                    # Collect from other ranks via queue
+                    for _ in range(1, world_size):
+                        remote_serialized = tensor_queue.get()
+                        gathered_tensors.append(remote_serialized)
+
+                    gather_time = time.perf_counter() - gather_start
+                    total_gather_time += gather_time
+
+                    # Update weights using gathered serialized tensors
+                    update_start = time.perf_counter()
+                    engine.update_weights_from_tensor(
+                        named_tensors=[
+                            (param_name, LocalSerializedTensor(values=gathered_tensors))
+                        ],
+                        flush_cache=(param_name == param_names[-1]),
+                    )
+                    update_time = time.perf_counter() - update_start
+                    total_update_time += update_time
+
+                    print(
+                        f"{param_name} - Gather: {gather_time:.03f}s, Update: {update_time:.03f}s"
+                    )
+
+                print(
+                    f"Sequential update - Total gather time: {total_gather_time:.03f}s, Total update time: {total_update_time:.03f}s, Total: {total_gather_time + total_update_time:.03f}s"
+                )
+
             # Check updated param values
             for param_name in param_names[:3]:
                 _check_param(engine, param_name, [1.5] * 5)
-            
-            
+
         else:
             # Non-rank-0 processes: Send serialized tensors via queue
             for param_name in param_names:
@@ -79,7 +145,7 @@ def worker_process(rank, world_size, tp_size, port, tensor_queue, barrier):
 
         if rank == 0:
             engine.shutdown()
-            
+
             # Memory cleanup and check
             del new_tensor
             gc.collect()
@@ -89,71 +155,57 @@ def worker_process(rank, world_size, tp_size, port, tensor_queue, barrier):
             assert (
                 memory_after <= memory_before + 1024
             ), f"Memory leak detected: {memory_after - memory_before} bytes"
-        
+
     except Exception as e:
         print(f"Error in rank {rank}: {e}")
         raise
 
-def test_update_weights_from_tensor_spmd(tp_size, world_size=2):
-    assert torch.cuda.device_count() >= max(tp_size, world_size), f"At least {max(tp_size, world_size)} GPUs are required"
+
+def test_update_weights_from_tensor_spmd(tp_size, world_size, batch_update=False):
+    assert torch.cuda.device_count() >= max(
+        tp_size, world_size
+    ), f"At least {max(tp_size, world_size)} GPUs are required"
     torch.cuda.empty_cache()
-    
+
     # Create shared resources
     tensor_queue = mp.Queue()
     barrier = mp.Barrier(world_size)
-    
+
     # Start worker processes
     processes = []
     for rank in range(world_size):
-        p = mp.Process(target=worker_process, args=(rank, world_size, tp_size, 0, tensor_queue, barrier))
+        p = mp.Process(
+            target=worker_process,
+            args=(rank, world_size, tp_size, 0, tensor_queue, barrier, batch_update),
+        )
         p.start()
         processes.append(p)
-    
+
     # Wait for all processes to complete
     for p in processes:
         p.join()
         assert p.exitcode == 0, f"Process failed with exit code {p.exitcode}"
 
 
-def test_update_weights_from_tensor(tp_size):
-    """Original single-process test for comparison."""
-    assert torch.cuda.device_count() >= tp_size, f"At least {tp_size} GPUs are required"
-    torch.cuda.empty_cache()
-
-    engine = sgl.Engine(model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST, tp_size=tp_size)
-
-    param_names = [f"model.layers.{i}.mlp.up_proj.weight" for i in range(6, 16)]
-
-    _check_param(engine, param_names[0], [0.0087, -0.0214, -0.0004, 0.0039, 0.0110])
-
-    memory_before = torch.cuda.memory_allocated()
-    new_tensor = torch.full((16384, 2048), 1.5, device="cuda")
-
-    time_start = time.perf_counter()
-    engine.update_weights_from_tensor([(x, new_tensor) for x in param_names])
-    print(f"Time delta: {time.perf_counter() - time_start:.03f}")
-
-    for param_name in param_names[:3]:
-        _check_param(engine, param_name, [1.5] * 5)
-
-    engine.shutdown()
-
-    del new_tensor
-    gc.collect()
-    torch.cuda.ipc_collect()
-    torch.cuda.empty_cache()
-    memory_after = torch.cuda.memory_allocated()
-    assert (
-        memory_after <= memory_before + 1024
-    ), f"Memory leak detected: {memory_after - memory_before} bytes"
-
-
 class TestUpdateWeightsFromTensor(CustomTestCase):
-    def test_update_weights_from_tensor_spmd(self):
+    def test_update_weights_from_tensor_spmd_sequential(self):
         """
-        Test SPMD version with 2 processes.
+        Test SPMD version with sequential updates (one by one).
         """
-        test_update_weights_from_tensor_spmd(2, world_size=2)
+        TP_SIZE = 2
+        test_update_weights_from_tensor_spmd(
+            TP_SIZE, world_size=TP_SIZE, batch_update=False
+        )
+
+    def test_update_weights_from_tensor_spmd_batch(self):
+        """
+        Test SPMD version with batch update (all layers at once).
+        """
+        TP_SIZE = 2
+        test_update_weights_from_tensor_spmd(
+            TP_SIZE, world_size=TP_SIZE, batch_update=True
+        )
+
 
 def _check_param(engine, param_name, expect_values):
     actual_values = torch.tensor(engine.get_weights_by_name(param_name))[0, :5]
@@ -164,5 +216,5 @@ def _check_param(engine, param_name, expect_values):
 
 if __name__ == "__main__":
     # Set multiprocessing start method
-    mp.set_start_method('spawn', force=True)
+    mp.set_start_method("spawn", force=True)
     unittest.main()

--- a/test/srt/test_update_weights_from_tensor_spmd.py
+++ b/test/srt/test_update_weights_from_tensor_spmd.py
@@ -1,0 +1,168 @@
+import gc
+import time
+import unittest
+import multiprocessing as mp
+import torch
+import os
+
+import sglang as sgl
+from sglang.test.test_utils import DEFAULT_SMALL_MODEL_NAME_FOR_TEST, CustomTestCase
+from sglang.srt.utils import MultiprocessingSerializer
+from sglang.srt.model_executor.model_runner import LocalSerializedTensor
+
+
+def _preprocess_tensor_for_update_weights(tensor: torch.Tensor):
+    """Preprocess tensor for update weights - handles DTensor conversion.
+    For test purposes, we just return the tensor as-is
+    In FSDP, we can call tensor.full_tensor() to gather the partial tensors into a full tensor
+    """
+    return tensor
+
+
+
+def worker_process(rank, world_size, tp_size, port, tensor_queue, barrier):
+    try:
+        torch.cuda.set_device(rank)
+        new_tensor = torch.full((16384, 2048), 1.5, device=f"cuda:{rank}")
+        
+        param_names = [f"model.layers.{i}.mlp.up_proj.weight" for i in range(6, 16)]
+        
+        if rank == 0:
+            # Process 0: Create engine and collect serialized tensors
+            engine = sgl.Engine(model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST, tp_size=tp_size)
+            
+            # Check initial param values  
+            _check_param(engine, param_names[0], [0.0087, -0.0214, -0.0004, 0.0039, 0.0110])
+            
+            memory_before = torch.cuda.memory_allocated()
+            
+            for param_name in param_names:
+                gathered_tensors = []
+                
+                # Add local tensor
+                local_serialized = MultiprocessingSerializer.serialize(
+                    _preprocess_tensor_for_update_weights(new_tensor)
+                )
+                gathered_tensors.append(local_serialized)
+                
+                # Collect from other ranks via queue
+                for _ in range(1, world_size):
+                    remote_serialized = tensor_queue.get()
+                    gathered_tensors.append(remote_serialized)
+                
+                # Update weights using gathered serialized tensors
+                time_start = time.perf_counter()
+                engine.update_weights_from_tensor(
+                    named_tensors=[(param_name, LocalSerializedTensor(values=gathered_tensors))],
+                    flush_cache=(param_name == param_names[-1])
+                )
+                print(f"Time delta for {param_name}: {time.perf_counter() - time_start:.03f}")
+            
+            # Check updated param values
+            for param_name in param_names[:3]:
+                _check_param(engine, param_name, [1.5] * 5)
+            
+            
+        else:
+            # Non-rank-0 processes: Send serialized tensors via queue
+            for param_name in param_names:
+                serialized_tensor = MultiprocessingSerializer.serialize(
+                    _preprocess_tensor_for_update_weights(new_tensor)
+                )
+                tensor_queue.put(serialized_tensor)
+
+        # Critical: Wait for all processes to complete before exiting
+        # This ensures tensor IPC handles remain valid until SGLang finishes
+        print(f"Rank {rank} waiting at barrier...")
+        barrier.wait()
+        print(f"Rank {rank} passed barrier")
+
+        if rank == 0:
+            engine.shutdown()
+            
+            # Memory cleanup and check
+            del new_tensor
+            gc.collect()
+            torch.cuda.ipc_collect()
+            torch.cuda.empty_cache()
+            memory_after = torch.cuda.memory_allocated()
+            assert (
+                memory_after <= memory_before + 1024
+            ), f"Memory leak detected: {memory_after - memory_before} bytes"
+        
+    except Exception as e:
+        print(f"Error in rank {rank}: {e}")
+        raise
+
+def test_update_weights_from_tensor_spmd(tp_size, world_size=2):
+    assert torch.cuda.device_count() >= max(tp_size, world_size), f"At least {max(tp_size, world_size)} GPUs are required"
+    torch.cuda.empty_cache()
+    
+    # Create shared resources
+    tensor_queue = mp.Queue()
+    barrier = mp.Barrier(world_size)
+    
+    # Start worker processes
+    processes = []
+    for rank in range(world_size):
+        p = mp.Process(target=worker_process, args=(rank, world_size, tp_size, 0, tensor_queue, barrier))
+        p.start()
+        processes.append(p)
+    
+    # Wait for all processes to complete
+    for p in processes:
+        p.join()
+        assert p.exitcode == 0, f"Process failed with exit code {p.exitcode}"
+
+
+def test_update_weights_from_tensor(tp_size):
+    """Original single-process test for comparison."""
+    assert torch.cuda.device_count() >= tp_size, f"At least {tp_size} GPUs are required"
+    torch.cuda.empty_cache()
+
+    engine = sgl.Engine(model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST, tp_size=tp_size)
+
+    param_names = [f"model.layers.{i}.mlp.up_proj.weight" for i in range(6, 16)]
+
+    _check_param(engine, param_names[0], [0.0087, -0.0214, -0.0004, 0.0039, 0.0110])
+
+    memory_before = torch.cuda.memory_allocated()
+    new_tensor = torch.full((16384, 2048), 1.5, device="cuda")
+
+    time_start = time.perf_counter()
+    engine.update_weights_from_tensor([(x, new_tensor) for x in param_names])
+    print(f"Time delta: {time.perf_counter() - time_start:.03f}")
+
+    for param_name in param_names[:3]:
+        _check_param(engine, param_name, [1.5] * 5)
+
+    engine.shutdown()
+
+    del new_tensor
+    gc.collect()
+    torch.cuda.ipc_collect()
+    torch.cuda.empty_cache()
+    memory_after = torch.cuda.memory_allocated()
+    assert (
+        memory_after <= memory_before + 1024
+    ), f"Memory leak detected: {memory_after - memory_before} bytes"
+
+
+class TestUpdateWeightsFromTensor(CustomTestCase):
+    def test_update_weights_from_tensor_spmd(self):
+        """
+        Test SPMD version with 2 processes.
+        """
+        test_update_weights_from_tensor_spmd(2, world_size=2)
+
+def _check_param(engine, param_name, expect_values):
+    actual_values = torch.tensor(engine.get_weights_by_name(param_name))[0, :5]
+    assert torch.allclose(
+        actual_values, torch.tensor(expect_values), atol=0.002
+    ), f"{actual_values=}"
+
+
+if __name__ == "__main__":
+    # Set multiprocessing start method
+    mp.set_start_method('spawn', force=True)
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
To debug: https://github.com/sgl-project/sglang/issues/6762

To debug the slowness of update weight in verl, we need a easy to profile test which mock the actual behavior of how VERL + SGLang update weight works

https://github.com/volcengine/verl/blob/8d9e350ea58c7ad4b50dd14d9dcb50577242c55f/verl/workers/sharding_manager/fsdp_sglang.py#L155-L183

## Finding

```bash
Time delta for model.layers.6.mlp.up_proj.weight: 0.200
Time delta for model.layers.7.mlp.up_proj.weight: 0.018
Time delta for model.layers.8.mlp.up_proj.weight: 0.018
Time delta for model.layers.9.mlp.up_proj.weight: 0.040
Time delta for model.layers.10.mlp.up_proj.weight: 0.017
Time delta for model.layers.11.mlp.up_proj.weight: 0.016
Time delta for model.layers.12.mlp.up_proj.weight: 0.018
Time delta for model.layers.13.mlp.up_proj.weight: 0.019
Time delta for model.layers.14.mlp.up_proj.weight: 0.032
Time delta for model.layers.15.mlp.up_proj.weight: 0.018
```
TP 0 Profiling result: no memcpy P2P

<img width="685" height="247" alt="Screenshot 2025-07-10 at 12 34 09 PM" src="https://github.com/user-attachments/assets/2974c64e-f9a9-48fd-8345-dd64d7df6fa1" />


TP 1 Profiling result: no memcpy P2p
<img width="533" height="185" alt="Screenshot 2025-07-10 at 12 34 43 PM" src="https://github.com/user-attachments/assets/57cd0741-374e-4a1c-9ad4-dcb8fd02bc15" />


This is different fro #6762 where we noticed a memcpy p2p in the profiling result from megatron + verl of TP2 

<img width="1322" height="92" alt="image" src="https://github.com/user-attachments/assets/e05f9036-3279-44cc-bf6a-8eef26172572" />


<img width="684" height="343" alt="Screenshot 2025-07-10 at 12 36 16 PM" src="https://github.com/user-attachments/assets/9a9ca994-e6b5-4a93-a179-a19eafa001c4" />

## More Finding
<img width="665" height="472" alt="Image" src="https://github.com/user-attachments/assets/548ac92e-c2e8-4e72-82d0-6147a2371e82" />

A potential optimization would be: 
- Learn from Slime's bucket update params: https://github.com/THUDM/slime/blob/8ebfaf683f149c7948dcbb19ee2f28e468cd4481/slime/ray/ppo_actor.py#L112 

As we can see from the screenshot, batch update tensors is much faster then per tensor update

## Attachment

TP0 Profiling Result 
[profiler_trace_0_20250710_192655.json](https://github.com/user-attachments/files/21170160/profiler_trace_0_20250710_192655.json)



TP1 Profiling Result
 [profiler_trace_1_20250710_192655.json](https://github.com/user-attachments/files/21170163/profiler_trace_1_20250710_192655.json)

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->



## Next
- Test whether bucket based update (inspired by https://github.com/THUDM/slime) would be faster than per tensor update
- Test the speed of Qwen 32B of both solution
- Test the speed of Qwen 235B of both solution if resources allowed

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
