### PR TITLE
Fix handling of incomplete `<think>` tokens in parse_streaming_increment

### DIFF
--- a/python/sglang/srt/reasoning_parser.py
+++ b/python/sglang/srt/reasoning_parser.py
@@ -228,10 +228,10 @@ if __name__ == "__main__":
     detector = Qwen3Detector(stream_reasoning=True)
     text = "<Direct answer without thinking."
     text_chunks = ["<", "Direct", " an", "swer", " without", " thinking."]
-    mormal_texts = []
+    normal_texts = []
     for chunk in text_chunks:
         result = detector.parse_streaming_increment(chunk)
-        mormal_texts.append(result.normal_text)
+        normal_texts.append(result.normal_text)
     assert (
-        "".join(mormal_texts) == text
+        "".join(normal_texts) == text
     ), "Streaming parsing failed to reconstruct the text"


### PR DESCRIPTION
This PR fixes compatibility issues in the BaseReasoningFormatDetector.parse_streaming_increment method when handling `<think>` tags that are split across multiple outputs. Previously, the implementation would incorrectly continue buffering when encountering text starting with `<` but not forming a `<think>`  tag, causing normal text to not be output promptly. The new implementation correctly distinguishes between tag prefixes and normal text, ensuring accurate streaming parsing.

Key changes:
- Improved prefix detection logic to ensure buffering only occurs when a complete tag is possible; otherwise, normal text is returned immediately.
- Added special handling for text starting with `<` that is not a `<think>`  tag, ensuring it is returned as normal text.
- Verified the fix with the test case `<Direct answer without thinking`.

Impact:
- Only affects streaming reasoning parsing logic; non-streaming parsing is unaffected.
- Compatible with reasoning tags for DeepSeek-R1, Qwen3, and Kimi models.