### PR TITLE
[Feature] Add tile-based method of supporting large VPT in moe_fused_gate kernel

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -274,6 +274,7 @@ set(SOURCES
     "csrc/moe/marlin_moe_wna16/kernel_fp16_ku8b128.cu"
     "csrc/moe/moe_align_kernel.cu"
     "csrc/moe/moe_fused_gate.cu"
+    "csrc/moe/moe_fused_gate_tile_more_experts.cu"
     "csrc/moe/moe_topk_softmax_kernels.cu"
     "csrc/moe/nvfp4_blockwise_moe.cu"
     "csrc/moe/fp8_blockwise_moe_kernel.cu"

--- a/sgl-kernel/benchmark/bench_moe_fused_gate.py
+++ b/sgl-kernel/benchmark/bench_moe_fused_gate.py
@@ -6,11 +6,11 @@ import triton
 import triton.language as tl
 from sgl_kernel import moe_fused_gate
 
-from sglang.srt.layers.moe.topk import biased_grouped_topk
+from sglang.srt.layers.moe.topk import biased_grouped_topk_impl
 
 
 def biased_grouped_topk_org(scores, bias, num_expert_group, topk_group, topk):
-    return biased_grouped_topk(
+    return biased_grouped_topk_impl(
         scores,
         scores,
         bias,
@@ -29,12 +29,14 @@ def biased_grouped_topk_org_fuse_kernel(
 
 
 seq_length_range = [5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000]
-configs = [(sq,) for sq in seq_length_range]
+configs = [(sq, 256, 8, 4, 8) for sq in seq_length_range]  # original config
+# configs = ([(sq, 64, 1, 1, 6) for sq in seq_length_range])  # kimi vl config
+# configs = ([(sq, 384, 1, 1, 8) for sq in seq_length_range])  # Kimi K2 config
 
 
 @triton.testing.perf_report(
     triton.testing.Benchmark(
-        x_names=["seq_length"],
+        x_names=["seq_length", "num_experts", "num_expert_group", "topk_group", "topk"],
         x_vals=[list(_) for _ in configs],
         line_arg="provider",
         line_vals=["original", "kernel"],
@@ -45,10 +47,9 @@ configs = [(sq,) for sq in seq_length_range]
         args={},
     )
 )
-def benchmark(seq_length, provider):
+def benchmark(seq_length, num_experts, num_expert_group, topk_group, topk, provider):
     dtype = torch.bfloat16
     device = torch.device("cuda")
-    num_experts, num_expert_group, topk_group, topk = 256, 8, 4, 8
 
     scores = torch.randn((seq_length, num_experts), device=device, dtype=dtype)
     bias = torch.rand(num_experts, device=device, dtype=dtype)

--- a/sgl-kernel/benchmark/bench_moe_fused_gate_tiled.py
+++ b/sgl-kernel/benchmark/bench_moe_fused_gate_tiled.py
@@ -1,0 +1,140 @@
+import itertools
+import math
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+from sgl_kernel import moe_fused_gate
+
+
+def biased_grouped_topk_ref_impl(scores, bias, num_expert_group, topk_group, topk):
+    # Pure PyTorch reference to avoid implicit kernel paths and control compile modes.
+    # Logic mirrors biased_grouped_topk_impl without shared experts handling (set to 0 for bench).
+    # scores: [N, E], bias: [E]
+    n, e = scores.shape
+    scores_sig = scores.sigmoid()
+    scores_for_choice = scores_sig + bias.unsqueeze(0)
+
+    # group selection via top2 sum
+    g = num_expert_group
+    per_group = e // g
+    view = scores_for_choice.view(n, g, per_group)
+    top2 = torch.topk(view, k=2, dim=-1).values
+    group_scores = top2.sum(dim=-1)  # [n, g]
+    group_idx = torch.topk(
+        group_scores, k=topk_group, dim=-1, sorted=False
+    ).indices  # [n, topk_group]
+
+    # mask and topk within selected groups
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = group_mask.unsqueeze(-1).expand(n, g, per_group).reshape(n, e)
+    tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
+
+    topk_vals, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)
+    topk_weights = scores_sig.gather(1, topk_ids)
+
+    # renormalize
+    topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-12)
+    return topk_weights, topk_ids
+
+
+# wrap reference with different compile modes
+def make_ref_fn(compile_mode: str):
+    fn = biased_grouped_topk_ref_impl
+    if compile_mode == "eager":
+        return fn
+    if compile_mode == "compile-static":
+        return torch.compile(fn, dynamic=False)
+    if compile_mode == "compile-dynamic":
+        return torch.compile(fn, dynamic=True)
+    raise ValueError(f"Unknown compile_mode: {compile_mode}")
+
+
+def moe_fused_gate_kernel(scores, bias, num_expert_group, topk_group, topk):
+    return moe_fused_gate(scores, bias, num_expert_group, topk_group, topk)
+
+
+# Choose a sequence length sweep consistent with existing benchmark style
+seq_length_range = [2048, 3072, 4096, 10240, 15360, 20480]
+
+# Focus on tiled-path configs (VPT > 32)
+configs = []
+configs += [(sq, 64, 1, 1, 6) for sq in seq_length_range]  # Kimi VL: VPT=64
+configs += [(sq, 384, 1, 1, 8) for sq in seq_length_range]  # Kimi K2: VPT=384
+
+
+def _bench_template(dtype: torch.dtype, plot_suffix: str):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=[
+                "seq_length",
+                "num_experts",
+                "num_expert_group",
+                "topk_group",
+                "topk",
+            ],
+            x_vals=[list(_) for _ in configs],
+            line_arg="provider",
+            line_vals=[
+                "orig-eager",
+                "orig-compile-static",
+                "orig-compile-dynamic",
+                "kernel",
+            ],
+            line_names=[
+                "Original-Eager",
+                "Original-Compile-Static",
+                "Original-Compile-Dynamic",
+                "SGL Kernel",
+            ],
+            styles=[("blue", "-"), ("green", "-"), ("orange", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name=f"moe-fused-gate-tiled-performance-{plot_suffix}",
+            args={},
+        )
+    )
+    def benchmark(
+        seq_length, num_experts, num_expert_group, topk_group, topk, provider
+    ):
+        device = torch.device("cuda")
+
+        scores = torch.randn((seq_length, num_experts), device=device, dtype=dtype)
+        bias = torch.rand(num_experts, device=device, dtype=dtype)
+
+        quantiles = [0.5, 0.2, 0.8]
+
+        if provider.startswith("orig"):
+            mode = provider.replace("orig-", "")
+            ref = make_ref_fn(mode)
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: ref(
+                    scores.clone(), bias.clone(), num_expert_group, topk_group, topk
+                ),
+                quantiles=quantiles,
+            )
+        elif provider == "kernel":
+            ms, min_ms, max_ms = triton.testing.do_bench(
+                lambda: moe_fused_gate_kernel(
+                    scores.clone(), bias.clone(), num_expert_group, topk_group, topk
+                ),
+                quantiles=quantiles,
+            )
+        else:
+            raise ValueError(provider)
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+benchmark_bf16 = _bench_template(torch.bfloat16, "bf16")
+benchmark_fp16 = _bench_template(torch.float16, "fp16")
+benchmark_fp32 = _bench_template(torch.float32, "fp32")
+
+
+if __name__ == "__main__":
+    benchmark_bf16.run(print_data=True)
+    benchmark_fp16.run(print_data=True)
+    benchmark_fp32.run(print_data=True)

--- a/sgl-kernel/csrc/moe/moe_fused_gate_tile_more_experts.cu
+++ b/sgl-kernel/csrc/moe/moe_fused_gate_tile_more_experts.cu
@@ -1,0 +1,589 @@
+// add support the number of group expert from the original 32 to 128/512 implemented with tiling
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <cutlass/array.h>
+#include <cutlass/numeric_types.h>
+#include <torch/all.h>
+
+#include <algorithm>
+#include <cfloat>
+#include <type_traits>
+
+// Reuse aliases compatible with moe_fused_gate.cu
+template <typename T, int N>
+using AlignedArray = cutlass::AlignedArray<T, N>;
+using bfloat16_t = cutlass::bfloat16_t;
+using float16_t = cutlass::half_t;
+using float32_t = float;
+
+static constexpr int WARP_SIZE = 32;
+static constexpr int WARPS_PER_CTA = 6;
+
+// Maximum experts per thread (VPT) we target via tiling
+// You can raise this to 512 if needed; performance and register pressure should be reassessed.
+static constexpr int MAX_TILED_VPT = 512;
+static constexpr int TILE_VPT = 32;  // tile size processed per thread per pass
+
+template <typename T>
+__device__ inline float to_float(T x) {
+  if constexpr (std::is_same<T, float16_t>::value || std::is_same<T, at::Half>::value) {
+    return static_cast<float>(x);
+  } else if constexpr (std::is_same<T, bfloat16_t>::value || std::is_same<T, at::BFloat16>::value) {
+    return static_cast<float>(x);
+  } else {
+    return static_cast<float>(x);
+  }
+}
+
+template <typename T>
+__device__ inline bool cmp_gt(const T& a, const T& b) {
+  // Cast to float to avoid half comparison ambiguity
+  return static_cast<float>(a) > static_cast<float>(b);
+}
+
+template <typename T>
+__device__ inline bool cmp_eq(const T& a, const T& b) {
+  return static_cast<float>(a) == static_cast<float>(b);
+}
+
+__device__ inline float sigmoidf_approx(float x) {
+  return 1.0f / (1.0f + __expf(-x));
+}
+
+struct KernelParamsDynamicTiled {
+  int VPT;              // experts per thread (per group)
+  int NUM_EXPERTS;      // total experts
+  int THREADS_PER_ROW;  // num_expert_group
+  int ROWS_PER_WARP;    // max(1, 32 / num_expert_group)
+  int ROWS_PER_CTA;     // WARPS_PER_CTA * ROWS_PER_WARP
+  int WARPS_PER_CTA;    // fixed as 6
+};
+
+// Argmin reduce across THREADS_PER_ROW lanes within a warp-subgroup
+__device__ inline void warp_argmin_pair(float& val, int& idx, int width) {
+  // width must be power of two and <= 32
+  unsigned mask = 0xFFFFFFFFu;
+  for (int offset = width / 2; offset > 0; offset >>= 1) {
+    float other_val = __shfl_xor_sync(mask, val, offset, width);
+    int other_idx = __shfl_xor_sync(mask, idx, offset, width);
+    // Keep the larger (worse) index on tie to follow original behavior
+    if (val > other_val || (val == other_val && other_idx > idx)) {
+      val = other_val;
+      idx = other_idx;
+    }
+  }
+}
+
+// Argmax reduce across THREADS_PER_ROW lanes within a warp-subgroup
+__device__ inline void warp_argmax_pair(float& val, int& idx, int width) {
+  unsigned mask = 0xFFFFFFFFu;
+  for (int offset = width / 2; offset > 0; offset >>= 1) {
+    float other_val = __shfl_xor_sync(mask, val, offset, width);
+    int other_idx = __shfl_xor_sync(mask, idx, offset, width);
+    // Keep the smaller index on tie to follow original behavior
+    if (other_val > val || (other_val == val && other_idx < idx)) {
+      val = other_val;
+      idx = other_idx;
+    }
+  }
+}
+
+template <typename T, int TILE>
+__global__ void moe_fused_gate_kernel_tiled(
+    const void* __restrict__ input,
+    const void* __restrict__ bias,
+    float* __restrict__ output_ptr,
+    int32_t* __restrict__ indices_ptr,
+    int64_t num_rows,
+    int64_t num_experts,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor) {
+  KernelParamsDynamicTiled params;
+  params.NUM_EXPERTS = static_cast<int>(num_experts);
+  params.THREADS_PER_ROW = static_cast<int>(num_expert_group);
+  params.VPT = static_cast<int>(num_experts / num_expert_group);
+  params.WARPS_PER_CTA = WARPS_PER_CTA;
+  params.ROWS_PER_WARP = max(1, WARP_SIZE / params.THREADS_PER_ROW);
+  params.ROWS_PER_CTA = params.WARPS_PER_CTA * params.ROWS_PER_WARP;
+
+  int lane = threadIdx.x;                                // 0..31
+  int warp_id = threadIdx.y;                             // 0..WARPS_PER_CTA-1
+  int thread_group_idx = lane % params.THREADS_PER_ROW;  // lane within group-subwarp
+  int row_in_warp = lane / params.THREADS_PER_ROW;       // which row this lane processes inside the warp
+
+  int64_t thread_row = static_cast<int64_t>(blockIdx.x) * params.ROWS_PER_CTA +
+                       static_cast<int64_t>(warp_id) * params.ROWS_PER_WARP + static_cast<int64_t>(row_in_warp);
+  if (thread_row >= num_rows) return;
+
+  const T* __restrict__ input_ptr = reinterpret_cast<const T*>(input);
+  const T* __restrict__ bias_ptr = reinterpret_cast<const T*>(bias);
+
+  int VPT = params.VPT;
+  int first_elt_read_by_thread = thread_group_idx * VPT;  // base expert index within the row handled by this lane
+
+  // Phase 1: exclude worst groups iteratively until only topk_group groups remain
+  bool group_active = true;
+  int groups_to_exclude = params.THREADS_PER_ROW - static_cast<int>(topk_group);
+  for (int iter = 0; iter < groups_to_exclude; ++iter) {
+    float local_best = -FLT_MAX;
+    float local_second = -FLT_MAX;
+
+    if (group_active) {
+      // Scan tiles to compute top-2 within this group's experts
+      for (int base = 0; base < VPT; base += TILE) {
+        int tile_elems = min(TILE, VPT - base);
+        int64_t row_offset = thread_row * params.NUM_EXPERTS + first_elt_read_by_thread + base;
+#pragma unroll
+        for (int ii = 0; ii < tile_elems; ++ii) {
+          float s = sigmoidf_approx(to_float(input_ptr[row_offset + ii]));
+          float v = s + to_float(bias_ptr[first_elt_read_by_thread + base + ii]);
+          if (v > local_best) {
+            local_second = local_best;
+            local_best = v;
+          } else if (v > local_second) {
+            local_second = v;
+          }
+        }
+      }
+    }
+
+    float group_score = group_active ? (local_best + local_second) : FLT_MAX;  // argmin
+    int marker = first_elt_read_by_thread;  // used to recover the group index via marker / VPT
+
+    // argmin across lanes in this row-subwarp
+    warp_argmin_pair(group_score, marker, params.THREADS_PER_ROW);
+
+    int thread_to_exclude = marker / VPT;
+    if (thread_group_idx == thread_to_exclude) {
+      group_active = false;
+    }
+    __syncwarp();
+  }
+
+  // Phase 2: pick topk_excluding_shared experts from remaining groups
+  int topk_excl_shared = static_cast<int>(topk - num_fused_shared_experts);
+  float output_sum = 0.0f;
+
+  // Track per-thread selected local indices to avoid picking them again
+  // Upper bound: one thread may win many times theoretically, but in practice topk is small.
+  const int MAX_LOCAL_SELECT = 64;  // safe upper bound for routing top-k
+  int selected_count = 0;
+  // Implement local selected indices container
+  int selected_local_indices[MAX_LOCAL_SELECT];
+
+  for (int k_idx = 0; k_idx < topk_excl_shared; ++k_idx) {
+    float local_max_val = -FLT_MAX;
+    int local_best_global = -1;
+
+    if (group_active) {
+      // Scan tiles and find local best candidate skipping previously selected indices
+      for (int base = 0; base < VPT; base += TILE) {
+        int tile_elems = min(TILE, VPT - base);
+        int64_t row_offset = thread_row * params.NUM_EXPERTS + first_elt_read_by_thread + base;
+#pragma unroll
+        for (int ii = 0; ii < tile_elems; ++ii) {
+          int local_idx = base + ii;
+          bool skip = false;
+          for (int t = 0; t < selected_count; ++t) {
+            if (selected_local_indices[t] == local_idx) {
+              skip = true;
+              break;
+            }
+          }
+          if (skip) continue;
+
+          float s = sigmoidf_approx(to_float(input_ptr[row_offset + ii]));
+          float v = s + to_float(bias_ptr[first_elt_read_by_thread + local_idx]);
+          if (v > local_max_val) {
+            local_max_val = v;
+            local_best_global = first_elt_read_by_thread + local_idx;
+          }
+        }
+      }
+    }
+
+    // Perform argmax across lanes (within group-subwarp)
+    int winner_global = local_best_global;
+    float winner_val = local_max_val;
+    warp_argmax_pair(winner_val, winner_global, params.THREADS_PER_ROW);
+
+    int winner_thread = (winner_global >= 0) ? (winner_global / VPT) : -1;
+    int64_t out_idx = topk * thread_row + k_idx;
+    if (winner_thread >= 0 && thread_group_idx == winner_thread) {
+      int expert_local = winner_global % VPT;
+      // Record local selection to avoid picking it again later
+      if (selected_count < MAX_LOCAL_SELECT) {
+        selected_local_indices[selected_count++] = expert_local;
+      }
+
+      // Write outputs (weight uses sigmoid only, index uses absolute expert id)
+      int64_t row_elem_base = thread_row * params.NUM_EXPERTS + first_elt_read_by_thread + expert_local;
+      float weight = sigmoidf_approx(to_float(input_ptr[row_elem_base]));
+      output_ptr[out_idx] = weight;
+      indices_ptr[out_idx] = static_cast<int32_t>(winner_global);
+    }
+
+    // Accumulate output sum once per row-subwarp
+    if (thread_group_idx == 0) {
+      // Note: winner thread writes before this read in same warp; safe within warp
+      output_sum += output_ptr[out_idx];
+    }
+    __syncwarp();
+  }
+
+  // Append fused shared experts if requested
+  if (thread_group_idx == 0 && num_fused_shared_experts > 0) {
+    int64_t last_idx = topk * thread_row + topk_excl_shared;
+    int64_t expert_offset = 0;
+    indices_ptr[last_idx] = static_cast<int32_t>(params.NUM_EXPERTS + expert_offset);
+    output_ptr[last_idx] = output_sum / static_cast<float>(routed_scaling_factor);
+
+    for (int i = 1; i < num_fused_shared_experts; ++i) {
+      ++last_idx;
+      ++expert_offset;
+      indices_ptr[last_idx] = static_cast<int32_t>(params.NUM_EXPERTS + expert_offset);
+      output_ptr[last_idx] = output_sum / static_cast<float>(routed_scaling_factor);
+    }
+  }
+  __syncwarp();
+
+  // Renormalize by the sum of real experts
+  if (thread_group_idx == 0) {
+    float denom = output_sum;
+    for (int i = 0; i < topk; ++i) {
+      int64_t idx = topk * thread_row + i;
+      output_ptr[idx] = output_ptr[idx] / denom;
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Static tiled kernel template (compile-time params). Currently supports
+// THREADS_PER_ROW == 1 path (no warp reductions). Can be extended later.
+// ----------------------------------------------------------------------------
+template <
+    typename T,
+    int NUM_EXPERTS,
+    int THREADS_PER_ROW,
+    int ROWS_PER_WARP,
+    int ROWS_PER_CTA,
+    int WARPS_PER_CTA_,
+    int TILE>
+__global__ void moe_fused_gate_kernel_tiled_static(
+    const void* __restrict__ input,
+    const void* __restrict__ bias,
+    float* __restrict__ output_ptr,
+    int32_t* __restrict__ indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor) {
+  static_assert(THREADS_PER_ROW == 1, "static tiled kernel currently supports THREADS_PER_ROW==1 only");
+  (void)WARPS_PER_CTA_;
+
+  int lane = threadIdx.x;     // 0..31
+  int warp_id = threadIdx.y;  // 0..WARPS_PER_CTA-1
+  int row_in_warp = lane;     // THREADS_PER_ROW=1 => row_in_warp = lane
+
+  int64_t thread_row = static_cast<int64_t>(blockIdx.x) * ROWS_PER_CTA + static_cast<int64_t>(warp_id) * ROWS_PER_WARP +
+                       static_cast<int64_t>(row_in_warp);
+  if (thread_row >= num_rows) return;
+
+  const T* __restrict__ input_ptr = reinterpret_cast<const T*>(input);
+  const T* __restrict__ bias_ptr = reinterpret_cast<const T*>(bias);
+
+  int64_t row_base = thread_row * NUM_EXPERTS;
+  int topk_excl_shared = static_cast<int>(topk - num_fused_shared_experts);
+  topk_excl_shared = max(0, topk_excl_shared);
+  const int MAX_TOPK = 32;
+  topk_excl_shared = min(topk_excl_shared, MAX_TOPK);
+
+  float best_choice[MAX_TOPK];
+  float best_weight[MAX_TOPK];
+  int best_index[MAX_TOPK];
+#pragma unroll
+  for (int i = 0; i < MAX_TOPK; ++i) {
+    best_choice[i] = -FLT_MAX;
+    best_weight[i] = 0.0f;
+    best_index[i] = -1;
+  }
+
+  for (int e = 0; e < NUM_EXPERTS; ++e) {
+    float s = sigmoidf_approx(to_float(input_ptr[row_base + e]));
+    float choice = s + to_float(bias_ptr[e]);
+    if (choice > best_choice[topk_excl_shared - 1]) {
+      int j = topk_excl_shared - 1;
+      while (j > 0 && choice > best_choice[j - 1]) {
+        best_choice[j] = best_choice[j - 1];
+        best_weight[j] = best_weight[j - 1];
+        best_index[j] = best_index[j - 1];
+        --j;
+      }
+      best_choice[j] = choice;
+      best_weight[j] = s;
+      best_index[j] = e;
+    }
+  }
+
+  float real_sum = 0.0f;
+  for (int k = 0; k < topk_excl_shared; ++k) {
+    int64_t out_idx = topk * thread_row + k;
+    output_ptr[out_idx] = best_weight[k];
+    indices_ptr[out_idx] = static_cast<int32_t>(best_index[k]);
+    real_sum += best_weight[k];
+  }
+
+  if (num_fused_shared_experts > 0) {
+    float shared_w = (real_sum == 0.0f) ? 0.0f : (real_sum / static_cast<float>(routed_scaling_factor));
+    int64_t base = topk * thread_row + topk_excl_shared;
+    for (int i = 0; i < num_fused_shared_experts; ++i) {
+      indices_ptr[base + i] = static_cast<int32_t>(NUM_EXPERTS + i);
+      output_ptr[base + i] = shared_w;
+    }
+  }
+
+  if (real_sum > 0.0f) {
+    for (int i = 0; i < topk; ++i) {
+      int64_t out_idx = topk * thread_row + i;
+      output_ptr[out_idx] = output_ptr[out_idx] / real_sum;
+    }
+  }
+}
+
+// Public dispatcher for static tiled instantiations
+std::vector<at::Tensor> moe_fused_gate_tiled_static(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor) {
+  TORCH_CHECK(input.is_cuda(), "input must be CUDA tensor");
+  TORCH_CHECK(bias.is_cuda(), "bias must be CUDA tensor");
+  int64_t num_rows = input.size(0);
+  int64_t num_experts = input.size(1);
+
+  auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+  auto output = torch::empty({num_rows, topk}, options);
+  auto indices = torch::empty({num_rows, topk}, options.dtype(torch::kInt32));
+
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
+
+  // Currently: specialize THREADS_PER_ROW=1 for selected NUM_EXPERTS with TILE=32
+  if (num_experts == 384 && num_expert_group == 1) {
+    constexpr int THREADS_PER_ROW = 1;
+    constexpr int ROWS_PER_WARP = WARP_SIZE / THREADS_PER_ROW;
+    constexpr int ROWS_PER_CTA = WARPS_PER_CTA * ROWS_PER_WARP;
+    int64_t rows_per_warp = ROWS_PER_WARP;
+    int64_t num_warps = (num_rows + rows_per_warp - 1) / rows_per_warp;
+    int64_t num_blocks = (num_warps + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+
+    if (input.scalar_type() == at::kBFloat16) {
+      moe_fused_gate_kernel_tiled_static<
+          bfloat16_t,
+          384,
+          THREADS_PER_ROW,
+          ROWS_PER_WARP,
+          ROWS_PER_CTA,
+          WARPS_PER_CTA,
+          TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr(),
+          bias.data_ptr(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          num_fused_shared_experts,
+          routed_scaling_factor);
+    } else if (input.scalar_type() == at::kHalf) {
+      moe_fused_gate_kernel_tiled_static<
+          float16_t,
+          384,
+          THREADS_PER_ROW,
+          ROWS_PER_WARP,
+          ROWS_PER_CTA,
+          WARPS_PER_CTA,
+          TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr(),
+          bias.data_ptr(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          num_fused_shared_experts,
+          routed_scaling_factor);
+    } else if (input.scalar_type() == at::kFloat) {
+      moe_fused_gate_kernel_tiled_static<
+          float32_t,
+          384,
+          THREADS_PER_ROW,
+          ROWS_PER_WARP,
+          ROWS_PER_CTA,
+          WARPS_PER_CTA,
+          TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr(),
+          bias.data_ptr(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          num_fused_shared_experts,
+          routed_scaling_factor);
+    } else {
+      TORCH_CHECK(false, "Unsupported dtype for moe_fused_gate_tiled_static");
+    }
+  } else if (num_experts == 64 && num_expert_group == 1) {
+    constexpr int THREADS_PER_ROW = 1;
+    constexpr int ROWS_PER_WARP = WARP_SIZE / THREADS_PER_ROW;
+    constexpr int ROWS_PER_CTA = WARPS_PER_CTA * ROWS_PER_WARP;
+    int64_t rows_per_warp = ROWS_PER_WARP;
+    int64_t num_warps = (num_rows + rows_per_warp - 1) / rows_per_warp;
+    int64_t num_blocks = (num_warps + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+
+    if (input.scalar_type() == at::kBFloat16) {
+      moe_fused_gate_kernel_tiled_static<
+          bfloat16_t,
+          64,
+          THREADS_PER_ROW,
+          ROWS_PER_WARP,
+          ROWS_PER_CTA,
+          WARPS_PER_CTA,
+          TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr(),
+          bias.data_ptr(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          num_fused_shared_experts,
+          routed_scaling_factor);
+    } else if (input.scalar_type() == at::kHalf) {
+      moe_fused_gate_kernel_tiled_static<
+          float16_t,
+          64,
+          THREADS_PER_ROW,
+          ROWS_PER_WARP,
+          ROWS_PER_CTA,
+          WARPS_PER_CTA,
+          TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr(),
+          bias.data_ptr(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          num_fused_shared_experts,
+          routed_scaling_factor);
+    } else if (input.scalar_type() == at::kFloat) {
+      moe_fused_gate_kernel_tiled_static<
+          float32_t,
+          64,
+          THREADS_PER_ROW,
+          ROWS_PER_WARP,
+          ROWS_PER_CTA,
+          WARPS_PER_CTA,
+          TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr(),
+          bias.data_ptr(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          num_fused_shared_experts,
+          routed_scaling_factor);
+    } else {
+      TORCH_CHECK(false, "Unsupported dtype for moe_fused_gate_tiled_static");
+    }
+  } else {
+    TORCH_CHECK(false, "moe_fused_gate_tiled_static: unsupported combination");
+  }
+
+  return {output, indices};
+}
+
+// Host launcher for tiled kernel. This does not auto-wire into the existing `moe_fused_gate` API.
+// Call this from the dispatcher when VPT > 32 and <= MAX_TILED_VPT.
+std::vector<at::Tensor> moe_fused_gate_tiled(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor) {
+  TORCH_CHECK(input.is_cuda(), "input must be CUDA tensor");
+  TORCH_CHECK(bias.is_cuda(), "bias must be CUDA tensor");
+  int64_t num_rows = input.size(0);
+  int64_t num_experts = input.size(1);
+
+  TORCH_CHECK(
+      ((num_experts & (num_experts - 1)) == 0) || (num_experts == 384),
+      "num_experts must be power of 2 or 384 (Kimi K2)");
+  TORCH_CHECK(num_experts % num_expert_group == 0, "num_experts must be divisible by num_expert_group");
+  int64_t VPT = num_experts / num_expert_group;
+  TORCH_CHECK(VPT <= MAX_TILED_VPT, "VPT exceeds MAX_TILED_VPT=", MAX_TILED_VPT);
+  TORCH_CHECK(num_expert_group <= WARP_SIZE, "num_expert_group must be <= 32");
+
+  auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+  auto output = torch::empty({num_rows, topk}, options);
+  auto indices = torch::empty({num_rows, topk}, options.dtype(torch::kInt32));
+
+  int64_t rows_per_warp = std::max<int64_t>(1, WARP_SIZE / num_expert_group);
+  int64_t num_warps = (num_rows + rows_per_warp - 1) / rows_per_warp;
+  int64_t num_blocks = (num_warps + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
+
+  // Launch tiled dynamic kernel by dtype
+  if (input.scalar_type() == at::kBFloat16) {
+    moe_fused_gate_kernel_tiled<bfloat16_t, TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor);
+  } else if (input.scalar_type() == at::kHalf) {
+    moe_fused_gate_kernel_tiled<float16_t, TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor);
+  } else if (input.scalar_type() == at::kFloat) {
+    moe_fused_gate_kernel_tiled<float32_t, TILE_VPT><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr(),
+        bias.data_ptr(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows,
+        num_experts,
+        num_expert_group,
+        topk_group,
+        topk,
+        num_fused_shared_experts,
+        routed_scaling_factor);
+  } else {
+    TORCH_CHECK(false, "Unsupported data type for moe_fused_gate_tiled");
+  }
+
+  return {output, indices};
+}

--- a/sgl-kernel/csrc/moe/moe_fused_gate_tiled.h
+++ b/sgl-kernel/csrc/moe/moe_fused_gate_tiled.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <torch/all.h>
+
+#include <vector>
+
+// Tiled moe fused gate dynamic dispatcher (VPT>32 fallback)
+std::vector<at::Tensor> moe_fused_gate_tiled(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor);
+
+// Tiled moe fused gate static specializations (compile-time params inside)
+std::vector<at::Tensor> moe_fused_gate_tiled_static(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t num_expert_group,
+    int64_t topk_group,
+    int64_t topk,
+    int64_t num_fused_shared_experts,
+    double routed_scaling_factor);
+
+// Keep a consistent launch style with LAUNCH_MOE_GATE_CONFIG
+#define LAUNCH_MOE_GATE_TILED_CONFIG(EXPERTS, EXPERT_GROUP, TILE)                                          \
+  do {                                                                                                     \
+    (void)(EXPERTS);                                                                                       \
+    (void)(EXPERT_GROUP);                                                                                  \
+    (void)(TILE);                                                                                          \
+    return moe_fused_gate_tiled_static(                                                                    \
+        input, bias, num_expert_group, topk_group, topk, num_fused_shared_experts, routed_scaling_factor); \
+  } while (0)

--- a/sgl-kernel/tests/test_moe_fused_gate_tiled_bench.py
+++ b/sgl-kernel/tests/test_moe_fused_gate_tiled_bench.py
@@ -1,0 +1,96 @@
+from statistics import median
+
+import pytest
+import torch
+from sgl_kernel import moe_fused_gate
+
+
+def _measure_time_ms(fn, warmup: int, repeat: int) -> list[float]:
+    times_ms: list[float] = []
+    # Warmup
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    # Timed runs
+    for _ in range(repeat):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        times_ms.append(start.elapsed_time(end))
+    return times_ms
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    "seq_length",
+    [256, 1024, 4096],
+)
+@pytest.mark.parametrize(
+    "params",
+    [
+        # Tiled path (VPT > 32)
+        (64, 1, 1, 6),  # kimi-vl: VPT=64
+        (384, 1, 1, 8),  # kimi-K2: VPT=384
+        (1024, 8, 4, 8),  # VPT=128
+        (2048, 8, 4, 8),  # VPT=256
+    ],
+)
+def test_moe_fused_gate_tiled_perf(seq_length, params):
+    num_experts, num_expert_group, topk_group, topk = params
+
+    warmup = 5
+    repeat = 10
+
+    dtype = torch.float32
+    device = "cuda"
+
+    # Inputs
+    torch.manual_seed(0)
+    scores = torch.rand((seq_length, num_experts), dtype=dtype, device=device)
+    bias = torch.rand((num_experts,), dtype=dtype, device=device)
+
+    def run_once():
+        # No shared experts here to focus on core selection cost
+        moe_fused_gate(
+            scores,
+            bias,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            topk=topk,
+            num_fused_shared_experts=0,
+            routed_scaling_factor=1.0,
+        )
+
+    # Measure latency
+    times_ms = _measure_time_ms(run_once, warmup=warmup, repeat=repeat)
+    avg_ms = sum(times_ms) / len(times_ms)
+    p50_ms = median(times_ms)
+    p90_ms = sorted(times_ms)[int(0.9 * (len(times_ms) - 1))]
+
+    # Sanity check on outputs
+    out, idx = moe_fused_gate(
+        scores,
+        bias,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        num_fused_shared_experts=0,
+        routed_scaling_factor=1.0,
+    )
+    assert out.shape == (seq_length, topk)
+    assert idx.shape == (seq_length, topk)
+    assert out.dtype == torch.float32
+    assert idx.dtype in (torch.int32, torch.int64)
+
+    # Emit concise perf line to test logs
+    print(
+        f"moe_fused_gate tiled perf | seq={seq_length} experts={num_experts} groups={num_expert_group} "
+        f"topk_group={topk_group} topk={topk} | avg={avg_ms:.3f}ms p50={p50_ms:.3f}ms p90={p90_ms:.3f}ms"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Motivation

The kimi-vl supported at #5383 and kimi-k2 model cannot use the fuse moe gate operator. This operator currently does not support the case where the group expert is greater than 32. The group expert of kimi-vl is 64, the group expert of kimi-k2 is 384, and this operator cannot be used at present.

## Modifications

@ttaohe @Misaka9468 The three of us completed the PR "Add tile-based method of supporting large VPT in moe_fused_gate kernel" together.


Since rebasing rewrote the commit history, GitHub can't properly update the original PR. so closed #6946 and opening a fresh PR with the cleaned-up single commit for easier review. Original PR for reference: #6946 ([Feature] Add tile-based method of supporting large VPT in moe_fused_gate kernel）


## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.