### PR TITLE
support prefill cuda graph

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -370,6 +370,7 @@ class AiterAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             qo_indptr = None
@@ -506,6 +507,7 @@ class AiterAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             kv_indptr = self.kv_indptr

--- a/python/sglang/srt/layers/attention/ascend_backend.py
+++ b/python/sglang/srt/layers/attention/ascend_backend.py
@@ -102,6 +102,7 @@ class AscendAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         metadata = ForwardMetadata()
 
@@ -123,6 +124,7 @@ class AscendAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         metadata = self.graph_metadata[bs]
         max_len = seq_lens_cpu[:bs].max().item()

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -32,6 +32,7 @@ class AttentionBackend(ABC):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Init the metadata for a forward pass for capturing a cuda graph."""
         raise NotImplementedError()
@@ -46,6 +47,7 @@ class AttentionBackend(ABC):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Init the metadata for a forward pass for replaying a cuda graph."""
         raise NotImplementedError()

--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -152,6 +152,7 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             if spec_info is None:
@@ -192,6 +193,7 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
 
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
@@ -538,6 +538,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[None],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         metadata = DualChunkFlashAttentionMetadata()
 
@@ -588,6 +589,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         spec_info: Optional[None],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: torch.Tensor = None,
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize forward metadata for replaying CUDA graph."""
         assert forward_mode.is_decode()

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1401,6 +1401,7 @@ class FlashAttentionBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize forward metadata for capturing CUDA graph."""
         metadata = FlashAttentionMetadata()
@@ -1616,6 +1617,7 @@ class FlashAttentionBackend(AttentionBackend):
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: Optional[torch.Tensor] = None,
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize forward metadata for replaying CUDA graph."""
         seq_lens = seq_lens[:bs]

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -82,7 +82,7 @@ class FlashInferAttnBackend(AttentionBackend):
         kv_last_page_len_buf: Optional[torch.Tensor] = None,
     ):
         super().__init__()
-
+        self.first_init = True
         # Parse constants
         self.decode_use_tensor_cores = should_use_tensor_core(
             kv_cache_dtype=model_runner.kv_cache_dtype,
@@ -278,33 +278,36 @@ class FlashInferAttnBackend(AttentionBackend):
         max_num_tokens: int,
         kv_indices_buf: Optional[torch.Tensor] = None,
     ):
-        if kv_indices_buf is None:
-            cuda_graph_kv_indices = torch.zeros(
-                (max_num_tokens * self.max_context_len,),
-                dtype=torch.int32,
-                device="cuda",
-            )
-        else:
-            cuda_graph_kv_indices = kv_indices_buf
+        if self.first_init:
+            if kv_indices_buf is None:
+                cuda_graph_kv_indices = torch.zeros(
+                    (max_num_tokens * self.max_context_len,),
+                    dtype=torch.int32,
+                    device="cuda",
+                )
+            else:
+                cuda_graph_kv_indices = kv_indices_buf
 
-        self.cuda_graph_kv_indices = [cuda_graph_kv_indices] + [
-            cuda_graph_kv_indices.clone() for _ in range(self.num_wrappers - 1)
-        ]
+            self.cuda_graph_kv_indices = [cuda_graph_kv_indices] + [
+                cuda_graph_kv_indices.clone() for _ in range(self.num_wrappers - 1)
+            ]
 
-        # Ensure tensors are properly allocated
-        for i in range(self.num_wrappers):
-            # Force allocation by performing a small operation
-            if len(self.cuda_graph_kv_indices[i]) > 0:
-                self.cuda_graph_kv_indices[i][0] = 0
+            # Ensure tensors are properly allocated
+            for i in range(self.num_wrappers):
+                # Force allocation by performing a small operation
+                if len(self.cuda_graph_kv_indices[i]) > 0:
+                    self.cuda_graph_kv_indices[i][0] = 0
 
-        if not self.skip_prefill:
-            self.cuda_graph_custom_mask = torch.zeros(
-                (max_num_tokens * self.max_context_len),
-                dtype=torch.uint8,
-                device="cuda",
-            )
-            self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
-            self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
+            if not self.skip_prefill:
+                self.cuda_graph_custom_mask = torch.zeros(
+                    (max_num_tokens * self.max_context_len),
+                    dtype=torch.uint8,
+                    device="cuda",
+                )
+                self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
+                self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
+
+            self.first_init = False
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -315,6 +318,7 @@ class FlashInferAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
@@ -378,7 +382,7 @@ class FlashInferAttnBackend(AttentionBackend):
             )
             self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(prefill_wrappers, False, False)
-        elif forward_mode.is_draft_extend():
+        elif forward_mode.is_draft_extend() or forward_mode.is_extend():
             prefill_wrappers = []
             for i in range(self.num_wrappers):
                 prefill_wrappers.append(
@@ -400,13 +404,18 @@ class FlashInferAttnBackend(AttentionBackend):
                 seq_lens,
                 seq_lens.cpu(),  # may add a little overhead in capture stage
                 seq_lens_sum,
-                prefix_lens=None,
+                prefix_lens=extend_prefix_lens if forward_mode.is_extend() else None,
                 prefill_wrappers=prefill_wrappers,
                 use_ragged=False,
                 encoder_lens=encoder_lens,
                 spec_info=spec_info,
             )
-            self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
+            if forward_mode.is_extend():
+                if seq_lens_sum not in self.prefill_cuda_graph_metadata:
+                    self.prefill_cuda_graph_metadata[seq_lens_sum] = {}
+                self.prefill_cuda_graph_metadata[seq_lens_sum][bs] = prefill_wrappers
+            else:
+                self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(prefill_wrappers, False, False)
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
@@ -421,6 +430,7 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
@@ -444,14 +454,21 @@ class FlashInferAttnBackend(AttentionBackend):
                 encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
                 spec_info=spec_info,
             )
-        elif forward_mode.is_draft_extend():
+        elif forward_mode.is_draft_extend() or forward_mode.is_extend():
+            if forward_mode.is_extend():
+                prefill_cuda_graph_metadata_tmp = self.prefill_cuda_graph_metadata[
+                    seq_lens_sum
+                ][bs]
+            else:
+                prefill_cuda_graph_metadata_tmp = self.prefill_cuda_graph_metadata[bs]
+            prefix_lens = extend_prefix_lens if forward_mode.is_extend() else None
             self.indices_updater_prefill.update(
                 req_pool_indices[:bs],
                 seq_lens[:bs],
                 seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
                 seq_lens_sum,
-                prefix_lens=None,
-                prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
+                prefix_lens=prefix_lens,
+                prefill_wrappers=prefill_cuda_graph_metadata_tmp,
                 use_ragged=False,
                 encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
                 spec_info=spec_info,
@@ -1001,11 +1018,15 @@ class FlashInferIndicesUpdaterPrefill:
             # Normal extend
             kv_indptr[1 : bs + 1] = torch.cumsum(paged_kernel_lens, dim=0)
             kv_indptr = kv_indptr[: bs + 1]
-            kv_indices = torch.empty(
-                paged_kernel_lens_sum + 256,
-                dtype=torch.int32,
-                device=req_pool_indices.device,
-            )
+            if wrapper_paged.is_cuda_graph_enabled:
+                # Directly write to the cuda graph input buffer
+                kv_indices = wrapper_paged._paged_kv_indices_buf
+            else:
+                kv_indices = torch.empty(
+                    paged_kernel_lens_sum + 256,
+                    dtype=torch.int32,
+                    device=req_pool_indices.device,
+                )
             create_flashinfer_kv_indices_triton[(bs,)](
                 self.req_to_token,
                 req_pool_indices,

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -358,6 +358,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
 
         if forward_mode.is_decode_or_idle():
@@ -439,6 +440,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
 
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -188,6 +188,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
@@ -259,6 +260,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
 
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -35,6 +35,7 @@ class HybridAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         self.decode_backend.init_forward_metadata_capture_cuda_graph(
             bs,
@@ -56,6 +57,7 @@ class HybridAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         self.decode_backend.init_forward_metadata_replay_cuda_graph(
             bs,

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -47,6 +47,7 @@ class TboAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: "ForwardMode",
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         self.primary.init_forward_metadata_capture_cuda_graph(
             bs=bs,
@@ -79,6 +80,7 @@ class TboAttnBackend(AttentionBackend):
         forward_mode: "ForwardMode",
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         self.primary.init_forward_metadata_replay_cuda_graph(
             bs=bs,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -433,6 +433,7 @@ class TritonAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         assert encoder_lens is None, "Not supported"
         window_kv_indptr = self.window_kv_indptr
@@ -590,6 +591,7 @@ class TritonAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         # NOTE: encoder_lens expected to be zeros or None
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -202,6 +202,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize metadata for CUDA graph capture."""
         metadata = TRTLLMMHAMetadata()
@@ -316,6 +317,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Replay CUDA graph with new inputs."""
         seq_lens = seq_lens[:bs]

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -191,6 +191,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize metadata for CUDA graph capture."""
 
@@ -238,6 +239,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Replay CUDA graph with new inputs."""
         # Delegate to parent for non-decode modes.

--- a/python/sglang/srt/layers/attention/wave_backend.py
+++ b/python/sglang/srt/layers/attention/wave_backend.py
@@ -394,6 +394,7 @@ class WaveAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         assert encoder_lens is None, "Not supported"
 
@@ -479,6 +480,7 @@ class WaveAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         # NOTE: encoder_lens expected to be zeros or None
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -176,11 +176,6 @@ class GraphBuffer:
                 dtype=torch.bool,
                 device=device,
             )
-            self.next_token_logits_buffer = torch.zeros(
-                (max_bs, model_runner.model_config.vocab_size),
-                dtype=torch.float,
-                device=device,
-            )
 
 
 @contextmanager
@@ -364,8 +359,9 @@ class CudaGraphRunner:
         self.model_runner = model_runner
         self.device = model_runner.device
         self.device_module = torch.get_device_module(self.device)
-        self.graphs = {}
-        self.output_buffers = {}
+        self.enable_prefill_cuda_graph = (
+            model_runner.server_args.enable_prefill_cuda_graph
+        )
         self.enable_torch_compile = model_runner.server_args.enable_torch_compile
         self.disable_padding = model_runner.server_args.disable_cuda_graph_padding
         self.is_encoder_decoder = model_runner.model_config.is_encoder_decoder
@@ -387,13 +383,12 @@ class CudaGraphRunner:
         self.attn_tp_size = get_attention_tp_size()
         self.attn_tp_rank = get_attention_tp_rank()
 
-        self.max_num_token = 0
+        max_num_token = 0
         # Batch sizes to capture
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(model_runner)
-        log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
         self.capture_forward_mode = ForwardMode.DECODE
         self.capture_hidden_mode = CaptureHiddenMode.NULL
-        rank0_log(f"Capture decode cuda graph bs {self.capture_bs}")
+        log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
         self.num_tokens_per_bs = 1
         if model_runner.spec_algorithm.is_eagle():
             if self.model_runner.is_draft_worker:
@@ -410,7 +405,7 @@ class CudaGraphRunner:
 
         # Attention backend
         self.max_bs = max(self.capture_bs)
-        self.max_num_token = self.max_bs * self.num_tokens_per_bs
+        max_num_token = self.max_bs * self.num_tokens_per_bs
         if self.enable_prefill_cuda_graph:
             self.capture_prefill_seqlen, self.compile_prefill_seqlen = (
                 get_prefill_seqlen_to_capture(self.model_runner)
@@ -418,14 +413,12 @@ class CudaGraphRunner:
             self.prefill_num_tokens_per_bs = max(self.capture_prefill_seqlen)
             self.max_prefill_bs = self.prefill_num_tokens_per_bs
             self.max_prefill_num_token = self.prefill_num_tokens_per_bs
-            self.max_num_token = (
-                self.max_num_token
-                if self.max_num_token > self.max_prefill_num_token
+            max_num_token = (
+                max_num_token
+                if max_num_token > self.max_prefill_num_token
                 else self.max_prefill_num_token
             )
-        self.model_runner.attn_backend.init_cuda_graph_state(
-            self.max_bs, self.max_num_token
-        )
+        self.model_runner.attn_backend.init_cuda_graph_state(self.max_bs, max_num_token)
         self.seq_len_fill_value = (
             self.model_runner.attn_backend.get_cuda_graph_seq_len_fill_value()
         )
@@ -443,76 +436,67 @@ class CudaGraphRunner:
             self.model_runner.lora_manager.init_cuda_graph_batch_info(self.max_bs)
 
         # Graph inputs
-        with torch.device(self.device):
-            self.input_ids = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            self.req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
-            self.seq_lens = torch.full(
-                (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
+        self.decode_graph_buffer = GraphBuffer()
+        self.decode_graph_buffer.set_all_buffer(
+            self.device,
+            self.model_runner,
+            self.max_bs,
+            self.num_tokens_per_bs,
+            max_num_token,
+            self.pp_size,
+            self.dp_size,
+            self.is_encoder_decoder,
+            self.encoder_len_fill_value,
+            self.require_gathered_buffer,
+            self.require_mlp_tp_gather,
+            is_decode=True,
+        )
+
+        # Capture
+        try:
+            with model_capture_mode():
+                self.capture()
+        except RuntimeError as e:
+            raise Exception(
+                f"Capture cuda graph failed: {e}\n{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
             )
-            self.out_cache_loc = torch.zeros(
-                (self.max_num_token,), dtype=self._cache_loc_dtype()
+
+        if self.enable_prefill_cuda_graph:
+            self.cuda_graph_prefill_max_bs = (
+                self.model_runner.server_args.cuda_graph_prefill_max_bs
+                if self.model_runner.server_args.cuda_graph_prefill_max_bs is not None
+                else 16
             )
-            self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
-            self.mrope_positions = torch.zeros((3, self.max_bs), dtype=torch.int64)
-            self.num_token_non_padded = torch.zeros((1,), dtype=torch.int32)
-            self.tbo_plugin = TboCudaGraphRunnerPlugin()
-
-            # pipeline parallelism
-            if self.pp_size > 1:
-                self.pp_proxy_tensors = {
-                    "hidden_states": torch.zeros(
-                        (self.max_bs, self.model_runner.model_config.hidden_size),
-                        dtype=torch.bfloat16,
-                    ),
-                    "residual": torch.zeros(
-                        (self.max_bs, self.model_runner.model_config.hidden_size),
-                        dtype=torch.bfloat16,
-                    ),
-                }
-
-            # Speculative_inference
-            if model_runner.spec_algorithm.is_eagle3():
-                self.model_runner.model.set_eagle3_layers_to_capture()
-
-            if self.is_encoder_decoder:
-                # NOTE: encoder_lens can influence the full_text_row_masked_out_mask tensor when doing mixed batch
-                self.encoder_lens = torch.full(
-                    (self.max_bs,), self.encoder_len_fill_value, dtype=torch.int32
+            try:
+                with model_capture_mode():
+                    self.capture_prefill()
+            except RuntimeError as e:
+                raise Exception(
+                    f"Capture prefill cuda graph failed: {e}\n{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
                 )
-            else:
-                self.encoder_lens = None
 
-            if self.require_gathered_buffer:
-                if self.require_mlp_tp_gather:
-                    self.global_num_tokens_gpu = torch.zeros(
-                        (self.dp_size,), dtype=torch.int32
-                    )
-                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
-                        (self.dp_size,), dtype=torch.int32
-                    )
-                else:
-                    assert self.require_attn_tp_gather
-                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
-                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
-                        (1,), dtype=torch.int32
-                    )
-            else:
-                self.global_num_tokens_gpu = None
-                self.global_num_tokens_for_logprob_gpu = None
-
-            self.custom_mask = torch.ones(
-                (
-                    (self.seq_lens.sum().item() + self.max_num_token)
-                    * self.num_tokens_per_bs
-                ),
-                dtype=torch.bool,
-                device=self.device,
-            )
-            self.next_token_logits_buffer = torch.zeros(
-                (self.max_num_token, self.model_runner.model_config.vocab_size),
-                dtype=torch.float,
-                device=self.device,
-            )
+    def capture_prefill(self):
+        log_info_on_rank0(
+            logger, f"Capture prefill cuda graph seqlen {self.capture_prefill_seqlen}"
+        )
+        self.capture_forward_mode = ForwardMode.EXTEND
+        self.capture_hidden_mode = CaptureHiddenMode.NULL
+        # Graph inputs
+        self.prefill_graph_buffer = GraphBuffer()
+        self.prefill_graph_buffer.set_all_buffer(
+            self.device,
+            self.model_runner,
+            self.max_prefill_bs,
+            self.prefill_num_tokens_per_bs,
+            self.max_prefill_num_token,
+            self.pp_size,
+            self.dp_size,
+            self.is_encoder_decoder,
+            self.encoder_len_fill_value,
+            self.require_gathered_buffer,
+            self.require_mlp_tp_gather,
+            is_decode=False,
+        )
 
         # Capture
         try:
@@ -721,7 +705,9 @@ class CudaGraphRunner:
     def _create_device_graph(self):
         return torch.cuda.CUDAGraph()
 
-    def capture_one_batch_size(self, bs: int, forward: Callable):
+    def capture_one_batch_size(
+        self, bs_capture: int, bs_or_seqlen: int, forward: Callable
+    ):
         graph = self._create_device_graph()
         stream = self.stream
         if (
@@ -761,7 +747,6 @@ class CudaGraphRunner:
         else:
             encoder_lens = None
         mrope_positions = self.cuda_graph_buffer.mrope_positions[:, :bs]
-        next_token_logits_buffer = self.cuda_graph_buffer.next_token_logits_buffer[:bs]
         self.cuda_graph_buffer.num_token_non_padded[...] = num_tokens
 
         # pipeline parallelism
@@ -839,7 +824,6 @@ class CudaGraphRunner:
             input_ids=input_ids,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
-            next_token_logits_buffer=next_token_logits_buffer,
             orig_seq_lens=seq_lens,
             req_to_token_pool=self.model_runner.req_to_token_pool,
             token_to_kv_pool=self.model_runner.token_to_kv_pool,
@@ -883,29 +867,16 @@ class CudaGraphRunner:
             self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
         # Attention backend
-        from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
-
-        if isinstance(self.model_runner.attn_backend, FlashInferAttnBackend):
-            self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_batch.forward_mode,
-                forward_batch.spec_info,
-                extend_prefix_lens=forward_batch.extend_prefix_lens,
-            )
-        else:
-            self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
-                bs,
-                num_tokens,
-                req_pool_indices,
-                seq_lens,
-                encoder_lens,
-                forward_batch.forward_mode,
-                forward_batch.spec_info,
-            )
+        self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
+            bs,
+            num_tokens,
+            req_pool_indices,
+            seq_lens,
+            encoder_lens,
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
+            extend_prefix_lens=forward_batch.extend_prefix_lens,
+        )
 
         # Run and capture
         def run_once():
@@ -1060,11 +1031,9 @@ class CudaGraphRunner:
                 forward_batch.mrope_positions
             )
         if self.require_gathered_buffer:
-            self.cuda_graph_buffer.global_num_tokens_gpu.fill_(
-                bs * raw_num_tokens_per_bs
-            )
+            self.cuda_graph_buffer.global_num_tokens_gpu.fill_(padding_num_tokens)
             self.cuda_graph_buffer.global_num_tokens_for_logprob_gpu.fill_(
-                bs * raw_num_tokens_per_bs
+                padding_num_tokens
             )
         if enable_num_token_non_padded(self.model_runner.server_args):
             num_token_non_padded = forward_batch.num_token_non_padded
@@ -1090,8 +1059,6 @@ class CudaGraphRunner:
         if forward_batch.forward_mode.is_idle() and forward_batch.spec_info is not None:
             forward_batch.spec_info.custom_mask = self.cuda_graph_buffer.custom_mask
         # Attention backend
-        from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
-
         if forward_batch.forward_mode == ForwardMode.EXTEND:
             seq_lens_sum_pad = forward_batch.seq_lens_sum + (
                 padding_num_tokens - raw_num_token
@@ -1101,37 +1068,21 @@ class CudaGraphRunner:
                 forward_batch.seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value
             )
 
-        if isinstance(self.model_runner.attn_backend, FlashInferAttnBackend):
-            self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
-                bs,
-                self.cuda_graph_buffer.req_pool_indices[:bs],
-                self.cuda_graph_buffer.seq_lens[:bs],
-                seq_lens_sum_pad,
-                (
-                    self.cuda_graph_buffer.encoder_lens[:bs]
-                    if self.is_encoder_decoder
-                    else None
-                ),
-                forward_batch.forward_mode,
-                forward_batch.spec_info,
-                seq_lens_cpu=self.seq_lens_cpu[:bs],
-                extend_prefix_lens=forward_batch.extend_prefix_lens,
-            )
-        else:
-            self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
-                bs,
-                self.cuda_graph_buffer.req_pool_indices[:bs],
-                self.cuda_graph_buffer.seq_lens[:bs],
-                seq_lens_sum_pad,
-                (
-                    self.cuda_graph_buffer.encoder_lens[:bs]
-                    if self.is_encoder_decoder
-                    else None
-                ),
-                forward_batch.forward_mode,
-                forward_batch.spec_info,
-                seq_lens_cpu=self.seq_lens_cpu[:bs],
-            )
+        self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
+            bs,
+            self.cuda_graph_buffer.req_pool_indices[:bs],
+            self.cuda_graph_buffer.seq_lens[:bs],
+            seq_lens_sum_pad,
+            (
+                self.cuda_graph_buffer.encoder_lens[:bs]
+                if self.is_encoder_decoder
+                else None
+            ),
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
+            seq_lens_cpu=self.seq_lens_cpu[:bs],
+            extend_prefix_lens=forward_batch.extend_prefix_lens,
+        )
 
         # Store fields
         self.raw_bs = raw_bs

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import os
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import torch
@@ -72,6 +73,114 @@ is_capture_mode = False
 
 def get_is_capture_mode():
     return is_capture_mode
+
+
+@dataclass
+class GraphBuffer:
+    def set_all_buffer(
+        self,
+        device,
+        model_runner,
+        max_bs,
+        num_tokens_per_bs,
+        max_num_token,
+        pp_size,
+        dp_size,
+        is_encoder_decoder,
+        encoder_len_fill_value,
+        require_gathered_buffer,
+        require_mlp_tp_gather,
+        is_decode,
+    ):
+        self.graphs = {}
+        self.output_buffers = {}
+        with torch.device(device):
+            self.input_ids = torch.zeros((max_num_token,), dtype=torch.int64)
+            self.req_pool_indices = torch.zeros((max_bs,), dtype=torch.int32)
+            self.seq_lens = torch.full((max_bs,), 1, dtype=torch.int32)
+            self.extend_prefix_lens = torch.zeros_like(self.seq_lens)
+            self.out_cache_loc = torch.zeros((max_num_token,), dtype=torch.int64)
+            self.positions = torch.zeros((max_num_token,), dtype=torch.int64)
+            self.mrope_positions = torch.zeros((3, max_bs), dtype=torch.int64)
+            self.num_token_non_padded = torch.zeros((1,), dtype=torch.int32)
+            self.tbo_plugin = TboCudaGraphRunnerPlugin()
+
+            # pipeline parallelism
+            if pp_size > 1:
+                self.pp_proxy_tensors = {
+                    "hidden_states": torch.zeros(
+                        (
+                            max_num_token,
+                            model_runner.model_config.hidden_size,
+                        ),
+                        dtype=torch.bfloat16,
+                    ),
+                    "residual": torch.zeros(
+                        (
+                            max_num_token,
+                            model_runner.model_config.hidden_size,
+                        ),
+                        dtype=torch.bfloat16,
+                    ),
+                }
+
+            # Speculative_inference
+            if model_runner.spec_algorithm.is_eagle3():
+                model_runner.model.set_eagle3_layers_to_capture()
+
+            if is_encoder_decoder:
+                # NOTE: encoder_lens can influence the full_text_row_masked_out_mask tensor when doing mixed batch
+                self.encoder_lens = torch.full(
+                    (max_bs,), encoder_len_fill_value, dtype=torch.int32
+                )
+
+            if require_gathered_buffer:
+                if require_mlp_tp_gather:
+                    self.global_num_tokens_gpu = torch.zeros(
+                        (dp_size,), dtype=torch.int32
+                    )
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (dp_size,), dtype=torch.int32
+                    )
+                    self.gathered_buffer = torch.zeros(
+                        (
+                            max_num_token * dp_size,
+                            model_runner.model_config.hidden_size,
+                        ),
+                        dtype=model_runner.dtype,
+                    )
+                else:
+                    assert self.require_attn_tp_gather
+                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (1,), dtype=torch.int32
+                    )
+                    self.gathered_buffer = torch.zeros(
+                        (
+                            max_num_token,
+                            model_runner.model_config.hidden_size,
+                        ),
+                        dtype=model_runner.dtype,
+                    )
+            else:
+                self.global_num_tokens_gpu = None
+                self.global_num_tokens_for_logprob_gpu = None
+                self.gathered_buffer = None
+
+            self.custom_mask = torch.ones(
+                (
+                    ((max_bs + max_num_token) * num_tokens_per_bs)
+                    if is_decode
+                    else (max_bs + max_num_token)
+                ),
+                dtype=torch.bool,
+                device=device,
+            )
+            self.next_token_logits_buffer = torch.zeros(
+                (max_bs, model_runner.model_config.vocab_size),
+                dtype=torch.float,
+                device=device,
+            )
 
 
 @contextmanager
@@ -160,6 +269,19 @@ def set_torch_compile_config():
         torch._dynamo.config.cache_size_limit = 1024
 
     monkey_patch_torch_compile()
+
+
+def get_prefill_seqlen_to_capture(model_runner: ModelRunner):
+    server_args = model_runner.server_args
+    cuda_graph_prefill_max_seqlen = (
+        server_args.cuda_graph_prefill_max_seqlen
+        if server_args.cuda_graph_prefill_max_seqlen is not None
+        else 1024
+    )
+    capture_prefill_seqlen = list(range(32, cuda_graph_prefill_max_seqlen + 1, 32))
+    # torch.compile on prefill may significantly increase startup time, and the actual benefits may not be significant, so it is not supported
+    compile_prefill_seqlen = []
+    return capture_prefill_seqlen, compile_prefill_seqlen
 
 
 def get_batch_sizes_to_capture(model_runner: ModelRunner):
@@ -265,11 +387,13 @@ class CudaGraphRunner:
         self.attn_tp_size = get_attention_tp_size()
         self.attn_tp_rank = get_attention_tp_rank()
 
+        self.max_num_token = 0
         # Batch sizes to capture
         self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(model_runner)
         log_info_on_rank0(logger, f"Capture cuda graph bs {self.capture_bs}")
         self.capture_forward_mode = ForwardMode.DECODE
         self.capture_hidden_mode = CaptureHiddenMode.NULL
+        rank0_log(f"Capture decode cuda graph bs {self.capture_bs}")
         self.num_tokens_per_bs = 1
         if model_runner.spec_algorithm.is_eagle():
             if self.model_runner.is_draft_worker:
@@ -287,6 +411,18 @@ class CudaGraphRunner:
         # Attention backend
         self.max_bs = max(self.capture_bs)
         self.max_num_token = self.max_bs * self.num_tokens_per_bs
+        if self.enable_prefill_cuda_graph:
+            self.capture_prefill_seqlen, self.compile_prefill_seqlen = (
+                get_prefill_seqlen_to_capture(self.model_runner)
+            )
+            self.prefill_num_tokens_per_bs = max(self.capture_prefill_seqlen)
+            self.max_prefill_bs = self.prefill_num_tokens_per_bs
+            self.max_prefill_num_token = self.prefill_num_tokens_per_bs
+            self.max_num_token = (
+                self.max_num_token
+                if self.max_num_token > self.max_prefill_num_token
+                else self.max_prefill_num_token
+            )
         self.model_runner.attn_backend.init_cuda_graph_state(
             self.max_bs, self.max_num_token
         )
@@ -400,11 +536,26 @@ class CudaGraphRunner:
         else:
             cuda_graph_bs = forward_batch.batch_size
 
-        is_bs_supported = (
-            cuda_graph_bs in self.graphs
-            if self.disable_padding
-            else cuda_graph_bs <= self.max_bs
-        )
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            is_bs_supported = (
+                (
+                    self.enable_prefill_cuda_graph
+                    and forward_batch.seq_lens_sum in self.prefill_graphs
+                    and cuda_graph_bs <= self.cuda_graph_prefill_max_bs
+                )
+                if self.disable_padding
+                else (
+                    self.enable_prefill_cuda_graph
+                    and forward_batch.seq_lens_sum <= self.prefill_num_tokens_per_bs
+                    and cuda_graph_bs <= self.cuda_graph_prefill_max_bs
+                )
+            )
+        else:
+            is_bs_supported = (
+                cuda_graph_bs in self.graphs
+                if self.disable_padding
+                else cuda_graph_bs <= self.max_bs
+            )
 
         if self.require_mlp_sync:
             is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
@@ -469,29 +620,82 @@ class CudaGraphRunner:
                     if get_tensor_model_parallel_rank() == 0
                     else reversed(self.capture_bs)
                 )
-                for i, bs in enumerate(capture_range):
+                if (
+                    hasattr(self, "capture_forward_mode")
+                    and self.capture_forward_mode == ForwardMode.EXTEND
+                ):
+                    capture_range = (
+                        tqdm.tqdm(list(self.capture_prefill_seqlen))
+                        if get_tensor_model_parallel_rank() == 0
+                        else reversed(self.capture_prefill_seqlen)
+                    )
+                for i, bs_or_seqlen in enumerate(capture_range):
                     if get_tensor_model_parallel_rank() == 0:
                         avail_mem = get_available_gpu_memory(
                             self.model_runner.device,
                             self.model_runner.gpu_id,
                             empty_cache=False,
                         )
-                        capture_range.set_description(
-                            f"Capturing batches ({bs=} {avail_mem=:.2f} GB)"
-                        )
+                        if (
+                            hasattr(self, "capture_forward_mode")
+                            and self.capture_forward_mode == ForwardMode.EXTEND
+                        ):
+                            capture_range.set_description(
+                                f"Capturing prefill seqlen ({bs_or_seqlen=} {avail_mem=:.2f} GB)"
+                            )
+                        else:
+                            capture_range.set_description(
+                                f"Capturing batches ({bs_or_seqlen=} {avail_mem=:.2f} GB)"
+                            )
 
                     with patch_model(
                         self.model_runner.model,
-                        bs in self.compile_bs,
-                        num_tokens=bs * self.num_tokens_per_bs,
+                        (
+                            (bs_or_seqlen in self.compile_prefill_seqlen)
+                            if hasattr(self, "capture_forward_mode")
+                            and self.capture_forward_mode == ForwardMode.EXTEND
+                            else (bs_or_seqlen in self.compile_bs)
+                        ),
+                        num_tokens=(
+                            (bs_or_seqlen)
+                            if hasattr(self, "capture_forward_mode")
+                            and self.capture_forward_mode == ForwardMode.EXTEND
+                            else (bs_or_seqlen * self.num_tokens_per_bs)
+                        ),
                         tp_group=self.model_runner.tp_group,
                     ) as forward:
-                        (
-                            graph,
-                            output_buffers,
-                        ) = self.capture_one_batch_size(bs, forward)
-                        self.graphs[bs] = graph
-                        self.output_buffers[bs] = output_buffers
+                        if self.capture_forward_mode == ForwardMode.EXTEND:
+                            for bs_prefill_capture in range(
+                                self.cuda_graph_prefill_max_bs
+                            ):
+                                (
+                                    graph,
+                                    output_buffers,
+                                ) = self.capture_one_batch_size(
+                                    bs_prefill_capture + 1, bs_or_seqlen, forward
+                                )
+                                if bs_or_seqlen not in self.cuda_graph_buffer.graphs:
+                                    self.cuda_graph_buffer.graphs[bs_or_seqlen] = {}
+                                    self.cuda_graph_buffer.output_buffers[
+                                        bs_or_seqlen
+                                    ] = {}
+                                self.cuda_graph_buffer.graphs[bs_or_seqlen][
+                                    bs_prefill_capture + 1
+                                ] = graph
+                                self.cuda_graph_buffer.output_buffers[bs_or_seqlen][
+                                    bs_prefill_capture + 1
+                                ] = output_buffers
+                        else:
+                            (
+                                graph,
+                                output_buffers,
+                            ) = self.capture_one_batch_size(
+                                bs_or_seqlen, bs_or_seqlen, forward
+                            )
+                            self.cuda_graph_buffer.graphs[bs_or_seqlen] = graph
+                            self.cuda_graph_buffer.output_buffers[bs_or_seqlen] = (
+                                output_buffers
+                            )
 
                     # Save gemlite cache after each capture
                     save_gemlite_cache()
@@ -520,59 +724,98 @@ class CudaGraphRunner:
     def capture_one_batch_size(self, bs: int, forward: Callable):
         graph = self._create_device_graph()
         stream = self.stream
-        num_tokens = bs * self.num_tokens_per_bs
+        if (
+            hasattr(self, "capture_forward_mode")
+            and self.capture_forward_mode == ForwardMode.EXTEND
+        ):
+            self.cuda_graph_buffer = self.prefill_graph_buffer
+        else:
+            self.cuda_graph_buffer = self.decode_graph_buffer
+
+        if (
+            hasattr(self, "capture_forward_mode")
+            and self.capture_forward_mode == ForwardMode.EXTEND
+        ):
+            num_tokens = bs_or_seqlen
+            bs = bs_capture
+            self.cuda_graph_buffer.seq_lens[:bs_capture].copy_(
+                torch.tensor(
+                    [
+                        bs_or_seqlen - bs_capture + 1 if i == bs_capture - 1 else 1
+                        for i in range(bs_capture)
+                    ]
+                )
+            )
+        else:
+            num_tokens = bs_or_seqlen * self.num_tokens_per_bs
+            bs = bs_or_seqlen
 
         # Graph inputs
-        input_ids = self.input_ids[:num_tokens]
-        req_pool_indices = self.req_pool_indices[:bs]
-        seq_lens = self.seq_lens[:bs]
-        out_cache_loc = self.out_cache_loc[:num_tokens]
-        positions = self.positions[:num_tokens]
+        input_ids = self.cuda_graph_buffer.input_ids[:num_tokens]
+        req_pool_indices = self.cuda_graph_buffer.req_pool_indices[:bs]
+        seq_lens = self.cuda_graph_buffer.seq_lens[:bs]
+        out_cache_loc = self.cuda_graph_buffer.out_cache_loc[:num_tokens]
+        positions = self.cuda_graph_buffer.positions[:num_tokens]
         if self.is_encoder_decoder:
-            encoder_lens = self.encoder_lens[:bs]
+            encoder_lens = self.cuda_graph_buffer.encoder_lens[:bs]
         else:
             encoder_lens = None
-        mrope_positions = self.mrope_positions[:, :bs]
-        next_token_logits_buffer = self.next_token_logits_buffer[:num_tokens]
-        self.num_token_non_padded[...] = num_tokens
+        mrope_positions = self.cuda_graph_buffer.mrope_positions[:, :bs]
+        next_token_logits_buffer = self.cuda_graph_buffer.next_token_logits_buffer[:bs]
+        self.cuda_graph_buffer.num_token_non_padded[...] = num_tokens
 
         # pipeline parallelism
         if self.pp_size > 1:
-            pp_proxy_tensors = PPProxyTensors(
-                {k: v[:num_tokens] for k, v in self.pp_proxy_tensors.items()}
-            )
+            if (
+                hasattr(self, "capture_forward_mode")
+                and self.capture_forward_mode == ForwardMode.EXTEND
+            ):
+                pp_proxy_tensors = PPProxyTensors(
+                    {
+                        k: v[:num_tokens]
+                        for k, v in self.prefill_pp_proxy_tensors.items()
+                    }
+                )
+            else:
+                pp_proxy_tensors = PPProxyTensors(
+                    {k: v[:num_tokens] for k, v in self.pp_proxy_tensors.items()}
+                )
 
         if self.require_mlp_tp_gather:
-            self.global_num_tokens_gpu.copy_(
+            self.cuda_graph_buffer.global_num_tokens_gpu.copy_(
                 torch.tensor(
                     [num_tokens] * self.dp_size,
                     dtype=torch.int32,
                     device=input_ids.device,
                 )
             )
-            self.global_num_tokens_for_logprob_gpu.copy_(
+            self.cuda_graph_buffer.global_num_tokens_for_logprob_gpu.copy_(
                 torch.tensor(
                     [num_tokens] * self.dp_size,
                     dtype=torch.int32,
                     device=input_ids.device,
                 )
             )
+            gathered_buffer = self.cuda_graph_buffer.gathered_buffer[
+                : num_tokens * self.dp_size
+            ]
             global_dp_buffer_len = num_tokens * self.dp_size
         elif self.require_attn_tp_gather:
-            self.global_num_tokens_gpu.copy_(
+            self.cuda_graph_buffer.global_num_tokens_gpu.copy_(
                 torch.tensor(
                     [num_tokens],
                     dtype=torch.int32,
                     device=input_ids.device,
                 )
             )
-            self.global_num_tokens_for_logprob_gpu.copy_(
+            self.cuda_graph_buffer.global_num_tokens_for_logprob_gpu.copy_(
                 torch.tensor(
                     [num_tokens],
                     dtype=torch.int32,
                     device=input_ids.device,
                 )
             )
+            gathered_buffer = self.cuda_graph_buffer.gathered_buffer[:num_tokens]
             global_dp_buffer_len = num_tokens
         else:
             global_dp_buffer_len = None
@@ -606,33 +849,63 @@ class CudaGraphRunner:
             encoder_lens=encoder_lens,
             return_logprob=False,
             positions=positions,
-            global_num_tokens_gpu=self.global_num_tokens_gpu,
-            global_num_tokens_for_logprob_gpu=self.global_num_tokens_for_logprob_gpu,
+            global_num_tokens_gpu=(self.cuda_graph_buffer.global_num_tokens_gpu),
+            global_num_tokens_for_logprob_gpu=(
+                self.cuda_graph_buffer.global_num_tokens_for_logprob_gpu
+            ),
             dp_padding_mode=DpPaddingMode.get_default_mode_in_cuda_graph(),
             global_dp_buffer_len=global_dp_buffer_len,
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
             capture_hidden_mode=self.capture_hidden_mode,
-            num_token_non_padded=self.num_token_non_padded,
+            num_token_non_padded=(self.cuda_graph_buffer.num_token_non_padded),
             global_forward_mode=self.capture_forward_mode,
             lora_ids=lora_ids,
+            extend_prefix_lens=(
+                self.cuda_graph_buffer.extend_prefix_lens[:bs]
+                if hasattr(self, "capture_forward_mode")
+                and self.capture_forward_mode == ForwardMode.EXTEND
+                else None
+            ),
+            extend_seq_lens=(
+                seq_lens
+                if hasattr(self, "capture_forward_mode")
+                and self.capture_forward_mode == ForwardMode.EXTEND
+                else None
+            ),
         )
-        self.tbo_plugin.capture_one_batch_size(forward_batch, num_tokens=num_tokens)
+        self.cuda_graph_buffer.tbo_plugin.capture_one_batch_size(
+            forward_batch, num_tokens=num_tokens
+        )
 
         if lora_ids is not None:
             self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
         # Attention backend
-        self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
-            bs,
-            num_tokens,
-            req_pool_indices,
-            seq_lens,
-            encoder_lens,
-            forward_batch.forward_mode,
-            forward_batch.spec_info,
-        )
+        from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
+
+        if isinstance(self.model_runner.attn_backend, FlashInferAttnBackend):
+            self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
+                bs,
+                num_tokens,
+                req_pool_indices,
+                seq_lens,
+                encoder_lens,
+                forward_batch.forward_mode,
+                forward_batch.spec_info,
+                extend_prefix_lens=forward_batch.extend_prefix_lens,
+            )
+        else:
+            self.model_runner.attn_backend.init_forward_metadata_capture_cuda_graph(
+                bs,
+                num_tokens,
+                req_pool_indices,
+                seq_lens,
+                encoder_lens,
+                forward_batch.forward_mode,
+                forward_batch.spec_info,
+            )
 
         # Run and capture
         def run_once():
@@ -708,10 +981,19 @@ class CudaGraphRunner:
         forward_batch: ForwardBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            self.cuda_graph_buffer = self.prefill_graph_buffer
+        else:
+            self.cuda_graph_buffer = self.decode_graph_buffer
+
         self.recapture_if_needed(forward_batch)
 
         raw_bs = forward_batch.batch_size
-        raw_num_token = raw_bs * self.num_tokens_per_bs
+        raw_num_token = (
+            forward_batch.seq_lens_sum
+            if forward_batch.forward_mode == ForwardMode.EXTEND
+            else raw_bs * self.num_tokens_per_bs
+        )
 
         # Pad
         if self.require_mlp_tp_gather:
@@ -723,18 +1005,37 @@ class CudaGraphRunner:
             )
             index = bisect.bisect_left(self.capture_bs, max_batch_size)
         else:
-            index = bisect.bisect_left(self.capture_bs, raw_bs)
-        bs = self.capture_bs[index]
+            index = (
+                bisect.bisect_left(
+                    self.capture_prefill_seqlen, forward_batch.seq_lens_sum
+                )
+                if forward_batch.forward_mode == ForwardMode.EXTEND
+                else bisect.bisect_left(self.capture_bs, raw_bs)
+            )
+        bs = (
+            raw_bs
+            if forward_batch.forward_mode == ForwardMode.EXTEND
+            else self.capture_bs[index]
+        )
+        padding_num_tokens = (
+            self.capture_prefill_seqlen[index]
+            if forward_batch.forward_mode == ForwardMode.EXTEND
+            else self.num_tokens_per_bs * bs
+        )
         if bs != raw_bs:
-            self.seq_lens.fill_(self.seq_len_fill_value)
-            self.out_cache_loc.zero_()
+            self.cuda_graph_buffer.seq_lens.fill_(self.seq_len_fill_value)
+            self.cuda_graph_buffer.out_cache_loc.zero_()
 
         # Common inputs
-        self.input_ids[:raw_num_token].copy_(forward_batch.input_ids)
-        self.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
-        self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
-        self.out_cache_loc[:raw_num_token].copy_(forward_batch.out_cache_loc)
-        self.positions[:raw_num_token].copy_(forward_batch.positions)
+        self.cuda_graph_buffer.input_ids[:raw_num_token].copy_(forward_batch.input_ids)
+        self.cuda_graph_buffer.req_pool_indices[:raw_bs].copy_(
+            forward_batch.req_pool_indices
+        )
+        self.cuda_graph_buffer.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
+        self.cuda_graph_buffer.out_cache_loc[:raw_num_token].copy_(
+            forward_batch.out_cache_loc
+        )
+        self.cuda_graph_buffer.positions[:raw_num_token].copy_(forward_batch.positions)
 
         seq_lens_cpu = None
         if forward_batch.seq_lens_cpu is not None:
@@ -744,17 +1045,27 @@ class CudaGraphRunner:
             seq_lens_cpu = self.seq_lens_cpu[:bs]
 
         if pp_proxy_tensors:
-            for key in self.pp_proxy_tensors.keys():
+            for key in self.cuda_graph_buffer.pp_proxy_tensors.keys():
                 dim = pp_proxy_tensors[key].shape[0]
-                self.pp_proxy_tensors[key][:dim].copy_(pp_proxy_tensors[key])
+                self.cuda_graph_buffer.pp_proxy_tensors[key][:dim].copy_(
+                    pp_proxy_tensors[key]
+                )
 
         if self.is_encoder_decoder:
-            self.encoder_lens[:raw_bs].copy_(forward_batch.encoder_lens)
+            self.cuda_graph_buffer.encoder_lens[:raw_bs].copy_(
+                forward_batch.encoder_lens
+            )
         if forward_batch.mrope_positions is not None:
-            self.mrope_positions[:, :raw_bs].copy_(forward_batch.mrope_positions)
+            self.cuda_graph_buffer.mrope_positions[:, :raw_bs].copy_(
+                forward_batch.mrope_positions
+            )
         if self.require_gathered_buffer:
-            self.global_num_tokens_gpu.fill_(bs * self.num_tokens_per_bs)
-            self.global_num_tokens_for_logprob_gpu.fill_(bs * self.num_tokens_per_bs)
+            self.cuda_graph_buffer.global_num_tokens_gpu.fill_(
+                bs * raw_num_tokens_per_bs
+            )
+            self.cuda_graph_buffer.global_num_tokens_for_logprob_gpu.fill_(
+                bs * raw_num_tokens_per_bs
+            )
         if enable_num_token_non_padded(self.model_runner.server_args):
             num_token_non_padded = forward_batch.num_token_non_padded
             if self.require_gathered_buffer:
@@ -764,34 +1075,69 @@ class CudaGraphRunner:
                     min=0,
                     max=tokens_per_rank,
                 )
-                self.num_token_non_padded.copy_(num_local_token_non_padded)
+                self.cuda_graph_buffer.num_token_non_padded.copy_(
+                    num_local_token_non_padded
+                )
             else:
-                self.num_token_non_padded.copy_(num_token_non_padded)
+                self.cuda_graph_buffer.num_token_non_padded.copy_(num_token_non_padded)
         if self.enable_two_batch_overlap:
-            self.tbo_plugin.replay_prepare(
-                forward_mode=self.capture_forward_mode,
+            self.cuda_graph_buffer.tbo_plugin.replay_prepare(
+                forward_mode=forward_batch.forward_mode,
                 bs=bs,
                 num_token_non_padded=len(forward_batch.input_ids),
                 spec_info=forward_batch.spec_info,
             )
         if forward_batch.forward_mode.is_idle() and forward_batch.spec_info is not None:
-            forward_batch.spec_info.custom_mask = self.custom_mask
+            forward_batch.spec_info.custom_mask = self.cuda_graph_buffer.custom_mask
         # Attention backend
-        self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
-            bs,
-            self.req_pool_indices[:bs],
-            self.seq_lens[:bs],
-            forward_batch.seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value,
-            self.encoder_lens[:bs] if self.is_encoder_decoder else None,
-            self.capture_forward_mode,
-            forward_batch.spec_info,
-            seq_lens_cpu=seq_lens_cpu,
-        )
+        from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
+
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            seq_lens_sum_pad = forward_batch.seq_lens_sum + (
+                padding_num_tokens - raw_num_token
+            )
+        else:
+            seq_lens_sum_pad = (
+                forward_batch.seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value
+            )
+
+        if isinstance(self.model_runner.attn_backend, FlashInferAttnBackend):
+            self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
+                bs,
+                self.cuda_graph_buffer.req_pool_indices[:bs],
+                self.cuda_graph_buffer.seq_lens[:bs],
+                seq_lens_sum_pad,
+                (
+                    self.cuda_graph_buffer.encoder_lens[:bs]
+                    if self.is_encoder_decoder
+                    else None
+                ),
+                forward_batch.forward_mode,
+                forward_batch.spec_info,
+                seq_lens_cpu=self.seq_lens_cpu[:bs],
+                extend_prefix_lens=forward_batch.extend_prefix_lens,
+            )
+        else:
+            self.model_runner.attn_backend.init_forward_metadata_replay_cuda_graph(
+                bs,
+                self.cuda_graph_buffer.req_pool_indices[:bs],
+                self.cuda_graph_buffer.seq_lens[:bs],
+                seq_lens_sum_pad,
+                (
+                    self.cuda_graph_buffer.encoder_lens[:bs]
+                    if self.is_encoder_decoder
+                    else None
+                ),
+                forward_batch.forward_mode,
+                forward_batch.spec_info,
+                seq_lens_cpu=self.seq_lens_cpu[:bs],
+            )
 
         # Store fields
         self.raw_bs = raw_bs
         self.raw_num_token = raw_num_token
         self.bs = bs
+        self.num_token = padding_num_tokens
 
     def replay(
         self,
@@ -803,18 +1149,34 @@ class CudaGraphRunner:
             self.replay_prepare(forward_batch, pp_proxy_tensors)
         else:
             # In speculative decoding, these two fields are still needed.
-            self.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
-            self.positions[: self.raw_num_token].copy_(forward_batch.positions)
+            self.cuda_graph_buffer.input_ids[: self.raw_num_token].copy_(
+                forward_batch.input_ids
+            )
+            self.cuda_graph_buffer.positions[: self.raw_num_token].copy_(
+                forward_batch.positions
+            )
 
         # Replay
-        self.graphs[self.bs].replay()
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            self.cuda_graph_buffer.graphs[self.num_token][self.raw_bs].replay()
+            output = self.cuda_graph_buffer.output_buffers[self.num_token][self.raw_bs]
+        else:
+            self.cuda_graph_buffer.graphs[self.bs].replay()
+            output = self.cuda_graph_buffer.output_buffers[self.bs]
 
-        output = self.output_buffers[self.bs]
         if isinstance(output, LogitsProcessorOutput):
             return LogitsProcessorOutput(
-                next_token_logits=output.next_token_logits[: self.raw_num_token],
+                next_token_logits=(
+                    output.next_token_logits[: self.raw_bs]
+                    if forward_batch.forward_mode == ForwardMode.EXTEND
+                    else output.next_token_logits[: self.raw_num_token]
+                ),
                 hidden_states=(
-                    output.hidden_states[: self.raw_num_token]
+                    (
+                        output.hidden_states[: self.raw_bs]
+                        if forward_batch.forward_mode == ForwardMode.EXTEND
+                        else output.hidden_states[: self.raw_num_token]
+                    )
                     if output.hidden_states is not None
                     else None
                 ),
@@ -833,7 +1195,7 @@ class CudaGraphRunner:
             else:
                 spec_info = EagleVerifyInput(
                     draft_token=None,
-                    custom_mask=self.custom_mask,
+                    custom_mask=(self.cuda_graph_buffer.custom_mask),
                     positions=None,
                     retrive_index=None,
                     retrive_next_token=None,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -90,7 +90,11 @@ from sglang.srt.mem_cache.memory_pool import (
     SWAKVPool,
 )
 from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_executor.forward_batch_info import (
+    ForwardBatch,
+    ForwardMode,
+    PPProxyTensors,
+)
 from sglang.srt.model_executor.npu_graph_runner import NPUGraphRunner
 from sglang.srt.model_loader import get_model
 from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
@@ -1771,8 +1775,14 @@ class ModelRunner:
         split_forward_count: int = 1,
     ) -> Tuple[Union[LogitsProcessorOutput, PPProxyTensors], bool]:
         can_run_cuda_graph = bool(
-            forward_batch.forward_mode.is_cuda_graph()
-            and self.graph_runner
+            self.graph_runner
+            and (
+                forward_batch.forward_mode.is_cuda_graph()
+                or (
+                    forward_batch.forward_mode == ForwardMode.EXTEND
+                    and self.graph_runner.enable_prefill_cuda_graph
+                )
+            )
             and self.graph_runner.can_run(forward_batch)
         )
         if can_run_cuda_graph:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -236,6 +236,9 @@ class ServerArgs:
     disable_radix_cache: bool = False
     cuda_graph_max_bs: Optional[int] = None
     cuda_graph_bs: Optional[List[int]] = None
+    enable_prefill_cuda_graph: bool = False
+    cuda_graph_prefill_max_seqlen: Optional[int] = None
+    cuda_graph_prefill_max_bs: Optional[int] = None
     disable_cuda_graph: bool = False
     disable_cuda_graph_padding: bool = False
     enable_profile_cuda_graph: bool = False
@@ -507,6 +510,13 @@ class ServerArgs:
                     f"TensorRT-LLM MHA only supports page_size of 16, 32 or 64, changing page_size from {self.page_size} to 64."
                 )
                 self.page_size = 64
+
+        if self.enable_prefill_cuda_graph:
+            logger.warning(
+                f"self.disable_radix_cache will be assigned as true and self.attention_backend will be assigned as flashinfer when you turn on --enable-prefill-cuda-graph"
+            )
+            self.disable_radix_cache = True
+            self.attention_backend = "flashinfer"
 
         if self.attention_backend == "dual_chunk_flash_attn":
             logger.warning(
@@ -1732,6 +1742,21 @@ class ServerArgs:
             type=int,
             nargs="+",
             help="Set the list of batch sizes for cuda graph.",
+        )
+        parser.add_argument(
+            "--enable-prefill-cuda-graph",
+            action="store_true",
+            help="Enable cuda graph for prefill.",
+        )
+        parser.add_argument(
+            "--cuda-graph-prefill-max-seqlen",
+            type=int,
+            help="Set the prefill seqlen range(32, cuda_graph_prefill_max_seqlen + 1, 32) for cuda graph.",
+        )
+        parser.add_argument(
+            "--cuda-graph-prefill-max-bs",
+            type=int,
+            help="Set the prefill bs range(1, cuda_graph_prefill_max_bs + 1, 1) for cuda graph.",
         )
         parser.add_argument(
             "--disable-cuda-graph",

--- a/test/srt/test_enable_prefill_cuda_graph.py
+++ b/test/srt/test_enable_prefill_cuda_graph.py
@@ -1,0 +1,86 @@
+import time
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_amd_ci,
+    popen_launch_server,
+)
+
+
+class TestPreillCudaGraph(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-prefill-cuda-graph",
+                "--cuda-graph-prefill-max-seqlen",
+                "256",
+                "--cuda-graph-prefill-max-bs",
+                "8",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.65)
+
+    def run_decode(self, max_new_tokens):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            },
+        )
+        return response.json()
+
+    def test_throughput(self):
+        # Warmup
+        res = self.run_decode(16)
+
+        max_tokens = 256
+        tic = time.perf_counter()
+        res = self.run_decode(max_tokens)
+        tok = time.perf_counter()
+        print(f"{res=}")
+        throughput = max_tokens / (tok - tic)
+        print(f"Throughput: {throughput} tokens/s")
+
+        if is_in_amd_ci():
+            self.assertGreaterEqual(throughput, 30)
+        else:
+            self.assertGreaterEqual(throughput, 40)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Added support for prefill CUDA graphs
## Modifications
1. Specified through the parameter --enable-prefill-cuda-graph
2. while using --cuda-graph-prefill-max-seqlen to limit the maximum seqlen that the prefill CUDA graph can function on, length below the maximum value will be padded to a multiple of 32. 
3. Currently, only flashinfer attention backend is supported
