### PR TITLE
[Bug] Fix to support compressed tensor 2 4 sparse mm serving in SGLang

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -18,6 +18,9 @@ from compressed_tensors.quantization import (
     QuantizationType,
 )
 from pydantic import BaseModel
+from transformers.utils.quantization_config import (
+    CompressedTensorsConfig as HfCompressedTensorsConfig,
+)
 
 from sglang.srt.layers.quantization.base_config import (
     LinearMethodBase,
@@ -40,6 +43,9 @@ from sglang.srt.layers.quantization.compressed_tensors.utils import (
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 
 try:
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_24 import (
+        CompressedTensors24,
+    )
     from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (
         WNA16_SUPPORTED_BITS,
         CompressedTensorsWNA16,
@@ -503,11 +509,13 @@ class CompressedTensorsConfig(QuantizationConfig):
                 else self.config
             )
 
+            cfg = HfCompressedTensorsConfig.from_dict(model_compression_config)
+
             scheme = CompressedTensors24(
                 quantized=weight_quant is not None or input_quant is not None,
                 weight_quant=weight_quant,
                 input_quant=input_quant,
-                model_compression_config=model_compression_config,
+                model_compression_config=cfg,
             )
         elif weight_quant is None:
             logger.warning_once(
@@ -636,6 +644,12 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
         the necessary parameters for the layer. See LinearMethodBase for param
         details
         """
+
+        if hasattr(layer, "prefix") and layer.prefix == "model.layers.0.mlp.down_proj":
+            # from remote_pdb import set_trace
+            # set_trace()
+            pass
+
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.scheme.create_weights(
             layer=layer,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -644,12 +644,6 @@ class CompressedTensorsLinearMethod(LinearMethodBase):
         the necessary parameters for the layer. See LinearMethodBase for param
         details
         """
-
-        if hasattr(layer, "prefix") and layer.prefix == "model.layers.0.mlp.down_proj":
-            # from remote_pdb import set_trace
-            # set_trace()
-            pass
-
         weight_loader = extra_weight_attrs.get("weight_loader")
         layer.scheme.create_weights(
             layer=layer,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -509,7 +509,12 @@ class CompressedTensorsConfig(QuantizationConfig):
                 else self.config
             )
 
-            cfg = HfCompressedTensorsConfig.from_dict(model_compression_config)
+            if model_compression_config is not None:
+                cfg = HfCompressedTensorsConfig.from_dict(model_compression_config)
+            else:
+                raise ValueError(
+                    "model_compression_config is expected for a 2:4 sparse model, but None is found."
+                )
 
             scheme = CompressedTensors24(
                 quantized=weight_quant is not None or input_quant is not None,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
After fix, we can apply vllm sparse mm successfully in our own enhanced Qwen3, Qwen2.5 alike dense model.

We have verfied 2:4 sparse model serving correctness and bandwidth w/wo disaggregated P/D schemes. Both colocated  and P/D in the same machine and different machines' throughputs have been benchmarked. We also provide NV profiling in the following section.

## Modifications

<!-- Describe the changes made in this PR. -->

Layer quantizaiton compressed tensor module, this is the follow up of #7270 to make fully support of vLLM/Redhat compressed tensor format.

With this PR we can support 2:4 sparse model. I also identied the sparse tensor performance issue in benchmarking. High NCCL when serving a dense model is expected (20% increased to 40%), however, from profiling, we didn't efficeint nccl-compute overlap for a dense model:

<img width="400" height="300" alt="pd_workflow_for_dense_overview" src="https://github.com/user-attachments/assets/8b0e4f64-d5bf-4668-9bfc-278026d07af3" />

<img width="400" height="300" alt="pd_workflow_for_dense_zoom_in" src="https://github.com/user-attachments/assets/ffede7b1-74c1-482d-8a14-b09b031eb190" />

## Accuracy Test

This PR does not modify modeling_xx.py .

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

- 80 GB (bf16) 2:4 sparsed model with sparse mm served by SGLANG with {(P1x4)x2}D1x4 scheme:

  <img width="600" height="350" alt="80G_sparse_tensor_workflow" src="https://github.com/user-attachments/assets/fbd185f6-8713-43ee-980e-953f878f42cc" />

  * The vllm sparse mm for bf16 inputs is poorly implemented in cutlass, optimization will be our next work
  * NCCL communication increase from 20 % to 40 % under P/D disaggregation scheme

- compared to the baseline 144 GB 2:4 zero setting Qwen alike model without PD serving scheme:

  <img width="600" height="350" alt="144G_zero_sparse_worload" src="https://github.com/user-attachments/assets/3669ca66-f124-42a9-aa2a-c56c2d0aadf6" />

The overal throughput:

<img width="600" height="350" alt="截屏2025-08-02 19 56 27" src="https://github.com/user-attachments/assets/99b79911-0d11-4b18-b915-b0866f78f66f" />

| P/D scheme           | tp_p | dp_p | tp_d | dp_d | ISL  | OSL | BS  | latency | Input Tput | Output Tput | last token generation | TTFT（s） |
| -------------------- | ---- | ---- | ---- | ---- | ---- | --- | --- | ------- | ---------- | ----------- | --------------------- | ------- |
|  (P1x4)D1x4 \*       | 4    | 1    | 4    | 1    | 2048 | 128 | 256 | 97.8    | 5628.17    | 7055.83     | 105.86                | 93.15   |
|                      | 4    | 1    | 4    | 1    | 2048 | 128 | 128 | 49.6    | 5870.28    | 3310.74     | 36.14                 | 44.66   |
| {(P1x4)x2}D1x4 \* \* | 4    | 1    | 4    | 1    | 2048 | 128 | 256 | 90.29   | 6090.59    | 7779.22     | 35.92                 | 86.08   |
|                      | 4    | 1    | 4    | 1    | 2048 | 128 | 128 | 49.76   | 5781.88    | 3708.59     | 70.31  | 45.34


## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
