### PR TITLE
feat: Prefix optimization using MHA

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1036,7 +1036,7 @@ class DeepseekV2AttentionMLA(nn.Module):
             ):
                 sum_seq_lens = sum(forward_batch.extend_seq_lens_cpu) 
                 assert forward_batch.batch_size != 0, "Invalid batch size: zero"
-                current_workload = sum_seq_lens // forward_batch.batch_size * sum_seq_lens
+                current_workload = sum_seq_lens / forward_batch.batch_size * sum_seq_lens
             # Flash Attention: Use MHA with chunked KV cache when prefilling on long sequences.
             if forward_batch.extend_prefix_lens_cpu is not None:
                 sum_extend_prefix_lens = sum(forward_batch.extend_prefix_lens_cpu)


### PR DESCRIPTION
## Motivation
Hi，Team！

This PR for optimizing MLA performance in prefix scenarios by dynamically switching the prefill phase from MLA to MHA for long sequences.

The choice between MHA and MQA mainly depends on the attention computation profile:

- **Long sequences :**
   - MHA is more efficient since the attention cost of MLA is ~3.4× that of MHA.
   - As prefix_len increases, MQA’s computation grows rapidly, making MHA increasingly favorable.
   
- **Short sequences :**
  - MQA generally has lower memory traffic.
  - As prefix_len increases, MHA’s memory usage grows faster, making MQA more advantageous.
  
- The threshold depends on the GPU’s compute-to-memory bandwidth ratio — higher ratios shift the threshold upward.

<!-- Detail the changes made in this pull request. -->
Based on benchmarks on H20 GPUs:

- When average_len >= 512: MHA outperforms MQA.
- When average_len < threshold:
  - Longer prefix_len favors MLA.
- When average_len > threshold:
  - Longer prefix_len favors MQA.

**In prefix scenarios:**
- Use MHA when average_len >= 512.
- Use MLA when average_len < 512

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Command:
`python3 -m sglang.bench_one_batch --model-path xxxx/DeepSeek-V3-0324 --batch 1 --input-len 1024 --output-len 1 --tp 8 --dp 8`

with this PR:
```
Prefill. latency: 3.59127 s, throughput:    285.14 token/s
Total. latency:  3.591 s, throughput:    285.41 token/s
Benchmark ...
Prefill. latency: 0.23663 s, throughput:   4327.44 token/s
Total. latency:  0.237 s, throughput:   4331.66 token/s
```
without this PR:
```
Prefill. latency: 3.60378 s, throughput:    284.15 token/s
Total. latency:  3.604 s, throughput:    284.42 token/s
Benchmark ...
Prefill. latency: 0.27267 s, throughput:   3755.46 token/s
Total. latency:  0.273 s, throughput:   3759.12 token/s
```

**Additional tests (long prefix, no perf regression)**
```
bs = 1 seq_len = 1024 prefix_len = 1024
with this PR:  
Prefill. latency: 0.99795 s, throughput:   2028.17 token/s
without this PR:
Prefill. latency: 1.79457 s, throughput:   1127.84 token/s

bs = 1 seq_len = 1024 prefix_len = 2048
with this PR:  
Prefill. latency: 0.88650 s, throughput:   3465.32 token/s
without this PR:
Prefill. latency: 2.12460 s, throughput:   1445.92 token/s
```


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
