### PR TITLE
Fix compile-deep-gemm warmup

### DIFF
--- a/python/sglang/compile_deep_gemm.py
+++ b/python/sglang/compile_deep_gemm.py
@@ -52,7 +52,7 @@ class CompileArgs:
 
 
 @warmup("compile-deep-gemm")
-async def warm_up_compile(disaggregation_mode: str, tokenizer_manager: TokenizerManager):
+async def warm_up_compile(_disaggregation_mode: str, tokenizer_manager: TokenizerManager):
     print("\nGenerate warm up request for compiling DeepGEMM...\n")
     generate_req_input = GenerateReqInput(
         input_ids=[0, 1, 2, 3],

--- a/python/sglang/compile_deep_gemm.py
+++ b/python/sglang/compile_deep_gemm.py
@@ -52,7 +52,7 @@ class CompileArgs:
 
 
 @warmup("compile-deep-gemm")
-async def warm_up_compile(tokenizer_manager: TokenizerManager):
+async def warm_up_compile(disaggregation_mode: str, tokenizer_manager: TokenizerManager):
     print("\nGenerate warm up request for compiling DeepGEMM...\n")
     generate_req_input = GenerateReqInput(
         input_ids=[0, 1, 2, 3],


### PR DESCRIPTION
## Motivation

Fixes
```
sglang-1  |   File "/usr/local/lib/python3.10/dist-packages/starlette/routing.py", line 694, in lifespan
sglang-1  |     async with self.lifespan_context(app) as maybe_state:
sglang-1  |   File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
sglang-1  |     return await anext(self.gen)
sglang-1  |   File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/http_server.py", line 148, in lifespan
sglang-1  |     await execute_warmups(
sglang-1  |   File "/sgl-workspace/sglang/python/sglang/srt/warmup.py", line 34, in execute_warmups
sglang-1  |     await _warmup_registry[warmup_name](disaggregation_mode, tokenizer_manager)
sglang-1  | TypeError: warm_up_compile() takes 1 positional argument but 2 were given
```

When running deepgemm warmup (broken by https://github.com/sgl-project/sglang/pull/7632, which adds the disaggregation_mode arg to warmup but does not update the deepgemm warmup)
