### PR TITLE
Reduce logging bloat in server startup

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -25,7 +25,7 @@ from transformers import PretrainedConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization import QUANTIZATION_METHODS
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import is_hip, retry
+from sglang.srt.utils import is_hip, log_info_on_rank0, retry
 from sglang.srt.utils.hf_transformers_utils import (
     get_config,
     get_context_length,
@@ -131,8 +131,9 @@ class ModelConfig:
             ]
             if self.hf_config.architectures[0] in mm_disabled_models:
                 enable_multimodal = False
-                logger.info(
-                    f"Multimodal is disabled for {self.hf_config.model_type}. To enable it, set --enable-multimodal."
+                log_info_on_rank0(
+                    logger,
+                    f"Multimodal is disabled for {self.hf_config.model_type}. To enable it, set --enable-multimodal.",
                 )
             else:
                 enable_multimodal = True

--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_config.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe_triton_config.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import triton
 
-from sglang.srt.utils import get_device_name, is_hip
+from sglang.srt.utils import get_device_name, is_hip, log_warning_on_rank0
 
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
@@ -86,7 +86,8 @@ def get_moe_configs(
         )
         if os.path.exists(try_config_file_path):
             with open(try_config_file_path) as f:
-                logger.warning(
+                log_warning_on_rank0(
+                    logger,
                     f"Config file not found at {config_file_path}. Fallback to triton version {try_triton_version} and use MoE kernel config from {try_config_file_path}. Performance might be sub-optimal!",
                 )
                 # If a configuration has been found, return it
@@ -94,12 +95,10 @@ def get_moe_configs(
 
     # If no optimized configuration is available, we will use the default
     # configuration
-    logger.warning(
-        (
-            "Using default MoE kernel config. Performance might be sub-optimal! "
-            "Config file not found at %s, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton"
-        ),
-        config_file_path,
+    log_warning_on_rank0(
+        logger,
+        f"Using default MoE kernel config. Performance might be sub-optimal! "
+        f"Config file not found at {config_file_path}, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton",
     )
     return None
 

--- a/python/sglang/srt/managers/multimodal_processor.py
+++ b/python/sglang/srt/managers/multimodal_processor.py
@@ -6,6 +6,7 @@ import pkgutil
 
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import log_warning_on_rank0
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,9 @@ def import_processors(package_name: str):
             try:
                 module = importlib.import_module(name)
             except Exception as e:
-                logger.warning(f"Ignore import error when loading {name}: {e}")
+                log_warning_on_rank0(
+                    logger, f"Ignore import error when loading {name}: {e}"
+                )
                 continue
             all_members = inspect.getmembers(module, inspect.isclass)
             classes = [

--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -34,7 +34,7 @@ from sglang.srt.managers.schedule_batch import (
     global_server_args_dict,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.utils import is_cpu
+from sglang.srt.utils import is_cpu, log_warning_on_rank0
 
 _is_cpu = is_cpu()
 
@@ -686,8 +686,9 @@ class Llama4ForConditionalGeneration(nn.Module):
             self._handle_default_weight(name, loaded_weight, params_dict)
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
-            logger.warning(
-                f"Some weights are not initialized from checkpoints {unloaded_params}"
+            log_warning_on_rank0(
+                logger,
+                f"Some weights are not initialized from checkpoints {unloaded_params}",
             )
 
     def _should_skip_weight(self, name: str) -> bool:

--- a/python/sglang/srt/models/registry.py
+++ b/python/sglang/srt/models/registry.py
@@ -9,6 +9,8 @@ from typing import AbstractSet, Dict, List, Optional, Tuple, Type, Union
 
 import torch.nn as nn
 
+from sglang.srt.utils import log_warning_on_rank0
+
 logger = logging.getLogger(__name__)
 
 
@@ -94,7 +96,9 @@ def import_model_classes(package_name: str):
             try:
                 module = importlib.import_module(name)
             except Exception as e:
-                logger.warning(f"Ignore import error when loading {name}: {e}")
+                log_warning_on_rank0(
+                    logger, f"Ignore import error when loading {name}: {e}"
+                )
                 continue
             if hasattr(module, "EntryClass"):
                 entry = module.EntryClass

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2510,6 +2510,13 @@ def log_info_on_rank0(logger, msg):
         logger.info(msg)
 
 
+def log_warning_on_rank0(logger, msg):
+    from sglang.srt.distributed import get_tensor_model_parallel_rank
+
+    if get_tensor_model_parallel_rank() == 0:
+        logger.warning(msg)
+
+
 def load_json_config(data: str):
     try:
         return json.loads(data)


### PR DESCRIPTION
Log on rank 0 when it's not relevant.

Otherwise we keep on getting

```
[2025-08-24 08:06:07 TP5] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP1] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP7] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP2] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP0] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP6] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP3] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:07 TP4] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:08 TP5] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:08 TP2] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:08 TP6] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:08 TP1] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
[2025-08-24 08:06:08 TP0] Multimodal is disabled for llama4. To enable it, set --enable-multimodal.
```