### PR TITLE
fix: should return a invalid request response when schema missing

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -80,6 +80,12 @@ class OpenAIServingChat(OpenAIServingBase):
                 f"max_completion_tokens is too large: {max_output_tokens}."
                 f"This model supports at most {server_context_length} completion tokens."
             )
+            
+        if request.response_format and request.response_format.type == "json_schema":
+            schema = getattr(request.response_format.json_schema, "schema_", None)
+            if schema is None:
+                return "schema_ is required for json_schema response format request."
+            
 
         return None
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -80,12 +80,11 @@ class OpenAIServingChat(OpenAIServingBase):
                 f"max_completion_tokens is too large: {max_output_tokens}."
                 f"This model supports at most {server_context_length} completion tokens."
             )
-            
+
         if request.response_format and request.response_format.type == "json_schema":
             schema = getattr(request.response_format.json_schema, "schema_", None)
             if schema is None:
                 return "schema_ is required for json_schema response format request."
-            
 
         return None
 


### PR DESCRIPTION
should return a invalid request response when schema missing in a json_schema response format request

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
it would give 500 error with following request

```
curl -X POST "http://localhost:1234/v1/chat/completions"   -H "Content-Type: application/json"   -d '{
    "model": "openai/gpt-oss-120b",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful teaching assistant that scores assignments based on a rubric."
      },
      {
        "role": "user",
        "content": "Text: Dr. Fenwick wrote a book compiling stories from 300 people.\n\nWhich label best fits?\n1. Books and Literature\n2. Politics\n3. Music\n\nConstraint: Reply only with the label number."
      }
    ],
    "temperature": 0,
    "stream": false,
    "response_format": {
      "type": "json_schema",
      "schema": {
        "type": "object",
        "properties": {
          "label": {
            "type": "integer",
            "description": "the number of the label"
          }
        },
        "required": ["label"],
        "additionalProperties": false
      }
    },
    "max_tokens": 64
  }'

```

call stack from server side:

```
[2025-08-21 20:42:31] Error in request: 'NoneType' object has no attribute 'schema_'
Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_base.py", line 35, in handle_request
    adapted_request, processed_request = self._convert_to_internal_request(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 101, in _convert_to_internal_request
    sampling_params = self._build_sampling_params(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 361, in _build_sampling_params
    request.response_format.json_schema.schema_
AttributeError: 'NoneType' object has no attribute 'schema_'
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
