### PR TITLE
bugfix: Fix multiple finish_reason chunks and tool_calls finish reason check

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -456,13 +456,8 @@ class OpenAIServingChat(OpenAIServingBase):
                     choice_data = ChatCompletionResponseStreamChoice(
                         index=index,
                         delta=delta,
-                        finish_reason=finish_reason_type,
-                        matched_stop=(
-                            finish_reason["matched"]
-                            if finish_reason and "matched" in finish_reason
-                            else None
-                        ),
-                        logprobs=choice_logprobs,
+                        finish_reason=None,
+                        logprobs=None,
                     )
                     chunk = ChatCompletionStreamResponse(
                         id=content["meta_info"]["id"],

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -489,7 +489,7 @@ class OpenAIServingChat(OpenAIServingBase):
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=index,
                             delta=DeltaMessage(reasoning_content=reasoning_text),
-                            finish_reason=finish_reason_type,
+                            finish_reason=None,
                         )
                         chunk = ChatCompletionStreamResponse(
                             id=content["meta_info"]["id"],
@@ -507,7 +507,6 @@ class OpenAIServingChat(OpenAIServingBase):
                         parser_dict,
                         content,
                         request,
-                        finish_reason_type,
                         has_tool_calls,
                     ):
                         if chunk:
@@ -528,7 +527,7 @@ class OpenAIServingChat(OpenAIServingBase):
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=index,
                             delta=DeltaMessage(content=delta if delta else None),
-                            finish_reason=None,  # Always None, finish_reason sent at the end
+                            finish_reason=None,
                             matched_stop=None,
                             logprobs=choice_logprobs,
                         )
@@ -868,7 +867,6 @@ class OpenAIServingChat(OpenAIServingBase):
         parser_dict: Dict[int, FunctionCallParser],
         content: Dict[str, Any],
         request: ChatCompletionRequest,
-        finish_reason_type: Optional[str],
         has_tool_calls: Dict[int, bool],
     ):
         """Process tool calls in streaming response"""
@@ -886,7 +884,7 @@ class OpenAIServingChat(OpenAIServingBase):
             choice_data = ChatCompletionResponseStreamChoice(
                 index=index,
                 delta=DeltaMessage(content=normal_text),
-                finish_reason=finish_reason_type,
+                finish_reason=None,
             )
             chunk = ChatCompletionStreamResponse(
                 id=content["meta_info"]["id"],
@@ -923,11 +921,7 @@ class OpenAIServingChat(OpenAIServingBase):
             choice_data = ChatCompletionResponseStreamChoice(
                 index=index,
                 delta=DeltaMessage(tool_calls=[tool_call]),
-                finish_reason=(
-                    None
-                    if request.stream_options and request.stream_options.include_usage
-                    else finish_reason_type
-                ),
+                finish_reason=None,
             )
             chunk = ChatCompletionStreamResponse(
                 id=content["meta_info"]["id"],

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -412,6 +412,8 @@ class OpenAIServingChat(OpenAIServingBase):
         is_firsts = {}
         stream_buffers = {}
         n_prev_tokens = {}
+        has_tool_calls = {}
+        finish_reasons = {}
 
         # Usage tracking
         prompt_tokens = {}
@@ -442,6 +444,10 @@ class OpenAIServingChat(OpenAIServingBase):
 
                 finish_reason = content["meta_info"]["finish_reason"]
                 finish_reason_type = finish_reason["type"] if finish_reason else None
+
+                # Track finish_reason for each index
+                if finish_reason_type:
+                    finish_reasons[index] = finish_reason
 
                 # First chunk with role
                 if is_firsts.get(index, True):
@@ -495,40 +501,35 @@ class OpenAIServingChat(OpenAIServingBase):
 
                 # Handle tool calls
                 if request.tool_choice != "none" and request.tools:
-                    async for (
-                        chunk,
-                        tool_call_finish_reason_type,
-                    ) in self._process_tool_call_stream(
+                    async for chunk in self._process_tool_call_stream(
                         index,
                         delta,
                         parser_dict,
                         content,
                         request,
                         finish_reason_type,
+                        has_tool_calls,
                     ):
                         if chunk:
                             yield chunk
-                        finish_reason_type = tool_call_finish_reason_type
+
+                    # Send any remaining tool call arguments when generation finishes
+                    if finish_reason_type is not None and index in parser_dict:
+                        parser = parser_dict[index]
+                        remaining_chunk = self._check_for_unstreamed_tool_args(
+                            parser, content, request, finish_reason_type, index
+                        )
+                        if remaining_chunk:
+                            yield remaining_chunk
 
                 else:
                     # Regular content
-                    if delta or not (
-                        request.stream_options and request.stream_options.include_usage
-                    ):
+                    if delta:
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=index,
                             delta=DeltaMessage(content=delta if delta else None),
-                            finish_reason=(
-                                None
-                                if request.stream_options
-                                and request.stream_options.include_usage
-                                else finish_reason_type
-                            ),
-                            matched_stop=(
-                                finish_reason["matched"]
-                                if finish_reason and "matched" in finish_reason
-                                else None
-                            ),
+                            finish_reason=None,  # Always None, finish_reason sent at the end
+                            matched_stop=None,
                             logprobs=choice_logprobs,
                         )
                         chunk = ChatCompletionStreamResponse(
@@ -539,26 +540,36 @@ class OpenAIServingChat(OpenAIServingBase):
                         )
                         yield f"data: {chunk.model_dump_json()}\n\n"
 
-            # Final chunk with finish_reason
-            finish_reason_chunk = ChatCompletionStreamResponse(
-                id=content["meta_info"]["id"],
-                created=int(time.time()),
-                choices=[
-                    ChatCompletionResponseStreamChoice(
-                        index=index,
-                        delta=DeltaMessage(),
-                        finish_reason=finish_reason_type,
-                        matched_stop=(
-                            finish_reason["matched"]
-                            if finish_reason and "matched" in finish_reason
-                            else None
-                        ),
-                    )
-                ],
-                model=request.model,
-                usage=None,
-            )
-            yield f"data: {finish_reason_chunk.model_dump_json()}\n\n"
+            # Send finish_reason chunks for each index that completed
+            for idx, finish_reason_data in finish_reasons.items():
+                finish_reason_type = finish_reason_data["type"]
+
+                # Change finish_reason to "tool_calls" if we had tool calls and stopped naturally
+                final_finish_reason = finish_reason_type
+                if has_tool_calls.get(idx, False) and finish_reason_type == "stop":
+                    final_finish_reason = "tool_calls"
+
+                finish_reason_chunk = ChatCompletionStreamResponse(
+                    id=content["meta_info"][
+                        "id"
+                    ],  # NOTE: openai uses the same chatcmpl-id for all indices
+                    created=int(time.time()),
+                    choices=[
+                        ChatCompletionResponseStreamChoice(
+                            index=idx,
+                            delta=DeltaMessage(),
+                            finish_reason=final_finish_reason,
+                            matched_stop=(
+                                finish_reason_data["matched"]
+                                if "matched" in finish_reason_data
+                                else None
+                            ),
+                        )
+                    ],
+                    model=request.model,
+                    usage=None,
+                )
+                yield f"data: {finish_reason_chunk.model_dump_json()}\n\n"
 
             # Send hidden states if requested
             if request.return_hidden_states and hidden_states:
@@ -578,7 +589,7 @@ class OpenAIServingChat(OpenAIServingBase):
                                     delta=DeltaMessage(
                                         hidden_states=last_token_hidden_states
                                     ),
-                                    finish_reason=finish_reason_type,
+                                    finish_reason=None,  # Hidden states don't need finish_reason
                                 )
                             ],
                             model=request.model,
@@ -831,6 +842,79 @@ class OpenAIServingChat(OpenAIServingBase):
         reasoning_parser = reasoning_parser_dict[index]
         return reasoning_parser.parse_stream_chunk(delta)
 
+    def _check_for_unstreamed_tool_args(
+        self,
+        parser: FunctionCallParser,
+        content: Dict[str, Any],
+        request: ChatCompletionRequest,
+        finish_reason_type: str,
+        index: int,
+    ) -> Optional[str]:
+        """
+        Check for any remaining tool call arguments that need to be streamed
+        when generation finishes. This ensures tool calls are properly completed
+        even if the model generates the final arguments in the last chunk.
+        """
+        # Only check if we have tool calls and the parser has tracked data
+        if (
+            not hasattr(parser.detector, "prev_tool_call_arr")
+            or not parser.detector.prev_tool_call_arr
+        ):
+            return None
+
+        if (
+            not hasattr(parser.detector, "streamed_args_for_tool")
+            or not parser.detector.streamed_args_for_tool
+        ):
+            return None
+
+        # Get the last tool call that was being processed
+        tool_index = len(parser.detector.prev_tool_call_arr) - 1
+        if tool_index < 0 or tool_index >= len(parser.detector.streamed_args_for_tool):
+            return None
+
+        # Get expected vs actual arguments
+        expected_args = parser.detector.prev_tool_call_arr[tool_index].get(
+            "arguments", {}
+        )
+        expected_call = json.dumps(expected_args, ensure_ascii=False)
+        actual_call = parser.detector.streamed_args_for_tool[tool_index]
+
+        # Check if there are remaining arguments to send
+        remaining_call = (
+            expected_call.replace(actual_call, "", 1)
+            if actual_call in expected_call
+            else ""
+        )
+
+        if remaining_call:
+            # Create tool call chunk with remaining arguments
+            tool_call = ToolCall(
+                id=None,  # No ID for argument deltas
+                index=tool_index,
+                function=FunctionResponse(
+                    name=None,  # No name for argument deltas
+                    arguments=remaining_call,
+                ),
+            )
+
+            choice_data = ChatCompletionResponseStreamChoice(
+                index=index,
+                delta=DeltaMessage(tool_calls=[tool_call]),
+                finish_reason=None,  # Don't send finish_reason with this chunk
+            )
+
+            chunk = ChatCompletionStreamResponse(
+                id=content["meta_info"]["id"],
+                created=int(time.time()),
+                choices=[choice_data],
+                model=request.model,
+            )
+
+            return f"data: {chunk.model_dump_json()}\n\n"
+
+        return None
+
     def _get_enable_thinking_from_request(request: ChatCompletionRequest) -> bool:
         """Extracts the 'enable_thinking' flag from request chat_template_kwargs.
 
@@ -858,6 +942,7 @@ class OpenAIServingChat(OpenAIServingBase):
         content: Dict[str, Any],
         request: ChatCompletionRequest,
         finish_reason_type: Optional[str],
+        has_tool_calls: Dict[int, bool],
     ):
         """Process tool calls in streaming response"""
         if index not in parser_dict:
@@ -882,10 +967,13 @@ class OpenAIServingChat(OpenAIServingBase):
                 choices=[choice_data],
                 model=request.model,
             )
-            yield f"data: {chunk.model_dump_json()}\n\n", finish_reason_type
+            yield f"data: {chunk.model_dump_json()}\n\n"
 
         # Yield tool calls
         for call_item in calls:
+            # Mark that this choice has tool calls
+            has_tool_calls[index] = True
+
             # Tool call ID should be generated only once per tool call
             if call_item.name:
                 # First chunk: include ID and function name
@@ -895,23 +983,6 @@ class OpenAIServingChat(OpenAIServingBase):
                 # Subsequent chunks: null ID and name for argument deltas
                 tool_call_id = None
                 function_name = None
-
-            if finish_reason_type == "stop":
-                # Handle remaining arguments
-                latest_delta_len = 0
-                if isinstance(call_item.parameters, str):
-                    latest_delta_len = len(call_item.parameters)
-
-                expected_call = json.dumps(
-                    parser.detector.prev_tool_call_arr[index].get("arguments", {}),
-                    ensure_ascii=False,
-                )
-                actual_call = parser.detector.streamed_args_for_tool[index]
-                if latest_delta_len > 0:
-                    actual_call = actual_call[:-latest_delta_len]
-                remaining_call = expected_call.replace(actual_call, "", 1)
-                call_item.parameters = remaining_call
-                finish_reason_type = "tool_calls"
 
             tool_call = ToolCall(
                 id=tool_call_id,
@@ -937,7 +1008,4 @@ class OpenAIServingChat(OpenAIServingBase):
                 choices=[choice_data],
                 model=request.model,
             )
-            yield f"data: {chunk.model_dump_json()}\n\n", finish_reason_type
-
-        if finish_reason_type == "stop":
-            yield None, "tool_calls"
+            yield f"data: {chunk.model_dump_json()}\n\n"

--- a/test/srt/openai_server/basic/test_openai_server.py
+++ b/test/srt/openai_server/basic/test_openai_server.py
@@ -233,6 +233,7 @@ class TestOpenAIServer(CustomTestCase):
 
         is_firsts = {}
         is_finished = {}
+        finish_reason_counts = {}
         for response in generator:
             usage = response.usage
             if usage is not None:
@@ -245,6 +246,7 @@ class TestOpenAIServer(CustomTestCase):
             finish_reason = response.choices[0].finish_reason
             if finish_reason is not None:
                 is_finished[index] = True
+                finish_reason_counts[index] = finish_reason_counts.get(index, 0) + 1
 
             data = response.choices[0].delta
 
@@ -283,6 +285,15 @@ class TestOpenAIServer(CustomTestCase):
             assert not is_firsts.get(
                 index, True
             ), f"index {index} is not found in the response"
+
+        # Verify that each choice gets exactly one finish_reason chunk
+        for index in range(parallel_sample_num):
+            assert (
+                index in finish_reason_counts
+            ), f"No finish_reason found for index {index}"
+            assert (
+                finish_reason_counts[index] == 1
+            ), f"Expected 1 finish_reason chunk for index {index}, got {finish_reason_counts[index]}"
 
     def test_completion(self):
         for echo in [False, True]:
@@ -418,91 +429,6 @@ The SmartHome Mini is a compact smart home assistant available in black or white
         # Test retrieving a non-existent model
         with self.assertRaises(openai.NotFoundError):
             client.models.retrieve("non-existent-model")
-
-
-# -------------------------------------------------------------------------
-#    EBNF Test Class: TestOpenAIServerEBNF
-#    Launches the server with xgrammar, has only EBNF tests
-# -------------------------------------------------------------------------
-class TestOpenAIServerEBNF(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.api_key = "sk-123456"
-
-        # passing xgrammar specifically
-        other_args = ["--grammar-backend", "xgrammar"]
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            api_key=cls.api_key,
-            other_args=other_args,
-        )
-        cls.base_url += "/v1"
-        cls.tokenizer = get_tokenizer(DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def test_ebnf(self):
-        """
-        Ensure we can pass `ebnf` to the local openai server
-        and that it enforces the grammar.
-        """
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-        ebnf_grammar = r"""
-        root ::= "Hello" | "Hi" | "Hey"
-        """
-        pattern = re.compile(r"^(Hello|Hi|Hey)[.!?]*\s*$")
-
-        response = client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": "You are a helpful EBNF test bot."},
-                {"role": "user", "content": "Say a greeting (Hello, Hi, or Hey)."},
-            ],
-            temperature=0,
-            max_tokens=32,
-            extra_body={"ebnf": ebnf_grammar},
-        )
-        text = response.choices[0].message.content.strip()
-        self.assertTrue(len(text) > 0, "Got empty text from EBNF generation")
-        self.assertRegex(text, pattern, f"Text '{text}' doesn't match EBNF choices")
-
-    def test_ebnf_strict_json(self):
-        """
-        A stricter EBNF that produces exactly {"name":"Alice"} format
-        with no trailing punctuation or extra fields.
-        """
-        client = openai.Client(api_key=self.api_key, base_url=self.base_url)
-        ebnf_grammar = r"""
-        root    ::= "{" pair "}"
-        pair    ::= "\"name\"" ":" string
-        string  ::= "\"" [A-Za-z]+ "\""
-        """
-        pattern = re.compile(r'^\{"name":"[A-Za-z]+"\}$')
-
-        response = client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": "EBNF mini-JSON generator."},
-                {
-                    "role": "user",
-                    "content": "Generate single key JSON with only letters.",
-                },
-            ],
-            temperature=0,
-            max_tokens=64,
-            extra_body={"ebnf": ebnf_grammar},
-        )
-        text = response.choices[0].message.content.strip()
-        self.assertTrue(len(text) > 0, "Got empty text from EBNF strict JSON test")
-        self.assertRegex(
-            text, pattern, f"Text '{text}' not matching the EBNF strict JSON shape"
-        )
 
 
 class TestOpenAIV1Rerank(CustomTestCase):

--- a/test/srt/openai_server/function_call/test_openai_function_calling.py
+++ b/test/srt/openai_server/function_call/test_openai_function_calling.py
@@ -266,8 +266,7 @@ class TestOpenAIServerFunctionCalling(CustomTestCase):
             "Final response of function calling should have finish_reason 'tool_calls'",
         )
 
-    # TODO: There is a bug in sglang preventing this UT from passing. We are working on it. Once done, we will add this UT back.
-    def _test_function_calling_streaming_no_tool_call(self):
+    def test_function_calling_streaming_no_tool_call(self):
         """
         Test: Whether the finish_reason is stop in streaming mode when no tool call is given.
         - Expect no function call to be found.


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR focuses on resolving multiple issues with `finish_reason` handling in OpenAI-compatible streaming responses.

### OpenAI Standanrd vs SGLang Issues:

**1. Duplicate finish_reason chunks during streaming**

OpenAI Standard: Only one finish_reason chunk at the end during streaming.

SGLang Behavior: Two finish_reason chunks sent, causing duplication. See <img width="1564" height="1050" alt="Screenshot 2025-07-27 at 11 57 36 AM" src="https://github.com/user-attachments/assets/6f411532-61aa-4e3a-87fd-42bc1ca3cf61" />

**Root Cause:** At L524 in serving_chat.py, when processing regular content, we incorrectly send finish_reason in content chunks. Then at L545, we send the final finish_reason chunk again, creating duplicates.
https://github.com/sgl-project/sglang/blob/22e00eeb4a4cb3a81e930619649234e34e8bd5fd/python/sglang/srt/entrypoints/openai/serving_chat.py#L524-L533

https://github.com/sgl-project/sglang/blob/22e00eeb4a4cb3a81e930619649234e34e8bd5fd/python/sglang/srt/entrypoints/openai/serving_chat.py#L545-L563

**Fix:** Remove finish_reason from regular content chunks (L534) and only send it in the final loop.

**2. Multi-choice streaming only sends finish_reason for last index**

OpenAI Standard: When request.n > 1, each choice gets its own finish_reason chunk individually. Each index may have different finish_reason values.

SGLang Behavior: Only sends one finish_reason chunk for the last index, missing finish_reason for other indices. See: <img width="1564" height="1050" alt="Screenshot 2025-07-27 at 1 50 37 AM" src="https://github.com/user-attachments/assets/f19cdbc0-3b66-45b9-bdfb-1417b55c0316" />

**Root Cause:** Lack of finish_reason tracking for different indices - we weren't maintaining per-index state.

**Fix:** Added finish_reasons dict to track finish_reason for each index separately, then loop through all indices to send individual finish_reason chunks.

**Note:** The current check here is incorrect. https://github.com/sgl-project/sglang/blob/22e00eeb4a4cb3a81e930619649234e34e8bd5fd/python/sglang/srt/entrypoints/openai/serving_chat.py#L945-L946 

It causes bug when there are no tool_calls in the results. The actual finish_reason determination should happen at the end of streaming when we have the final finish_reason_type and can check if the choice had tool calls.

**3. Incomplete tool argument streaming on generation end**

OpenAI Standard: When generation ends (any finish_reason), remaining tool call arguments should be streamed to complete the tool call.

SGLang Behavior: Only checks for `finish_reason == "stop"`, missing cases where `finish_reason == "length"` and tool calls are incomplete.

**Root Cause:** Incomplete condition check - tool calls can be cut off by length limits, not just natural stops.

**Fix:** Added comprehensive check for any `finish_reason_type` to ensure remaining tool arguments are always streamed when generation ends, regardless of the specific finish_reason.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

**Summary of the Fix:**

  1. Track finish_reason per index: finish_reasons[index] = finish_reason
  2. Remove finish_reason from regular content: Always finish_reason=None during streaming
  5. Send finish_reason chunks for all indices: Loop through all completed indices and send finish_reason chunks
  6. Apply tool_calls logic per index: Check has_tool_calls.get(idx, False) for each specific index

  Now the behavior will be:

  With tool calls (n=2):
  - Index 0 completes → tracked in finish_reasons[0]
  - Index 1 completes → tracked in finish_reasons[1]
  - At the end → send finish_reason chunk for index 0 ("tool_calls") and index 1 ("tool_calls")

  Without tool calls (n=2):
  - Index 0 completes → tracked in finish_reasons[0]
  - Index 1 completes → tracked in finish_reasons[1]
  - At the end → send finish_reason chunk for index 0 ("stop") and index 1 ("stop")

**Add Tests**

Test 1: `test_streaming_multiple_choices_finish_reason`

  - Tests: Multiple choices (n=2) with tool calls in streaming mode
  - Verifies: Each choice (index 0 and 1) gets its own finish_reason chunk
  - Expected: Both indices should have finish_reason="tool_calls"
  - Catches: The bug where only the last index got a finish_reason chunk

Test 2: `test_streaming_multiple_choices_without_tools`

  - Tests: Multiple choices (n=2) without tools in streaming mode
  - Verifies: Each choice gets its own finish_reason chunk for regular content
  - Expected: Both indices should have finish_reason="stop" or "length"
  - Catches: The bug where regular content with multiple choices had issues

Test 3: Added Check in run_chat_completion_stream:

  1. Track finish_reason counts per index (line 249): Each time a finish_reason is encountered, increment the counter for that index
  2. Verify exactly one finish_reason per choice (lines 290-292):
    - Each index should appear in finish_reason_counts
    - Each index should have exactly 1 finish_reason chunk

**Additional changes:**
  - Remove `TestOpenAIServerEBNF` in test_openai_server.py. As it is a duplication of `test/srt/openai_server/features/test_openai_server_ebnf.py`. 
  
<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
