### PR TITLE
[Performance][PD Disaggregation] optimize TokenToKVPoolAllocator by sorting free pages

### DIFF
--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -51,6 +51,7 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         self._kvcache = kvcache
 
         self.free_pages = None
+        self.release_pages = None
         self.is_not_in_free_group = True
         self.free_group = []
 
@@ -58,16 +59,16 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         return ""
 
     def available_size(self):
-        return len(self.free_pages) * self.page_size
+        return (len(self.free_pages) + len(self.release_pages)) * self.page_size
 
     def get_kvcache(self):
         return self._kvcache
 
-    def restore_state(self, free_pages):
-        self.free_pages = free_pages
+    def restore_state(self, state):
+        self.free_pages, self.release_pages = state
 
     def backup_state(self):
-        return self.free_pages
+        return (self.free_pages, self.release_pages)
 
     def free_group_begin(self):
         self.is_not_in_free_group = False
@@ -77,6 +78,14 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         self.is_not_in_free_group = True
         if self.free_group:
             self.free(torch.cat(self.free_group))
+
+    def merge_and_sort_free(self):
+        if len(self.release_pages) > 0:
+            self.free_pages = torch.cat((self.free_pages, self.release_pages))
+            self.free_pages, _ = torch.sort(self.free_pages)
+            self.release_pages = torch.empty(
+                (0,), dtype=self.release_pages.dtype, device=self.device
+            )
 
     def get_cpu_copy(self, *args, **kwargs):
         # FIXME: reuse the get_cpu_copy after paged allocator is implemented
@@ -119,12 +128,15 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         self.is_not_in_free_group = True
         self.free_group = []
+        self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
 
     def available_size(self):
         # To avoid minor "len(free_pages) * 1" overhead
-        return len(self.free_pages)
+        return len(self.free_pages) + len(self.release_pages)
 
     def alloc(self, need_size: int):
+        if need_size > len(self.free_pages):
+            self.merge_and_sort_free()
         if need_size > len(self.free_pages):
             return None
 
@@ -137,7 +149,7 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return
 
         if self.is_not_in_free_group:
-            self.free_pages = torch.cat((self.free_pages, free_index))
+            self.release_pages = torch.cat((self.release_pages, free_index))
         else:
             self.free_group.append(free_index)
 
@@ -422,6 +434,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         num_pages = need_size // self.page_size
         if num_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+        if num_pages > len(self.free_pages):
             return None
 
         out_pages = self.free_pages[:num_pages]
@@ -445,6 +459,17 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             assert torch.all(
                 (last_loc + 1) % self.page_size == prefix_lens % self.page_size
             )
+
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (prefix_lens + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
+            self.merge_and_sort_free()
 
         bs = len(prefix_lens)
         out_indices = torch.empty(
@@ -483,6 +508,17 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 (last_loc + 2) % self.page_size == seq_lens % self.page_size
             )
 
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (seq_lens - 1 + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+
         bs = len(seq_lens)
         out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
         alloc_decode_kernel[(bs,)](
@@ -511,7 +547,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.is_not_in_free_group:
             free_page_indices = torch.unique(free_index // self.page_size)
-            self.free_pages = torch.cat((free_page_indices, self.free_pages))
+            self.release_pages = torch.cat((free_page_indices, self.release_pages))
         else:
             self.free_group.append(free_index)
 
@@ -525,6 +561,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         self.is_not_in_free_group = True
         self.free_group = []
+        self.release_pages = torch.empty((0,), dtype=torch.int64, device=self.device)
 
     def get_cpu_copy(self, indices):
         return self._kvcache.get_cpu_copy(indices)
@@ -633,6 +670,17 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
                 (last_loc + 1) % self.page_size == prefix_lens % self.page_size
             )
 
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (prefix_lens + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+
         bs = len(prefix_lens)
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int32, device=self.device
@@ -668,6 +716,17 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
                 (last_loc + 2) % self.page_size == seq_lens % self.page_size
             )
 
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (seq_lens - 1 + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+
         bs = len(seq_lens)
         out_indices = torch.empty((bs,), dtype=torch.int32, device=self.device)
 
@@ -692,3 +751,4 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
     def clear(self):
         super().clear()
         self.free_pages = self.free_pages.to(torch.int32)
+        self.release_pages = self.release_pages.to(torch.int32)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

In large-scale distributed inference, especially with PD Disaggregation, fast and efficient management of KV cache token indices is crucial. Fragmentation of available indices can disrupt peer-to-peer (p2p) data transfers by making it harder to allocate large contiguous regions, resulting in inefficient communication patterns. This fragmentation directly increases end-to-end latency, especially the time to first token (TTFT).
This PR introduces release cache mechanisms to optimize TokenToKVPoolAllocator page management. By deferring the actual release of freed pages and supporting batch reclamation, this design significantly reduces allocation contention and fragmentation during high-concurrency operations, thereby boosting p2p transfer efficiency and reducing TTFT.

## Modifications

### Introduced release_pages
Freed token indices are now buffered in a temporary cache rather than immediately added to the free pool.

### On allocation, merging and sorting
When an allocation request cannot be satisfied by the current free pool alone, the allocator will merge the buffered indices from release cache with the free pool, sort them, and then retry the allocation. This sorting and merging process helps to coalesce adjacent free regions, mitigating fragmentation.

### Test on 2 * A10 * 8（RDMA），qwen 0.6b，1P1D

Case 1（200 warmup；400 nr；16 concurrency; 1024 input len; 512 output len）
without optimization:  TTFT 81ms
with optimization: TTFT 69ms（improve 14.8%）

Case 2（200 warmup；400 nr；16 concurrency; 2048 input len; 1024 output len）
without optimization:  TTFT 144ms
with optimization: TTFT 108ms（improve 25%）

A simple comparison of the number of kv_blocks that need to be transferred by send_kvcache() (1024 in; 512 out)
<img width="4340" height="2236" alt="sglang" src="https://github.com/user-attachments/assets/dd9cbd75-8105-4dbd-a0d6-79441172affa" />

### Detailed data
#### 1024 input len; 512 output len without optimization
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     400
Benchmark duration (s):                  188.20
Total input tokens:                      409600
Total generated tokens:                  204800
Total generated tokens (retokenized):    204796
Request throughput (req/s):              2.13
Input token throughput (tok/s):          2176.35
Output token throughput (tok/s):         1088.18
Total token throughput (tok/s):          3264.53
Concurrency:                             15.98
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   7517.90
Median E2E Latency (ms):                 7501.12
---------------Time to First Token----------------
Mean TTFT (ms):                          81.29
Median TTFT (ms):                        74.55
P99 TTFT (ms):                           300.72
---------------Inter-Token Latency----------------
Mean ITL (ms):                           14.55
Median ITL (ms):                         14.47
P95 ITL (ms):                            14.88
P99 ITL (ms):                            15.69
Max ITL (ms):                            33.38

#### 1024 input len; 512 output len with optimization
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     400
Benchmark duration (s):                  185.05
Total input tokens:                      409600
Total generated tokens:                  204800
Total generated tokens (retokenized):    204792
Request throughput (req/s):              2.16
Input token throughput (tok/s):          2213.43
Output token throughput (tok/s):         1106.71
Total token throughput (tok/s):          3320.14
Concurrency:                             15.98
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   7393.70
Median E2E Latency (ms):                 7386.50
---------------Time to First Token----------------
Mean TTFT (ms):                          69.35
Median TTFT (ms):                        59.20
P99 TTFT (ms):                           363.33
---------------Inter-Token Latency----------------
Mean ITL (ms):                           14.33
Median ITL (ms):                         14.27
P95 ITL (ms):                            14.67
P99 ITL (ms):                            15.65
Max ITL (ms):                            35.02

#### 2048 input len; 1024 output len without optimization
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     400
Benchmark duration (s):                  395.88
Total input tokens:                      819200
Total generated tokens:                  409600
Total generated tokens (retokenized):    409584
Request throughput (req/s):              1.01
Input token throughput (tok/s):          2069.32
Output token throughput (tok/s):         1034.66
Total token throughput (tok/s):          3103.98
Concurrency:                             15.97
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   15803.31
Median E2E Latency (ms):                 15800.76
---------------Time to First Token----------------
Mean TTFT (ms):                          144.02
Median TTFT (ms):                        118.62
P99 TTFT (ms):                           975.52
---------------Inter-Token Latency----------------
Mean ITL (ms):                           15.31
Median ITL (ms):                         15.17
P95 ITL (ms):                            16.62
P99 ITL (ms):                            16.91
Max ITL (ms):                            44.18

#### 2048 input len; 1024 output len with optimization
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     400
Benchmark duration (s):                  392.21
Total input tokens:                      819200
Total generated tokens:                  409600
Total generated tokens (retokenized):    409586
Request throughput (req/s):              1.02
Input token throughput (tok/s):          2088.66
Output token throughput (tok/s):         1044.33
Total token throughput (tok/s):          3132.99
Concurrency:                             15.98
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   15669.23
Median E2E Latency (ms):                 15658.25
---------------Time to First Token----------------
Mean TTFT (ms):                          108.04
Median TTFT (ms):                        89.39
P99 TTFT (ms):                           733.34
---------------Inter-Token Latency----------------
Mean ITL (ms):                           15.21
Median ITL (ms):                         15.08
P95 ITL (ms):                            16.57
P99 ITL (ms):                            16.89
Max ITL (ms):                            39.90

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
