### PR TITLE
fix: fix unsupported palette mode of images in bench_serving for mmmu

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -864,11 +864,11 @@ def sample_mmmu_requests(
                     if image.mode == "RGBA":
                         image = image.convert("RGB")
 
-                    # Encode image to base64
+                    # Encode image to base64 (save as PNG to support palette/alpha modes)
                     buffered = io.BytesIO()
-                    image.save(buffered, format="JPEG")
+                    image.save(buffered, format="PNG")
                     img_str = pybase64.b64encode(buffered.getvalue()).decode("utf-8")
-                    image_data = f"data:image/jpeg;base64,{img_str}"
+                    image_data = f"data:image/png;base64,{img_str}"
                 else:
                     continue
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation


When benchmarking VLMs with dataset mmmu and bench_serving, an error would constantly be prompted:
```
Loading MMMU dataset from HuggingFace...
Attempting to load MMMU Math dataset...
Successfully loaded MMMU Math dataset from HuggingFace with 505 examples
Selected 500 examples for benchmarking
Error processing example 57: cannot write mode P as JPEG
Error processing example 58: cannot write mode P as JPEG
```

This is due to the fact that some images of MMMU is in `palette` mode, which does not work well when saving it in JPEG format

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Save and load the image in `PNG`
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
