### PR TITLE
fix: benchmark chunks index out of range

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -231,7 +231,7 @@ async def async_request_openai_completions(
                             # NOTE: Some completion API might have a last
                             # usage summary response without a token so we
                             # want to check a token was generated
-                            if data["choices"][0]["text"]:
+                            if data["choices"] and data["choices"][0]["text"]:
                                 timestamp = time.perf_counter()
                                 # First token
                                 if ttft == 0.0:


### PR DESCRIPTION
## Motivation

While using the benchmark code in this project to benchmark my own vLLM service, I discovered that the last chunk of each inference response contains an empty choices list. However, the code directly accesses the list without length validation, causing an index out of bounds error.
<img width="1351" height="333" alt="image" src="https://github.com/user-attachments/assets/d56fbc2f-f80b-4541-a7c2-1a8e559abd5a" />

## Modifications

Added null/empty validation before accessing the choices list to prevent index out of bounds errors when the choices array is empty.

## Accuracy Tests

N/A - This is a bug fix that doesn't affect model outputs or inference logic.

## Benchmarking and Profiling

N/A - This change only adds safety checks and doesn't impact inference speed.

## Checklist

- [ x ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ x ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ x ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ x ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
