### PR TITLE
faster per_token_group_quant_8bit kernel with stride support

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -235,6 +235,7 @@ set(SOURCES
     "csrc/gemm/nvfp4_scaled_mm_kernels.cu"
     "csrc/gemm/per_tensor_quant_fp8.cu"
     "csrc/gemm/per_token_group_quant_8bit.cu"
+    "csrc/gemm/per_token_group_quant_8bit_prologue.cu"
     "csrc/gemm/per_token_quant_fp8.cu"
     "csrc/gemm/qserve_w4a8_per_chn_gemm.cu"
     "csrc/gemm/qserve_w4a8_per_group_gemm.cu"

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -123,6 +123,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       " float eps, float int8_min, float int8_max) -> ()");
   m.impl("sgl_per_token_group_quant_int8", torch::kCUDA, &sgl_per_token_group_quant_int8);
 
+  m.def(
+      "sgl_per_token_group_quant_8bit(Tensor input, Tensor output_q, Tensor output_s, int group_size, float eps, float "
+      "fp8_min, float fp8_max, bool ue8m0) -> ()");
+  m.impl("sgl_per_token_group_quant_8bit", torch::kCUDA, &sgl_per_token_group_quant_8bit);
+
   m.def("sgl_per_tensor_quant_fp8(Tensor input, Tensor output_q, Tensor output_s, bool is_static) -> ()");
   m.impl("sgl_per_tensor_quant_fp8", torch::kCUDA, &sgl_per_tensor_quant_fp8);
 

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -125,7 +125,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def(
       "sgl_per_token_group_quant_8bit(Tensor input, Tensor output_q, Tensor output_s, int group_size, float eps, float "
-      "fp8_min, float fp8_max, bool ue8m0) -> ()");
+      "min_8bit, float max_8bit, bool ue8m0) -> ()");
   m.impl("sgl_per_token_group_quant_8bit", torch::kCUDA, &sgl_per_token_group_quant_8bit_prologue);
 
   m.def("sgl_per_tensor_quant_fp8(Tensor input, Tensor output_q, Tensor output_s, bool is_static) -> ()");

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -126,7 +126,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "sgl_per_token_group_quant_8bit(Tensor input, Tensor output_q, Tensor output_s, int group_size, float eps, float "
       "fp8_min, float fp8_max, bool ue8m0) -> ()");
-  m.impl("sgl_per_token_group_quant_8bit", torch::kCUDA, &sgl_per_token_group_quant_8bit);
+  m.impl("sgl_per_token_group_quant_8bit", torch::kCUDA, &sgl_per_token_group_quant_8bit_prologue);
 
   m.def("sgl_per_tensor_quant_fp8(Tensor input, Tensor output_q, Tensor output_s, bool is_static) -> ()");
   m.impl("sgl_per_tensor_quant_fp8", torch::kCUDA, &sgl_per_tensor_quant_fp8);

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -1,13 +1,9 @@
 #include <ATen/cuda/CUDAContext.h>
-#include <cuda_bf16.h>
-#include <cuda_fp16.h>
-#include <cutlass/bfloat16.h>
 #include <cutlass/float8.h>
-#include <torch/extension.h>
 
-#include <cute/algorithm/copy.hpp>
-#include <cute/algorithm/gemm.hpp>
 #include <cute/tensor.hpp>
+
+#include "utils.h"
 
 namespace cute {
 template <typename T>

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -240,7 +240,7 @@ union ComposedKey {
     at::ScalarType type_in;
     at::ScalarType type_out;
     at::ScalarType type_scale;
-    at::ScalarType _unused;
+    at::ScalarType _unused = 0;
     int group_size;
   } keys;
   int64_t composed;
@@ -268,8 +268,8 @@ class PerTokenGroupQuantDispatcher {
 
     if (dispatch_map.find(composed_key.composed) == dispatch_map.end()) {
       std::ostringstream oss;
-      oss << __PRETTY_FUNCTION__ << " failed to dispatch data type " << type_in << ' ' << type_out << ' ' << type_scale
-          << ' ' << group_size << ", supported params should be " << supported_string();
+      oss << __PRETTY_FUNCTION__ << " failed to dispatch data type [" << type_in << ',' << type_out << ',' << type_scale
+          << ',' << group_size << "], " << supported_string();
       TORCH_CHECK(false, oss.str());
     }
 

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -357,7 +357,7 @@ void check_contiguous_except_last(torch::Tensor x) {
   }
 }
 
-void sgl_per_token_group_quant_8bit(
+void sgl_per_token_group_quant_8bit_prologue(
     torch::Tensor input,
     torch::Tensor output_q,
     torch::Tensor output_scale,

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -1,0 +1,412 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cutlass/bfloat16.h>
+#include <cutlass/float8.h>
+#include <torch/extension.h>
+
+#include <cute/algorithm/copy.hpp>
+#include <cute/algorithm/gemm.hpp>
+#include <cute/tensor.hpp>
+
+namespace cute {
+template <typename T>
+__device__ inline T max_func(T a, T b) {
+  return ::max(a, b);
+}
+template <>
+__device__ inline nv_half max_func(nv_half a, nv_half b) {
+  return __hmax(a, b);
+}
+template <>
+__device__ inline nv_bfloat16 max_func(nv_bfloat16 a, nv_bfloat16 b) {
+  return __hmax(a, b);
+}
+template <typename T>
+__device__ inline T min_func(T a, T b) {
+  return ::min(a, b);
+}
+template <>
+__device__ inline nv_half min_func(nv_half a, nv_half b) {
+  return __hmin(a, b);
+}
+template <>
+__device__ inline nv_bfloat16 min_func(nv_bfloat16 a, nv_bfloat16 b) {
+  return __hmin(a, b);
+}
+template <typename T>
+__device__ inline T abs_func(T val) {
+  return ::abs(val);
+}
+template <>
+__device__ inline nv_half abs_func(nv_half val) {
+  return __habs(val);
+}
+template <>
+__device__ inline nv_bfloat16 abs_func(nv_bfloat16 val) {
+  return __habs(val);
+}
+
+template <typename T, int N>
+__device__ inline T warp_reduce_max(T val) {
+  // perform warp_reduce_max with N groups, N should be power of 2
+  // e.g. N=2, with 2 groups: thread0~15 and thread16~31
+  static_assert(16 % N == 0);
+  CUTE_UNROLL
+  for (int offset = 16 / N; offset > 0; offset >>= 1) {
+    T shfl_val = __shfl_xor_sync(0xffffffff, val, offset);
+    val = max_func(val, shfl_val);
+  }
+  return val;
+}
+
+template <typename T>
+__device__ inline T convert_scale(float scale) {
+  // store ue8m0 scale as float if output_scale dtype is torch.float
+  return scale;
+}
+
+template <>
+__device__ inline uint8_t convert_scale(float scale) {
+  return (uint8_t)(((int)log2f(scale)) + 127);
+}
+
+template <
+    typename TI,
+    typename TO,
+    typename TS,
+    typename ProbShape,
+    typename InStride,
+    typename OutStride,
+    typename ScaleLayout,
+    typename WarpTiler>
+__global__ void per_token_group_quant_with_prologue_kernel(
+    TO* __restrict__ out_ptr,
+    TS* __restrict__ scale_ptr,
+    const TI* __restrict__ in_ptr,
+    ProbShape shape,
+    InStride in_stride,
+    OutStride out_stride,
+    ScaleLayout scale_layout,
+    WarpTiler warp_tiler,
+    float eps,
+    float min_val,
+    float max_val,
+    bool scale_ue8m0) {
+  int global_warp_idx = threadIdx.x / 32 + blockIdx.y * blockDim.x / 32;
+  int lane_idx = threadIdx.x % 32;
+  if (global_warp_idx * get<0>(warp_tiler) >= get<1>(shape)) {
+    return;
+  }
+  constexpr int VEC_SIZE = get<0>(warp_tiler) / 32;
+  auto copy_in = make_tiled_copy(
+      Copy_Atom<UniversalCopy<uint_byte_t<VEC_SIZE * sizeof(TI)>>, TI>{},
+      Layout<Shape<_32>>{},
+      Layout<Shape<Int<VEC_SIZE>>>{});
+  auto copy_out = make_tiled_copy(
+      Copy_Atom<UniversalCopy<uint_byte_t<VEC_SIZE * sizeof(TO)>>, TO>{},
+      Layout<Shape<_32>>{},
+      Layout<Shape<Int<VEC_SIZE>>>{});
+
+  auto in = make_tensor(make_gmem_ptr(in_ptr), shape, in_stride)(blockIdx.x, _);
+  auto warp_in = local_tile(in, warp_tiler, global_warp_idx);
+  auto thd_in = copy_in.get_slice(lane_idx).partition_S(warp_in);
+  auto reg_in = make_tensor_like(thd_in);
+  copy(copy_in, thd_in, reg_in);
+
+  // compute scale
+  TI abs_max(eps);
+  CUTE_UNROLL
+  for (int i = 0; i < size(reg_in); i += 2) {
+    abs_max = max_func(abs_max, abs_func(reg_in(i)));
+  }
+  abs_max = warp_reduce_max<TI, 1>(abs_max);
+  float y_s = float(abs_max) / float(max_val);
+  if (scale_ue8m0) {
+    y_s = exp2f(ceilf(log2f(fmaxf(fabsf(y_s), 1e-10f))));
+  }
+
+  // store scale
+  auto scale = make_tensor(scale_ptr, scale_layout);
+  if (lane_idx == 0) {
+    scale(blockIdx.x, global_warp_idx) = convert_scale<TS>(y_s);
+  }
+
+  // quant and store output
+  auto out = make_tensor(make_gmem_ptr(out_ptr), shape, out_stride)(blockIdx.x, _);
+  auto warp_out = local_tile(out, warp_tiler, global_warp_idx);
+  auto thd_out = copy_out.get_slice(lane_idx).partition_D(warp_out);
+  auto reg_out = make_tensor_like(thd_out);
+
+  CUTE_UNROLL
+  for (int i = 0; i < size(reg_out); ++i) {
+    reg_out(i) = TO(min_func(max_func(float(reg_in(i)) / y_s, min_val), max_val));
+  }
+  copy(copy_out, reg_out, thd_out);
+}
+
+template <typename TI, typename TO, typename TS, int GROUP_SIZE>
+void per_token_group_quant_with_prologue(
+    void* output_q,
+    void* output_scale,
+    void* input,
+    int token_count,
+    int hidden_dim,
+    int in_hidden_stride,
+    int out_hidden_stride,
+    int scale_stride0,
+    int scale_stride1,
+    float eps,
+    float min_val,
+    float max_val,
+    bool scale_ue8m0,
+    cudaStream_t stream) {
+  static_assert(GROUP_SIZE % 32 == 0);
+  constexpr int VEC_SIZE = GROUP_SIZE / 32;
+  auto shape = make_shape(token_count, hidden_dim);
+  auto in_stride = make_stride(in_hidden_stride, _1{});
+  auto out_stride = make_stride(out_hidden_stride, _1{});
+
+  int num_threads = 128;
+  dim3 grid(token_count, (hidden_dim + VEC_SIZE * num_threads - 1) / (VEC_SIZE * num_threads));
+  auto warp_tiler = make_shape(Int<VEC_SIZE * 32>{});
+  if (scale_ue8m0 && std::is_same<TS, uint8_t>::value) {
+    auto scale_layout = make_layout(
+        make_shape(token_count, make_shape(_4{}, ceil_div(hidden_dim / GROUP_SIZE, 4))),
+        make_stride(_4{}, make_stride(scale_stride0, 4 * scale_stride1)));
+    per_token_group_quant_with_prologue_kernel<<<grid, num_threads, 0, stream>>>(
+        (TO*)output_q,
+        (TS*)output_scale,
+        (TI*)input,
+        shape,
+        in_stride,
+        out_stride,
+        scale_layout,
+        warp_tiler,
+        eps,
+        min_val,
+        max_val,
+        scale_ue8m0);
+  } else {
+    auto scale_layout =
+        make_layout(make_shape(token_count, hidden_dim / GROUP_SIZE), make_stride(scale_stride0, scale_stride1));
+    per_token_group_quant_with_prologue_kernel<<<grid, num_threads, 0, stream>>>(
+        (TO*)output_q,
+        (TS*)output_scale,
+        (TI*)input,
+        shape,
+        in_stride,
+        out_stride,
+        scale_layout,
+        warp_tiler,
+        eps,
+        min_val,
+        max_val,
+        scale_ue8m0);
+  }
+}
+
+}  // namespace cute
+
+namespace {
+template <typename T>
+struct ScaleTypeConvert {
+  using type = T;
+};
+
+template <>
+struct ScaleTypeConvert<int> {
+  using type = uint8_t;
+};
+
+template <typename T>
+struct TorchTypeToNvType {
+  using type = T;
+};
+
+template <>
+struct TorchTypeToNvType<c10::BFloat16> {
+  using type = __nv_bfloat16;
+};
+
+template <>
+struct TorchTypeToNvType<c10::Half> {
+  using type = nv_half;
+};
+
+template <>
+struct TorchTypeToNvType<c10::Float8_e4m3fn> {
+  using type = __nv_fp8_e4m3;
+};
+
+union ComposedKey {
+  struct {
+    at::ScalarType type_in;
+    at::ScalarType type_out;
+    at::ScalarType type_scale;
+    at::ScalarType _unused;
+    int group_size;
+  } keys;
+  int64_t composed;
+};
+
+class PerTokenGroupQuantDispatcher {
+  using FuncPtr = decltype(&cute::per_token_group_quant_with_prologue<float, int8_t, float, 128>);
+
+ public:
+  PerTokenGroupQuantDispatcher() {
+    register_func<
+        std::size(supported_in_types) - 1,
+        std::size(supported_out_types) - 1,
+        std::size(supported_scale_types) - 1,
+        std::size(supported_group_size) - 1>(dispatch_map);
+  }
+
+  FuncPtr
+  get_kernel_launcher(at::ScalarType type_in, at::ScalarType type_out, at::ScalarType type_scale, int group_size) {
+    static std::unordered_map<int64_t, FuncPtr> dispatch_map;
+    if (dispatch_map.empty()) {
+      register_func<
+          std::size(supported_in_types) - 1,
+          std::size(supported_out_types) - 1,
+          std::size(supported_scale_types) - 1,
+          std::size(supported_group_size) - 1>(dispatch_map);
+    }
+    ComposedKey composed_key;
+    composed_key.keys.type_in = type_in;
+    composed_key.keys.type_out = type_out;
+    composed_key.keys.type_scale = type_scale;
+    composed_key.keys.group_size = group_size;
+
+    return dispatch_map.at(composed_key.composed);
+  }
+
+ private:
+  static constexpr at::ScalarType supported_in_types[] = {
+      at::ScalarType::Float,
+#ifdef FLASHINFER_ENABLE_F16
+      at::ScalarType::Half,
+#endif
+#ifdef FLASHINFER_ENABLE_BF16
+      at::ScalarType::BFloat16,
+#endif
+  };
+  static constexpr at::ScalarType supported_out_types[] = {
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
+      // for FP8
+      at::ScalarType::Float8_e4m3fn,
+#endif
+      // for Int8
+      at::ScalarType::Char,
+  };
+  static constexpr at::ScalarType supported_scale_types[] = {
+      at::ScalarType::Float,
+      // for UE8M0 packed
+      at::ScalarType::Int,
+  };
+  static constexpr int supported_group_size[] = {32, 64, 128};
+  std::unordered_map<int64_t, FuncPtr> dispatch_map;
+
+  template <at::ScalarType type_in, at::ScalarType type_out, at::ScalarType type_scale, int group_size>
+  FuncPtr get_func_by_params() {
+    using TI_TORCH = typename c10::impl::ScalarTypeToCPPType<type_in>::type;
+    using TI = typename TorchTypeToNvType<TI_TORCH>::type;
+    using TO_TORCH = typename c10::impl::ScalarTypeToCPPType<type_out>::type;
+    using TO = typename TorchTypeToNvType<TO_TORCH>::type;
+    using TS_PACKED = typename c10::impl::ScalarTypeToCPPType<type_scale>::type;
+    using TS = typename ScaleTypeConvert<TS_PACKED>::type;
+    return &cute::per_token_group_quant_with_prologue<TI, TO, TS, group_size>;
+  }
+
+  template <int TYPE_IN_IDX, int TYPE_OUT_IDX, int TYPE_SCALE_IDX, int GROUP_SIZE_IDX>
+  void register_func(std::unordered_map<int64_t, FuncPtr>& dispatch_map) {
+    constexpr auto type_in = supported_in_types[TYPE_IN_IDX];
+    constexpr auto type_out = supported_out_types[TYPE_OUT_IDX];
+    constexpr auto type_scale = supported_scale_types[TYPE_SCALE_IDX];
+    constexpr auto group_size = supported_group_size[GROUP_SIZE_IDX];
+    ComposedKey composed_key;
+    composed_key.keys.type_in = type_in;
+    composed_key.keys.type_out = type_out;
+    composed_key.keys.type_scale = type_scale;
+    composed_key.keys.group_size = group_size;
+    dispatch_map[composed_key.composed] = get_func_by_params<type_in, type_out, type_scale, group_size>();
+    if constexpr (TYPE_IN_IDX > 0) {
+      register_func<TYPE_IN_IDX - 1, TYPE_OUT_IDX, TYPE_SCALE_IDX, GROUP_SIZE_IDX>(dispatch_map);
+    } else if constexpr (TYPE_OUT_IDX > 0) {
+      register_func<std::size(supported_in_types) - 1, TYPE_OUT_IDX - 1, TYPE_SCALE_IDX, GROUP_SIZE_IDX>(dispatch_map);
+    } else if constexpr (TYPE_SCALE_IDX > 0) {
+      register_func<
+          std::size(supported_in_types) - 1,
+          std::size(supported_out_types) - 1,
+          TYPE_SCALE_IDX - 1,
+          GROUP_SIZE_IDX>(dispatch_map);
+    } else if constexpr (GROUP_SIZE_IDX > 0) {
+      register_func<
+          std::size(supported_in_types) - 1,
+          std::size(supported_out_types) - 1,
+          std::size(supported_scale_types) - 1,
+          GROUP_SIZE_IDX - 1>(dispatch_map);
+    }
+  }
+};
+
+PerTokenGroupQuantDispatcher dispatcher;
+
+}  // namespace
+
+void check_contiguous_except_last(torch::Tensor x) {
+  CHECK(x.stride(x.dim() - 1) == 1);
+  for (int i = 0; i < x.dim() - 3; ++i) {
+    CHECK(x.stride(i) / x.stride(i + 1) == x.size(i + 1));
+  }
+}
+
+void sgl_per_token_group_quant_8bit(
+    torch::Tensor input,
+    torch::Tensor output_q,
+    torch::Tensor output_scale,
+    int64_t group_size,
+    double eps,
+    double min_8bit,
+    double max_8bit,
+    bool scale_ue8m0) {
+  // dispatch different impl by input.dtype, output_q.dtype, output_scale.dtype and group_size
+  check_contiguous_except_last(input);
+  check_contiguous_except_last(output_q);
+
+  int in_hidden_dim = input.size(input.dim() - 1);
+  int out_hidden_dim = output_q.size(output_q.dim() - 1);
+  CHECK(in_hidden_dim == out_hidden_dim);
+  CHECK(in_hidden_dim % group_size == 0);
+
+  int in_token_count = input.numel() / in_hidden_dim;
+  int out_token_count = output_q.numel() / out_hidden_dim;
+  CHECK(in_token_count == out_token_count);
+
+  int in_hidden_stride = input.stride(input.dim() - 2);
+  int out_hidden_stride = output_q.stride(output_q.dim() - 2);
+
+  CHECK(output_scale.dim() == 2);
+  int scale_hidden_dim = output_scale.size(1);
+
+  int output_scale_stride0 = output_scale.stride(0);
+  int output_scale_stride1 = output_scale.stride(1);
+
+  auto kernel_launcher = dispatcher.get_kernel_launcher(
+      input.scalar_type(), output_q.scalar_type(), output_scale.scalar_type(), group_size);
+  kernel_launcher(
+      output_q.data_ptr(),
+      output_scale.data_ptr(),
+      input.data_ptr(),
+      in_token_count,
+      in_hidden_dim,
+      in_hidden_stride,
+      out_hidden_stride,
+      output_scale_stride0,
+      output_scale_stride1,
+      eps,
+      min_8bit,
+      max_8bit,
+      scale_ue8m0,
+      at::cuda::getCurrentCUDAStream());
+}

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -240,10 +240,10 @@ union ComposedKey {
     at::ScalarType type_in;
     at::ScalarType type_out;
     at::ScalarType type_scale;
-    at::ScalarType _unused = at::ScalarType::Float;
+    at::ScalarType _unused;
     int group_size;
   } keys;
-  int64_t composed;
+  int64_t composed = 0;
 };
 
 class PerTokenGroupQuantDispatcher {

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -113,13 +113,13 @@ __global__ void per_token_group_quant_with_prologue_kernel(
   // compute scale
   TI abs_max(eps);
   CUTE_UNROLL
-  for (int i = 0; i < size(reg_in); i += 2) {
+  for (int i = 0; i < size(reg_in); ++i) {
     abs_max = max_func(abs_max, abs_func(reg_in(i)));
   }
   abs_max = warp_reduce_max<TI, 1>(abs_max);
   float y_s = float(abs_max) / float(max_val);
   if (scale_ue8m0) {
-    y_s = exp2f(ceilf(log2f(fmaxf(fabsf(y_s), 1e-10f))));
+    y_s = exp2f(ceilf(log2f(fmaxf(y_s, 1e-10f))));
   }
 
   // store scale
@@ -405,7 +405,6 @@ void sgl_per_token_group_quant_8bit_prologue(
   int out_hidden_stride = output_q.stride(output_q.dim() - 2);
 
   CHECK(output_scale.dim() == 2);
-  int scale_hidden_dim = output_scale.size(1);
 
   int output_scale_stride0 = output_scale.stride(0);
   int output_scale_stride1 = output_scale.stride(1);

--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit_prologue.cu
@@ -240,7 +240,7 @@ union ComposedKey {
     at::ScalarType type_in;
     at::ScalarType type_out;
     at::ScalarType type_scale;
-    at::ScalarType _unused = 0;
+    at::ScalarType _unused = at::ScalarType::Float;
     int group_size;
   } keys;
   int64_t composed;

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -192,7 +192,7 @@ void sgl_per_token_group_quant_int8(
     double eps,
     double int8_min,
     double int8_max);
-void sgl_per_token_group_quant_8bit(
+void sgl_per_token_group_quant_8bit_prologue(
     torch::Tensor input,
     torch::Tensor output_q,
     torch::Tensor output_scale,

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -192,6 +192,15 @@ void sgl_per_token_group_quant_int8(
     double eps,
     double int8_min,
     double int8_max);
+void sgl_per_token_group_quant_8bit(
+    torch::Tensor input,
+    torch::Tensor output_q,
+    torch::Tensor output_scale,
+    int64_t group_size,
+    double eps,
+    double min_8bit,
+    double max_8bit,
+    bool scale_ue8m0);
 void sgl_per_tensor_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void sgl_per_token_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s);
 void bmm_fp8(

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -132,18 +132,18 @@ def sgl_per_token_group_quant_8bit(
     output_s: torch.Tensor,
     group_size: int,
     eps: float,
-    int8_min: float,
-    int8_max: float,
+    min_8bit: float,
+    max_8bit: float,
     scale_ue8m0: bool,
 ) -> None:
     """
-    Quantize input tensor to 8bit according to  output_q.dtype and output_s.dtype.
-    If output_s.dtype is fp8, fp8 quant will be invoked, and int8 quant for output_s.dtype is int8.
-    If scale_ue8m0 is True, scale will be rounded to power of 2,
-    and output_s.dtype can be float(still store with float) or int(for ue8m0 packed)
+        Quantize input tensor to 8-bit. The quantization type is determined by `output_q.dtype`.
+    If `output_q.dtype` is `torch.float8_e4m3fn`, fp8 quantization is performed. If it is `torch.int8`, int8 quantization is performed.
+    If `scale_ue8m0` is True, scale will be rounded to power of 2,
+    and `output_s.dtype` can be `torch.float` (still store with float) or `torch.int` (for ue8m0 packed).
     """
     torch.ops.sgl_kernel.sgl_per_token_group_quant_8bit.default(
-        input, output_q, output_s, group_size, eps, int8_min, int8_max, scale_ue8m0
+        input, output_q, output_s, group_size, eps, min_8bit, max_8bit, scale_ue8m0
     )
 
 

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -126,6 +126,27 @@ def sgl_per_token_group_quant_int8(
     )
 
 
+def sgl_per_token_group_quant_8bit(
+    input: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    int8_min: float,
+    int8_max: float,
+    scale_ue8m0: bool,
+) -> None:
+    """
+    Quantize input tensor to 8bit according to  output_q.dtype and output_s.dtype.
+    If output_s.dtype is fp8, fp8 quant will be invoked, and int8 quant for output_s.dtype is int8.
+    If scale_ue8m0 is True, scale will be rounded to power of 2,
+    and output_s.dtype can be float(still store with float) or int(for ue8m0 packed)
+    """
+    torch.ops.sgl_kernel.sgl_per_token_group_quant_8bit.default(
+        input, output_q, output_s, group_size, eps, int8_min, int8_max, scale_ue8m0
+    )
+
+
 def sgl_per_tensor_quant_fp8(
     input: torch.Tensor,
     output_q: torch.Tensor,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
I want some new features for per_token_group_quant_8bit for future optimize:
- support scale.dtype=float even if ue8m0 is on, to test ue8m0 quant on hopper gpus
- support stride for future fusion
So I decided to rewrite it with cute, and got some benefits.

Following test is tested on H20:
```
per-token-group-quant-8bit-performance:
   batch_size  seq_len  group_size            dst_dtype  SGL Kernel  new kernel
0           1     1024         128           torch.int8   36.800001    36.063999
1           1     1024         128  torch.float8_e4m3fn   37.983999    32.992002
2           1     4096         128           torch.int8  117.183998   117.311999
3           1     4096         128  torch.float8_e4m3fn  128.191993   113.407999
4           1     8192         128           torch.int8  223.488003   223.391995
5           1     8192         128  torch.float8_e4m3fn  244.448006   218.367994
6           1    16384         128           torch.int8  435.167998   435.615987
7           1    16384         128  torch.float8_e4m3fn  477.600008   426.815987
```

and in this case, the result differs, but I think my impl is correct:
```
import sgl_kernel
import torch
from sgl_kernel.gemm import sgl_per_token_group_quant_8bit as per_token_group_quant_with_prologue
from sgl_kernel import sgl_per_token_group_quant_fp8
import torch

a = torch.randn([3, 128], device='cuda', dtype=torch.bfloat16)
group_size = 128

def allocate_qs(input, q_dtype, aligned=False, scale_ue8m0=False):
  q = torch.empty_like(input, device='cuda', dtype=q_dtype)
  m, n = input.shape
  if scale_ue8m0:
    am = (m + 3) // 4 * 4
    an = (n // group_size + 3) // 4 * 4
    s = torch.zeros([an // 4, am], device='cuda', dtype=torch.int).T[:m, :]
  elif aligned:
    am = (m + 3) // 4 * 4
    s = torch.empty([n // group_size, am], device='cuda', dtype=torch.float32).T[:m, :]
  else:
    s = torch.empty([m, n // group_size], device='cuda', dtype=torch.float32)
  return q, s

def my_quant(q_dtype, aligned, scale_ue8m0):
  q, s = allocate_qs(a, q_dtype, aligned, scale_ue8m0)
  per_token_group_quant_with_prologue(a, q, s, group_size, 1e-10, -448, 448, scale_ue8m0)
  return q, s

def sgl_quant(q_dtype, aligned, scale_ue8m0):
  q, s = allocate_qs(a, q_dtype, aligned, scale_ue8m0)
  sgl_per_token_group_quant_fp8(a, q, s, group_size, 1e-10, -448, 448, scale_ue8m0=scale_ue8m0)
  return q, s

q_dtype = torch.int8
aligned = True
scale_ue8m0 = True
q1, s1 = my_quant(q_dtype, aligned, scale_ue8m0)
q2, s2 = sgl_quant(q_dtype, aligned, scale_ue8m0)
```

If `hidden_dim // group_size` cannot be divided by 4, the row_size calculated here is not correct. 
https://github.com/sgl-project/sglang/blob/8abd3e77feca9ed740356c1b879e524d09482fb2/sgl-kernel/csrc/gemm/per_token_group_quant_8bit.cu#L56

## Modifications

<!-- Describe the changes made in this PR. -->
A new kernel written with cute.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
