### PR TITLE
Kernel changes to support relaxed thinking when using greedy search.

### DIFF
--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -230,6 +230,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("verify_tree_greedy", torch::kCUDA, &verify_tree_greedy);
 
   m.def(
+      "verify_tree_relaxed(Tensor! predicts, Tensor! accept_index, Tensor! accept_token_num, "
+      "Tensor candidates, Tensor retrive_index, Tensor retrive_next_token, Tensor retrive_next_sibling, "
+      "Tensor target_topk_ids, Tensor target_topk_probs, Tensor relax_top_ks, Tensor relax_ratios, "
+      "int cuda_stream) -> ()");
+  m.impl("verify_tree_relaxed", torch::kCUDA, &verify_tree_relaxed);
+
+  m.def(
       "build_tree_kernel_efficient(Tensor parent_list, Tensor selected_index, Tensor verified_seq_len, "
       "Tensor! tree_mask, Tensor! positions, Tensor! retrive_index, Tensor! retrive_next_token, "
       "Tensor! retrive_next_sibling, int topk, int depth, int draft_token_num, int tree_mask_mode) -> "

--- a/sgl-kernel/csrc/speculative/eagle_utils.cu
+++ b/sgl-kernel/csrc/speculative/eagle_utils.cu
@@ -341,7 +341,7 @@ __global__ void VerifyTreeRelaxed(
       IdType2 draft_index = retrive_index[bx * num_draft_tokens + cur_index];
       IdType2 draft_token_id = candidates[bx * num_draft_tokens + cur_index];
 
-      IdType2 cur_prob_offset = bx * num_draft_tokens * top_k + last_accepted_retrive_idx * top_k;
+      IdType2 cur_prob_offset = last_accepted_retrive_idx * top_k;
       DType target_top1_prob = target_topk_probs[cur_prob_offset];
 
       for (uint32_t k = 0; k < relax_top_k; ++k) {
@@ -365,7 +365,7 @@ __global__ void VerifyTreeRelaxed(
     if (!found_match) break;
   }
   accept_token_num[bx] = num_accepted_tokens;
-  IdType2 final_offset = bx * num_draft_tokens * top_k + last_accepted_retrive_idx * top_k;
+  IdType2 final_offset = last_accepted_retrive_idx * top_k;
   predicts[last_accepted_retrive_idx] = target_topk_ids[final_offset];
 }
 
@@ -436,8 +436,6 @@ void verify_tree_relaxed(
   CHECK_EQ(num_draft_tokens, retrive_next_sibling.size(1));
   CHECK_EQ(num_draft_tokens, target_topk_ids.size(1));
   CHECK_EQ(num_draft_tokens, target_topk_probs.size(1));
-  CHECK_EQ(batch_size, accept_index.size(0));
-  CHECK_EQ(batch_size, accept_token_num.size(0));
   CHECK_EQ(batch_size, relax_top_ks.size(0));
   CHECK_EQ(batch_size, relax_ratios.size(0));
   if (predicts.scalar_type() != at::kInt) {

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -389,6 +389,20 @@ void build_tree_kernel_efficient(
     int64_t draft_token_num,
     int64_t tree_mask_mode);
 
+void verify_tree_relaxed(
+    at::Tensor predicts,          // mutable
+    at::Tensor accept_index,      // mutable
+    at::Tensor accept_token_num,  // mutable
+    at::Tensor candidates,
+    at::Tensor retrive_index,
+    at::Tensor retrive_next_token,
+    at::Tensor retrive_next_sibling,
+    at::Tensor target_topk_ids,
+    at::Tensor target_topk_probs,
+    at::Tensor relax_top_ks,
+    at::Tensor relax_ratios,
+    int64_t cuda_stream = 0);
+
 void segment_packbits(
     at::Tensor x,
     at::Tensor input_indptr,

--- a/sgl-kernel/python/sgl_kernel/speculative.py
+++ b/sgl-kernel/python/sgl_kernel/speculative.py
@@ -60,6 +60,35 @@ def verify_tree_greedy(
     )
 
 
+def verify_tree_relaxed(
+    predicts: torch.Tensor,  # mutable
+    accept_index: torch.Tensor,  # mutable
+    accept_token_num: torch.Tensor,  # mutable
+    candidates: torch.Tensor,
+    retrive_index: torch.Tensor,
+    retrive_next_token: torch.Tensor,
+    retrive_next_sibling: torch.Tensor,
+    target_topk_ids: torch.Tensor,
+    target_topk_probs: torch.Tensor,
+    relax_top_ks: torch.Tensor,
+    relax_ratios: torch.Tensor,
+) -> None:
+    torch.ops.sgl_kernel.verify_tree_relaxed.default(
+        predicts,
+        accept_index,
+        accept_token_num,
+        candidates,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+        target_topk_ids,
+        target_topk_probs,
+        relax_top_ks,
+        relax_ratios,
+        get_cuda_stream(),
+    )
+
+
 def build_tree_kernel_efficient(
     parent_list: torch.Tensor,
     selected_index: torch.Tensor,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
<img width="1790" height="246" alt="image" src="https://github.com/user-attachments/assets/b00e89d5-1070-49fd-a5f4-11e9b7c71ea0" />
<img width="2054" height="1124" alt="image" src="https://github.com/user-attachments/assets/0345b1e7-69fd-4ae2-8fb3-c139ada20667" />
As stated in Nvidia's publicly available optimization presentation, we can assume that during the model's thinking process, the quality of the generated content can be relatively low without affecting the final result. Therefore, the idea is to use a relatively lenient verification method for speculative decoding during the thinking stage, and then switch to a normal verification method after the thinking stage ends.

Modifications within the framework are similar to PR https://github.com/sgl-project/sglang/pull/8068.

## Modifications
In our implemention, subtracting a threshold has been replaced with multiplying by a threshold between 0 and 1 for easier control. Related hyperparameters: relaxed_ratio, relax_top_k.
This PR is about the kernel changes to support relaxed thinking. This implemention is used in greedy search.

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling
QwQ model and [QwQ-EAGLE model](https://huggingface.co/reinforce20001/QwQ-32B-Eagle)
2*A100
Enable Relaxed Thinking:
```
python3 -m sglang.launch_server \
--model-path /mnt4/QwQ-32B \
--trust-remote-code \
--tp 2  \
--speculative-draft-model-path /mnt4/qwq_eagle \
--speculative-algorithm=EAGLE \
--speculative-num-steps=5 \
--speculative-eagle-topk=4 \
--speculative-num-draft-tokens=12 \
--speculative-relax-ratio=0.1 \
--speculative-relax-topk=3 \
--speculative-relaxed-thinking \
--speculative-reasoning-parser=deepseek-r1
```
Benchmark serving:
```
python3 -m sglang.bench_serving \
--backend sglang \
--dataset-name sharegpt \
--dataset-path /ShareGPT_V3_unfiltered_cleaned_split.json \
--num-prompt 10 \
--max-concurrency 1 \
--backend=sglang-oai-chat  \
--temperature=0 \
--port 30000
```

### Results
Baseline:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     10        
Benchmark duration (s):                  50.51     
Total input tokens:                      5114      
Total generated tokens:                  3414      
Total generated tokens (retokenized):    3037      
Request throughput (req/s):              0.20      
Input token throughput (tok/s):          101.24    
Output token throughput (tok/s):         67.59     
Total token throughput (tok/s):          168.83    
Concurrency:                             1.00      
Accept length:                           2.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5050.43   
Median E2E Latency (ms):                 3533.49   
---------------Time to First Token----------------
Mean TTFT (ms):                          131.90    
Median TTFT (ms):                        63.04     
P99 TTFT (ms):                           531.78    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           32.62     
Median ITL (ms):                         32.45     
P95 ITL (ms):                            33.48     
P99 ITL (ms):                            34.08     
Max ITL (ms):                            43.01     
==================================================
```
Enable Relaxed Thinking:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     10        
Benchmark duration (s):                  42.33     
Total input tokens:                      5114      
Total generated tokens:                  3414      
Total generated tokens (retokenized):    2933      
Request throughput (req/s):              0.24      
Input token throughput (tok/s):          120.80    
Output token throughput (tok/s):         80.64     
Total token throughput (tok/s):          201.44    
Concurrency:                             1.00      
Accept length:                           2.33      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4232.18   
Median E2E Latency (ms):                 2681.32   
---------------Time to First Token----------------
Mean TTFT (ms):                          118.54    
Median TTFT (ms):                        62.33     
P99 TTFT (ms):                           480.07    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           32.96     
Median ITL (ms):                         32.78     
P95 ITL (ms):                            34.06     
P99 ITL (ms):                            34.90     
Max ITL (ms):                            36.65     
==================================================
```
## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
