### PR TITLE
Fix FlashInfer GPU <-> CPU sync

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1372,7 +1372,14 @@ def fast_decode_plan(
 
         if self.use_tensor_cores:
             # ALSO convert last_page_len to CPU
-            last_page_len_host = last_page_len.cpu()
+            if page_size == 1:
+                # When page size is 1, last_page_len is always 1.
+                # Directly construct the host tensor rather than executing a device-to-host copy.
+                last_page_len_host = torch.ones(
+                    (batch_size,), dtype=torch.int32, device="cpu"
+                )
+            else:
+                last_page_len_host = last_page_len.cpu()
 
             kv_lens_arr_host = get_seq_lens(indptr_host, last_page_len_host, page_size)
 


### PR DESCRIPTION
## Motivation

There is an unnecessary GPU <-> CPU synchronization when running FlashInfer with tensor cores + page size 1. This is caused by moving `last_page_len` from the GPU to the CPU [here](https://github.com/sgl-project/sglang/blob/f96413c444a4ce16c6b01770e28a636350df24bf/python/sglang/srt/layers/attention/flashinfer_backend.py#L1375). When the page size is 1, `last_page_len` is always 1, so we do not need to transfer this tensor from the GPU to the CPU.

## Modifications

When `page_size = 1`, we directly construct a tensor of ones rather than moving `last_page_len` from the GPU to the CPU.

## Accuracy Tests

I've run

```
python3 -m sglang.test.few_shot_gsm8k --num-questions 200
Accuracy: 0.835
Invalid: 0.000
Latency: 19.890 s
Output throughput: 1493.781 token/s
```

Please let me know if there are any other tests I should run.

## Benchmarking and Profiling

On a B200, running Qwen2.5-7B:

```
python3 -m sglang.bench_offline_throughput --model-path Qwen/Qwen2.5-7B --num-prompts 8 --max-running-requests 1

# main
====== Offline Throughput Benchmark Result =======
Backend:                                 engine    
Successful requests:                     8         
Benchmark duration (s):                  8.03      
Total input tokens:                      1408      
Total generated tokens:                  2004      
Last generation throughput (tok/s):      254.13    
Request throughput (req/s):              1.00      
Input token throughput (tok/s):          175.39    
Output token throughput (tok/s):         249.63    
Total token throughput (tok/s):          425.01    
==================================================

# this branch
====== Offline Throughput Benchmark Result =======
Backend:                                 engine    
Successful requests:                     8         
Benchmark duration (s):                  7.80      
Total input tokens:                      1408      
Total generated tokens:                  2004      
Last generation throughput (tok/s):      270.42    
Request throughput (req/s):              1.03      
Input token throughput (tok/s):          180.60    
Output token throughput (tok/s):         257.04    
Total token throughput (tok/s):          437.64    
==================================================
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
