### PR TITLE
Add quantization before allgather and reducescatter support for gpt-oss

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -802,6 +802,8 @@ def get_moe_impl_class(quant_config: Optional[QuantizationConfig] = None):
                 )
 
                 return FlashInferFP4MoE
+            elif quantization == "mxfp4":
+                return FusedMoE
         except:
             pass
 

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -203,14 +203,6 @@ class FusedMoE(torch.nn.Module):
         assert self.quant_method is not None
 
         self.quant_config = quant_config
-        self.use_flashinfer_mxfp4_moe = get_moe_runner_backend().is_flashinfer_mxfp4()
-        # TODO maybe we should remove this `if`, since `Mxfp4MoEMethod` does another round-up logic
-        if (
-            self.quant_config is not None
-            and self.quant_config.get_name() == "mxfp4"
-            and self.use_flashinfer_mxfp4_moe
-        ):
-            hidden_size = round_up(hidden_size, 256)
         self.quant_method.create_weights(
             layer=self,
             num_experts=self.num_local_experts,
@@ -477,9 +469,12 @@ class FusedMoE(torch.nn.Module):
                 dim1 = loaded_weight.shape[1]
                 param.data[:, :dim1].copy_(loaded_weight)
             else:
+                packing_factor = (
+                    param.data.element_size() // loaded_weight.element_size()
+                )
                 dim1 = loaded_weight.shape[1]
-                dim2 = loaded_weight.shape[2]
-                param.data[:, :dim1, :dim2].copy_(loaded_weight)
+                dim2 = loaded_weight.shape[2] // packing_factor
+                param.data[:, :dim1, :dim2].copy_(loaded_weight.view(param.data.dtype))
             return
 
         global_expert_location_metadata = get_global_expert_location_metadata()
@@ -730,12 +725,13 @@ class FusedMoE(torch.nn.Module):
             if "bias" in weight_name:
                 dim1 = loaded_weight.shape[1]
                 param.data[:, :dim1].copy_(loaded_weight)
-            elif "scale" in weight_name:
-                param.data.copy_(loaded_weight)
             else:
                 dim1 = loaded_weight.shape[1]
-                dim2 = loaded_weight.shape[2]
-                param.data[:, :dim1, :dim2].copy_(loaded_weight)
+                packing_factor = (
+                    param.data.element_size() // loaded_weight.element_size()
+                )
+                dim2 = loaded_weight.shape[2] // packing_factor
+                param.data[:, :dim1, :dim2].copy_(loaded_weight.view(param.data.dtype))
             return
 
         # compressed-tensors checkpoints with packed weights are stored flipped

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -256,10 +256,7 @@ class TopK(CustomOp):
                 sm_first=not self.topk_config.renormalize,
             )
             return TritonKernelTopKOutput(routing_data, gather_idx, scatter_idx)
-        elif not self.force_topk and (
-            should_use_flashinfer_trtllm_moe()
-            or get_moe_runner_backend().is_flashinfer_mxfp4()
-        ):
+        elif not self.force_topk and should_use_flashinfer_trtllm_moe():
             return BypassedTopKOutput(
                 hidden_states=hidden_states,
                 router_logits=router_logits,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -195,6 +195,6 @@ def should_use_flashinfer_cutlass_moe_fp4_allgather():
         not DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
         and get_moe_runner_backend().is_flashinfer_cutlass()
         and is_dp_attention_enabled()
-        and MOE_QUANTIZATION == "modelopt_fp4"
+        and (MOE_QUANTIZATION == "modelopt_fp4" or MOE_QUANTIZATION == "mxfp4")
         and get_moe_expert_parallel_world_size() == get_attention_dp_size()
     )

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -46,7 +46,6 @@ class MoeRunnerBackend(Enum):
     TRITON_KERNEL = "triton_kernel"
     FLASHINFER = "flashinfer_trtllm"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
-    FLASHINFER_MXFP4 = "flashinfer_mxfp4"
 
     def is_auto(self):
         return self == MoeRunnerBackend.AUTO
@@ -62,9 +61,6 @@ class MoeRunnerBackend(Enum):
 
     def is_flashinfer_cutlass(self):
         return self == MoeRunnerBackend.FLASHINFER_CUTLASS
-
-    def is_flashinfer_mxfp4(self):
-        return self == MoeRunnerBackend.FLASHINFER_MXFP4
 
 
 class DeepEPMode(Enum):
@@ -105,6 +101,7 @@ IS_TBO_ENABLED: Optional[bool] = None
 TBO_TOKEN_DISTRIBUTION_THRESHOLD: Optional[float] = None
 DEEPEP_CONFIG: Optional[str] = None
 DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER: Optional[bool] = None
+MOE_QUANTIZATION: Optional[str] = None
 
 
 def initialize_moe_config(server_args: ServerArgs):
@@ -115,6 +112,7 @@ def initialize_moe_config(server_args: ServerArgs):
     global IS_TBO_ENABLED
     global TBO_TOKEN_DISTRIBUTION_THRESHOLD
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
+    global MOE_QUANTIZATION
 
     MOE_A2A_BACKEND = MoeA2ABackend(server_args.moe_a2a_backend)
     MOE_RUNNER_BACKEND = MoeRunnerBackend(server_args.moe_runner_backend)
@@ -125,6 +123,7 @@ def initialize_moe_config(server_args: ServerArgs):
     DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = (
         server_args.disable_flashinfer_cutlass_moe_fp4_allgather
     )
+    MOE_QUANTIZATION = server_args.quantization
 
 
 def get_moe_a2a_backend() -> MoeA2ABackend:
@@ -196,5 +195,6 @@ def should_use_flashinfer_cutlass_moe_fp4_allgather():
         not DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
         and get_moe_runner_backend().is_flashinfer_cutlass()
         and is_dp_attention_enabled()
+        and MOE_QUANTIZATION == "modelopt_fp4"
         and get_moe_expert_parallel_world_size() == get_attention_dp_size()
     )

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -50,6 +50,7 @@ has_triton_kernels = is_triton_kernels_available()
 
 if is_flashinfer_available():
     from flashinfer import (
+        block_scale_interleave,
         mxfp8_quantize,
         shuffle_matrix_a,
         shuffle_matrix_sf_a,
@@ -70,6 +71,11 @@ if _is_hip:
     from aiter.fused_moe import fused_moe
     from aiter.ops.triton.quant import dynamic_mxfp4_quant
     from aiter.utility.fp4_utils import e8m0_shuffle
+
+try:
+    from flashinfer.fused_moe import cutlass_fused_moe as flashinfer_cutlass_fused_moe
+except ImportError:
+    flashinfer_cutlass_fused_moe = None
 
 
 def _swizzle_mxfp4(quant_tensor, scale, num_warps):
@@ -255,7 +261,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.topk_indices_dtype = None
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernel()
         self.with_bias = False
-        self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
+        self.enable_flashinfer_cutlass_moe = (
+            get_moe_runner_backend().is_flashinfer_cutlass()
+        )
+        self.use_flashinfer = (
+            get_moe_runner_backend().is_flashinfer_trtllm()
+            or self.enable_flashinfer_cutlass_moe
+        )
         self.flashinfer_mxfp4_moe_precision = global_server_args_dict[
             "flashinfer_mxfp4_moe_precision"
         ]
@@ -273,6 +285,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             self.triton_kernel_moe_forward = _tk_forward
             self.triton_kernel_moe_with_bias_forward = _tk_with_bias_forward
 
+        self.weight_dtype = (
+            torch.int64 if self.enable_flashinfer_cutlass_moe else torch.uint8
+        )
+        self.initial_weight_dtype = torch.uint8
+        self.initial_scale_dtype = torch.uint8
+        self.scale_dtype = (
+            torch.int32 if self.enable_flashinfer_cutlass_moe else torch.uint8
+        )
+        self.weight_alignment = 128 if self.enable_flashinfer_cutlass_moe else 256
+        self.weight_vec_size = torch.iinfo(self.weight_dtype).bits // 4
+        self.scaling_vector_size = 32
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -284,20 +308,19 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         **extra_weight_attrs,
     ):
         self.num_experts = num_experts
-        weight_dtype = torch.uint8
-        scale_dtype = torch.uint8
         self.with_bias = with_bias
-        mxfp4_block = 32
 
+        self.initial_intermediate_size = intermediate_size
+        self.initial_hidden_size = hidden_size
         # pad the intermediate size to be a multiple of 2 * mxfp4_block
         # for to hold non-uniform sharded tensor as well as swizzling
         intermediate_size_per_partition_after_pad = intermediate_size
         if _is_sm100_supported:
             if self.use_flashinfer:
                 intermediate_size_per_partition_after_pad = round_up(
-                    intermediate_size, 256
+                    intermediate_size, self.weight_alignment
                 )
-                hidden_size = round_up(hidden_size, 256)
+                hidden_size = round_up(hidden_size, self.weight_alignment)
             else:
                 intermediate_size_per_partition_after_pad = round_up(
                     intermediate_size, 64
@@ -318,20 +341,19 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             torch.zeros(
                 layer.num_local_experts,
                 2 * intermediate_size_per_partition_after_pad,
-                hidden_size // 2,
-                dtype=weight_dtype,
+                hidden_size // self.weight_vec_size,
+                dtype=self.weight_dtype,
             ),
             requires_grad=False,
         )
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
-
         w13_weight_scale = torch.nn.Parameter(
             torch.zeros(
                 layer.num_local_experts,
                 2 * intermediate_size_per_partition_after_pad,
-                hidden_size // mxfp4_block,
-                dtype=scale_dtype,
+                hidden_size // self.scaling_vector_size,
+                dtype=self.initial_scale_dtype,
             ),
             requires_grad=False,
         )
@@ -354,8 +376,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             torch.zeros(
                 layer.num_local_experts,
                 hidden_size,
-                intermediate_size_per_partition_after_pad // 2,
-                dtype=weight_dtype,
+                intermediate_size_per_partition_after_pad // self.weight_vec_size,
+                dtype=self.weight_dtype,
             ),
             requires_grad=False,
         )
@@ -366,8 +388,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             torch.zeros(
                 layer.num_local_experts,
                 hidden_size,
-                intermediate_size_per_partition_after_pad // mxfp4_block,
-                dtype=scale_dtype,
+                intermediate_size_per_partition_after_pad // self.scaling_vector_size,
+                dtype=self.initial_scale_dtype,
             ),
             requires_grad=False,
         )
@@ -382,11 +404,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
-        if self.use_flashinfer:
-            log_info_on_rank0(
-                logger,
-                f"Shuffling MoE weights for FlashInfer MXFP4 moe kernel (layer: {self.prefix}), it might take a while...",
+        if self.enable_flashinfer_cutlass_moe:
+            fake_input_scale = torch.nn.Parameter(
+                torch.ones(layer.num_local_experts, dtype=torch.float32),
+                requires_grad=False,
             )
+            layer.register_parameter("fake_input_scale", fake_input_scale)
+
+        if self.use_flashinfer:
             # TODO: these values are hardcoded for now, we need to get them from the model
             layer.gemm1_alpha = Parameter(
                 torch.tensor([1.702] * self.num_experts, dtype=torch.float32).cuda(),
@@ -400,31 +425,33 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 torch.tensor([7.0] * self.num_experts, dtype=torch.float32).cuda(),
                 requires_grad=False,
             )
-            sf_block_size = 32  # mxfp4 block size
 
             assert (
                 layer.w13_weight.dim() == 3
                 and layer.w13_weight.shape[0] == self.num_experts
                 and layer.w13_weight.shape[1] == self.intermediate_size * 2
-                and layer.w13_weight.shape[2] == self.hidden_size // 2
+                and layer.w13_weight.shape[2]
+                == self.hidden_size // self.weight_vec_size
             )
             assert (
                 layer.w13_weight_scale.dim() == 3
                 and layer.w13_weight_scale.shape[0] == self.num_experts
                 and layer.w13_weight_scale.shape[1] == self.intermediate_size * 2
-                and layer.w13_weight_scale.shape[2] == self.hidden_size // sf_block_size
+                and layer.w13_weight_scale.shape[2]
+                == self.hidden_size // self.scaling_vector_size
             )
             assert (
                 layer.w2_weight.dim() == 3
                 and layer.w2_weight.shape[0] == self.num_experts
                 and layer.w2_weight.shape[1] == self.hidden_size
-                and layer.w2_weight.shape[2] == self.intermediate_size // 2
+                and layer.w2_weight.shape[2]
+                == self.intermediate_size // self.weight_vec_size
             )
             assert (
                 layer.w2_weight_scale.dim() == 3
                 and layer.w2_weight_scale.shape[1] == self.hidden_size
                 and layer.w2_weight_scale.shape[2]
-                == self.intermediate_size // sf_block_size
+                == self.intermediate_size // self.scaling_vector_size
             )
             assert (
                 layer.w13_weight_bias.dim() == 2
@@ -441,100 +468,159 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             w2_weight_scale = layer.w2_weight_scale.data
             w13_weight = layer.w13_weight.data
             w2_weight = layer.w2_weight.data
-            w13_bias = layer.w13_weight_bias.data.to(torch.float32)
-            w2_bias = layer.w2_weight_bias.data.to(torch.float32)
+            w13_bias = layer.w13_weight_bias.data
+            w2_bias = layer.w2_weight_bias.data
 
-            # Swap w1 and w3 as the definition of
-            # swiglu is different in the trtllm-gen
-            def swap_every_two_rows(x, axis=-1):
-                shape = x.shape
-                if axis < 0:
-                    axis = len(shape) + axis
-
-                # Create a new shape with pairs swapped along specified axis
-                new_shape = list(shape)
-                new_shape[axis] = shape[axis] // 2
-                new_shape.insert(axis + 1, 2)
-
-                # Reshape to expose pairs, swap them, and reshape back
-                x = x.reshape(*new_shape)
-                x = x.flip(axis + 1)
-                new_shape = list(shape)
-                return x.reshape(*new_shape)
-
-            w13_weight_scale = swap_every_two_rows(w13_weight_scale, -2)
-            w13_weight = swap_every_two_rows(w13_weight, -2)
-            w13_bias = swap_every_two_rows(w13_bias, -1)
-
-            # Shuffle weights and scaling factors for transposed mma output
-            gemm1_weights_mxfp4_shuffled = []
-            gemm1_scales_mxfp4_shuffled = []
-            gemm2_weights_mxfp4_shuffled = []
-            gemm2_scales_mxfp4_shuffled = []
-            gemm1_bias_shuffled = []
-            gemm2_bias_shuffled = []
-            epilogue_tile_m = 128  # FIXME: this depends on the kernel internals
-            for i in range(self.num_experts):
-                gemm1_weights_mxfp4_shuffled.append(
-                    shuffle_matrix_a(w13_weight[i].view(torch.uint8), epilogue_tile_m)
+            if self.enable_flashinfer_cutlass_moe:
+                # Deinterleave gate and up
+                gate_weight, up_weight = w13_weight[:, ::2, :], w13_weight[:, 1::2, :]
+                w13_weight = torch.cat([up_weight, gate_weight], dim=-2)
+                gate_weight_scale, up_weight_scale = (
+                    w13_weight_scale[:, ::2, :],
+                    w13_weight_scale[:, 1::2, :],
                 )
-                gemm1_scales_mxfp4_shuffled.append(
-                    shuffle_matrix_sf_a(
-                        w13_weight_scale[i].view(torch.uint8), epilogue_tile_m
+                w13_weight_scale = torch.cat(
+                    [up_weight_scale, gate_weight_scale], dim=-2
+                )
+                gate_bias, up_bias = w13_bias[:, ::2], w13_bias[:, 1::2]
+                w13_bias = torch.cat([up_bias, gate_bias], dim=-1)
+
+                layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+                layer.w13_weight_bias = Parameter(w13_bias, requires_grad=False)
+
+                w13_original_shape = w13_weight_scale.shape
+                w2_original_shape = w2_weight_scale.shape
+                interleaved_w13_weight_scale = []
+                interleaved_w2_weight_scale = []
+                for i in range(self.num_experts):
+                    interleaved_w13_weight_scale.append(
+                        block_scale_interleave(w13_weight_scale[i])
                     )
-                )
-                gemm1_bias_shuffled.append(
-                    shuffle_matrix_a(
-                        w13_bias[i].clone().reshape(-1, 1), epilogue_tile_m
+                    interleaved_w2_weight_scale.append(
+                        block_scale_interleave(w2_weight_scale[i])
                     )
+
+                w13_weight_scale = (
+                    torch.stack(interleaved_w13_weight_scale)
+                    .reshape(w13_original_shape)
+                    .view(self.scale_dtype)
+                )
+                w2_weight_scale = (
+                    torch.stack(interleaved_w2_weight_scale)
+                    .reshape(w2_original_shape)
+                    .view(self.scale_dtype)
+                )
+                layer.w13_weight_scale = Parameter(
+                    w13_weight_scale, requires_grad=False
+                )
+                layer.w2_weight_scale = Parameter(w2_weight_scale, requires_grad=False)
+            else:
+                log_info_on_rank0(
+                    logger,
+                    f"Shuffling MoE weights for FlashInfer MXFP4 moe kernel (layer: {self.prefix}), it might take a while...",
                 )
 
-                gemm2_weights_mxfp4_shuffled.append(
-                    shuffle_matrix_a(w2_weight[i].view(torch.uint8), epilogue_tile_m)
-                )
-                gemm2_scales_mxfp4_shuffled.append(
-                    shuffle_matrix_sf_a(
-                        w2_weight_scale[i].view(torch.uint8), epilogue_tile_m
+                # Swap w1 and w3 as the definition of
+                # swiglu is different in the trtllm-gen
+                def swap_every_two_rows(x, axis=-1):
+                    shape = x.shape
+                    if axis < 0:
+                        axis = len(shape) + axis
+
+                    # Create a new shape with pairs swapped along specified axis
+                    new_shape = list(shape)
+                    new_shape[axis] = shape[axis] // 2
+                    new_shape.insert(axis + 1, 2)
+
+                    # Reshape to expose pairs, swap them, and reshape back
+                    x = x.reshape(*new_shape)
+                    x = x.flip(axis + 1)
+                    new_shape = list(shape)
+                    return x.reshape(*new_shape)
+
+                w13_weight_scale = swap_every_two_rows(w13_weight_scale, -2)
+                w13_weight = swap_every_two_rows(w13_weight, -2)
+                w13_bias = swap_every_two_rows(w13_bias, -1)
+
+                # Shuffle weights and scaling factors for transposed mma output
+                gemm1_weights_mxfp4_shuffled = []
+                gemm1_scales_mxfp4_shuffled = []
+                gemm2_weights_mxfp4_shuffled = []
+                gemm2_scales_mxfp4_shuffled = []
+                gemm1_bias_shuffled = []
+                gemm2_bias_shuffled = []
+                epilogue_tile_m = 128  # FIXME: this depends on the kernel internals
+                w13_bias = w13_bias.to(torch.float32)
+                w2_bias = w2_bias.to(torch.float32)
+                for i in range(self.num_experts):
+                    gemm1_weights_mxfp4_shuffled.append(
+                        shuffle_matrix_a(
+                            w13_weight[i].view(torch.uint8), epilogue_tile_m
+                        )
                     )
-                )
-                gemm2_bias_shuffled.append(
-                    shuffle_matrix_a(w2_bias[i].clone().reshape(-1, 1), epilogue_tile_m)
+                    gemm1_scales_mxfp4_shuffled.append(
+                        shuffle_matrix_sf_a(
+                            w13_weight_scale[i].view(torch.uint8), epilogue_tile_m
+                        )
+                    )
+                    gemm1_bias_shuffled.append(
+                        shuffle_matrix_a(
+                            w13_bias[i].clone().reshape(-1, 1), epilogue_tile_m
+                        )
+                    )
+
+                    gemm2_weights_mxfp4_shuffled.append(
+                        shuffle_matrix_a(
+                            w2_weight[i].view(torch.uint8), epilogue_tile_m
+                        )
+                    )
+                    gemm2_scales_mxfp4_shuffled.append(
+                        shuffle_matrix_sf_a(
+                            w2_weight_scale[i].view(torch.uint8), epilogue_tile_m
+                        )
+                    )
+                    gemm2_bias_shuffled.append(
+                        shuffle_matrix_a(
+                            w2_bias[i].clone().reshape(-1, 1), epilogue_tile_m
+                        )
+                    )
+
+                w13_weight = torch.stack(gemm1_weights_mxfp4_shuffled)
+                w13_weight_scale = (
+                    torch.stack(gemm1_scales_mxfp4_shuffled)
+                    .reshape(
+                        self.num_experts,
+                        2 * self.intermediate_size,
+                        self.hidden_size // self.scaling_vector_size,
+                    )
+                    .view(torch.float8_e4m3fn)
                 )
 
-            w13_weight = torch.stack(gemm1_weights_mxfp4_shuffled)
-            w13_weight_scale = (
-                torch.stack(gemm1_scales_mxfp4_shuffled)
-                .reshape(
-                    self.num_experts,
-                    2 * self.intermediate_size,
-                    self.hidden_size // sf_block_size,
+                w2_weight = torch.stack(gemm2_weights_mxfp4_shuffled)
+                w2_weight_scale = (
+                    torch.stack(gemm2_scales_mxfp4_shuffled)
+                    .reshape(
+                        self.num_experts,
+                        self.hidden_size,
+                        self.intermediate_size // self.scaling_vector_size,
+                    )
+                    .view(torch.float8_e4m3fn)
                 )
-                .view(torch.float8_e4m3fn)
-            )
 
-            w2_weight = torch.stack(gemm2_weights_mxfp4_shuffled)
-            w2_weight_scale = (
-                torch.stack(gemm2_scales_mxfp4_shuffled)
-                .reshape(
-                    self.num_experts,
-                    self.hidden_size,
-                    self.intermediate_size // sf_block_size,
+                layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+                layer.w13_weight_scale = Parameter(
+                    w13_weight_scale, requires_grad=False
                 )
-                .view(torch.float8_e4m3fn)
-            )
-
-            layer.w13_weight = Parameter(w13_weight, requires_grad=False)
-            layer.w13_weight_scale = Parameter(w13_weight_scale, requires_grad=False)
-            layer.w2_weight = Parameter(w2_weight, requires_grad=False)
-            layer.w2_weight_scale = Parameter(w2_weight_scale, requires_grad=False)
-            layer.w13_weight_bias = Parameter(
-                torch.stack(gemm1_bias_shuffled).reshape(self.num_experts, -1),
-                requires_grad=False,
-            )
-            layer.w2_weight_bias = Parameter(
-                torch.stack(gemm2_bias_shuffled).reshape(self.num_experts, -1),
-                requires_grad=False,
-            )
+                layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+                layer.w2_weight_scale = Parameter(w2_weight_scale, requires_grad=False)
+                layer.w13_weight_bias = Parameter(
+                    torch.stack(gemm1_bias_shuffled).reshape(self.num_experts, -1),
+                    requires_grad=False,
+                )
+                layer.w2_weight_bias = Parameter(
+                    torch.stack(gemm2_bias_shuffled).reshape(self.num_experts, -1),
+                    requires_grad=False,
+                )
             return
 
         if self.use_triton_kernels:
@@ -637,12 +723,50 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                         value=0.0,
                     )
             elif self.flashinfer_mxfp4_moe_precision == "default":
-                x_quant, x_scale = mxfp8_quantize(x, False, alignment=self.hidden_size)
+                x_quant, x_scale = mxfp8_quantize(
+                    x,
+                    self.enable_flashinfer_cutlass_moe,
+                    alignment=self.weight_alignment,
+                )
                 x_scale = x_scale.view(torch.float8_e4m3fn).reshape(-1)
             else:
                 raise NotImplementedError
 
             assert x_quant.shape[-1] == self.hidden_size
+
+        if self.enable_flashinfer_cutlass_moe:
+            topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
+            output_dtype = x.dtype
+
+            output = flashinfer_cutlass_fused_moe(
+                input=x_quant,
+                token_selected_experts=topk_ids.to(torch.int),
+                token_final_scales=topk_weights,
+                fc1_expert_weights=layer.w13_weight,
+                fc1_expert_biases=layer.w13_weight_bias,
+                fc2_expert_weights=layer.w2_weight,
+                fc2_expert_biases=layer.w2_weight_bias,
+                output_dtype=output_dtype,
+                input_sf=x_scale,
+                swiglu_alpha=layer.gemm1_alpha,
+                swiglu_beta=layer.gemm1_beta,
+                swiglu_limit=layer.gemm1_clamp_limit,
+                quant_scales=[
+                    layer.w13_weight_scale,
+                    layer.fake_input_scale,
+                    layer.w2_weight_scale,
+                    layer.fake_input_scale,
+                ],
+                ep_size=layer.moe_ep_size,
+                ep_rank=layer.moe_ep_rank,
+                tp_size=layer.moe_tp_size,
+                tp_rank=layer.moe_tp_rank,
+                tune_max_num_tokens=next_power_of_2(x.shape[0]),
+                use_mxfp8_act_scaling=True,
+            )[0]
+            return output
+
+        if self.use_flashinfer:
             assert TopKOutputChecker.format_is_bypassed(topk_output)
 
             top_k = topk_output.topk_config.top_k

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -330,7 +330,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             # intermediate_size_per_partition_after_pad the same as the
             # per_rank_intermediate_size during weight loading
             intermediate_size_per_partition_after_pad = round_up(
-                intermediate_size, mxfp4_block
+                intermediate_size, self.scaling_vector_size
             )
 
         self.intermediate_size = intermediate_size_per_partition_after_pad

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -162,9 +162,12 @@ class GptOssSparseMoeBlock(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: Optional[ForwardBatch] = None,
         should_allreduce_fusion: bool = False,
+        use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
         if not get_moe_a2a_backend().is_deepep():
-            return self.forward_normal(hidden_states, should_allreduce_fusion)
+            return self.forward_normal(
+                hidden_states, should_allreduce_fusion, use_reduce_scatter
+            )
         else:
             raise Exception("forward_deepep branch not implemented yet")
 
@@ -179,6 +182,7 @@ class GptOssSparseMoeBlock(nn.Module):
         self,
         hidden_states: torch.Tensor,
         should_allreduce_fusion: bool = False,
+        use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
 
@@ -186,7 +190,7 @@ class GptOssSparseMoeBlock(nn.Module):
         topk_output = self.topk(hidden_states, router_logits)
         final_hidden_states = self.experts(hidden_states, topk_output)
 
-        if self.tp_size > 1 and not should_allreduce_fusion:
+        if self.tp_size > 1 and not should_allreduce_fusion and not use_reduce_scatter:
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         ans = final_hidden_states.view(num_tokens, hidden_dim)
@@ -458,6 +462,7 @@ class GptOssDecoderLayer(nn.Module):
             is_last_layer=(
                 self.is_nextn or (self.layer_id == self.config.num_hidden_layers - 1)
             ),
+            allow_reduce_scatter=True,
         )
 
     def forward(
@@ -488,7 +493,13 @@ class GptOssDecoderLayer(nn.Module):
             )
         )
 
-        hidden_states = self.mlp(hidden_states, forward_batch, should_allreduce_fusion)
+        # For DP with padding, reduce scatter can be used instead of all-reduce.
+        use_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(
+            forward_batch
+        )
+        hidden_states = self.mlp(
+            hidden_states, forward_batch, should_allreduce_fusion, use_reduce_scatter
+        )
 
         if should_allreduce_fusion:
             hidden_states._sglang_needs_allreduce_fusion = True

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -188,7 +188,6 @@ class ServerArgs:
         "triton_kernel",
         "flashinfer_trtllm",
         "flashinfer_cutlass",
-        "flashinfer_mxfp4",
     ] = "auto"
     flashinfer_mxfp4_moe_precision: Literal["default", "bf16"] = "default"
     enable_flashinfer_allreduce_fusion: bool = False
@@ -335,9 +334,9 @@ class ServerArgs:
                 "NOTE: --enable-flashinfer-trtllm-moe is deprecated. Please set `--moe-runner-backend` to 'flashinfer_trtllm' instead."
             )
         if self.enable_flashinfer_mxfp4_moe:
-            self.moe_runner_backend = "flashinfer_mxfp4"
+            self.moe_runner_backend = "flashinfer_trtllm"
             print_deprecated_warning(
-                "NOTE: --enable-flashinfer-mxfp4-moe is deprecated. Please set `--moe-runner-backend` to 'flashinfer_mxfp4' instead."
+                "NOTE: --enable-flashinfer-mxfp4-moe is deprecated. Please set `--moe-runner-backend` to 'flashinfer_trtllm' instead."
             )
 
         # Set missing default values
@@ -550,8 +549,8 @@ class ServerArgs:
         # MoE kernel
         if self.moe_runner_backend == "flashinfer_cutlass":
             assert (
-                self.quantization == "modelopt_fp4"
-            ), "modelopt_fp4 quantization is required for Flashinfer MOE"
+                self.quantization == "modelopt_fp4" or self.quantization == "mxfp4"
+            ), "modelopt_fp4 or mxfp4 quantization is required for Flashinfer MOE"
             assert self.ep_size in [
                 1,
                 self.tp_size,
@@ -2257,9 +2256,11 @@ class ServerArgs:
             )
 
             if is_sm100_supported() and is_mxfp4_quant_format:
-                self.moe_runner_backend = "flashinfer_mxfp4"
+                if self.moe_runner_backend == "auto":
+                    self.moe_runner_backend = "flashinfer_trtllm"
+                self.quantization = "mxfp4"
                 logger.warning(
-                    "Detected SM100 and MXFP4 quantization format for GPT-OSS model, enabling FlashInfer MXFP4 MOE kernel."
+                    "Detected SM100 and MXFP4 quantization format for GPT-OSS model, enabling FlashInfer trtllm MOE kernel."
                 )
             else:
                 if self.moe_runner_backend == "triton_kernel":

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -338,6 +338,11 @@ class ServerArgs:
             print_deprecated_warning(
                 "NOTE: --enable-flashinfer-mxfp4-moe is deprecated. Please set `--moe-runner-backend` to 'flashinfer_trtllm' instead."
             )
+        if self.moe_runner_backend == "flashinfer_mxfp4":
+            self.moe_runner_backend = "flashinfer_trtllm"
+            print_deprecated_warning(
+                "NOTE: --moe-runner-backend=flashinfer_mxfp4 is deprecated. Please set `--moe-runner-backend` to 'flashinfer_trtllm' instead."
+            )
 
         # Set missing default values
         if self.tokenizer_path is None:

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -136,7 +136,7 @@ suites = {
         TestFile("test_full_deepseek_v3.py", 333),
     ],
     "per-commit-8-gpu-b200": [
-        # add more here
+        TestFile("test_gpt_oss_4gpu.py", 531),
     ],
     "per-commit-4-gpu-deepep": [
         TestFile("ep/test_deepep_small.py", 531),

--- a/test/srt/test_gpt_oss_4gpu.py
+++ b/test/srt/test_gpt_oss_4gpu.py
@@ -2,6 +2,8 @@ import unittest
 
 from test_gpt_oss_common import BaseTestGptOss
 
+from sglang.srt.utils import get_device_sm
+
 
 class TestGptOss4Gpu(BaseTestGptOss):
     def test_bf16_120b(self):
@@ -22,7 +24,7 @@ class TestGptOss4Gpu(BaseTestGptOss):
             model_variant="120b",
             quantization="mxfp4",
             expected_score_of_reasoning_effort={
-                "low": 0.61,
+                "low": 0.58,
                 # remove to speed up
                 # "medium": 0.61,
                 # "high": 0.61,
@@ -32,6 +34,66 @@ class TestGptOss4Gpu(BaseTestGptOss):
                 "4",
                 "--cuda-graph-max-bs",
                 "200",
+                "--mem-fraction-static",
+                "0.93",
+            ],
+        )
+
+    @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
+    def test_mxfp4_trtllm_moe_120b(self):
+        self.run_test(
+            model_variant="120b",
+            quantization="mxfp4",
+            expected_score_of_reasoning_effort={
+                "low": 0.58,
+                # remove to speed up
+                # "medium": 0.61,
+                # "high": 0.61,
+            },
+            other_args=[
+                "--tp",
+                "4",
+                "--ep",
+                "4",
+                "--dp",
+                "4",
+                "--enable-dp-attention",
+                "--attention-backend",
+                "trtllm_mha",
+                "--moe-runner-backend",
+                "flashinfer_trtllm",
+                "--cuda-graph-max-bs",
+                "640",
+                "--mem-fraction-static",
+                "0.93",
+            ],
+        )
+
+    @unittest.skipIf(get_device_sm() < 100, "Test requires CUDA SM 100 or higher")
+    def test_mxfp4_cutlass_moe_120b(self):
+        self.run_test(
+            model_variant="120b",
+            quantization="mxfp4",
+            expected_score_of_reasoning_effort={
+                "low": 0.58,
+                # remove to speed up
+                # "medium": 0.61,
+                # "high": 0.61,
+            },
+            other_args=[
+                "--tp",
+                "4",
+                "--ep",
+                "4",
+                "--dp",
+                "4",
+                "--enable-dp-attention",
+                "--attention-backend",
+                "trtllm_mha",
+                "--moe-runner-backend",
+                "flashinfer_cutlass",
+                "--cuda-graph-max-bs",
+                "640",
                 "--mem-fraction-static",
                 "0.93",
             ],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Depends on #9667 (needs to rebase after meged)

Add 4% e2e perf gain on top of #9667
`18,810.15 tok/s/gpu`

## Modifications

Server cmd:
```
python3 -m sglang.launch_server --model openai/gpt-oss-120b --disable-radix-cache  --attention-backend trtllm_mha --tp-size 4 --ep 4 --cuda-graph-max-bs 640 --enable-dp-attention --dp 4 --stream-interval 10 --mem-fraction-static 0.9 --cuda-graph-bs 1 2 4 8 16 24 32 40 48 56 64 72 80 88 96 104 112 120 128 256 512 640 --max-running-requests 2560 --enable-dp-lm-head --enable-flashinfer-cutlass-moe
```

Client cmd:
```
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompt 12800 --random-input 1024 --random-output 2048 --random-range-ratio 1 --max-concurrency 2560
```

```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 2560
Successful requests:                     12800
Benchmark duration (s):                  348.41
Total input tokens:                      13107200
Total generated tokens:                  26214400
Total generated tokens (retokenized):    25133199
Request throughput (req/s):              36.74
Input token throughput (tok/s):          37620.30
Output token throughput (tok/s):         75240.61
Total token throughput (tok/s):          112860.91
Concurrency:                             2543.68
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   69237.33
Median E2E Latency (ms):                 69678.86
---------------Time to First Token----------------
Mean TTFT (ms):                          5481.16
Median TTFT (ms):                        5098.77
P99 TTFT (ms):                           11347.04
---------------Inter-Token Latency----------------
Mean ITL (ms):                           31.15
Median ITL (ms):                         27.94
P95 ITL (ms):                            59.92
P99 ITL (ms):                            87.94
Max ITL (ms):                            1023.42
==================================================
```

## Accuracy Tests

```
# python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
Accuracy: 0.812
Invalid: 0.041
Latency: 16.485 s
Output throughput: 26837.372 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
