### PR TITLE
[Feat.] Implement online per-tensor quantization for FP8 KV cache

### DIFF
--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -92,7 +92,7 @@ class RadixAttention(nn.Module):
             # For cross-layer sharing, kv can be None
             assert v is not None
             if forward_batch.kv_cache_dtype_is_fp8_e4m3:
-                MAX_FP8_E4M3_SCALE = 240.0
+                MAX_FP8_E4M3_SCALE = 448.0
                 k_max = k.abs().max()
                 v_max = v.abs().max()
                 k_scale = k_max / MAX_FP8_E4M3_SCALE if k_max > 1e-6 else 1.0

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -167,6 +167,9 @@ class ForwardBatch:
     # The sum of all sequence lengths
     seq_lens_sum: int
 
+    # Whether the kv cache is fp8 e4m3
+    kv_cache_dtype_is_fp8_e4m3: bool = False
+
     # Optional seq_lens on cpu
     seq_lens_cpu: Optional[torch.Tensor] = None
 
@@ -316,6 +319,10 @@ class ForwardBatch:
             tbo_split_seq_index=batch.tbo_split_seq_index,
         )
         device = model_runner.device
+        ret.kv_cache_dtype_is_fp8_e4m3 = model_runner.kv_cache_dtype in [
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+        ]
 
         if batch.extend_input_logprob_token_ids is not None:
             ret.extend_input_logprob_token_ids_gpu = (


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently, the system uses fixed scale values for FP8 quantization, which can lead to suboptimal precision when the numerical range of different batches varies significantly. By implementing online per-tensor quantization, we can dynamically adapt the scaling factors to each batch's data distribution, resulting in better preservation of the original values and improved model inference quality.

## Modifications

- Added `kv_cache_dtype_is_fp8_e4m3` attribute to the ForwardBatch class in forward_batch_info.py to efficiently detect FP8 KV cache usage.
- Enhanced the forward method in RadixAttention class to dynamically calculate optimal scaling factors for each batch when using FP8 KV cache.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
