### PR TITLE
[router] allow router to have empty workers

### DIFF
--- a/sgl-router/py_src/sglang_router/launch_router.py
+++ b/sgl-router/py_src/sglang_router/launch_router.py
@@ -97,7 +97,8 @@ class RouterArgs:
         parser.add_argument(
             "--worker-urls",
             type=str,
-            nargs="+",
+            nargs="*",
+            default=[],
             help="List of worker URLs (e.g., http://worker1:8000 http://worker2:8000)",
         )
 

--- a/sgl-router/py_test/test_launch_router.py
+++ b/sgl-router/py_test/test_launch_router.py
@@ -90,7 +90,9 @@ class TestLaunchRouter(unittest.TestCase):
 
     def test_launch_router_with_empty_worker_urls(self):
         args = self.create_router_args(worker_urls=[])
-        self.run_router_process(args)  # Expected error
+        self.run_router_process(
+            args
+        )  # Should start successfully with empty worker list
 
     def test_launch_router_with_service_discovery(self):
         # Test router startup with service discovery enabled but no selectors
@@ -278,6 +280,25 @@ class TestLaunchRouter(unittest.TestCase):
         )
         self.assertEqual(router_args.prefill_selector, {})
         self.assertEqual(router_args.decode_selector, {})
+
+    def test_empty_worker_urls_args_parsing(self):
+        """Test that router accepts no worker URLs and defaults to empty list."""
+        import argparse
+
+        from sglang_router.launch_router import RouterArgs
+
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+
+        # Test with no --worker-urls argument at all
+        args = parser.parse_args(["--policy", "random", "--port", "30000"])
+        router_args = RouterArgs.from_cli_args(args)
+        self.assertEqual(router_args.worker_urls, [])
+
+        # Test with explicit empty --worker-urls
+        args = parser.parse_args(["--worker-urls", "--policy", "random"])
+        router_args = RouterArgs.from_cli_args(args)
+        self.assertEqual(router_args.worker_urls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fixes #8148. The router crashes when launched without `--worker-urls`, preventing dynamic worker registration.

## Modifications

  - Changed `--worker-urls` from `nargs="+"` to` nargs="*"` with `default=[]`
  - Updated test comment to reflect new behavior
  - Added test for empty worker URLs argument parsing

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
