### PR TITLE
[PD] Fix the /health_generate entrypoint doesn't work in PD disaggregation deployment

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1361,8 +1361,8 @@ def _execute_server_warmup(
                     "ignore_eos": True,
                 },
                 "bootstrap_host": [FAKE_BOOTSTRAP_HOST] * server_args.dp_size,
-                # This is a hack to ensure fake transfer is enabled during prefill warmup
-                # ensure each dp rank has a unique bootstrap_room during prefill warmup
+                # This is a hack to ensure fake transfer is enabled during warmup
+                # ensure each dp rank has a unique bootstrap_room during warmup
                 "bootstrap_room": [
                     i * (2**63 // server_args.dp_size) + (i % server_args.tp_size)
                     for i in range(server_args.dp_size)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -358,6 +358,13 @@ class TokenizerManager(TokenizerCommunicatorMixin):
                 # If it's a single value, add worker_id prefix
                 obj.rid = f"{self.worker_id}_{obj.rid}"
 
+        if self.disaggregation_mode != DisaggregationMode.NULL and (
+            obj.bootstrap_host is None or obj.bootstrap_room is None
+        ):
+            raise ValueError(
+                "bootstrap_host and bootstrap_room are required fields in PD disaggregation mode."
+            )
+
         if self.log_requests:
             max_length, skip_names, _ = self.log_request_metadata
             logger.info(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The /health_generate entrypoint doesn't work in PD disaggregation deployment, it always return OK from mini_lb, and it leads crash if send /health_generate request to P or D directly.

## Modifications

<!-- Describe the changes made in this PR. -->
Make the mini_lb support forwarding `/health_generate` requests to prefill and decode servers.
1. Send GET rather than POST health_generate reqquest from mini_lb, which is the method the P/D/normal nodes can handle as before.
2. The error status from servers can be returned to client via mini_lb as well.
3. ~The health_generate handler on server deal with the request like warmup request, using a hack `bootstrap_host` and `bootstrap_room` fields.~ (Done by #8444)
4. SGLang server in PD disaggregation deployment will not crash if the required `bootstrap_host` and `bootstrap_room` fields are missing.

check:
```
# start prefill
python -m sglang.launch_server --model-path /models/Qwen/Qwen3-0.6B --disaggregation-mode prefill --port 30000 --base-gpu-id 0

# start decode
python -m sglang.launch_server --model-path /models/Qwen/Qwen3-0.6B --disaggregation-mode decode --port 30200 --base-gpu-id 1

# start mini_lb
python -m sglang.srt.disaggregation.mini_lb --prefill http://127.0.0.1:30000 --decode http://127.0.0.1:30200 --host 0.0.0.0 --port 30400
```

send requests:
```
timr curl -i http://localhost:30000/health_generate
timr curl -i http://localhost:30200/health_generate
timr curl -i http://localhost:30400/health_generate
```

check response and logs:
```
#response example
HTTP/1.1 200 OK
date: Sat, 02 Aug 2025 16:57:38 GMT
server: uvicorn
content-length: 0

curl -i http://localhost:30000/health_generate  0.00s user 0.00s system 0% cpu 1.009 total
```


send /generate to P/D will not make them crash, but just got 503:
```
curl -X POST http://localhost:30000/v1/chat/completions    -H "Content-Type: application/json" -d '{
          "model": "base_model", "messages": [{"role": "user",
                        "content": "when 1+1=3?"}],
          "max_tokens": 1024,
          "stream": true}'
data: {"error": {"object": "error", "message": "bootstrap_host and bootstrap_room are required fields in PD disaggregation mode.", "type": "BadRequestError", "param": null, "code": 400}}

data: [DONE]
```

False test:
```
curl -H "Content-Type: application/json" -d '{"forward_sleep_time": 90.0}' -X POST "http://localhost:30200/slow_down"
curl -X POST http://localhost:30400/v1/chat/completions    -H "Content-Type: application/json" -d '{
          "model": "base_model", "messages": [{"role": "user",
                        "content": "when 1+1=3?"}],
          "max_tokens": 1024,
          "stream": true}'
time curl -i http://localhost:30200/health_generate
```

response:
```
HTTP/1.1 503 Service Unavailable
date: Sat, 02 Aug 2025 16:57:44 GMT
server: uvicorn
content-length: 32
content-type: application/json
```

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
