### PR TITLE
[BugFix]fix ToolChoice in openai api

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -1500,10 +1500,12 @@ pub struct StreamOptions {
 
 /// Tool choice value for simple string options
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
 pub enum ToolChoiceValue {
+    #[serde(rename = "auto")]
     Auto,
+    #[serde(rename = "required")]
     Required,
+    #[serde(rename = "none")]
     None,
 }
 


### PR DESCRIPTION
## Motivation

I meet some requests with `tool_choice:auto` or  `tool_choice:none` online.
But I find router return response as 422, detail message is about:
`Failed to deserialize the JSON body into the target type: tool_choice: data did not match any variant of untagged enum ToolChoice at line 1 column 193`
so I fix proto of ToolChoice to make it could parse String

## Modifications

just fix ToolChoice Proto in sgl-router/src/openai_api_types.rs

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
