### PR TITLE
Add chunking for FP8 cutlass moe via SGLANG_CUTLASS_MOE_CHUNK_SIZE env var

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -60,6 +60,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_ENABLE_FLASHINFER_GEMM` | Use flashinfer kernels when running blockwise fp8 GEMM on Blackwell GPUs | `false` |
 | `SGLANG_SUPPORT_CUTLASS_BLOCK_FP8` | Use Cutlass kernels when running blockwise fp8 GEMM on Hopper or Blackwell GPUs | `false` |
 | `SGLANG_CUTLASS_MOE` | Use Cutlass FP8 MoE kernel on Blackwell GPUs | `false` |
+| `SGLANG_CUTLASS_MOE_CHUNK_SIZE` | Chunk size in number of tokens for Cutlass FP8 MoE to reduce peak memory usage | `0` |
 
 
 ## Distributed Computing


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When using `SGLANG_CUTLASS_MOE=1` it is possible to run out of memory on B200 at high concurrency (3k+) because a large amount of memory is needed for intermediate buffers in MOE. We can break the tokens into chunks to reduce the memory requirements

## Modifications

Split `cutlass_fused_experts_fp8` into chunks if `SGLANG_CUTLASS_MOE_CHUNK_SIZE` is set.

## Accuracy Tests

```
Accuracy: 0.961
Invalid: 0.000
Latency: 373.565 s
Output throughput: 380.231 token/s
```

## Benchmarking and Profiling

This config would go out of memory before, but using chunking allows it to run.
```
SGLANG_CUTLASS_MOE_CHUNK_SIZE=512 SGL_ENABLE_JIT_DEEPGEMM=0 SGLANG_CUTLASS_MOE=1 python3 -m sglang.launch_server --tokenizer-path deepseek-ai/DeepSeek-R1-0528 --trust-remote-code --enable-dp-attention --disable-radix-cache --max-running-requests 3072 --chunked-prefill-size 32768 --mem-fraction-static 0.85 --cuda-graph-bs 3072 --cuda-graph-max-bs 3072 --max-prefill-tokens 32768 --attention-backend cutlass_mla --model-path=/model/deepseek-ai-DeepSeek-R1-0528/models--deepseek-ai--DeepSeek-R1-0528/snapshots/4236a6af538feda4548eca9ab308586007567f52 --host 0.0.0.0 --port 8000 --tensor-parallel-size=8 --data-parallel-size=8
```

```
python3 -m sglang.bench_serving --model deepseek-ai/DeepSeek-R1-0528 --dataset-name random --backend sglang-oai --random-range-ratio 1 --random-input-len 1024 --random-output-len 1024 --max-concurrency 3072 --num-prompts 6144 --port 8000
```

```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf
Max request concurrency:                 3072
Successful requests:                     6144
Benchmark duration (s):                  2266.47
Total input tokens:                      6291456
Total generated tokens:                  6291456
Total generated tokens (retokenized):    6270601
Request throughput (req/s):              2.71
Input token throughput (tok/s):          2775.88
Output token throughput (tok/s):         2775.88
Total token throughput (tok/s):          5551.76
Concurrency:                             3070.04
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1132512.86
Median E2E Latency (ms):                 1132661.09
---------------Time to First Token----------------
Mean TTFT (ms):                          121894.68
Median TTFT (ms):                        121298.74
P99 TTFT (ms):                           233749.66
---------------Inter-Token Latency----------------
Mean ITL (ms):                           990.66
Median ITL (ms):                         885.01
P95 ITL (ms):                            959.37
P99 ITL (ms):                            1234.68
Max ITL (ms):                            274884.44
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
