### PR TITLE
fix import location error problem

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -6,7 +6,7 @@ import triton
 
 from sglang.srt.layers.quantization.fp8_kernel import per_token_group_quant_fp8
 from sglang.srt.utils import ceil_div, dispose_tensor, is_cuda
-from sglang.utils import is_in_ci
+from sglang.test.test_utils import is_in_ci
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Python package import location error problem

```
[2025-08-11 19:11:38 DP0 TP0 EP0] TpModelWorkerClient hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 141, in forward_thread_func
    self.forward_thread_func_()
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 176, in forward_thread_func_
    self.worker.forward_batch_generation(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 238, in forward_batch_generation
    logits_output, can_run_cuda_graph = self.model_runner.forward(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1613, in forward
    output = self._forward_raw(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1658, in _forward_raw
    ret = self.forward_extend(
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 1558, in forward_extend
    return self.model.forward(
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2136, in forward
    hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2033, in forward
    hidden_states, residual = model_forward_maybe_tbo(
  File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 648, in model_forward_maybe_tbo
    return _model_forward_tbo(
  File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 674, in _model_forward_tbo
    outputs_arr = execute_overlapped_operations(
  File "/sgl-workspace/sglang/python/sglang/srt/operations.py", line 45, in execute_overlapped_operations
    executor_b.next()
  File "/sgl-workspace/sglang/python/sglang/srt/operations.py", line 84, in next
    self._stage_output = op.fn(
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 683, in op_experts
    state.hidden_states_experts_output = self.experts.moe_impl(
  File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 454, in moe_impl
    return self.forward_deepgemm_contiguous(dispatch_output)
  File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 631, in forward_deepgemm_contiguous
    ep_gather(down_output, topk_idx, topk_weights, output_index, gather_out)
  File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/ep_moe/kernels.py", line 1064, in ep_gather
    BLOCK_D = 1024 if not is_in_ci() else 128  # block size of quantization
  File "/sgl-workspace/sglang/python/sglang/utils.py", line 352, in is_in_ci
    from sglang.test.test_utils import is_in_ci
ModuleNotFoundError: No module named 'sglang.test.test_utils'
```
