### PR TITLE
add error message for runai

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -708,7 +708,12 @@ def runai_safetensors_weights_iterator(
     hf_weights_files: List[str],
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model safetensor files."""
-    from runai_model_streamer import SafetensorsStreamer
+    try:
+        from runai_model_streamer import SafetensorsStreamer
+    except ImportError as e:
+        raise ImportError(
+            "You may have to `pip install runai-model-streamer`"
+        ) from e
 
     enable_tqdm = (
         not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0


### PR DESCRIPTION
repro:
invoke sglang with 
```
python3 -m sglang.launch_server \
  --host 0.0.0.0 \
  --model-path "s3://path/to/my/model/"
```

you will encounter this error

```
[2025-08-14 17:50:07 TP4] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/scheduler.py", line 2733, in run_scheduler_process
    scheduler = Scheduler(server_args, port_args, gpu_id, tp_rank, pp_rank, dp_rank)
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/scheduler.py", line 339, in __init__
    self.tp_worker = TpWorkerClass(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/tp_worker_overlap_thread.py", line 66, in __init__
    self.worker = TpModelWorker(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/managers/tp_worker.py", line 81, in __init__
    self.model_runner = ModelRunner(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_executor/model_runner.py", line 233, in __init__
    self.initialize(min_per_gpu_memory)
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_executor/model_runner.py", line 276, in initialize
    self.load_model()
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_executor/model_runner.py", line 616, in load_model
    self.model = get_model(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/__init__.py", line 22, in get_model
    return loader.load_model(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/loader.py", line 1467, in load_model
    self._load_model_from_remote_fs(
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/loader.py", line 1422, in _load_model_from_remote_fs
    model.load_weights(self._get_weights_iterator_fs(client))
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/models/qwen3.py", line 389, in load_weights
    for name, loaded_weight in weights:
  File "/usr/local/lib/python3.10/dist-packages/sglang/srt/model_loader/weight_utils.py", line 709, in runai_safetensors_weights_iterator
    from runai_model_streamer import SafetensorsStreamer
```

sglang should probably take a dependency on `runai-model-streamer` or `runai-model-streamer[s3]` in https://github.com/sgl-project/sglang/blob/main/python/pyproject.toml or at least add a more descriptive message like in this PR.