### PR TITLE
Remove deprecated cafile parameter in http_request

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -7,6 +7,7 @@ import os
 import random
 import signal
 import socket
+import ssl
 import subprocess
 import sys
 import time
@@ -156,7 +157,11 @@ def http_request(
             data = bytes(dumps(json), encoding="utf-8")
 
         try:
-            resp = urllib.request.urlopen(req, data=data, cafile=verify)
+            if verify is not None:
+                context = ssl.create_default_context(cafile=verify)
+                resp = urllib.request.urlopen(req, data=data, context=context)
+            else:
+                resp = urllib.request.urlopen(req, data=data)
             return HttpResponse(resp)
         except urllib.error.HTTPError as e:
             return HttpResponse(e)


### PR DESCRIPTION
## Motivation

Fix issue #3876 

## Modifications

Replace deprecated cafile parameter with SSL context in urllib.request.urlopen

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
