### PR TITLE
fix bug when eos_ids==0

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -475,7 +475,7 @@ class ModelConfig:
 
     def get_hf_eos_token_id(self) -> Optional[Set[int]]:
         eos_ids = getattr(self.hf_config, "eos_token_id", None)
-        if eos_ids:
+        if eos_ids is not None:
             # it can be either int or list of int
             eos_ids = {eos_ids} if isinstance(eos_ids, int) else set(eos_ids)
         if eos_ids is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR aims to fix a bug in the `get_hf_eos_token_id` function that causes a `TypeError` when the `eos_token_id` is `0`.

Currently, the conditional check `if eos_ids:` incorrectly evaluates to `False` for the value `0`. This prevents `eos_ids` from being properly converted to a `set`, which later results in an `unsupported operand type(s) for |: 'int' and 'set'` error when performing a set union.

This change ensures that `0` is handled as a valid token ID. This resolves issue \#8313.

## Modifications

The fix is to change the conditional statement from a "truthiness" check to an explicit `None` check. This ensures that `eos_ids` is always converted to a `set` before any union operations are attempted.

```diff
- if eos_ids:
+ if eos_ids is not None:
```