### PR TITLE
[feat] DeepSeek-R1 W4AFP8: unify ep_moe and support DeepEP normal & low_latency

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Cutlass W4A8 MoE kernel."""
+import logging
 from typing import Optional
 
 import torch
+
 from sgl_kernel import (
     cutlass_w4a8_moe_mm,
     get_cutlass_w4a8_moe_mm_data,
@@ -11,10 +13,16 @@ from sgl_kernel import (
 )
 
 from sglang.srt.layers.moe.ep_moe.kernels import (
+    deepep_ll_get_cutlass_w4a8_moe_mm_data,
+    deepep_permute_triton_kernel,
+    deepep_post_reorder_triton_kernel,
+    deepep_run_moe_deep_preprocess,
     post_reorder_triton_kernel_for_cutlass_moe,
     pre_reorder_triton_kernel_for_cutlass_moe,
     run_cutlass_moe_ep_preproess,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def cutlass_w4a8_moe(
@@ -43,7 +51,10 @@ def cutlass_w4a8_moe(
     a1_scale: Optional[torch.Tensor] = None,
     a2_scale: Optional[torch.Tensor] = None,
     apply_router_weight_on_input: bool = False,
+    deepep_mode=None,
 ) -> torch.Tensor:
+    # Import here to avoid circular import
+    from sglang.srt.layers.moe.token_dispatcher.base_dispatcher import DispatchOutputFormat
     """
     This function computes a w4a8-quantized Mixture of Experts (MoE) layer
     using two sets of quantized weights, w1_q and w2_q, and top-k gating
@@ -83,10 +94,15 @@ def cutlass_w4a8_moe(
     Returns:
     - torch.Tensor: The fp8 output tensor after applying the MoE layer.
     """
-    assert topk_weights.shape == topk_ids_.shape, "topk shape mismatch"
+    assert (
+        topk_weights is None or topk_weights.shape == topk_ids_.shape
+    ), "topk shape mismatch"
     assert w1_q.dtype == torch.int8
     assert w2_q.dtype == torch.int8
-    assert a.shape[1] // 2 == w1_q.shape[2], "Hidden size mismatch w1"
+    assert (
+        deepep_mode is None or a.shape[1] // 2 == w1_q.shape[2] 
+        or a.shape[2] // 2 == w1_q.shape[2]
+    ), "Hidden size mismatch w1"
     assert w1_q.shape[2] * 2 == w2_q.shape[1], "Hidden size mismatch w2"
     assert w1_q.shape[0] == w2_q.shape[0], "Expert number mismatch"
     assert w1_q.shape[0] == w1_scale.shape[0], "w1 scales expert number mismatch"
@@ -105,7 +121,7 @@ def cutlass_w4a8_moe(
     assert a_strides2.shape[0] == w2_q.shape[0], "A Strides 2 expert number  mismatch"
     assert b_strides2.shape[0] == w2_q.shape[0], "B Strides 2 expert number mismatch"
     num_experts = w1_q.size(0)
-    m = a.size(0)
+    m = a.size(0) if deepep_mode is None or deepep_mode != DispatchOutputFormat.DEEPEP_LL else a.size(1)
     k = w1_q.size(2) * 2  # w1_q is transposed and packed
     n = w2_q.size(2) * 2  # w2_q is transposed and packed
     topk = topk_ids_.size(1)
@@ -115,48 +131,102 @@ def cutlass_w4a8_moe(
 
     device = a.device
 
-    _, src2dst, _ = run_cutlass_moe_ep_preproess(
-        local_topk_ids,
-        num_experts,
-    )
+    if not deepep_mode:
+        _, src2dst, _ = run_cutlass_moe_ep_preproess(
+            local_topk_ids,
+            num_experts,
+        )
 
-    gateup_input = torch.empty(
-        (m * topk, k),
-        device=device,
-        dtype=torch.float8_e4m3fn,
-    )
+        gateup_input = torch.empty(
+            (m * topk, k),
+            device=device,
+            dtype=torch.float8_e4m3fn,
+        )
 
-    pre_reorder_triton_kernel_for_cutlass_moe[(m,)](
-        a,
-        gateup_input,
-        src2dst,
-        local_topk_ids,
-        a1_scale,
-        total_num_experts,
-        topk,
-        k,
-        BLOCK_SIZE=512,
-    )
+        pre_reorder_triton_kernel_for_cutlass_moe[(m,)](
+            a,
+            gateup_input,
+            src2dst,
+            local_topk_ids,
+            a1_scale,
+            total_num_experts,
+            topk,
+            k,
+            BLOCK_SIZE=512,
+        )
+    elif deepep_mode == DispatchOutputFormat.DEEPEP_NORMAL:
+        
+        reorder_topk_ids, src2dst, _ = deepep_run_moe_deep_preprocess(
+            topk_ids_, num_experts
+        )
+        num_total_tokens = reorder_topk_ids.numel()
+        gateup_input_pre_reorder = torch.empty(
+            (int(num_total_tokens), a.shape[1]),
+            device=a.device,
+            dtype=a.dtype,
+        )
+        # PreReorder
+        deepep_permute_triton_kernel[(a.shape[0],)](
+            a,
+            gateup_input_pre_reorder,
+            src2dst,
+            topk_ids_.to(torch.int64),
+            None,
+            topk,
+            a.shape[1],
+            BLOCK_SIZE=512,
+        )
+        gateup_input = torch.empty(
+            gateup_input_pre_reorder.shape, dtype=torch.float8_e4m3fn, device=device
+        )
+        sgl_per_tensor_quant_fp8(
+            gateup_input_pre_reorder, gateup_input, a1_scale.float(), True
+        )
+        del gateup_input_pre_reorder
+        local_topk_ids = topk_ids_
+        local_topk_ids = (
+            torch.where(local_topk_ids == -1, num_experts, topk_ids_).to(torch.int32)
+        ).contiguous()
+    elif deepep_mode == DispatchOutputFormat.DEEPEP_LL:
 
-    # NOTE: a_map and c_map are not used in the get_cutlass_w4a8_moe_mm_data kernel,
-    # they are kept to allow for a quick switch of the permutation logic
-    # from the current triton kernel implementation to the cutlass-based one if needed.
-    a_map = torch.empty((local_topk_ids.numel()), dtype=torch.int32, device=device)
-    c_map = torch.empty((local_topk_ids.numel()), dtype=torch.int32, device=device)
-    get_cutlass_w4a8_moe_mm_data(
-        local_topk_ids,
-        expert_offsets,
-        problem_sizes1,
-        problem_sizes2,
-        a_map,
-        c_map,
-        num_experts,
-        n,
-        k,
-    )
+        problem_sizes1, problem_sizes2 = deepep_ll_get_cutlass_w4a8_moe_mm_data(
+            local_topk_ids,
+            problem_sizes1,
+            problem_sizes2,
+            num_experts,
+            n,
+            k,
+        )
 
-    c1 = torch.empty((m * topk, n * 2), device=device, dtype=torch.half)
-    c2 = torch.zeros((m * topk, k), device=device, dtype=torch.half)
+        gateup_input = torch.empty(a.shape, dtype=torch.float8_e4m3fn, device=device)
+        sgl_per_tensor_quant_fp8(a, gateup_input, a1_scale.float(), True)
+        c1 = torch.empty((num_experts, m, n * 2), device=device, dtype=torch.bfloat16)
+        c2 = torch.empty((num_experts, m, k), device=device, dtype=torch.bfloat16)
+        intermediate = torch.empty((num_experts, m, n), device=device, dtype=torch.bfloat16)
+    else:
+        raise ValueError(f"Invalid deepep_mode: {deepep_mode}")
+    
+    if deepep_mode is None or deepep_mode != DispatchOutputFormat.DEEPEP_LL:
+        # NOTE: a_map and c_map are not used in the get_cutlass_w4a8_moe_mm_data kernel,
+        # they are kept to allow for a quick switch of the permutation logic
+        # from the current triton kernel implementation to the cutlass-based one if needed.
+        a_map = torch.empty((local_topk_ids.numel()), dtype=torch.int32, device=device)
+        c_map = torch.empty((local_topk_ids.numel()), dtype=torch.int32, device=device)
+        get_cutlass_w4a8_moe_mm_data(
+            local_topk_ids,
+            expert_offsets,
+            problem_sizes1,
+            problem_sizes2,
+            a_map,
+            c_map,
+            num_experts,
+            n,
+            k,
+        )
+
+        c1 = torch.empty((m * topk, n * 2), device=device, dtype=torch.bfloat16)
+        c2 = torch.zeros((m * topk, k), device=device, dtype=torch.bfloat16)
+        intermediate = torch.empty((m * topk, n), device=device, dtype=torch.bfloat16)
 
     cutlass_w4a8_moe_mm(
         c1,
@@ -173,8 +243,6 @@ def cutlass_w4a8_moe(
         128,
         topk,
     )
-
-    intermediate = torch.empty((m * topk, n), device=device, dtype=torch.half)
     silu_and_mul(c1, intermediate)
 
     intermediate_q = torch.empty(
@@ -198,17 +266,39 @@ def cutlass_w4a8_moe(
         topk,
     )
 
-    output = torch.empty_like(a)
-    post_reorder_triton_kernel_for_cutlass_moe[(m,)](
-        c2,
-        output,
-        src2dst,
-        local_topk_ids,
-        topk_weights,
-        num_experts,
-        topk,
-        k,
-        0,
-        BLOCK_SIZE=512,
-    )
+    if not deepep_mode:
+        output = torch.empty_like(a)
+        post_reorder_triton_kernel_for_cutlass_moe[(m,)](
+            c2,
+            output,
+            src2dst,
+            local_topk_ids,
+            topk_weights,
+            num_experts,
+            topk,
+            k,
+            0,
+            BLOCK_SIZE=512,
+        )
+    elif deepep_mode == DispatchOutputFormat.DEEPEP_NORMAL:
+        num_tokens = src2dst.shape[0] // topk
+        output = torch.empty(
+            (num_tokens, c2.shape[1]),
+            device=c2.device,
+            dtype=torch.bfloat16,
+        )
+        deepep_post_reorder_triton_kernel[(num_tokens,)](
+            c2,
+            output,
+            src2dst,
+            topk_ids_,
+            topk_weights,
+            topk,
+            c2.shape[1],
+            BLOCK_SIZE=512,
+        )
+    elif deepep_mode == DispatchOutputFormat.DEEPEP_LL:
+        output = c2
+    else:
+        raise ValueError(f"Invalid deepep_mode: {deepep_mode}")
     return output

--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -1362,3 +1362,107 @@ def moe_ep_deepgemm_preprocess(
         gateup_input,
         gateup_input_scale,
     )
+
+
+@triton.jit
+def compute_problem_sizes_w4a8_kernel(
+    masked_m_ptr,
+    problem_sizes1_ptr,
+    problem_sizes2_ptr,
+    n,
+    k,
+    num_experts,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = pid < num_experts
+    final_occurrences = tl.load(masked_m_ptr + pid, mask=mask, other=0)
+
+    ps1_idx_0 = pid * 3
+    ps1_idx_1 = ps1_idx_0 + 1
+    ps1_idx_2 = ps1_idx_0 + 2
+
+    ps2_idx_0 = pid * 3
+    ps2_idx_1 = ps2_idx_0 + 1
+    ps2_idx_2 = ps2_idx_0 + 2
+
+    ps1_mask_0 = ps1_idx_0 < num_experts * 3
+    ps1_mask_1 = ps1_idx_1 < num_experts * 3
+    ps1_mask_2 = ps1_idx_2 < num_experts * 3
+    ps2_mask_0 = ps2_idx_0 < num_experts * 3
+    ps2_mask_1 = ps2_idx_1 < num_experts * 3
+    ps2_mask_2 = ps2_idx_2 < num_experts * 3
+
+    tl.store(problem_sizes1_ptr + ps1_idx_0, 2 * n, mask=ps1_mask_0)
+    tl.store(problem_sizes1_ptr + ps1_idx_1, final_occurrences, mask=ps1_mask_1)
+    tl.store(problem_sizes1_ptr + ps1_idx_2, k, mask=ps1_mask_2)
+
+    tl.store(problem_sizes2_ptr + ps2_idx_0, k, mask=ps2_mask_0)
+    tl.store(problem_sizes2_ptr + ps2_idx_1, final_occurrences, mask=ps2_mask_1)
+    tl.store(problem_sizes2_ptr + ps2_idx_2, n, mask=ps2_mask_2)
+
+
+def compute_problem_sizes_w4a8(
+    masked_m, problem_sizes1, problem_sizes2, n, k, num_experts
+):
+    BLOCK_SIZE = 256
+    grid = lambda meta: (triton.cdiv(num_experts, meta["BLOCK_SIZE"]),)
+    compute_problem_sizes_w4a8_kernel[grid](
+        masked_m,
+        problem_sizes1,
+        problem_sizes2,
+        n,
+        k,
+        num_experts,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return problem_sizes1, problem_sizes2
+
+
+@triton.jit
+def compute_expert_offsets_w4a8_kernel(
+    problem_sizes_ptr, expert_offsets_ptr, num_experts, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    block_end = min(block_start + BLOCK_SIZE, num_experts)
+    tot_offset = 0
+    if pid == 0:
+        tl.store(expert_offsets_ptr + 0, 0)
+    for i in range(block_start, block_end):
+        problem_size = tl.load(problem_sizes_ptr + i * 3 + 1)
+        tot_offset += problem_size
+        tl.store(expert_offsets_ptr + i + 1, tot_offset)
+
+
+def compute_expert_offsets_w4a8(
+    problem_sizes: torch.Tensor, expert_offsets: torch.Tensor
+):
+    num_experts = problem_sizes.size(0)
+    BLOCK_SIZE = 32
+    grid = lambda meta: (triton.cdiv(num_experts, meta["BLOCK_SIZE"]),)
+
+    compute_expert_offsets_w4a8_kernel[grid](
+        problem_sizes,
+        expert_offsets,
+        num_experts,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return expert_offsets
+
+
+def deepep_ll_get_cutlass_w4a8_moe_mm_data(
+    masked_m,
+    problem_sizes1,
+    problem_sizes2,
+    num_experts,
+    n,
+    k,
+):
+    problem_sizes1, problem_sizes2 = compute_problem_sizes_w4a8(
+        masked_m, problem_sizes1, problem_sizes2, n, k, num_experts
+    )
+    return (
+        problem_sizes1.to(torch.int32),
+        problem_sizes2.to(torch.int32),
+    )

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -814,7 +814,9 @@ class FusedMoE(torch.nn.Module):
             final_hidden_states = self.quant_method.apply(
                 layer=self,
                 x=hidden_states,
-                topk_output=topk_output,
+                topk_weights=topk_output.topk_weights,
+                topk_ids=topk_output.topk_ids,
+                masked_m=None,
                 moe_runner_config=self.moe_runner_config,
             )
             sm.tag(final_hidden_states)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -419,6 +419,7 @@ class DeepseekV2MoE(nn.Module):
                 deepep_mode=get_deepep_mode(),
                 async_finish=True,
                 return_recv_hook=True,
+                quant_config=quant_config,
             )
 
         self._enable_deepep_moe = get_moe_a2a_backend().is_deepep()

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_get_group_starts.cuh
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_get_group_starts.cuh
@@ -34,6 +34,40 @@ __global__ void int4_fp8_get_group_gemm_starts(
   b_scales_offsets[expert_id] = b_scales_base_as_int + (per_out_ch ? expert_id * n * 4 * k / 512 : expert_id);
 }
 
+template <typename ElementA, typename ElementB, typename ElementC, typename ElementAccumulator>
+__global__ void int4_fp8_get_group_gemm_starts_3d(
+    ElementA** a_offsets,
+    ElementB** b_offsets,
+    ElementC** out_offsets,
+    ElementAccumulator** a_scales_offsets,
+    cutlass::bfloat16_t** b_scales_offsets,
+    ElementA* a_base_as_int,
+    ElementB* b_base_as_int,
+    ElementC* out_base_as_int,
+    ElementAccumulator* a_scales_base_as_int,
+    cutlass::bfloat16_t* b_scales_base_as_int,
+    int64_t n,
+    int64_t m,
+    int64_t k,
+    bool per_act_token,
+    bool per_out_ch,
+    int num_experts) {
+  int expert_id = blockIdx.x * blockDim.x + threadIdx.x;
+  if (expert_id >= num_experts) return;
+
+  int64_t a_offset = expert_id * m * k;
+  int64_t b_offset = expert_id * k * n / 2;
+  int64_t out_offset = expert_id * m * n;
+  int64_t a_scales_offset = 0;
+  int64_t b_scales_offset = per_out_ch ? expert_id * n * 4 * k / 512 : expert_id;
+
+  a_offsets[expert_id] = a_base_as_int + a_offset;
+  b_offsets[expert_id] = b_base_as_int + b_offset;
+  out_offsets[expert_id] = out_base_as_int + out_offset;
+  a_scales_offsets[expert_id] = a_scales_base_as_int + a_scales_offset;
+  b_scales_offsets[expert_id] = b_scales_base_as_int + b_scales_offset;
+}
+
 #define __CALL_W4A8_GET_STARTS_KERNEL(TENSOR_C_TYPE, C_TYPE)                              \
   else if (out_tensors.dtype() == TENSOR_C_TYPE) {                                        \
     int4_fp8_get_group_gemm_starts<cutlass::float_e4m3_t, cutlass::int8_t, C_TYPE, float> \
@@ -53,6 +87,28 @@ __global__ void int4_fp8_get_group_gemm_starts(
             a_tensors.size(1),                                                            \
             per_act_token,                                                                \
             per_out_ch);                                                                  \
+  }
+
+#define __CALL_W4A8_GET_STARTS_KERNEL_3D(TENSOR_C_TYPE, C_TYPE)                              \
+  else if (out_tensors.dtype() == TENSOR_C_TYPE) {                                           \
+    int4_fp8_get_group_gemm_starts_3d<cutlass::float_e4m3_t, cutlass::int8_t, C_TYPE, float> \
+        <<<1, num_experts, 0, stream>>>(                                                     \
+            static_cast<cutlass::float_e4m3_t**>(a_ptrs.data_ptr()),                         \
+            static_cast<cutlass::int8_t**>(b_ptrs.data_ptr()),                               \
+            static_cast<C_TYPE**>(out_ptrs.data_ptr()),                                      \
+            static_cast<float**>(a_scales_ptrs.data_ptr()),                                  \
+            static_cast<cutlass::bfloat16_t**>(b_scales_ptrs.data_ptr()),                    \
+            static_cast<cutlass::float_e4m3_t*>(a_tensors.data_ptr()),                       \
+            static_cast<cutlass::int8_t*>(b_tensors.data_ptr()),                             \
+            static_cast<C_TYPE*>(out_tensors.data_ptr()),                                    \
+            static_cast<float*>(a_scales.data_ptr()),                                        \
+            static_cast<cutlass::bfloat16_t*>(b_scales.data_ptr()),                          \
+            out_tensors.size(2),                                                             \
+            a_tensors.size(1),                                                               \
+            a_tensors.size(2),                                                               \
+            per_act_token,                                                                   \
+            per_out_ch,                                                                      \
+            num_experts);                                                                    \
   }
 
 namespace {
@@ -80,12 +136,22 @@ void run_int4_fp8_get_group_gemm_starts(
 
   auto stream = at::cuda::getCurrentCUDAStream(expert_offsets.device().index());
 
-  if (false) {
-  }
-  __CALL_W4A8_GET_STARTS_KERNEL(torch::kBFloat16, cutlass::bfloat16_t)
-  __CALL_W4A8_GET_STARTS_KERNEL(torch::kFloat16, half)
-  else {
-    TORCH_CHECK(false, "Invalid output type (must be float16 or bfloat16)");
+  if (a_tensors.dim() == 3) {
+    if (false) {
+    }
+    __CALL_W4A8_GET_STARTS_KERNEL_3D(torch::kBFloat16, cutlass::bfloat16_t)
+    __CALL_W4A8_GET_STARTS_KERNEL_3D(torch::kFloat16, half)
+    else {
+      TORCH_CHECK(false, "Invalid output type (must be float16 or bfloat16)");
+    }
+  } else {
+    if (false) {
+    }
+    __CALL_W4A8_GET_STARTS_KERNEL(torch::kBFloat16, cutlass::bfloat16_t)
+    __CALL_W4A8_GET_STARTS_KERNEL(torch::kFloat16, half)
+    else {
+      TORCH_CHECK(false, "Invalid output type (must be float16 or bfloat16)");
+    }
   }
 }
 

--- a/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cuh
+++ b/sgl-kernel/csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cuh
@@ -42,8 +42,8 @@ using QuantType = cutlass::int4b_t;        // 4-bit integer type
 using ElementAccumulator = float;          // Accumulator type
 using ElementScale = cutlass::bfloat16_t;  // Scale type
 using ElementScalePacked = cutlass::Array<ElementScale, 4>;
-using ElementC = cutlass::half_t;  // Default output type (FP16)
-using ElementD = ElementC;         // Default output type (FP16)
+using ElementC = cutlass::bfloat16_t;  // Default output type (FP16)
+using ElementD = ElementC;             // Default output type (FP16)
 using ProblemShape = cutlass::gemm::GroupProblemShape<Shape<int, int, int>>;
 
 // Architecture-specific configurations
@@ -171,7 +171,7 @@ void cutlass_w4a8_group_gemm_caller(
   bool per_out_ch = b_scales.numel() != num_experts;
 
   // Check inputs
-  TORCH_CHECK(a_tensors.dim() == 2, "A tensor must be 2D");
+  TORCH_CHECK(a_tensors.dim() == 2 || a_tensors.dim() == 3, "A tensor must be 2D or 3D");
   TORCH_CHECK(b_tensors.dim() == 3, "B tensor must be 3D [E, N, K/2]");
   TORCH_CHECK(b_scales.dim() == 3, "Scale tensor must be 3D [E, K//512, N*4]");
   TORCH_CHECK(a_scales.dim() == 1, "A Scale tensor must be 1D [1]");
@@ -183,8 +183,16 @@ void cutlass_w4a8_group_gemm_caller(
   TORCH_CHECK(problem_sizes.size(1) == 3, "problem_sizes must have 3 columns (N, M, K)");
   TORCH_CHECK(b_tensors.size(0) == num_experts, "B tensor first dimension must match number of groups");
   TORCH_CHECK(b_scales.size(0) == num_experts, "Scale tensor first dimension must match number of groups");
-  TORCH_CHECK(b_tensors.size(2) * 2 == a_tensors.size(1), "B tensor K/2 dimension must match A tensor K dimension");
-  TORCH_CHECK(b_scales.size(1) == a_tensors.size(1) / 512, "Scale tensor second dimension must be K//512");
+  TORCH_CHECK(
+      b_tensors.size(2) * 2 == a_tensors.size(1) || 
+      b_tensors.size(2) * 2 == a_tensors.size(2), 
+      "B tensor K/2 dimension must match A tensor K dimension"
+  );
+  TORCH_CHECK(
+      b_scales.size(1) == a_tensors.size(1) / 512 || 
+      b_scales.size(1) == a_tensors.size(2) / 512, 
+      "Scale tensor second dimension must be K//512"
+  );
   TORCH_CHECK(b_scales.size(2) == 4 * b_tensors.size(1), "Scale tensor last dimension must be 4*N");
 
   // Check tensor types


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR unifies and refactors related implementations from previous PRs (e.g., #7762, #7772, #8247, #8464).  
It adds support for both **normal** and **low_latency** modes of `deepep` for the DeepSeek-R1 W4AFP8 model, reducing code duplication and improving extensibility.  
Thanks to contributions from @yangsijia-serena, @rainj-me, and @ayrnb.

## Modifications

- Unified support for:
  - `ep_moe`
  - `deepep normal`
  - `deepep low_latency`
  into `W4AFp8MoEMethod.apply()`
- Refactored code for better maintainability and future extension
- No compatibility break for existing features

## Usage

ep moe
```
SGL_ENABLE_JIT_DEEPGEMM=1 python3 -m sglang.launch_server --model-path /data/models/DeepSeek-R1-W4AFP8 \
    --context-length 8192 --tp-size 8 --ep-size 8 --trust-remote-code --host 0.0.0.0 --port 8000 \
    --mem-fraction-static 0.95 --cuda-graph-max-bs 256 --cuda-graph-bs 1 2 4 8 16 32 64 128 256 \
    --max-running-requests 256 --disable-radix-cache 2>&1 | tee log_ep_moe.log 
```

deepep normal
```
SGL_ENABLE_JIT_DEEPGEMM=1 python3 -m sglang.launch_server --model-path /data/models/DeepSeek-R1-W4AFP8 \
    --tp-size 8 --trust-remote-code --host 0.0.0.0 --port 8000 --mem-fraction-static 0.95 \
    --max-running-requests 1024 --context-length 4096 --disable-cuda-graph --chunked-prefill-size 4096 \
    --moe-dense-tp-size 1 --deepep-mode normal --moe-a2a-backend deepep 2>&1 | tee log_normal.log 
```

deepep low latency
```
SGL_ENABLE_JIT_DEEPGEMM=1 python3 -m sglang.launch_server --model-path /data/models/DeepSeek-R1-W4AFP8 \
    --tp-size 8 --trust-remote-code --host 0.0.0.0 --port 8000 --mem-fraction-static 0.95 \
    --max-running-requests 256 --context-length 8192 --cuda-graph-max-bs 256 \
    --cuda-graph-bs 1 2 4 8 16 32 64 128 256 --moe-dense-tp-size 1 --disable-radix-cache \
    --dp-size 8 --enable-dp-attention --moe-a2a-backend deepep --deepep-mode low_latency 2>&1 | tee log_ll.log 
```

## Accuracy & Benchmarking

- Verified against baseline (#7762) with no accuracy regression  
- Benchmark results consistent with #8247 and #8464  

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
