### PR TITLE
[Optimization][Perf] Disable the GC during CUDA graph capture to speed up by up to 3x

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -215,6 +215,7 @@ class ServerArgs:
     disable_cuda_graph: bool = False
     disable_cuda_graph_padding: bool = False
     enable_profile_cuda_graph: bool = False
+    enable_cudagraph_gc: bool = False
     enable_nccl_nvls: bool = False
     enable_tokenizer_batch_encode: bool = False
     disable_outlines_disk_cache: bool = False
@@ -1550,6 +1551,11 @@ class ServerArgs:
             "--enable-profile-cuda-graph",
             action="store_true",
             help="Enable profiling of cuda graph capture.",
+        )
+        parser.add_argument(
+            "--enable-cudagraph-gc",
+            action="store_true",
+            help="Enable garbage collection during CUDA graph capture. If disabled (default), GC is frozen during capture to speed up the process.",
         )
         parser.add_argument(
             "--enable-nccl-nvls",


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Disable the Python GC during the CUDA graph capture, to speed up the capture process and startup time. **Disabling Python GC during CUDA graph capture resulted in a 2.3x–3.7x speedup in capture time.**

Speedup occurs because `gc.freeze()` prevents Python's garbage collector from scanning long-lived objects during CUDA graph capture, eliminating `gc.collect()` overhead.

From https://github.com/vllm-project/vllm/pull/21146, thanks to @mgoin for the original idea!

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Freeze the GC.

<!-- Describe the changes made in this PR. -->

## Accuracy Test
`lm-eval` is the same.

## Benchmark & Profiling

For Llama4 and Qwen3, fresh container environment on both. I believe the CUDA graph capture is disabled on server shutdown so it does not matter, but I did so anyway. I used the default CUDA graph capture sizes without any overrides.

 ###  Before & After: for `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`
```
Capturing batches (bs=1 avail_mem=8.89 GB): 100%|█████████████████████████████| 23/23 [00:25<00:00,  1.09s/it]
```
After:
```
Capturing batches (bs=1 avail_mem=8.89 GB): 100%|█████████████████████████████| 23/23 [00:10<00:00,  2.25it/s]
```

###  Before & After: for `Qwen/Qwen3-0.6B` (small model)
```
Capturing batches (bs=1 avail_mem=7.61 GB): 100%|█████████████████████████████| 23/23 [00:06<00:00,  3.55it/s]
```

```
Capturing batches (bs=1 avail_mem=7.61 GB): 100%|█████████████████████████████| 23/23 [00:01<00:00, 13.31it/s]
```