### PR TITLE
fix(hicache): fix prefetch under heavy workload

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -772,31 +772,19 @@ class HiCacheController:
                 if operation is None:
                     continue
 
-                # Check if this operation has already been queried for storage hits
-                if hasattr(operation, '_hash_value_cached'):
-                    # Restore cached values from previous query
-                    hash_value = operation._hash_value_cached
-                    storage_hit_count = operation._storage_hit_count_cached
-                else:
-                    # First time processing this operation
-                    hash_value = []
-                    storage_hit_count = 0
-                    
-                    if operation.host_indices is not None:
-                        if self.prefetch_rate_limit_check():
-                            # Query storage for available pages
-                            hash_value, storage_hit_count = self._generic_storage_hit_query(
-                                operation
-                            )
-                            # Cache the results to avoid re-querying
-                            operation._hash_value_cached = hash_value
-                            operation._storage_hit_count_cached = storage_hit_count
-                        else:
-                            # Rate limited - re-queue the operation to try again later
-                            # This prevents the operation from being stuck in ongoing_prefetch
-                            time.sleep(0.1)  # Small delay to avoid busy waiting
-                            self.prefetch_queue.put(operation)
-                            continue
+                hash_value = []
+                storage_hit_count = 0
+                
+                if operation.host_indices is not None:
+                    if self.prefetch_rate_limit_check():
+                        # Query storage for available pages
+                        hash_value, storage_hit_count = self._generic_storage_hit_query(
+                            operation
+                        )
+                    else:
+                        # Rate limited - re-queue the operation to try again later
+                        self.prefetch_queue.put(operation)
+                        continue
 
                 if self.tp_world_size > 1:
                     storage_hit_count_tensor = torch.tensor(

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -573,6 +573,11 @@ class HiRadixCache(RadixCache):
         if host_indices is None:
             self.evict_host(prefetch_length)
             host_indices = self.cache_controller.mem_pool_host.alloc(prefetch_length)
+
+        # System is under heavy load, skip prefetching
+        if host_indices is None:
+            return
+        
         operation = self.cache_controller.prefetch(
             req_id, host_indices, new_input_tokens, last_hash
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When the system encounters high hit ratio scenarios (such as dozens of long requests with nearly 100% hit ratios during my stress testing), it causes two critical issues:

1. **Memory allocation failures**

My current fix involves disabling prefetch operations.

2. **Rate limiting causes undefined operation states, leading to deadlocks**

The solution is to implement a brief requeue mechanism.

Here are some potential solutions worth discussing:

1. Defer memory allocation until just before batch_get operations to prevent excessive memory pinning in short timeframes, which would simultaneously address both issues mentioned above.

2. Implement backpressure using queue size limitations.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
