### PR TITLE
Speed up CUDA graph capture on Flashinfer

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -909,9 +909,10 @@ class FlashInferIndicesUpdaterPrefill:
         for wrapper_id in range(2):
             if wrapper_id == 0:
                 # window attention use paged only
+                # Avoid creating a CPU tensor inside a CUDA expression; use python int for device-side op
                 paged_kernel_lens = torch.minimum(
                     seq_lens,
-                    torch.tensor(self.sliding_window_size) + seq_lens - prefix_lens,
+                    seq_lens - prefix_lens + self.sliding_window_size,
                 )
                 paged_kernel_lens_sum = paged_kernel_lens.sum().item()
             else:

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -333,10 +333,12 @@ class FlashInferAttnBackend(AttentionBackend):
                     )
                 )
             seq_lens_sum = seq_lens.sum().item()
+            # Prefer runner-provided CPU seq_lens to avoid device->host copy during capture
+            seq_lens_cpu_capture = getattr(self, "_capture_seq_lens_cpu", None)
             self.indices_updater_decode.update(
                 req_pool_indices,
                 seq_lens,
-                seq_lens.cpu(),  # may add a little overhead in capture stage
+                (seq_lens_cpu_capture[:bs] if seq_lens_cpu_capture is not None else seq_lens.cpu()),
                 seq_lens_sum,
                 decode_wrappers=decode_wrappers,
                 encoder_lens=encoder_lens,
@@ -365,10 +367,11 @@ class FlashInferAttnBackend(AttentionBackend):
                     )
                 )
             seq_lens_sum = seq_lens.sum().item()
+            seq_lens_cpu_capture = getattr(self, "_capture_seq_lens_cpu", None)
             self.indices_updater_prefill.update(
                 req_pool_indices,
                 seq_lens,
-                seq_lens.cpu(),  # may add a little overhead in capture stage
+                (seq_lens_cpu_capture[:bs] if seq_lens_cpu_capture is not None else seq_lens.cpu()),
                 seq_lens_sum,
                 prefix_lens=None,
                 prefill_wrappers=prefill_wrappers,
@@ -395,10 +398,11 @@ class FlashInferAttnBackend(AttentionBackend):
                 )
 
             seq_lens_sum = seq_lens.sum().item()
+            seq_lens_cpu_capture = getattr(self, "_capture_seq_lens_cpu", None)
             self.indices_updater_prefill.update(
                 req_pool_indices,
                 seq_lens,
-                seq_lens.cpu(),  # may add a little overhead in capture stage
+                (seq_lens_cpu_capture[:bs] if seq_lens_cpu_capture is not None else seq_lens.cpu()),
                 seq_lens_sum,
                 prefix_lens=None,
                 prefill_wrappers=prefill_wrappers,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -320,7 +320,11 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
     ):
-        cpu_view = (self._capture_seq_lens_cpu[:bs] if self._capture_seq_lens_cpu is not None else None)
+        cpu_view = (
+            self._capture_seq_lens_cpu[:bs]
+            if self._capture_seq_lens_cpu is not None
+            else None
+        )
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
             for i in range(self.num_wrappers):

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -122,3 +122,9 @@ class HybridAttnBackend(AttentionBackend):
         return self.prefill_backend.forward_extend(
             q, k, v, layer, forward_batch, save_kv_cache, **kwargs
         )
+
+    def support_triton(self):
+        """Delegate to decode backend for triton support.
+        Hybrid backend is primarily used on the decode path for CUDA graphs.
+        """
+        return getattr(self.decode_backend, "support_triton", lambda: True)()

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -11,6 +11,8 @@ from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
 class HybridAttnBackend(AttentionBackend):
     """Support different backends for prefill and decode."""
 
+    __slots__ = ("prefill_backend", "decode_backend")
+
     def __init__(
         self, prefill_backend: AttentionBackend, decode_backend: AttentionBackend
     ):
@@ -70,6 +72,28 @@ class HybridAttnBackend(AttentionBackend):
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.decode_backend.get_cuda_graph_seq_len_fill_value()
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        fm = forward_batch.forward_mode
+        if fm.is_idle():
+            return q.new_empty(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+        elif fm.is_decode():
+            return self.decode_backend.forward_decode(
+                q, k, v, layer, forward_batch, save_kv_cache, **kwargs
+            )
+        else:
+            return self.prefill_backend.forward_extend(
+                q, k, v, layer, forward_batch, save_kv_cache, **kwargs
+            )
 
     def forward_decode(
         self,

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -625,7 +625,9 @@ class CudaGraphRunner:
 
         # Attention backend
         # Provide CPU seq_lens to attn backend to avoid sync.
-        setter = getattr(self.model_runner.attn_backend, "set_capture_seq_lens_cpu", None)
+        setter = getattr(
+            self.model_runner.attn_backend, "set_capture_seq_lens_cpu", None
+        )
         if callable(setter):
             setter(self.seq_lens_cpu)
 

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -624,7 +624,7 @@ class CudaGraphRunner:
             self.model_runner.lora_manager.prepare_lora_batch(forward_batch)
 
         # Attention backend
-        # Provide CPU seq_lens to attn backend(s) for capture to avoid extra .cpu() copies
+        # Provide CPU seq_lens to attn backend to avoid sync.
         setter = getattr(self.model_runner.attn_backend, "set_capture_seq_lens_cpu", None)
         if callable(setter):
             setter(self.seq_lens_cpu)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

After #8340, try to speed up the graph capture by removing the host->device sync.

@DarkSharpness 

<!-- Describe the purpose and goals of this pull request. -->

## Benchmarking and Profiling

On A100-SXM4-40GB

## Before

```bash
SGLANG_ENABLE_TORCH_COMPILE=0 python3 -m sglang.launch_server \
    --attention-backend flashinfer \
    --model-path Qwen/Qwen2.5-7B-Instruct

Capture cuda graph bs [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160]
```

Cold start
```
[2025-08-25 15:31:27] Capture cuda graph end. Time elapsed: 25.39 s. mem usage=0.56 GB. avail mem=8.00 GB.
```

Non-cold start
```
[2025-08-25 15:32:45] Capture cuda graph end. Time elapsed: 3.57 s. mem usage=0.56 GB. avail mem=8.00 GB.
...
[2025-08-25 15:34:38] Capture cuda graph end. Time elapsed: 3.70 s. mem usage=0.56 GB. avail mem=8.00 GB.
```

---

## After

Cold start
```
[2025-08-25 15:40:06] Capture cuda graph end. Time elapsed: 24.57 s. mem usage=0.56 GB. avail mem=8.00 GB.
```

Non-cold start
```
[2025-08-25 15:41:27] Capture cuda graph end. Time elapsed: 3.40 s. mem usage=0.56 GB. avail mem=8.00 GB.
...
[2025-08-25 15:42:25] Capture cuda graph end. Time elapsed: 3.37 s. mem usage=0.56 GB. avail mem=8.00 GB.
```

## Checklist
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
