### PR TITLE
[Improvements] Merge health check route

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -460,6 +460,7 @@ class SchedulerDisaggregationPrefillMixin:
 
         # We need to remove the sync in the following function for overlap schedule.
         self.set_next_batch_sampling_info_done(batch)
+        self.maybe_send_health_check_signal()
 
     def process_disagg_prefill_inflight_queue(
         self: Scheduler, rids_to_check: Optional[List[str]] = None

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -89,12 +89,11 @@ from sglang.srt.managers.io_struct import (
     VertexGenerateReqInput,
 )
 from sglang.srt.managers.template_manager import TemplateManager
-from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.managers.tokenizer_manager import ServerStatus, TokenizerManager
 from sglang.srt.metrics.func_timer import enable_func_timer
 from sglang.srt.reasoning_parser import ReasoningParser
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import (
-    ServerStatus,
     add_api_key_middleware,
     add_prometheus_middleware,
     delete_directory,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -23,7 +23,6 @@ import json
 import logging
 import multiprocessing as multiprocessing
 import os
-import random
 import threading
 import time
 from http import HTTPStatus
@@ -263,9 +262,7 @@ async def health_generate(request: Request) -> Response:
             != DisaggregationMode.NULL
         ):
             gri.bootstrap_host = FAKE_BOOTSTRAP_HOST
-            gri.bootstrap_room = random.randint(
-                0, _global_state.tokenizer_manager.server_args.dp_size
-            )
+            gri.bootstrap_room = 0
     else:
         gri = EmbeddingReqInput(
             rid=rid, input_ids=[0], sampling_params=sampling_params, log_metrics=False

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -242,6 +242,9 @@ async def health_generate(request: Request) -> Response:
     if not _global_state.tokenizer_manager.server_status.is_healthy():
         return Response(status_code=503)
 
+    if _global_state.tokenizer_manager.is_image_gen:
+        return Response(status_code=200)
+
     """Step2: Check the health of the inference server by generating one token."""
     sampling_params = {"max_new_tokens": 1, "temperature": 0.0}
     rid = f"HEALTH_CHECK_{time.time()}"

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1744,6 +1744,9 @@ class Scheduler(
         elif batch.forward_mode.is_dummy_first():
             self.set_next_batch_sampling_info_done(batch)
 
+        self.maybe_send_health_check_signal()
+
+    def maybe_send_health_check_signal(self):
         if self.return_health_check_ct:
             # Return some signal for the health check.
             # This is used to prevent the health check signal being blocked by long context prefill.

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -116,6 +116,7 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.mm_utils import TensorTransportMode
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
+from sglang.srt.managers.scheduler import is_health_check_generate_req
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.metrics.collector import TokenizerMetricsCollector
 from sglang.srt.sampling.sampling_params import SamplingParams
@@ -1769,6 +1770,8 @@ class TokenizerManager:
         asyncio.create_task(asyncio.to_thread(background_task))
 
     def _handle_abort_req(self, recv_obj):
+        if is_health_check_generate_req(recv_obj):
+            return
         state = self.rid_to_state[recv_obj.rid]
         state.finished = True
         if recv_obj.finished_reason:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -29,6 +29,7 @@ import uuid
 from collections import deque
 from contextlib import nullcontext
 from datetime import datetime
+from enum import Enum
 from http import HTTPStatus
 from typing import (
     Any,
@@ -122,7 +123,6 @@ from sglang.srt.metrics.collector import TokenizerMetricsCollector
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import (
-    ServerStatus,
     dataclass_to_string_truncated,
     get_bool_env_var,
     get_zmq_socket,
@@ -180,7 +180,6 @@ class TokenizerManager:
         server_args: ServerArgs,
         port_args: PortArgs,
     ):
-        self.server_status = ServerStatus.Starting
         # Parse args
         self.server_args = server_args
         self.enable_metrics = server_args.enable_metrics
@@ -258,6 +257,7 @@ class TokenizerManager:
         self.health_check_failed = False
         self.gracefully_exit = False
         self.last_receive_tstamp = 0
+        self.server_status = ServerStatus.Starting
 
         # Dumping
         self.dump_requests_folder = ""  # By default do not dump
@@ -1904,6 +1904,16 @@ class TokenizerManager:
             scores.append(score_list)
 
         return scores
+
+
+class ServerStatus(Enum):
+    Up = "Up"
+    Starting = "Starting"
+    UnHealthy = "UnHealthy"
+    Crashed = "Crashed"
+
+    def is_healthy(self) -> bool:
+        return self == ServerStatus.Up
 
 
 def _determine_tensor_transport_mode(server_args: ServerArgs) -> TensorTransportMode:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -121,6 +121,7 @@ from sglang.srt.metrics.collector import TokenizerMetricsCollector
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import (
+    ServerStatus,
     dataclass_to_string_truncated,
     get_bool_env_var,
     get_zmq_socket,
@@ -178,6 +179,7 @@ class TokenizerManager:
         server_args: ServerArgs,
         port_args: PortArgs,
     ):
+        self.server_status = ServerStatus.Starting
         # Parse args
         self.server_args = server_args
         self.enable_metrics = server_args.enable_metrics

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -44,7 +44,6 @@ import traceback
 import warnings
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
-from enum import Enum
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
@@ -92,19 +91,6 @@ logger = logging.getLogger(__name__)
 
 show_time_cost = False
 time_infos = {}
-
-
-#########################
-# Constants & Enums
-#########################
-class ServerStatus(Enum):
-    Up = "Up"
-    Starting = "Starting"
-    UnHealthy = "UnHealthy"
-    Crashed = "Crashed"
-
-    def is_healthy(self) -> bool:
-        return self == ServerStatus.Up
 
 
 HIP_FP8_E4M3_FNUZ_MAX = 224.0

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -93,6 +93,20 @@ logger = logging.getLogger(__name__)
 show_time_cost = False
 time_infos = {}
 
+
+#########################
+# Constants & Enums
+#########################
+class ServerStatus(Enum):
+    Up = "Up"
+    Starting = "Starting"
+    UnHealthy = "UnHealthy"
+    Crashed = "Crashed"
+
+    def is_healthy(self) -> bool:
+        return self == ServerStatus.Up
+
+
 HIP_FP8_E4M3_FNUZ_MAX = 224.0
 
 


### PR DESCRIPTION
Although PR #8115 (which introduced a refined health check mechanism) has been reverted, the core issues it aimed to address—inadequate health monitoring in production and cloud-native environments—remain unresolved. 

Merge the routing logic of the original /health and /health_generate endpoints. To maintain compatibility, both routes will be retained but will follow the same logic:

Step 1: When sglang starts, initialize the state as Starting. Once the warmup request succeeds, set the state to Healthy.

Step 2: Only when the state is Healthy will the system intelligently determine whether it can successfully generate a token based on the load situation to judge if the current server is healthy.

This PR, combined with Kubernetes probes, ensures that traffic is only routed to the engine after it has fully started, and the health_generate logic will only be executed when the engine is running normally.

CC @ByronHsu   @merrymercy 