### PR TITLE
torch.compile() mrope

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1029,6 +1029,7 @@ class MRotaryEmbedding(RotaryEmbedding):
                     f"Corrected mrope_section: {self.mrope_section} (sum={sum(self.mrope_section)})"
                 )
 
+    @torch.compile(dynamic=True)
     def forward(
         self,
         positions: torch.Tensor,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
`MRotaryEmbedding.forward()` defaults to a torch native forward pass without any fusion. For smaller VLMs, the latency of the mrope kernels during decode is about 30% of the latency of the entire transformer layer. Adding `torch.compile()` as the default is a good step towards reducing the number of kernel launch overheads, reducing mrope latency by 8x on `Qwen2.5-VL-3B-Instruct`.

## Modifications

<!-- Detail the changes made in this pull request. -->
Added `torch.compile(dynamic=True)` to `MRotaryEmbedding.forward()`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### Before
```
Benchmark time: 76.03708224199909
answers saved to: ./answer_sglang.json
Evaluating...
{'Accounting': {'acc': 0.433, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.367, 'num': 30},
 'Art': {'acc': 0.567, 'num': 30},
 'Art_Theory': {'acc': 0.7, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.667, 'num': 30},
 'Biology': {'acc': 0.367, 'num': 30},
 'Chemistry': {'acc': 0.267, 'num': 30},
 'Clinical_Medicine': {'acc': 0.4, 'num': 30},
 'Computer_Science': {'acc': 0.3, 'num': 30},
 'Design': {'acc': 0.633, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.433, 'num': 30},
 'Economics': {'acc': 0.3, 'num': 30},
 'Electronics': {'acc': 0.133, 'num': 30},
 'Energy_and_Power': {'acc': 0.4, 'num': 30},
 'Finance': {'acc': 0.267, 'num': 30},
 'Geography': {'acc': 0.3, 'num': 30},
 'History': {'acc': 0.733, 'num': 30},
 'Literature': {'acc': 0.833, 'num': 30},
 'Manage': {'acc': 0.3, 'num': 30},
 'Marketing': {'acc': 0.5, 'num': 30},
 'Materials': {'acc': 0.433, 'num': 30},
 'Math': {'acc': 0.333, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.367, 'num': 30},
 'Music': {'acc': 0.233, 'num': 30},
 'Overall': {'acc': 0.452, 'num': 900},
 'Overall-Art and Design': {'acc': 0.533, 'num': 120},
 'Overall-Business': {'acc': 0.36, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.533, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.7, 'num': 120},
 'Overall-Science': {'acc': 0.327, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.362, 'num': 210},
 'Pharmacy': {'acc': 0.6, 'num': 30},
 'Physics': {'acc': 0.367, 'num': 30},
 'Psychology': {'acc': 0.6, 'num': 30},
 'Public_Health': {'acc': 0.567, 'num': 30},
 'Sociology': {'acc': 0.633, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.452
```

### After
```
Benchmark time: 73.77103035300024
answers saved to: ./answer_sglang.json
Evaluating...
{'Accounting': {'acc': 0.467, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.367, 'num': 30},
 'Art': {'acc': 0.567, 'num': 30},
 'Art_Theory': {'acc': 0.7, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.667, 'num': 30},
 'Biology': {'acc': 0.367, 'num': 30},
 'Chemistry': {'acc': 0.267, 'num': 30},
 'Clinical_Medicine': {'acc': 0.367, 'num': 30},
 'Computer_Science': {'acc': 0.3, 'num': 30},
 'Design': {'acc': 0.6, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.433, 'num': 30},
 'Economics': {'acc': 0.3, 'num': 30},
 'Electronics': {'acc': 0.133, 'num': 30},
 'Energy_and_Power': {'acc': 0.333, 'num': 30},
 'Finance': {'acc': 0.3, 'num': 30},
 'Geography': {'acc': 0.333, 'num': 30},
 'History': {'acc': 0.733, 'num': 30},
 'Literature': {'acc': 0.833, 'num': 30},
 'Manage': {'acc': 0.3, 'num': 30},
 'Marketing': {'acc': 0.5, 'num': 30},
 'Materials': {'acc': 0.4, 'num': 30},
 'Math': {'acc': 0.3, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.367, 'num': 30},
 'Music': {'acc': 0.3, 'num': 30},
 'Overall': {'acc': 0.45, 'num': 900},
 'Overall-Art and Design': {'acc': 0.542, 'num': 120},
 'Overall-Business': {'acc': 0.373, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.533, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.683, 'num': 120},
 'Overall-Science': {'acc': 0.327, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.348, 'num': 210},
 'Pharmacy': {'acc': 0.6, 'num': 30},
 'Physics': {'acc': 0.367, 'num': 30},
 'Psychology': {'acc': 0.567, 'num': 30},
 'Public_Health': {'acc': 0.6, 'num': 30},
 'Sociology': {'acc': 0.6, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.45
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

### Before
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     200       
Benchmark duration (s):                  79.12     
Total input tokens:                      13654     
Total generated tokens:                  204800    
Total generated tokens (retokenized):    124526    
Request throughput (req/s):              2.53      
Input token throughput (tok/s):          172.58    
Output token throughput (tok/s):         2588.58   
Total token throughput (tok/s):          2761.16   
Concurrency:                             15.40     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6091.23   
Median E2E Latency (ms):                 6082.71   
---------------Time to First Token----------------
Mean TTFT (ms):                          97.26     
Median TTFT (ms):                        65.02     
P99 TTFT (ms):                           511.28    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           5.86      
Median ITL (ms):                         5.89      
P95 ITL (ms):                            6.10      
P99 ITL (ms):                            6.34      
Max ITL (ms):                            38.79     
==================================================
```

<img width="1710" height="1107" alt="Screenshot 2025-08-21 at 11 31 47 PM" src="https://github.com/user-attachments/assets/c5c975d2-623c-435c-b017-7bb7c88a8bd8" />


### After
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     200       
Benchmark duration (s):                  61.59     
Total input tokens:                      13654     
Total generated tokens:                  204800    
Total generated tokens (retokenized):    128753    
Request throughput (req/s):              3.25      
Input token throughput (tok/s):          221.70    
Output token throughput (tok/s):         3325.33   
Total token throughput (tok/s):          3547.03   
Concurrency:                             15.45     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4756.19   
Median E2E Latency (ms):                 4662.42   
---------------Time to First Token----------------
Mean TTFT (ms):                          175.25    
Median TTFT (ms):                        60.41     
P99 TTFT (ms):                           1520.52   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           4.48      
Median ITL (ms):                         4.50      
P95 ITL (ms):                            4.67      
P99 ITL (ms):                            4.82      
Max ITL (ms):                            35.53     
==================================================
```

<img width="1710" height="1107" alt="Screenshot 2025-08-21 at 11 32 04 PM" src="https://github.com/user-attachments/assets/ed588401-92ce-4f5e-9bae-c465a5d3a193" />

## Repro Script
The following script was run on 1xH200.
```
#! /bin/bash

# Start SGLang server
python -m sglang.launch_server \
    --model-path Qwen/Qwen2.5-VL-3B-Instruct \
    --port 30000 &
PID=$!

# Wait for server to start
while ! curl -s http://localhost:30000/health > /dev/null; do
    sleep 1
done

# Run accuracy benchmark
python benchmark/mmmu/bench_sglang.py \
    --port 30000 \
    --concurrency 16

# Flush cache
curl -X POST http://localhost:30000/flush_cache

# Run latency benchmark
python -m sglang.bench_serving \
    --backend sglang \
    --dataset-name mmmu \
    --num-prompts 200 \
    --max-concurrency 16

# Kill server
kill $PID
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
