### PR TITLE
[Refactor/Small] Route ACT fn through `get_act_fn` in Qwen2.5VL

### DIFF
--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -185,6 +185,7 @@ _ACTIVATION_REGISTRY = {
     "gelu_pytorch_tanh": nn.GELU(approximate="tanh"),
     "gelu_new": NewGELU(),
     "relu2": ReLU2(),
+    "silu": nn.SiLU(),
 }
 
 

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -212,7 +212,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
                     quant_config=quant_config,
                     prefix=add_prefix("mlp.0", prefix),
                 ),
-                get_act_fn("gelu", approximate="None"),
+                get_act_fn("gelu"),
                 RowParallelLinear(
                     self.hidden_size,
                     dim,

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -42,6 +42,7 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
 )
 
 from sglang.srt.hf_transformers_utils import get_processor
+from sglang.srt.layers.activation import get_act_fn
 from sglang.srt.layers.attention.vision import VisionAttention
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
@@ -211,7 +212,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
                     quant_config=quant_config,
                     prefix=add_prefix("mlp.0", prefix),
                 ),
-                nn.GELU(),
+                get_act_fn("gelu", approximate="None"),
                 RowParallelLinear(
                     self.hidden_size,
                     dim,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Summary
Corrected, it shouldn't affect performance, but it's a bit more consistent.
<details>
| Metric                                 | Main       | New        | Delta     | Delta %  |
|----------------------------------------|------------:|-----------:|----------:|---------:|
| Request throughput (req/s)             | 3.49       | 3.56       | +0.07     | +2.01%  |
| Input token throughput (tok/s)         | 303.70     | 308.06     | +4.36     | +1.44%  |
| Output token throughput (tok/s)        | 432.84     | 441.85     | +9.01     | +2.08%  |
| Total token throughput (tok/s)         | 736.54     | 749.91     | +13.37    | +1.82%  |
| Mean E2E Latency (ms)                  | 15062.01   | 14707.64   | -354.37   | -2.35%  |
| Median E2E Latency (ms)                | 15307.70   | 14867.68   | -440.02   | -2.87%  |
| Mean TTFT (ms)                         | 3761.66    | 3614.21    | -147.45   | -3.92%  |
| Median TTFT (ms)                       | 3415.18    | 3324.81    | -90.37    | -2.65%  |
| P99 TTFT (ms)                          | 8776.47    | 8396.95    | -379.52   | -4.32%  |
| Mean ITL (ms)                          | 91.79      | 90.11      | -1.68     | -1.83%  |
| Median ITL (ms)                        | 36.56      | 36.56      | +0.00     | +0.00%  |
| P95 ITL (ms)                           | 151.29     | 161.57     | +10.28    | +6.79%  |
| P99 ITL (ms)                           | 637.87     | 631.09     | -6.78     | -1.06%  |
| Max ITL (ms)                           | 11379.93   | 10920.64   | -459.29   | -4.04%  |

<details>


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Route ACT fn through `get_act_fn`. Model pass is equivalent. MMMU stays the same.
`ACT2FN` is defined at https://github.com/huggingface/transformers/blob/98289c5546cf167fb10178053b36719f9732fc03/src/transformers/activations.py#L210

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
They're both nn.Gelu()
<details>
With optimization. Done two warmup runs of the same cmd on `main`, then take the result. Repeat for the optimized branch. Main on `bc80dc4ce0ae5a97b8a58faa1d8b8cfbb56e21f5`
```python3
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --dataset-name random-image \
  --random-image-num-images 1 \
  --random-image-resolution 720p \
  --random-input-len 128 \
  --random-output-len 256 \
  --num-prompts 100 \
  --request-rate 20 \
  --max-concurrency 64 \
  --apply-chat-template \
  --warmup-requests 5 \
  --output-details
benchmark_args=Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=100, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=100, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

/root/sglang/python/sglang/bench_serving.py:1211: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
  img = Image.fromarray(arr, mode="RGB")
#Input tokens: 8653
#Output tokens: 12411
Starting warmup with 5 sequences...
Warmup completed with 5 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:28<00:00,  3.56it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    20.0      
Max request concurrency:                 64        
Successful requests:                     100       
Benchmark duration (s):                  28.09     
Total input tokens:                      8653      
Total generated tokens:                  12411     
Total generated tokens (retokenized):    10272     
Request throughput (req/s):              3.56      
Input token throughput (tok/s):          308.06    
Output token throughput (tok/s):         441.85    
Total token throughput (tok/s):          749.91    
Concurrency:                             52.36     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   14707.64  
Median E2E Latency (ms):                 14867.68  
---------------Time to First Token----------------
Mean TTFT (ms):                          3614.21   
Median TTFT (ms):                        3324.81   
P99 TTFT (ms):                           8396.95   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           90.11     
Median ITL (ms):                         36.56     
P95 ITL (ms):                            161.57    
P99 ITL (ms):                            631.09    
Max ITL (ms):                            10920.64  
==================================================
```

Without opt
```python3
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 --port 30000 \
  --model Qwen/Qwen2.5-VL-7B-Instruct \
  --dataset-name random-image \
  --random-image-num-images 1 \
  --random-image-resolution 720p \
  --random-input-len 128 \
  --random-output-len 256 \
  --num-prompts 100 \
  --request-rate 20 \
  --max-concurrency 64 \
  --apply-chat-template \
  --warmup-requests 5 \
  --output-details
benchmark_args=Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=100, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)
Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='random-image', dataset_path='', model='Qwen/Qwen2.5-VL-7B-Instruct', tokenizer=None, num_prompts=100, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=256, random_range_ratio=0.0, random_image_num_images=1, random_image_resolution='720p', request_rate=20.0, max_concurrency=64, output_file=None, output_details=True, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, lora_name=None, prompt_suffix='', pd_separated=False, flush_cache=False, warmup_requests=5, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256)

/root/sglang/python/sglang/bench_serving.py:1211: DeprecationWarning: 'mode' parameter is deprecated and will be removed in Pillow 13 (2026-10-15)
  img = Image.fromarray(arr, mode="RGB")
#Input tokens: 8708
#Output tokens: 12411
Starting warmup with 5 sequences...
Warmup completed with 5 sequences. Starting main benchmark run...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:28<00:00,  3.49it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    20.0      
Max request concurrency:                 64        
Successful requests:                     100       
Benchmark duration (s):                  28.67     
Total input tokens:                      8708      
Total generated tokens:                  12411     
Total generated tokens (retokenized):    10140     
Request throughput (req/s):              3.49      
Input token throughput (tok/s):          303.70    
Output token throughput (tok/s):         432.84    
Total token throughput (tok/s):          736.54    
Concurrency:                             52.53     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   15062.01  
Median E2E Latency (ms):                 15307.70  
---------------Time to First Token----------------
Mean TTFT (ms):                          3761.66   
Median TTFT (ms):                        3415.18   
P99 TTFT (ms):                           8776.47   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           91.79     
Median ITL (ms):                         36.56     
P95 ITL (ms):                            151.29    
P99 ITL (ms):                            637.87    
Max ITL (ms):                            11379.93  
==================================================

```
<details>
MMMU ~ 0.517 on both.
I run this on `L40S`

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
