### PR TITLE
[Bugfix] Reasoning parser must not drop parts of xml tags

### DIFF
--- a/python/sglang/srt/reasoning_parser.py
+++ b/python/sglang/srt/reasoning_parser.py
@@ -105,7 +105,7 @@ class BaseReasoningFormatDetector:
         # If we're not in a reasoning block return as normal text
         if not self._in_reasoning:
             self._buffer = ""
-            return StreamingParseResult(normal_text=new_text)
+            return StreamingParseResult(normal_text=current_text)
 
         return StreamingParseResult()
 

--- a/test/srt/test_reasoning_parser.py
+++ b/test/srt/test_reasoning_parser.py
@@ -147,6 +147,45 @@ class TestBaseReasoningFormatDetector(CustomTestCase):
         self.assertEqual(result.reasoning_text, "reasoning")
         self.assertEqual(result.normal_text, "normal")
 
+    def test_parse_streaming_increment_mixed_content_chunks(self):
+        """Test streaming parse with mixed content in multiple chunks."""
+        chunks = ["<think>", "reasoning", "</think>", "some text"]
+
+        all_reasoning = ""
+        all_normal = ""
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk)
+            all_reasoning += result.reasoning_text
+            all_normal += result.normal_text
+
+        self.assertEqual(all_reasoning, "reasoning")
+        self.assertEqual(all_normal, "some text")
+
+    def test_parse_streaming_increment_mixed_content_chunks_with_xml_tags(self):
+        """Test streaming parse with mixed content in multiple chunks."""
+        chunks = [
+            "<think>",
+            "reasoning",
+            "</think>",
+            "<",
+            "MY_TOOL",
+            ">",
+            "text",
+            "</",
+            "MY_TOOL",
+            ">",
+        ]
+
+        all_reasoning = ""
+        all_normal = ""
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk)
+            all_reasoning += result.reasoning_text
+            all_normal += result.normal_text
+
+        self.assertEqual(all_reasoning, "reasoning")
+        self.assertEqual(all_normal, "<MY_TOOL>text</MY_TOOL>")
+
 
 class TestDeepSeekR1Detector(CustomTestCase):
     def setUp(self):


### PR DESCRIPTION
## Motivation

In streaming mode, the sglang reasoning parser buffers chunks that can be completed to an opening <think> token. Unfortunately, when the reasoning parser finds out that the buffered text was NOT part of a think token, only the new text is returned, but not the full buffer. As a result, xml-like model output that comes in chunks like `"<", "my-tag", ">"` will be scrambled to just `"my-tag", ">"`. 

## Modifications

The reasoning parser now flushes the entire buffer (not just the new text) once it knows that the buffer can not be completed to a think token. 

## Unit Tests

Two tests were added:
- test_parse_streaming_increment_mixed_content_chunks
- test_parse_streaming_increment_mixed_content_chunks_with_xml_tags (this one failed without the suggested modification)
