### PR TITLE
support enable in the reasoning field to enable thingking for thinkin…

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -462,6 +462,34 @@ class ChatCompletionRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def normalize_reasoning_inputs(cls, values: Dict):
+        r = values.get("reasoning")
+        if r is None:
+            return values
+
+        if isinstance(r, dict):
+            effort = r.get("effort") or r.get("reasoning_effort")
+            if effort in {"low", "medium", "high"}:
+                values["reasoning_effort"] = effort
+
+            enabled = (
+                r.get("enabled")
+                if r.get("enabled") is not None
+                else r.get("enable", False)
+            )
+            if isinstance(enabled, str):
+                enabled = enabled.strip().lower() in {"1", "true", "yes", "y", "on"}
+            if enabled:
+                ctk = values.get("chat_template_kwargs")
+                if not isinstance(ctk, dict):
+                    ctk = {}
+                ctk.setdefault("thinking", True)
+                values["chat_template_kwargs"] = ctk
+
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
     def set_json_schema(cls, values):
         response_format = values.get("response_format")
         if not response_format:

--- a/test/srt/openai_server/basic/test_protocol.py
+++ b/test/srt/openai_server/basic/test_protocol.py
@@ -192,6 +192,20 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.stream_reasoning)
         self.assertEqual(request.chat_template_kwargs, {"custom_param": "value"})
 
+    def test_chat_completion_reasoning_effort(self):
+        """Test chat completion with reasoning effort"""
+        messages = [{"role": "user", "content": "Hello"}]
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            reasoning={
+                "enabled": True,
+                "reasoning_effort": "high",
+            },
+        )
+        self.assertEqual(request.reasoning_effort, "high")
+        self.assertEqual(request.chat_template_kwargs, {"thinking": True})
+
     def test_chat_completion_json_format(self):
         """Test chat completion json format"""
         transcript = "Good morning! It's 7:00 AM, and I'm just waking up. Today is going to be a busy day, "


### PR DESCRIPTION
…g model

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

UT passed.

root:/sgl-workspace/sglang# python3 /sgl-workspace/sglang/test/srt/openai_server/basic/test_protocol.py
test_basic_chat_completion_request (__main__.TestChatCompletionRequest.test_basic_chat_completion_request)
Test basic chat completion request ... ok
test_chat_completion_json_format (__main__.TestChatCompletionRequest.test_chat_completion_json_format)
Test chat completion json format ... ok
test_chat_completion_reasoning_effort (__main__.TestChatCompletionRequest.test_chat_completion_reasoning_effort)
Test chat completion with reasoning effort ... ok
test_chat_completion_sglang_extensions (__main__.TestChatCompletionRequest.test_chat_completion_sglang_extensions)
Test chat completion with SGLang extensions ... ok
test_chat_completion_tool_choice_validation (__main__.TestChatCompletionRequest.test_chat_completion_tool_choice_validation)
Test tool choice validation logic ... ok
test_basic_completion_request (__main__.TestCompletionRequest.test_basic_completion_request)
Test basic completion request ... ok
test_completion_request_sglang_extensions (__main__.TestCompletionRequest.test_completion_request_sglang_extensions)
Test completion request with SGLang-specific extensions ... ok
test_completion_request_validation_errors (__main__.TestCompletionRequest.test_completion_request_validation_errors)
Test completion request validation errors ... ok
test_model_card_serialization (__main__.TestModelCard.test_model_card_serialization)
Test model card JSON serialization ... ok
test_empty_model_list (__main__.TestModelList.test_empty_model_list)
Test empty model list creation ... ok
test_model_list_with_cards (__main__.TestModelList.test_model_list_with_cards)
Test model list with model cards ... ok
test_hidden_states_excluded_when_none (__main__.TestModelSerialization.test_hidden_states_excluded_when_none)
Test that None hidden_states are excluded with exclude_none=True ... ok
test_hidden_states_included_when_not_none (__main__.TestModelSerialization.test_hidden_states_included_when_not_none)
Test that non-None hidden_states are included ... ok
test_invalid_tool_choice_type (__main__.TestValidationEdgeCases.test_invalid_tool_choice_type)
Test invalid tool choice type ... ok
test_model_serialization_roundtrip (__main__.TestValidationEdgeCases.test_model_serialization_roundtrip)
Test that models can be serialized and deserialized ... /sgl-workspace/sglang/test/srt/openai_server/basic/test_protocol.py:363: DeprecationWarning: max_tokens is deprecated in favor of the max_completion_tokens field
  self.assertEqual(restored_request.max_tokens, original_request.max_tokens)
ok
test_negative_token_limits (__main__.TestValidationEdgeCases.test_negative_token_limits)
Test negative token limits ... ok

----------------------------------------------------------------------
Ran 16 tests in 0.002s

OK

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
