### PR TITLE
[Performance] Improve Qwen RMSNorm by replacing with native RMSNorm op

### DIFF
--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -189,7 +189,6 @@ class Qwen2_5_VisionBlock(nn.Module):
         attn = rearrange(attn, "b s h -> s b h")
 
         # norm2 with fused residual-add: also 2D
-        x2d = x.reshape(-1, H)
         attn2d = attn.reshape(-1, H)
         x_norm_2d, x_after_add_2d = self.norm2(x2d, residual=attn2d)
         x_norm = x_norm_2d.reshape(S, B, H)
@@ -438,8 +437,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
                 torch.tensor([0], device=x.device, dtype=torch.int32),
                 (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2])
                 .cumsum(dim=0)
-                .to(torch.int32)
-                .to(x.device),
+                .to(device=x.device, dtype=torch.int32),
             ]
         )
         cu_seqlens = F.pad(cu_seqlens, (1, 0), "constant", 0)

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -31,7 +31,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
 from transformers.activations import ACT2FN
-from transformers.models.qwen2.modeling_qwen2 import Qwen2RMSNorm
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
     Qwen2_5_VLConfig,
     Qwen2_5_VLVisionConfig,

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -182,10 +182,9 @@ class Qwen2_5_VisionBlock(nn.Module):
             position_embeddings=position_embeddings,
         )
         attn = rearrange(attn, "b s ... -> s b ...")
-        x = x + attn
-        norm2 = self.norm2(x)
-        mlp = self.mlp(norm2)
-        x = x + mlp
+        x_norm, x_after_add = self.norm2(x, residual=attn)
+        mlp_out = self.mlp(x_norm)
+        x = x_after_add + mlp_out
         return x
 
 

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -43,6 +43,7 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
 
 from sglang.srt.hf_transformers_utils import get_processor
 from sglang.srt.layers.attention.vision import VisionAttention
+from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.pooler import Pooler, PoolingType
@@ -122,8 +123,8 @@ class Qwen2_5_VisionBlock(nn.Module):
         super().__init__()
         if norm_layer is None:
             norm_layer = partial(nn.LayerNorm, eps=1e-6)
-        self.norm1 = Qwen2RMSNorm(dim, eps=1e-6)
-        self.norm2 = Qwen2RMSNorm(dim, eps=1e-6)
+        self.norm1 = RMSNorm(dim, eps=1e-6)
+        self.norm2 = RMSNorm(dim, eps=1e-6)
 
         if attn_implementation is None:
             softmax_in_single_precision = False
@@ -200,7 +201,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = context_dim * (spatial_merge_size**2)
-        self.ln_q = Qwen2RMSNorm(context_dim, eps=1e-6)
+        self.ln_q = RMSNorm(context_dim, eps=1e-6)
         self.mlp = nn.ModuleList(
             [
                 ColumnParallelLinear(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Use SGLang RMSNorm in Qwen2.5 instead of huggingface Qwen2RMSNorm (Equivalent to T5LayerNorm)
Summary at the bottom. Improve by 4% speed
<img width="2404" height="1778" alt="CleanShot 2025-08-27 at 15 55 12@2x" src="https://github.com/user-attachments/assets/34822f8d-f350-4849-9007-fe96b93223ef" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
New:
```python
python benchmark/mmmu/bench_sglang.py --port 30000 --concurrency 16
Preparing samples...
Loading datasets for 30 subjects...
Loading datasets: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:12<00:00,  2.31it/s]
Saving images to: /root/.cache/mmmu/images
Processing samples...
Processing samples: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 186819.44it/s]
Skipping 0 samples with large images, 0.0% of dataset
Samples have been prepared
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [02:55<00:00,  5.12it/s]
Benchmark time: 175.61567665599978
answers saved to: ./answer_sglang.json
Evaluating...
{'Accounting': {'acc': 0.433, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.533, 'num': 30},
 'Art': {'acc': 0.667, 'num': 30},
 'Art_Theory': {'acc': 0.833, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.6, 'num': 30},
 'Biology': {'acc': 0.367, 'num': 30},
 'Chemistry': {'acc': 0.333, 'num': 30},
 'Clinical_Medicine': {'acc': 0.633, 'num': 30},
 'Computer_Science': {'acc': 0.433, 'num': 30},
 'Design': {'acc': 0.667, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.467, 'num': 30},
 'Economics': {'acc': 0.467, 'num': 30},
 'Electronics': {'acc': 0.267, 'num': 30},
 'Energy_and_Power': {'acc': 0.267, 'num': 30},
 'Finance': {'acc': 0.367, 'num': 30},
 'Geography': {'acc': 0.4, 'num': 30},
 'History': {'acc': 0.667, 'num': 30},
 'Literature': {'acc': 0.8, 'num': 30},
 'Manage': {'acc': 0.333, 'num': 30},
 'Marketing': {'acc': 0.467, 'num': 30},
 'Materials': {'acc': 0.433, 'num': 30},
 'Math': {'acc': 0.5, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.5, 'num': 30},
 'Music': {'acc': 0.5, 'num': 30},
 'Overall': {'acc': 0.513, 'num': 900},
 'Overall-Art and Design': {'acc': 0.667, 'num': 120},
 'Overall-Business': {'acc': 0.413, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.593, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.675, 'num': 120},
 'Overall-Science': {'acc': 0.407, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.424, 'num': 210},
 'Pharmacy': {'acc': 0.633, 'num': 30},
 'Physics': {'acc': 0.433, 'num': 30},
 'Psychology': {'acc': 0.7, 'num': 30},
 'Public_Health': {'acc': 0.633, 'num': 30},
 'Sociology': {'acc': 0.533, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.513
```
Main
```python
python benchmark/mmmu/bench_sglang.py --port 30000 --concurrency 16
Preparing samples...
Loading datasets for 30 subjects...
Loading datasets: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:11<00:00,  2.52it/s]
Saving images to: /root/.cache/mmmu/images
Processing samples...
Processing samples: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 200609.75it/s]
Skipping 0 samples with large images, 0.0% of dataset
Samples have been prepared
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [03:07<00:00,  4.81it/s]
Benchmark time: 187.17282119399988
answers saved to: ./answer_sglang.json
Evaluating...
{'Accounting': {'acc': 0.433, 'num': 30},
 'Agriculture': {'acc': 0.533, 'num': 30},
 'Architecture_and_Engineering': {'acc': 0.5, 'num': 30},
 'Art': {'acc': 0.633, 'num': 30},
 'Art_Theory': {'acc': 0.833, 'num': 30},
 'Basic_Medical_Science': {'acc': 0.6, 'num': 30},
 'Biology': {'acc': 0.367, 'num': 30},
 'Chemistry': {'acc': 0.333, 'num': 30},
 'Clinical_Medicine': {'acc': 0.633, 'num': 30},
 'Computer_Science': {'acc': 0.433, 'num': 30},
 'Design': {'acc': 0.7, 'num': 30},
 'Diagnostics_and_Laboratory_Medicine': {'acc': 0.433, 'num': 30},
 'Economics': {'acc': 0.467, 'num': 30},
 'Electronics': {'acc': 0.267, 'num': 30},
 'Energy_and_Power': {'acc': 0.267, 'num': 30},
 'Finance': {'acc': 0.367, 'num': 30},
 'Geography': {'acc': 0.433, 'num': 30},
 'History': {'acc': 0.667, 'num': 30},
 'Literature': {'acc': 0.8, 'num': 30},
 'Manage': {'acc': 0.4, 'num': 30},
 'Marketing': {'acc': 0.467, 'num': 30},
 'Materials': {'acc': 0.433, 'num': 30},
 'Math': {'acc': 0.467, 'num': 30},
 'Mechanical_Engineering': {'acc': 0.5, 'num': 30},
 'Music': {'acc': 0.5, 'num': 30},
 'Overall': {'acc': 0.513, 'num': 900},
 'Overall-Art and Design': {'acc': 0.667, 'num': 120},
 'Overall-Business': {'acc': 0.427, 'num': 150},
 'Overall-Health and Medicine': {'acc': 0.587, 'num': 150},
 'Overall-Humanities and Social Science': {'acc': 0.675, 'num': 120},
 'Overall-Science': {'acc': 0.407, 'num': 150},
 'Overall-Tech and Engineering': {'acc': 0.419, 'num': 210},
 'Pharmacy': {'acc': 0.633, 'num': 30},
 'Physics': {'acc': 0.433, 'num': 30},
 'Psychology': {'acc': 0.7, 'num': 30},
 'Public_Health': {'acc': 0.633, 'num': 30},
 'Sociology': {'acc': 0.533, 'num': 30}}
eval out saved to ./val_sglang.json
Overall accuracy: 0.513
```
So the accuracy is the same. We use @ `43de1d7304063ddb432a0990e65271d82f622e1f` on `main`. This shouldn't change anything anyways.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Speed it up by 4-6% across all metrics.
Provide the following to get the same result. On A100-40GB
Server launch CMD
```python
SGLANG_VLM_CACHE_SIZE_MB=0 python -m sglang.launch_server \
    --model-path Qwen/Qwen2.5-VL-7B-Instruct \
    --mem-fraction-static 0.8 \
    --chat-template 'qwen2-vl' \
    --tp 1 \
    --disable-radix-cache \
    --cuda-graph-bs 256 \
    --cuda-graph-max-bs 256 \
    --chunked-prefill-size 8192 \
    --max-prefill-tokens 8192 \
    --max-running-requests 256 \
    --enable-multimodal
```
Benchmark Command:
On main:
```python
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --dataset-name random-image \
  --random-image-num-images 1 \
  --random-image-resolution 720p \
  --random-input-len 128 \
  --random-output-len 256 \
  --num-prompts 500 \
  --request-rate 20 \
  --max-concurrency 64 \
  --apply-chat-template \
  --warmup-requests 5 \
  --output-details
benchmark_args=Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=500, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=500, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

/root/sglang/python/sglang/bench_serving.py:1211: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
  img = Image.fromarray(arr, mode="RGB")
#Input tokens: 44417
#Output tokens: 62361
Starting warmup with 5 sequences...
Warmup completed with 5 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [02:40<00:00,  3.12it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    20.0      
Max request concurrency:                 64        
Successful requests:                     500       
Benchmark duration (s):                  160.40    
Total input tokens:                      44417     
Total generated tokens:                  62362     
Total generated tokens (retokenized):    50798     
Request throughput (req/s):              3.12      
Input token throughput (tok/s):          276.92    
Output token throughput (tok/s):         388.80    
Total token throughput (tok/s):          665.71    
Concurrency:                             62.00     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   19888.11  
Median E2E Latency (ms):                 18653.94  
---------------Time to First Token----------------
Mean TTFT (ms):                          2317.63   
Median TTFT (ms):                        1164.60   
P99 TTFT (ms):                           13668.96  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           142.01    
Median ITL (ms):                         32.33     
P95 ITL (ms):                            825.44    
P99 ITL (ms):                            1422.96   
Max ITL (ms):                            16330.56  
==================================================
```

On new branch:
```python
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --dataset-name random-image \
  --random-image-num-images 1 \
  --random-image-resolution 720p \
  --random-input-len 128 \
  --random-output-len 256 \
  --num-prompts 500 \
  --request-rate 20 \
  --max-concurrency 64 \
  --apply-chat-template \
  --warmup-requests 5 \
  --output-details
benchmark_args=Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=500, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=500, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

/root/sglang/python/sglang/bench_serving.py:1211: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
  img = Image.fromarray(arr, mode="RGB")
#Input tokens: 44489
#Output tokens: 62361
Starting warmup with 5 sequences...
Warmup completed with 5 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [02:32<00:00,  3.27it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    20.0      
Max request concurrency:                 64        
Successful requests:                     500       
Benchmark duration (s):                  153.00    
Total input tokens:                      44489     
Total generated tokens:                  62362     
Total generated tokens (retokenized):    51028     
Request throughput (req/s):              3.27      
Input token throughput (tok/s):          290.78    
Output token throughput (tok/s):         407.60    
Total token throughput (tok/s):          698.39    
Concurrency:                             61.86     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   18928.03  
Median E2E Latency (ms):                 17681.19  
---------------Time to First Token----------------
Mean TTFT (ms):                          2171.95   
Median TTFT (ms):                        1094.55   
P99 TTFT (ms):                           12949.94  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           135.43    
Median ITL (ms):                         31.26     
P95 ITL (ms):                            752.35    
P99 ITL (ms):                            1421.37   
Max ITL (ms):                            15660.48  
==================================================
```

For the profiling step:
```python
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --dataset-name random-image \
  --random-image-num-images 1 \
  --random-image-resolution 720p \
  --random-input-len 128 \
  --random-output-len 256 \
  --num-prompts 20 \
  --request-rate 20 \
  --max-concurrency 64 \
  --apply-chat-template \
  --warmup-requests 5 \
  --output-details \
  --profile
```
Note that the profile introduce overhead, so don't use it to measure stats except profile
Once you ran the server with `--profile`, you can run:
```python
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --dataset-name random-image \
  --random-image-num-images 1 \
  --random-image-resolution 720p \
  --random-input-len 128 \
  --random-output-len 256 \
  --num-prompts 20 \
  --request-rate 20 \
  --max-concurrency 64 \
  --apply-chat-template \
  --warmup-requests 5 \
  --output-details \
  --profile
``` 
To PROFILE the result. Reminder: Don't prof with > 20 prompts otherwise the writing of the logs will take too long.

The profiler results are as follows:
Results:
https://github.com/vincentzed/sglang-trace-files#
Before:
`1756317170.6509697-TP-0.trace.json.gz`
After:
`1756318651.6023033-TP-0.trace.json.gz`

And the result of the important parts (I skip attaching a GUI screenshot since it's hard to view anyways).
```SQL
SELECT
  COUNT(*)              AS calls,
  SUM(dur)/1e6         AS total_ms,
  AVG(dur)/1e6         AS mean_ms,
  PERCENTILE(dur,50)/1e6 AS p50_ms,
  PERCENTILE(dur,95)/1e6 AS p95_ms
FROM slice
WHERE name = 'python/sglang/srt/model_executor/model_runner.py(1738): forward';
```

Before:
calls	total_ms	mean_ms	p50_ms	p95_ms
259	4026.40341	15.545959111969111	3.65334	13.158490199999996
After:
calls	total_ms	mean_ms	p50_ms	p95_ms
259	3835.939124	14.810575768339769	2.944004	4.545669599999999


Formatted nicely:
| Metric   |   Before   |    After    |    Delta    |   Delta %   |
|----------|------------|-------------|-------------|-------------|
| calls    | 259.000000 | 259.000000  | 0.000000    | 0.000000    |
| total_ms | 4026.40341 | 3835.939124 | -190.464286 | -4.730383   |
| mean_ms  | 15.545959  | 14.810576   | -0.735383   | -4.730383   |
| p50_ms   | 3.653340   | 2.944004    | -0.709336   | -19.416096  |
| p95_ms   | 13.158490  | 4.545670    | -8.612821   | -65.454474  |

## Note
The Qwen2RMSNorm is equivalent to T5LayerNorm.


| Metric                        | Main     | New      | Delta     | Delta %   |
|-------------------------------|----------|----------|-----------|-----------|
| Request throughput (req/s)    | 3.12     | 3.27     | +0.15     | +4.81%    |
| Input token throughput (tok/s)| 276.92   | 290.78   | +13.86    | +5.01%    |
| Output token throughput (tok/s)| 388.80  | 407.60   | +18.80    | +4.84%    |
| Total token throughput (tok/s)| 665.71   | 698.39   | +32.68    | +4.91%    |
| Mean E2E Latency (ms)         | 19888.11 | 18928.03 | -960.08   | -4.83%    |
| Median E2E Latency (ms)       | 18653.94 | 17681.19 | -972.75   | -5.21%    |
| Mean TTFT (ms)                | 2317.63  | 2171.95  | -145.68   | -6.29%    |
| Median TTFT (ms)              | 1164.60  | 1094.55  | -70.05    | -6.02%    |
| P99 TTFT (ms)                 | 13668.96 | 12949.94 | -719.02   | -5.26%    |
| Mean ITL (ms)                 | 142.01   | 135.43   | -6.58     | -4.63%    |
| Median ITL (ms)               | 32.33    | 31.26    | -1.07     | -3.31%    |
| P95 ITL (ms)                  | 825.44   | 752.35   | -73.09    | -8.85%    |
| P99 ITL (ms)                  | 1422.96  | 1421.37  | -1.59     | -0.11%    |
| Max ITL (ms)                  | 16330.56 | 15660.48 | -670.08   | -4.10%    |

## Summary
- Throughput improvements: ~4.8–5% across requests, input tokens, output tokens, and total tokens.
- Latency reductions: ~5% lower for mean and median E2E latency, and similar reductions in TTFT and ITL.
- Outlier latency (P99 ITL) remained nearly flat (-0.11%).
- Overall: branch change yields consistent 4–6% performance gain in throughput with reduced latency.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
