### PR TITLE
Optimize per_group_transpose

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import torch
 
 from sglang.srt.layers.moe.cutlass_moe_params import CutlassMoEParams
-from sglang.srt.layers.utils import is_sm100_supported, is_sm90_supported
+from sglang.srt.layers.utils import is_sm90_supported, is_sm100_supported
 from sglang.srt.utils import is_cuda
 
 _is_cuda = is_cuda()
@@ -245,6 +245,7 @@ def cutlass_fused_experts_fp8(
 
 FLOAT4_E2M1_MAX = 6.0
 FLOAT8_E4M3_MAX = 448.0
+
 
 def cutlass_moe_fp4(
     a: torch.Tensor,

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -250,62 +250,6 @@ def cutlass_fused_experts_fp8(
 FLOAT4_E2M1_MAX = 6.0
 FLOAT8_E4M3_MAX = 448.0
 
-
-def cutlass_moe_fp8(
-    a: torch.Tensor,
-    a_scale: torch.Tensor,
-    w: torch.Tensor,
-    w_scale: torch.Tensor,
-    c: torch.Tensor,
-    m_indices: torch.Tensor,
-) -> None:
-    """Performs EP MoE computation using CUTLASS-like kernels with per-block-fp8-quant weights and per-token-group-fp8-quant activations."""
-    device = a.device
-    num_experts, k_g, n_g = w.shape
-    layout_sfa = torch.zeros((num_experts, 5), device=device, dtype=torch.int32)
-    layout_sfb = torch.zeros((num_experts, 5), device=device, dtype=torch.int32)
-    a_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
-    b_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
-    out_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
-    a_scales_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
-    b_scales_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
-    workspace = torch.empty((1024 * 1024 * 1024), device=device, dtype=torch.uint8)
-    a_strides = torch.full(
-        (num_experts,), a.stride(0), device=device, dtype=torch.int64
-    )
-    c_strides = torch.full(
-        (num_experts,), c.stride(0), device=device, dtype=torch.int64
-    )
-    m_tensor = m_indices[1:] - m_indices[:-1]
-    n_tensor = torch.full_like(m_tensor, fill_value=n_g)
-    k_tensor = torch.full_like(m_tensor, fill_value=k_g)
-    problem_sizes = torch.stack([m_tensor, n_tensor, k_tensor], dim=1)
-    # (E, K, N):(K*N, N, 1) -> (E, N, K):(N*K, 1, N) -> (E, N, K):(N*K, K, 1)
-    # w_scale = w_scale.transpose(1, 2).contiguous()
-    # TODO: a_scale
-    
-    fp8_blockwise_scaled_grouped_mm(
-        c,
-        a_ptrs,
-        b_ptrs,
-        out_ptrs,
-        a_scales_ptrs,
-        b_scales_ptrs,
-        a,
-        w,
-        a_scale,
-        w_scale,
-        a_strides,
-        a_strides,
-        c_strides,
-        layout_sfa,
-        layout_sfb,
-        problem_sizes,
-        m_indices[:-1],
-        workspace,
-    )
-    
-
 def cutlass_moe_fp4(
     a: torch.Tensor,
     a1_gscale: torch.Tensor,

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -169,7 +169,6 @@ def cutlass_fused_experts_fp8(
                 problem_sizes1,
                 m * topk,
                 a_map,
-                M_ALIGNMENT=16,
             )
     else:
         raise NotImplementedError("Only support sm100 and sm90 for now")
@@ -215,7 +214,6 @@ def cutlass_fused_experts_fp8(
                 expert_offsets[:-1],
                 problem_sizes2,
                 m * topk,
-                M_ALIGNMENT=16,
             )
     w2_scale = w2_scale.contiguous()
 

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -169,6 +169,7 @@ def cutlass_fused_experts_fp8(
                 problem_sizes1,
                 m * topk,
                 a_map,
+                M_ALIGNMENT=16,
             )
     else:
         raise NotImplementedError("Only support sm100 and sm90 for now")
@@ -214,6 +215,7 @@ def cutlass_fused_experts_fp8(
                 expert_offsets[:-1],
                 problem_sizes2,
                 m * topk,
+                M_ALIGNMENT=16,
             )
     w2_scale = w2_scale.contiguous()
 

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1586,7 +1586,6 @@ def per_group_transpose(
         a, trans_a, expert_offsets, k, M_ALIGNMENT, BLOCK_SIZE_M=16, BLOCK_SIZE_K=8
     )
     return trans_a
-<<<<<<< HEAD
 
 
 def is_weak_contiguous(x: torch.Tensor):
@@ -1805,7 +1804,7 @@ def triton_scaled_mm(
     )
 
     return result.to(out_dtype)
-=======
+
 shuffle_autotune = triton.autotune(
     configs=[
         triton.Config({"BLOCK_M": block_m, "GROUP_M": group_m}, num_warps=num_warps)
@@ -1944,4 +1943,3 @@ def shuffle_fp8_scale_hopper_moe_mn_major(
         )
 
     return sfa
->>>>>>> 753990ea (add shuffle_fp8_scale_hopper_moe_mn_major)

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1840,8 +1840,9 @@ def _shuffle_map_fp8_scale_hopper_moe_mn_major(
     k_offset = (pid % width) // group_size
 
     m = tl.load(problem_sizes + expert_id * 3)
-    m = tl.multiple_of(m, M_ALIGNMENT)
     current_expert_offset = tl.load(expert_offsets + expert_id).to(tl.int64)
+    m = tl.multiple_of(m, M_ALIGNMENT)
+    current_expert_offset = tl.multiple_of(current_expert_offset, M_ALIGNMENT)
 
     for i in tl.range(tl.cdiv(m, BLOCK_M)):
         coord_m = i * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -1881,8 +1882,9 @@ def _shuffle_fp8_scale_hopper_moe_mn_major(
     k_offset = (pid % width) // group_size
 
     m = tl.load(problem_sizes + expert_id * 3)
-    m = tl.multiple_of(m, M_ALIGNMENT)
     current_expert_offset = tl.load(expert_offsets + expert_id).to(tl.int64)
+    m = tl.multiple_of(m, M_ALIGNMENT)
+    current_expert_offset = tl.multiple_of(current_expert_offset, M_ALIGNMENT)
 
     for i in tl.range(tl.cdiv(m, BLOCK_M)):
         coord_m = i * BLOCK_M + tl.arange(0, BLOCK_M)

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1911,7 +1911,7 @@ def shuffle_fp8_scale_hopper_moe_mn_major(
     output_m: int,
     shuffle_map: Optional[torch.Tensor] = None,
     expert_tokens_alignment: int = 1,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor:
     assert a_s.dim() == 2
     assert a_s.is_contiguous(), "`A` is not contiguous"
 

--- a/python/sglang/test/test_cutlass_moe.py
+++ b/python/sglang/test/test_cutlass_moe.py
@@ -276,7 +276,7 @@ def run_test(tp_size, batch_size, model_config, check=False):
                 expert_offsets,
                 problem_sizes1,
                 problem_sizes2,
-                use_shuffle=True
+                use_shuffle=True,
             )
 
             # Run Triton version (requires original shape weights, use inplace=False)
@@ -305,7 +305,12 @@ def run_test(tp_size, batch_size, model_config, check=False):
         print("Correctness check passed.")
 
 
-def main(tp_size=8, batch_sizes=[1, 4, 8, 16, 32, 64, 128, 256, 512, 32768], check=False, prof=False):
+def main(
+    tp_size=8,
+    batch_sizes=[1, 4, 8, 16, 32, 64, 128, 256, 512, 32768],
+    check=False,
+    prof=False,
+):
     model_config = get_model_config(tp_size)
     print("Model Config:", model_config)
     for batch_size in batch_sizes:

--- a/python/sglang/test/test_cutlass_moe.py
+++ b/python/sglang/test/test_cutlass_moe.py
@@ -21,7 +21,7 @@ def calc_diff(x, y):
 
 def get_model_config(tp_size: int):
     config = AutoConfig.from_pretrained(
-        "deepseek-ai/deepseek-R1", trust_remote_code=True
+        "/workdir/huggingface.co/deepseek-ai/DeepSeek-V3-0324/", trust_remote_code=True
     )
     E = config.n_routed_experts
     topk = config.num_experts_per_tok

--- a/python/sglang/test/test_cutlass_moe.py
+++ b/python/sglang/test/test_cutlass_moe.py
@@ -151,6 +151,7 @@ def run_test(tp_size, batch_size, model_config, check=False):
         expert_offsets,
         problem_sizes1,
         problem_sizes2,
+        use_shuffle=False,
     )
 
     cutlass_shuffle_lambda = lambda: cutlass_fused_experts_fp8(

--- a/python/sglang/test/test_cutlass_moe.py
+++ b/python/sglang/test/test_cutlass_moe.py
@@ -21,7 +21,7 @@ def calc_diff(x, y):
 
 def get_model_config(tp_size: int):
     config = AutoConfig.from_pretrained(
-        "/workdir/huggingface.co/deepseek-ai/DeepSeek-V3-0324/", trust_remote_code=True
+        "deepseek-ai/deepseek-R1", trust_remote_code=True
     )
     E = config.n_routed_experts
     topk = config.num_experts_per_tok

--- a/python/sglang/test/test_cutlass_moe.py
+++ b/python/sglang/test/test_cutlass_moe.py
@@ -21,7 +21,7 @@ def calc_diff(x, y):
 
 def get_model_config(tp_size: int):
     config = AutoConfig.from_pretrained(
-        "/workdir/huggingface.co/deepseek-ai/DeepSeek-V3-0324/", trust_remote_code=True
+        "deepseek-ai/deepseek-R1", trust_remote_code=True
     )
     E = config.n_routed_experts
     topk = config.num_experts_per_tok
@@ -109,7 +109,6 @@ def run_test(tp_size, batch_size, model_config, check=False):
         torch.rand(batch_size, topk, device="cuda", dtype=dtype), dim=-1
     )
     topk_ids = torch.randint(0, E, (batch_size, topk), dtype=torch.int32, device="cuda")
-    router_logits = torch.rand(batch_size, E, device="cuda", dtype=dtype)
 
     a1_strides = torch.full((E,), H, dtype=torch.int64, device="cuda")
     c1_strides = torch.full((E,), I, dtype=torch.int64, device="cuda")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Fusing shuffle_rows and per_group_transpose
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
e2e performance on H20 by test_cutlass_moe.py and observe enhancement when batch size>=4096

```
Running benchmarks with TP size: 8
Testing batch sizes: [4096, 8192, 16384, 32768]
Model Config: {'num_experts': 256, 'topk': 8, 'hidden_size': 7168, 'shard_intermediate_size': 512, 'dtype': torch.bfloat16, 'block_shape': [128, 128]}

--- Batch Size: 4096 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Cutlass shuffle fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 2.590 ms (median) [2.589 - 2.591]
Shuffle fused_experts time: 2.576 ms (median) [2.575 - 2.577]
Triton  fused_experts time: 2.600 ms (median) [2.600 - 2.600]

--- Batch Size: 8192 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Cutlass shuffle fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 4.378 ms (median) [4.378 - 4.379]
Shuffle fused_experts time: 4.345 ms (median) [4.344 - 4.345]
Triton  fused_experts time: 4.697 ms (median) [4.696 - 4.697]

--- Batch Size: 16384 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Cutlass shuffle fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 7.906 ms (median) [7.904 - 7.907]
Shuffle fused_experts time: 7.830 ms (median) [7.829 - 7.830]
Triton  fused_experts time: 8.802 ms (median) [8.797 - 8.804]

--- Batch Size: 32768 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Cutlass shuffle fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 14.953 ms (median) [14.947 - 14.963]
Shuffle fused_experts time: 14.786 ms (median) [14.780 - 14.790]
Triton  fused_experts time: 16.952 ms (median) [16.949 - 16.953]
```

e2e accuracy test
```shell
# gsm8k: python3 bench_sglang.py --num-questions 1400 --parallel 200
Accuracy: 0.939
Invalid: 0.000
Latency: 135.454 s
Output throughput: 988.672 token/s
```

```shell
# mmlu: python3 bench_sglang.py --parallel 200
subject: abstract_algebra, #q:100, acc: 0.770
subject: anatomy, #q:135, acc: 0.889
subject: astronomy, #q:152, acc: 0.947
subject: business_ethics, #q:100, acc: 0.860
subject: clinical_knowledge, #q:265, acc: 0.917
subject: college_biology, #q:144, acc: 0.965
subject: college_chemistry, #q:100, acc: 0.660
subject: college_computer_science, #q:100, acc: 0.860
subject: college_mathematics, #q:100, acc: 0.790
subject: college_medicine, #q:173, acc: 0.873
subject: college_physics, #q:102, acc: 0.853
subject: computer_security, #q:100, acc: 0.890
subject: conceptual_physics, #q:235, acc: 0.949
subject: econometrics, #q:114, acc: 0.807
subject: electrical_engineering, #q:145, acc: 0.883
subject: elementary_mathematics, #q:378, acc: 0.944
subject: formal_logic, #q:126, acc: 0.817
subject: global_facts, #q:100, acc: 0.680
subject: high_school_biology, #q:310, acc: 0.958
subject: high_school_chemistry, #q:203, acc: 0.901
subject: high_school_computer_science, #q:100, acc: 0.950
subject: high_school_european_history, #q:165, acc: 0.891
subject: high_school_geography, #q:198, acc: 0.960
subject: high_school_government_and_politics, #q:193, acc: 0.984
subject: high_school_macroeconomics, #q:390, acc: 0.908
subject: high_school_mathematics, #q:270, acc: 0.778
subject: high_school_microeconomics, #q:238, acc: 0.962
subject: high_school_physics, #q:151, acc: 0.848
subject: high_school_psychology, #q:545, acc: 0.963
subject: high_school_statistics, #q:216, acc: 0.856
subject: high_school_us_history, #q:204, acc: 0.961
subject: high_school_world_history, #q:237, acc: 0.949
subject: human_aging, #q:223, acc: 0.870
subject: human_sexuality, #q:131, acc: 0.931
subject: international_law, #q:121, acc: 0.950
subject: jurisprudence, #q:108, acc: 0.898
subject: logical_fallacies, #q:163, acc: 0.926
subject: machine_learning, #q:112, acc: 0.795
subject: management, #q:103, acc: 0.932
subject: marketing, #q:234, acc: 0.949
subject: medical_genetics, #q:100, acc: 0.940
subject: miscellaneous, #q:783, acc: 0.953
subject: moral_disputes, #q:346, acc: 0.864
subject: moral_scenarios, #q:895, acc: 0.790
subject: nutrition, #q:306, acc: 0.922
subject: philosophy, #q:311, acc: 0.904
subject: prehistory, #q:324, acc: 0.944
subject: professional_accounting, #q:282, acc: 0.855
subject: professional_law, #q:1534, acc: 0.711
subject: professional_medicine, #q:272, acc: 0.949
subject: professional_psychology, #q:612, acc: 0.912
subject: public_relations, #q:110, acc: 0.809
subject: security_studies, #q:245, acc: 0.869
subject: sociology, #q:201, acc: 0.965
subject: us_foreign_policy, #q:100, acc: 0.950
subject: virology, #q:166, acc: 0.590
subject: world_religions, #q:171, acc: 0.930
Total latency: 164.891
Average accuracy: 0.875
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
