### PR TITLE
fix unexcepted answer in EAGLE mode

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -177,11 +177,22 @@ class EagleDraftInput:
         )
         return kv_indices, cum_kv_seq_len, qo_indptr, None
 
-    def filter_batch(self, new_indices: torch.Tensor):
-        self.topk_p = self.topk_p[: len(new_indices)]
-        self.topk_index = self.topk_index[: len(new_indices)]
-        self.hidden_states = self.hidden_states[: len(new_indices)]
-        self.verified_id = self.verified_id[: len(new_indices)]
+    def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
+        if has_been_filtered:
+            # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
+            # therefore, we don't need to filter the batch again in scheduler
+            if len(new_indices) != len(self.topk_p):
+                logger.warning(f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, this should not happen")
+            self.topk_p = self.topk_p[: len(new_indices)]
+            self.topk_index = self.topk_index[: len(new_indices)]
+            self.hidden_states = self.hidden_states[: len(new_indices)]
+            self.verified_id = self.verified_id[: len(new_indices)]
+        else:
+            # in some cases(e.g draft_extend), we have not filtered the batch by `unfinished_index`
+            self.topk_p = self.topk_p[new_indices]
+            self.topk_index = self.topk_index[new_indices]
+            self.hidden_states = self.hidden_states[new_indices]
+            self.verified_id = self.verified_id[new_indices]
 
     def merge_batch(self, spec_info: EagleDraftInput):
         if self.hidden_states is None:

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -182,7 +182,9 @@ class EagleDraftInput:
             # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
             # therefore, we don't need to filter the batch again in scheduler
             if len(new_indices) != len(self.topk_p):
-                logger.warning(f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, this should not happen")
+                logger.warning(
+                    f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, this should not happen"
+                )
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]
             self.hidden_states = self.hidden_states[: len(new_indices)]

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -844,9 +844,13 @@ class EAGLEWorker(TpModelWorker):
                 unfinished_req_index.append(i)
         if has_finished:
             unfinished_index_device = torch.tensor(
-                unfinished_req_index, dtype=torch.int64, device=batch.spec_info.topk_p.device
+                unfinished_req_index,
+                dtype=torch.int64,
+                device=batch.spec_info.topk_p.device,
             )
-            batch.spec_info.filter_batch(unfinished_index_device, has_been_filtered=False)
+            batch.spec_info.filter_batch(
+                unfinished_index_device, has_been_filtered=False
+            )
 
     def forward_draft_extend_after_decode(self, batch: ScheduleBatch):
         assert isinstance(batch.spec_info, EagleDraftInput)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -836,6 +836,17 @@ class EAGLEWorker(TpModelWorker):
         assert isinstance(forward_batch.spec_info, EagleDraftInput)
         assert forward_batch.spec_info is batch.spec_info
         self.capture_for_decode(logits_output, forward_batch.spec_info)
+        has_finished, unfinished_req_index = False, []
+        for i, req in enumerate(batch.reqs):
+            if req.finished():
+                has_finished = True
+            else:
+                unfinished_req_index.append(i)
+        if has_finished:
+            unfinished_index_device = torch.tensor(
+                unfinished_req_index, dtype=torch.int64, device=batch.spec_info.topk_p.device
+            )
+            batch.spec_info.filter_batch(unfinished_index_device, has_been_filtered=False)
 
     def forward_draft_extend_after_decode(self, batch: ScheduleBatch):
         assert isinstance(batch.spec_info, EagleDraftInput)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to fix #8671 

## Modifications

<!-- Detail the changes made in this pull request. -->

In the `filter_batch`, previous we had `self.topk_p = self.topk_p[: len(new_indices)]`, This line should never be used to filter since it makes no meaning if `len(new_indices) !=len(self.topk_p)`
- Before Verification, we will filter finished requests. That's why we cannot use `self.topk_p = self.topk_p[new_indices]`. Since after verification, `len(topk_p)` might not be equal to `len(new_indices)`.
- While After Draft Extend, we won't filter finished requests. Consider the case that the json schema is invalid. The request will still be sent to Extend, and will be filtered right after Extend. In this case, using `self.topk_p = self.topk_p[: len(new_indices)]` will cause the useful info to be filtered, and keep the info that belongs to the bad request.

My Modification is to add one filter after extend. This should minimize the modification.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
The test script can be found in #8671 
Before the modification:
<img width="3456" height="630" alt="6db665aa198f515d8e70d45fc3c5ebce" src="https://github.com/user-attachments/assets/55666439-81ec-4841-bc3a-67ace3d63270" />
After the modification:
<img width="3456" height="810" alt="6a00f2ef8ea23e660a579d3bb8af7352" src="https://github.com/user-attachments/assets/bce6b40e-abd0-4c51-be18-b80b5a094de6" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
