### PR TITLE
support torch.compile(dynamic=True) to avoid recompile

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -52,6 +52,7 @@ from sglang.srt.two_batch_overlap import TboCudaGraphRunnerPlugin
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
+    get_bool_env_var,
     get_device_memory_capacity,
     rank0_log,
     require_attn_tp_gather,
@@ -135,7 +136,9 @@ def patch_model(
                 mode=os.environ.get(
                     "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
                 ),
-                dynamic=False,
+                dynamic=get_bool_env_var(
+                    "SGLANG_ENABLE_DYNAMIC_TORCH_COMPILE", "false"
+                ),
             )
         else:
             yield model.forward


### PR DESCRIPTION
Currently, when both torch compile and CUDA graph are enabled, torch compile incurs a non-negligible overhead (~270s on deepseek r1). This patch supports using an environment variable to enable dynamic mode in torch.compile(), avoiding recompilation caused by inconsistent tensor sizes(~130s on deepseek r1).

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Speed up engine startup time (when torch.compile is enabled).

## Modifications

<!-- Detail the changes made in this pull request. -->

Add an new ENV `SGLANG_ENABLE_DYNAMIC_TORCH_COMPILE` to enable dynamic torch.compile().


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Tested on DeepSeek R1 on 8*H20 with commands below:
```
python -m sglang.launch_server \
  --model-path /data/deepseek-r1/ \
  --trust-remote-code \
  --tp-size 8 \
  --quantization fp8 \
  --log-level info \
  --max-running-requests 64 \
  --mem-fraction-static 0.9 \
  --context-length 65535 \
  --enable-torch-compile \
  --torch-compile-max-bs 48 \
  --attention-backend flashinfer \
  --disable-shared-experts-fusion
```
Cost of cudagraph capturing(cuda graph capture + torch.compile())
|    | cost(s) |
| :----- | :--: |
| dynamic=false  |  270  |
| dynamic=true   |  130  |



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
