### PR TITLE
fix benchmark fp8 blockwise group gemm

### DIFF
--- a/sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py
+++ b/sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py
@@ -97,9 +97,7 @@ def bench_deepgemm(
     )
 
     def run_deepgemm():
-        deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
-            x_fp8, y_fp8, out, m_indices
-        )
+        deep_gemm.m_grouped_fp8_gemm_nt_contiguous(x_fp8, y_fp8, out, m_indices)
 
     # warmup
     for _ in range(num_warmup):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

DeepGemm's signature m_grouped_gemm_fp8_fp8_bf16_nt_contiguous has been changed to m_grouped_fp8_gemm_nt_contiguous, so the benchmark bench_fp8_blockwise_group_gemm.py is broken. This PR is to fix it.

Main:
```
➜  sglang_dev git:(main) ✗ python ./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py

Benchmark: expected_m_per_group=128, n=512, k=7168, num_groups=256
Traceback (most recent call last):
  File "/sgl-workspace/sglang_dev/./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py", line 330, in <module>
    main()
  File "/sgl-workspace/sglang_dev/./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py", line 326, in main
    benchmark_one_shape(shape_args, args.num_warmup, args.num_run)
  File "/sgl-workspace/sglang_dev/./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py", line 280, in benchmark_one_shape
    average_time, m = kernel_func(
  File "/sgl-workspace/sglang_dev/./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py", line 106, in bench_deepgemm
    run_deepgemm()
  File "/sgl-workspace/sglang_dev/./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py", line 100, in run_deepgemm
    deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
AttributeError: module 'deep_gemm' has no attribute 'm_grouped_gemm_fp8_fp8_bf16_nt_contiguous'
```

This PR:
```
➜  sglang_dev git:(main) ✗ python ./sgl-kernel/benchmark/bench_fp8_blockwise_group_gemm.py

Benchmark: expected_m_per_group=128, n=512, k=7168, num_groups=256
deepgemm: 492.9952144622803 us
cutlass: 210.7424020767212 us

Benchmark: expected_m_per_group=256, n=512, k=7168, num_groups=256
deepgemm: 491.44320487976074 us
cutlass: 318.9055919647217 us

Benchmark: expected_m_per_group=256, n=256, k=7168, num_groups=256
deepgemm: 492.01598167419434 us
cutlass: 183.2095980644226 us

Benchmark: expected_m_per_group=512, n=256, k=7168, num_groups=256
deepgemm: 471.8592166900635 us
cutlass: 320.3999996185303 us

Benchmark: expected_m_per_group=1, n=512, k=7168, num_groups=256
deepgemm: 470.3775882720947 us
cutlass: 175.3119945526123 us

Benchmark: expected_m_per_group=2, n=256, k=7168, num_groups=256
deepgemm: 440.1088237762451 us
cutlass: 105.60640096664429 us

Benchmark: expected_m_per_group=256, n=4096, k=7168, num_groups=32
deepgemm: 475.15201568603516 us
cutlass: 295.9264039993286 us

Benchmark: expected_m_per_group=512, n=4096, k=7168, num_groups=16
deepgemm: 474.9472141265869 us
cutlass: 273.81439208984375 us

Benchmark: expected_m_per_group=4, n=4096, k=7168, num_groups=32
deepgemm: 461.87520027160645 us
cutlass: 164.88640308380127 us

Benchmark: expected_m_per_group=8, n=4096, k=7168, num_groups=16
deepgemm: 452.09598541259766 us
cutlass: 94.44479942321777 us

Benchmark: expected_m_per_group=1024, n=768, k=4096, num_groups=128
deepgemm: 534.3264102935791 us
cutlass: 529.3888092041016 us

Benchmark: expected_m_per_group=1024, n=4096, k=384, num_groups=128
deepgemm: 479.4015884399414 us
cutlass: 755.3919792175293 us

Benchmark: expected_m_per_group=16, n=768, k=4096, num_groups=128
deepgemm: 453.5520076751709 us
cutlass: 87.94559836387634 us

Benchmark: expected_m_per_group=16, n=4096, k=384, num_groups=128
deepgemm: 436.60478591918945 us
cutlass: 90.79999923706055 us
```

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
