### PR TITLE
[bugfix] build failure when compile mscclpp with nvcc 12.0

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -98,11 +98,22 @@ FetchContent_Declare(
 FetchContent_Populate(repo-flash-attention)
 
 # mscclpp
+if("${CUDA_VERSION}" VERSION_LESS 12.1)
+    set(SED_PTN
+        [[s|\\(^\\s*set(CMAKE_CUDA_ARCHITECTURES \${CMAKE_CUDA_ARCHITECTURES} 90)\\)|#\\1|]]
+    )
+    set(MSCCLPP_PATCH_COMMAND
+        COMMAND sed -i ${SED_PTN} CMakeLists.txt
+    )
+else()
+    set(MSCCLPP_PATCH_COMMAND "")
+endif()
 FetchContent_Declare(
     repo-mscclpp
     GIT_REPOSITORY https://github.com/microsoft/mscclpp.git
     GIT_TAG        51eca89d20f0cfb3764ccd764338d7b22cd486a6
     GIT_SHALLOW    OFF
+    PATCH_COMMAND  ${MSCCLPP_PATCH_COMMAND}
 )
 FetchContent_Populate(repo-mscclpp)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The following error occurs when building mscclpp with nvcc 12.0. It seems nvcc 12.0 does not fully support compute_90

```shell
ptxas /tmp/tmpxft_000475be_00000000-6_nccl.compute_90.ptx, line 1086; error   : Unknown modifier '.ld_reduce'
ptxas /tmp/tmpxft_000475be_00000000-6_nccl.compute_90.ptx, line 1086; error   : Not a name of any known instruction: 'multimem'
ptxas /tmp/tmpxft_000475be_00000000-6_nccl.compute_90.ptx, line 1092; error   : Unknown modifier '.st'
```

## Modifications

<!-- Detail the changes made in this pull request. -->

When build with nvcc 12.0, use sed to comment out the following declaration in mscclpp
```shell
# Previous
if(CUDAToolkit_VERSION_MAJOR GREATER_EQUAL 12)
    set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES} 90)
endif()

# After
if(CUDAToolkit_VERSION_MAJOR GREATER_EQUAL 12)
#    set(CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES} 90)
endif()
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
