### PR TITLE
Fix occasional OOM inside LogitsProcessor

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -517,6 +517,7 @@ class LogitsProcessor(nn.Module):
             logits = logits[:, : self.config.vocab_size]
 
         if self.final_logit_softcapping:
+            logits = logits.to(dtype=torch.float32)
             fused_softcap(logits, self.final_logit_softcapping)
 
         return logits

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -326,7 +326,7 @@ class LogitsProcessor(nn.Module):
         logits = self._get_logits(pruned_states, lm_head, logits_metadata)
         sampled_logits = (
             logits[sample_indices] if sample_indices is not None else logits
-        )
+        ).to(dtype=torch.float32)
 
         if self.debug_tensor_dump_output_folder:
             assert (
@@ -514,7 +514,7 @@ class LogitsProcessor(nn.Module):
             logits_buffer.copy_(logits[:, : self.config.vocab_size])
             logits = logits_buffer
         else:
-            logits = logits[:, : self.config.vocab_size].float()
+            logits = logits[:, : self.config.vocab_size]
 
         if self.final_logit_softcapping:
             fused_softcap(logits, self.final_logit_softcapping)


### PR DESCRIPTION
## Motivation

Occasionally an OOM can occur inside `LogitsProcessor` where the logits are casted to fp32. This tends to occur after a few steps of RL, depending on the initial `mem_fraction_static`, due to an increase in the overall GPU memory usage during RL training.

## Modifications

This PR simply defers the fp32 cast to after the logits are sliced.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
