### PR TITLE
fix:reorder topk experts to ensure shared expert replaces minimal score

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -158,7 +158,7 @@ def grouped_topk_gpu(
         .reshape(num_token, -1)
     )  # [n, e]
     tmp_scores = scores.masked_fill(~score_mask.bool(), 0.0)  # [n, e]
-    topk_weights, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)
+    topk_weights, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=True)
     if num_fused_shared_experts:
         topk_ids[:, -1] = torch.randint(
             low=num_experts,
@@ -246,7 +246,7 @@ def biased_grouped_topk_impl(
     tmp_scores = scores_for_choice.masked_fill(
         ~score_mask.bool(), float("-inf")
     )  # [n, e]
-    _, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)
+    _, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=True)
     topk_weights = scores.gather(1, topk_ids)
 
     if num_fused_shared_experts:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- In the MoE (Mixture of Experts) layer, when selecting top-k experts for each token, we need to reorder the selected experts to guarantee the last expert in the list has the smallest score. The current implementation uses torch.topk with sorted=False, which means the returned experts aren't necessarily in score order. When we replace the last expert with the shared expert, we might accidentally replace a non-minimal-scored expert, altering the layer's expected behavior. This fix ensures proper expert selection by sorting the top-k experts before replacement. -->

