### PR TITLE
[pd-router] add retry and circuit breakfor for pd router

### DIFF
--- a/sgl-router/src/core/mod.rs
+++ b/sgl-router/src/core/mod.rs
@@ -16,7 +16,7 @@ pub use circuit_breaker::{
     CircuitBreaker, CircuitBreakerConfig, CircuitBreakerStats, CircuitState,
 };
 pub use error::{WorkerError, WorkerResult};
-pub use retry::{BackoffCalculator, RetryError, RetryExecutor};
+pub use retry::{is_retryable_status, BackoffCalculator, RetryError, RetryExecutor};
 pub use worker::{
     start_health_checker, BasicWorker, DPAwareWorker, HealthChecker, Worker, WorkerCollection,
     WorkerFactory, WorkerLoadGuard, WorkerType,

--- a/sgl-router/src/routers/pd_router.rs
+++ b/sgl-router/src/routers/pd_router.rs
@@ -232,12 +232,8 @@ impl PDRouter {
         let core_cb_config = CircuitBreakerConfig {
             failure_threshold: circuit_breaker_config.failure_threshold,
             success_threshold: circuit_breaker_config.success_threshold,
-            timeout_duration: std::time::Duration::from_secs(
-                circuit_breaker_config.timeout_duration_secs,
-            ),
-            window_duration: std::time::Duration::from_secs(
-                circuit_breaker_config.window_duration_secs,
-            ),
+            timeout_duration: Duration::from_secs(circuit_breaker_config.timeout_duration_secs),
+            window_duration: Duration::from_secs(circuit_breaker_config.window_duration_secs),
         };
 
         // Convert URLs to Worker trait objects
@@ -474,7 +470,7 @@ impl PDRouter {
     }
 
     // Execute the dual dispatch to prefill and decode servers with retries and bootstrap injection
-    async fn execute_dual_dispatch_with_retry_generic<T: Serialize + Clone>(
+    async fn execute_dual_dispatch<T: Serialize + Clone>(
         &self,
         headers: Option<&HeaderMap>,
         original_request: &T,
@@ -1614,8 +1610,7 @@ impl RouterTrait for PDRouter {
         };
 
         // Execute with retry and bootstrap injection
-        self.execute_dual_dispatch_with_retry_generic(headers, body, context)
-            .await
+        self.execute_dual_dispatch(headers, body, context).await
     }
 
     async fn route_chat(
@@ -1656,8 +1651,7 @@ impl RouterTrait for PDRouter {
         };
 
         // Execute with retry and bootstrap injection
-        self.execute_dual_dispatch_with_retry_generic(headers, body, context)
-            .await
+        self.execute_dual_dispatch(headers, body, context).await
     }
 
     async fn route_completion(
@@ -1694,8 +1688,7 @@ impl RouterTrait for PDRouter {
         };
 
         // Execute with retry and bootstrap injection
-        self.execute_dual_dispatch_with_retry_generic(headers, body, context)
-            .await
+        self.execute_dual_dispatch(headers, body, context).await
     }
 
     async fn flush_cache(&self) -> Response {

--- a/sgl-router/src/routers/router.rs
+++ b/sgl-router/src/routers/router.rs
@@ -83,12 +83,8 @@ impl Router {
         let core_cb_config = CircuitBreakerConfig {
             failure_threshold: circuit_breaker_config.failure_threshold,
             success_threshold: circuit_breaker_config.success_threshold,
-            timeout_duration: std::time::Duration::from_secs(
-                circuit_breaker_config.timeout_duration_secs,
-            ),
-            window_duration: std::time::Duration::from_secs(
-                circuit_breaker_config.window_duration_secs,
-            ),
+            timeout_duration: Duration::from_secs(circuit_breaker_config.timeout_duration_secs),
+            window_duration: Duration::from_secs(circuit_breaker_config.window_duration_secs),
         };
 
         // Create Worker trait objects from URLs


### PR DESCRIPTION
## Summary

This PR adds circuit breaker and retry support to the PD (Prefill-Decode) router, bringing it to feature parity with the regular router. The implementation includes a critical update for bootstrap injection to ensure correct prefill-decode coordination during retries.

## Motivation

The PD router previously lacked retry and circuit breaker capabilities, making it less resilient to transient failures compared to the regular router. #8917 

## Key Changes

### 1. Circuit Breaker Integration
- Enhanced worker selection to check circuit breaker state via `is_available()`
- Automatic failure tracking and circuit state management per worker
- Workers are automatically excluded when circuits open and re-included when they recover

### 2. Retry Logic Implementation
- Added `execute_dual_dispatch()` method with exponential backoff
- Supports retrying with different workers on each attempt
- Preserves parallel prefill/decode dispatch semantics
- Maintains fire-and-forget optimization for non-logprob requests

### 3. Bootstrap Injection Fix
- **Critical Fix**: Moved bootstrap injection inside retry loop to ensure consistency
- Bootstrap information now always matches the actual prefill worker used
- Prevents decode failures from mismatched bootstrap data
- Implemented generic retry method that handles all request types

### 4. Code Improvements
- Refactored `is_retryable_status()` into shared core module (DRY principle)
- Created `pick_worker_by_policy()` helper for cleaner worker selection
- Fixed deprecation warnings in rand crate usage
- Added `PDRequestContext` for clean parameter passing

## Technical Details

### Request Flow
```
1. Route handler extracts request parameters
2. Creates PDRequestContext with route-specific info
3. Calls generic retry method
4. For each retry attempt:
   - Selects fresh workers (avoiding failed ones)
   - Serializes request and injects bootstrap
   - Executes parallel prefill/decode dispatch
   - Records circuit breaker outcomes
```

### Bootstrap Components
- `bootstrap_host`: Hostname from prefill worker URL
- `bootstrap_port`: Optional port from prefill configuration
- `bootstrap_room`: Unique ID per request for prefill-decode coordination

## Performance Impact

- Minimal overhead: Bootstrap injection only occurs on retry attempts
- Worker selection uses existing efficient methods
- Circuit breaker checks are lightweight (simple state checks)
- Fire-and-forget optimization preserved for non-logprob requests

## Breaking Changes

None. The changes are backward compatible and maintain the existing PD router API.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
