### PR TITLE
[bugfix] fix import path in HiCacheController

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -243,12 +243,12 @@ class HiCacheController:
                 self.storage_backend = HiCacheFile()
                 self.get_hash_str = get_hash_str
             elif storage_backend == "nixl":
-                from sglang.srt.mem_cache.nixl.hicache_nixl import HiCacheNixl
+                from sglang.srt.mem_cache.storage.nixl.hicache_nixl import HiCacheNixl
 
                 self.storage_backend = HiCacheNixl()
                 self.get_hash_str = get_hash_str
             elif storage_backend == "mooncake":
-                from sglang.srt.mem_cache.mooncake_store.mooncake_store import (
+                from sglang.srt.mem_cache.storage.mooncake_store.mooncake_store import (
                     MooncakeStore,
                     get_hash_str_mooncake,
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
In https://github.com/sgl-project/sglang/pull/8719, a new subdirectory 'storage' was added under directory 'mem_cache', and the hicache storage code has been moved into it. However, the import paths of these storages in `HiCacheController`  have not been updated, which will cause the following issue.
```bash
[2025-08-04 12:42:12 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/root/paddlejob/open-sglang/sglang/python/sglang/srt/managers/scheduler.py", line 2534, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/root/paddlejob/open-sglang/sglang/python/sglang/srt/managers/scheduler.py", line 393, in __init__
    self.init_memory_pool_and_cache()
  File "/root/paddlejob/open-sglang/sglang/python/sglang/srt/managers/scheduler.py", line 599, in init_memory_pool_and_cache
    self.tree_cache = HiRadixCache(
                      ^^^^^^^^^^^^^
  File "/root/paddlejob/open-sglang/sglang/python/sglang/srt/mem_cache/hiradix_cache.py", line 76, in __init__
    self.cache_controller = HiCacheController(
                            ^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/open-sglang/sglang/python/sglang/srt/managers/cache_controller.py", line 251, in __init__
    from sglang.srt.mem_cache.mooncake_store.mooncake_store import (
ModuleNotFoundError: No module named 'sglang.srt.mem_cache.mooncake_store'
```

my script:
```bash
export MOONCAKE_TE_META_DATA_SERVER=http://10.96.240.25:8080/metadata
export MOONCAKE_LOCAL_BUFFER_SIZE=1073741824
export MOONCAKE_GLOBAL_SEGMENT_SIZE=3355443200
export MOONCAKE_PROTOCOL=rdma
export MOONCAKE_DEVICE=mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_9
export MOONCAKE_MASTER=10.96.240.25:8931
export LOCAL_HOSTNAME=10.63.64.82
export CUDA_VISIBLE_DEVICES=6,7


nohup python -m sglang.launch_server --model-path /raid0/models/huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct --port 8908 --host 0.0.0.0 --tp 2 --enable-hierarchical-cache --hicache-storage-backend mooncake --hicache-write-policy write_through  > server.log &
```
cc @xiezhq-hermann 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
