### PR TITLE
[Fix] ensure DeepGEMM is only enabled for FP8_W8A8 models

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -1272,6 +1272,12 @@ class DeepEPMoE(EPMoE):
             routed_scaling_factor=routed_scaling_factor,
         )
         self.deepep_mode = deepep_mode
+        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
+            assert self.use_fp8_w8a8, (
+                "DeepGEMM requires an fp8_w8a8 model; "
+                "alternatively, you can disable DeepGEMM by turning off the ENABLE_JIT_DEEPGEMM environment variable."
+            )
+
         if self.deepep_mode.enable_low_latency():
             assert (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

If a user erroneously enables the ENABLE_JIT_DEEPGEMM environment variable in non-FP8 model scenarios (e.g., when using Qwen3-235B-FP16), sglang will enter a failed state during launch and sglang‘s rank scheduler will stuck at the following stack:


Thread 66311 (active+gil): "Thread-3 (forward_thread_func)"
    dispatch (deep_ep/buffer.py:349)
    _dispatch_core (ep_moe/token_dispatcher.py:349)
    dispatch_b (ep_moe/token_dispatcher.py:265)
    dispatch_b (ep_moe/token_dispatcher.py:703)
    dispatch (ep_moe/token_dispatcher.py:681)
    _execute (two_batch_overlap.py:795)
    dispatch (two_batch_overlap.py:798)
    forward_deepep (qwen3_moe.py:228)
    forward (qwen3_moe.py:168)


**This PR introduces an initialization check to detect such misconfigurations**: when ENABLE_JIT_DEEPGEMM is enabled without an FP8 quantized model present, the system will throw a fatal error with instructions to adjust configuration parameters.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
