### PR TITLE
[Doc] add LWS(LeaderWorkerSet) use case in sgl-router README

### DIFF
--- a/sgl-router/README.md
+++ b/sgl-router/README.md
@@ -229,6 +229,15 @@ python -m sglang_router.launch_router \
     --prefill-selector app=sglang component=prefill \
     --decode-selector app=sglang component=decode \
     --service-discovery-namespace sglang-system
+
+# in lws case, such as tp16(1 leader pod, 1 worker pod)
+python -m sglang_router.launch_router \
+    --pd-disaggregation \
+    --policy cache_aware \
+    --service-discovery \
+    --prefill-selector app=sglang component=prefill role=leader\
+    --decode-selector app=sglang component=decode role=leader\
+    --service-discovery-namespace sglang-system
 ```
 
 #### Kubernetes Pod Configuration


### PR DESCRIPTION
## Motivation

When I deployed tp16 prefill/decode(using lws & sgl-router), I found many 404 error response.And then I find that when enable service-discovery, the router does not distinguish between  leader pod and worker pod, so many requests are delivered to worker pods, and of course, worker pods have no service endpoint.So I add some code to support it.

## Modifications

1. enhance PodType to Prefill{Leader/Worker}, Decode{Leader/Worker}, Regular. Both enhance PodInfo struct(add is_leader,leader_name, workerIndex)
2. provide a determine_pod_type, get role_type by reading lws label
3. change should_include , if pd_mode, only leader pods could be added as servers

## Update
just add role item in lws labels and add prefill_selector/decode_selector with role=leader
code revert, just add note in sgl-router/README

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
