### PR TITLE
[Kimi K2] num_experts extends to 384

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -45,6 +45,10 @@ _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
 _is_npu = is_npu()
 
+# Maximum VPT (Values Per Thread) supported by moe_fused_gate kernel
+# This should match MAX_VPT in moe_fused_gate.cu
+MAX_VPT_SUPPORTED = 384
+
 if _is_cuda:
     from sgl_kernel import moe_fused_gate
 
@@ -321,7 +325,7 @@ def biased_grouped_topk_gpu(
     if (
         _is_cuda
         and gating_output.shape[1] // num_expert_group
-        <= 32  # moe_fused_gate kernel ensure that num_experts/num_expert_group does not exceed MAX_VPT=32 now. And when kernel can handle MAX_VPT > 32, we can remove this assertion.
+        <= MAX_VPT_SUPPORTED  # moe_fused_gate kernel ensure that num_experts/num_expert_group does not exceed MAX_VPT now.
         and is_power_of_two(correction_bias.shape[0])
     ):
         topk_weights, topk_ids = moe_fused_gate(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -246,7 +246,7 @@ class MoEGate(nn.Module):
             and not self.is_nextn
             and hidden_states.shape[0] < 4
             and hidden_states.shape[1] == 7168
-            and self.weight.shape[0] == 256
+            and self.weight.shape[0] in [256, 384]
             and _device_sm >= 90
         ):
             logits = dsv3_router_gemm(hidden_states, self.weight).to(
@@ -2111,7 +2111,7 @@ class DeepseekV2ForCausalLM(nn.Module):
             not _is_cuda
             or torch.cuda.get_device_capability("cuda") < (8, 0)
             or self.config.architectures[0] != architecture
-            or self.config.n_routed_experts != 256
+            or self.config.n_routed_experts not in [256, 384]
             or self.config.n_shared_experts != 1
         ):
             disable_reason = "Only Deepseek V3/R1 on NV-platform with capability >= 80 can use shared experts fusion optimization."

--- a/sgl-kernel/csrc/cpu/topk.cpp
+++ b/sgl-kernel/csrc/cpu/topk.cpp
@@ -466,6 +466,9 @@ topk_sigmoid_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t t
       case 256:
         LAUNCH_TOPK_SIGMOID_KERNEL(256);
         break;
+      case 384:
+        LAUNCH_TOPK_SIGMOID_KERNEL(384);
+        break;
       default:
         TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
     }
@@ -519,6 +522,9 @@ topk_softmax_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t t
         break;
       case 256:
         LAUNCH_TOPK_SOFTMAX_KERNEL(256);
+        break;
+      case 384:
+        LAUNCH_TOPK_SOFTMAX_KERNEL(384);
         break;
       default:
         TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
@@ -596,6 +602,9 @@ std::tuple<at::Tensor, at::Tensor> grouped_topk_cpu(
         break;
       case 256:
         LAUNCH_GROUPED_TOPK_KERNEL(256);
+        break;
+      case 384:
+        LAUNCH_GROUPED_TOPK_KERNEL(384);
         break;
       default:
         TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);


### PR DESCRIPTION
Kimi K2  has `"n_routed_experts": 384`
 
change the code , to avoid go to `"Unexpected num_experts: "`



Test Result for CUDA code on A800:
```
python3  sgl-kernel/tests/test_moe_fused_gate.py

sgl-kernel/tests/test_moe_fused_gate.py 

============ warnings summary ===================================

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============== 594 passed, 1 warning in 11.16s =================================
```


```
python sgl-kernel/benchmark/bench_moe_fused_gate.py

moe-fused-gate-performance:
   seq_length    Original  SGL Kernel
0      5000.0   39.503999   39.519999
1     10000.0   60.704000   59.967998
2     15000.0   79.712003   79.712003
3     20000.0   98.112002   97.216003
4     25000.0  115.103997  115.808003
5     30000.0  133.504003  132.671997
6     35000.0  150.335997  150.368005
7     40000.0  168.240003  168.096006
···