### PR TITLE
Fix GLM45 tool call multi-turn bug

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -207,6 +207,25 @@ class OpenAIServingChat(OpenAIServingBase):
                 audio_data,
                 modalities,
             )
+
+            # per the Transformers docs & maintainers, tool call arguments in
+            # assistant-role messages with tool_calls need to be dicts not JSON str -
+            # this is how tool-use chat templates will expect them moving forwards
+            # so, for messages that have tool_calls, parse the string (which we get
+            # from openAI format) to dict
+            if (
+                processed_msg["role"] == "assistant"
+                and "tool_calls" in processed_msg
+                and isinstance(processed_msg["tool_calls"], list)
+            ):
+                for item in processed_msg["tool_calls"]:
+                    if "arguments" in item["function"] and isinstance(
+                        item["function"]["arguments"], str
+                    ):
+                        item["function"]["arguments"] = json.loads(
+                            item["function"]["arguments"]
+                        )
+
             openai_compatible_messages.append(processed_msg)
 
         # Handle assistant prefix for continue_final_message


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Close https://github.com/sgl-project/sglang/issues/9489

## Modifications

Adapted from https://github.com/sgl-project/sglang/pull/8584

## Accuracy Tests

Function Call UT `python3 -m unittest test_openai_function_calling` passes

<img width="1071" height="121" alt="image" src="https://github.com/user-attachments/assets/e4d495ef-8023-4485-9007-1b50b257854e" />

<img width="1132" height="306" alt="image" src="https://github.com/user-attachments/assets/ad307a04-a491-4ca9-b3ea-01fcd6727c55" />

(tearDownClass error is expected b/c i'm testing against a different sglang server but not the server launched within UT)

Also tested `test_openai_function_calling with multiturn tool call UT enabled` on `stepfun-ai/step3-fp8, openai/gpt-oss-20b, Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8, Qwen/Qwen2.5-14B-Instruct, meta-llama/Llama-3.3-70B-Instruct, deepseek-ai/DeepSeek-R1-0528, deepseek-ai/DeepSeek-V3`: All work as expected.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
