### PR TITLE
[4/n] DP Enhancement: Optimize communication when `dp < tp` by using `all_gather_into_tensor` and `reduce_scatter_tensor`

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -354,12 +354,13 @@ def dp_scatter(
         )
 
 
-def attn_tp_reduce_scatter(
-    output: torch.Tensor,
-    input_list: List[torch.Tensor],
-):
-    return get_attention_tp_group().reduce_scatter(output, input_list)
+def attn_tp_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor):
+    return get_attention_tp_group().reduce_scatter_tensor(output, input)
 
 
-def attn_tp_all_gather(output_list: List[torch.Tensor], input_: torch.Tensor):
-    return get_attention_tp_group().all_gather(input_, output_tensor_list=output_list)
+def attn_tp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):
+    return get_attention_tp_group().all_gather_into_tensor(output, input)
+
+
+def attn_tp_all_gather(output_list: List[torch.Tensor], input: torch.Tensor):
+    return get_attention_tp_group().all_gather(input, output_tensor_list=output_list)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #8279
* #8278
* #8277
* #8276

## Motivation and Modifications

#8278 padded the token size to a multiple of `attn_tp_size`. As a result, each DP rank's hidden states can be evenly scattered across its TP group. This enables the use of `reduce_scatter_tensor` and `all_gather_into_tensor` to optimize communication efficiency.

## Benchmark

### TP MoE

Benchmark command:

```bash
# launch
python3 -m sglang.launch_server --model-path /dev/shm/DeepSeek-V3-0324 --tp-size 8 --enable-dp-attention --dp-size 4 --enable-deepep-moe --trust-remote-code  --chunked-prefill-size 4096 --cuda-graph-max-bs 256 --max-running-requests 1024 --enable-dp-lm-head --moe-dense-tp-size 1 --mem-fraction-static 0.75 --disable-radix-cache
# benchmark
python3 -m sglang.bench_one_batch_server --model /dev/shm/DeepSeek-V3-0324 --base-url http://localhost:30000/ --batch-size 4096 --input-len 128 --output-len 32
```

Output throughput: 

| Main | #8278 | #8279 |
|---|---|---|
| 4154.71 | 4163.29 | 4261.29

### DeepEP MoE

Benchmark command:

```bash
# launch
python3 -m sglang.launch_server --model-path /dev/shm/DeepSeek-V3-0324 --tp-size 8 --enable-dp-attention --dp-size 4 --enable-deepep-moe --trust-remote-code  --chunked-prefill-size 4096 --cuda-graph-max-bs 128 --max-running-requests 512 --enable-deepep-moe --enable-dp-lm-head --moe-dense-tp-size 1 --mem-fraction-static 0.75 --disable-radix-cache 
# benchmark
python3 -m sglang.bench_one_batch_server --model /dev/shm/DeepSeek-V3-0324 --base-url http://localhost:30000 --batch-size 4096 --input-len 128 --output-len 32
```

Output throughput: 

| Main | #8278 | #8279 |
|---|---|---|
| 2405.84 | 2397.82 | 2443.36 |
