### PR TITLE
[Bugfix] Fix Llama4 Divide by Zero when interleave_moe_layer_step is zero

### DIFF
--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -403,10 +403,10 @@ class Llama4DecoderLayer(nn.Module):
         )
 
     def _is_moe_layer(self, layer_id: int) -> bool:
-        # If interleave_moe_layer_step is 0, then no MoE layers are used.
-        if self.config.interleave_moe_layer_step == 0:
-            return False
-        return (layer_id + 1) % self.config.interleave_moe_layer_step == 0
+        return (
+            self.config.interleave_moe_layer_step > 0
+            and (layer_id + 1) % self.config.interleave_moe_layer_step == 0
+        )
 
     def forward(
         self,

--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -403,6 +403,9 @@ class Llama4DecoderLayer(nn.Module):
         )
 
     def _is_moe_layer(self, layer_id: int) -> bool:
+        # If interleave_moe_layer_step is 0, then no MoE layers are used.
+        if self.config.interleave_moe_layer_step == 0:
+            return False
         return (layer_id + 1) % self.config.interleave_moe_layer_step == 0
 
     def forward(


### PR DESCRIPTION


## Motivation

 - Bugfix to eliminate divide by zero crash when config.moe_layer_step is zero (such as with Llama-Guard-4-12B). 

## Modifications

 - If config.moe_layer_step is zero, just assume no MoE layers are used. 

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
