### PR TITLE
Support manually set dp_ranks for slow_down

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -910,6 +910,7 @@ class ResumeMemoryOccupationReqOutput:
 @dataclass
 class SlowDownReqInput:
     forward_sleep_time: Optional[float]
+    dp_ranks: Optional[Union[int, List[int]]] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -418,6 +418,7 @@ class Scheduler(
         if self.device == "cpu":
             self.current_stream.synchronize = lambda: None  # No-op for CPU
         self.forward_sleep_time = None
+        self.dp_ranks_for_slowdown = None
 
         # Init chunked prefill
         self.chunked_prefill_size = server_args.chunked_prefill_size
@@ -1713,9 +1714,10 @@ class Scheduler(
 
         # Whether to run the profiler
         self._profile_batch_predicate(batch)
-        if self.forward_sleep_time is not None:
-            logger.info(f"Scheduler.run_batch sleep {self.forward_sleep_time}s")
-            time.sleep(self.forward_sleep_time)
+        if self.dp_ranks_for_slowdown is not None and self.dp_rank in self.dp_ranks_for_slowdown:
+            if self.forward_sleep_time is not None:
+                logger.info(f"Scheduler.run_batch sleep {self.forward_sleep_time}s")
+                time.sleep(self.forward_sleep_time)
 
         # Run forward
         if self.is_generation:
@@ -2416,9 +2418,17 @@ class Scheduler(
 
     def slow_down(self, recv_req: SlowDownReqInput):
         t = recv_req.forward_sleep_time
+        drs = recv_req.dp_ranks
         if t is not None and t <= 0:
             t = None
         self.forward_sleep_time = t
+        if drs is not None:
+            if isinstance(drs, int):
+                drs = [drs]
+            drs = [rank for rank in drs if rank >= 0]
+            if not drs:
+                drs = None
+        self.dp_ranks_for_slowdown = drs
         return SlowDownReqOutput()
 
     def expert_distribution_handle(self, recv_req: ExpertDistributionReq):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Support specifying dp_ranks when sending a /slow_down request. This enables targeted slowdown for specific dp_ranks, providing finer-grained control in test.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Added support for passing a dp_ranks_for_slowdown parameter in the /slow_down API endpoint.
Updated the slowdown handling logic in the scheduler to apply the slowdown only to the specified data parallel ranks.
Set {"dp_ranks_for_slowdown": 1, "forward_sleep_time": 0.08} or {"dp_ranks_for_slowdown": [0, 1, 2, 3], "forward_sleep_time": 0.08} for multi dp ranks.
<!-- Detail the changes made in this pull request. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
