### PR TITLE
[Bug] fix green context's incompatibility with `cuda < 12.4`

### DIFF
--- a/sgl-kernel/csrc/spatial/greenctx_stream.cu
+++ b/sgl-kernel/csrc/spatial/greenctx_stream.cu
@@ -7,6 +7,8 @@
 #include "cuda_utils.h"
 #include "greenctx_stream.h"
 
+#if CUDA_VERSION >= 12040
+
 static std::vector<int64_t> create_greenctx_stream_fallback(CUgreenCtx gctx[2]) {
   CUstream streamA, streamB;
   CUcontext ctx;
@@ -94,3 +96,18 @@ std::vector<int64_t> create_greenctx_stream_by_value(int64_t smA, int64_t smB, i
 
   return vec;
 }
+
+#else
+
+std::vector<int64_t> create_greenctx_stream_by_value(int64_t smA, int64_t smB, int64_t device) {
+  TORCH_CHECK(
+      false,
+      "Green Contexts feature requires CUDA Toolkit 12.4 or newer. Current CUDA version: " +
+          std::to_string(CUDA_VERSION));
+
+  // This is a stub function that should never be reached
+  // Return empty vector to satisfy return type requirement
+  return {};
+}
+
+#endif

--- a/sgl-kernel/python/sgl_kernel/spatial.py
+++ b/sgl-kernel/python/sgl_kernel/spatial.py
@@ -14,6 +14,11 @@ def create_greenctx_stream_by_value(
     Returns:
         tuple[ExternalStream, ExternalStream]: The two streams.
     """
+    if torch.version.cuda < "12.4":
+        raise RuntimeError(
+            "Green Contexts feature requires CUDA Toolkit 12.4 or newer."
+        )
+
     if device_id is None:
         device_id = torch.cuda.current_device()
 


### PR DESCRIPTION
```bash
from sgl_kernel import (
File "/usr/local/lib/python3.10/dist-packages/sgl_kernel/__init__.py", line 13, in <module>
from sgl_kernel import common_ops
ImportError: /usr/local/lib/python3.10/dist-packages/sgl_kernel/common_ops.abi3.so: undefined symbol: cuGreenCtxDestroy
```

This will fix the above issue.