### PR TITLE
Fix triton_fused_moe unit test and benchmark

### DIFF
--- a/benchmark/kernels/fused_moe_triton/benchmark_sglang_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_sglang_fused_moe_triton.py
@@ -82,19 +82,19 @@ def fused_moe_triton_api(
     input_gating,
     topk,
 ):
-    topk_output = TopK(
+    topk_op = TopK(
         top_k=topk,
         renormalize=False,
         use_grouped_topk=False,
     )
-    topk_output.use_triton_kernels = True
-    triton_topk_output = topk_output.forward_cuda(
+    topk_op.use_triton_kernels = True
+    triton_topk_output = topk_op.forward_cuda(
         hidden_states=x,
         router_logits=input_gating,
     )
 
     moe_runner_config = MoeRunnerConfig(
-        inplace=True,
+        inplace=False,
     )
     return triton_kernel_moe_forward(
         x,
@@ -133,6 +133,7 @@ def fused_moe_sglang_api(
         w2_scale=w2_scale,
         a1_scale=a1_scale,
         a2_scale=a2_scale,
+        block_shape=block_shape,
     )
 
 

--- a/benchmark/kernels/fused_moe_triton/benchmark_sglang_fused_moe_triton.py
+++ b/benchmark/kernels/fused_moe_triton/benchmark_sglang_fused_moe_triton.py
@@ -17,6 +17,8 @@ from sglang.srt.layers.moe.fused_moe_triton.fused_moe import (
 from sglang.srt.layers.moe.fused_moe_triton.triton_kernels_moe import (
     triton_kernel_moe_forward,
 )
+from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
+from sglang.srt.layers.moe.topk import TopK, TopKConfig, select_experts
 
 
 def get_model_config(model_name: str, tp_size: int):
@@ -80,13 +82,26 @@ def fused_moe_triton_api(
     input_gating,
     topk,
 ):
+    topk_output = TopK(
+        top_k=topk,
+        renormalize=False,
+        use_grouped_topk=False,
+    )
+    topk_output.use_triton_kernels = True
+    triton_topk_output = topk_output.forward_cuda(
+        hidden_states=x,
+        router_logits=input_gating,
+    )
+
+    moe_runner_config = MoeRunnerConfig(
+        inplace=True,
+    )
     return triton_kernel_moe_forward(
         x,
         w1,
         w2,
-        input_gating,
-        topk,
-        renormalize=False,
+        triton_topk_output,
+        moe_runner_config,
     )
 
 
@@ -103,20 +118,21 @@ def fused_moe_sglang_api(
     a2_scale=None,
     block_shape=None,
 ):
+    topk_output = select_experts(
+        hidden_states=x,
+        router_logits=input_gating,
+        topk_config=TopKConfig(top_k=topk, renormalize=False),
+    )
     return fused_moe_sglang(
         x,
         w1,
         w2,
-        input_gating,
-        topk,
-        renormalize=False,
-        inplace=True,
+        topk_output,
         use_fp8_w8a8=use_fp8_w8a8,
         w1_scale=w1_scale,
         w2_scale=w2_scale,
         a1_scale=a1_scale,
         a2_scale=a2_scale,
-        block_shape=block_shape,
     )
 
 

--- a/test/srt/test_triton_fused_moe.py
+++ b/test/srt/test_triton_fused_moe.py
@@ -94,19 +94,19 @@ class TestFusedMOE(CustomTestCase):
         w2_tri = w2_tri.transpose(-2, -1).contiguous()
         score = self.create_random_cuda_tensor((m, e), dtype)
 
-        topk_output = TopK(
+        topk_op = TopK(
             top_k=topk,
             renormalize=False,
             use_grouped_topk=False,
         )
-        topk_output.use_triton_kernels = True
-        triton_topk_output = topk_output.forward_cuda(
+        topk_op.use_triton_kernels = True
+        triton_topk_output = topk_op.forward_cuda(
             hidden_states=a,
             router_logits=score,
         )
 
         moe_runner_config = MoeRunnerConfig(
-            inplace=True,
+            inplace=False,
         )
         triton_output = triton_kernel_moe_forward(
             a, w1_tri, w2_tri, triton_topk_output, moe_runner_config

--- a/test/srt/test_triton_fused_moe.py
+++ b/test/srt/test_triton_fused_moe.py
@@ -8,6 +8,8 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.moe.fused_moe_triton.triton_kernels_moe import (
     triton_kernel_moe_forward,
 )
+from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
+from sglang.srt.layers.moe.topk import TopK
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -92,8 +94,22 @@ class TestFusedMOE(CustomTestCase):
         w2_tri = w2_tri.transpose(-2, -1).contiguous()
         score = self.create_random_cuda_tensor((m, e), dtype)
 
+        topk_output = TopK(
+            top_k=topk,
+            renormalize=False,
+            use_grouped_topk=False,
+        )
+        topk_output.use_triton_kernels = True
+        triton_topk_output = topk_output.forward_cuda(
+            hidden_states=a,
+            router_logits=score,
+        )
+
+        moe_runner_config = MoeRunnerConfig(
+            inplace=True,
+        )
         triton_output = triton_kernel_moe_forward(
-            a, w1_tri, w2_tri, score, topk, renormalize=False
+            a, w1_tri, w2_tri, triton_topk_output, moe_runner_config
         )
         torch_output = self.torch_naive_moe(a, w1, w2, score, topk)
         torch.testing.assert_close(triton_output, torch_output, rtol=rtol, atol=atol)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The test_triton_fused_moe and benchmark_sglang_fused_moe_triton have been broken due to recent refactor. This PR is to fix these cases.

**Unit test result:**
```
$python ./test/srt/test_triton_fused_moe.py
INFO 08-17 21:26:58 [__init__.py:235] Automatically detected platform cuda.
All deep_gemm operations loaded successfully!
WARNING:sglang.srt.layers.quantization.deep_gemm_wrapper.compile_utils:NVCC Compiler not found, use NVRTC for DeepGEMM JIT and may have performance loss with some cases.
INFO 08-17 21:26:59 [__init__.py:235] Automatically detected platform cuda.
INFO 08-17 21:26:59 [__init__.py:235] Automatically detected platform cuda.
INFO 08-17 21:26:59 [__init__.py:235] Automatically detected platform cuda.
INFO 08-17 21:26:59 [__init__.py:235] Automatically detected platform cuda.
INFO 08-17 21:26:59 [__init__.py:235] Automatically detected platform cuda.
W0817 21:26:59.966000 46222 site-packages/torch/utils/cpp_extension.py:2425] TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
W0817 21:26:59.966000 46222 site-packages/torch/utils/cpp_extension.py:2425] If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'] to specific architectures.
WARNING:sglang.srt.utils:MOE_RUNNER_BACKEND is not initialized, using triton backend
Running MoE tests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 96/96 [00:02<00:00, 34.13it/s]
.
----------------------------------------------------------------------
Ran 1 test in 2.814s

OK
```

**Benchmark triton kernel with enable cuda graph**
```
$python ./benchmark/kernels/fused_moe_triton/benchmark_sglang_fused_moe_triton.py --use-cuda-graph
INFO 08-18 17:18:53 [__init__.py:235] Automatically detected platform cuda.
All deep_gemm operations loaded successfully!
WARNING:sglang.srt.layers.quantization.deep_gemm_wrapper.compile_utils:NVCC Compiler not found, use NVRTC for DeepGEMM JIT and may have performance loss with some cases.
INFO 08-18 17:18:54 [__init__.py:235] Automatically detected platform cuda.
INFO 08-18 17:18:54 [__init__.py:235] Automatically detected platform cuda.
INFO 08-18 17:18:54 [__init__.py:235] Automatically detected platform cuda.
INFO 08-18 17:18:54 [__init__.py:235] Automatically detected platform cuda.
INFO 08-18 17:18:54 [__init__.py:235] Automatically detected platform cuda.
W0818 17:18:54.698000 66458 site-packages/torch/utils/cpp_extension.py:2425] TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
W0818 17:18:54.698000 66458 site-packages/torch/utils/cpp_extension.py:2425] If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'] to specific architectures.
WARNING:sglang.srt.utils:MOE_RUNNER_BACKEND is not initialized, using triton backend
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
shape_configs={'num_experts': 128, 'topk': 8, 'hidden_size': 2048, 'shard_intermediate_size': 768, 'dtype': torch.bfloat16, 'block_shape': None}
benchmark sglang_fused_moe_triton_v340 with batch_size=128
benchmark sglang_fused_moe_triton with batch_size=128
WARNING:sglang.srt.layers.moe.fused_moe_triton.fused_moe:Config file not found at /opt/conda/lib/python3.10/site-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/E=128,N=384,device_name=NVIDIA_H20.json. Fallback to triton version 3.2.0 and use MoE kernel config from /opt/conda/lib/python3.10/site-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=128,N=384,device_name=NVIDIA_H20.json. Performance might be sub-optimal!
benchmark sglang_fused_moe_triton_v340 with batch_size=256
benchmark sglang_fused_moe_triton with batch_size=256
benchmark sglang_fused_moe_triton_v340 with batch_size=512
benchmark sglang_fused_moe_triton with batch_size=512
benchmark sglang_fused_moe_triton_v340 with batch_size=1024
benchmark sglang_fused_moe_triton with batch_size=1024
benchmark sglang_fused_moe_triton_v340 with batch_size=2048
benchmark sglang_fused_moe_triton with batch_size=2048
benchmark sglang_fused_moe_triton_v340 with batch_size=4096
benchmark sglang_fused_moe_triton with batch_size=4096
benchmark sglang_fused_moe_triton_v340 with batch_size=8192
benchmark sglang_fused_moe_triton with batch_size=8192
fused-moe-performance:
   batch_size  sglang_fused_moe_triton_v340  sglang_fused_moe_triton
0       128.0                      0.232000                 0.209408
1       256.0                      0.304416                 0.237200
2       512.0                      0.477056                 0.320576
3      1024.0                      0.518464                 0.479488
4      2048.0                      0.991968                 0.761376
5      4096.0                      1.614560                 1.384752
6      8192.0                      2.870144                 2.592288

```


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
