### PR TITLE
[FA3] Init Spec Page Table only when Spec is enabled to save ~40MB

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1163,6 +1163,8 @@ class FlashAttentionBackend(AttentionBackend):
         This creates fixed-size tensors that will be reused during CUDA graph replay
         to avoid memory allocations.
         """
+        max_num_pages = (self.max_context_len + self.page_size - 1) // self.page_size
+
         # This is being used by normal decode and draft decode when topk == 1
         self.decode_cuda_graph_metadata = {
             "cache_seqlens": torch.zeros(max_bs, dtype=torch.int32, device=self.device),
@@ -1174,7 +1176,7 @@ class FlashAttentionBackend(AttentionBackend):
             ),
             "page_table": torch.zeros(
                 max_bs,
-                (self.max_context_len + self.page_size - 1) // self.page_size,
+                max_num_pages,
                 dtype=torch.int32,
                 device=self.device,
             ),
@@ -1270,7 +1272,7 @@ class FlashAttentionBackend(AttentionBackend):
             # "page_table_draft_decode" will be set only when spec decoding enabled to save memory
             self.decode_cuda_graph_metadata["page_table_draft_decode"] = torch.zeros(
                 max_bs,
-                (self.max_context_len + self.page_size - 1) // self.page_size,
+                max_num_pages,
                 dtype=torch.int32,
                 device=self.device,
             )
@@ -1291,7 +1293,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "page_table": torch.zeros(
                     max_bs,
-                    (self.max_context_len + self.page_size - 1) // self.page_size,
+                    max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),
@@ -1314,7 +1316,7 @@ class FlashAttentionBackend(AttentionBackend):
                 ),
                 "page_table": torch.zeros(
                     max_bs,
-                    (self.max_context_len + self.page_size - 1) // self.page_size,
+                    max_num_pages,
                     dtype=torch.int32,
                     device=self.device,
                 ),


### PR DESCRIPTION
Co-authored-by: Baizhou Zhang <sobereddiezhang@gmail.com>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

```
(Pdb) self.decode_cuda_graph_metadata["page_table"].shape torch.Size([256, 40960]) 

(Pdb) self.decode_cuda_graph_metadata["page_table"].device device(type='cuda', index=0)

(Pdb) self.decode_cuda_graph_metadata["page_table"] tensor([[0, 0, 0, ..., 0, 0, 0], [0, 0, 0, ..., 0, 0, 0], [0, 0, 0, ..., 0, 0, 0], ..., [0, 0, 0, ..., 0, 0, 0], [0, 0, 0, ..., 0, 0, 0], [0, 0, 0, ..., 0, 0, 0]], device='cuda:0', dtype=torch.int32)
```


Let's use QWen 32B as example:
The draft decode page table has shape **\[256, 40960]** and dtype **int32**.

1. **Number of elements**:

   $$
   256 \times 40960 = (256 \times 40000) + (256 \times 960)
   = 10{,}240{,}000 + 245{,}760
   = 10{,}485{,}760 \ \text{elements.}
   $$

2. **Bytes per element**:
   For `torch.int32`, each element takes **4 bytes**.



3. **Total size in bytes**:

$$
\text{Total size in bytes:}\quad
10\,485\,760 \times 4 = 41\,943\,040\ \text{bytes}
$$


4. **Convert to MB** (1 MB = 1,048,576 bytes):

$$
\text{Convert to MB (1 MB = 1,048,576 bytes):}\quad
\frac{41\,943\,040}{1\,048\,576} \approx 40.0\ \text{MB}
$$


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
