### PR TITLE
[Bug Fix] GPT-OSS: Support commentary channel output from gpt-oss which avoids server cr…

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -781,12 +781,13 @@ class OpenAIServingChat(OpenAIServingBase):
                     reasoning_content = output_msgs[0].content[0].text
                     final_content = parser.current_content
                 else:
-                    if len(output_msgs) != 2:
-                        raise ValueError(
-                            "Expected 2 output messages (reasoning and final), "
-                            f"but got {len(output_msgs)}."
-                        )
-                    reasoning_msg, final_msg = output_msgs
+                    reasoning_msg = None
+                    final_msg = None
+                    for msg in output_msgs:
+                        if msg.channel == "analysis":
+                            reasoning_msg = msg
+                        elif msg.channel == "final":
+                            final_msg = msg
                     reasoning_content = reasoning_msg.content[0].text
                     final_content = final_msg.content[0].text
                     is_tool_call = final_msg.recipient is not None


### PR DESCRIPTION
…ash during chat completion API

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Support commentary channel output from gpt-oss which avoids server crash during chat completion API

Close https://github.com/sgl-project/sglang/issues/8976

## Modifications

We shouldn't assume the model outputs at most two channels. 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
