### PR TITLE
[Perf]Use Cooperative Schedule for H100 & H200 & H800 in fp8_blockwise_scaled_grouped_mm

### DIFF
--- a/sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
+++ b/sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
@@ -485,7 +485,8 @@ void sm90_fp8_blockwise_group_mm_dispatch_shape(
   torch::TensorOptions options_int = torch::TensorOptions().dtype(torch::kInt64).device(a.device());
   torch::Tensor problem_sizes_transpose = torch::empty(num_experts * 3, options_int);
 
-  if (a.size(1) > 128) {
+  if (at::cuda::getCurrentDeviceProperties()->multiProcessorCount == 78 && a.size(1) > 128) {
+    // For H20 with K > 128, use Pingpong Schedule
     run_get_group_gemm_starts<MmaConfig0::LayoutSFA, MmaConfig0::LayoutSFB, MmaConfig0::ScaleConfig>(
         expert_offsets,
         a_ptrs,
@@ -517,7 +518,7 @@ void sm90_fp8_blockwise_group_mm_dispatch_shape(
         expert_offsets,
         workspace);
   } else {
-    // Small K
+    // For H20 with K <= 128, and H100 & H200 & H800, use Cooperative Schedule
     run_get_group_gemm_starts<MmaConfig1::LayoutSFA, MmaConfig1::LayoutSFB, MmaConfig1::ScaleConfig>(
         expert_offsets,
         a_ptrs,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Fix https://github.com/sgl-project/sglang/pull/7278#discussion_r2225518835
Migrating fp8_blockwise_scaled_grouped_mm from H20 to H100, H200, and H800 resulted in a performance regression. After in-depth profiling, we identified several key causes of the regression:

1. The reduction in Mainloop execution time may not be enough to cover the Epilogue overhead.
2. The fp8 blockwise calculation logic is to execute 4 Tensor Core MMAs and then 1 CUDA Core FMA. When migrating from H20 to H100, H200, and H800, the time for the 4 Tensor Core MMAs is obviously reduced to 1/4 of the original time. In the Pingpong schedule, the mainloops of the two warp groups are interleaved, which means that CUDA Core FMA cannot be overlapped. Originally, its proportion on H20 was low, but now after migrating to H100, H200, and H800, its proportion has increased significantly, resulting in a decrease in SM Tensor Pipe Throughput.
3. In the Pingpong schedule, the TMA copies smaller tiles and completes the input matrix copying with more requests. This approach is less efficient and causes more Stall Long Scoreboards.

Clearly, the Cooperative Schedule's competition for Tensor Cores can address the issue of declining Tensor Pipe Throughput. Furthermore, Cooperative Epilogue offers pipeline optimizations, which is why we chose to use Cooperative Schedule on the H100, H200, and H800.

Thanks @yuan-luo for reporting the performance regression.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
sgl-kernel/csrc/moe/fp8_blockwise_moe_kernel.cu
<!-- Describe the changes made in this PR. -->

## Accuracy Test
<img width="3448" height="374" alt="image" src="https://github.com/user-attachments/assets/79d73652-16e4-43af-aa27-c82154721606" />

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling(Running on H200)
Before:
<img width="2116" height="486" alt="H200 Baseline" src="https://github.com/user-attachments/assets/5546b4df-07a6-48f5-b00f-cbc2645221b0" />
After:
<img width="2116" height="442" alt="H200 OPT" src="https://github.com/user-attachments/assets/f35031f8-7edc-4893-81c8-ee045861b5d0" />

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
