### PR TITLE
Fix dtype error in CI

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -524,7 +524,7 @@ def biased_grouped_topk_gpu(
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
         aiter_biased_grouped_topk(
-            gating_output,
+            gating_output.to(dtype=torch.float32),
             correction_bias,
             topk_weights,
             topk_ids,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

https://github.com/sgl-project/sglang/actions/runs/16400875083/job/46340127530#step:5:489
```
  File "/sglang-checkout/python/sglang/srt/layers/moe/topk.py", line 526, in biased_grouped_topk_gpu
    aiter_biased_grouped_topk(
  File "/sgl-workspace/aiter/aiter/jit/core.py", line 631, in wrapper
    return op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
RuntimeError: gating_output.dtype() == correction_bias.dtype()
```

ref: https://github.com/sgl-project/sglang/pull/7825

Will remove the type conversion once `bf16bf16fp32` gemm supported.