### PR TITLE
[Bug] Fix w4afp8 moe kernel

### DIFF
--- a/sgl-kernel/csrc/cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_mixed_input_.hpp
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/collective/sm90_mma_array_tma_gmma_rs_warpspecialized_mixed_input_.hpp
@@ -1488,6 +1488,10 @@ struct CollectiveMmaArrayMixedInput<
   template <class... TMs>
   CUTLASS_DEVICE void
   tensormaps_cp_fence_release(TensorMapStorage& shared_tensormaps, cute::tuple<TMs...> const& input_tensormaps) {
+    if (cute::elect_one_sync()) {
+      cute::tma_desc_commit_group();
+      cute::tma_desc_wait_group();
+    }
     // Entire warp must do this (i.e. it's aligned)
     tma_descriptor_cp_fence_release(get<0>(input_tensormaps), shared_tensormaps.smem_tensormap_A);
     tma_descriptor_cp_fence_release(get<1>(input_tensormaps), shared_tensormaps.smem_tensormap_B);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR fixes an issue introduced in [PR7772](https://github.com/sgl-project/sglang/pull/7772).
When running `test_int4_fp8_grouped_gemm_multi_experts` in `sgl-kernel/tests/test_cutlass_w4a8_moe_mm.py` with `k = 512, n = 1024`, the test may occasionally produce incorrect results. (It happens very rarely, but you can reproduce it more easily by setting `batch_size = 512` and `num_experts = 256`.)

This bug also affects the E2E results of DeepSeek-R1 in w4afp8 TP mode ([PR8118](https://github.com/sgl-project/sglang/pull/8118)), where you may observe inconsistent outputs even with the same random seed and prompt.

## Modifications

<!-- Detail the changes made in this pull request. -->

This fix is adapted from [NVIDIA CUTLASS v4.0.0](https://github.com/NVIDIA/cutlass/pull/2294/files#diff-33619fb73da11116cba19dfe6c4ca78e6510ea4b28c915e461d496152af72bbf), and has also been merged into [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/pull/7072).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
