### PR TITLE
Fix triton kernels topk with keyword arguments

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -649,11 +649,12 @@ def biased_grouped_topk_cpu(
 
 def triton_kernels_topk(
     router_logits: torch.Tensor,
-    topk: torch.Tensor,
+    topk: int,
     renormalize: bool = False,
     sm_first: bool = False,
-):
-    assert renormalize == False, "Triton kernels topk doesn't support renormalize"
+) -> TritonKernelTopKOutput:
+    """Top-k routing for Triton kernels."""
+    assert not renormalize, "Triton kernels topk doesn't support renormalize"
     routing_data, gather_idx, scatter_idx = routing(
         logits=router_logits,
         n_expts_act=topk,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -653,7 +653,7 @@ def triton_kernels_topk(
     renormalize: bool = False,
     sm_first: bool = False,
 ) -> TritonKernelTopKOutput:
-    """Top-k routing for Triton kernels."""
+    """Top-K routing for Triton kernels MoE."""
     assert not renormalize, "Triton kernels topk doesn't support renormalize"
     routing_data, gather_idx, scatter_idx = routing(
         logits=router_logits,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

For the triton kernels topk routing function, the meaning of `sm_first` is not exactly the same as `renormalize`. Use keyword arguments to avoid confusion and unknown bugs.
- If `sm_first` = True, the softmax will before the topk, so the result can be unnormalized before sort. `renormalize` is not supported in triton kernels rounting funciton.
- If `sm_first` = False, the softmax will after the topk, so the result is already normalized, so we don't need to renormalize.