### PR TITLE
[Feature] Add support for TNG-R1T2-Chimera tool call parsing.

### DIFF
--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -18,6 +18,7 @@ from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.srt.function_call.tng_r1t2_detector import TngR1T2Detector
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ class FunctionCallParser:
         "qwen3_coder": Qwen3CoderDetector,
         "glm45": Glm4MoeDetector,
         "step3": Step3Detector,
+        "tng_r1t2": TngR1T2Detector,
     }
 
     def __init__(self, tools: List[Tool], tool_call_parser: str):

--- a/python/sglang/srt/function_call/tng_r1t2_detector.py
+++ b/python/sglang/srt/function_call/tng_r1t2_detector.py
@@ -1,0 +1,48 @@
+import logging
+from typing import List
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.function_call.ebnf_composer import EBNFComposer
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+
+logger = logging.getLogger(__name__)
+
+
+class TngR1T2Detector(Qwen25Detector):
+    """
+    Detector for tngtech/DeepSeek-TNG-R1T2-Chimera call format.
+
+    Format Structure (identical to Qwen25):
+    ```
+    <tool_call>\n{"name":"func1", "arguments":{...}}\n</tool_call>\n<tool_call>\n{"name":"func2", "arguments":{...}}\n</tool_call>
+    ```
+
+    In contrast to Qwen2.5 models, the TNG-R1T2 model does not generate `<tool_call>` and `</tool_call>`
+    as single tokens but in multiple chunks. (e.g., ['<', 'tool', '_call', '>\n'] and ['</', 'tool', '_call', '>']).
+    While the Qwen25Detector can handle
+    - non-streamed messages (here, there is effectively no difference to Qwen-2.5)
+    - streamed messages with tool_choice=auto (here, no structure constraints are effective)
+    - streamed messages with strict tool formats
+
+    Qwen25Detector fails, however, for tool_choice=auto requests that make use of EBNF grammar.
+    The reason is that the model tends to generate closing tool call tags with trailing newline
+    (like ['</', 'tool', '_call', '>\n']), which satisfies the EBNF grammar ONLY IF it is followed
+    by another tool call.
+    The TngR1T2Detector solves this issue by accepting a trailing newline after the closing </tool_call> tag
+    in the EBNF grammar.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<tool_call>\n"
+        self.eot_token = "\n</tool_call>"
+        self.tool_call_separator = "\n"
+
+    def build_ebnf(self, tools: List[Tool]):
+        return EBNFComposer.build_ebnf(
+            tools,
+            individual_call_start_token=self.bot_token.replace("\n", "\\n"),
+            individual_call_end_token=self.eot_token.replace("\n", "\\n") + "\\n",
+            tool_call_separator="\\n",
+            function_format="json",
+        )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1130,9 +1130,10 @@ class ServerArgs:
                 "qwen3_coder",
                 "glm45",
                 "step3",
+                "tng_r1t2",
             ],
             default=ServerArgs.tool_call_parser,
-            help="Specify the parser for handling tool-call interactions. Options include: 'qwen25', 'mistral', 'llama3', 'deepseekv3', 'pythonic', 'kimi_k2', 'qwen3_coder', 'glm45', and 'step3'.",
+            help="Specify the parser for handling tool-call interactions. Options include: 'qwen25', 'mistral', 'llama3', 'deepseekv3', 'pythonic', 'kimi_k2', 'qwen3_coder', 'glm45', 'step3', and 'tng_r1t2'.",
         )
 
         # Data parallelism


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR adds full tool calling support for models like tngtech/DeepSeek-TNG-R1T2-Chimera. 
The supported tool call format is almost fully compatible with qwen25, i.e. `<tool_call>\n{"name": "my_tool", "arguments": {...}}\n</tool_call>`. The key difference is that TNG-R1T2 does not use single-token representations for `<tool_call>` and `</tool_call>`, unlike Qwen2.5. 
While Qwen25Detector can be used 
- for parsing non-streamed tool calls
- for parsing streamed tool calls without structure constraint
- for parsing streamed tool calls with strutural tags
it fails to reliably end generation when used with EBNF (i.e. for tool_choice=required). 
This PR adds a slightly different EBNF grammar to fully support models like TNG-R1T2. 

## Modifications

Because the closing </tool_call> tag is not a single token, it is often generated as `['</', 'tool', '_call', '>\n']` with a trailing newline. During generation without structural constraint, this is completely fine with Qwen25Detector. 
However, the EBNF grammar for qwen25 only allows a trailing newline if it is followed by another tool call. As a consequence, TNG-R1T2 would generate multiple tool calls, often only stopped by length limit.

This PR solves the issue by explicitly adding the newline to the expected closing tag `</tool_call>\n`. That way, the generation can easily stop. It is still possible for the model to continue generating multiple tool calls if desired by the user prompt. 
