### PR TITLE
bugfix: Fix the commentary msg extraction in GptOssDetector

### DIFF
--- a/python/sglang/srt/reasoning_parser.py
+++ b/python/sglang/srt/reasoning_parser.py
@@ -295,15 +295,15 @@ class GptOssDetector(BaseReasoningFormatDetector):
         for match in reversed(list(commentary_pattern.finditer(full_normal_text))):
             # Check if this commentary is a tool call by looking at the text before <|message|>
             match_start = match.start()
-            # Find the start of this commentary section
-            commentary_start = full_normal_text.rfind(
-                "<|channel|>commentary", 0, match_start
-            )
-            if commentary_start != -1:
-                # Extract text between "commentary" and "<|message|>"
-                message_pos = full_normal_text.find("<|message|>", commentary_start)
-                if message_pos != -1:
-                    between_text = full_normal_text[commentary_start:message_pos]
+            # Find where "<|channel|>commentary" starts within the matched pattern
+            # The pattern starts with "<|start|>assistant<|channel|>commentary"
+            # So we look for the text between "commentary" and "<|message|>" in the match
+            match_text = full_normal_text[match_start : match.end()]
+            commentary_idx = match_text.find("<|channel|>commentary")
+            if commentary_idx != -1:
+                message_idx = match_text.find("<|message|>", commentary_idx)
+                if message_idx != -1:
+                    between_text = match_text[commentary_idx:message_idx]
                     # If no "to=" found, this is regular commentary (reasoning content)
                     if " to=" not in between_text:
                         content = match.group(1).strip()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fix the extraction of `commentary` messages in gpt-oss with non-stream tool-call.

The root cause is when the regex matches `<|start|>assistant<|channel|>commentary<|message|>`, the `match.start()` points to the beginning of this string. Then `rfind("<|channel|>commentary", 0, match_start)` will find the `<|channel|>commentary` in a different match, not within the same match.

For instance, 
```
clean_text = '<|channel|>commentary to=functions.sales_search 
  <|constrain|>json<|message|>{\n  "firstName": 
  "John"\n}<|call|><|start|>assistant<|start|>assistant<|channel|>commentary<|message|>{\n  "error": "No 
  data found for the given first name."\n}<|call|><|start|>assistant<|channel|>final<|message|>I’m sorry,
   but I couldn’t find any sales data for a representative named\u202fJohn. If you have additional 
  details (such as a last name, employee ID, or a different time range), please let me know and I’ll try 
  again.'
```

- rfind finds the `<|channel|>commentary` at position 0 (the previous one)
- It then checks if `to=` exists between position 0 and wherever `<|message|>` is found after position 0
- This gives wrong results because it's checking the wrong commentary section


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Fix the logic in `detect_and_parse`

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
