### PR TITLE
[PD] optimize kv cache transfer directly using batch transfer

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -356,7 +356,7 @@ class MooncakeKVManager(BaseKVManager):
             ]
         assert layers_params is not None
 
-        def set_transfer_blocks(src_ptr: int, dst_ptr: int, item_len: int) -> int:
+        def set_transfer_blocks(src_ptr: int, dst_ptr: int, item_len: int) -> List[Tuple[int, int, int]]:
             transfer_blocks = []
             for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
                 src_addr = src_ptr + int(prefill_index[0]) * item_len
@@ -371,7 +371,7 @@ class MooncakeKVManager(BaseKVManager):
             return self._transfer_data(mooncake_session_id, transfer_blocks)
         
         # Worker function for processing all layers in a batch
-        def process_layers(layers_params):
+        def process_layers(layers_params: List[Tuple[int, int, int]]) -> int:
             transfer_blocks = []
             for src_ptr, dst_ptr, item_len in layers_params:
                 transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -356,33 +356,47 @@ class MooncakeKVManager(BaseKVManager):
             ]
         assert layers_params is not None
 
-        # Worker function for processing a single layer
-        def process_layer(src_ptr: int, dst_ptr: int, item_len: int) -> int:
+        def set_transfer_blocks(src_ptr: int, dst_ptr: int, item_len: int) -> int:
             transfer_blocks = []
             for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
                 src_addr = src_ptr + int(prefill_index[0]) * item_len
                 dst_addr = dst_ptr + int(decode_index[0]) * item_len
                 length = item_len * len(prefill_index)
                 transfer_blocks.append((src_addr, dst_addr, length))
-
+            return transfer_blocks
+        
+        # Worker function for processing a single layer
+        def process_layer(src_ptr: int, dst_ptr: int, item_len: int) -> int:
+            transfer_blocks = set_transfer_blocks(src_ptr, dst_ptr, item_len)
             return self._transfer_data(mooncake_session_id, transfer_blocks)
-
-        futures = [
-            executor.submit(
-                process_layer,
-                src_ptr,
-                dst_ptr,
-                item_len,
-            )
-            for (src_ptr, dst_ptr, item_len) in layers_params
-        ]
-
-        for future in concurrent.futures.as_completed(futures):
-            status = future.result()
-            if status != 0:
-                for f in futures:
-                    f.cancel()
-                return status
+        
+        # Worker function for processing all layers in a batch
+        def process_layers(layers_params):
+            transfer_blocks = []
+            for src_ptr, dst_ptr, item_len in layers_params:
+                transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
+            return self._transfer_data(mooncake_session_id, transfer_blocks)
+        
+        if self.enable_custom_mem_pool:
+            futures = [
+                executor.submit(
+                    process_layer,
+                    src_ptr,
+                    dst_ptr,
+                    item_len,
+                )
+                for (src_ptr, dst_ptr, item_len) in layers_params
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                status = future.result()
+                if status != 0:
+                    for f in futures:
+                        f.cancel()
+                    return status
+        else:
+            # use batch transfer, so we pass all layers params to one thread
+            # compared to use multiple executors, this is more efficient
+            return process_layers(layers_params)
 
         return 0
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -394,8 +394,8 @@ class MooncakeKVManager(BaseKVManager):
                         f.cancel()
                     return status
         else:
-            # use batch transfer, so we pass all layers params to one thread
-            # compared to use multiple executors, this is more efficient
+            # Combining all layers' params in one batch transfer is more efficient 
+            # compared to using multiple threads
             return process_layers(layers_params)
 
         return 0

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -356,7 +356,9 @@ class MooncakeKVManager(BaseKVManager):
             ]
         assert layers_params is not None
 
-        def set_transfer_blocks(src_ptr: int, dst_ptr: int, item_len: int) -> List[Tuple[int, int, int]]:
+        def set_transfer_blocks(
+            src_ptr: int, dst_ptr: int, item_len: int
+        ) -> List[Tuple[int, int, int]]:
             transfer_blocks = []
             for prefill_index, decode_index in zip(prefill_kv_blocks, dst_kv_blocks):
                 src_addr = src_ptr + int(prefill_index[0]) * item_len
@@ -364,19 +366,19 @@ class MooncakeKVManager(BaseKVManager):
                 length = item_len * len(prefill_index)
                 transfer_blocks.append((src_addr, dst_addr, length))
             return transfer_blocks
-        
+
         # Worker function for processing a single layer
         def process_layer(src_ptr: int, dst_ptr: int, item_len: int) -> int:
             transfer_blocks = set_transfer_blocks(src_ptr, dst_ptr, item_len)
             return self._transfer_data(mooncake_session_id, transfer_blocks)
-        
+
         # Worker function for processing all layers in a batch
         def process_layers(layers_params: List[Tuple[int, int, int]]) -> int:
             transfer_blocks = []
             for src_ptr, dst_ptr, item_len in layers_params:
                 transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
             return self._transfer_data(mooncake_session_id, transfer_blocks)
-        
+
         if self.enable_custom_mem_pool:
             futures = [
                 executor.submit(
@@ -394,7 +396,7 @@ class MooncakeKVManager(BaseKVManager):
                         f.cancel()
                     return status
         else:
-            # Combining all layers' params in one batch transfer is more efficient 
+            # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads
             return process_layers(layers_params)
 


### PR DESCRIPTION
## Motivation
To accelerate the KV Cache transfer via batch transfer interface.

## Modifications
Pack all layers' transfer parameters to one single batch. Call batch transfer interface directly instead of using multiple executors to fully unleash the potential of batch transfer.


## Accuracy Tests
This PR does not involve change of computation or communication process. It's just pack transfer task into one single batch task, so there shouldn't be any effect on accuracy.

## Benchmarking and Profiling
We tested the transfer speed on DeepSeek V3, using Prefill PP2 + Decode TP16 + input 10240
Baseline:
use multiple executor to trigger batch transfer per layer
transfer speed : 0.6 - 1.1 GB/s
transfer time per rank : 180+ ms
<img width="1474" height="210" alt="image" src="https://github.com/user-attachments/assets/d68395c5-dee9-40aa-92d9-0621c639dc31" />

Optimize:
directly call batch transfer, do not use executor
transfer speed : 3.8 - 3.9 GB/s
trasnsfer time per rank : 80+ ms
<img width="1620" height="482" alt="image" src="https://github.com/user-attachments/assets/58b4ce63-55e5-4c44-906a-c548c1ad8d33" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
