### PR TITLE
Bug: apply final_hidden_states*=self.routed_scaling_factor at MoE lay…

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -473,7 +473,7 @@ class EPMoE(FusedMoE):
             m_max * self.start_expert_id,
             BLOCK_SIZE=512,
         )
-        return output
+        return output * self.routed_scaling_factor
 
     def forward_normal(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
         return self.quant_method.apply(self, hidden_states, topk_output)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -506,7 +506,7 @@ class DeepseekV2MoE(nn.Module):
         else:
             kwargs["router_logits"] = router_logits
         final_hidden_states = self.experts(**kwargs)
-        if not _is_cuda and not _use_aiter or global_server_args_dict["enable_ep_moe"]:
+        if not _is_cuda and not _use_aiter:
             # fused in biased_grouped_topk so we can skip here
             # TODO: please fix me
             # However, biased_grouped_topk is not guaranteed to run *=self.routed_scaling_factor when not _is_cuda and not _use_aiter

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -508,9 +508,6 @@ class DeepseekV2MoE(nn.Module):
         final_hidden_states = self.experts(**kwargs)
         if not _is_cuda and not _use_aiter:
             # fused in biased_grouped_topk so we can skip here
-            # TODO: please fix me
-            # However, biased_grouped_topk is not guaranteed to run *=self.routed_scaling_factor when not _is_cuda and not _use_aiter
-            # In addition, `self.experts` sometimes run *=self.routed_scaling_factor again during TP & deepep
             final_hidden_states *= self.routed_scaling_factor
         if shared_output is not None:
             final_hidden_states = final_hidden_states + shared_output

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -506,8 +506,11 @@ class DeepseekV2MoE(nn.Module):
         else:
             kwargs["router_logits"] = router_logits
         final_hidden_states = self.experts(**kwargs)
-        if not _is_cuda and not _use_aiter:
+        if not _is_cuda and not _use_aiter or global_server_args_dict["enable_ep_moe"]:
             # fused in biased_grouped_topk so we can skip here
+            # TODO: please fix me
+            # However, biased_grouped_topk is not guaranteed to run *=self.routed_scaling_factor when not _is_cuda and not _use_aiter
+            # In addition, `self.experts` sometimes run *=self.routed_scaling_factor again during TP & deepep
             final_hidden_states *= self.routed_scaling_factor
         if shared_output is not None:
             final_hidden_states = final_hidden_states + shared_output


### PR DESCRIPTION
…er if epmoe is enabled

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation


Issue: https://github.com/sgl-project/sglang/issues/8402

Also noticed significant regression when running epmoe during recent GLM4.5 support work: GSM8K accuracy drops from 0.965 to 0.745 when EPMOE is enabled. Accuracy is good for TP & DeepEP.

```
python3 -m sglang.launch_server --model  /shared/public/elr-models/zai-org/GLM-4.5 --tp-size 8 --trust-remote-code

python3 benchmark/gsm8k/bench_sglang.py
```

## Modifications

There is a bug in DeepSeek-V2 and GLM-4.5 related to how routed_scaling_factor is applied in MoE (Mixture-of-Experts) layers.

Currently, the routed_scaling_factor is applied in three different places, leading to ambiguity:
- self.topk.forward: The scaling is applied only in the n out of m condition, but not in the m - n out of m condition.
- self.experts.forward: Same as above — the factor is only applied in n out of m.
- Model-level logic: The model itself may apply routed_scaling_factor, but it cannot know whether self.topk or self.experts have already done so.

This results in uncertain and inconsistent scaling, as the model layer has no visibility into whether routed_scaling_factor has already been applied upstream.

🎪 TL;DR: The model can't know if it should apply * routed_scaling_factor or not, because topk and experts may or may not have already done it, depending on the code path.

My PR forces model layer to apply * routed_scaling_factor when EPMOE is enabled because from the current codebase, epmoe won't apply *routed_scaling_factor by itself. 

Need to follow up and possibly refactor sglang moe codebase to make it clear which layer should apply * routed_scaling_factor 

## Accuracy Test
- GLM4.5 GSM8K accuracy jumps from 0.745 to 0.965 under EPMOE which is the same as TP & DeepEP results
- Need to run gsm8k for deepseek-v3 too - WIP
## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
