### PR TITLE
[1/2] sgl-kernel: Fuse routed scaling factor into select_experts

### DIFF
--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -174,7 +174,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def(
       "moe_fused_gate(Tensor input, Tensor bias, int num_expert_group, int topk_group, int topk, int "
-      "num_fused_shared_experts, float routed_scaling_factor) -> "
+      "num_fused_shared_experts, float routed_scaling_factor, bool apply_routed_scaling_factor_on_output) -> "
       "(Tensor[])");
   m.impl("moe_fused_gate", torch::kCUDA, &moe_fused_gate);
   m.def(

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -243,7 +243,8 @@ std::vector<at::Tensor> moe_fused_gate(
     int64_t topk_group,
     int64_t topk,
     int64_t num_fused_shared_experts,
-    double routed_scaling_factor);
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output);
 
 void fp8_blockwise_scaled_grouped_mm(
     torch::Tensor& output,

--- a/sgl-kernel/python/sgl_kernel/moe.py
+++ b/sgl-kernel/python/sgl_kernel/moe.py
@@ -44,6 +44,7 @@ def moe_fused_gate(
     topk,
     num_fused_shared_experts=0,
     routed_scaling_factor=0,
+    apply_routed_scaling_factor_on_output=False,
 ):
     # This fused kernel function is used to select topk expert in a hierarchical 2-layer fashion
     # it split group of expert into num_expert_group, and use top2 expert weight sum in each group
@@ -51,8 +52,13 @@ def moe_fused_gate(
     # the #experts is decided by the input tensor shape and we currently only support power of 2 #experts
     # and #experts should be divisible by num_expert_group. #expert/num_expert_group <= 32 is limited for now.
     # for non-supported case, we suggest to use the biased_grouped_topk func in sglang.srt.layers.moe.topk
-    # num_fused_shared_experts: if > 0, the last several experts will be replaced with shared experts
-    # routed_scaling_factor: if > 0, the shared experts will be scaled by this factor
+    # num_fused_shared_experts: if > 0, the last several experts will be
+    #   replaced with shared experts. the shared experts will be divided by the
+    #   routed_scaling_factor - this is intended to cancel out later when routed+shared
+    #   output is scaled so that shared experts are not scaled.
+    # routed_scaling_factor: if > 0, the experts will be scaled by this factor
+    # apply_routed_scaling_factor_on_output: if true, output will be
+    #   scaled by the routed_scaling_factor
     return torch.ops.sgl_kernel.moe_fused_gate.default(
         input_tensor,
         bias,
@@ -61,6 +67,7 @@ def moe_fused_gate(
         topk,
         num_fused_shared_experts,
         routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
     )
 
 

--- a/sgl-kernel/tests/test_moe_fused_gate.py
+++ b/sgl-kernel/tests/test_moe_fused_gate.py
@@ -19,7 +19,10 @@ from sglang.srt.layers.moe.topk import biased_grouped_topk
     ],
 )
 @pytest.mark.parametrize("num_fused_shared_experts", [0, 1, 2])
-def test_moe_fused_gate_combined(seq_length, params, num_fused_shared_experts):
+@pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [True, False])
+def test_moe_fused_gate_combined(
+    seq_length, params, num_fused_shared_experts, apply_routed_scaling_factor_on_output
+):
     num_experts, num_expert_group, topk_group, topk = params
     dtype = torch.float32
 
@@ -37,6 +40,7 @@ def test_moe_fused_gate_combined(seq_length, params, num_fused_shared_experts):
         topk=topk,
         num_fused_shared_experts=num_fused_shared_experts,
         routed_scaling_factor=2.5,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
     )
     ref_output, ref_indices = biased_grouped_topk(
         scores,
@@ -48,6 +52,7 @@ def test_moe_fused_gate_combined(seq_length, params, num_fused_shared_experts):
         topk_group=topk_group,
         num_fused_shared_experts=num_fused_shared_experts,
         routed_scaling_factor=2.5,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
     )
 
     # When num_fused_shared_experts > 0, ignore the comparison of the last topk dimension


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Follow up to https://github.com/sgl-project/sglang/pull/8333
Fuse the multiply by routed_scaling_factor into select_experts, following example of TRT-LLM:
https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/models/modeling_deepseekv3.py#L323
https://github.com/NVIDIA/TensorRT-LLM/blob/738ab615930fd08dccb94fa388bd74dc91c5f235/cpp/tensorrt_llm/kernels/noAuxTcKernels.cu#L651

For the non-FP4 paths, the routed_scaling_factor is fused into moe_sum_reduce. However, we could move it into select_experts for those paths too if we wanted to simplify the code.

## Modifications

Add boolean argument to fused_moe_gate()


## Results

Prefill:
10.46% speedup at BS 1
1.86% speedup at BS 128
Decode:
1.22% speedup at BS1
0.26% speedup at BS128

Server command
```
python3 -m sglang.launch_server --model-path nvidia/DeepSeek-R1-0528-FP4 --trust-remote-code --quantization modelopt_fp4 --tp 8 --enable-flashinfer-cutlass-moe --enable-ep-moe --ep-size 8
```

BEFORE results
```
python3 -m sglang.bench_one_batch_server --model-path nvidia/DeepSeek-R1-0528-FP4 --base-url http://127.0.0.1:30000/ --batch-size 1 --input-len 1024 --output-len 1024

#Input tokens: 1024
#Output tokens: 1024
batch size: 1
input_len: 1024
output_len: 1024
latency: 10.60 s
ttft: 0.11 s
last generation throughput: 96.61 tok/s
input throughput: 9392.46 tok/s
output throughput: 97.62 tok/s

python3 -m sglang.bench_one_batch_server --model-path nvidia/DeepSeek-R1-0528-FP4 --base-url http://127.0.0.1:30000/ --batch-size 128 --input-len 1024 --output-len 1024

#Input tokens: 131072
#Output tokens: 131072
batch size: 128
input_len: 1024
output_len: 1024
latency: 39.79 s
ttft: 7.56 s
last generation throughput: 3693.98 tok/s
input throughput: 17344.15 tok/s
output throughput: 4066.24 tok/s
```

AFTER results
```
python3 -m sglang.bench_one_batch_server --model-path nvidia/DeepSeek-R1-0528-FP4 --base-url http://127.0.0.1:30000/ --batch-size 1 --input-len 1024 --output-len 1024

#Input tokens: 1024
#Output tokens: 1024
batch size: 1
input_len: 1024
output_len: 1024
latency: 10.46 s
ttft: 0.10 s
last generation throughput: 97.88 tok/s
input throughput: 10375.70 tok/s
output throughput: 98.82 tok/s

python3 -m sglang.bench_one_batch_server --model-path nvidia/DeepSeek-R1-0528-FP4 --base-url http://127.0.0.1:30000/ --batch-size 128 --input-len 1024 --output-len 1024

#Input tokens: 131072
#Output tokens: 131072
batch size: 128
input_len: 1024
output_len: 1024
latency: 39.57 s
ttft: 7.42 s
last generation throughput: 3698.44 tok/s
input throughput: 17667.47 tok/s
output throughput: 4076.75 tok/s
```


Accuracy
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319 --port=30000

# Before
Accuracy: 0.960
Invalid: 0.000
Latency: 23.902 s
Output throughput: 6057.485 token/s

# After
Accuracy: 0.961
Invalid: 0.000
Latency: 23.413 s
Output throughput: 6128.773 token/s
```

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
