### PR TITLE
Fix GLM45v launch server cuda torch compile bug

### DIFF
--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -526,6 +526,7 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module):
     def get_input_embeddings(self):
         return self.model.embed_tokens
 
+    @torch.no_grad()
     def forward(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

After recent sglang code changes, glm45v launch server would fail with this error during torch compile
```
[2025-08-24 03:58:12 TP4] Scheduler hit an exception: Traceback (most recent call last):
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 384, in __init__
    self.capture()
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 492, in capture
    ) = self.capture_one_batch_size(bs, forward)
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 663, in capture_one_batch_size
    run_once()
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 652, in run_once
    logits_output_or_pp_proxy_tensors = forward(
  File "/home/jobuser/sglang/python/sglang/srt/models/qwen2_5_vl.py", line 561, in forward
    hidden_states = general_mm_embed_routine(
  File "/home/jobuser/sglang/python/sglang/srt/managers/mm_utils.py", line 659, in general_mm_embed_routine
    hidden_states = language_model(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/deepseek_v2.py", line 2075, in forward
    hidden_states, residual = layer(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/glm4_moe.py", line 684, in forward
    hidden_states = self.mlp(hidden_states, forward_batch)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/deepseek_v2.py", line 454, in forward
    return self.forward_normal(
  File "/home/jobuser/sglang/python/sglang/srt/models/glm4_moe.py", line 556, in forward_normal
    final_hidden_states = self.experts(hidden_states, topk_output)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 818, in forward
    final_hidden_states = self.quant_method.apply(
  File "/home/jobuser/sglang/python/sglang/srt/layers/quantization/unquant.py", line 233, in apply
    return self.forward(
  File "/home/jobuser/sglang/python/sglang/srt/custom_op.py", line 59, in forward
    return self._forward_method(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/layers/quantization/unquant.py", line 304, in forward_cuda
    return fused_experts(
  File "/home/jobuser/sglang/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 1220, in fused_experts
    torch.ops.sglang.inplace_fused_experts(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_ops.py", line 1243, in __call__
    return self._op(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 1034, in inplace_fused_experts
    fused_experts_impl(
  File "/home/jobuser/sglang/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 1604, in fused_experts_impl
    moe_sum_reduce_torch_compile(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 736, in compile_wrapper
    return fn(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 1495, in __call__
    return self._torchdynamo_orig_callable(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 1272, in __call__
    result = self._inner_convert(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 629, in __call__
    return _compile(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 1111, in _compile
    guarded_code = compile_inner(code, one_graph, hooks, transform)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_utils_internal.py", line 97, in wrapper_function
    return function(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 793, in compile_inner
    return _compile_inner(code, one_graph, hooks, transform)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 832, in _compile_inner
    out_code = transform_code_object(code, transform)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/bytecode_transformation.py", line 1424, in transform_code_object
    transformations(instructions, code_options)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 267, in _fn
    return fn(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/convert_frame.py", line 753, in transform
    tracer.run()
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 3497, in run
    super().run()
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 1363, in run
    while self.step():
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 1267, in step
    self.dispatch_table[inst.opcode](self, inst)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 834, in wrapper
    return inner_fn(self, inst)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 2240, in CALL_FUNCTION_KW
    self.call_function(fn, args, kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/symbolic_convert.py", line 1193, in call_function
    self.push(fn.call_function(self, args, kwargs))  # type: ignore[arg-type]
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/variables/lazy.py", line 201, in realize_and_forward
    return getattr(self.realize(), name)(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/variables/torch.py", line 1338, in call_function
    tensor_variable = wrap_fx_proxy(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/variables/builder.py", line 2559, in wrap_fx_proxy
    return wrap_fx_proxy_cls(target_cls=TensorVariable, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/variables/builder.py", line 2625, in wrap_fx_proxy_cls
    return _wrap_fx_proxy(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/variables/builder.py", line 2723, in _wrap_fx_proxy
    example_value = get_fake_value(proxy.node, tx, allow_non_graph_fake=True)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 3355, in get_fake_value
    raise TorchRuntimeError(str(e)).with_traceback(e.__traceback__) from None
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 3253, in get_fake_value
    ret_val = wrap_fake_exception(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2753, in wrap_fake_exception
    return fn()
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 3254, in <lambda>
    lambda: run_node(tx.output, node, args, kwargs, nnmodule)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 3462, in run_node
    raise RuntimeError(make_error_message(e)).with_traceback(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 3421, in run_node
    return node.target(*args, **kwargs)
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in method sum of type object at 0x7071412f8460>(*(FakeTensor(..., device='cuda:4', size=(32, 8, 4096), dtype=torch.bfloat16),), **{'dim': 1, 'out': FakeTensor(..., device='cuda:4', size=(32, 4096), dtype=torch.bfloat16,
           grad_fn=<AsStridedBackward0>)}): got RuntimeError("sum(): functions with out=... arguments don't support automatic differentiation, but one of the arguments requires grad.")

from user code:
   File "/home/jobuser/sglang/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 1365, in moe_sum_reduce_torch_compile
    torch.sum(x, dim=1, out=out)

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jobuser/sglang/python/sglang/srt/managers/scheduler.py", line 2552, in run_scheduler_process
    scheduler = Scheduler(
  File "/home/jobuser/sglang/python/sglang/srt/managers/scheduler.py", line 321, in __init__
    self.tp_worker = TpWorkerClass(
  File "/home/jobuser/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 67, in __init__
    self.worker = TpModelWorker(
  File "/home/jobuser/sglang/python/sglang/srt/managers/tp_worker.py", line 84, in __init__
    self.model_runner = ModelRunner(
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/model_runner.py", line 244, in __init__
    self.initialize(min_per_gpu_memory)
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/model_runner.py", line 349, in initialize
    self.init_device_graphs()
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/model_runner.py", line 1624, in init_device_graphs
    CudaGraphRunner(self) if not _is_npu else NPUGraphRunner(self)
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 386, in __init__
    raise Exception(
Exception: Capture cuda graph failed: Dynamo failed to run FX node with fake tensors: call_function <built-in method sum of type object at 0x7071412f8460>(*(FakeTensor(..., device='cuda:4', size=(32, 8, 4096), dtype=torch.bfloat16),), **{'dim': 1, 'out': FakeTensor(..., device='cuda:4', size=(32, 4096), dtype=torch.bfloat16,
           grad_fn=<AsStridedBackward0>)}): got RuntimeError("sum(): functions with out=... arguments don't support automatic differentiation, but one of the arguments requires grad.")

from user code:
   File "/home/jobuser/sglang/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 1365, in moe_sum_reduce_torch_compile
    torch.sum(x, dim=1, out=out)

Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```

## Modifications

- From https://discuss.pytorch.org/t/index-select-functions-with-out-arguments-dont-support-automatic-differentiation/28974/4, `out=` in torch-compile does not work if grad is required. Thus, we can disable grad during model forward. It is anyways not required for inference.
<img width="598" height="156" alt="image" src="https://github.com/user-attachments/assets/9d22dd89-4c3f-4145-9bc0-8a34e051079c" />
- Glm4vForConditionalGeneration extends from Qwen2_5_VLForConditionalGeneration so adding `torch.no_grad` in Qwen2_5_VLForConditionalGeneration would work
## Accuracy Tests

- GLM45v is able to launch server with cuda graph & torch compile enabled now
- Tested mmmu. [GLM45V](https://huggingface.co/zai-org/GLM-4.5V) sglang MMMU score keeps the same as before: 0.748

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
