### PR TITLE
fix: zmq bind should be with ip instead dist-init-addr

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1268,6 +1268,10 @@ def get_zmq_socket(
         raise ValueError(f"Unsupported socket type: {socket_type}")
 
     if bind:
+        # bind with local ip first
+        if endpoint.startswith("tcp://"):
+            portBase = int(endpoint.split(":")[-1])
+            endpoint = f"tcp://0.0.0.0:{portBase}"
         socket.bind(endpoint)
     else:
         socket.connect(endpoint)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

There is such error shown as below when PD enabled with multi-node.
I think the *bind* operation should be local ip and port instead passed down by --dist-init-address.

```
Traceback (most recent call last):
File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
return _run_code(code, main_globals, None,
File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
exec(code, run_globals)
File "/usr/local/lib/python3.10/dist-packages/sglang/launch__server.py", line 14, in <module>
launch_server(server_args)
File "/usr/local/lib/python3.10/dist-packages/sglang/srt/entrypoints/http_server.py", line 854, in launch_serveer
tokenizer_manager, template_manager, scheduler_info =_launch_subprocesses(
File "/usr/local/lib/python3.10/dist-packages/sglang/srt/entrypoints/engine.py", line 756, in _launch_subprocesses
tokenizer_manager = TokenizerManager(server_args, port_args)
File "/usr/local/lib/python3.10/dist-packages/sglang/srt/mainagers/tokenizer_manager.py", line 189, in __init_
self.recv_from_detokenizer = get_zmq_socket(
File "/usr/local/lib/python3.10/dist-packages/sglang/srt/utilis.py", line 1102, in get_zmq_socket
socket.bind(endpoint)
File "/usr/local/lib/python3.10/dist-packages/zmq/sugar/socket.py", line 320, in bind
super().bind(addr)
File "zmq/backend/cython/_zmq.py", line 998, in zmq.backend.cython._zmq.Socket.bind
File "zmq/backend/cython/_zmq.py", line 187, in zmq.backend.cython._zmq._check_rc
zmq error ZMQError: No such device (addr='tcp://d-20250721175004-0xx02-decode-0.xxxx')
```


## Modifications

<!-- Describe the changes made in this PR. -->

when *bind* operation happend, only bind local ip and desired port.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
