### PR TITLE
bugfix: fix sglang crash in NVIDIA MIG container

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1422,10 +1422,12 @@ def get_nvgpu_memory_capacity():
         ]
 
         if not memory_values:
-            # Fallback to torch.cuda.mem_get_info() when failed to get memory capacity from nvidia-smi, 
+            # Fallback to torch.cuda.mem_get_info() when failed to get memory capacity from nvidia-smi,
             # typically in NVIDIA MIG mode.
             if torch.cuda.is_available():
-                logger.warning("Failed to get GPU memory capacity from nvidia-smi, falling back to torch.cuda.mem_get_info().")
+                logger.warning(
+                    "Failed to get GPU memory capacity from nvidia-smi, falling back to torch.cuda.mem_get_info()."
+                )
                 return torch.cuda.mem_get_info()[1] // 1024 // 1024  # unit: MB
             raise ValueError("No GPU memory values found.")
 

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1422,6 +1422,11 @@ def get_nvgpu_memory_capacity():
         ]
 
         if not memory_values:
+            # Fallback to torch.cuda.mem_get_info() when failed to get memory capacity from nvidia-smi, 
+            # typically in NVIDIA MIG mode.
+            if torch.cuda.is_available():
+                logger.warning("Failed to get GPU memory capacity from nvidia-smi, falling back to torch.cuda.mem_get_info().")
+                return torch.cuda.mem_get_info()[1] // 1024 // 1024  # unit: MB
             raise ValueError("No GPU memory values found.")
 
         # Return the minimum memory value


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix #6110,#2933.

In a **NVIDIA Multi-Instance GPU(MIG)** container, process has no permission to call `nvidia-smi --query-gpu=memory.total` in order to get GPU memory capacity, leading to a crash.

```bash
nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits
[Insufficient Permissions]
```

## Modifications
Fallback to use `torch.cuda.mem_get_info()` when failed to get a valid memory capacity in `get_nvgpu_memory_capacity`.


## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
