### PR TITLE
Fix gpt-oss response api streaming issue

### DIFF
--- a/python/sglang/srt/entrypoints/context.py
+++ b/python/sglang/srt/entrypoints/context.py
@@ -107,6 +107,8 @@ class HarmonyContext(ConversationContext):
         return self._messages
 
     def need_builtin_tool_call(self) -> bool:
+        if not self.messages:
+            return False
         last_msg = self.messages[-1]
         recipient = last_msg.recipient
         return recipient is not None and (

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -944,7 +944,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                                     type="output_text",
                                     text="",
                                     annotations=[],
-                                    logprobs=[],
+                                    logprobs=None,
                                 ),
                             )
                         )
@@ -992,7 +992,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                                     type="output_text",
                                     text="",
                                     annotations=[],
-                                    logprobs=[],
+                                    logprobs=None,
                                 ),
                             )
                         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The streaming response API for gpt-oss models was experiencing two critical errors that prevented proper functionality. These issues needed to be resolved to ensure the API works correctly with streaming requests. 
Error shown from client side: `curl: (18) transfer closed with outstanding read data remaining`

## Issue 1: Pydantic Validation Error

### Problem
`ResponseOutputText` validation failed during streaming response generation.

### Raw Error Message
```
File "/home/ubuntu/.local/lib/python3.10/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ResponseOutputText
text
  Field required [type=missing, input_value={'content': [Content(text...text', 'logprobs': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

### Root Cause
In streaming response handler (`serving_responses.py`), `ResponseOutputText` objects were created with `logprobs=[]` (empty list) instead of `logprobs=None`, inconsistent with the non-streaming code.

### Modification
Changed `logprobs=[]` to `logprobs=None` in two locations:
- Line 947: Fixed `ResponseContentPartAddedEvent` for final channel  
- Line 995: Fixed `ResponseContentPartAddedEvent` for analysis channel

### Files Modified
- `/home/ubuntu/sglang/python/sglang/srt/entrypoints/openai/serving_responses.py`

## Issue 2: IndexError in Streaming

### Problem
Runtime crash when accessing message list during streaming response generation.

### Raw Error Message
```
File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
    await response(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/responses.py", line 270, in __call__
    with collapse_excgroups():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    raise exc
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/responses.py", line 274, in wrap
    await func()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/responses.py", line 254, in stream_response
    async for chunk in self.body_iterator:
  File "/home/ubuntu/sglang/python/sglang/srt/entrypoints/openai/serving_responses.py", line 831, in responses_stream_generator
    async for ctx in result_generator:
  File "/home/ubuntu/sglang/python/sglang/srt/entrypoints/openai/serving_responses.py", line 1232, in _generate_with_builtin_tools
    if not context.need_builtin_tool_call():
  File "/home/ubuntu/sglang/python/sglang/srt/entrypoints/context.py", line 110, in need_builtin_tool_call
    last_msg = self.messages[-1]
IndexError: list index out of range
```

### Root Cause
The method tried to access the last message without checking if the messages list was empty. In `StreamingHarmonyContext`, `self.messages` returns `self.parser.messages` which starts empty during streaming.

### Modification
Added safety check `if not self.messages: return False` before accessing `self.messages[-1]`, consistent with the existing `call_tool()` method.

### Files Modified
- `/home/ubuntu/sglang/python/sglang/srt/entrypoints/context.py`

## Accuracy Tests
```
event: response.completed
data: {"response":{"id":"resp_76ec3178e4e74b2fa91e751a3f5b99a6","created_at":1755646445.0,"error":null,"incomplete_details":null,"instructions":null,"metadata":null,"model":"gpt-oss","object":"response","output":[{"id":"rs_9b7106c7ef6e4cfc81ddf1d8b849da67","summary":[],"type":"reasoning","content":[{"text":"The user says: \"Count","type":"reasoning_text"}],"encrypted_content":null,"status":null}],"parallel_tool_calls":true,"temperature":null,"tool_choice":"auto","tools":[],"top_p":null,"background":null,"max_output_tokens":null,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"prompt_cache_key":null,"reasoning":null,"safety_identifier":null,"service_tier":null,"status":"completed","text":null,"top_logprobs":null,"truncation":null,"usage":{"input_tokens":0,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":0},"user":null},"sequence_number":10,"type":"response.completed"}
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
