### PR TITLE
[feat]Support fusion kernel for constructing quant input and scale factor for fp8_blockwise_scaled_grouped_mm

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+from triton.language.extra import libdevice
 
 from sglang.srt.layers.quantization import deep_gemm_wrapper
 from sglang.srt.utils import (
@@ -1166,3 +1167,92 @@ def scaled_fp8_quant(
         )  # True for static
 
     return output, scale
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": block_m}, num_warps=num_warps)
+        for block_m in [16, 32, 64, 128]
+        for num_warps in [2, 4, 8]
+    ],
+    key=["K", "BLOCK_K", "M_ALIGNMENT"],
+)
+@triton.jit
+def _per_token_group_quant_fp8_hopper_moe_mn_major(
+    a,  # (M, K):(K, 1)
+    expert_offsets,  # (num_experts,)
+    problem_sizes,  # (num_experts, 3)
+    a_fp8,  # (M, K):(K, 1)
+    sfa,  # (M, k)
+    K: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    M_ALIGNMENT: tl.constexpr,
+    BLOCK_M: tl.constexpr,  # tune
+):
+    k_offset = tl.program_id(0)
+    expert_id = tl.program_id(1)
+
+    m = tl.load(problem_sizes + expert_id * 3)
+    current_expert_offset = tl.load(expert_offsets + expert_id).to(tl.int64)
+    tl.multiple_of(m, M_ALIGNMENT)
+    tl.multiple_of(current_expert_offset, M_ALIGNMENT)
+
+    coord_k = k_offset * BLOCK_K + tl.arange(0, BLOCK_K)
+    for i in tl.range(tl.cdiv(m, BLOCK_M)):
+        coord_m = i * BLOCK_M + tl.arange(0, BLOCK_M)
+        a_ptrs = a + current_expert_offset * K + coord_m[:, None] * K + coord_k[None, :]
+        a_mask = (coord_m < m)[:, None] & (coord_k < K)[None, :]
+
+        inp = tl.load(a_ptrs, mask=a_mask).to(tl.float32)  # [BLOCK_M, BLOCK_K]
+        inp_amax = tl.max(tl.abs(inp), axis=1)  # [BLOCK_M,]
+        inp_amax = tl.clamp(inp_amax, min=1e-4, max=float("inf"))
+        inp_fp8 = (inp * libdevice.fast_dividef(float(448.0), inp_amax[:, None])).to(
+            a_fp8.dtype.element_ty
+        )
+
+        # Store fp8
+        a_fp8_ptrs = (
+            a_fp8 + current_expert_offset * K + coord_m[:, None] * K + coord_k[None, :]
+        )
+        tl.store(a_fp8_ptrs, inp_fp8, mask=a_mask)
+
+        # Store sfa
+        k = tl.cdiv(K, BLOCK_K)
+        sfa_ptrs = (
+            sfa + current_expert_offset * k + k_offset * m + coord_m
+        )  # MN-Major with sfa
+        tl.store(
+            sfa_ptrs, libdevice.fast_dividef(inp_amax, float(448.0)), mask=coord_m < m
+        )
+
+
+def per_token_group_quant_fp8_hopper_moe_mn_major(
+    A: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    problem_sizes: torch.Tensor,
+    group_size: int,
+    expert_tokens_alignment: int = 1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert A.dim() == 2
+    assert A.is_contiguous(), "`A` is not contiguous"
+    assert (
+        A.shape[-1] % group_size == 0
+    ), "the last dimension of `A` cannot be divisible by `group_size`"
+
+    a_q = torch.empty_like(A, device=A.device, dtype=fp8_dtype)
+    M, K = A.shape[0], A.shape[1]
+    k = K // group_size
+    sfa = torch.empty((M, k), device=A.device, dtype=torch.float32)
+    num_experts = problem_sizes.shape[0]
+    grid = (k, num_experts)
+    _per_token_group_quant_fp8_hopper_moe_mn_major[grid](
+        A,
+        expert_offsets,
+        problem_sizes,
+        a_q,
+        sfa,
+        K,
+        group_size,
+        expert_tokens_alignment,
+    )
+    return a_q, sfa


### PR DESCRIPTION
Follow https://github.com/sgl-project/sglang/pull/7278, https://github.com/sgl-project/sglang/pull/7782, https://github.com/sgl-project/sglang/pull/7932

On the Hopper architecture, the FP8 Blockwise Scaling Grouped GEMM based on CUTLASS has a different scale factor format from the Blackwell architecture and DeepGEMM. Therefore, some optimized quant kernels(e.g. https://github.com/sgl-project/sglang/blob/main/sgl-kernel/csrc/gemm/per_token_group_quant_8bit.cu) in SGLang cannot be directly used to construct scale factors. 

We have developed a Triton-based fusion kernel to calculate quantized input and scale factors for Hopper.

Since this is a new kernel, we don't have a baseline for comparison, so we show some profile results. In some scenarios (such as when num_groups or K dimension is large), this kernel can effectively utilize memory bandwidth:
<img width="3840" height="2160" alt="quant performace 0714" src="https://github.com/user-attachments/assets/9e65fb8b-8ab0-4200-a4fc-e02fddeb299e" />
For example, on H20, when num_groups=256 and K=7168, this kernel can achieve more than 80% memory bandwidth utilization (H20's maximum memory bandwidth is up to 4TB/s).

In fact, if CUTLASS supports K-Major scale factors, this kernel is not necessary. We are also tracking this through this issue: https://github.com/NVIDIA/cutlass/issues/2464

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Optimize scalability and performance for fp8_blockwise_scaled_grouped_mm.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
python/sglang/srt/layers/quantization/fp8_kernel.py
sgl-kernel/tests/test_fp8_blockwise_moe.py
<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
<img width="3840" height="2112" alt="lint done 0714" src="https://github.com/user-attachments/assets/1601cfd2-f299-4fe9-a19c-c9be2bfa6b47" />

- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).

Accuracy test in Hopper:
<img width="3840" height="2112" alt="unitest hopper pass 0714" src="https://github.com/user-attachments/assets/af840f35-00c5-44c1-8483-1909baaa7014" />
Accuracy test in Blackwell:
<img width="3840" height="2112" alt="unitest Blackwell pass 0714" src="https://github.com/user-attachments/assets/8f93ca04-7ced-4a92-9f8c-b969c1e91bb8" />

- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Future Work
- [ ] Adapt this solution to python/sglang/srt/layers/moe/cutlass_moe.py in TP and EP scenarios. @TianQiLin666666 