### PR TITLE
fix qwen3 context length resolving bug

### DIFF
--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -191,7 +191,7 @@ def get_context_length(config):
     if rope_scaling:
         rope_scaling_factor = rope_scaling.get("factor", 1)
         if "original_max_position_embeddings" in rope_scaling:
-            return (
+            return int(
                 rope_scaling["original_max_position_embeddings"] * rope_scaling_factor
             )
         if rope_scaling.get("rope_type", None) == "llama3":

--- a/python/sglang/srt/hf_transformers_utils.py
+++ b/python/sglang/srt/hf_transformers_utils.py
@@ -191,7 +191,9 @@ def get_context_length(config):
     if rope_scaling:
         rope_scaling_factor = rope_scaling.get("factor", 1)
         if "original_max_position_embeddings" in rope_scaling:
-            rope_scaling_factor = 1
+            return (
+                rope_scaling["original_max_position_embeddings"] * rope_scaling_factor
+            )
         if rope_scaling.get("rope_type", None) == "llama3":
             rope_scaling_factor = 1
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When serving Qwen3 models with YaRN-extended context length following [Qwen's offical HF page](https://huggingface.co/Qwen/Qwen3-32B#processing-long-texts) and feed the model with a long prompt, it will report an error: e.g.
"The input (70000 tokens) is longer than the model's context length (40960)."

The server is started as below, you can reproduce the bug with any long enough request.
```bash
uv run -m sglang.launch_server \
--model-path Qwen/Qwen3-4B \
--json-model-override-args '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768}}' \
--host 0.0.0.0 \
--port 30000
```

## Modifications
While this bug can be resolved by simply providing the command with another flag:
```bash
--context-length 131072
```
Automatic context length resolution is preferred.

The bug is related to the following function:

https://github.com/sgl-project/sglang/blob/a562c8a35c93d70374e2d3b57c12f66718113f17/python/sglang/srt/hf_transformers_utils.py#L187-L204

https://github.com/sgl-project/sglang/blob/a562c8a35c93d70374e2d3b57c12f66718113f17/python/sglang/srt/hf_transformers_utils.py#L193-L194

When `original_max_position_embeddings` is provided in the `rope_scaling` dict, the correct target context length should be computed by `original_max_position_embeddings * rope_scaling_factor`

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
