### PR TITLE
Fix None-Type comparison causing TypeError in schedule_batch.py

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -665,7 +665,7 @@ class Req:
         # request has at least one token. Later, we can relax this requirement and use `input_len`.
         max_prefix_len = input_len - 1
 
-        if self.sampling_params.max_new_tokens and self.sampling_params.max_new_tokens > 0:
+        if self.sampling_params.max_new_tokens is not None and self.sampling_params.max_new_tokens > 0:
             # Need at least one token to compute logits
             max_prefix_len = min(max_prefix_len, input_len - 1)
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -665,7 +665,7 @@ class Req:
         # request has at least one token. Later, we can relax this requirement and use `input_len`.
         max_prefix_len = input_len - 1
 
-        if self.sampling_params.max_new_tokens > 0:
+        if self.sampling_params.max_new_tokens and self.sampling_params.max_new_tokens > 0:
             # Need at least one token to compute logits
             max_prefix_len = min(max_prefix_len, input_len - 1)
 


### PR DESCRIPTION
## Motivation

Uncaught TypeError in schedule_batch.py if self.sampling_params.max_new_tokens = None.

Goal: prevent this from raising an Exception.
TypeError ("> between instances of Type None and int not allowed").

## Modifications

Condition now checks that self.sampling_params.max_new_tokens is not None (comes before 

Note: the statement executed if the condition resolves true, currently doesnt have any sensible effect given the statement in line 666 before (not addressed in this MR).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
