### PR TITLE
Apply fused sorted token ids padding

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -776,10 +776,10 @@ def moe_align_block_size(
             dtype=torch.int32,
             device=topk_ids.device,
         )
-        pad_sorted_token_ids = False
-        if sorted_ids.shape[0] <= 4096:
-            pad_sorted_token_ids = True
-        else:
+
+        # Threshold based on benchmark results
+        fuse_sorted_ids_padding = sorted_ids.shape[0] <= 4096
+        if not fuse_sorted_ids_padding:
             sorted_ids.fill_(topk_ids.numel())
 
         sgl_moe_align_block_size(
@@ -791,7 +791,7 @@ def moe_align_block_size(
             num_tokens_post_pad,
             token_cnts_buffer,
             cumsum_buffer,
-            pad_sorted_token_ids,
+            fuse_sorted_ids_padding,
         )
     return sorted_ids, expert_ids, num_tokens_post_pad
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Apply https://github.com/sgl-project/sglang/pull/7437.

## Accuracy
For `DeepSeek-V3-0324`.
```
Accuracy: 0.936
Invalid: 0.000
Latency: 32.717 s
Output throughput: 4104.390 token/s
```

## Benchmark
main branch:
```
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+====================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |             91.811 |              91.811 |        161.828 |          158.319 |       184.206 |         10.738 |           10.738 |        10.741 |                91.811 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |             4.000 |            306.596 |             306.596 |        449.659 |          320.894 |      1541.033 |         12.605 |           12.466 |        13.667 |                76.649 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |            16.000 |            822.728 |             822.728 |        691.112 |          741.801 |       949.421 |         18.768 |           18.773 |        19.277 |                51.421 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  3 |            32.000 |           1210.724 |            1210.724 |       1040.937 |          971.016 |      1529.293 |         25.405 |           25.399 |        26.258 |                37.835 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```

this PR:
```
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+====================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |             92.424 |              92.424 |        162.596 |          157.162 |       195.684 |         10.665 |           10.665 |        10.666 |                92.424 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |             4.000 |            309.523 |             309.523 |        424.853 |          305.060 |      1463.097 |         12.507 |           12.371 |        13.541 |                77.381 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |            16.000 |            823.407 |             823.407 |        706.265 |          738.359 |       999.449 |         18.738 |           18.744 |        19.255 |                51.463 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  3 |            32.000 |           1211.274 |            1211.274 |       1031.336 |         1000.080 |      1446.310 |         25.403 |           25.379 |        26.198 |                37.852 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```
## Profile
main branch:
<img width="311" height="386" alt="image" src="https://github.com/user-attachments/assets/17f0b7b1-a500-4ac3-8647-44db6b3f5a50" />

this PR:
<img width="319" height="361" alt="image" src="https://github.com/user-attachments/assets/0d712bd0-3c39-429c-aefe-bec91977cee2" />

