### PR TITLE
Remove mrope position sync

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1433,24 +1433,6 @@ class MRotaryEmbedding(RotaryEmbedding):
 
             return position_ids, mrope_position_deltas
 
-    @staticmethod
-    def get_next_input_positions(
-        mrope_position_delta: int,
-        context_len: int,
-        seq_len: int,
-    ) -> torch.Tensor:
-        return torch.tensor(
-            [
-                list(
-                    range(
-                        context_len + mrope_position_delta,
-                        seq_len + mrope_position_delta,
-                    )
-                )
-                for _ in range(3)
-            ]
-        )
-
 
 class DualChunkRotaryEmbedding(CustomOp):
     """Rotary positional embedding for Dual Chunk Attention."""

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -525,14 +525,14 @@ class ForwardBatch:
                         device=model_runner.device,
                     )
                 else:
-                    mrope_position_deltas = (
-                        mm_input.mrope_position_delta
-                        .flatten()
-                        .to(model_runner.device, non_blocking=True)
+                    mrope_position_deltas = mm_input.mrope_position_delta.flatten().to(
+                        model_runner.device, non_blocking=True
                     )
                     mrope_positions_list[batch_idx] = (
-                        mrope_position_deltas + self.seq_lens[batch_idx] - 1
-                    ).unsqueeze(0).repeat(3, 1)
+                        (mrope_position_deltas + self.seq_lens[batch_idx] - 1)
+                        .unsqueeze(0)
+                        .repeat(3, 1)
+                    )
             elif self.forward_mode.is_extend():
                 extend_seq_len, extend_prefix_len = (
                     batch.extend_seq_lens[batch_idx],

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -516,24 +516,23 @@ class ForwardBatch:
         for batch_idx in range(batch_size):
             mm_input = batch.multimodal_inputs[batch_idx]
             if self.forward_mode.is_decode():
-                mrope_position_deltas = (
-                    [0]
-                    if mm_input is None
-                    else flatten_nested_list(mm_input.mrope_position_delta.tolist())
-                )
-                next_input_positions = []
-                for mrope_position_delta in mrope_position_deltas:
-                    # batched deltas needs to be processed separately
-                    # Convert list of lists to tensor with shape [3, seq_len]
-                    next_input_positions += [
-                        MRotaryEmbedding.get_next_input_positions(
-                            mrope_position_delta,
-                            int(self.seq_lens[batch_idx]) - 1,
-                            int(self.seq_lens[batch_idx]),
-                        )
-                    ]
                 # 3 * N
-                mrope_positions_list[batch_idx] = torch.cat(next_input_positions, dim=1)
+                if mm_input is None:
+                    mrope_positions_list[batch_idx] = torch.full(
+                        (3, 1),
+                        self.seq_lens[batch_idx] - 1,
+                        dtype=torch.int64,
+                        device=model_runner.device,
+                    )
+                else:
+                    mrope_position_deltas = (
+                        mm_input.mrope_position_delta
+                        .flatten()
+                        .to(model_runner.device, non_blocking=True)
+                    )
+                    mrope_positions_list[batch_idx] = (
+                        mrope_position_deltas + self.seq_lens[batch_idx] - 1
+                    ).unsqueeze(0).repeat(3, 1)
             elif self.forward_mode.is_extend():
                 extend_seq_len, extend_prefix_len = (
                     batch.extend_seq_lens[batch_idx],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Running `_compute_mrope_positions()` on the forward batch during decode incurs an unnecessary host sync. This prevents us from achieving full overlap on Qwen2.5 VL series among other VLMs. 

## Modifications

<!-- Detail the changes made in this pull request. -->
We avoid moving `mrope_position_delta` to the host by computing position indices directly on the GPU.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### Before
```
Benchmark time: 76.03708224199909
answers saved to: ./answer_sglang.json
Evaluating...
{'Accounting': {'acc': 0.433, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.367, 'num': 30},
 'Art': {'acc': 0.567, 'num': 30},
 'Art_Theory': {'acc': 0.7, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.667, 'num': 30},
 'Biology': {'acc': 0.367, 'num': 30},
 'Chemistry': {'acc': 0.267, 'num': 30},
 'Clinical_Medicine': {'acc': 0.4, 'num': 30},
 'Computer_Science': {'acc': 0.3, 'num': 30},
 'Design': {'acc': 0.633, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.433, 'num': 30},
 'Economics': {'acc': 0.3, 'num': 30},
 'Electronics': {'acc': 0.133, 'num': 30},
 'Energy_and_Power': {'acc': 0.4, 'num': 30},
 'Finance': {'acc': 0.267, 'num': 30},
 'Geography': {'acc': 0.3, 'num': 30},
 'History': {'acc': 0.733, 'num': 30},
 'Literature': {'acc': 0.833, 'num': 30},
 'Manage': {'acc': 0.3, 'num': 30},
 'Marketing': {'acc': 0.5, 'num': 30},
 'Materials': {'acc': 0.433, 'num': 30},
 'Math': {'acc': 0.333, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.367, 'num': 30},
 'Music': {'acc': 0.233, 'num': 30},
 'Overall': {'acc': 0.452, 'num': 900},
 'Overall-Art and Design': {'acc': 0.533, 'num': 120},
 'Overall-Business': {'acc': 0.36, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.533, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.7, 'num': 120},
 'Overall-Science': {'acc': 0.327, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.362, 'num': 210},
 'Pharmacy': {'acc': 0.6, 'num': 30},
 'Physics': {'acc': 0.367, 'num': 30},
 'Psychology': {'acc': 0.6, 'num': 30},
 'Public_Health': {'acc': 0.567, 'num': 30},
 'Sociology': {'acc': 0.633, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.452
```

### After
```
Benchmark time: 77.83271087400044
answers saved to: ./answer_sglang.json
Evaluating...
{'Accounting': {'acc': 0.433, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.367, 'num': 30},
 'Art': {'acc': 0.567, 'num': 30},
 'Art_Theory': {'acc': 0.7, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.667, 'num': 30},
 'Biology': {'acc': 0.367, 'num': 30},
 'Chemistry': {'acc': 0.267, 'num': 30},
 'Clinical_Medicine': {'acc': 0.4, 'num': 30},
 'Computer_Science': {'acc': 0.3, 'num': 30},
 'Design': {'acc': 0.6, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.433, 'num': 30},
 'Economics': {'acc': 0.3, 'num': 30},
 'Electronics': {'acc': 0.133, 'num': 30},
 'Energy_and_Power': {'acc': 0.4, 'num': 30},
 'Finance': {'acc': 0.267, 'num': 30},
 'Geography': {'acc': 0.333, 'num': 30},
 'History': {'acc': 0.733, 'num': 30},
 'Literature': {'acc': 0.833, 'num': 30},
 'Manage': {'acc': 0.3, 'num': 30},
 'Marketing': {'acc': 0.5, 'num': 30},
 'Materials': {'acc': 0.433, 'num': 30},
 'Math': {'acc': 0.367, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.367, 'num': 30},
 'Music': {'acc': 0.233, 'num': 30},
 'Overall': {'acc': 0.453, 'num': 900},
 'Overall-Art and Design': {'acc': 0.525, 'num': 120},
 'Overall-Business': {'acc': 0.36, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.533, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.7, 'num': 120},
 'Overall-Science': {'acc': 0.34, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.362, 'num': 210},
 'Pharmacy': {'acc': 0.6, 'num': 30},
 'Physics': {'acc': 0.367, 'num': 30},
 'Psychology': {'acc': 0.6, 'num': 30},
 'Public_Health': {'acc': 0.567, 'num': 30},
 'Sociology': {'acc': 0.633, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.453
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

### Before
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     200       
Benchmark duration (s):                  79.12     
Total input tokens:                      13654     
Total generated tokens:                  204800    
Total generated tokens (retokenized):    124526    
Request throughput (req/s):              2.53      
Input token throughput (tok/s):          172.58    
Output token throughput (tok/s):         2588.58   
Total token throughput (tok/s):          2761.16   
Concurrency:                             15.40     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6091.23   
Median E2E Latency (ms):                 6082.71   
---------------Time to First Token----------------
Mean TTFT (ms):                          97.26     
Median TTFT (ms):                        65.02     
P99 TTFT (ms):                           511.28    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           5.86      
Median ITL (ms):                         5.89      
P95 ITL (ms):                            6.10      
P99 ITL (ms):                            6.34      
Max ITL (ms):                            38.79     
==================================================
```

### After
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     200       
Benchmark duration (s):                  65.90     
Total input tokens:                      13654     
Total generated tokens:                  204800    
Total generated tokens (retokenized):    126196    
Request throughput (req/s):              3.03      
Input token throughput (tok/s):          207.19    
Output token throughput (tok/s):         3107.72   
Total token throughput (tok/s):          3314.91   
Concurrency:                             15.39     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5071.40   
Median E2E Latency (ms):                 5077.57   
---------------Time to First Token----------------
Mean TTFT (ms):                          59.60     
Median TTFT (ms):                        61.08     
P99 TTFT (ms):                           73.16     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           4.90      
Median ITL (ms):                         4.92      
P95 ITL (ms):                            5.24      
P99 ITL (ms):                            5.41      
Max ITL (ms):                            31.61     
==================================================
```

## Repro Script
The following script was run on 1xH200.
```
#! /bin/bash

# Start SGLang server
python -m sglang.launch_server \
    --model-path Qwen/Qwen2.5-VL-3B-Instruct \
    --port 30000 &
PID=$!

# Wait for server to start
while ! curl -s http://localhost:30000/health > /dev/null; do
    sleep 1
done

# Run accuracy benchmark
python benchmark/mmmu/bench_sglang.py \
    --port 30000 \
    --concurrency 16

# Flush cache
curl -X POST http://localhost:30000/flush_cache

# Run latency benchmark
python -m sglang.bench_serving \
    --backend sglang \
    --dataset-name mmmu \
    --num-prompts 200 \
    --max-concurrency 16

# Kill server
kill $PID
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
