### PR TITLE
Fix get_ip when no external network

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -1964,6 +1964,15 @@ def get_ip() -> str:
     except Exception:
         pass
 
+    # try  using hostname
+    hostname = socket.gethostname()
+    try:
+        ip_addr = socket.gethostbyname(hostname)
+        warnings.warn("using local ip address: {}".format(ip_addr))
+        return ip_addr
+    except Exception:
+        pass
+
     warnings.warn(
         "Failed to get the IP address, using 0.0.0.0 by default."
         "The value can be set by the environment variable"


### PR DESCRIPTION
When all worker nodes fail to connect to the external network, the current logic for retrieving the outbound IP becomes invalid and will return 0.0.0.0. To address this, we will add a fallback method to obtain the local IP via the hostname.

This fallback mechanism works by resolving the local hostname to its corresponding IP address (using system calls like gethostbyname or framework-specific functions such as Python’s socket.gethostbyname(socket.gethostname())). It ensures that even in offline environments (where external network-dependent IP retrieval fails), the node can still obtain a valid local IP for internal communication or logging purposes.

The implementation will prioritize the original outbound IP check first, then seamlessly switch to the hostname-based method if the former fails, maintaining compatibility while enhancing robustness in network-restricted scenarios.

CC @ShangmingCai @zhyncs @merrymercy 
