### PR TITLE
fix greenctx stream compability

### DIFF
--- a/sgl-kernel/csrc/spatial/greenctx_stream.cu
+++ b/sgl-kernel/csrc/spatial/greenctx_stream.cu
@@ -7,52 +7,96 @@
 #include "cuda_utils.h"
 #include "greenctx_stream.h"
 
+std::vector<int64_t> create_greenctx_stream_fallback(CUgreenCtx gctx[2]) {
+  CUstream streamA, streamB;
+  CUcontext ctx;
+
+  // Stream A
+  CUDA_DRV(cuCtxFromGreenCtx(&ctx, gctx[0]));
+  CUDA_DRV(cuCtxPushCurrent(ctx));
+  CUDA_DRV(cuStreamCreate(&streamA, CU_STREAM_NON_BLOCKING));
+  CUDA_DRV(cuCtxPopCurrent(nullptr));
+
+  // Stream B
+  CUDA_DRV(cuCtxFromGreenCtx(&ctx, gctx[1]));
+  CUDA_DRV(cuCtxPushCurrent(ctx));
+  CUDA_DRV(cuStreamCreate(&streamB, CU_STREAM_NON_BLOCKING));
+  CUDA_DRV(cuCtxPopCurrent(nullptr));
+
+  return {(int64_t)streamA, (int64_t)streamB};
+}
+
+#if CUDA_VERSION >= 12050
+std::vector<int64_t> create_greenctx_stream_direct(CUgreenCtx gctx[2], int smCountA, int smCountB) {
+  CUstream streamA;
+  CUstream streamB;
+
+  CUDA_DRV(cuGreenCtxStreamCreate(&streamA, gctx[0], CU_STREAM_NON_BLOCKING, 0));
+  CUDA_DRV(cuGreenCtxStreamCreate(&streamB, gctx[1], CU_STREAM_NON_BLOCKING, 0));
+
+  std::vector<int64_t> vec = {(int64_t)streamA, (int64_t)streamB};
+  return vec;
+}
+#endif  // End of CUDA_VERSION >= 12050 block
+
 std::vector<int64_t> create_greenctx_stream_by_value(int64_t smA, int64_t smB, int64_t device) {
+  TORCH_CHECK(CUDA_VERSION >= 12040, "Green Contexts feature requires CUDA Toolkit 12.4 or newer.");
+
+  CUDA_RT(cudaSetDevice(device));
+  cudaDeviceProp props;
+  CUDA_RT(cudaGetDeviceProperties(&props, device));
+  TORCH_CHECK(
+      props.major >= 9,
+      "Green Contexts require Hopper (SM 9.0) or newer architecture. Current device is SM ",
+      props.major,
+      ".",
+      props.minor);
+
   CUgreenCtx gctx[3];
   CUdevResourceDesc desc[3];
   CUdevResource input;
   CUdevResource resources[4];
-  CUstream streamA;
-  CUstream streamB;
-
   unsigned int nbGroups = 1;
 
   if (smA <= 0 || smB <= 0) {
     TORCH_CHECK(false, "SM counts must be positive");
   }
 
-  // Initialize device
-  CUDA_RT(cudaInitDevice(device, 0, 0));
-
-  // Query input SMs
   CUDA_DRV(cuDeviceGetDevResource((CUdevice)device, &input, CU_DEV_RESOURCE_TYPE_SM));
-  // We want 3/4 the device for our green context
   unsigned int minCount = (unsigned int)(smA + smB);
   unsigned int minCountA = (unsigned int)(smA);
-
   TORCH_CHECK(minCount <= input.sm.smCount, "Not enough SMs available for the requested configuration");
 
-  // Split resources
   CUDA_DRV(cuDevSmResourceSplitByCount(&resources[2], &nbGroups, &input, &resources[3], 0, minCount));
-
   CUDA_DRV(cuDevResourceGenerateDesc(&desc[2], &resources[2], 1));
   CUDA_DRV(cuGreenCtxCreate(&gctx[2], desc[2], (CUdevice)device, CU_GREEN_CTX_DEFAULT_STREAM));
   CUDA_DRV(cuGreenCtxGetDevResource(gctx[2], &input, CU_DEV_RESOURCE_TYPE_SM));
   CUDA_DRV(cuDevSmResourceSplitByCount(&resources[0], &nbGroups, &input, &resources[1], 0, minCountA));
-
   CUDA_DRV(cuDevResourceGenerateDesc(&desc[0], &resources[0], 1));
   CUDA_DRV(cuGreenCtxCreate(&gctx[0], desc[0], (CUdevice)device, CU_GREEN_CTX_DEFAULT_STREAM));
   CUDA_DRV(cuDevResourceGenerateDesc(&desc[1], &resources[1], 1));
   CUDA_DRV(cuGreenCtxCreate(&gctx[1], desc[1], (CUdevice)device, CU_GREEN_CTX_DEFAULT_STREAM));
-
-  CUDA_DRV(cuGreenCtxStreamCreate(&streamA, gctx[0], CU_STREAM_NON_BLOCKING, 0));
-  CUDA_DRV(cuGreenCtxStreamCreate(&streamB, gctx[1], CU_STREAM_NON_BLOCKING, 0));
-
   int smCountA = resources[0].sm.smCount;
   int smCountB = resources[1].sm.smCount;
 
+  std::vector<int64_t> stream_handles;
+
+#if CUDA_VERSION >= 12050
+  stream_handles = create_greenctx_stream_direct(gctx, smCountA, smCountB);
+#else
+  stream_handles = create_greenctx_stream_fallback(gctx, smCountA, smCountB);
+#endif
+
   CUDA_DRV(cuGreenCtxDestroy(gctx[2]));
 
-  std::vector<int64_t> vec = {(int64_t)streamA, (int64_t)streamB, smCountA, smCountB};
+  std::vector<int64_t> vec = {
+      stream_handles[0],  // streamA
+      stream_handles[1],  // streamB
+      (int64_t)smCountA,
+      (int64_t)smCountB,
+      (int64_t)gctx[0],  // gctxA
+      (int64_t)gctx[1]   // gctxB
+  };
+
   return vec;
 }

--- a/sgl-kernel/csrc/spatial/greenctx_stream.cu
+++ b/sgl-kernel/csrc/spatial/greenctx_stream.cu
@@ -83,10 +83,7 @@ std::vector<int64_t> create_greenctx_stream_by_value(int64_t smA, int64_t smB, i
       stream_handles[0],  // streamA
       stream_handles[1],  // streamB
       (int64_t)smCountA,
-      (int64_t)smCountB,
-      (int64_t)gctx[0],  // gctxA
-      (int64_t)gctx[1]   // gctxB
-  };
+      (int64_t)smCountB};
 
   return vec;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
cuGreenCtxStreamCreate is introduced in CUDA12.5 which leads to compile failure in CUDA12.4 enviroment.
related PR:https://github.com/sgl-project/sglang/pull/7649

<img width="1308" height="564" alt="image" src="https://github.com/user-attachments/assets/ba9716e3-552c-41da-ae27-b2da3321e828" />


## Modifications

add fallback method for CUDA12.4

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
