### PR TITLE
feature(pd-hicache): Prefill instances support reusing the RemoteStorage Cache via HiCache.

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1281,6 +1281,9 @@ class Scheduler(
     def _add_request_to_queue(self, req: Req):
         req.queue_time_start = time.perf_counter()
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            if self.enable_hicache_storage:
+                self._prefetch_from_remote(req)
+
             self.disagg_prefill_bootstrap_queue.add(
                 req, self.model_config.num_key_value_heads
             )
@@ -1288,15 +1291,20 @@ class Scheduler(
             self.disagg_decode_prealloc_queue.add(req)
         else:
             if self.enable_hicache_storage:
-                req.init_next_round_input(self.tree_cache)
-                last_hash = req.last_host_node.get_last_hash_value()
-                matched_len = len(req.prefix_indices) + req.host_hit_length
-                if (matched_len > 0 and last_hash is not None) or matched_len == 0:
-                    new_input_tokens = req.fill_ids[matched_len:]
-                    self.tree_cache.prefetch_from_storage(
-                        req.rid, req.last_host_node, new_input_tokens, last_hash
-                    )
+                self._prefetch_from_remote(req)
+
             self.waiting_queue.append(req)
+
+    def _prefetch_from_remote(self, req: Req):
+        if self.enable_hicache_storage:
+            req.init_next_round_input(self.tree_cache)
+            last_hash = req.last_host_node.get_last_hash_value()
+            matched_len = len(req.prefix_indices) + req.host_hit_length
+            if (matched_len > 0 and last_hash is not None) or matched_len == 0:
+                new_input_tokens = req.fill_ids[matched_len:]
+                self.tree_cache.prefetch_from_storage(
+                    req.rid, req.last_host_node, new_input_tokens, last_hash
+                )
 
     def _extend_requests_to_queue(self, reqs: List[Req], is_retracted: bool = False):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1281,25 +1281,22 @@ class Scheduler(
     def _add_request_to_queue(self, req: Req):
         req.queue_time_start = time.perf_counter()
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            if self.enable_hicache_storage:
-                self._prefetch_from_remote(req)
-
+            self._prefetch_kvcache(req)
             self.disagg_prefill_bootstrap_queue.add(
                 req, self.model_config.num_key_value_heads
             )
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             self.disagg_decode_prealloc_queue.add(req)
         else:
-            if self.enable_hicache_storage:
-                self._prefetch_from_remote(req)
-
+            self._prefetch_kvcache(req)
             self.waiting_queue.append(req)
 
-    def _prefetch_from_remote(self, req: Req):
+    def _prefetch_kvcache(self, req: Req):
         if self.enable_hicache_storage:
             req.init_next_round_input(self.tree_cache)
             last_hash = req.last_host_node.get_last_hash_value()
             matched_len = len(req.prefix_indices) + req.host_hit_length
+            # todo, free-form fetching, calculating hash keys on the fly
             if (matched_len > 0 and last_hash is not None) or matched_len == 0:
                 new_input_tokens = req.fill_ids[matched_len:]
                 self.tree_cache.prefetch_from_storage(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

co-author: @ShangmingCai 
parent issue: https://github.com/sgl-project/sglang/issues/8210

## Motivation
In the ​previous PR​ (https://github.com/sgl-project/sglang/pull/7704), support for ​HICache + L3 RemoteCache​ (e.g., mooncake/3fs, etc.) was already implemented.

The ​goal of this PR​ is to enable ​KVCache reuse across Prefill instances​ via ​HICache + L3 RemoteCache​ in ​PD-Separation scenarios.


## Modifications

## Test Case (Prefill Cold-Start)
**Step 1: Test Environment Setup​**
Two ​PD-Separation instances​ (each configured as ​1P1D) mount the same ​shared cloud disk​ at /sgl-workspace/mnt/hicache, with ​HICache (file backend)​​ enabled on both.

prefil-decode-startup:
```python
export SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR=/sgl-workspace/mnt/hicache1 && \
python3 -m sglang.launch_server \
    --model-path /sgl-workspace/mnt/models/Qwen3-32B/ \
    --host 0.0.0.0 --port 10000 \
    --page-size 64 \
    --enable-hierarchical-cache \
    --hicache-ratio 2 --hicache-size 0 \
    --hicache-write-policy write_through \
    --hicache-storage-backend file 
     --tp 2 \
    --disaggregation-mode prefill/decode \
    --disaggregation-transfer-backend mooncake`
```


**​Step 2: First Benchmark Execution​**
Launch the benchmark on the ​first PD instance. This will ​populate KVCache​ into /sgl-workspace/mnt/hicache.
```python
Successful requests:                     500       
Benchmark duration (s):                  121.99    
Total input tokens:                      512000    
Total generated tokens:                  64000     
Total generated tokens (retokenized):    57213     
Request throughput (req/s):              4.10      
Input token throughput (tok/s):          4196.95   
Output token throughput (tok/s):         524.62    
Total token throughput (tok/s):          4721.57   
Concurrency:                             117.59    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   28689.37  
Median E2E Latency (ms):                 31680.18  
---------------Time to First Token----------------
Mean TTFT (ms):                          23396.42  
Median TTFT (ms):                        29627.80  
P99 TTFT (ms):                           32693.85  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           15.90     
Median ITL (ms):                         15.45     
P95 ITL (ms):                            17.61     
P99 ITL (ms):                            21.35     
Max ITL (ms):                            348.99   

```


**​Step 3: Second Benchmark Execution​**
Launch the benchmark on the ​second PD instance. The ​Prefill nodes​ can now ​reuse the remote KVCache​ generated by the first group's Prefill nodes ​via HICache.
```python
Successful requests:                     500       
Benchmark duration (s):                  55.46     
Total input tokens:                      512000    
Total generated tokens:                  64000     
Total generated tokens (retokenized):    63997     
Request throughput (req/s):              9.02      
Input token throughput (tok/s):          9231.72   
Output token throughput (tok/s):         1153.96   
Total token throughput (tok/s):          10385.68  
Concurrency:                             103.06    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11431.72  
Median E2E Latency (ms):                 10687.77  
---------------Time to First Token----------------
Mean TTFT (ms):                          8061.64   
Median TTFT (ms):                        7119.13   
P99 TTFT (ms):                           15846.01  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           26.54     
Median ITL (ms):                         26.71     
P95 ITL (ms):                            40.98     
P99 ITL (ms):                            47.05     
Max ITL (ms):                            210.27 

```



## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
