### PR TITLE
update cudnn to support cuda graph capture with FP4 quantization

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,6 +171,9 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.31.1/cmake-3.31.1
     && cp -r cmake-3.31.1-linux-x86_64/share/* /usr/local/share/ \
     && rm -rf cmake-3.31.1-linux-x86_64 cmake-3.31.1-linux-x86_64.tar.gz
 
+# Upgrade cuDNN to support FP4 quantization (requires version >= 9.1.002)
+RUN python3 -m pip install --upgrade --force-reinstall nvidia-cudnn-cu12
+
 # Add yank script
 COPY --chown=root:root <<-"EOF" /usr/local/bin/yank
 #!/bin/bash


### PR DESCRIPTION
upgrade cudnn to fix the error when using fp4 quantization with cudagraph.
```
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 362, in __init__
    raise Exception(
Exception: Capture cuda graph failed: cuDNN FP4 requires backend version >= 91002, found 90701. Please upgrade cuDNN backend.
```

