### PR TITLE
[NVIDIA] [2/N] Optimize `silu_and_mul_scaled_fp4_grouped_quant` perf

### DIFF
--- a/benchmark/kernels/quantization/bench_fp4_quant.py
+++ b/benchmark/kernels/quantization/bench_fp4_quant.py
@@ -18,6 +18,7 @@ def _test_accuracy_once(E, M, K, input_dtype, device):
     out1, blk_scales1 = scaled_fp4_grouped_quant(
         silu_and_mul(x),
         glb_scales,
+        masks,
     )
 
     torch.testing.assert_close(out, out1)
@@ -89,6 +90,7 @@ def benchmark(M, K, provider):
             lambda: scaled_fp4_grouped_quant(
                 silu_and_mul(x),
                 glb_scales,
+                masks,
             ),
             quantiles=quantiles,
         )

--- a/benchmark/kernels/quantization/bench_fp4_quant.py
+++ b/benchmark/kernels/quantization/bench_fp4_quant.py
@@ -1,0 +1,131 @@
+import argparse
+import itertools
+
+import torch
+import triton
+from sgl_kernel import scaled_fp4_grouped_quant, silu_and_mul_scaled_fp4_grouped_quant
+from sgl_kernel.elementwise import silu_and_mul
+
+from sglang.srt.layers.moe.ep_moe.kernels import silu_and_mul_masked_post_quant_fwd
+from sglang.srt.layers.quantization import deep_gemm_wrapper
+
+
+def _test_accuracy_once(E, M, K, input_dtype, device):
+    x = torch.randn(E, M, K, device=device, dtype=input_dtype)
+    glb_scales = torch.ones((E,), dtype=torch.float32, device=device)
+    masks = torch.full((E,), M, dtype=torch.int32, device=device)
+    out, blk_scales = silu_and_mul_scaled_fp4_grouped_quant(x, glb_scales, masks)
+    out1, blk_scales1 = scaled_fp4_grouped_quant(
+        silu_and_mul(x),
+        glb_scales,
+    )
+
+    torch.testing.assert_close(out, out1)
+    torch.testing.assert_close(blk_scales, blk_scales1)
+    print(f"E: {E}, M: {M}, K: {K}, type: {input_dtype} OK")
+
+
+NUM_RANKS = 48
+M_PER_RANKs = [128, 256, 512, 1024]
+Ms = [M_PER_RANK * NUM_RANKS for M_PER_RANK in M_PER_RANKs]
+Ks = [2048, 4096, 7168]
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["M", "K"],
+        x_vals=list(itertools.product(Ms, Ks)),
+        x_log=False,
+        line_arg="provider",
+        line_vals=["triton_fp8", "cuda_unfused_fp4", "cuda_fused_fp4"],
+        line_names=["triton_fp8", "cuda_unfused_fp4", "cuda_fused_fp4"],
+        styles=[("blue", "-"), ("orange", "-"), ("green", "-")],
+        ylabel="ms",
+        plot_name="fp4 quant",
+        args={},
+    )
+)
+def benchmark(M, K, provider):
+    E = 6
+    device = "cuda"
+    x = torch.randn(E, M, K, device=device, dtype=torch.bfloat16)
+    glb_scales = torch.ones((E,), dtype=torch.float32, device=device)
+    masks = torch.randint(1, 4096, (E,), dtype=torch.int32, device=device)
+    fp8_out = torch.empty(
+        (
+            x.shape[0],
+            x.shape[1],
+            x.shape[2] // 2,
+        ),
+        device=x.device,
+        dtype=torch.float8_e4m3fn,
+    )
+    scale_block_size = 128
+    fp8_scales = torch.empty(
+        (
+            x.shape[0],
+            x.shape[1],
+            x.shape[2] // 2 // scale_block_size,
+        ),
+        device=x.device,
+        dtype=torch.float32,
+    )
+
+    quantiles = [0.5, 0.2, 0.8]
+    if provider == "triton_fp8":
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: silu_and_mul_masked_post_quant_fwd(
+                x,
+                fp8_out,
+                fp8_scales,
+                scale_block_size,
+                masks,
+                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+            ),
+            quantiles=quantiles,
+        )
+    if provider == "cuda_unfused_fp4":
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: scaled_fp4_grouped_quant(
+                silu_and_mul(x),
+                glb_scales,
+            ),
+            quantiles=quantiles,
+        )
+    if provider == "cuda_fused_fp4":
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: silu_and_mul_scaled_fp4_grouped_quant(
+                x,
+                glb_scales,
+                masks,
+            ),
+            quantiles=quantiles,
+        )
+
+    return ms, min_ms, max_ms
+
+
+def test_accuracy():
+    E = 6
+    N_RANKS = 48
+    Ms = [128, 256, 512, 1024]
+    Ks = [2048, 4096, 7168]
+    input_dtype = torch.bfloat16
+    for M in Ms:
+        for K in Ks:
+            _test_accuracy_once(E, N_RANKS * M, K, input_dtype, "cuda")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--save_path",
+        type=str,
+        default="./bench_fp4_quant_res",
+        help="Path to save fp4 quant benchmark results",
+    )
+    args = parser.parse_args()
+
+    test_accuracy()
+
+    benchmark.run(print_data=True, show_plots=True, save_path=args.save_path)

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -159,8 +159,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def(
       "silu_and_mul_scaled_fp4_experts_quant(Tensor! output, Tensor! output_scale,"
-      "Tensor input, Tensor input_global_scale, Tensor input_offset_by_experts,"
-      "Tensor output_scale_offset_by_experts, Tensor mask, bool use_silu_and_mul) -> ()");
+      "Tensor input, Tensor input_global_scale, Tensor mask, bool use_silu_and_mul) -> ()");
   m.impl("silu_and_mul_scaled_fp4_experts_quant", torch::kCUDA, &silu_and_mul_scaled_fp4_experts_quant);
 
   m.def(

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -160,7 +160,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def(
       "silu_and_mul_scaled_fp4_experts_quant(Tensor! output, Tensor! output_scale,"
       "Tensor input, Tensor input_global_scale, Tensor input_offset_by_experts,"
-      "Tensor output_scale_offset_by_experts, Tensor mask) -> ()");
+      "Tensor output_scale_offset_by_experts, Tensor mask, bool use_silu_and_mul) -> ()");
   m.impl("silu_and_mul_scaled_fp4_experts_quant", torch::kCUDA, &silu_and_mul_scaled_fp4_experts_quant);
 
   m.def(

--- a/sgl-kernel/csrc/gemm/nvfp4_expert_quant.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_expert_quant.cu
@@ -439,8 +439,7 @@ cvt_fp16_to_fp4_expert(
   int actualColsPerRow = use_silu_and_mul ? colsPerRow * 2 : colsPerRow;
 
   // Each global thread processes one element
-  for (int globalIdx = tid_in_expert + expert_idx * m * colsPerRow;
-       globalIdx < (expert_idx + 1) * m * colsPerRow;
+  for (int globalIdx = tid_in_expert + expert_idx * m * colsPerRow; globalIdx < (expert_idx + 1) * m * colsPerRow;
        globalIdx += actual_stride) {
     // Calculate which row and column this global thread should process
     int rowIdx = globalIdx / colsPerRow;

--- a/sgl-kernel/csrc/gemm/nvfp4_expert_quant.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_expert_quant.cu
@@ -347,7 +347,7 @@ cvt_fp16_to_fp4(
       }
     }
 
-    // Eerly exit when using masks.
+    // Early exit when using masks.
     if (use_mask && rowIdx_in_expert >= mask[expert_idx]) {
       continue;
     }
@@ -449,7 +449,7 @@ cvt_fp16_to_fp4_expert(
     // Find index within the experts
     int rowIdx_in_expert = rowIdx - input_offset_by_experts[expert_idx];
 
-    // Eerly exit when using masks.
+    // Early exit when using masks.
     if (use_mask && rowIdx_in_expert >= mask[expert_idx]) {
       break;
     }

--- a/sgl-kernel/csrc/gemm/nvfp4_expert_quant.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_expert_quant.cu
@@ -773,7 +773,7 @@ void scaled_fp4_experts_quant_sm100a(
         input_offset_by_experts.data_ptr(),
         output_scale_offset_by_experts.data_ptr(),
         nullptr,  // mask
-        false,  // use_silu_and_mul
+        false,    // use_silu_and_mul
         m_topk,
         k,
         n_experts,
@@ -787,7 +787,7 @@ void scaled_fp4_experts_quant_sm100a(
         input_offset_by_experts.data_ptr(),
         output_scale_offset_by_experts.data_ptr(),
         nullptr,  // mask
-        false,  // use_silu_and_mul
+        false,    // use_silu_and_mul
         m_topk,
         k,
         n_experts,

--- a/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
@@ -32,8 +32,6 @@ void silu_and_mul_scaled_fp4_experts_quant_sm100a(
     torch::Tensor& output_scale,
     torch::Tensor const& input,
     torch::Tensor const& input_global_scale,
-    torch::Tensor const& input_offset_by_experts,
-    torch::Tensor const& output_scale_offset_by_experts,
     torch::Tensor const& mask,
     bool use_silu_and_mul);
 
@@ -66,8 +64,6 @@ void silu_and_mul_scaled_fp4_experts_quant(
     torch::Tensor& output_scale,
     torch::Tensor const& input,
     torch::Tensor const& input_global_scale,
-    torch::Tensor const& input_offset_by_experts,
-    torch::Tensor const& output_scale_offset_by_experts,
     torch::Tensor const& mask,
     bool use_silu_and_mul) {
 #if defined ENABLE_NVFP4 && ENABLE_NVFP4
@@ -76,8 +72,6 @@ void silu_and_mul_scaled_fp4_experts_quant(
       output_scale,
       input,
       input_global_scale,
-      input_offset_by_experts,
-      output_scale_offset_by_experts,
       mask,
       use_silu_and_mul);
 #endif

--- a/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
@@ -68,7 +68,7 @@ void silu_and_mul_scaled_fp4_experts_quant(
     bool use_silu_and_mul) {
 #if defined ENABLE_NVFP4 && ENABLE_NVFP4
   return silu_and_mul_scaled_fp4_experts_quant_sm100a(
-    output, output_scale, input, input_global_scale, mask, use_silu_and_mul);
+      output, output_scale, input, input_global_scale, mask, use_silu_and_mul);
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled nvfp4 experts quantization kernel");
 }

--- a/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
@@ -68,12 +68,7 @@ void silu_and_mul_scaled_fp4_experts_quant(
     bool use_silu_and_mul) {
 #if defined ENABLE_NVFP4 && ENABLE_NVFP4
   return silu_and_mul_scaled_fp4_experts_quant_sm100a(
-      output,
-      output_scale,
-      input,
-      input_global_scale,
-      mask,
-      use_silu_and_mul);
+    output, output_scale, input, input_global_scale, mask, use_silu_and_mul);
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled nvfp4 experts quantization kernel");
 }

--- a/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
@@ -34,7 +34,8 @@ void silu_and_mul_scaled_fp4_experts_quant_sm100a(
     torch::Tensor const& input_global_scale,
     torch::Tensor const& input_offset_by_experts,
     torch::Tensor const& output_scale_offset_by_experts,
-    torch::Tensor const& mask);
+    torch::Tensor const& mask,
+    bool use_silu_and_mul);
 
 #endif
 
@@ -67,10 +68,11 @@ void silu_and_mul_scaled_fp4_experts_quant(
     torch::Tensor const& input_global_scale,
     torch::Tensor const& input_offset_by_experts,
     torch::Tensor const& output_scale_offset_by_experts,
-    torch::Tensor const& mask) {
+    torch::Tensor const& mask,
+    bool use_silu_and_mul) {
 #if defined ENABLE_NVFP4 && ENABLE_NVFP4
   return silu_and_mul_scaled_fp4_experts_quant_sm100a(
-      output, output_scale, input, input_global_scale, input_offset_by_experts, output_scale_offset_by_experts, mask);
+      output, output_scale, input, input_global_scale, input_offset_by_experts, output_scale_offset_by_experts, mask, use_silu_and_mul);
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled nvfp4 experts quantization kernel");
 }

--- a/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
+++ b/sgl-kernel/csrc/gemm/nvfp4_quant_entry.cu
@@ -72,7 +72,14 @@ void silu_and_mul_scaled_fp4_experts_quant(
     bool use_silu_and_mul) {
 #if defined ENABLE_NVFP4 && ENABLE_NVFP4
   return silu_and_mul_scaled_fp4_experts_quant_sm100a(
-      output, output_scale, input, input_global_scale, input_offset_by_experts, output_scale_offset_by_experts, mask, use_silu_and_mul);
+      output,
+      output_scale,
+      input,
+      input_global_scale,
+      input_offset_by_experts,
+      output_scale_offset_by_experts,
+      mask,
+      use_silu_and_mul);
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(false, "No compiled nvfp4 experts quantization kernel");
 }

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -394,8 +394,6 @@ void silu_and_mul_scaled_fp4_experts_quant(
     torch::Tensor& output_scale,
     torch::Tensor const& input,
     torch::Tensor const& input_global_scale,
-    torch::Tensor const& input_offset_by_experts,
-    torch::Tensor const& output_scale_offset_by_experts,
     torch::Tensor const& mask,
     bool use_silu_and_mul);
 /*

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -396,7 +396,8 @@ void silu_and_mul_scaled_fp4_experts_quant(
     torch::Tensor const& input_global_scale,
     torch::Tensor const& input_offset_by_experts,
     torch::Tensor const& output_scale_offset_by_experts,
-    torch::Tensor const& mask);
+    torch::Tensor const& mask,
+    bool use_silu_and_mul);
 /*
  * From csrc/moe/cutlass_moe/w4a8
  */

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -332,22 +332,12 @@ def scaled_fp4_grouped_quant(
     output_scales = torch.empty(
         l, padded_m, padded_k_int32, device=device, dtype=torch.int32
     )
-    input_offsets = torch.arange(0, (l + 1) * m, step=m, dtype=torch.int, device=device)
-    output_offsets = torch.arange(
-        0,
-        (l + 1) * padded_m,
-        step=padded_m,
-        dtype=torch.int,
-        device=device,
-    )
 
     torch.ops.sgl_kernel.silu_and_mul_scaled_fp4_experts_quant.default(
         output.view(l * m, k // 2),
         output_scales.view(l * padded_m, padded_k_int32),
         input_tensor.view(l * m, k),
         input_global_scale,
-        input_offsets,
-        output_offsets,
         mask,
         use_silu_and_mul=False,
     )
@@ -403,22 +393,12 @@ def silu_and_mul_scaled_fp4_grouped_quant(
     output_scales = torch.empty(
         l, padded_m, padded_k_int32, device=device, dtype=torch.int32
     )
-    input_offsets = torch.arange(0, (l + 1) * m, step=m, dtype=torch.int, device=device)
-    output_offsets = torch.arange(
-        0,
-        (l + 1) * padded_m,
-        step=padded_m,
-        dtype=torch.int,
-        device=device,
-    )
 
     torch.ops.sgl_kernel.silu_and_mul_scaled_fp4_experts_quant.default(
         output.view(l * m, k // 2),
         output_scales.view(l * padded_m, padded_k_int32),
         input_tensor.view(l * m, k_by_2),
         input_global_scale,
-        input_offsets,
-        output_offsets,
         mask,
         use_silu_and_mul=True,
     )

--- a/sgl-kernel/tests/test_fp4_quantize.py
+++ b/sgl-kernel/tests/test_fp4_quantize.py
@@ -174,11 +174,12 @@ def test_quantize_to_fp4_padded(pad_shape: tuple[int, int]) -> None:
 @pytest.mark.skipif(
     skip_condition, reason="Nvfp4 Requires compute capability of 10 or above."
 )
-def test_quantize_to_fp4_grouped():
+@pytest.mark.parametrize("shape", [(2, 512, 2048), (2, 100, 128), (2, 128, 96)])
+def test_quantize_to_fp4_grouped(shape):
     torch.manual_seed(42)
     torch.set_default_device("cuda:0")
 
-    l, m, k = 2, 512, 2048
+    l, m, k = shape
     x = torch.randn((l, m, k), dtype=torch.bfloat16)
     tensor_amax = x.abs().amax(dim=(1, 2)).to(torch.float32)
     x_sf_global = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
@@ -196,22 +197,24 @@ def test_quantize_to_fp4_grouped():
     for i in range(l):
         a_fp4, a_scale_interleaved = scaled_fp4_quant(x[i], x_sf_global[i])
         torch.testing.assert_close(a_fp4, output[i])
-        torch.testing.assert_close(
-            a_scale_interleaved.to(torch.float), output_scales[i].to(torch.float)
-        )
+        # Recover swizzled scales to linear layout and drop padded values, so
+        # no extra checks on padding are needed.
+        scale_ref = recover_swizzled_scales(a_scale_interleaved, m, k)
+        scale_ans = recover_swizzled_scales(output_scales[i], m, k)
+        torch.testing.assert_close(scale_ref, scale_ans)
 
 
 @pytest.mark.skipif(
     skip_condition, reason="Nvfp4 Requires compute capability of 10 or above."
 )
-@pytest.mark.parametrize("shape", [(32, 100, 2048), (32, 512, 2048)])
-def test_silu_and_mul_quantize_to_fp4_grouped(shape: tuple[int, int]) -> None:
+@pytest.mark.parametrize("shape", [(32, 100, 2048), (32, 512, 2048), (6, 6144, 2048)])
+def test_silu_and_mul_quantize_to_fp4_grouped(shape):
     torch.manual_seed(42)
     torch.set_default_device("cuda:0")
 
     l, m, k = shape
     x = torch.randn((l, m, k * 2), dtype=torch.bfloat16)
-    max_m = 8
+    max_m = m // 2
     assert max_m <= m
     mask = torch.randint(1, max_m, (l,), dtype=torch.int32)
 

--- a/sgl-kernel/tests/test_fp4_quantize.py
+++ b/sgl-kernel/tests/test_fp4_quantize.py
@@ -181,11 +181,15 @@ def test_quantize_to_fp4_grouped(shape):
 
     l, m, k = shape
     x = torch.randn((l, m, k), dtype=torch.bfloat16)
+    max_m = m // 2
+    assert max_m <= m
+    mask = torch.randint(1, max_m, (l,), dtype=torch.int32)
     tensor_amax = x.abs().amax(dim=(1, 2)).to(torch.float32)
     x_sf_global = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
     output, output_scales = scaled_fp4_grouped_quant(
         x,
         x_sf_global,
+        mask,
     )
     # output in logical (m, k, l), but its physical layout is (l, m, k).
     # So permute first to (l, m, k).
@@ -196,12 +200,12 @@ def test_quantize_to_fp4_grouped(shape):
     output_scales = output_scales.permute(5, 2, 4, 0, 1, 3).view(l, padded_m, -1)
     for i in range(l):
         a_fp4, a_scale_interleaved = scaled_fp4_quant(x[i], x_sf_global[i])
-        torch.testing.assert_close(a_fp4, output[i])
+        torch.testing.assert_close(a_fp4[: mask[i]], output[i][: mask[i]])
         # Recover swizzled scales to linear layout and drop padded values, so
         # no extra checks on padding are needed.
         scale_ref = recover_swizzled_scales(a_scale_interleaved, m, k)
         scale_ans = recover_swizzled_scales(output_scales[i], m, k)
-        torch.testing.assert_close(scale_ref, scale_ans)
+        torch.testing.assert_close(scale_ref[: mask[i]], scale_ans[: mask[i]])
 
 
 @pytest.mark.skipif(
@@ -224,6 +228,7 @@ def test_silu_and_mul_quantize_to_fp4_grouped(shape):
     ref_output, ref_output_scales = scaled_fp4_grouped_quant(
         ref_y,
         y_sf_global,
+        mask,
     )
     output, output_scales = silu_and_mul_scaled_fp4_grouped_quant(
         x,


### PR DESCRIPTION
This PR further optimizes `silu_and_mul_scaled_fp4_grouped_quant` for DeepEP low-latency scenarios. When the mask contains small values, the kernel achieves up to 82× speedup over the previous version. The change also improves performance for non-masked NVFP4 expert quantization (`scaled_fp4_experts_quant`) and NVFP4 group quantization (`scaled_fp4_grouped_quant`), delivering about 1.5× gains.

The new design changes how threads are assigned in expert-aware kernels. Previously, all threads started with the first expert and then strided to the next, requiring extra computation to determine which expert they were handling. This needs frequent access to the offset tensors, hence the earlier optimization like [here](https://github.com/sgl-project/sglang/pull/8777). Now, threads are evenly partitioned across experts, and each thread only processes its assigned expert. This (1) removes the need to recompute expert indices or reaccess the offset tensor, and (2) makes early exit with masking straightforward.

cc. @wenscarl @fzyzcjy @kushanam 