### PR TITLE
Fix suffix mismatch for the metrics.

### DIFF
--- a/sgl-router/src/metrics.rs
+++ b/sgl-router/src/metrics.rs
@@ -132,7 +132,7 @@ pub fn start_prometheus(config: PrometheusConfig) {
     // Initialize metric descriptions
     init_metrics();
 
-    let duration_matcher = Matcher::Suffix(String::from("duration"));
+    let duration_matcher = Matcher::Suffix(String::from("duration_seconds"));
     let duration_bucket = [
         0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 45.0,
         60.0, 90.0, 120.0, 180.0, 240.0,


### PR DESCRIPTION
## Motivation

The suffix matcher for the suffix "duration" does not match the metric names "sgl_router_request_duration_seconds" or "sgl_router_pd_request_duration_seconds". As a result, the matcher doesn't set the bucket for those metrics as expected. Without the bucket info, the histogram metrics fall back to summary metrics, and it looks like this:
```
sgl_router_generate_duration_seconds{route="/generate",quantile="0.9"} 10
sgl_router_generate_duration_seconds{route="/generate",quantile="0.95"} 20
sgl_router_generate_duration_seconds{route="/generate",quantile="0.99"} 15
sgl_router_generate_duration_seconds{route="/generate",quantile="0.999"} 50
sgl_router_generate_duration_seconds{route="/generate",quantile="1"} 15
```
But it was originally intended to be like this:
```
sglang:time_to_first_token_seconds_bucket{le="0.1",model_name="meta-llama/Llama-3.1-8B-Instruct"} 6.0
sglang:time_to_first_token_seconds_bucket{le="0.25",model_name="meta-llama/Llama-3.1-8B-Instruct"} 6.0
sglang:time_to_first_token_seconds_bucket{le="0.5",model_name="meta-llama/Llama-3.1-8B-Instruct"} 6.0
sglang:time_to_first_token_seconds_bucket{le="0.75",model_name="meta-llama/Llama-3.1-8B-Instruct"} 6.0
sglang:time_to_first_token_seconds_bucket{le="1.0",model_name="meta-llama/Llama-3.1-8B-Instruct"} 27.0
```

## Modifications

Give a correct suffix for the matcher. It should be "duration_seconds" as the suffix to match the name "sgl_router_request_duration_seconds", not "duration".

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
