### PR TITLE
[FIX] Assert with hint if `page_size` is not `1` in Llama4

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -366,6 +366,14 @@ class ServerArgs:
             None,
         }, "moe_dense_tp_size only support 1 and None currently"
 
+        model_arch = get_model_arch(self)
+
+        if "Llama4" in model_arch:
+            # TODO: remove this after Llama4 supports page size > 1
+            assert (
+                self.page_size == 1
+            ), "Page size > 1 is not supported for Llama4 models. Please use --page-size 1."
+
         if self.attention_backend == "flashmla":
             logger.warning(
                 "FlashMLA only supports a page_size of 64, change page_size to 64."
@@ -487,8 +495,6 @@ class ServerArgs:
                     "Mixed chunked prefill is disabled because of using "
                     "eagle speculative decoding."
                 )
-
-            model_arch = get_model_arch(self)
 
             if model_arch == "DeepseekV3ForCausalLM":
                 # Auto set draft_model_path DeepSeek-V3/R1


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix issue https://github.com/sgl-project/sglang/issues/7936

To avoid garbage output when page size is not 1 for Llama4, we should assert with hint.

> Most attention backends (FlashInfer, Triton) don't actually support page sizes greater than 1 and internally convert them to `page_size = 1` anyway, but here Llama4 uses FA3 as default attention backend. (refs: https://docs.sglang.ai/backend/attention_backend.html)

## Reproduction

A. Excepted output with `page_size = 1`:

  0. `page_size` = 1
      <img width="560" height="640" alt="page_size_1" src="https://github.com/user-attachments/assets/7c230d06-0e2d-4dc3-bd10-0292f6e7c3a4" />

B. Garbage output with different `page_size != 1`:

  1. `page_size` = 4
      <img width="439" height="628" alt="page_size_4" src="https://github.com/user-attachments/assets/09f4ee6b-96e9-4b73-8b68-e9550805a6e0" />
  2. `page_size` = 64
      <img width="553" height="630" alt="page_size_64" src="https://github.com/user-attachments/assets/1c843c36-85ba-4829-b1c5-2a6ca14eaec1" />
  3. `page_size` = 128
      <img width="698" height="631" alt="page_size_128" src="https://github.com/user-attachments/assets/57813c61-103f-47c1-aa18-d31a1a00076c" />

## Modifications

<!-- Describe the changes made in this PR. -->

Adds assertion with hint for non-1 page sizes in Llama4 to prevent garbage output. Temporary fix while digging into the root cause.

## Checklist

- [X] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
