### PR TITLE
[router] remove all tokenizer metrics for performance

### DIFF
--- a/sgl-router/src/tokenizer/factory.rs
+++ b/sgl-router/src/tokenizer/factory.rs
@@ -1,11 +1,9 @@
-use super::traits::{self, Tokenizer as TokenizerTrait};
-use crate::metrics::TokenizerMetrics;
+use super::traits;
 use anyhow::{Error, Result};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
 
 #[cfg(feature = "huggingface")]
 use super::huggingface::HuggingFaceTokenizer;
@@ -34,8 +32,6 @@ pub fn create_tokenizer_with_chat_template(
     file_path: &str,
     chat_template_path: Option<&str>,
 ) -> Result<Arc<dyn traits::Tokenizer>> {
-    let start_time = Instant::now();
-
     // Special case for testing
     if file_path == "mock" || file_path == "test" {
         return Ok(Arc::new(super::mock::MockTokenizer::new()));
@@ -45,7 +41,6 @@ pub fn create_tokenizer_with_chat_template(
 
     // Check if file exists
     if !path.exists() {
-        TokenizerMetrics::record_factory_error("file_not_found");
         return Err(Error::msg(format!("File not found: {}", file_path)));
     }
 
@@ -64,14 +59,10 @@ pub fn create_tokenizer_with_chat_template(
                     chat_template_path,
                 )?;
 
-                TokenizerMetrics::record_factory_load("json");
-                TokenizerMetrics::set_vocab_size("huggingface", tokenizer.vocab_size());
-
                 Ok(Arc::new(tokenizer) as Arc<dyn traits::Tokenizer>)
             }
             #[cfg(not(feature = "huggingface"))]
             {
-                TokenizerMetrics::record_factory_error("huggingface_disabled");
                 Err(Error::msg(
                     "HuggingFace support not enabled. Enable the 'huggingface' feature.",
                 ))
@@ -79,26 +70,18 @@ pub fn create_tokenizer_with_chat_template(
         }
         Some("model") => {
             // SentencePiece model file
-            TokenizerMetrics::record_factory_error("unsupported_sentencepiece");
             Err(Error::msg("SentencePiece models not yet supported"))
         }
         Some("gguf") => {
             // GGUF format
-            TokenizerMetrics::record_factory_error("unsupported_gguf");
             Err(Error::msg("GGUF format not yet supported"))
         }
         _ => {
             // Try to auto-detect by reading file content
-            auto_detect_tokenizer(file_path).inspect(|tokenizer| {
-                TokenizerMetrics::record_factory_load("auto_detected");
-                TokenizerMetrics::set_vocab_size("auto_detected", tokenizer.vocab_size());
-            })
+            auto_detect_tokenizer(file_path)
         }
     };
 
-    if result.is_ok() {
-        TokenizerMetrics::record_factory_load_duration(start_time.elapsed());
-    }
     result
 }
 
@@ -190,8 +173,6 @@ pub fn create_tokenizer(model_name_or_path: &str) -> Result<Arc<dyn traits::Toke
         {
             use super::tiktoken::TiktokenTokenizer;
             let tokenizer = TiktokenTokenizer::from_model_name(model_name_or_path)?;
-            TokenizerMetrics::record_factory_load("tiktoken");
-            TokenizerMetrics::set_vocab_size("tiktoken", tokenizer.vocab_size());
             return Ok(Arc::new(tokenizer));
         }
     }
@@ -286,7 +267,7 @@ mod tests {
         // Test encoding and decoding
         let text = "Hello, world!";
         let encoding = tokenizer.encode(text).unwrap();
-        let decoded = tokenizer.decode(&encoding.token_ids(), false).unwrap();
+        let decoded = tokenizer.decode(encoding.token_ids(), false).unwrap();
         assert_eq!(decoded, text);
     }
 }

--- a/sgl-router/src/tokenizer/huggingface.rs
+++ b/sgl-router/src/tokenizer/huggingface.rs
@@ -1,10 +1,8 @@
 use super::traits::{
     Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait,
 };
-use crate::metrics::TokenizerMetrics;
 use anyhow::{Error, Result};
 use std::collections::HashMap;
-use std::time::Instant;
 use tokenizers::tokenizer::Tokenizer as HfTokenizer;
 
 #[cfg(feature = "minijinja")]
@@ -196,36 +194,17 @@ impl HuggingFaceTokenizer {
 
 impl Encoder for HuggingFaceTokenizer {
     fn encode(&self, input: &str) -> Result<Encoding> {
-        let start = Instant::now();
-
-        TokenizerMetrics::record_encode_request("huggingface");
-        TokenizerMetrics::record_chars_per_encode(input.len());
-
         self.tokenizer
             .encode(input, false)
-            .map_err(|e| {
-                TokenizerMetrics::record_encode_error("encoding_failed");
-                Error::msg(format!("Encoding failed: {}", e))
-            })
-            .map(|encoding| {
-                TokenizerMetrics::record_tokens_per_encode(encoding.get_ids().len());
-                TokenizerMetrics::record_encode_duration(start.elapsed());
-                Encoding::Hf(Box::new(encoding))
-            })
+            .map_err(|e| Error::msg(format!("Encoding failed: {}", e)))
+            .map(|encoding| Encoding::Hf(Box::new(encoding)))
     }
 
     fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
-        let start = Instant::now();
-
         let encodings = self
             .tokenizer
             .encode_batch(inputs.to_vec(), false)
-            .map_err(|e| {
-                TokenizerMetrics::record_encode_error("batch_encoding_failed");
-                Error::msg(format!("Batch encoding failed: {}", e))
-            })?;
-
-        TokenizerMetrics::record_encode_batch_duration(start.elapsed(), inputs.len());
+            .map_err(|e| Error::msg(format!("Batch encoding failed: {}", e)))?;
 
         Ok(encodings
             .into_iter()
@@ -236,20 +215,9 @@ impl Encoder for HuggingFaceTokenizer {
 
 impl Decoder for HuggingFaceTokenizer {
     fn decode(&self, token_ids: &[TokenIdType], skip_special_tokens: bool) -> Result<String> {
-        let start = Instant::now();
-
-        TokenizerMetrics::record_decode_request("huggingface");
-        TokenizerMetrics::record_tokens_per_decode(token_ids.len());
-
         self.tokenizer
             .decode(token_ids, skip_special_tokens)
-            .map_err(|e| {
-                TokenizerMetrics::record_decode_error("decoding_failed");
-                Error::msg(format!("Decoding failed: {}", e))
-            })
-            .inspect(|_| {
-                TokenizerMetrics::record_decode_duration(start.elapsed());
-            })
+            .map_err(|e| Error::msg(format!("Decoding failed: {}", e)))
     }
 }
 

--- a/sgl-router/src/tokenizer/tests.rs
+++ b/sgl-router/src/tokenizer/tests.rs
@@ -129,9 +129,7 @@ fn test_thread_safety() {
             thread::spawn(move || {
                 let text = "Hello test".to_string();
                 let encoding = tokenizer_clone.encode(&text).unwrap();
-                let decoded = tokenizer_clone
-                    .decode(&encoding.token_ids(), false)
-                    .unwrap();
+                let decoded = tokenizer_clone.decode(encoding.token_ids(), false).unwrap();
                 assert!(decoded.contains("Hello") || decoded.contains("test"));
                 i
             })

--- a/sgl-router/src/tokenizer/tiktoken.rs
+++ b/sgl-router/src/tokenizer/tiktoken.rs
@@ -213,7 +213,7 @@ mod tests {
         let text = "Hello, world!";
         let encoding = tokenizer.encode(text).unwrap();
 
-        let decoded = tokenizer.decode(&encoding.token_ids(), false).unwrap();
+        let decoded = tokenizer.decode(encoding.token_ids(), false).unwrap();
         assert_eq!(decoded, text);
     }
 
@@ -226,7 +226,7 @@ mod tests {
 
         assert_eq!(encodings.len(), 3);
         for (i, encoding) in encodings.iter().enumerate() {
-            let decoded = tokenizer.decode(&encoding.token_ids(), false).unwrap();
+            let decoded = tokenizer.decode(encoding.token_ids(), false).unwrap();
             assert_eq!(decoded, texts[i]);
         }
     }

--- a/sgl-router/src/tokenizer/traits.rs
+++ b/sgl-router/src/tokenizer/traits.rs
@@ -36,22 +36,19 @@ pub enum Encoding {
 }
 
 impl Encoding {
-    /// Returns a reference to token IDs when possible, owned Vec for compatibility
-    pub fn token_ids(&self) -> Vec<TokenIdType> {
-        match self {
-            Encoding::Hf(inner) => inner.get_ids().to_vec(),
-            Encoding::Sp(inner) => inner.clone(),
-            Encoding::Tiktoken(inner) => inner.clone(),
-        }
-    }
-
-    /// Returns a reference to token IDs where possible
-    pub fn token_ids_ref(&self) -> &[TokenIdType] {
+    /// Returns a reference to token IDs - zero-copy operation
+    pub fn token_ids(&self) -> &[TokenIdType] {
         match self {
             Encoding::Hf(inner) => inner.get_ids(),
             Encoding::Sp(inner) => inner,
-            Encoding::Tiktoken(inner) => inner, // Now works with tiktoken-rs 0.7.0!
+            Encoding::Tiktoken(inner) => inner,
         }
+    }
+
+    /// Deprecated: Use token_ids() instead (kept for compatibility)
+    #[deprecated(since = "0.1.0", note = "Use token_ids() instead")]
+    pub fn token_ids_ref(&self) -> &[TokenIdType] {
+        self.token_ids()
     }
 
     /// Get a hash of the token IDs for caching purposes

--- a/sgl-router/tests/tokenizer_integration.rs
+++ b/sgl-router/tests/tokenizer_integration.rs
@@ -136,7 +136,7 @@ fn test_tokenizer_encode_decode_lifecycle() {
         let encoding = tokenizer.encode(prompt).expect("Failed to encode prompt");
 
         let decoded = tokenizer
-            .decode(&encoding.token_ids(), false)
+            .decode(encoding.token_ids(), false)
             .expect("Failed to decode token_ids");
 
         assert_eq!(decoded, *prompt, "Encode-decode mismatch for: {}", prompt);
@@ -171,7 +171,7 @@ fn test_sequence_operations() {
 
         for token_id in encoding.token_ids() {
             let text = decoder
-                .append_token(token_id)
+                .append_token(*token_id)
                 .expect("Failed to append token");
             output.push_str(&text);
         }
@@ -201,7 +201,7 @@ fn test_decode_stream() {
         let mut output = String::new();
 
         for token_id in encoding.token_ids() {
-            if let Some(text) = decoder.step(token_id).expect("Failed to decode token") {
+            if let Some(text) = decoder.step(*token_id).expect("Failed to decode token") {
                 output.push_str(&text);
             }
         }
@@ -227,11 +227,11 @@ fn test_long_sequence_incremental_decode_with_prefill() {
             .encode(output_text)
             .expect("Failed to encode output");
 
-        let mut decoder = DecodeStream::new(tokenizer.clone(), &input_encoding.token_ids(), false);
+        let mut decoder = DecodeStream::new(tokenizer.clone(), input_encoding.token_ids(), false);
 
         let mut output = String::new();
         for token_id in output_encoding.token_ids() {
-            if let Some(text) = decoder.step(token_id).expect("Failed to decode token") {
+            if let Some(text) = decoder.step(*token_id).expect("Failed to decode token") {
                 output.push_str(&text);
             }
         }
@@ -269,7 +269,7 @@ fn test_stop_sequence_decoder() {
         let mut stopped = false;
 
         for token_id in encoding.token_ids() {
-            match decoder.process_token(token_id).unwrap() {
+            match decoder.process_token(*token_id).unwrap() {
                 SequenceDecoderOutput::Text(text) => output.push_str(&text),
                 SequenceDecoderOutput::StoppedWithText(text) => {
                     output.push_str(&text);
@@ -315,7 +315,7 @@ fn test_factory_creation() {
     let encoding = tokenizer.encode(TEST_PROMPTS[0]).expect("Failed to encode");
 
     let decoded = tokenizer
-        .decode(&encoding.token_ids(), false)
+        .decode(encoding.token_ids(), false)
         .expect("Failed to decode");
 
     assert_eq!(decoded, TEST_PROMPTS[0]);
@@ -335,7 +335,7 @@ fn test_batch_encoding() {
 
     for (i, encoding) in encodings.iter().enumerate() {
         let decoded = tokenizer
-            .decode(&encoding.token_ids(), false)
+            .decode(encoding.token_ids(), false)
             .expect("Failed to decode");
         assert_eq!(decoded, TEST_PROMPTS[i]);
     }
@@ -377,7 +377,7 @@ fn test_thread_safety() {
                     .encode(prompt)
                     .expect("Failed to encode in thread");
                 let decoded = tokenizer_clone
-                    .decode(&encoding.token_ids(), false)
+                    .decode(encoding.token_ids(), false)
                     .expect("Failed to decode in thread");
                 assert_eq!(decoded, prompt);
             })


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

1. Tokenizer metrics add severe overhead
2. Existing tokenizer allocates too much memory than needed

## Modification
1. remove all metrics for now
2. use reference instead of cloning for token ids to reduce memory consumption

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
