### PR TITLE
Fix fused MoE when `routed_scaling_factor is None`

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -280,7 +280,9 @@ class EPMoE(FusedMoE):
             m_max * self.start_expert_id,
             BLOCK_SIZE=512,
         )
-        return output * self.routed_scaling_factor
+        if self.routed_scaling_factor is not None:
+            output *= self.routed_scaling_factor
+        return output
 
 
 class DeepEPMoE(EPMoE):

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -134,9 +134,7 @@ class FusedMoE(torch.nn.Module):
             if not self.enable_flashinfer_cutlass_moe:
                 self.expert_map_gpu = self.expert_map_cpu.to(device="cuda")
 
-        self.routed_scaling_factor = (
-            routed_scaling_factor if routed_scaling_factor is not None else 1.0
-        )
+        self.routed_scaling_factor = routed_scaling_factor
         assert intermediate_size % self.moe_tp_size == 0
         self.intermediate_size_per_partition = intermediate_size // self.moe_tp_size
         self.reduce_results = reduce_results

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -134,7 +134,9 @@ class FusedMoE(torch.nn.Module):
             if not self.enable_flashinfer_cutlass_moe:
                 self.expert_map_gpu = self.expert_map_cpu.to(device="cuda")
 
-        self.routed_scaling_factor = routed_scaling_factor
+        self.routed_scaling_factor = (
+            routed_scaling_factor if routed_scaling_factor is not None else 1.0
+        )
         assert intermediate_size % self.moe_tp_size == 0
         self.intermediate_size_per_partition = intermediate_size // self.moe_tp_size
         self.reduce_results = reduce_results


### PR DESCRIPTION
Reproduction:

```bash
python3 -m sglang.compile_deep_gemm --host=0.0.0.0 --port=8000 --model=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 --tp=8 --trust-remote-code --enable-ep-moe --tool-call-parser=qwen25 --reasoning-parser=qwen3 --context-length=131072
```

Issue:

```bash
  File "/root/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 283, in forward_deepgemm
    return output * self.routed_scaling_factor
TypeError: unsupported operand type(s) for *: 'Tensor' and 'NoneType'
```
