### PR TITLE
fix: remove redundant rotary embedding cache recomputation in MiniCPM

### DIFF
--- a/python/sglang/srt/models/minicpm.py
+++ b/python/sglang/srt/models/minicpm.py
@@ -138,8 +138,6 @@ class MiniCPMAttention(nn.Module):
             base=rope_theta,
             rope_scaling=rope_scaling,
         )
-        # set rope as fp32 instead of bf16
-        self.rotary_emb.cos_sin_cache = self.rotary_emb._compute_cos_sin_cache()
         self.attn = RadixAttention(
             self.num_heads,
             self.head_dim,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Fix #7926
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
### Summary
This PR fixes a redundant rotary embedding cache recomputation in the MiniCPM model that was bypassing proper dtype handling.

### Problem
The `MiniCPMAttention` class was unnecessarily recomputing the rotary embedding cache after initialization:
```python
# Redundant line that was removed
self.rotary_emb.cos_sin_cache = self.rotary_emb._compute_cos_sin_cache()
```

### Solution
Removed the redundant cache recomputation since:
- The `RotaryEmbedding` constructor already handles proper cache initialization
- FP32 conversion for numerical stability is already handled appropriately
- This avoids bypassing the proper dtype handling logic
https://github.com/sgl-project/sglang/blob/c07f647c9f3fd6f5b4b5747b70d8adbdfe75b35d/python/sglang/srt/layers/rotary_embedding.py#L543-L563
<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
