### PR TITLE
`from python.sglang.srt` -> `from sglang.srt`

### DIFF
--- a/python/sglang/srt/models/nemotron_nas.py
+++ b/python/sglang/srt/models/nemotron_nas.py
@@ -20,12 +20,12 @@ import torch
 from torch import nn
 from transformers import LlamaConfig
 
-from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
 from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.layers.vocab_parallel_embedding import (
     DEFAULT_VOCAB_PADDING_SIZE,
     ParallelLMHead,

--- a/python/sglang/srt/models/nemotron_nas.py
+++ b/python/sglang/srt/models/nemotron_nas.py
@@ -20,7 +20,7 @@ import torch
 from torch import nn
 from transformers import LlamaConfig
 
-from python.sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput


### PR DESCRIPTION
This is a slight fix to `nemotron_nas` imports so import after sglang packaging will be guaranteed to work, and also consistency.