### PR TITLE
[sgl-kernel performace] fix fp8 quant kernels dispatch __nv_fp8_e4m3 bug to improve performance 10%-20%

### DIFF
--- a/sgl-kernel/csrc/gemm/per_token_group_quant_8bit.cu
+++ b/sgl-kernel/csrc/gemm/per_token_group_quant_8bit.cu
@@ -1,5 +1,4 @@
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/util/Float8_e4m3fn.h>
 #include <cuda_fp8.h>
 
 #include <cmath>


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Follow: https://github.com/sgl-project/sglang/pull/8449

Thanks to @strgrb .

To boost kernel performance, we recommend using the `__nv_fp8_e4m3` data type instead of `c10::Float8_e4m3fn` to do float->fp8 dtype. This change reduces the number of instructions needed for data conversion, which in turn optimizes overall execution efficiency.

<img width="1503" height="720" alt="图片" src="https://github.com/user-attachments/assets/4cd106a4-5836-4c24-8c08-d1428d38bc68" />


From the SASS code in ncu, we can find that current kernel use many instructions to do convert float to fp8 :

```shell
// 第1次调用
MOV R8, 0xc50
CALL.REL.NOINC 0x7fce7d7975c0

// 第2次调用  
MOV R8, 0xe50
CALL.REL.NOINC 0x7fce7d7975c0

// 第3次调用
MOV R8, 0x1080
CALL.REL.NOINC 0x7fce7d7975c0

// 第4次调用
MOV R8, 0x1290
CALL.REL.NOINC 0x7fce7d7975c0

// 第5次调用
MOV R8, 0x14b0
CALL.REL.NOINC 0x7fce7d7975c0

// 第6次调用
MOV R8, 0x16c0
CALL.REL.NOINC 0x7fce7d7975c0

// 第7次调用
MOV R8, 0x18e0
CALL.REL.NOINC 0x7fce7d7975c0

// 第8次调用
MOV R8, 0x1af0
CALL.REL.NOINC 0x7fce7d7975c0

// 第9次调用
MOV R8, 0x1d10
CALL.REL.NOINC 0x7fce7d7975c0


```

<img width="838" height="310" alt="图片" src="https://github.com/user-attachments/assets/80b02819-3bbd-45cb-b784-109f88774ff8" />


With pr fix:

<img width="747" height="221" alt="图片" src="https://github.com/user-attachments/assets/fea750f4-80d6-4e15-89fc-63ec71d4f0f4" />

The performance degradation of `c10::Float8_e4m3fn` primarily stems from its reliance on software-implemented conversion functions instead of hardware-accelerated FP8 conversion instructions. This leads to a significant increase in the number of instructions, higher branch prediction overhead, and changes in memory access patterns.

## Benchmark In B200

10%-20% performance improvement.

### main branch

```shell

➜  sgl-kernel git:(main) ✗ python3 /home/yineng/bbuf/sglang/sgl-kernel/benchmark/bench_per_tensor_quant_fp8.py
INFO 07-28 20:40:56 [__init__.py:235] Automatically detected platform cuda.
✅ All implementations match
per-tensor-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    26.272001    25.792001
1         16.0    128.0    36.704000    32.671999
2         16.0    256.0    51.328000    45.024000
3         16.0    512.0    92.160001    77.760004
4         16.0   1024.0   171.744004   143.296003
5         16.0   2048.0   317.344010   264.463991
6         32.0     64.0    36.736000    32.607999
7         32.0    128.0    51.360000    45.024000
8         32.0    256.0    92.160001    77.823997
9         32.0    512.0   171.072006   143.424004
10        32.0   1024.0   317.312002   264.335990
11        32.0   2048.0   604.319990   501.488000
12        64.0     64.0    51.295999    44.992000
13        64.0    128.0    92.160001    77.760004
14        64.0    256.0   170.975998   143.552005
15        64.0    512.0   317.279994   264.351994
16        64.0   1024.0   603.327990   501.568019
17        64.0   2048.0  1178.463995   957.280010
18       128.0     64.0    92.128001    77.791996
19       128.0    128.0   170.816004   143.391997
20       128.0    256.0   317.247987   264.272004
21       128.0    512.0   603.456020   501.215994
22       128.0   1024.0  1178.591967   957.583994
23       128.0   2048.0  2327.423930  1868.095994

➜  sgl-kernel git:(main) ✗ python3 /home/yineng/bbuf/sglang/sgl-kernel/benchmark/bench_per_token_quant_fp8.py 
INFO 07-28 20:41:36 [__init__.py:235] Automatically detected platform cuda.
✅ All implementations match
per-token-dynamic-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    21.183999    21.472000
1         16.0    128.0    28.511999    30.751999
2         16.0    256.0    43.903999    47.263999
3         16.0    512.0    78.879997    73.760003
4         16.0   1024.0   140.159994   131.040007
5         16.0   2048.0   265.632004   228.128001
6         16.0   4096.0   518.335998   424.495995
7         32.0     64.0    28.511999    30.688001
8         32.0    128.0    43.712001    47.375999
9         32.0    256.0    78.911997    73.951997
10        32.0    512.0   140.320003   131.072000
11        32.0   1024.0   265.760005   228.095993
12        32.0   2048.0   518.527985   424.416006
13        32.0   4096.0  1014.143944   799.488008
14        64.0     64.0    43.552000    47.263999
15        64.0    128.0    78.752004    73.696002
16        64.0    256.0   140.223995   131.007999
17        64.0    512.0   265.695989   228.192002
18        64.0   1024.0   518.416017   424.383998
19        64.0   2048.0  1014.783978   799.647987
20        64.0   4096.0  2010.143995  1548.256040
21       128.0     64.0    78.815997    73.792003
22       128.0    128.0   140.223995   130.943999
23       128.0    256.0   265.632004   227.904007
24       128.0    512.0   518.335998   424.224004
25       128.0   1024.0  1014.719963   799.647987
26       128.0   2048.0  2009.183884  1548.287988
27       128.0   4096.0  3996.495962  3045.552015
```

### pr

```shell

  sgl-kernel git:(main) ✗ python3 /home/yineng/bbuf/sglang/sgl-kernel/benchmark/bench_per_tensor_quant_fp8.py 
INFO 07-28 21:53:16 [__init__.py:235] Automatically detected platform cuda.
✅ All implementations match
per-tensor-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    25.984000    23.968000
1         16.0    128.0    36.160000    28.096000
2         16.0    256.0    51.231999    36.800001
3         16.0    512.0    92.096001    61.087999
4         16.0   1024.0   171.552002   110.656001
5         16.0   2048.0   317.088008   206.367999
6         32.0     64.0    36.095999    27.968001
7         32.0    128.0    51.199999    36.575999
8         32.0    256.0    92.096001    60.927998
9         32.0    512.0   171.072006   110.912003
10        32.0   1024.0   316.832006   206.432000
11        32.0   2048.0   604.031980   399.648011
12        64.0     64.0    51.199999    36.640000
13        64.0    128.0    92.096001    60.736001
14        64.0    256.0   170.992002   110.944003
15        64.0    512.0   316.927999   206.367999
16        64.0   1024.0   603.200018   399.951994
17        64.0   2048.0  1177.872002   772.351980
18       128.0     64.0    93.152002    60.800001
19       128.0    128.0   170.975998   111.231998
20       128.0    256.0   316.895992   206.432000
21       128.0    512.0   603.424013   399.744004
22       128.0   1024.0  1178.319991   773.343980
23       128.0   2048.0  2327.344060  1525.455952

➜  sgl-kernel git:(main) ✗ python3 /home/yineng/bbuf/sglang/sgl-kernel/benchmark/bench_per_token_quant_fp8.py
INFO 07-28 21:52:31 [__init__.py:235] Automatically detected platform cuda.
✅ All implementations match
per-token-dynamic-quant-fp8-performance:
    batch_size  seq_len         VLLM   SGL Kernel
0         16.0     64.0    21.600001    19.936001
1         16.0    128.0    28.352000    28.543999
2         16.0    256.0    43.903999    36.991999
3         16.0    512.0    78.879997    56.768000
4         16.0   1024.0   140.592001   105.952002
5         16.0   2048.0   266.240001   183.487996
6         16.0   4096.0   519.136012   337.280005
7         32.0     64.0    29.088000    28.960001
8         32.0    128.0    44.415999    37.856001
9         32.0    256.0    79.328001    56.832001
10        32.0    512.0   140.415996   105.407998
11        32.0   1024.0   265.695989   182.559997
12        32.0   2048.0   518.735975   336.511999
13        32.0   4096.0  1014.271975   642.080009
14        64.0     64.0    45.952000    37.184000
15        64.0    128.0    79.200000    56.864001
16        64.0    256.0   140.640005   106.016003
17        64.0    512.0   266.207993   183.359995
18        64.0   1024.0   519.263983   337.568015
19        64.0   2048.0  1015.504003   643.136024
20        64.0   4096.0  2060.096025  1255.615950
21       128.0     64.0    81.568003    56.832001
22       128.0    128.0   140.799999   105.696000
23       128.0    256.0   266.463995   182.720006
24       128.0    512.0   519.263983   336.928010
25       128.0   1024.0  1015.679955   643.215984
26       128.0   2048.0  2011.104107  1271.391988
27       128.0   4096.0  4044.928074  2506.623983
```

Tests passed too.

<img width="1140" height="251" alt="图片" src="https://github.com/user-attachments/assets/eb6b8e06-1c23-42c9-8536-7186d6c405e6" />


## Modifications

<!-- Describe the changes made in this PR. -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
