### PR TITLE
bench: add attention sink op benchmark, triton and trtllm-gen [B200]

### DIFF
--- a/benchmark/bench_attention_sink/bench_attention_sink_triton.py
+++ b/benchmark/bench_attention_sink/bench_attention_sink_triton.py
@@ -1,0 +1,131 @@
+import argparse
+import itertools
+
+import torch
+import triton
+
+from sglang.srt.layers.attention.triton_ops.decode_attention import (
+    decode_attention_fwd, # not used in gpt oss
+    decode_attention_fwd_grouped,
+)
+from sglang.srt.layers.attention.triton_ops.extend_attention import extend_attention_fwd
+
+# gpt oss
+head_num = 64
+head_dim = 64
+head_kv_num = 8
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["S"],  # sequence length on x-axis
+        x_vals=[128, 256, 512, 1024, 2048, 4096],
+        x_log=True,
+        line_arg="B",  # batch size as different lines
+        line_vals=[1, 8, 32, 128],
+        line_names=["B=1", "B=8", "B=32", "B=128"],
+        styles=[
+            ("blue", "-"),
+            ("green", "-"),
+            ("red", "-"),
+            ("cyan", "-"),
+        ],
+        ylabel="TFLOPS",
+        plot_name="attention-sink-triton",
+        args={},
+    )
+)
+def benchmark(B, S, H_Q, H_KV, D):
+    D_V = D
+    dtype = torch.bfloat16
+    seq_len = S
+    total_tokens = B * seq_len
+    device = torch.device("cuda")
+    sm_scale = 1.0 / (D**0.5)
+    max_kv_splits = 8
+    num_kv_splits = torch.full((B,), 4, dtype=torch.int32, device="cuda")
+
+    # q represents the new token being generated, one per batch
+    q = torch.randn(B, H_Q, D, dtype=dtype, device="cuda")
+
+    # k_buffer and v_buffer represent all previous tokens
+    k_buffer = torch.randn(total_tokens, H_KV, D, dtype=dtype, device="cuda")
+    v_buffer = torch.randn(total_tokens, H_KV, D, dtype=dtype, device="cuda")
+
+    o = torch.zeros(B, H_Q, D_V, dtype=dtype, device="cuda")
+    o_grouped = torch.zeros(B, H_Q, D_V, dtype=dtype, device="cuda")
+
+    b_seq_len = torch.full((B,), seq_len, device="cuda")
+
+    kv_indptr = torch.zeros((B + 1,), dtype=torch.int32, device="cuda")
+    kv_indptr[1 : B + 1] = torch.cumsum(b_seq_len[:B], dim=0)
+    kv_indices = torch.arange(total_tokens, device="cuda")
+
+    attn_logits1 = torch.empty(
+        (B, H_Q, max_kv_splits, D_V),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    attn_lse1 = torch.empty(
+        (B, H_Q, max_kv_splits, D_V),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    sink = torch.randn(H_Q, device=device, dtype=torch.float32)
+
+    # warmup
+    for _ in range(5):
+        decode_attention_fwd_grouped(
+            q,
+            k_buffer,
+            v_buffer,
+            o,
+            kv_indptr,
+            kv_indices,
+            attn_logits1,
+            attn_lse1,
+            num_kv_splits,
+            max_kv_splits,
+            sm_scale,
+            logit_cap=0.0,
+            sinks=sink,
+        )
+
+    # benchmark
+    run_step = 500
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(run_step):
+        decode_attention_fwd_grouped(
+            q,
+            k_buffer,
+            v_buffer,
+            o,
+            kv_indptr,
+            kv_indices,
+            attn_logits1,
+            attn_lse1,
+            num_kv_splits,
+            max_kv_splits,
+            sm_scale,
+            logit_cap=0.0,
+            sinks=sink,
+        )
+    end_event.record()
+    end_event.synchronize()
+    torch.cuda.synchronize()
+    ms = start_event.elapsed_time(end_event) / run_step
+    tflops = lambda ms: (2 * B * S * H_Q * H_KV * D) * 1e-9 / ms  # must be causal
+    return tflops(ms)
+
+
+if __name__ == "__main__":
+    benchmark.run(
+        print_data=True,
+        show_plots=True,
+        save_path="attention-sink-triton",
+        H_Q=head_num,
+        H_KV=head_kv_num,
+        D=head_dim,
+    )
+    print("Benchmark finished!")

--- a/benchmark/bench_attention_sink/bench_attention_sink_triton.py
+++ b/benchmark/bench_attention_sink/bench_attention_sink_triton.py
@@ -192,6 +192,7 @@ def benchmark_extend(B, S, H_Q, H_KV, D):
             max_len_extend=extend_len,
             sm_scale=sm_scale,
             sliding_window_size=sliding_window,
+            sinks=sink,
         )
 
     # benchmark
@@ -224,7 +225,7 @@ def benchmark_extend(B, S, H_Q, H_KV, D):
     ms = start_event.elapsed_time(end_event) / run_step
 
     # FLOPS calculation: each attention operation requires 2 multiplications per element
-    total_flops = 2 * total_extend_tokens * H_Q * (prefill_len + extend_len) * D
+    total_flops = 2 * total_extend_tokens * H_Q * (prefill_len + extend_len / 2) * D
     tflops = lambda ms: total_flops * 1e-12 / (ms * 1e-3)  # convert to TFLOPS
     return tflops(ms)
 

--- a/benchmark/bench_attention_sink/bench_attention_sink_triton.py
+++ b/benchmark/bench_attention_sink/bench_attention_sink_triton.py
@@ -30,11 +30,11 @@ head_kv_num = 8
             ("cyan", "-"),
         ],
         ylabel="TFLOPS",
-        plot_name="attention-sink-triton",
+        plot_name="attention-sink-triton-decode",
         args={},
     )
 )
-def benchmark(B, S, H_Q, H_KV, D):
+def benchmark_decode(B, S, H_Q, H_KV, D):
     D_V = D
     dtype = torch.bfloat16
     seq_len = S
@@ -120,7 +120,7 @@ def benchmark(B, S, H_Q, H_KV, D):
 
 
 if __name__ == "__main__":
-    benchmark.run(
+    benchmark_decode.run(
         print_data=True,
         show_plots=True,
         save_path="attention-sink-triton",

--- a/benchmark/bench_attention_sink/bench_attention_sink_triton.py
+++ b/benchmark/bench_attention_sink/bench_attention_sink_triton.py
@@ -1,12 +1,8 @@
 import argparse
-import itertools
 
 import torch
 import triton
 
-from sglang.srt.layers.attention.triton_ops.decode_attention import (
-    decode_attention_fwd,  # not used in gpt oss
-)
 from sglang.srt.layers.attention.triton_ops.decode_attention import (
     decode_attention_fwd_grouped,
 )
@@ -122,13 +118,131 @@ def benchmark_decode(B, S, H_Q, H_KV, D):
     return tflops(ms)
 
 
-if __name__ == "__main__":
-    benchmark_decode.run(
-        print_data=True,
-        show_plots=True,
-        save_path="attention-sink-triton",
-        H_Q=head_num,
-        H_KV=head_kv_num,
-        D=head_dim,
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["S"],  # sequence length on x-axis
+        x_vals=[128, 256, 512, 1024, 2048, 4096],
+        x_log=True,
+        line_arg="B",  # batch size as different lines
+        line_vals=[1, 8, 32, 128],
+        line_names=["B=1", "B=8", "B=32", "B=128"],
+        styles=[
+            ("blue", "-"),
+            ("green", "-"),
+            ("red", "-"),
+            ("cyan", "-"),
+        ],
+        ylabel="TFLOPS",
+        plot_name="attention-sink-triton-extend",
+        args={},
     )
+)
+def benchmark_extend(B, S, H_Q, H_KV, D):
+    # S here represents N_CTX from the test
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    # Split S into prefix and extend lengths
+    prefill_len = S // 2  # Similar to test's N_CTX // 2
+    extend_len = S // 4  # Make extend length smaller than prefix
+
+    # Calculate total tokens and extend tokens
+    total_extend_tokens = B * extend_len
+    total_prefix_tokens = B * prefill_len
+
+    # Create query, key, value tensors for extension
+    q_extend = torch.randn(total_extend_tokens, H_Q, D, dtype=dtype, device=device)
+    k_extend = torch.randn(total_extend_tokens, H_KV, D, dtype=dtype, device=device)
+    v_extend = torch.randn(total_extend_tokens, H_KV, D, dtype=dtype, device=device)
+    o_extend = torch.empty_like(q_extend)
+
+    # Create key-value buffers for prefix
+    k_buffer = torch.randn(total_prefix_tokens, H_KV, D, dtype=dtype, device=device)
+    v_buffer = torch.randn(total_prefix_tokens, H_KV, D, dtype=dtype, device=device)
+
+    # Create index pointers
+    qo_indptr = torch.arange(0, (B + 1) * extend_len, extend_len, device=device).to(
+        torch.int32
+    )
+    kv_indptr = torch.arange(0, (B + 1) * prefill_len, prefill_len, device=device).to(
+        torch.int32
+    )
+    kv_indices = torch.arange(0, total_prefix_tokens, device=device).to(torch.int32)
+
+    sm_scale = 1.0 / (D**0.5)
+    sliding_window = 128  # From GPT-OSS config
+
+    # warmup
+    for _ in range(5):
+        extend_attention_fwd(
+            q_extend,
+            k_extend,
+            v_extend,
+            o_extend,
+            k_buffer,
+            v_buffer,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            custom_mask=None,
+            is_causal=True,
+            mask_indptr=None,
+            max_len_extend=extend_len,
+            sm_scale=sm_scale,
+            sliding_window_size=sliding_window,
+        )
+
+    # benchmark
+    run_step = 500
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(run_step):
+        extend_attention_fwd(
+            q_extend,
+            k_extend,
+            v_extend,
+            o_extend,
+            k_buffer,
+            v_buffer,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            custom_mask=None,
+            is_causal=True,
+            mask_indptr=None,
+            max_len_extend=extend_len,
+            sm_scale=sm_scale,
+            sliding_window_size=sliding_window,
+        )
+    end_event.record()
+    end_event.synchronize()
+    torch.cuda.synchronize()
+    ms = start_event.elapsed_time(end_event) / run_step
+
+    # FLOPS calculation: each attention operation requires 2 multiplications per element
+    total_flops = (
+        2 * total_extend_tokens * H_Q * (total_prefix_tokens + total_extend_tokens) * D
+    )
+    tflops = lambda ms: total_flops * 1e-12 / (ms * 1e-3)  # convert to TFLOPS
+    return tflops(ms)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bench", type=str, default="all", help="all, extend, decode")
+    args = parser.parse_args()
+
+    kwargs = {
+        "H_Q": head_num,
+        "H_KV": head_kv_num,
+        "D": head_dim,
+    }
+
+    if args.bench in ["all", "decode"]:
+        benchmark_decode.run(print_data=True, show_plots=False, **kwargs)
+
+    if args.bench in ["all", "extend"]:
+        benchmark_extend.run(print_data=True, show_plots=False, **kwargs)
+
     print("Benchmark finished!")

--- a/benchmark/bench_attention_sink/bench_attention_sink_triton.py
+++ b/benchmark/bench_attention_sink/bench_attention_sink_triton.py
@@ -5,7 +5,9 @@ import torch
 import triton
 
 from sglang.srt.layers.attention.triton_ops.decode_attention import (
-    decode_attention_fwd, # not used in gpt oss
+    decode_attention_fwd,  # not used in gpt oss
+)
+from sglang.srt.layers.attention.triton_ops.decode_attention import (
     decode_attention_fwd_grouped,
 )
 from sglang.srt.layers.attention.triton_ops.extend_attention import extend_attention_fwd
@@ -14,6 +16,7 @@ from sglang.srt.layers.attention.triton_ops.extend_attention import extend_atten
 head_num = 64
 head_dim = 64
 head_kv_num = 8
+
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
@@ -115,7 +118,7 @@ def benchmark_decode(B, S, H_Q, H_KV, D):
     end_event.synchronize()
     torch.cuda.synchronize()
     ms = start_event.elapsed_time(end_event) / run_step
-    tflops = lambda ms: (2 * B * S * H_Q * H_KV * D) * 1e-9 / ms  # must be causal
+    tflops = lambda ms: (2 * B * S * H_Q * D) * 1e-9 / ms  # must be causal
     return tflops(ms)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Add attention sink benchmark.
Skip sliding window since full attention could reveal the performance diff.

## Modifications

<!-- Describe the changes made in this PR. -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

attention-sink-triton-decode:
        S       B=1       B=8       B=32      B=128
0   128.0  0.022331  0.181509   0.727048   2.907385
1   256.0  0.045476  0.362345   1.449098   5.416506
2   512.0  0.092769  0.742682   2.983902   9.557173
3  1024.0  0.184653  1.469193   5.899336  12.057570
4  2048.0  0.362013  2.926617  11.414873  13.980454
5  4096.0  0.731054  5.867932  12.725427  15.295053

attention-sink-triton-extend:
        S        B=1         B=8       B=32      B=128
0   128.0   0.689445    6.193939  11.702149  11.601592
1   256.0   3.102890   24.951886  35.724784  34.188172
2   512.0  12.314143   65.555206  73.152077  75.868482
3  1024.0  37.468824   81.788711  86.319996  87.659901
4  2048.0  73.627067   98.199645  94.726409  91.690718
5  4096.0  87.346041  101.621049  99.726437  90.033213

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
