### PR TITLE
fused silu_and_mul with fp8 per tensor quant

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -670,7 +670,10 @@ def invoke_fused_moe_kernel(
             padded_size = padding_size
             # activations apply per-token quantization when weights apply per-channel quantization by default
             A, A_scale = scaled_fp8_quant(
-                A, A_scale, use_per_token_if_dynamic=per_channel_quant, use_fused_silu_and_quant=use_fused_silu_and_quant
+                A,
+                A_scale,
+                use_per_token_if_dynamic=per_channel_quant,
+                use_fused_silu_and_quant=use_fused_silu_and_quant,
             )
         else:
             # activation block-wise fp8 quantization
@@ -1551,7 +1554,9 @@ def fused_experts_impl(
                 if not use_fused_silu_and_quant:
                     silu_and_mul(intermediate_cache1.view(-1, N), intermediate_cache2)
                 else:
-                    intermediate_cache2 = intermediate_cache1.view(-1, N) # silu not applied
+                    intermediate_cache2 = intermediate_cache1.view(
+                        -1, N
+                    )  # silu not applied
             else:
                 vllm_ops.silu_and_mul(
                     intermediate_cache2, intermediate_cache1.view(-1, N)

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -138,6 +138,7 @@ class FusedMoE(torch.nn.Module):
         gemm1_clamp_limit: Optional[float] = None,
         use_weight_loader_fused: bool = False,
         with_bias=False,
+        use_fused_silu_and_quant: bool = False
     ):
         super().__init__()
 
@@ -160,6 +161,7 @@ class FusedMoE(torch.nn.Module):
             routed_scaling_factor=routed_scaling_factor,
             gemm1_alpha=gemm1_alpha,
             gemm1_clamp_limit=gemm1_clamp_limit,
+            use_fused_silu_and_quant=use_fused_silu_and_quant,
         )
 
         enable_flashinfer_cutlass_moe = get_moe_runner_backend().is_flashinfer_cutlass()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -138,7 +138,7 @@ class FusedMoE(torch.nn.Module):
         gemm1_clamp_limit: Optional[float] = None,
         use_weight_loader_fused: bool = False,
         with_bias=False,
-        use_fused_silu_and_quant: bool = False
+        use_fused_silu_and_quant: bool = False,
     ):
         super().__init__()
 

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -11,3 +11,4 @@ class MoeRunnerConfig:
     routed_scaling_factor: Optional[float] = None
     gemm1_alpha: Optional[float] = None
     gemm1_clamp_limit: Optional[float] = None
+    use_fused_silu_and_quant: bool = False

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1410,6 +1410,7 @@ else:
         num_token_padding: Optional[int] = None,
         use_per_token_if_dynamic: bool = False,
         use_fused_silu_and_quant: bool = False,
+        intermediate_cache_silu: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
 
         assert input.ndim == 2, f"Expected 2D input tensor, got {input.ndim}D"
@@ -1419,6 +1420,9 @@ else:
             assert (
                 scale is None and not use_per_token_if_dynamic
             ), "fused silu and quant only support dynamic per_tensor quant"
+            assert (
+                intermediate_cache_silu is not None
+            ), "intermediate_cache_silu is required"
         else:
             shape = input.shape
         if num_token_padding:
@@ -1435,11 +1439,11 @@ else:
             else:
                 scale = torch.zeros(1, device=input.device, dtype=torch.float32)
                 if use_fused_silu_and_quant:
-                    input_gate, input_up = input.chunk(2, dim=-1)
-                    input_gate = input_gate.contiguous()
-                    input_up = input_up.contiguous()
+                    # input_gate, input_up = input.chunk(2, dim=-1)
+                    # input_gate = input_gate.contiguous()
+                    # input_up = input_up.contiguous()
                     sgl_silu_and_mul_per_tensor_quant_fp8(
-                        input_gate, input_up, output, scale, is_static=False
+                        input, intermediate_cache_silu, output, scale, is_static=False
                     )  # False for dynamic
                     # sgl_per_tensor_quant_fp8(
                     #     input_1, output, scale, is_static=False

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -48,6 +48,10 @@ if _is_cuda:
         sgl_per_token_group_quant_fp8,
         sgl_per_token_quant_fp8,
     )
+    try:
+        from sgl_kernel import sgl_silu_and_mul_per_tensor_quant_fp8
+    except:
+        print(f"Failed to import sgl_silu_and_mul_per_tensor_quant_fp8")
 
 if _is_hip:
     if _use_aiter:
@@ -1404,10 +1408,16 @@ else:
         scale: Optional[torch.Tensor] = None,
         num_token_padding: Optional[int] = None,
         use_per_token_if_dynamic: bool = False,
+        use_fused_silu_and_quant: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
 
         assert input.ndim == 2, f"Expected 2D input tensor, got {input.ndim}D"
-        shape = input.shape
+        if use_fused_silu_and_quant:
+            ## double hidden dimension, silu is not applied yet.
+            shape = (input.shape[0], input.shape[1] // 2)
+            assert scale is None and not use_per_token_if_dynamic, "fused silu and quant only support dynamic per_tensor quant"
+        else:
+            shape = input.shape
         if num_token_padding:
             shape = (max(num_token_padding, input.shape[0]), shape[1])
         output = torch.empty(shape, device=input.device, dtype=fp8_dtype)
@@ -1421,9 +1431,20 @@ else:
                 sgl_per_token_quant_fp8(input, output, scale)
             else:
                 scale = torch.zeros(1, device=input.device, dtype=torch.float32)
-                sgl_per_tensor_quant_fp8(
-                    input, output, scale, is_static=False
-                )  # False for dynamic
+                if use_fused_silu_and_quant:
+                    input_1, input_2 = input.chunk(2, dim=-1)
+                    input_1 = input_1.contiguous()
+                    input_2 = input_2.contiguous()
+                    sgl_silu_and_mul_per_tensor_quant_fp8(
+                        input_1, input_2, output, scale, is_static=False
+                    )  # False for dynamic
+                    # sgl_per_tensor_quant_fp8(
+                    #     input_1, output, scale, is_static=False
+                    # )  # False for dynamic
+                else:
+                    sgl_per_tensor_quant_fp8(
+                        input, output, scale, is_static=False
+                    )  # False for dynamic
         else:
             # Static scaling
             assert (

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -48,6 +48,7 @@ if _is_cuda:
         sgl_per_token_group_quant_fp8,
         sgl_per_token_quant_fp8,
     )
+
     try:
         from sgl_kernel import sgl_silu_and_mul_per_tensor_quant_fp8
     except ImportError:
@@ -1415,7 +1416,9 @@ else:
         if use_fused_silu_and_quant:
             ## double hidden dimension, silu is not applied yet.
             shape = (input.shape[0], input.shape[1] // 2)
-            assert scale is None and not use_per_token_if_dynamic, "fused silu and quant only support dynamic per_tensor quant"
+            assert (
+                scale is None and not use_per_token_if_dynamic
+            ), "fused silu and quant only support dynamic per_tensor quant"
         else:
             shape = input.shape
         if num_token_padding:

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -1432,11 +1432,11 @@ else:
             else:
                 scale = torch.zeros(1, device=input.device, dtype=torch.float32)
                 if use_fused_silu_and_quant:
-                    input_1, input_2 = input.chunk(2, dim=-1)
-                    input_1 = input_1.contiguous()
-                    input_2 = input_2.contiguous()
+                    input_gate, input_up = input.chunk(2, dim=-1)
+                    input_gate = input_gate.contiguous()
+                    input_up = input_up.contiguous()
                     sgl_silu_and_mul_per_tensor_quant_fp8(
-                        input_1, input_2, output, scale, is_static=False
+                        input_gate, input_up, output, scale, is_static=False
                     )  # False for dynamic
                     # sgl_per_tensor_quant_fp8(
                     #     input_1, output, scale, is_static=False

--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -50,8 +50,8 @@ if _is_cuda:
     )
     try:
         from sgl_kernel import sgl_silu_and_mul_per_tensor_quant_fp8
-    except:
-        print(f"Failed to import sgl_silu_and_mul_per_tensor_quant_fp8")
+    except ImportError:
+        logging.warning(f"Failed to import sgl_silu_and_mul_per_tensor_quant_fp8")
 
 if _is_hip:
     if _use_aiter:

--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -661,6 +661,15 @@ class InternVLChatModel(nn.Module):
 
             loaded_params.add(name)
         unloaded_params = params_dict.keys() - loaded_params
+        # Skip params that are created by quantization wrappers and are not expected in the ckpt
+        _quant_only_fragments = (
+            "weight_scale",  # per-matrix FP8 scales (e.g., w2_weight_scale, w13_weight_scale)
+        )
+        unloaded_params = {
+            n
+            for n in unloaded_params
+            if not any(frag in n for frag in _quant_only_fragments)
+        }
         if unloaded_params:
             raise RuntimeError(
                 f"Some weights are not initialized from checkpoints: {unloaded_params}"

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -76,6 +76,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layer_id = layer_id
+        self.use_fused_silu_and_quant = getattr(config, "use_fused_silu_and_quant", True)
         if self.tp_size > config.num_experts:
             raise ValueError(
                 f"Tensor parallel size {self.tp_size} is greater than "
@@ -87,8 +88,14 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             renormalize=config.norm_topk_prob,
             use_grouped_topk=False,
         )
+        experts_type = get_moe_impl_class()
+        extra_kwargs = {}
+        if experts_type.__name__ == "FusedMoE":
+            extra_kwargs = {
+                "use_fused_silu_and_quant": self.use_fused_silu_and_quant
+            }
 
-        self.experts = get_moe_impl_class()(
+        self.experts = experts_type(
             num_experts=config.num_experts
             + global_server_args_dict["ep_num_redundant_experts"],
             top_k=config.num_experts_per_tok,
@@ -97,6 +104,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             quant_config=quant_config,
             prefix=add_prefix("experts", prefix),
+            **extra_kwargs,
         )
 
         self.gate = ReplicatedLinear(

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -76,7 +76,9 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layer_id = layer_id
-        self.use_fused_silu_and_quant = getattr(config, "use_fused_silu_and_quant", True)
+        self.use_fused_silu_and_quant = getattr(
+            config, "use_fused_silu_and_quant", True
+        )
         if self.tp_size > config.num_experts:
             raise ValueError(
                 f"Tensor parallel size {self.tp_size} is greater than "
@@ -91,9 +93,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         experts_type = get_moe_impl_class()
         extra_kwargs = {}
         if experts_type.__name__ == "FusedMoE":
-            extra_kwargs = {
-                "use_fused_silu_and_quant": self.use_fused_silu_and_quant
-            }
+            extra_kwargs = {"use_fused_silu_and_quant": self.use_fused_silu_and_quant}
 
         self.experts = experts_type(
             num_experts=config.num_experts

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -77,7 +77,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layer_id = layer_id
         self.use_fused_silu_and_quant = getattr(
-            config, "use_fused_silu_and_quant", True
+            config, "use_fused_silu_and_quant", False
         )
         if self.tp_size > config.num_experts:
             raise ValueError(

--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -265,6 +265,7 @@ set(SOURCES
     "csrc/gemm/per_tensor_quant_fp8.cu"
     "csrc/gemm/per_token_group_quant_8bit.cu"
     "csrc/gemm/per_token_quant_fp8.cu"
+    "csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu"
     "csrc/gemm/qserve_w4a8_per_chn_gemm.cu"
     "csrc/gemm/qserve_w4a8_per_group_gemm.cu"
     "csrc/gemm/marlin/gptq_marlin.cu"

--- a/sgl-kernel/benchmark/bench_silu_and_mul_per_tensor_quant_fp8.py
+++ b/sgl-kernel/benchmark/bench_silu_and_mul_per_tensor_quant_fp8.py
@@ -1,0 +1,111 @@
+import itertools
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import triton
+import triton.testing
+from sgl_kernel import (
+    sgl_per_tensor_quant_fp8,
+    sgl_silu_and_mul_per_tensor_quant_fp8,
+    silu_and_mul,
+)
+
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
+fp8_type_ = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn
+
+
+def sglang_silu_and_mul_scaled_fp8_quant(
+    input: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fp8_type_: torch.dtype = torch.float8_e4m3fn
+    output = torch.empty_like(input, device=input.device, dtype=fp8_type_)
+
+    intermediate_cache = torch.empty(
+        input.shape[0], input.shape[1] // 2, device=input.device, dtype=input.dtype
+    )
+    silu_and_mul(input, intermediate_cache)
+    scale = torch.zeros(1, device=input.device, dtype=torch.float32)
+    sgl_per_tensor_quant_fp8(intermediate_cache, output, scale, is_static=False)
+
+    return output, scale
+
+
+def sglang_fused_silu_and_mul_scaled_fp8_quant(
+    input: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fp8_type_: torch.dtype = torch.float8_e4m3fn
+    output = torch.empty_like(input, device=input.device, dtype=fp8_type_)
+    scale = torch.zeros(1, device=input.device, dtype=torch.float32)
+    input_gate, input_up = input.chunk(2, dim=-1)
+    input_gate = input_gate.contiguous()
+    input_up = input_up.contiguous()
+    sgl_silu_and_mul_per_tensor_quant_fp8(
+        input_gate, input_up, output, scale, is_static=False
+    )
+
+    return output, scale
+
+
+def calculate_diff(batch_size: int, seq_len: int):
+    """Calculate difference between VLLM and SGLang implementations."""
+    device = torch.device("cuda")
+    x = torch.rand((batch_size, seq_len), dtype=torch.float16, device=device)
+
+    sglang_out, sglang_scale = sglang_silu_and_mul_scaled_fp8_quant(x)
+    fused_out, fused_scale = sglang_fused_silu_and_mul_scaled_fp8_quant(x)
+
+    scale_diff = torch.abs(fused_scale - sglang_scale).item()
+    output_diff = torch.abs(fused_out.float() - sglang_out.float()).mean().item()
+
+    if torch.allclose(
+        fused_out.to(torch.float32), sglang_out.to(torch.float32), rtol=1e-3, atol=1e-5
+    ) and torch.allclose(fused_scale, sglang_scale, rtol=1e-3, atol=1e-5):
+        print("✅ All implementations match")
+    else:
+        print("❌ Implementations differ")
+
+
+batch_size_range = [16, 32, 64, 128]
+seq_len_range = [64, 128, 256, 512, 1024, 2048]
+
+configs = list(itertools.product(batch_size_range, seq_len_range))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["batch_size", "seq_len"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=["sglang_fused", "sglang"],
+        line_names=["sglang_fused", "sglang"],
+        styles=[("blue", "-"), ("green", "-")],
+        ylabel="us",
+        plot_name="silu-and-mul-per-tensor-quant-fp8-performance",
+        args={},
+    )
+)
+def benchmark(batch_size, seq_len, provider):
+    dtype = torch.float16
+    device = torch.device("cuda")
+
+    x = torch.randn(batch_size * seq_len, 4096, device=device, dtype=dtype)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "sglang_fused":
+        fn = lambda: sglang_fused_silu_and_mul_scaled_fp8_quant(x.clone())
+    elif provider == "sglang":
+        fn = lambda: sglang_silu_and_mul_scaled_fp8_quant(x.clone())
+
+    ms, min_ms, max_ms = triton.testing.do_bench(fn, quantiles=quantiles)
+
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+
+if __name__ == "__main__":
+    calculate_diff(batch_size=4, seq_len=4096)
+    benchmark.run(print_data=True)

--- a/sgl-kernel/benchmark/bench_silu_and_mul_per_tensor_quant_fp8.py
+++ b/sgl-kernel/benchmark/bench_silu_and_mul_per_tensor_quant_fp8.py
@@ -45,12 +45,15 @@ def sglang_fused_silu_and_mul_scaled_fp8_quant(
     output = torch.empty(
         input.shape[0], input.shape[1] // 2, device=input.device, dtype=fp8_type_
     )
+    intermediate_cache = torch.empty(
+        input.shape[0], input.shape[1] // 2, device=input.device, dtype=input.dtype
+    )
     scale = torch.zeros(1, device=input.device, dtype=torch.float32)
-    input_gate, input_up = input.chunk(2, dim=-1)
-    input_gate = input_gate.contiguous()
-    input_up = input_up.contiguous()
+    # input_gate, input_up = input.chunk(2, dim=-1)
+    # input_gate = input_gate.contiguous()
+    # input_up = input_up.contiguous()
     sgl_silu_and_mul_per_tensor_quant_fp8(
-        input_gate, input_up, output, scale, is_static=False
+        input, intermediate_cache, output, scale, is_static=False
     )
 
     return output, scale

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -136,6 +136,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("sgl_per_token_quant_fp8(Tensor input, Tensor output_q, Tensor output_s) -> ()");
   m.impl("sgl_per_token_quant_fp8", torch::kCUDA, &sgl_per_token_quant_fp8);
 
+  m.def("sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input_gate, Tensor input_up, Tensor output_q, Tensor output_s) -> ()");
+  m.impl("sgl_silu_and_mul_per_tensor_quant_fp8", torch::kCUDA, &sgl_silu_and_mul_per_tensor_quant_fp8);
+
   m.def(
       "cutlass_scaled_fp4_mm(Tensor! out, Tensor a, Tensor b,"
       "                      Tensor block_scale_a, Tensor block_scale_b,"

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -136,7 +136,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("sgl_per_token_quant_fp8(Tensor input, Tensor output_q, Tensor output_s) -> ()");
   m.impl("sgl_per_token_quant_fp8", torch::kCUDA, &sgl_per_token_quant_fp8);
 
-  m.def("sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input_gate, Tensor input_up, Tensor output_q, Tensor output_s) -> ()");
+  m.def("sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input_gate, Tensor input_up, Tensor output_q, Tensor output_s, bool is_static) -> ()");
   m.impl("sgl_silu_and_mul_per_tensor_quant_fp8", torch::kCUDA, &sgl_silu_and_mul_per_tensor_quant_fp8);
 
   m.def(

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -136,7 +136,9 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.def("sgl_per_token_quant_fp8(Tensor input, Tensor output_q, Tensor output_s) -> ()");
   m.impl("sgl_per_token_quant_fp8", torch::kCUDA, &sgl_per_token_quant_fp8);
 
-  m.def("sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input_gate, Tensor input_up, Tensor output_q, Tensor output_s, bool is_static) -> ()");
+  m.def(
+      "sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input_gate, Tensor input_up, Tensor output_q, Tensor output_s, "
+      "bool is_static) -> ()");
   m.impl("sgl_silu_and_mul_per_tensor_quant_fp8", torch::kCUDA, &sgl_silu_and_mul_per_tensor_quant_fp8);
 
   m.def(

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -137,7 +137,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("sgl_per_token_quant_fp8", torch::kCUDA, &sgl_per_token_quant_fp8);
 
   m.def(
-      "sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input_gate, Tensor input_up, Tensor output_q, Tensor output_s, "
+      "sgl_silu_and_mul_per_tensor_quant_fp8(Tensor input, Tensor output, Tensor output_q, Tensor output_s, "
       "bool is_static) -> ()");
   m.impl("sgl_silu_and_mul_per_tensor_quant_fp8", torch::kCUDA, &sgl_silu_and_mul_per_tensor_quant_fp8);
 

--- a/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
@@ -1,0 +1,134 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/util/Float8_e4m3fn.h>
+
+#include <cmath>
+#include <cub/block/block_reduce.cuh>
+#include <flashinfer/vec_dtypes.cuh>
+
+#include "utils.h"
+
+__device__ __forceinline__ float silu(const float& val) {
+  return val / (1.0f + __expf(-val));
+}
+
+template <typename T>
+__global__ void
+silu_and_mul_per_tensor_absmax_kernel(T* __restrict__ input, const T* __restrict__ input_2, float* __restrict__ output_s, const int64_t num_elements, const int hidden_dim) {
+  float max_value = 0.0f;
+  unsigned int tid = threadIdx.x;
+  unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int grid_size = blockDim.x * gridDim.x;
+
+  constexpr uint32_t vec_size = 16 / sizeof(T);
+  using vec_t = flashinfer::vec_t<T, vec_size>;
+
+  const int32_t num_vec_elems = num_elements / vec_size;
+
+  for (int32_t i = gid; i < num_vec_elems; i += grid_size) {
+    vec_t input_vec;
+    vec_t input_vec_2;
+    input_vec.cast_load(input + i * vec_size);
+    input_vec_2.cast_load(input + i * vec_size + hidden_dim);
+
+#pragma unroll
+    for (uint32_t j = 0; j < vec_size; ++j) {
+      input_vec[j] = silu(static_cast<float>(input_vec[j])) * static_cast<float>(input_vec_2[j]);
+      float val = static_cast<float>(input_vec[j]);
+      max_value = fmaxf(max_value, fabsf(val));
+    }
+    input_vec.cast_store(input + i * vec_size);
+  }
+
+  const int32_t remaining_start = num_vec_elems * vec_size;
+  for (int32_t idx = remaining_start + gid; idx < num_elements; idx += grid_size) {
+    float val = silu(static_cast<float>(input[idx])) * static_cast<float>(input_2[idx]);
+    max_value = fmaxf(max_value, fabsf(static_cast<float>(val)));
+    input[idx] = static_cast<T>(val);
+  }
+
+  max_value = blockReduceMax(max_value);
+
+  if (tid == 0) {
+    atomicMaxFloat(output_s, max_value / FP8_E4M3_MAX);
+  }
+}
+
+template <typename T, typename DST_DTYPE>
+__global__ void per_tensor_quant_fp8_kernel(
+    const T* __restrict__ input,
+    DST_DTYPE* __restrict__ output,
+    const float* __restrict__ scale,
+    const int64_t num_elements) {
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int grid_size = blockDim.x * gridDim.x;
+  const float scale_val = 1.0f / (*scale);
+
+  // We want to store 128 bits of data at a time. 16 = 128 / 8 bits
+  // Load is already vectorized, so 16 elements work for T.
+  const uint32_t VEC_SIZE = 16;
+  using vec_t = flashinfer::vec_t<T, VEC_SIZE>;
+
+  const int32_t num_vec_elems = num_elements / VEC_SIZE;
+
+  for (int32_t i = gid; i < num_vec_elems; i += grid_size) {
+    vec_t input_vec;
+    input_vec.cast_load(input + i * VEC_SIZE);
+
+    DST_DTYPE output_arr[VEC_SIZE];
+#pragma unroll
+    for (uint32_t j = 0; j < VEC_SIZE; ++j) {
+      float val = fmax(fmin(static_cast<float>(input_vec[j]) * scale_val, FP8_E4M3_MAX), -FP8_E4M3_MAX);
+#ifndef USE_ROCM
+      output_arr[j] = static_cast<DST_DTYPE>(val);
+#else
+      output_arr[j] = c10::Float8_e4m3fnuz(
+          __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+          c10::Float8_e4m3fnuz::from_bits());
+#endif
+    }
+    *(uint4*)(output + i * VEC_SIZE) = *(uint4*)output_arr;
+  }
+
+  const int32_t remaining_start = num_vec_elems * VEC_SIZE;
+  for (int32_t idx = remaining_start + gid; idx < num_elements; idx += grid_size) {
+    float val = fmax(-FP8_E4M3_MAX, fmin(static_cast<float>(input[idx]) * scale_val, FP8_E4M3_MAX));
+#ifndef USE_ROCM
+    output[idx] = static_cast<DST_DTYPE>(val);
+#else
+    output[idx] = c10::Float8_e4m3fnuz(
+        __hip_cvt_float_to_fp8(val, fp8::fp8_type::__default_saturation, fp8::fp8_type::__default_interpret),
+        c10::Float8_e4m3fnuz::from_bits());
+#endif
+  }
+}
+
+void sgl_silu_and_mul_per_tensor_quant_fp8(torch::Tensor input_gate, torch::Tensor input_up, torch::Tensor output_q, torch::Tensor output_s, bool is_static) {
+  CHECK_INPUT(input_gate);
+  CHECK_INPUT(input_up);
+  CHECK_INPUT(output_q);
+  CHECK_INPUT(output_s);
+  TORCH_CHECK(is_static == false, "Static mode is not supported for silu_and_mul_per_tensor_quant_fp8");
+
+  const int block_size = 256;
+  const int num_elements = input.numel();
+  const int num_blocks = min((num_elements + block_size - 1) / block_size, 1024);
+  const int hidden_dim = input.size(-1);
+
+  dim3 grid(num_blocks);
+  dim3 block(block_size);
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), scalar_t, [&] {
+
+    silu_and_mul_per_tensor_absmax_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        static_cast<scalar_t*>(input_gate.data_ptr()), static_cast<scalar_t*>(input_up.data_ptr()) static_cast<float*>(output_s.data_ptr()), num_elements, hidden_dim);
+
+    silu_and_mul_per_tensor_quant_fp8_kernel<scalar_t, __nv_fp8_e4m3><<<grid, block, 0, stream>>>(
+        static_cast<scalar_t*>(input_gate.data_ptr()),
+        static_cast<__nv_fp8_e4m3*>(output_q.data_ptr()),
+        static_cast<float*>(output_s.data_ptr()),
+        num_elements, hidden_dim);
+    return true;
+  });
+}

--- a/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
@@ -122,7 +122,7 @@ void sgl_silu_and_mul_per_tensor_quant_fp8(torch::Tensor input_gate, torch::Tens
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), scalar_t, [&] {
 
     silu_and_mul_per_tensor_absmax_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        static_cast<scalar_t*>(input_gate.data_ptr()), static_cast<scalar_t*>(input_up.data_ptr()) static_cast<float*>(output_s.data_ptr()), num_elements, hidden_dim);
+        static_cast<scalar_t*>(input_gate.data_ptr()), static_cast<scalar_t*>(input_up.data_ptr()), static_cast<float*>(output_s.data_ptr()), num_elements, hidden_dim);
 
     silu_and_mul_per_tensor_quant_fp8_kernel<scalar_t, __nv_fp8_e4m3><<<grid, block, 0, stream>>>(
         static_cast<scalar_t*>(input_gate.data_ptr()),

--- a/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
@@ -115,8 +115,8 @@ void sgl_silu_and_mul_per_tensor_quant_fp8(
   TORCH_CHECK(is_static == false, "Static mode is not supported for silu_and_mul_per_tensor_quant_fp8");
 
   const int block_size = 256;
-  const int64_t num_elements = input_gate.numel();
-  const uint32_t num_blocks = min((num_elements + block_size - 1) / block_size, 1024);
+  const int num_elements = input_gate.numel();
+  const int num_blocks = min((num_elements + block_size - 1) / block_size, 1024);
   const int hidden_dim = input_gate.size(-1);
 
   dim3 grid(num_blocks);

--- a/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
+++ b/sgl-kernel/csrc/gemm/silu_and_mul_per_tensor_quant_fp8.cu
@@ -106,7 +106,7 @@ __global__ void per_tensor_quant_fp8_kernel(
   }
 }
 
-void sgl_silu_and_mul_per_tensor_quant_fp8(
+void sgl_silu_and_mul_per_tensor_quant_fp8_chunk(
     torch::Tensor input_gate, torch::Tensor input_up, torch::Tensor output_q, torch::Tensor output_s, bool is_static) {
   CHECK_INPUT(input_gate);
   CHECK_INPUT(input_up);
@@ -137,6 +137,151 @@ void sgl_silu_and_mul_per_tensor_quant_fp8(
         static_cast<__nv_fp8_e4m3*>(output_q.data_ptr()),
         static_cast<float*>(output_s.data_ptr()),
         num_elements);
+    return true;
+  });
+}
+
+// Fused SiLU and Mul kernel that takes concatenated input [seq_len, hidden_dim*2]
+// and produces output [seq_len, hidden_dim] without requiring pre-chunking
+template <typename T>
+__global__ void fused_silu_mul_per_tensor_absmax_kernel(
+    const T* __restrict__ input,   // [seq_len, hidden_dim*2] - concatenated gate and up
+    T* __restrict__ output,        // [seq_len, hidden_dim]
+    float* __restrict__ output_s,  // scalar for quantization
+    const int64_t seq_len,
+    const int64_t hidden_dim) {
+  float max_value = 0.0f;
+  unsigned int tid = threadIdx.x;
+  unsigned int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int grid_size = blockDim.x * gridDim.x;
+
+  // Use vectorized operations for better performance
+  constexpr uint32_t vec_size = 16 / sizeof(T);
+  using vec_t = flashinfer::vec_t<T, vec_size>;
+
+  const int64_t total_output_elements = seq_len * hidden_dim;
+  const int64_t num_vec_elems = total_output_elements / vec_size;
+
+  // Vectorized processing
+  for (int64_t i = gid; i < num_vec_elems; i += grid_size) {
+    // Calculate which row and column range we're processing
+    int64_t output_idx = i * vec_size;
+    int64_t row = output_idx / hidden_dim;
+    int64_t col_start = output_idx % hidden_dim;
+
+    vec_t gate_vec;
+    vec_t up_vec;
+    vec_t output_vec;
+
+    // Check if we're crossing row boundary
+    if (col_start + vec_size <= hidden_dim) {
+      // All elements in same row - most common case
+      int64_t gate_offset = row * (hidden_dim * 2) + col_start;
+      int64_t up_offset = row * (hidden_dim * 2) + hidden_dim + col_start;
+
+      gate_vec.cast_load(input + gate_offset);
+      up_vec.cast_load(input + up_offset);
+
+#pragma unroll
+      for (uint32_t j = 0; j < vec_size; ++j) {
+        float gate_val = static_cast<float>(gate_vec[j]);
+        float up_val = static_cast<float>(up_vec[j]);
+        float result = silu(gate_val) * up_val;
+        output_vec[j] = static_cast<T>(result);
+        max_value = fmaxf(max_value, fabsf(result));
+      }
+
+      output_vec.cast_store(output + output_idx);
+    } else {
+      // Handle boundary case - process element by element
+      for (uint32_t j = 0; j < vec_size; ++j) {
+        int64_t elem_idx = output_idx + j;
+        if (elem_idx < total_output_elements) {
+          int64_t elem_row = elem_idx / hidden_dim;
+          int64_t elem_col = elem_idx % hidden_dim;
+
+          int64_t gate_idx = elem_row * (hidden_dim * 2) + elem_col;
+          int64_t up_idx = elem_row * (hidden_dim * 2) + hidden_dim + elem_col;
+
+          float gate_val = static_cast<float>(input[gate_idx]);
+          float up_val = static_cast<float>(input[up_idx]);
+          float result = silu(gate_val) * up_val;
+
+          output[elem_idx] = static_cast<T>(result);
+          max_value = fmaxf(max_value, fabsf(result));
+        }
+      }
+    }
+  }
+
+  // Handle remaining elements
+  const int64_t remaining_start = num_vec_elems * vec_size;
+  for (int64_t idx = remaining_start + gid; idx < total_output_elements; idx += grid_size) {
+    int64_t row = idx / hidden_dim;
+    int64_t col = idx % hidden_dim;
+
+    int64_t gate_idx = row * (hidden_dim * 2) + col;
+    int64_t up_idx = row * (hidden_dim * 2) + hidden_dim + col;
+
+    float gate_val = static_cast<float>(input[gate_idx]);
+    float up_val = static_cast<float>(input[up_idx]);
+    float result = silu(gate_val) * up_val;
+
+    output[idx] = static_cast<T>(result);
+    max_value = fmaxf(max_value, fabsf(result));
+  }
+
+  // Reduce max value across block
+  max_value = blockReduceMax(max_value);
+
+  if (tid == 0) {
+    atomicMaxFloat(output_s, max_value / FP8_E4M3_MAX);
+  }
+}
+
+// Host function that takes concatenated input without requiring pre-chunking
+void sgl_silu_and_mul_per_tensor_quant_fp8(
+    torch::Tensor input,     // [seq_len, hidden_dim*2] - concatenated gate and up
+    torch::Tensor output,    // [seq_len, hidden_dim] - intermediate output
+    torch::Tensor output_q,  // [seq_len, hidden_dim] - quantized output
+    torch::Tensor output_s,  // scalar for quantization
+    bool is_static) {
+  CHECK_INPUT(input);
+  CHECK_INPUT(output);
+  CHECK_INPUT(output_q);
+  CHECK_INPUT(output_s);
+
+  TORCH_CHECK(is_static == false, "Static mode is not supported for fused_silu_and_mul_per_tensor_quant_fp8");
+  TORCH_CHECK(input.dim() == 2, "Input must be 2D tensor");
+  TORCH_CHECK(input.size(1) % 2 == 0, "Input hidden dimension must be even (hidden_dim*2)");
+
+  const int seq_len = input.size(0);
+  const int hidden_dim = input.size(1) / 2;
+  const int num_output_elements = seq_len * hidden_dim;
+
+  const int block_size = 256;
+  const int num_blocks = min((num_output_elements + block_size - 1) / block_size, 1024);
+
+  dim3 grid(num_blocks);
+  dim3 block(block_size);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), scalar_t, [&] {
+    // Fused SiLU and Mul kernel
+    fused_silu_mul_per_tensor_absmax_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        static_cast<scalar_t*>(input.data_ptr()),
+        static_cast<scalar_t*>(output.data_ptr()),
+        static_cast<float*>(output_s.data_ptr()),
+        seq_len,
+        hidden_dim);
+
+    // Quantization kernel
+    per_tensor_quant_fp8_kernel<scalar_t, __nv_fp8_e4m3><<<grid, block, 0, stream>>>(
+        static_cast<scalar_t*>(output.data_ptr()),
+        static_cast<__nv_fp8_e4m3*>(output_q.data_ptr()),
+        static_cast<float*>(output_s.data_ptr()),
+        num_output_elements);
+
     return true;
   });
 }

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -226,7 +226,8 @@ void sgl_per_token_group_quant_int8(
     double int8_max);
 void sgl_per_tensor_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void sgl_per_token_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s);
-void sgl_silu_and_mul_per_tensor_quant_fp8(at::Tensor input_gate, at::Tensor input_up, at::Tensor output_q, at::Tensor output_s, bool is_static);
+void sgl_silu_and_mul_per_tensor_quant_fp8(
+    at::Tensor input_gate, at::Tensor input_up, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void bmm_fp8(
     at::Tensor A,
     at::Tensor B,

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -227,7 +227,7 @@ void sgl_per_token_group_quant_int8(
 void sgl_per_tensor_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void sgl_per_token_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s);
 void sgl_silu_and_mul_per_tensor_quant_fp8(
-    at::Tensor input_gate, at::Tensor input_up, at::Tensor output_q, at::Tensor output_s, bool is_static);
+    at::Tensor input, at::Tensor output, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void bmm_fp8(
     at::Tensor A,
     at::Tensor B,

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -226,6 +226,7 @@ void sgl_per_token_group_quant_int8(
     double int8_max);
 void sgl_per_tensor_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void sgl_per_token_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s);
+void sgl_silu_and_mul_per_token_quant_fp8(at::Tensor input_gate, at::Tensor input_up, at::Tensor output_q, at::Tensor output_s);
 void bmm_fp8(
     at::Tensor A,
     at::Tensor B,

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -226,7 +226,7 @@ void sgl_per_token_group_quant_int8(
     double int8_max);
 void sgl_per_tensor_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void sgl_per_token_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s);
-void sgl_silu_and_mul_per_token_quant_fp8(at::Tensor input_gate, at::Tensor input_up, at::Tensor output_q, at::Tensor output_s);
+void sgl_silu_and_mul_per_tensor_quant_fp8(at::Tensor input_gate, at::Tensor input_up, at::Tensor output_q, at::Tensor output_s, bool is_static);
 void bmm_fp8(
     at::Tensor A,
     at::Tensor B,

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -58,6 +58,7 @@ from sgl_kernel.gemm import (
     sgl_per_token_group_quant_fp8,
     sgl_per_token_group_quant_int8,
     sgl_per_token_quant_fp8,
+    sgl_silu_and_mul_per_tensor_quant_fp8,
     shuffle_rows,
     silu_and_mul_scaled_fp4_grouped_quant,
 )

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -157,6 +157,7 @@ def sgl_silu_and_mul_per_tensor_quant_fp8(
         input_gate, input_up, output_q, output_s, is_static
     )
 
+
 def cutlass_scaled_fp4_mm(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -147,14 +147,14 @@ def sgl_per_token_quant_fp8(
 
 
 def sgl_silu_and_mul_per_tensor_quant_fp8(
-    input_gate: torch.Tensor,
-    input_up: torch.Tensor,
+    input: torch.Tensor,
+    output: torch.Tensor,
     output_q: torch.Tensor,
     output_s: torch.Tensor,
     is_static: bool,
 ) -> None:
     torch.ops.sgl_kernel.sgl_silu_and_mul_per_tensor_quant_fp8.default(
-        input_gate, input_up, output_q, output_s, is_static
+        input, output, output_q, output_s, is_static
     )
 
 

--- a/sgl-kernel/python/sgl_kernel/gemm.py
+++ b/sgl-kernel/python/sgl_kernel/gemm.py
@@ -146,6 +146,17 @@ def sgl_per_token_quant_fp8(
     torch.ops.sgl_kernel.sgl_per_token_quant_fp8.default(input, output_q, output_s)
 
 
+def sgl_silu_and_mul_per_tensor_quant_fp8(
+    input_gate: torch.Tensor,
+    input_up: torch.Tensor,
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    is_static: bool,
+) -> None:
+    torch.ops.sgl_kernel.sgl_silu_and_mul_per_tensor_quant_fp8.default(
+        input_gate, input_up, output_q, output_s, is_static
+    )
+
 def cutlass_scaled_fp4_mm(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/sgl-kernel/tests/test_silu_and_mul_per_tensor_quant_fp8.py
+++ b/sgl-kernel/tests/test_silu_and_mul_per_tensor_quant_fp8.py
@@ -1,0 +1,73 @@
+import itertools
+from typing import Optional, Tuple
+
+import pytest
+import torch
+from sgl_kernel import (
+    sgl_per_tensor_quant_fp8,
+    sgl_silu_and_mul_per_tensor_quant_fp8,
+    silu_and_mul,
+)
+
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
+fp8_type_ = torch.float8_e4m3fnuz if _is_hip else torch.float8_e4m3fn
+
+
+def sglang_silu_and_mul_scaled_fp8_quant(
+    input: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fp8_type_: torch.dtype = torch.float8_e4m3fn
+    output = torch.empty_like(input, device=input.device, dtype=fp8_type_)
+
+    intermediate_cache = torch.empty(
+        input.shape[0], input.shape[1] // 2, device=input.device, dtype=input.dtype
+    )
+    silu_and_mul(input, intermediate_cache)
+    scale = torch.zeros(1, device=input.device, dtype=torch.float32)
+    sgl_per_tensor_quant_fp8(intermediate_cache, output, scale, is_static=False)
+
+    return output, scale
+
+
+def sglang_fused_silu_and_mul_scaled_fp8_quant(
+    input: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fp8_type_: torch.dtype = torch.float8_e4m3fn
+    output = torch.empty_like(input, device=input.device, dtype=fp8_type_)
+    scale = torch.zeros(1, device=input.device, dtype=torch.float32)
+    input_gate, input_up = input.chunk(2, dim=-1)
+    input_gate = input_gate.contiguous()
+    input_up = input_up.contiguous()
+    sgl_silu_and_mul_per_tensor_quant_fp8(
+        input_gate, input_up, output, scale, is_static=False
+    )
+
+    return output, scale
+
+
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim",
+    list(itertools.product([128, 256, 512], [512, 2048, 4096])),
+)
+def test_silu_and_mul_per_tensor_quant_compare_implementations(
+    num_tokens: int,
+    hidden_dim: int,
+):
+    device = torch.device("cuda")
+    x = torch.rand((num_tokens, hidden_dim), dtype=torch.float16, device=device)
+
+    sglang_out, sglang_scale = sglang_silu_and_mul_scaled_fp8_quant(x)
+    fused_out, fused_scale = sglang_fused_silu_and_mul_scaled_fp8_quant(x)
+
+    torch.testing.assert_close(
+        sglang_out.float(), fused_out.float(), rtol=1e-3, atol=1e-3
+    )
+    torch.testing.assert_close(
+        sglang_scale.float(), fused_scale.float(), rtol=1e-3, atol=1e-3
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Implement silu_and_mul fused with per_tensor_quant_fp8 in FusedMoE. 

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
machine: H100
launch server:
python3 -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B --dp 1 --tp 2 --trust-remote-code --quantization fp8 --host 0.0.0.0 --attention-backend fa3 --cuda-graph-max-bs 128

python3 -m sglang.test.few_shot_gsm8k --num-questions 200
============Before Fusion===========
Accuracy: 0.925
Invalid: 0.000
Latency: 7.315 s
Output throughput: 3046.282 token/s
============After Fusion===========
Accuracy: 0.925
Invalid: 0.000
Latency: 7.075 s
Output throughput: 3247.546 token/s

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
<img width="729" height="394" alt="image" src="https://github.com/user-attachments/assets/f99ed154-8ac8-4158-ab4f-b68963b0f430" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
