### PR TITLE
Fix FP4 MoE accuracy from missing routed_scaling_factor

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -433,10 +433,6 @@ class ServerArgs:
                 self.quantization == "modelopt_fp4"
             ), "modelopt_fp4 quantization is required for Flashinfer MOE"
             os.environ["TRTLLM_ENABLE_PDL"] = "1"
-            self.disable_shared_experts_fusion = True
-            logger.warning(
-                f"Flashinfer MoE is enabled. Shared expert fusion is disabled."
-            )
 
         # DeepEP MoE
         if self.enable_deepep_moe:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR fixes the accuracy issues with FP4 MoE.

Fixes https://github.com/sgl-project/sglang/issues/7166

Before:
```
sglang (pretrained=nvidia/DeepSeek-R1-0528-FP4,trust_remote_code=True,quantization=modelopt_fp4,tp_size=8,max_model_len=32768,add_bos_token=True,enable_flashinfer_moe=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 512
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8704|±  |0.0093|
|     |       |strict-match    |     5|exact_match|↑  |0.8681|±  |0.0093|
```

After, using FP4 flashinfer cutlass moe:
```
sglang (pretrained=nvidia/DeepSeek-R1-0528-FP4,trust_remote_code=True,quantization=modelopt_fp4,tp_size=8,max_model_len=32768,add_bos_token=True,enable_flashinfer_moe=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 512
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9492|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|
```

After, using FP4 flashinfer cutlass moe and epmoe:
```
sglang (pretrained=nvidia/DeepSeek-R1-0528-FP4,trust_remote_code=True,quantization=modelopt_fp4,tp_size=8,max_model_len=32768,add_bos_token=True,enable_flashinfer_moe=True,enable_ep_moe=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 512
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9545|±  |0.0057|
|     |       |strict-match    |     5|exact_match|↑  |0.9500|±  |0.0060|
```

After, using FP4 cutlass moe:
```
sglang (pretrained=nvidia/DeepSeek-R1-0528-FP4,trust_remote_code=True,quantization=modelopt_fp4,tp_size=8,max_model_len=32768,add_bos_token=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 512
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9500|±  |0.0060|
|     |       |strict-match    |     5|exact_match|↑  |0.9477|±  |0.0061|
```


## Modifications

A previous PR https://github.com/sgl-project/sglang/pull/6970 moved routed expert scaling into `moe_sum_reduce` and removed it from the model forward. However the `ModelOptNvFp4FusedMoEMethod` code path does not use `moe_sum_reduce`, so the routed expert scales were not being applied.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
