### PR TITLE
Fix TRTLLM MLA Cuda KV Blocks Causing accuracy drop

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -51,6 +51,7 @@ class TRTLLMMLADecodeMetadata:
 
     workspace: Optional[torch.Tensor] = None
     block_kv_indices: Optional[torch.Tensor] = None
+    max_seq_len: Optional[int] = None
 
 
 class TRTLLMMLABackend(FlashInferMLAAttnBackend):
@@ -207,8 +208,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             )
 
         # Custom fast-path for decode/idle.
-        max_seqlen_pad = self._calc_padded_blocks(seq_lens.max().item())
-        block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_seqlen_pad]
+        # Capture with full width so future longer sequences are safe during replay
+        max_blocks_per_seq = self._calc_padded_blocks(self.max_context_len)
+        block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_blocks_per_seq]
 
         create_flashmla_kv_indices_triton[(bs,)](
             self.req_to_token,
@@ -217,13 +219,20 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             None,
             block_kv_indices,
             self.req_to_token.stride(0),
-            max_seqlen_pad,
+            max_blocks_per_seq,
             NUM_PAGE_PER_BLOCK=TRITON_PAD_NUM_PAGE_PER_BLOCK,
             PAGED_SIZE=self.page_size,
         )
 
+        # Record the true maximum sequence length for this capture batch so that
+        # the kernel launch path (which requires an int not a tensor) can reuse
+        # it safely during both capture and replay.
+        max_seq_len_val = int(seq_lens.max().item())
+
         metadata = TRTLLMMLADecodeMetadata(
-            self.decode_cuda_graph_workspace, block_kv_indices
+            self.decode_cuda_graph_workspace,
+            block_kv_indices,
+            max_seq_len_val,
         )
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_metadata = metadata
@@ -268,6 +277,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             PAGED_SIZE=self.page_size,
         )
 
+        # Update stored max_seq_len so subsequent kernel calls use the correct value
+        metadata.max_seq_len = int(seq_lens.max().item())
+
     def get_cuda_graph_seq_len_fill_value(self) -> int:
         """Get the fill value for sequence lengths in CUDA graph."""
         return 1
@@ -295,8 +307,10 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             forward_batch.seq_lens.device,
         )
 
+        # Precompute actual max(seq_lens) for forward batch
+        max_seq_len_val = int(torch.max(forward_batch.seq_lens).item())
         self.forward_metadata = TRTLLMMLADecodeMetadata(
-            self.workspace_buffer, block_kv_indices
+            self.workspace_buffer, block_kv_indices, max_seq_len_val
         )
         forward_batch.decode_trtllm_mla_metadata = self.forward_metadata
 
@@ -471,14 +485,12 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             qk_rope_head_dim=self.qk_rope_head_dim,
             block_tables=metadata.block_kv_indices,
             seq_lens=forward_batch.seq_lens.to(torch.int32),
-            max_seq_len=int(metadata.block_kv_indices.shape[1] * self.page_size),
+            max_seq_len=metadata.max_seq_len,
             bmm1_scale=bmm1_scale,
         )
 
-        # Extract value projection part and reshape
-        raw_out_v = raw_out[..., : layer.v_head_dim].contiguous()
-        output = raw_out_v.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-
+        # Reshape output directly without slicing
+        output = raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
         return output
 
 

--- a/python/sglang/test/attention/test_trtllm_mla_backend.py
+++ b/python/sglang/test/attention/test_trtllm_mla_backend.py
@@ -208,6 +208,15 @@ class MockModelRunner:
         self.kv_cache_dtype = config["kv_cache_dtype"]
         self.page_size = config["page_size"]
 
+        # Server args stub - needed by attention backends
+        self.server_args = type(
+            "ServerArgs",
+            (),
+            {
+                "enable_dp_attention": False,  # Default value for testing
+            },
+        )
+
         # Model-config stub with MLA attributes
         self.model_config = type(
             "ModelConfig",
@@ -833,7 +842,7 @@ class TestTRTLLMMLA(CustomTestCase):
 
                 # Test workspace properties
                 self.assertEqual(metadata.workspace.device.type, "cuda")
-                self.assertEqual(metadata.workspace.dtype, torch.int8)
+                self.assertEqual(metadata.workspace.dtype, torch.uint8)
                 self.assertGreater(
                     metadata.workspace.numel(), 0, "Workspace should have non-zero size"
                 )
@@ -993,8 +1002,8 @@ class TestTRTLLMMLA(CustomTestCase):
         )
 
         # Verify CUDA graph buffers are allocated
-        self.assertIsNotNone(backend.cuda_graph_kv_indices)
-        self.assertIsNotNone(backend.cuda_graph_workspace)
+        self.assertIsNotNone(backend.decode_cuda_graph_kv_indices)
+        self.assertIsNotNone(backend.decode_cuda_graph_workspace)
 
         # Test capture metadata
         seq_lens = torch.full(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix for issue https://github.com/sgl-project/sglang/pull/8638#issuecomment-3193478283 by setting number of `kv_indices` based on `self.max_context_len`


## Modifications

`max_blocks_per_seq = self._calc_padded_blocks(self.max_context_len)`

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests



<details>
<summary>GPQA</summary>

```
CUDA_VISIBLE_DEVICES=4,5,6,7 \
python3 -m sglang.launch_server \
  --model nvidia/DeepSeek-R1-0528-FP4 \
  --trust-remote-code \
  --quantization modelopt_fp4 \
  --enable-flashinfer-cutlass-moe \
  --enable-ep-moe \
  --attention-backend trtllm_mla --kv-cache-dtype fp8_e4m3 \
  --tp-size 4 \
  --dp-size 4 \
  --enable-dp-attention \
  --mem-fraction-static 0.80 \
  --chunked-prefill-size 32768 \
  --max-running-requests 1024 \
  --cuda-graph-max-bs 256 \
  --host 0.0.0.0 \
  --port 30001 
```

SGLANG flashinfer BF16
```
nemo-run_1/0 ----------------------------------------- gpqa ----------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 198         |    7655   |   737     |    74.24 %      |    11.61 %
```

SGLANG trtllm_mla FP8
```
nemo-run_1/0 ----------------------------------------- gpqa ----------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 198         | 7781       | 608         | 76.26%           | 8.59%    
```
</details>



<details>
<summary>GSM8k </summary>

SGLANG trtllm_mla fp8
```
python3 benchmark/gsm8k/bench_sglang.py     --num-shots 5     --num-questions 1319     --parallel 512 --port 30001
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:02<00:00, 21.01it/s]
Accuracy: 0.947
Invalid: 0.000
Latency: 63.017 s
Output throughput: 2191.097 token/s
```
</details>



<details>
<summary>MMLU Pro</summary>

```
CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server   --model nvidia/DeepSeek-R1-0528-FP4  --trust-remote-code   --quantization modelopt_fp4   --attention-backend trtllm_mla --kv-cache-dtype fp8_e4m3   --tp-size 4   --mem-fraction-static 0.80   --max-running-requests 1024   --cuda-graph-max-bs 256  --port 30001
```


```
nemo-run/0 100%|██████████| 12032/12032 [00:00<00:00, 14117.85it/s]                                                                                 
nemo-run_1/0 --------------------------------------- mmlu-pro --------------------------------------                                                
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer                                                
nemo-run_1/0 pass@1          | 12032       | 3385       | 10552       | 81.91%           | 4.22%                                                    
nemo-run_1/0         
```
</details>

<details>
<summary>Math 500</summary>
Ran the above server command with `--disable-chunked-prefix-cache` due to a bug found https://github.com/sgl-project/sglang/issues/9704/

```
CUDA_VISIBLE_DEVICES=4,5,6,7 \
python3 -m sglang.launch_server \
  --model nvidia/DeepSeek-R1-0528-FP4 \
  --trust-remote-code \
  --quantization modelopt_fp4 \
  --enable-flashinfer-cutlass-moe \
  --enable-ep-moe \
  --attention-backend trtllm_mla --kv-cache-dtype fp8_e4m3 \
  --tp-size 4 \
  --dp-size 4 \
  --enable-dp-attention \
  --mem-fraction-static 0.80 \
  --disable-chunked-prefix-cache \
  --chunked-prefill-size 32768 \
  --max-running-requests 1024 \
  --cuda-graph-max-bs 256 \
  --host 0.0.0.0 \
  --port 30001 
  ```

### Flashinfer MLA BF16 with 32k tokens
```
nemo-run_1/0 --------------------------------------- math-500 --------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 500         | 5302       | 1370         | 98.0%           | 0.8%    
```

### SGLANG trtllm_mla BF16 with 32k tokens
```
nemo-run_1/0 --------------------------------------- math-500 --------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 500         | 5378       | 1425        | 97.20%           | 1.40%    
nemo-run_1/0 
```


### SGLANG trtllm_mla FP8 with 16384 tokens 
- TP only command 32k (cuda graph ON) 
```
nemo-run_1/0 --------------------------------------- math-500 --------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 500         | 5492       | 1849        | 97.60%           | 1.20%    
nemo-run_1/0 
nemo-run_1/0 
nemo-run_1/0 Metrics are saved to ./nemo_skills_output_trtllm_mla_fp8_tp_only_20250828_200449/eval-results/math-500/metrics.json
```

- TP EP DP command (original command above) 32k + cuda graph OFF
```
nemo-run_1/0 --------------------------------------- math-500 --------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 500         | 5746       | 2553        | 95.80%           | 3.00%    
nemo-run_1/0 
```


- TP EP DP command (original command above) 16k + cuda graph ON => **CONCERNING**
```
nemo-run_1/0 --------------------------------------- math-500 --------------------------------------
nemo-run_1/0 evaluation_mode | num_entries | avg_tokens | gen_seconds | symbolic_correct | no_answer
nemo-run_1/0 pass@1          | 500         | 6108       | 644         | 84.60%           | 15.00%   
```


</details>

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Sanity benchmark WIP against old results in https://github.com/sgl-project/sglang/pull/8638
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
