### PR TITLE
Support ibm_grouped_gemm and unit test

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_ibm/persistent_gg_bf16.py
+++ b/python/sglang/srt/layers/moe/fused_moe_ibm/persistent_gg_bf16.py
@@ -1,0 +1,206 @@
+import torch
+import triton
+import triton.language as tl
+
+from .tma_cuda_autotune import (
+    HOPPER_CONFIGS,
+    STANDARD_CONFIGS,
+    CudaUtils,
+    early_config_prune,
+)
+
+
+@triton.jit
+def _compute_pid(tile_id, num_pid_in_group, num_pid_m, super_group_m):
+    group_id = tile_id // num_pid_in_group
+    first_pid_m = group_id * super_group_m
+    group_size_m = min(num_pid_m - first_pid_m, super_group_m)
+    pid_m = first_pid_m + (tile_id % group_size_m)
+    pid_n = (tile_id % num_pid_in_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.autotune(
+    configs=STANDARD_CONFIGS,
+    key=["M_TOTAL", "N", "K"],
+    prune_configs_by={"early_config_prune": early_config_prune},
+)
+@triton.jit
+def _kernel_grouped_gemm_persistent_bf16(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    # Pointer to indices array
+    indices_ptr,
+    # Matrix dimensions
+    M_TOTAL: tl.constexpr,  # Total M dimension (sum of all groups)
+    N: tl.constexpr,  # N dimension
+    K: tl.constexpr,  # K dimension
+    # Number of experts
+    NUM_EXPERTS: tl.constexpr,
+    # Tiling parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    # NUM_CONSUMER_GROUPS: tl.constexpr,
+    # Group size (for aligned loads)
+    GROUP_SIZE_M: tl.constexpr = 128,
+    SUPER_GROUP_M: tl.constexpr = 32,  # 32 works best
+):
+    """
+    Contiguous Grouped GEMM kernel forward.
+    IMPORTANT: Assumes GROUP_SIZE_M is a multiple of BLOCK_SIZE_M or vice versa,
+    and all inputs are pre-aligned to these block boundaries.
+    """
+
+    c_type = c_ptr.dtype.element_ty
+
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M_TOTAL, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    num_pid_in_group = SUPER_GROUP_M * num_pid_n
+
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS):
+
+        tile_m_idx, tile_n_idx = _compute_pid(
+            tile_id, num_pid_in_group, num_pid_m, SUPER_GROUP_M
+        )
+
+        # starting indices for this tile
+        m_start = tile_m_idx * BLOCK_SIZE_M
+        n_start = tile_n_idx * BLOCK_SIZE_N
+
+        # Only process if in bounds
+        if m_start < M_TOTAL:
+
+            offs_m = m_start + tl.arange(0, BLOCK_SIZE_M)
+            offs_n = n_start + tl.arange(0, BLOCK_SIZE_N)
+
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for ki in range(k_tiles):
+
+                # Offsets for K dim
+                offs_k = ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+
+                # Create masks for bounds checking
+                mask_m = offs_m < M_TOTAL
+                mask_n = offs_n < N
+                mask_k = offs_k < K
+
+                # masks for A and B
+                mask_a = mask_m[:, None] & mask_k[None, :]
+                mask_b = mask_n[:, None] & mask_k[None, :]
+
+                # Determine the expert group index and load expert ID
+                group_idx = m_start // GROUP_SIZE_M
+                expert_idx = tl.load(indices_ptr + group_idx * GROUP_SIZE_M)
+
+                # Load inputs (A) with bounds checking
+                a_ptrs = a_ptr + offs_m[:, None] * K + offs_k[None, :]
+                a = tl.load(a_ptrs, mask=mask_a, other=0.0)
+
+                # Load expert weights (B) for the expert assigned to this block
+                b_ptrs = (
+                    b_ptr + expert_idx * N * K + offs_n[:, None] * K + offs_k[None, :]
+                )
+                b = tl.load(b_ptrs, mask=mask_b, other=0.0)
+
+                # Accumulate matrix multiplication for this K tile
+                accumulator += tl.dot(a, b.T)
+
+            tile_id_c += NUM_SMS
+            tile_m_idx, tile_n_idx = _compute_pid(
+                tile_id_c, num_pid_in_group, num_pid_m, SUPER_GROUP_M
+            )
+
+            offs_m = tile_m_idx * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+            offs_n = tile_n_idx * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+
+            # Create masks for bounds checking
+            mask_m = offs_m < M_TOTAL
+            mask_n = offs_n < N
+            mask_c = mask_m[:, None] & mask_n[None, :]
+
+            c = accumulator.to(tl.float32)
+
+            # Store output (C) with bounds checking
+            c_ptrs = c_ptr + offs_m[:, None] * N + offs_n[None, :]
+            tl.store(c_ptrs, c.to(c_type), mask=mask_c)
+
+
+# =============== Wrapper for BF16 GGEMM =================
+def _grouped_gemm_persistent(
+    inputs: torch.Tensor,  # [M_total, K]
+    expert_weights: torch.Tensor,  # [num_experts, N, K]
+    expert_indices: torch.Tensor,  # [M_total]
+    group_size_m: int = 128,
+) -> torch.Tensor:
+    """
+    contiguous grouped GEMM forward pass for MoE.
+    All tokens mapped to the same expert must be in contiguous blocks of size group_size_m.
+    Args:
+        inputs: Input tensor of shape [M_total, K]
+        expert_weights: Expert weight tensor of shape [num_experts, N, K]
+        expert_indices: Indices tensor of shape [M_total] mapping each token to its expert
+        group_size_m: Size of contiguous token blocks for each expert (default: 128)
+    Returns:
+        Output tensor of shape [M_total, N]
+    """
+    # Validate inputs
+
+    assert inputs.is_contiguous(), "Input tensor must be contiguous"
+    assert expert_weights.is_contiguous(), "Expert weights tensor must be contiguous"
+    assert expert_indices.is_contiguous(), "Expert indices tensor must be contiguous"
+
+    # Check if inputs are properly aligned
+    M_total, K = inputs.shape
+    assert (
+        M_total % group_size_m == 0
+    ), f"M_total ({M_total}) must be a multiple of group_size_m ({group_size_m})"
+
+    # Convert expert_indices to int32 if needed
+    if expert_indices.dtype != torch.int32:
+        expert_indices = expert_indices.to(torch.int32)
+
+    # Get dimensions
+    num_experts, N, K_weights = expert_weights.shape
+
+    # Validate dimensions
+    assert K == K_weights, f"Input K ({K}) must match weight K ({K_weights})"
+    assert (
+        expert_indices.shape[0] == M_total
+    ), "Expert indices length must match M_total"
+
+    # Create output tensor
+    output = torch.empty((M_total, N), device=inputs.device, dtype=torch.bfloat16)
+
+    # Calculate grid size for the kernel
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    grid = (NUM_SMS, 1, 1)
+    # Launch kernel
+    _kernel_grouped_gemm_persistent_bf16[grid](
+        inputs,
+        expert_weights,
+        output,
+        expert_indices,
+        M_TOTAL=M_total,
+        N=N,
+        K=K,
+        NUM_EXPERTS=num_experts,
+        GROUP_SIZE_M=group_size_m,
+        NUM_SMS=NUM_SMS,
+    )
+    return output
+
+
+def grouped_gemm_persistent(
+    inputs: torch.Tensor,  # [M_total, K]
+    expert_weights: torch.Tensor,  # [num_experts, N, K]
+    expert_indices: torch.Tensor,  # [M_total]
+) -> torch.Tensor:
+    return _grouped_gemm_persistent(inputs, expert_weights, expert_indices)

--- a/python/sglang/srt/layers/moe/fused_moe_ibm/tma_cuda_autotune.py
+++ b/python/sglang/srt/layers/moe/fused_moe_ibm/tma_cuda_autotune.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from triton.runtime import driver
+
+
+# ===== Supporting utils, CUDA and TMA =====
+class CudaUtils:
+    @staticmethod
+    def is_cuda() -> bool:
+        """Check if Triton is running on CUDA backend."""
+        return driver.active.get_current_target().backend == "cuda"
+
+    @staticmethod
+    def verify_tma() -> bool:
+        """Check if TMA is supported on the current device."""
+        return (
+            CudaUtils.is_cuda()
+            and torch.cuda.is_available()
+            and torch.cuda.get_device_capability()[0] >= 9
+        )
+
+    @staticmethod
+    def get_num_sms() -> int:
+        """Get the number of streaming multiprocessors on the current device."""
+        if not CudaUtils.is_cuda():
+            raise RuntimeError("Triton is not running on CUDA backend")
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        return torch.cuda.get_device_properties("cuda").multi_processor_count
+
+
+# ================== End of supporting functions ==================
+
+
+# Define standard configurations for Hopper GPUs
+HOPPER_CONFIGS = [
+    # Configurations for small matrices
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+        num_stages=2,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32},
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32},
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32},
+        num_stages=4,
+        num_warps=4,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+        num_stages=4,
+        num_warps=4,
+    ),
+    # Configurations for medium to large matrices
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64},
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 64},
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64},
+        num_stages=4,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+        num_stages=4,
+        num_warps=8,
+    ),
+]
+
+
+# Define standard configurations - simplified for robustness
+STANDARD_CONFIGS = [
+    # Configurations for small matrices
+    triton.Config(
+        {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32},
+        num_stages=2,
+        num_warps=4,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32},
+        num_stages=2,
+        num_warps=4,
+    ),
+    # Medium sizes
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+        num_stages=2,
+        num_warps=8,
+    ),
+    # Larger sizes with more warps, stages
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+        num_stages=4,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128},
+        num_stages=4,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128},
+        num_stages=4,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128},
+        num_stages=4,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 256},
+        num_stages=4,
+        num_warps=8,
+    ),
+]
+
+
+WS_CONFIGS = [
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 64,
+            "NUM_CONSUMER_GROUPS": 2,
+        },
+        num_stages=2,
+        num_warps=4,
+        num_consumer_groups=2,
+        num_buffers_warp_spec=3,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 128,
+            "NUM_CONSUMER_GROUPS": 1,
+        },
+        num_stages=3,
+        num_warps=4,
+        num_consumer_groups=0,  # disable warp specialization
+        num_buffers_warp_spec=3,
+    ),
+]
+
+
+_NV_WS_CONFIGS = [
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": block_size_m,
+            "BLOCK_SIZE_N": block_size_n,
+            "BLOCK_SIZE_K": block_size_k,
+            "NUM_CONSUMER_GROUPS": max(1, num_consumer_groups),
+        },
+        num_stages=num_stages,
+        num_warps=num_warps,
+        num_ctas=1,
+        num_consumer_groups=num_consumer_groups,
+        num_buffers_warp_spec=num_stages,
+    )
+    for block_size_m in [64, 128]
+    for block_size_n in [64, 128, 256]
+    for block_size_k in [64, 128, 256]
+    for num_stages in [2, 3, 4]
+    for num_warps in [4, 8]
+    for num_consumer_groups in [0, 2]
+]
+
+
+def early_config_prune(configs, args, **kwargs):
+    """Filter out configurations that would exceed shared memory capacity."""
+    k = kwargs.get("K", 0)
+    valid_configs = [
+        config for config in configs if config.kwargs.get("BLOCK_SIZE_K", 0) <= k
+    ]
+    # If all configs were filtered out, return at least one config
+    if not valid_configs and configs:
+        # Find the config with the smallest BLOCK_SIZE_K
+        return [min(configs, key=lambda c: c.kwargs.get("BLOCK_SIZE_K", float("inf")))]
+
+    return valid_configs

--- a/test/srt/test_fused_moe_ibm.py
+++ b/test/srt/test_fused_moe_ibm.py
@@ -1,0 +1,205 @@
+import dataclasses
+from typing import Optional
+
+import pytest
+import torch
+from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
+
+from sglang.srt.layers.moe.fused_moe_ibm.persistent_gg_bf16 import (
+    grouped_gemm_persistent as ibm_gg_bf16,
+)
+
+
+def _fp8_perm(m: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+    """
+    A permutation routine that works on fp8 types.
+    """
+    if torch.is_floating_point(m) and m.dtype.itemsize == 1:
+        return m.view(dtype=torch.uint8)[idx, ...].view(dtype=m.dtype)
+    else:
+        return m[idx, ...]
+
+
+def _moe_permute(
+    curr_hidden_states: torch.Tensor,
+    a1q_scale: Optional[torch.Tensor],
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    expert_map: Optional[torch.Tensor],
+    block_size: int,
+) -> tuple[
+    torch.Tensor, Optional[torch.Tensor], torch.Tensor, torch.Tensor, torch.Tensor
+]:
+    """
+    Determine the sorted_token_ids, expert_ids for the given problem size.
+    Permute the hidden states and scales according to `sorted_token_ids`.
+    """
+    top_k_num = topk_ids.size(1)
+
+    tokens_in_chunk = curr_hidden_states.size(0)
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    sorted_ids_cuda = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    sorted_ids_cuda.fill_(topk_ids.numel())
+    max_num_m_blocks = max_num_tokens_padded // block_size
+    expert_ids_cuda = torch.zeros(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad_cuda = torch.empty(
+        (1), dtype=torch.int32, device=topk_ids.device
+    )
+    cumsum_buffer = torch.zeros(
+        num_experts + 1, dtype=torch.int32, device=topk_ids.device
+    )
+
+    sgl_moe_align_block_size(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids_cuda,
+        expert_ids_cuda,
+        num_tokens_post_pad_cuda,
+        cumsum_buffer,
+    )
+
+    inv_perm: Optional[torch.Tensor] = None
+
+    num_tokens = top_k_num * tokens_in_chunk
+    expert_ids_cuda = torch.repeat_interleave(expert_ids_cuda, block_size, dim=0)
+    inv_perm = torch.argsort(sorted_ids_cuda)[:num_tokens]
+
+    # Permute according to sorted token ids.
+    sorted_ids_cuda = sorted_ids_cuda.clamp(max=num_tokens - 1)
+
+    curr_hidden_states = _fp8_perm(curr_hidden_states, sorted_ids_cuda // top_k_num)
+
+    if a1q_scale is not None:
+        a1q_scale = a1q_scale[sorted_ids_cuda // top_k_num]
+
+    return (curr_hidden_states, a1q_scale, sorted_ids_cuda, expert_ids_cuda, inv_perm)
+
+
+@dataclasses.dataclass
+class TestConfig:
+    m: int
+    n: int
+    k: int
+    e: int
+    num_topk: int
+    dtype: torch.dtype
+    group_size: int
+
+
+@dataclasses.dataclass
+class TestTensors:
+    a: torch.Tensor
+    w: torch.Tensor
+    topk_ids: torch.Tensor
+
+    def __repr__(self):
+
+        def describe_t(t: torch.Tensor, name: str) -> str:
+            return f"  - {name} : {t.shape} {t.dtype} {t.device}\n"
+
+        s = ""
+        s += "Test Tensors :\n"
+        s += describe_t(self.a, "a")
+        s += describe_t(self.w, "w")
+        s += describe_t(self.topk_ids, "topk_ids")
+        return s
+
+    @staticmethod
+    def make(cfg: TestConfig) -> "TestTensors":
+        m, n, k, e, num_topk, dtype = (
+            cfg.m,
+            cfg.n,
+            cfg.k,
+            cfg.e,
+            cfg.num_topk,
+            cfg.dtype,
+        )
+        device = "cuda"
+        a = torch.randn((m, k), device=device, dtype=dtype) / 10
+        w = torch.randn((e, n, k), device=device, dtype=dtype) / 10
+        topk_ids = torch.randint(low=0, high=e, size=(m, num_topk), device=device)
+        return TestTensors(a=a, w=w, topk_ids=topk_ids)
+
+
+@dataclasses.dataclass
+class GroupedTestTensors:
+    a_grouped: torch.Tensor
+    w: torch.Tensor
+    expert_ids_grouped: torch.Tensor
+    inv_perm: torch.Tensor
+
+    group_size: int
+
+    @staticmethod
+    def make(tt: TestTensors, tc: TestConfig) -> "GroupedTestTensors":
+        a_grouped, _, _, expert_ids, inv_perm = _moe_permute(
+            curr_hidden_states=tt.a,
+            a1q_scale=None,
+            topk_ids=tt.topk_ids,
+            num_experts=tc.e,
+            expert_map=None,
+            block_size=tc.group_size,
+        )
+
+        return GroupedTestTensors(
+            a_grouped, tt.w, expert_ids, inv_perm, group_size=tc.group_size
+        )
+
+
+def torch_gg(gtt: GroupedTestTensors) -> torch.Tensor:
+    group_size = gtt.group_size
+    m = gtt.a_grouped.size(0)
+    n = gtt.w.size(1)
+    torch_out = torch.empty((m, n), dtype=gtt.a_grouped.dtype, device="cuda")
+    expert_ids_cpu = gtt.expert_ids_grouped.to(device="cpu")
+    num_groups = m // group_size
+
+    for g in range(num_groups):
+        s = g * group_size
+        e = s + group_size
+        ei = expert_ids_cpu[s]
+        o = torch_out[s:e]
+        a = gtt.a_grouped[s:e]
+        torch.mm(a, gtt.w[ei].t(), out=o)
+
+    return torch_out
+
+
+Ms = [128, 256]
+Ns = [512, 1024, 2048]
+Ks = [1024]
+Es = [128]
+TOPKs = [4]
+IMPLs = [ibm_gg_bf16]
+
+
+@pytest.mark.parametrize("M", Ms)
+@pytest.mark.parametrize("N", Ns)
+@pytest.mark.parametrize("K", Ks)
+@pytest.mark.parametrize("E", Es)
+@pytest.mark.parametrize("TOPK", TOPKs)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("impl", IMPLs)
+def test_ibm_bf16(M, N, K, E, TOPK, dtype, impl):
+
+    config: TestConfig = TestConfig(
+        m=M, n=N, k=K, e=E, num_topk=TOPK, dtype=dtype, group_size=128
+    )
+    tt: TestTensors = TestTensors.make(config)
+    gtt: GroupedTestTensors = GroupedTestTensors.make(tt, config)
+
+    print(
+        f"M {M} N {N} K {K} E {E} TOPK {TOPK} | A {gtt.a_grouped.shape}  ...",
+        flush=True,
+    )
+
+    ref_output = torch_gg(gtt)
+    impl_output = impl(gtt.a_grouped, gtt.w, gtt.expert_ids_grouped)
+
+    torch.testing.assert_close(ref_output, impl_output)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
PyTorch announced support for a triton persistent-cache-aware grouped GEMM this morning. 
https://pytorch.org/blog/accelerating-moes-with-a-triton-persistent-cache-aware-grouped-gemm-kernel/

This PR attempts to integrate this grouped gemm into sglang. Thanks to sgl_moe_align_block_size, the basic UT functionality runs successfully, and the grouped GEMM output accuracy meets expectations.

Limitation:
1. The IBM grouped GEMM requires M_total (for example 8326) must be a multiple of group_size_m (for example 128)
2. Not yet introduce Triton v3.4.0 TMA API in this PR, so TMA is not supported.

Credits:

The idea is inspired by @BBuf and @ispobock .
This PR refers to https://github.com/pytorch/torchtitan/pull/1154 and https://github.com/vllm-project/vllm/pull/19443 with some modifications to adapt to SGLang MoE. Thanks for the contributions.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
$python -m pytest test/srt/test_fused_moe_ibm.py -s
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.10.13, pytest-8.3.5, pluggy-1.5.0
rootdir: /root/luoyuan.luo/workspace/SGLang/test
configfile: pytest.ini
plugins: anyio-4.8.0
collected 6 items                                                                                                                                                                                             

test/srt/test_fused_moe_ibm.py M 128 N 512 K 1024 E 128 TOPK 8 | A torch.Size([17280, 1024])  ...
.M 256 N 512 K 1024 E 128 TOPK 8 | A torch.Size([18304, 1024])  ...
.M 128 N 1024 K 1024 E 128 TOPK 8 | A torch.Size([17280, 1024])  ...
.M 256 N 1024 K 1024 E 128 TOPK 8 | A torch.Size([18304, 1024])  ...
.M 128 N 2048 K 1024 E 128 TOPK 8 | A torch.Size([17280, 1024])  ...
.M 256 N 2048 K 1024 E 128 TOPK 8 | A torch.Size([18304, 1024])  ...
.

============================================================================================== warnings summary ===============================================================================================
../../../../opt/conda/lib/python3.10/site-packages/_pytest/config/__init__.py:1441
  /opt/conda/lib/python3.10/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: asyncio_mode
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

test/srt/test_fused_moe_ibm.py:85
  /root/luoyuan.luo/workspace/SGLang/test/srt/test_fused_moe_ibm.py:85: PytestCollectionWarning: cannot collect test class 'TestConfig' because it has a __init__ constructor (from: srt/test_fused_moe_ibm.py)
    @dataclasses.dataclass

test/srt/test_fused_moe_ibm.py:96
  /root/luoyuan.luo/workspace/SGLang/test/srt/test_fused_moe_ibm.py:96: PytestCollectionWarning: cannot collect test class 'TestTensors' because it has a __init__ constructor (from: srt/test_fused_moe_ibm.py)
    @dataclasses.dataclass

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== 6 passed, 3 warnings in 7.21s ========================================================================================

```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
