### PR TITLE
[Feature][PD] Support parallel_sample_num n > 1 for PD

### DIFF
--- a/python/sglang/srt/disaggregation/mini_lb.py
+++ b/python/sglang/srt/disaggregation/mini_lb.py
@@ -316,23 +316,17 @@ async def _forward_to_backend(request_data: dict, endpoint_name: str):
     parallel_sample_n = request_data.get("n", 1)
 
     if parallel_sample_n > 1:
-        modified_request.update(
-            {
-                "bootstrap_host": hostname,
-                "bootstrap_port": bootstrap_port,
-                "bootstrap_room": [
-                    _generate_bootstrap_room() for _ in range(parallel_sample_n)
-                ],
-            }
-        )
+        bootstrap_room = [_generate_bootstrap_room() for _ in range(parallel_sample_n)]
     else:
-        modified_request.update(
-            {
-                "bootstrap_host": hostname,
-                "bootstrap_port": bootstrap_port,
-                "bootstrap_room": _generate_bootstrap_room(),
-            }
-        )
+        bootstrap_room = _generate_bootstrap_room()
+
+    modified_request.update(
+        {
+            "bootstrap_host": hostname,
+            "bootstrap_port": bootstrap_port,
+            "bootstrap_room": bootstrap_room,
+        }
+    )
 
     if request_data.get("stream", False):
         return await load_balancer.generate_stream(

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -481,7 +481,7 @@ class ChatCompletionRequest(BaseModel):
     # For PD disaggregation
     bootstrap_host: Optional[str] = None
     bootstrap_port: Optional[int] = None
-    bootstrap_room: Optional[int] = None
+    bootstrap_room: Optional[Union[int, List[int]]] = None
 
 
 class ChatMessage(BaseModel):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -120,7 +120,7 @@ class GenerateReqInput:
     # For disaggregated inference
     bootstrap_host: Optional[Union[List[str], str]] = None
     bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
-    bootstrap_room: Optional[Union[List[int], int]] = None
+    bootstrap_room: Optional[Union[List[List[int]], List[int], int]] = None
 
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
@@ -223,6 +223,13 @@ class GenerateReqInput:
                 self.input_ids = [self.input_ids]
             if self.input_embeds is not None:
                 self.input_embeds = [self.input_embeds]
+
+            if self.bootstrap_host is not None:
+                self.bootstrap_host = [self.bootstrap_host]
+            if self.bootstrap_port is not None:
+                self.bootstrap_port = [self.bootstrap_port]
+            if self.bootstrap_room is not None:
+                self.bootstrap_room = [self.bootstrap_room]
 
     def _normalize_single_inputs(self):
         """Normalize inputs for a single example."""
@@ -524,7 +531,7 @@ class TokenizedGenerateReqInput:
     # For disaggregated inference
     bootstrap_host: Optional[str] = None
     bootstrap_port: Optional[int] = None
-    bootstrap_room: Optional[int] = None
+    bootstrap_room: Optional[Union[int, List[int]]] = None
 
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -54,6 +54,7 @@ from fastapi import BackgroundTasks
 from sglang.srt.aio_rwlock import RWLock
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.disaggregation.utils import (
+    FAKE_BOOTSTRAP_HOST,
     DisaggregationMode,
     KVClassType,
     TransferBackend,
@@ -881,11 +882,7 @@ class TokenizerManager:
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     tokenized_obj.rid = tmp_obj.regenerate_rid()
                     if tokenized_obj.bootstrap_host is not None:
-                        # For PD disaggregation, we need to fake the bootstrap host for the prefill server
-                        logger.info(
-                            f"[SampleParallel] bootstrap_host: {tokenized_obj.bootstrap_host}->fake_host"
-                        )
-                        tokenized_obj.bootstrap_host = "2.2.2.2"
+                        tokenized_obj.bootstrap_host = FAKE_BOOTSTRAP_HOST
                     tokenized_obj.sampling_params = copy.copy(
                         tokenized_obj.sampling_params
                     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Support parallel_sample_num > 1 with PD disggregation mode.

## Modifications

The proposed solution is designed as follows: 

Retain the preliminary run logic for Prefill without kv-cache transmission. Subsequent n Prefill requests will follow normal inference/kv_cache transmission while maximizing prefix-cache reuse. 
Decode requests will be treated as n independent requests, executing the original kv_cache reception and inference process, with request aggregation performed upon response return. The following additions are required:

1. Each of the n sub-requests must carry its own bootstrap room, passed through minilb.

2. During the Prefill preliminary run, dummy transmission must be performed based on the fake_connector."

TODO:

- [ ] support generate request
- [ ] add uni-test

## Accuracy Tests

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
