### PR TITLE
Fix model loading error when doing weights sync in RL training

### DIFF
--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -1139,7 +1139,7 @@ class GptOssForCausalLM(nn.Module):
         not_loaded_params = [k for k, v in params_checker.items() if not v]
         if tp_rank == 0:
             if len(not_loaded_params) > 0:
-                raise Exception(f"Not all parameters loaded: {not_loaded_params}")
+                logging.warning(f"Not all parameters loaded: {not_loaded_params}")
             else:
                 logging.info("All parameters loaded successfully.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In RL training, we have to sync training model weights to inference engine, e.g. sgl backend. When we are doing the weight sync, sometimes, we pass in the whole model weights, but we only need to load the model parameters that are only needed on the current rank. This PR is to fix the gpt-oss weight sync issue.

## Modifications
When there are extra model parameters that are not loaded by the model, it's okay. We don't want to raise the error.

## Accuracy Tests

Test training run works. 

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
