### PR TITLE
[bugfix] Fix typo in modelopt quant: 'FusedMoE' object has no attribute 'local_num_experts'

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -776,7 +776,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         # GEMM 1
         w13_weight = ModelWeightParameter(
             data=torch.empty(
-                layer.local_num_experts,
+                layer.num_local_experts,
                 2 * intermediate_size_per_partition,
                 # 2 fp4 items are packed in the input dimension
                 hidden_size // 2,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

After https://github.com/sgl-project/sglang/pull/8552 was merged, I get this error `AttributeError: 'FusedMoE' object has no attribute 'local_num_experts'`. It should be `num_local_experts` instead.
