### PR TITLE
supported configurable eagle3 aux layers for cuda graph

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -27,6 +27,7 @@ import torch
 import tqdm
 from torch.profiler import ProfilerActivity, profile
 
+from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.custom_op import CustomOp
 from sglang.srt.distributed import get_tensor_model_parallel_rank
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
@@ -331,7 +332,29 @@ class CudaGraphRunner:
 
             # Speculative_inference
             if model_runner.spec_algorithm.is_eagle3():
-                self.model_runner.model.set_eagle3_layers_to_capture()
+                # load draft config
+                draft_model_config = ModelConfig.from_server_args(
+                    self.model_runner.server_args,
+                    model_path=(
+                        self.model_runner.server_args.speculative_draft_model_path
+                    ),
+                    is_draft_model=True,
+                )
+
+                try:
+                    # get the aux layer from draft model config
+                    eagle_config = getattr(
+                        draft_model_config.hf_config, "eagle_config", None
+                    )
+                    eagle_aux_hidden_state_layer_ids = eagle_config[
+                        "eagle_aux_hidden_state_layer_ids"
+                    ]
+                except:
+                    # if there is no aux layer, set to None
+                    eagle_aux_hidden_state_layer_ids = None
+                self.model_runner.model.set_eagle3_layers_to_capture(
+                    eagle_aux_hidden_state_layer_ids
+                )
 
             if self.is_encoder_decoder:
                 # NOTE: encoder_lens can influence the full_text_row_masked_out_mask tensor when doing mixed batch

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -341,17 +341,17 @@ class CudaGraphRunner:
                     is_draft_model=True,
                 )
 
-                try:
-                    # get the aux layer from draft model config
-                    eagle_config = getattr(
-                        draft_model_config.hf_config, "eagle_config", None
-                    )
-                    eagle_aux_hidden_state_layer_ids = eagle_config[
-                        "eagle_aux_hidden_state_layer_ids"
-                    ]
-                except:
-                    # if there is no aux layer, set to None
+                # get the aux layer from draft model config
+                eagle_config = getattr(
+                    draft_model_config.hf_config, "eagle_config", None
+                )
+                if eagle_config is None:
                     eagle_aux_hidden_state_layer_ids = None
+                else:
+                    eagle_aux_hidden_state_layer_ids = eagle_config.get(
+                        "eagle_aux_hidden_state_layer_ids", None
+                    )
+                print(eagle_aux_hidden_state_layer_ids)
                 self.model_runner.model.set_eagle3_layers_to_capture(
                     eagle_aux_hidden_state_layer_ids
                 )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -366,7 +366,6 @@ class ModelRunner:
             except:
                 # if there is no aux layer, set to None
                 eagle_aux_hidden_state_layer_ids = None
-
             self.model.set_eagle3_layers_to_capture(eagle_aux_hidden_state_layer_ids)
 
     def model_specific_adjustment(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -366,6 +366,7 @@ class ModelRunner:
             except:
                 # if there is no aux layer, set to None
                 eagle_aux_hidden_state_layer_ids = None
+
             self.model.set_eagle3_layers_to_capture(eagle_aux_hidden_state_layer_ids)
 
     def model_specific_adjustment(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Eagle3 has a list of default aux layer IDs, however, sometimes this is not enough as we may use some self-defined layer ids for hidden states. For example, GPT-OSS has a hybrid structure and we better set the aux layers to full attention layers. To enable this, we need to make aux layer IDs configurable.

## Modifications

Read the aux layer configurations before we set the aux layers in CUDA graph runner. It has been done so in the model runner class, just not in the cuda graph runner.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
