### PR TITLE
feat: support shortest queue scheduler in data-parallel controller

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -422,7 +422,7 @@ class DecodePreallocQueue:
         ]
 
         return preallocated_reqs
-    
+
     @property
     def num_tokens_pre_allocated(self):
         return sum(
@@ -628,7 +628,7 @@ class DecodeTransferQueue:
 
                 if hasattr(decode_req.kv_receiver, "clear"):
                     decode_req.kv_receiver.clear()
-                
+
                 # special handling for sampling_params.max_new_tokens == 1
                 if decode_req.req.sampling_params.max_new_tokens == 1:
                     # finish immediately
@@ -786,7 +786,7 @@ class SchedulerDisaggregationDecodeMixin:
                     self.stream_output(
                         batch.reqs, any(req.return_logprob for req in batch.reqs)
                     )
-                    if prepare_mlp_sync_flag::
+                    if prepare_mlp_sync_flag:
                         batch_, result = self._prepare_idle_batch_and_run(
                             None, delay_process=True
                         )
@@ -794,7 +794,7 @@ class SchedulerDisaggregationDecodeMixin:
                             result_queue.append((batch_.copy(), result))
                             last_batch_in_queue = True
                 else:
-                    if prepare_mlp_sync_flag::
+                    if prepare_mlp_sync_flag:
                         self.prepare_mlp_sync_batch(batch)
                     start_time = time.perf_counter()
                     result = self.run_batch(batch)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -21,15 +21,18 @@ Life cycle of a request in the decode server
 from __future__ import annotations
 
 import logging
+import os
 from collections import deque
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+import time
+import requests
 
+import numpy as np
 import torch
 from torch.distributed import ProcessGroup
 
-from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.disaggregation.base import BaseKVManager, BaseKVReceiver, KVPoll
 from sglang.srt.disaggregation.utils import (
     FAKE_BOOTSTRAP_HOST,
@@ -45,12 +48,14 @@ from sglang.srt.disaggregation.utils import (
     prepare_abort,
 )
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
-from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
-from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+from sglang.srt.mem_cache.memory_pool import (
+    KVCache,
+    ReqToTokenPool,
+    TokenToKVPoolAllocator,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.torch_memory_saver_adapter import TorchMemorySaverAdapter
-from sglang.srt.utils import require_mlp_sync
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +92,7 @@ class DecodeReqToTokenPool:
         self.max_context_len = max_context_len
         self.device = device
         self.pre_alloc_size = pre_alloc_size
-        with memory_saver_adapter.region(tag=GPU_MEMORY_TYPE_KV_CACHE):
+        with memory_saver_adapter.region():
             self.req_to_token = torch.zeros(
                 (size + pre_alloc_size, max_context_len),
                 dtype=torch.int32,
@@ -136,7 +141,7 @@ class DecodePreallocQueue:
     def __init__(
         self,
         req_to_token_pool: ReqToTokenPool,
-        token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+        token_to_kv_pool_allocator: TokenToKVPoolAllocator,
         draft_token_to_kv_pool: Optional[KVCache],
         req_to_metadata_buffer_idx_allocator: ReqToMetadataIdxAllocator,
         metadata_buffers: MetadataBuffers,
@@ -416,12 +421,6 @@ class DecodePreallocQueue:
 
         return preallocated_reqs
 
-    @property
-    def num_tokens_pre_allocated(self):
-        return sum(
-            len(decode_req.req.fill_ids) for decode_req in self.transfer_queue.queue
-        )
-
     def _allocatable_tokens(
         self, retractable_tokens: Optional[int] = None, count_retracted: bool = True
     ) -> int:
@@ -439,13 +438,7 @@ class DecodePreallocQueue:
             else 0
         )
 
-        if self.scheduler.model_config.is_hybrid:
-            available_size = min(
-                self.token_to_kv_pool_allocator.full_available_size(),
-                self.token_to_kv_pool_allocator.swa_available_size(),
-            )
-        else:
-            available_size = self.token_to_kv_pool_allocator.available_size()
+        available_size = self.token_to_kv_pool_allocator.available_size()
 
         allocatable_tokens = available_size - max(
             # preserve some space for future decode
@@ -549,7 +542,6 @@ class DecodeTransferQueue:
         self.metadata_buffers = metadata_buffers
         self.scheduler = scheduler
         self.tree_cache = tree_cache
-        self.spec_algorithm = scheduler.spec_algorithm
 
     def add(self, decode_req: DecodeRequest) -> None:
         self.queue.append(decode_req)
@@ -595,12 +587,10 @@ class DecodeTransferQueue:
                     output_token_logprobs_idx,
                     output_top_logprobs_val,
                     output_top_logprobs_idx,
-                    output_hidden_states,
                 ) = self.metadata_buffers.get_buf(idx)
 
                 decode_req.req.output_ids.append(output_id[0].item())
-                if not self.spec_algorithm.is_none():
-                    decode_req.req.hidden_states_tensor = output_hidden_states
+
                 if decode_req.req.return_logprob:
                     decode_req.req.output_token_logprobs_val.append(
                         output_token_logprobs_val[0].item()
@@ -618,21 +608,9 @@ class DecodeTransferQueue:
                             : decode_req.req.top_logprobs_num
                         ].tolist()
                     )
-
                 if hasattr(decode_req.kv_receiver, "clear"):
                     decode_req.kv_receiver.clear()
-
-                # special handling for sampling_params.max_new_tokens == 1
-                if decode_req.req.sampling_params.max_new_tokens == 1:
-                    # finish immediately
-                    decode_req.req.check_finished()
-                    self.scheduler.stream_output(
-                        [decode_req.req], decode_req.req.return_logprob
-                    )
-                    self.tree_cache.cache_finished_req(decode_req.req)
-                else:
-                    transferred_reqs.append(decode_req.req)
-
+                transferred_reqs.append(decode_req.req)
                 indices_to_remove.add(i)
             elif poll in [
                 KVPoll.Bootstrapping,
@@ -660,6 +638,28 @@ class SchedulerDisaggregationDecodeMixin:
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
+        
+        if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
+            master_ip = self.server_args.dist_init_addr.split(":")[0]
+        else:
+            raise NotImplementedError()
+        master_port = 8001
+        controller_url = f"http://{master_ip}:{master_port}/update_load" 
+        self.pending_updates = { "num_tokens": 0,"time":0}
+            
+        async def _send_load_update_async(dp_rank):
+            """异步发送负载更新"""
+            try:
+                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0.5)) as session:
+                    payload = {
+                        "dp_rank": dp_rank,
+                        "num_tokens": self.pending_updates["num_tokens"],
+                        "time": self.pending_updates["time"],
+                    }
+                    async with session.post(controller_url, json=payload) as response:
+                        if response.status == 200:
+                            self.pending_updates = { "num_tokens": 0,"time":0} # cho
+                            return True
 
         while True:
             recv_reqs = self.recv_requests()
@@ -669,7 +669,10 @@ class SchedulerDisaggregationDecodeMixin:
             batch = self.get_next_disagg_decode_batch_to_run()
             self.cur_batch = batch
 
-            prepare_mlp_sync_flag = require_mlp_sync(self.server_args)
+            prepare_dp_attn_flag = (
+                self.server_args.enable_dp_attention
+                or self.server_args.enable_sp_layernorm
+            )
 
             if batch:
                 # Generate fake extend output.
@@ -678,14 +681,23 @@ class SchedulerDisaggregationDecodeMixin:
                     self.stream_output(
                         batch.reqs, any(req.return_logprob for req in batch.reqs)
                     )
-                    if prepare_mlp_sync_flag:
+                    if prepare_dp_attn_flag:
                         self._prepare_idle_batch_and_run(None)
                 else:
-                    if prepare_mlp_sync_flag:
-                        self.prepare_mlp_sync_batch(batch)
+                    if prepare_dp_attn_flag:
+                        self.prepare_dp_attn_batch(batch)
+                    start_time = time.perf_counter()
                     result = self.run_batch(batch)
                     self.process_batch_result(batch, result)
-            elif prepare_mlp_sync_flag:
+                    cost_time = time.perf_counter()-start_time
+                    
+                    if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
+                        completed_tokens = sum(len(req.origin_input_ids) for req in batch.reqs)
+                        self.pending_updates["time"]+=cost_time
+                        self.pending_updates["num_tokens"] += completed_tokens
+                        _send_load_update_async(self.dp_rank) 
+                    
+            elif prepare_dp_attn_flag:
                 batch, _ = self._prepare_idle_batch_and_run(None)
 
             if batch is None and (
@@ -703,6 +715,30 @@ class SchedulerDisaggregationDecodeMixin:
 
     @torch.no_grad()
     def event_loop_overlap_disagg_decode(self: Scheduler):
+        if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
+            master_ip = self.server_args.dist_init_addr.split(":")[0]
+        else:
+            raise NotImplementedError()
+        master_port = 8001
+        controller_url = f"http://{master_ip}:{master_port}/update_load" 
+        self.pending_updates = { "num_tokens": 0,"time":0}
+            
+        async def _send_load_update_async(dp_rank):
+            """异步发送负载更新"""
+            try:
+                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0.5)) as session:
+                    payload = {
+                        "dp_rank": dp_rank,
+                        "num_tokens": self.pending_updates["num_tokens"],
+                        "time": self.pending_updates["time"],
+                    }
+                    async with session.post(controller_url, json=payload) as response:
+                        if response.status == 200:
+                            self.pending_updates = { "num_tokens": 0,"time":0} # cho
+                            return True
+            except Exception as e:
+                logger.debug(f"Load update failed: {e}")
+            return False
         result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None
         self.last_batch_in_queue = False  # last batch is modified in-place, so we need another variable to track if it's extend
@@ -716,7 +752,10 @@ class SchedulerDisaggregationDecodeMixin:
             self.cur_batch = batch
             last_batch_in_queue = False
 
-            prepare_mlp_sync_flag = require_mlp_sync(self.server_args)
+            prepare_dp_attn_flag = (
+                self.server_args.enable_dp_attention
+                or self.server_args.enable_sp_layernorm
+            )
 
             if batch:
                 # Generate fake extend output.
@@ -725,7 +764,7 @@ class SchedulerDisaggregationDecodeMixin:
                     self.stream_output(
                         batch.reqs, any(req.return_logprob for req in batch.reqs)
                     )
-                    if prepare_mlp_sync_flag:
+                    if prepare_dp_attn_flag:
                         batch_, result = self._prepare_idle_batch_and_run(
                             None, delay_process=True
                         )
@@ -733,10 +772,19 @@ class SchedulerDisaggregationDecodeMixin:
                             result_queue.append((batch_.copy(), result))
                             last_batch_in_queue = True
                 else:
-                    if prepare_mlp_sync_flag:
-                        self.prepare_mlp_sync_batch(batch)
+                    if prepare_dp_attn_flag:
+                        self.prepare_dp_attn_batch(batch)
+                    start_time = time.perf_counter()
                     result = self.run_batch(batch)
+                    cost_time = time.perf_counter()-start_time
                     result_queue.append((batch.copy(), result))
+                    
+                    if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
+                        completed_tokens = sum(len(req.origin_input_ids) for req in batch.reqs)
+                        self.pending_updates["time"]+=cost_time
+                        self.pending_updates["num_tokens"] += completed_tokens
+                        _send_load_update_async(self.dp_rank) 
+                    
 
                     if (self.last_batch is None) or (not self.last_batch_in_queue):
                         # Create a dummy first batch to start the pipeline for overlap schedule.
@@ -749,7 +797,7 @@ class SchedulerDisaggregationDecodeMixin:
                         self.set_next_batch_sampling_info_done(tmp_batch)
                     last_batch_in_queue = True
 
-            elif prepare_mlp_sync_flag:
+            elif prepare_dp_attn_flag:
                 batch, result = self._prepare_idle_batch_and_run(
                     None, delay_process=True
                 )
@@ -779,8 +827,8 @@ class SchedulerDisaggregationDecodeMixin:
             self.last_batch = batch
             self.last_batch_in_queue = last_batch_in_queue
 
-    def _prepare_idle_batch_and_run(self: Scheduler, batch, delay_process=False):
-        batch = self.prepare_mlp_sync_batch(batch)
+    def _prepare_idle_batch_and_run(self, batch, delay_process=False):
+        batch, _ = self.prepare_dp_attn_batch(batch)
         result = None
         if batch:
             result = self.run_batch(batch)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -26,6 +26,8 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
+import time
+import requests
 
 from sglang.srt.disaggregation.base import BaseKVManager, KVPoll
 from sglang.srt.disaggregation.utils import (
@@ -265,6 +267,31 @@ class SchedulerDisaggregationPrefillMixin:
     @torch.no_grad()
     def event_loop_normal_disagg_prefill(self: Scheduler) -> None:
         """A normal scheduler loop for prefill worker in disaggregation mode."""
+        if self.server_args.dp_size!=1 and self.server_args.load_balance_method=="shortest_queue":
+            if self.server_args.dist_init_addr is not None:
+                master_ip = self.server_args.dist_init_addr.split(":")[0]
+            else:
+                raise NotImplementedError()
+            master_port = 8001
+            controller_url = f"http://{master_ip}:{master_port}/update_load" 
+            self.pending_updates = { "num_tokens": 0,"time":0}
+              
+            async def _send_load_update_async(dp_rank):
+                """异步发送负载更新"""
+                try:
+                    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0.5)) as session:
+                        payload = {
+                            "dp_rank": dp_rank,
+                            "num_tokens": self.pending_updates["num_tokens"],
+                            "time": self.pending_updates["time"],
+                        }
+                        async with session.post(controller_url, json=payload) as response:
+                            if response.status == 200:
+                                self.pending_updates = { "num_tokens": 0,"time":0} # cho
+                                return True
+                except Exception as e:
+                    logger.debug(f"Load update failed: {e}")
+                return False
 
         while True:
             recv_reqs = self.recv_requests()
@@ -280,8 +307,16 @@ class SchedulerDisaggregationPrefillMixin:
             self.cur_batch = batch
 
             if batch:
+                start_time = time.perf_counter()
                 result = self.run_batch(batch)
+                cost_time = time.perf_counter()-start_time
                 self.process_batch_result_disagg_prefill(batch, result)
+            
+            if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
+                    completed_tokens = sum(len(req.origin_input_ids) for req in batch.reqs)
+                    self.pending_updates["time"]+=cost_time
+                    self.pending_updates["num_tokens"] += completed_tokens
+                    _send_load_update_async(self.dp_rank) 
 
             if len(self.disagg_prefill_inflight_queue) > 0:
                 self.process_disagg_prefill_inflight_queue()
@@ -298,6 +333,32 @@ class SchedulerDisaggregationPrefillMixin:
 
     @torch.no_grad()
     def event_loop_overlap_disagg_prefill(self: Scheduler) -> None:
+        
+        if self.server_args.dp_size!=1 and self.server_args.load_balance_method=="shortest_queue":
+            if self.server_args.dist_init_addr is not None:
+                master_ip = self.server_args.dist_init_addr.split(":")[0]
+            else:
+                raise NotImplementedError()
+            master_port = 8001
+            controller_url = f"http://{master_ip}:{master_port}/update_load" 
+            self.pending_updates = { "num_tokens": 0,"time":0}
+              
+            async def _send_load_update_async(dp_rank):
+                """异步发送负载更新"""
+                try:
+                    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0.5)) as session:
+                        payload = {
+                            "dp_rank": dp_rank,
+                            "num_tokens": self.pending_updates["num_tokens"],
+                            "time": self.pending_updates["time"],
+                        }
+                        async with session.post(controller_url, json=payload) as response:
+                            if response.status == 200:
+                                self.pending_updates = { "num_tokens": 0,"time":0} # cho
+                                return True
+                except Exception as e:
+                    logger.debug(f"Load update failed: {e}")
+                return False
         self.result_queue = deque()
 
         while True:
@@ -313,8 +374,16 @@ class SchedulerDisaggregationPrefillMixin:
                 batch = self.prepare_mlp_sync_batch(batch)
             self.cur_batch = batch
             if batch:
+                start_time = time.perf_counter()
                 result = self.run_batch(batch)
+                cost_time = time.perf_counter()-start_time
                 self.result_queue.append((batch.copy(), result))
+                
+                if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
+                    completed_tokens = sum(len(req.origin_input_ids) for req in batch.reqs)
+                    self.pending_updates["time"]+=cost_time
+                    self.pending_updates["num_tokens"] += completed_tokens
+                    _send_load_update_async(self.dp_rank) 
 
                 if self.last_batch is None:
                     # Create a dummy first batch to start the pipeline for overlap schedule.

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -60,68 +60,53 @@ class LoadTable:
     def __init__(self,dp_size):
         self._table = {
             rank:{
-                "pending_requests":0,
-                "nums_tokens":0,
-                "last_updateTime":time.time(),
-                "estimated_completed_time":0.0,
-                "avg_processing_speed":5000, 
-                "processing_history":[]
+                "num_tokens":0,
+                "gen_throughput(tok/s)": float('inf'),
+                "estimated_completed_time":0,
             } for rank in range(dp_size)
         }
-        self._lock = threading.Lock()
-        
-    def update_processing_speed(self, rank, completed_tokens, time_taken):
-        """update processing speed"""
-        if time_taken <= 0:
-            return
-            
-        with self._lock:
-            current_speed = completed_tokens / time_taken
-            
-            alpha = 0.3  # smoothing factor
-            old_speed = self._table[rank]["avg_processing_speed"]
-            new_speed = alpha * current_speed + (1 - alpha) * old_speed
-            
-            self._table[rank]["avg_processing_speed"] = new_speed
-            
-    def _update_estimated_completion_time(self, rank):
-        """def update estimated completion time"""
-        with self._lock:
-            rank_info = self._table[rank]
-            pending_tokens = rank_info["nums_tokens"]
-            processing_speed = rank_info["avg_processing_speed"]
-            if processing_speed > 0:
-                estimated_time = pending_tokens / processing_speed                
-                self._table[rank]["estimated_completion_time"] = estimated_time
+    
+    def update_add(self, rank, num_tokens):
+        self._table[rank]["num_tokens"] += num_tokens
+        throughput = self._table[rank]["gen_throughput(tok/s)"]
+        if not isinstance(throughput, (float, int)):
+            if str(throughput).lower() in ("inf", "+inf"):
+                throughput = float('inf')
             else:
-                rank_info["estimated_completion_time"] = float('inf')
-            
-    def update_add(self,rank,requests=0,tokens = 0):
-        self._table[rank]["pending_requests"] += requests
-        self._table[rank]["nums_tokens"] += tokens
-        self._table[rank]["last_update"] = time.time()
-        self._update_estimated_completion_time(rank)
+                try:
+                    throughput = float(throughput)
+                except Exception as e:
+                    raise ValueError(f"gen_throughput(tok/s)类型异常: {throughput} {type(throughput)}") from e
+            self._table[rank]["gen_throughput(tok/s)"] = throughput 
+        if throughput != float('inf'):
+            self._table[rank]["estimated_completed_time"] = self._table[rank]["num_tokens"] / throughput
+        else:
+            self._table[rank]["estimated_completed_time"] = 0
+    
+    def update_sub(self,num_input_tokens,rank,time):
+        if time >0:
+            self._table[rank]["num_tokens"] -= num_input_tokens
+            self._table[rank]["gen_throughput(tok/s)"] = num_input_tokens / time
+            self._table[rank]["estimated_completed_time"] = self._table[rank]["num_tokens"] / self._table[rank]["gen_throughput(tok/s)"]
+        else:
+            raise KeyError(f"time error")
         
-        
-    def update_sub(self, rank, requests=0, completed_tokens=0,processing_time = None):
-        self._table[rank]["pending_requests"] = max(0, self._table[rank]["pending_requests"] - requests)
-        self._table[rank]["nums_tokens"] = max(0, self._table[rank]["nums_tokens"] - completed_tokens)
-        self._table[rank]["last_update"] = time.time()
-        
-        if processing_time is not None and processing_time > 0 and completed_tokens > 0:
-            self.update_processing_speed(rank, completed_tokens, processing_time)
-        self._update_estimated_completion_time(rank)
-
-    def get_min_load_rank(self):
-        """get minimal load rank"""
-        with self._lock: 
-            return min(
-                self._table.items(), 
-                key=lambda x: (       
-                    x[1]["estimated_completed_time"], 
-                    x[1]["nums_tokens"]  
-                )
-            )[0]
+    def get_shortest_queue(self):
+        inf_items = [(rank, info) for rank, info in self._table.items()
+                    if info["gen_throughput(tok/s)"] == float('inf')]
+        if inf_items:
+	        # 在inf节点之间选num_tokens最少的，如果有多个再选rank最小
+	        return min(
+	            inf_items,
+	            key=lambda x: (x[1]["num_tokens"], x[0])
+	        )[0]
+        return min(
+            self._table.items(),
+            key=lambda x: (
+                x[1]["estimated_completed_time"],
+                x[1]["num_tokens"],
+            )
+        )[0]
     
 
 class DataParallelController:
@@ -175,33 +160,35 @@ class DataParallelController:
         self.max_req_input_len = None
         
         if server_args.dp_size!=1 and server_args.load_balance_method=="shortest_queue":
-            if server_args.node_rank == 0:
-                self.load_table = LoadTable(server_args.dp_size)
-
-                self.app = FastAPI()
-                @self.app.post("/update_load")
-                async def update_load(request:Request):
-                    try:
-                        data = await request.json()
-                        rank = data["rank"]
-                        completed_requests = data["completed_requests"]
-                        completed_tokens = data["completed_tokens"]
-                        taken_time = data["taken_time"]
-                        self.load_table.update_sub(rank,requests=completed_requests,tokens=completed_tokens,processing_time = taken_time)
-                        return {"status":"success"}
-                    except Exception as e:
-                        raise HTTPException(status_code=400,detail=str(e))
-                if self.server_args.dist_init_addr != "null":   
-                    self.master_ip = server_args.dist_init_addr.split(":")[0]
-                    self.master_port = 8001
-                    self.http_thread = threading.Thread(
-                        target=self._run_http_server,
-                        args=(self.master_port,),
-                        daemon=True
-                    )
-                    self.http_thread.start()
-                else:
-                    raise NotImplementedError()
+            self.load_table = LoadTable(server_args.dp_size)   
+            self.app = FastAPI()
+            @self.app.post("/update_load")
+            async def update_load(request:Request):
+                try:
+                    data = await request.json()
+                    rank = data["dp_rank"]
+                    nums_token = data["num_tokens"]
+                    time = data["time"]
+                
+                    self.load_table.update_sub(rank=rank,num_input_tokens=nums_token,time=time)
+                
+                    return {"status":"success"}
+                except Exception as e:
+                    raise HTTPException(status_code=400,detail=str(e))
+            if server_args.dist_init_addr is not None:
+                self.master_ip = server_args.dist_init_addr.split(":")[0]
+            else:
+                raise NotImplementedError()
+            self.master_port = 8001
+            self.http_thread = threading.Thread(
+                target=self._run_http_server,
+                args=(self.master_port,),
+                daemon=True
+                )
+            self.http_thread.start() 
+    
+    def _run_http_server(self, port):
+        uvicorn.run(self.app, host="0.0.0.0", port=port, log_level="warning")
                 
 
     def launch_dp_schedulers(self, server_args, port_args):

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -357,10 +357,9 @@ class DataParallelController:
             return
         
         seq_len = len(input_requests.input_ids)
-        selected_rank = self.load_table.get_min_load_rank()
-        self.load_table.update_add(rank=selected_rank,requests=1,tokens=seq_len)
+        selected_rank = self.load_table.get_shortest_queue()
+        self.load_table.update_add(selected_rank,seq_len)
         self.workers[selected_rank].send_pyobj(input_requests)
-
     def event_loop(self):
         while True:
             while True:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -844,16 +844,7 @@ class Scheduler(
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
                 end_time = time.time()
-                
-                if self.server_args.dp_size != 1 and self.server_args.load_balance_method == "shortest_queue":
-                    completed_count = len(batch.requests)
-                    completed_tokens = sum(len(req.input_ids) for req in batch.requests)
-                    
-                    self.pending_updates["requests"] += completed_count
-                    self.pending_updates["tokens"] += completed_tokens
-                    self.pending_updates["taken_time"] +=(end_time-start_time)
-                    self._send_load_update()    
-                    
+                 
             else:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -540,10 +540,7 @@ class Scheduler(
         self.init_disaggregation()
 
         if get_bool_env_var("SGLANG_GC_LOG"):
-            configure_gc_logger()
-        
-    
-
+            configure_gc_logger()  
 
     def current_scheduler_metrics_enabled(self):
         return self.attn_tp_rank == 0 or self.enable_metrics_for_all_schedulers
@@ -805,8 +802,7 @@ class Scheduler(
 
             if batch:
                 result = self.run_batch(batch)
-                self.process_batch_result(batch, result)
-                 
+                self.process_batch_result(batch, result)                
             else:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -540,7 +540,7 @@ class Scheduler(
         self.init_disaggregation()
 
         if get_bool_env_var("SGLANG_GC_LOG"):
-            configure_gc_logger()  
+            configure_gc_logger()
 
     def current_scheduler_metrics_enabled(self):
         return self.attn_tp_rank == 0 or self.enable_metrics_for_all_schedulers
@@ -802,7 +802,7 @@ class Scheduler(
 
             if batch:
                 result = self.run_batch(batch)
-                self.process_batch_result(batch, result)                
+                self.process_batch_result(batch, result)
             else:
                 # When the server is idle, do self-check and re-init some states
                 self.check_memory()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple, Union
 
-import requests
 import psutil
 import setproctitle
 import torch
@@ -542,43 +541,8 @@ class Scheduler(
 
         if get_bool_env_var("SGLANG_GC_LOG"):
             configure_gc_logger()
-            
-        if self.server_args.dp_size!=1 and self.server_args.load_balance_method=="shortest_queue":
-            if self.master_ip != "null":
-                self.master_ip = self.server_args.dist_init_addr.split(":")[0]
-                self.master_port = 8001
-                self.dp_rank = dp_rank
-                self.controller_url = f"http://{self.master_ip}:{self.master_port}/update_load"  
-                self.pending_updates = {"requests": 0, "tokens": 0,"taken_time":0}
-                self.last_report_time = time.time()
-            else:
-                raise NotImplementedError()
-    
-    def _send_load_update(self):
-        """Send load update to rank 0"""
-        if self.pending_updates["requests"] == 0:
-            return
         
-        try:
-            payload = {
-                "rank": self.dp_rank,
-                "completed_requests": self.pending_updates["requests"],
-                "time":self.pending_updates["taken_time"],
-                "completed_tokens": self.pending_updates["tokens"]
-            }
-            
-            response = requests.post(
-                self.controller_url,
-                json=payload,
-                timeout=1  
-            )
-            if response.status_code == 200:
-                self.pending_updates = {"requests": 0, "tokens": 0,"taken_time":0}
-                self.last_report_time = time.time()
-            else:
-                logger.error(f"Load update failed with status {response.status_code}")
-        except Exception as e:
-            logger.error(f"Failed to send load update: {str(e)}")
+    
 
 
     def current_scheduler_metrics_enabled(self):
@@ -840,10 +804,8 @@ class Scheduler(
             self.cur_batch = batch
 
             if batch:
-                start_time = time.time()
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
-                end_time = time.time()
                  
             else:
                 # When the server is idle, do self-check and re-init some states


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

# Motivation & Modifications
In order to balance the usage of GPUs in the inference process, we support the short queue scheduling method for data parallelism.

The load data from all DP groups is periodically collected on the TP0 node, where TP0 interacts with the dispatcher via HTTP to share the load information in real time.

The load table consists of the following parts:

num_tokens: The number of tokens currently being processed and waiting to be processed by each DP group's scheduler.
gen_throughput (tok/s): The generation throughput (tokens per second) of each DP group.
estimated_completed_time: The estimated completion time for each DP group.

To enable this feature, simply add --load-balance-method shortest_queue to the startup arguments.

# Performance
## rabdom
|  |  | 512 | 1024 | 2048 |
|-----|-----|-----|-----|-----|
|  round_robin  |  Request throughput (req/s)  |  2.50  |  3.73  |  4.79  |
|    |  Input token throughput (tok/s) |  5115.65  |  7612.15  |  9938.68  |
|    |  Output token throughput (tok/s) |  1919.66  |  2888.31  |  3714.81  |
|    |  Total token throughput  |  7035.31  |  10500.46  |  13653.49  |
|  shortest_queue  |  Request throughput (req/s)  |  2.54  |  3.89  |  4.89  |
|    |  Input token throughput (tok/s)  |  5209.02  |  7926.06 |  10147.70  |
|    |  Output token throughput (tok/s)  |  1954.69  |  3007.41  |  3792.93  |
|    |  Total token throughput   |  7163.71  |  10933.47  |  13940.63  |
|  minimum_tokens   | Request throughput (req/s) |2.52 |3.74 |4.87 |
|   | Input token throughput (tok/s) |5158.40 |7629.39 |10113.66 |
|   | Output token throughput (tok/s) |1935.70 |10524.23 |3780.06 |
|    | Total token throughput |7094.10 |10524.23 |13893.32 |


## Sharegpt
|  |  | 512 | 1024 | 2048 |
|-----|-----|-----|-----|-----|
|  round_robin  |  Request throughput (req/s)  |3.33 |6.26 |11.17 |
|    | Input token throughput (tok/s) |1032.68 |1909.53 |3597.88 |
| | Output token throughput (tok/s) |612.16 |1183.34 |2091.62 |
| | Total token throughput |1644.85 |3092.87 |5689.50 |
|  shortest_queue  | Request throughput (req/s) |3.36 |6.42 |12.04 |
| | Input token throughput (tok/s) |1044.71 |1958.25 |3878.72 |
| | Output token throughput (tok/s) |619.29 |1213.53 |2254.89 |
| | Total token throughput |1664.00 |3171.78 |6133.60 |
|  minimum_tokens   | Request throughput (req/s) |3.21 |6.28 |10.80 |
| | Input token throughput (tok/s) |998.12 |1589.80 |3477.89 |
| | Output token throughput (tok/s) |591.68 |1188.52 |2021.87 |
| | Total token throughput |1589.80 |2778.32 |5499.75 |


# Script
- prefill

```
PAGE_SIZE=$(( 64 ))
ATTENTION_BACKEND="fa3"
DP_SIZE_PER_DECODE_NODE
NUM_DECODE=2
MAX_RUNNING_REQUEST_PER_GPU=32
GPUS_PER_NODE=8
DP_SIZE_PER_DECODE_NODE=8
MAX_RUNNING_REQUEST_PER_DP_RANK=$(( MAX_RUNNING_REQUEST_PER_GPU * GPUS_PER_NODE / DP_SIZE_PER_DECODE_NODE ))

SGLANG_TORCH_PROFILER_DIR=${PROFILER_DIR} \
                    PYTHONUNBUFFERED=1 \
                    SGL_ENABLE_JIT_DEEPGEMM=1 \

python3 -m sglang.launch_server \
                    --trust-remote-code \
                    --model-path /home/moyun.zty/models/deepseek-ai__DeepSeek-R1 \
                    --disaggregation-mode prefill \
                    --disaggregation-transfer-backend mooncake \
                    --disaggregation-ib-device mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3 \
                    --host 0.0.0.0 \
                    --port ${DEFAULT_PORT} \
                    --tp-size 8 \
                    --page-size ${PAGE_SIZE} \
                    --attention-backend ${ATTENTION_BACKEND} \
                    --mem-fraction-static 0.92 \
                    --chunked-prefill-size 8192 \
                    --max-running-requests $((DP_SIZE_PER_DECODE_NODE * NUM_DECODE * MAX_RUNNING_REQUEST_PER_DP_RANK)) \
                    --max-total-tokens 131076 \
                    --context-length 65535 \
                    --enable-cache-report \
                    --log-level info \
                    --disable-radix-cache \
                    --disable-shared-experts-fusion \
```
- decode
```
DECODE_MAX_RUNNING_REQUEST_PER_DP_RANK=48
DECODE_MAX_RUNNING_REQUEST_PER_GPU=48
GPUS_PER_NODE = 8
NUM_DECODE =2
DP_SIZE_PER_DECODE_NODE = 8
CHUNKED_PREFILL_SIZE_PER_DP_RANK=4096
MAX_RUNNING_REQUEST_PER_GPU=48
GPUS_PER_NODE = 8
DP_SIZE_PER_DECODE_NODE = 8
MAX_RUNNING_REQUEST_PER_DP_RANK=$(( MAX_RUNNING_REQUEST_PER_GPU * GPUS_PER_NODE / DP_SIZE_PER_DECODE_NODE ))
CUDA_GRAPH_MAX_BATCH_SIZE=$MAX_RUNNING_REQUEST_PER_DP_RANK


cmd="SGLANG_TORCH_PROFILER_DIR=${PROFILER_DIR} \
                PYTHONUNBUFFERED=1 \
                SGL_ENABLE_JIT_DEEPGEMM=1 \
                SGL_DEEP_EP_MAX_DISPATCH_TOKENS_PER_RANK=${DECODE_MAX_RUNNING_REQUEST_PER_GPU} \
                SGL_DEEP_EP_ALLOW_NVLINK=true \
                SGL_DEEP_EP_RECV_HOOK=false \
                nohup python3 -m sglang.launch_server \
                --model-path /home/moyun.zty/models/deepseek-ai__DeepSeek-R1 \
                --disaggregation-mode decode \
                --disaggregation-transfer-backend mooncake \
                --disaggregation-ib-device mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3 \
                --attention-backend ${ATTENTION_BACKEND} \
                --host 0.0.0.0 \
                --port ${DEFAULT_PORT} \
                --trust-remote-code \
                --dist-init-addr ${DECODE_MASTER_IP}:${MASTER_PORT} \
                --nnodes ${NUM_DECODE} \
                --node-rank $node_rank \
                --tp-size $((GPUS_PER_NODE * NUM_DECODE)) \
                --dp-size $((DP_SIZE_PER_DECODE_NODE * NUM_DECODE)) \
                --enable-eplb \
                --enable-dp-attention \
                --eplb-rebalance-num-iterations 50 \
                --mem-fraction-static 0.9 \
                --chunked-prefill-size $((DP_SIZE_PER_DECODE_NODE * NUM_DECODE * CHUNKED_PREFILL_SIZE_PER_DP_RANK)) \
                --max-running-requests $((DP_SIZE_PER_DECODE_NODE * NUM_DECODE * DECODE_MAX_RUNNING_REQUEST_PER_DP_RANK)) \
                --context-length 65535 \
                --log-level info \
                --decode-log-interval 50 \
                --page-size ${PAGE_SIZE} \
                --cuda-graph-max-bs ${DECODE_MAX_RUNNING_REQUEST_PER_DP_RANK} \
                --schedule-conservativeness 0.3 \
                --enable-cache-report \
                --moe-dense-tp-size 1 \
                --enable-deepep-moe \
                --deepep-mode low_latency \
                --enable-dp-lm-head \
                --expert-distribution-recorder-mode stat \
                > ${WORKDIR}/decode.log 2>&1 &"
```
- test
```
DEFAULT_BATCH_SIZE=1024
DEFAULT_NUM_PROMPT_MULTIPLIER=1
DEFAULT_REQUEST_RATES="1"
DEFAULT_RANDOM_INPUT=4096
DEFAULT_RANDOM_OUTPUT=1536
DEFAULT_WARM_UP_REQUESTS=2

# 从命令行参数读取配置，或者使用默认值
BATCH_SIZE=${1:-$DEFAULT_BATCH_SIZE}
NUM_PROMPT_MULTIPLIER=${2:-$DEFAULT_NUM_PROMPT_MULTIPLIER}
REQUEST_RATES_INPUT=${3:-$DEFAULT_REQUEST_RATES}
RANDOM_INPUT=${4:-$DEFAULT_RANDOM_INPUT}
RANDOM_OUTPUT=${5:-$DEFAULT_RANDOM_OUTPUT}
WARM_UP_REQUESTS=${6:-$DEFAULT_WARM_UP_REQUESTS}
UNIQ_REQUEST_COUNT=${7:-$((BATCH_SIZE * NUM_PROMPT_MULTIPLIER))}

python3 -m sglang.bench_serving \
      --port 8000 \
      --backend sglang \
      --dataset-path /home/nas/data/ShareGPT_V3_unfiltered_cleaned_split.json \
      --dataset-name random \
      --num-prompt 1024 \
      --random-input ${RANDOM_INPUT} \
      --random-output ${RANDOM_OUTPUT} \
      --random-range-ratio 0 \
      --request-rate inf \
      --max-concurrency ${BATCH_SIZE} \
      --flush-cache \
      --pd-separated \
```

```
python3 -m sglang.bench_serving \
      --port 8000 \
      --backend sglang \
      --dataset-path /home/nas/data/ShareGPT_V3_unfiltered_cleaned_split.json \
      --dataset-name sharegpt \
      --num-prompt 512 \
      --request-rate inf \
      --max-concurrency ${BATCH_SIZE} \
      --flush-cache \
      --pd-separated \
```

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
