### PR TITLE
[Fix] Fix wrong backend chosen in hybrid backend

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -391,7 +391,12 @@ class ModelRunner:
                 2.3 Otherwise, we will use triton backend.
             """
 
-            if not self.use_mla_backend:
+            if server_args.prefill_attention_backend is not None and (
+                server_args.prefill_attention_backend
+                == server_args.decode_attention_backend
+            ):  # override the default attention backend
+                server_args.attention_backend = server_args.prefill_attention_backend
+            elif not self.use_mla_backend:
                 # MHA architecture
                 if (
                     is_hopper_with_cuda_12_3()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -378,6 +378,12 @@ class ModelRunner:
             )
             server_args.attention_backend = "torch_native"
 
+        if server_args.prefill_attention_backend is not None and (
+            server_args.prefill_attention_backend
+            == server_args.decode_attention_backend
+        ):  # override the default attention backend
+            server_args.attention_backend = server_args.prefill_attention_backend
+
         if server_args.attention_backend is None:
             """
             Auto select the fastest attention backend.
@@ -391,12 +397,7 @@ class ModelRunner:
                 2.3 Otherwise, we will use triton backend.
             """
 
-            if server_args.prefill_attention_backend is not None and (
-                server_args.prefill_attention_backend
-                == server_args.decode_attention_backend
-            ):  # override the default attention backend
-                server_args.attention_backend = server_args.prefill_attention_backend
-            elif not self.use_mla_backend:
+            if not self.use_mla_backend:
                 # MHA architecture
                 if (
                     is_hopper_with_cuda_12_3()


### PR DESCRIPTION
## Motivation

When both `--prefill-attention` and `--decode-attention` are set to the same backend, the current logic may incorrectly fall back to a different backend, which may be misleading.

**Reproduction:**
```bash
python3 -m sglang.launch_server \
    --model-path meta-llama/Llama-3.1-8B-Instruct \
    --prefill-attention fa3 \
    --decode-attention fa3 \
    --enable-hierarchical-cache
````

This code will choose `flashinfer` as the attention backend. However, when both `--prefill-attention` and `--decode-attention` are explicitly specified as `fa3`, the configuration should be overridden accordingly. This is caused by the logic [here](https://github.com/sgl-project/sglang/blob/f352b793be65a555194db31280a69b53dd40c4d4/python/sglang/srt/model_executor/model_runner.py#L1336), which fails to handle the case where `--prefill-attention` and `--decode-attention` are the same and not `None`.

While this is admittedly a rare edge case, the behavior should still be correct.

## Modifications

Fix the fallback logic when `--prefill-attention` and `--decode-attention` are identical. It will override the `attention-backend` in this case.

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
