### PR TITLE
[fix] torch 2.8.0 `dtype`, `DLPack`

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -254,6 +254,7 @@ class MHATokenToKVPool(KVCache):
                 np.prod(x.shape[1:]) * x.dtype.itemsize
                 for x in self.k_buffer + self.v_buffer
             ],
+            dtype=torch.int32,
             device=self.device,
         )
 

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1023,7 +1023,7 @@ def broadcast_pyobj(
             size = len(serialized_data)
 
             tensor_data = torch.ByteTensor(
-                np.frombuffer(serialized_data, dtype=np.uint8)
+                np.frombuffer(serialized_data, dtype=np.uint8).copy()
             ).to(device)
             tensor_size = torch.tensor([size], dtype=torch.long, device=device)
 


### PR DESCRIPTION
Fixes 2 errors introduced in https://github.com/sgl-project/sglang/pull/8836

<details>
<summary>`dtype`</summary>

```python
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 2475, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 312, in __init__
    self.tp_worker = TpWorkerClass(
                     ^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 67, in __init__
    self.worker = TpModelWorker(
                  ^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/tp_worker.py", line 84, in __init__
    self.model_runner = ModelRunner(
                        ^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/model_executor/model_runner.py", line 242, in __init__
    self.initialize(min_per_gpu_memory)
  File "/sglang/python/sglang/srt/model_executor/model_runner.py", line 331, in initialize
    self.init_memory_pool(
  File "/sglang/python/sglang/srt/model_executor/model_runner.py", line 1251, in init_memory_pool
    self.token_to_kv_pool = MHATokenToKVPool(
                            ^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 203, in __init__
    self._create_buffers()
  File "/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 252, in _create_buffers
    self.data_strides = torch.tensor(
                        ^^^^^^^^^^^^^
RuntimeError: Could not infer dtype of numpy.int64
```
</details>

<details>
<summary>`DLPack`</summary>

```python
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 2475, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 312, in __init__
    self.tp_worker = TpWorkerClass(
                     ^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 67, in __init__
    self.worker = TpModelWorker(
                  ^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/tp_worker.py", line 151, in __init__
    self.random_seed = broadcast_pyobj(
                       ^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/utils.py", line 1068, in broadcast_pyobj
    tensor_data = torch.ByteTensor(
                  ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/dlpack.py", line 117, in from_dlpack
    dlpack = ext_tensor.__dlpack__()
             ^^^^^^^^^^^^^^^^^^^^^^^
BufferError: Cannot export readonly array since signalling readonly is unsupported by DLPack (supported by newer DLPack version).
```
</details>