### PR TITLE
chore(gb200): update dockerfile to handle fp4 disaggregation

### DIFF
--- a/docker/Dockerfile.gb200
+++ b/docker/Dockerfile.gb200
@@ -53,12 +53,10 @@ RUN mkdir -p /tmp/gdrcopy && cd /tmp \
 RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libmlx5.so.1 /usr/lib/$(uname -m)-linux-gnu/libmlx5.so
 
 # Clone and install SGLang
-# NOTE: flashinfer v0.2.9rc1 is not installing for aarch64
 WORKDIR /sgl-workspace
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel html5lib six \
- && git clone https://github.com/sgl-project/sglang.git \
+ && git clone --depth 1 https://github.com/sgl-project/sglang.git \
  && cd sglang \
- && git checkout a167fd0bcb9ef4b0f4331a109e40c8cdc770b026 \
  && case "$CUDA_VERSION" in \
       12.6.1) CUINDEX=126 ;; \
       12.8.1) CUINDEX=128 ;; \
@@ -93,7 +91,7 @@ RUN wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.3.9/sour
 # Python tools
 RUN python3 -m pip install --no-cache-dir \
     datamodel_code_generator \
-    mooncake_transfer_engine==0.3.5 \
+    mooncake-transfer-engine==0.3.5 \
     pre-commit \
     pytest \
     black \
@@ -102,6 +100,15 @@ RUN python3 -m pip install --no-cache-dir \
     uv \
     wheel \
     scikit-build-core
+
+# These will be automatically installed by future versions of flashinfer after 0.2.9rc2
+RUN python3 -m pip install --no-cache-dir \
+    nvidia-cudnn-cu12 \
+    nvidia-cudnn-frontend
+
+# Allows for FP4 disaggregation
+RUN python3 -m pip install --no-cache-dir \
+    nixl
 
 # Install development tools and utilities
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This dockerfile allows for FP4 disaggregation with DSR1. The commands are as follows 

prefill

```bash
NCCL_MNNVL_ENABLE=1 \
NCCL_CUMEM_ENABLE=1 \
SGLANG_USE_MESSAGE_QUEUE_BROADCASTER=0 \
PYTHONUNBUFFERED=1 \
python3 -m sglang.launch_server \
--disaggregation-transfer-backend nixl \
--disaggregation-mode decode \
--host 0.0.0.0 \
--decode-log-interval 1 \
--max-running-requests 1536 \
--context-length 4224 \
--max-total-tokens=2048 \
--disable-radix-cache \
--disable-shared-experts-fusion \
--attention-backend cutlass_mla \
--watchdog-timeout 1000000 \
--model-path /model/ \
--served-model-name nvidia/DeepSeek-R1-0528-FP4 \
--trust-remote-code \
--tp-size 4 \
--dp-size 4 \
--enable-dp-attention \
--cuda-graph-bs 64 \
--port 30000 \
--quantization modelopt_fp4 \
--enable-flashinfer-cutlass-moe \
--enable-ep-moe
```

decode

```bash
NCCL_MNNVL_ENABLE=1 \
NCCL_CUMEM_ENABLE=1 \
SGLANG_USE_MESSAGE_QUEUE_BROADCASTER=0 \
SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 \
PYTHONUNBUFFERED=1 \
python3 -m sglang.launch_server \
--disaggregation-transfer-backend nixl \
--disaggregation-mode prefill \
--host 0.0.0.0 \
--decode-log-interval 1 \
--max-running-requests 1536 \
--context-length 4224 \
--disable-radix-cache \
--disable-shared-experts-fusion \
--attention-backend cutlass_mla \
--watchdog-timeout 1000000 \
--model-path /model/ \
--served-model-name nvidia/DeepSeek-R1-0528-FP4 \
--trust-remote-code \
--tp-size 4 \
--dp-size 4 \
--enable-dp-attention \
--disable-cuda-graph \
--chunked-prefill-size 32768 \
--max-total-tokens 131072 \
--port 30000 \
--max-prefill-tokens 32768 \
--quantization modelopt_fp4 \
--enable-flashinfer-cutlass-moe \
--enable-ep-moe
```