### PR TITLE
fix openai_harmony.HarmonyError: Unexpected token

### DIFF
--- a/python/sglang/srt/entrypoints/harmony_utils.py
+++ b/python/sglang/srt/entrypoints/harmony_utils.py
@@ -366,5 +366,20 @@ def parse_remaining_state(parser: StreamableParser):
 def parse_output_into_messages(token_ids: Iterable[int]):
     parser = get_streamable_parser_for_assistant()
     for token_id in token_ids:
-        parser.process(token_id)
+        try:
+            parser.process(token_id)
+        except Exception as e:
+            # Log the error but continue processing
+            print(f"Warning: Error processing token {token_id} in harmony parser: {e}")
+            # For unexpected token errors, try to reset and continue
+            if "Unexpected token" in str(e) and "while expecting start token" in str(e):
+                parser = get_streamable_parser_for_assistant()
+                try:
+                    parser.process(token_id)
+                except Exception:
+                    # If still fails, skip this token
+                    continue
+            else:
+                # For other errors, skip the token
+                continue
     return parser

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -7,7 +7,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from fastapi import Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
-from openai_harmony import Message as OpenAIMessage
+from openai_harmony import HarmonyError, Message as OpenAIMessage
 
 from sglang.srt.conversation import generate_chat_conv
 from sglang.srt.entrypoints.harmony_utils import (
@@ -519,7 +519,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     for token_id in new_token_ids:
                         try:
                             harmony_parser.process(token_id)
-                        except Exception as e:
+                        except HarmonyError as e:
                             # Log the error with detailed information
                             logger.warning(
                                 f"Harmony parser error for token {token_id} at index {index}: {e}. "
@@ -527,20 +527,21 @@ class OpenAIServingChat(OpenAIServingBase):
                                 f"current_role: {getattr(harmony_parser, 'current_role', 'unknown')}"
                             )
                             
-                            # Handle specific harmony errors
+                            # Handle specific harmony errors - check for token sequence errors
                             if "Unexpected token" in str(e) and "while expecting start token" in str(e):
                                 logger.info(f"Reinitializing harmony parser for index {index} due to token sequence error")
                                 # Reset parser state and try to continue
                                 harmony_parsers[index] = get_streamable_parser_for_assistant()
                                 try:
                                     harmony_parsers[index].process(token_id)
-                                except Exception as retry_e:
+                                except HarmonyError as retry_e:
                                     logger.error(f"Failed to process token {token_id} even after parser reset: {retry_e}")
                                     # Skip this token and continue
                                     continue
-                            else:
-                                # For other errors, skip the token but don't reset parser
-                                continue                            
+                        except Exception as e:
+                            # Handle any other unexpected errors
+                            logger.error(f"Unexpected error processing token {token_id} at index {index}: {e}")
+                            continue                            
 
                     is_final = harmony_parser.current_channel == "final"
                     is_analysis = harmony_parser.current_channel == "analysis"


### PR DESCRIPTION
```
[2025-08-07 10:13:12] ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/usr/local/lib/python3.12/dist-packages/starlette/_utils.py", line 77, in collapse_excgroups
  |     yield
  |   File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 271, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/usr/local/lib/python3.12/dist-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/usr/local/lib/python3.12/dist-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/dist-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    |     return await self.app(scope, receive, send)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/dist-packages/fastapi/applications.py", line 1054, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/applications.py", line 113, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 186, in __call__
    |     raise exc
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/cors.py", line 85, in __call__
    |     await self.app(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/exceptions.py", line 63, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 716, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 736, in app
    |     await route.handle(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 290, in handle
    |     await self.app(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 78, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 76, in app
    |     await response(scope, receive, send)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 270, in __call__
    |     with collapse_excgroups():
    |          ^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/_utils.py", line 83, in collapse_excgroups
    |     raise exc
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 274, in wrap
    |     await func()
    |   File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 254, in stream_response
    |     async for chunk in self.body_iterator:
    |   File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 520, in _generate_chat_stream
    |     harmony_parser.process(token_id)
    |   File "/usr/local/lib/python3.12/dist-packages/openai_harmony/__init__.py", line 627, in process
    |     self._inner.process(token)
    | openai_harmony.HarmonyError: Unexpected token 12606 while expecting start token 200006
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/cors.py", line 85, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 290, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 78, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 76, in app
    await response(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 270, in __call__
    with collapse_excgroups():
         ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/usr/local/lib/python3.12/dist-packages/starlette/_utils.py", line 83, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 274, in wrap
    await func()
  File "/usr/local/lib/python3.12/dist-packages/starlette/responses.py", line 254, in stream_response
    async for chunk in self.body_iterator:
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 520, in _generate_chat_stream
    harmony_parser.process(token_id)
  File "/usr/local/lib/python3.12/dist-packages/openai_harmony/__init__.py", line 627, in process
    self._inner.process(token)
openai_harmony.HarmonyError: Unexpected token 12606 while expecting start token 200006
```