### PR TITLE
fix mem leak in process_batch_result_prefill (#6888)

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -78,18 +78,12 @@ class SchedulerOutputProcessorMixin:
                 if self.is_mixed_chunk and self.enable_overlap and req.finished():
                     # Free the one delayed token for the mixed decode batch
                     j = len(batch.out_cache_loc) - len(batch.reqs) + i
-                    if self.page_size == 1:
+                    # Only free when the extra token is in a new page.
+                    # If page_size is 1, every token is in a new page.
+                    if self.page_size == 1 or (req.seqlen - 1) % self.page_size == 0:
                         self.token_to_kv_pool_allocator.free(
                             batch.out_cache_loc[j : j + 1]
                         )
-                    else:
-                        # Only free when the extra token is in a new page
-                        if (
-                            len(req.origin_input_ids) + len(req.output_ids) - 1
-                        ) % self.page_size == 0:
-                            self.token_to_kv_pool_allocator.free(
-                                batch.out_cache_loc[j : j + 1]
-                            )
                     continue
 
                 if req.is_chunked <= 0:


### PR DESCRIPTION
Only free when extra token is in a new page when overlap-schedule is enabled and page size > 1.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix mem leak bug. 
When `overlap-schedule` is enabled, and page-size > 1, and `mixed-chunk-prefill` is enabled, a request can be finished in a decode batch, and the next prefill (mixed) batch will be executed for an extra token. If the token is not in a new page, the last page of the request will be freed twice, that is to say, `process_batch_result_decode` frees all the pages of the request, then in next prefill (mixed) batch, `process_batch_result_prefill` frees the last page again. 

## Modifications

Check for the presence of an extra page to prevent the last page from being released twice in function `process_batch_result_prefill`. 

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
