### PR TITLE
[Bugfix] Avoid unnecessary reduce-scatter call in prepare_mlp

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -292,6 +292,10 @@ def _dp_gather_via_all_gather(
     forward_batch: ForwardBatch,
     is_partial: bool,
 ):
+    if get_attention_tp_size() == 1:
+        get_tp_group().all_gather_into_tensor(global_tokens, local_tokens)
+        return
+
     if not is_partial:
         if get_attention_tp_rank() != 0:
             local_tokens.fill_(0)


### PR DESCRIPTION

## Motivation

When _dp_gather_via_all_gather is used in prepare_mlp, it uses reduce scatter and all gather to gather data. The reduce scatter and all gather operation generates cuevents, causing intervals between attention kernels and nccl kernels during decode phase.

<img width="2016" height="158" alt="image" src="https://github.com/user-attachments/assets/3e72b24b-1060-41af-adbd-604cd985639f" />

During this interval, ncclReduceScatter and ncclAllGather activities are performed. When dp attention is enabled and attention tp size is 1 ncclReduceScatter is unnecessary, and we can avoid these ReduceScatter costs.

<img width="2922" height="852" alt="image" src="https://github.com/user-attachments/assets/8be21183-e51c-43f2-a3ad-b27e8ce62516" />

## Modifications

Add a shortcut at the beginning of _dp_gather_via_all_gather.

## Accuracy Tests

```
python3 -m sglang.launch_server --model-path /models/Qwen3-235B-A22B-Instruct-2507-FP8 --disable-radix-cache --mem-fraction-static 0.85 --tp-size 4 --ep-size 4 --enable-ep-moe --max-prefill-tokens 524288 --enable-dp-attention --dp-size 4
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319 --port=30000
Accuracy: 0.957
Invalid: 0.000
Latency: 336.577 s
Output throughput: 571.761 token/s

```

## Benchmarking and Profiling

```
python3 -m sglang.launch_server --model-path /models/Qwen3-235B-A22B-Instruct-2507-FP8 --disable-radix-cache --mem-fraction-static 0.85 --tp-size 4 --ep-size 4 --enable-ep-moe --max-prefill-tokens 524288 --enable-dp-attention --dp-size 4
python3 -m sglang.bench_serving --backend sglang --dataset-name random --dataset-path /mnt/ShareGPT_V3_unfiltered_cleaned_split.json --random-input-len 3500 --random-output-len 500 --max-concurrency 200 --num-prompts 52 --request-rate inf --random-range-ratio 1
```

Before this PR
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 200
Successful requests:                     52
Benchmark duration (s):                  49.20
Total input tokens:                      182000
Total generated tokens:                  26000
Total generated tokens (retokenized):    26000
Request throughput (req/s):              1.06
Input token throughput (tok/s):          3699.13
Output token throughput (tok/s):         528.45
Total token throughput (tok/s):          4227.57
Concurrency:                             51.95
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   49153.08
Median E2E Latency (ms):                 49185.41
---------------Time to First Token----------------
Mean TTFT (ms):                          9658.41
Median TTFT (ms):                        9638.96
P99 TTFT (ms):                           16641.81
---------------Inter-Token Latency----------------
Mean ITL (ms):                           79.15
Median ITL (ms):                         65.63
P95 ITL (ms):                            67.98
P99 ITL (ms):                            68.85
Max ITL (ms):                            15274.04
==================================================
```

With this PR
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 200
Successful requests:                     52
Benchmark duration (s):                  47.94
Total input tokens:                      182000
Total generated tokens:                  26000
Total generated tokens (retokenized):    26000
Request throughput (req/s):              1.08
Input token throughput (tok/s):          3796.45
Output token throughput (tok/s):         542.35
Total token throughput (tok/s):          4338.80
Concurrency:                             51.95
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   47897.02
Median E2E Latency (ms):                 47928.22
---------------Time to First Token----------------
Mean TTFT (ms):                          9659.10
Median TTFT (ms):                        9640.72
P99 TTFT (ms):                           16645.17
---------------Inter-Token Latency----------------
Mean ITL (ms):                           76.63
Median ITL (ms):                         62.86
P95 ITL (ms):                            65.01
P99 ITL (ms):                            65.72
Max ITL (ms):                            15284.12
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
