### PR TITLE
[bugfix] Add add_special_tokens=False to TokenizerManager

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -499,7 +499,9 @@ class TokenizerManager:
                     "the engine with skip_tokenizer_init=False."
                 )
             encoded = self.tokenizer(
-                input_text, return_token_type_ids=is_cross_encoder_request
+                input_text,
+                add_special_tokens=False,
+                return_token_type_ids=is_cross_encoder_request,
             )
 
             input_ids = encoded["input_ids"]
@@ -659,7 +661,7 @@ class TokenizerManager:
         texts = [req.text for req in requests]
 
         # Batch tokenize all texts
-        encoded = self.tokenizer(texts)
+        encoded = self.tokenizer(texts, add_special_tokens=False)
         input_ids_list = encoded["input_ids"]
 
         # Process all requests


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The origin implementation (`tokenizer(text)`) would add an additional bos token to the encoded prompt. And we need to add `add_special_token=False` to avoid this behavior.

We could reproduce such behavior with the following code:
```python
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("NousResearch/Meta-Llama-3.1-8B-Instruct", trust_remote_code=True)
messages = [{"role": "user", "content": "Hello, how are you?"}]
s = tokenizer.apply_chat_template(messages, tokenize=False)

print("Original string:")
print(s)

print("token with add_special_tokens=True:")
print(tokenizer(s)['input_ids'])
print(tokenizer.decode(tokenizer(s)['input_ids']))

print("token with add_special_tokens=False:")
print(tokenizer(s, add_special_tokens=False)['input_ids'])
print(tokenizer.decode(tokenizer(s, add_special_tokens=False)['input_ids']))
```
<img width="815" height="284" alt="image" src="https://github.com/user-attachments/assets/bb822aea-2a7b-44b9-ab80-a62ecafcda80" />

## Modifications

<!-- Describe the changes made in this PR. -->
Add `add_special_tokens=False`.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
