### PR TITLE
feat: Support custom logging format configuration for Uvicorn

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -6,14 +6,18 @@ SGLang supports various environment variables that can be used to configure its 
 
 ## General Configuration
 
-| Environment Variable | Description | Default Value |
-| --- | --- | --- |
-| `SGLANG_USE_MODELSCOPE` | Enable using models from ModelScope | `false` |
-| `SGLANG_HOST_IP` | Host IP address for the server | `0.0.0.0` |
-| `SGLANG_PORT` | Port for the server | auto-detected |
-| `SGLANG_LOGGING_CONFIG_PATH` | Custom logging configuration path | Not set |
-| `SGLANG_DISABLE_REQUEST_LOGGING` | Disable request logging | `false` |
-| `SGLANG_HEALTH_CHECK_TIMEOUT` | Timeout for health check in seconds | `20` |
+| Environment Variable             | Description                                 | Default Value |
+|----------------------------------|---------------------------------------------|---------------|
+| `SGLANG_USE_MODELSCOPE`          | Enable using models from ModelScope         | `false`       |
+| `SGLANG_HOST_IP`                 | Host IP address for the server              | `0.0.0.0`     |
+| `SGLANG_PORT`                    | Port for the server                         | Auto-detected |
+| `SGLANG_LOGGING_CONFIG_PATH`     | Custom logging configuration file path      | Not set       |
+| `SGLANG_DISABLE_REQUEST_LOGGING` | Disable HTTP request logging                | `false`       |
+| `SGLANG_HEALTH_CHECK_TIMEOUT`    | Health check timeout (seconds)              | `20`          |
+| `SGLANG_UVICORN_DEFAULT_FORMAT`  | Uvicorn default log format (Python logging) | Not set       |
+| `SGLANG_UVICORN_ACCESS_FORMAT`   | Uvicorn HTTP access log format              | Not set       |
+| `SGLANG_UVICORN_DATE_FORMAT`     | Uvicorn log timestamp format                | Not set       |
+
 
 ## Performance Tuning
 

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1881,16 +1881,44 @@ def kill_itself_when_parent_died():
 
 
 def set_uvicorn_logging_configs():
-    from uvicorn.config import LOGGING_CONFIG
+    """Configure Uvicorn logging with environment variable overrides.
 
-    LOGGING_CONFIG["formatters"]["default"][
-        "fmt"
-    ] = "[%(asctime)s] %(levelprefix)s %(message)s"
-    LOGGING_CONFIG["formatters"]["default"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
-    LOGGING_CONFIG["formatters"]["access"][
-        "fmt"
-    ] = '[%(asctime)s] %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    LOGGING_CONFIG["formatters"]["access"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
+    Allows customization of log formats through environment variables:
+    - SGLANG_UVICORN_DEFAULT_FORMAT: Format for default logs
+    - SGLANG_UVICORN_ACCESS_FORMAT: Format for access logs
+    - SGLANG_UVICORN_DATE_FORMAT: Date format for all logs
+    """
+    from uvicorn.config import LOGGING_CONFIG
+    import os
+
+    # Define constants for environment variable names to improve maintainability
+    default_format_env = "SGLANG_UVICORN_DEFAULT_FORMAT"
+    access_format_env = "SGLANG_UVICORN_ACCESS_FORMAT"
+    date_format_env = "SGLANG_UVICORN_DATE_FORMAT"
+
+    # Default log format (can be overridden by env var)
+    default_fmt = os.getenv(
+        default_format_env,
+        "[%(asctime)s] %(levelprefix)s %(message)s"
+    )
+
+    # Access log format (can be overridden by env var)
+    access_fmt = os.getenv(
+        access_format_env,
+        '[%(asctime)s] %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+    )
+
+    # Date format for all logs (can be overridden by env var)
+    date_fmt = os.getenv(
+        date_format_env,
+        "%Y-%m-%d %H:%M:%S"
+    )
+
+    # Apply the configurations
+    LOGGING_CONFIG["formatters"]["default"]["fmt"] = default_fmt
+    LOGGING_CONFIG["formatters"]["default"]["datefmt"] = date_fmt
+    LOGGING_CONFIG["formatters"]["access"]["fmt"] = access_fmt
+    LOGGING_CONFIG["formatters"]["access"]["datefmt"] = date_fmt
 
 
 def get_ip() -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Currently, SGLang supports custom logging configuration via the environment variable SGLANG_LOGGING_CONFIG_PATH, but this only applies to SGLang's own logs and cannot override Uvicorn's default logging format. In enterprise log collection systems , a unified log format is often required, and Uvicorn's default format may be incompatible with these tools, causing parsing failures or missing fields.

## Modifications
Updated python/sglang/srt/utils.py

Added support for customizing Uvicorn log formats via the following environment variables:

- SGLANG_UVICORN_DEFAULT_FORMAT: Overrides Uvicorn’s default log format (e.g., %(levelname)s - %(message)s)

- SGLANG_UVICORN_ACCESS_FORMAT: Overrides Uvicorn’s access log format (e.g., %(asctime)s - %(client_addr)s %(request_line)s %(status_code)s)
- SGLANG_UVICORN_DATE_FORMAT: Overrides the timestamp format (e.g., %Y-%m-%d %H:%M:%S)



## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
