### PR TITLE
Surface DeepGEMM commit in README.md

### DIFF
--- a/sgl-kernel/README.md
+++ b/sgl-kernel/README.md
@@ -49,6 +49,14 @@ python -m uv build --wheel -Cbuild-dir=build -Ccmake.define.SGL_KERNEL_ENABLE_FP
 ```
 See CMakeLists.txt for more options.
 
+### Using Custom Dependency Versions
+
+#### DeepGEMM Commit Override
+
+By default, the build system automatically selects the appropriate DeepGEMM repository and commit based on your CUDA version:
+- CUDA 12.8/12.9: Uses `sgl-project/DeepGEMM` with `blackwell` tag
+- Other versions: Uses `deepseek-ai/DeepGEMM` with commit `391755ada0ffefa9a6a52b6f14dcaf22d1a463e0`
+
 ### Parallel Build
 
 We highly recommend you build sgl-kernel with Ninja. Ninja can automatically build sgl-kernel in parallel.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

SGLang version:
```
(base) ray@k-a256418f0015a0000:~/default/work/DeepGEMM$ pip show sglang
Name: sglang
Version: 0.5.1.post2
Summary: SGLang is yet another fast serving framework for large language models and vision language models.
Home-page: https://github.com/sgl-project/sglang
Author: 
Author-email: 
License: 
Location: /home/ray/anaconda3/lib/python3.11/site-packages
Editable project location: /sgl-workspace/sglang/python
Requires: aiohttp, IPython, numpy, requests, setproctitle, tqdm
Required-by: 
(base) ray@k-a256418f0015a0000:~/default/work/DeepGEMM$ 
```

With latest DeepGEMM commit, can't launch server:
```
(base) ray@k-a256418f0015a0000:~/default/work/DeepGEMM$ git show
commit 51d1e9cdd3fb246842f530195fd1903a5d8640b6 (HEAD -> main, origin/main, origin/HEAD)
Author: Rain Jiang <96632942+rainj-me@users.noreply.github.com>
Date:   Tue Aug 26 18:30:08 2025 -0700

    Support compilation with CUDA 13.0 (#174)

modified: setup.py
@ setup.py:16 @ cxx_flags = ['-std=c++17', '-O3', '-fPIC', '-Wno-psabi', '-Wno-deprecated-declar
sources = ['csrc/python_api.cpp']
build_include_dirs = [
    f'{CUDA_HOME}/include',
    f'{CUDA_HOME}/include/cccl',
    'deep_gemm/include',
    'third-party/cutlass/include',
    'third-party/fmt/include',

modified: third-party/cutlass
@ third-party/cutlass:1 @
Subproject commit b244379d9b15574e07b73b814b88bd2233f0b3ce
Subproject commit a49a78ffefc86a87160dfe0ccc3a3a2d1622c918
```

Error:
```
[2025-08-29 13:33:27 DP4 TP4 EP4] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2612, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 325, in __init__
    self.tp_worker = TpWorkerClass(
                     ^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 67, in __init__
    self.worker = TpModelWorker(
                  ^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 84, in __init__
    self.model_runner = ModelRunner(
                        ^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 245, in __init__
    self.initialize(min_per_gpu_memory)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 291, in initialize
    self.load_model()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 687, in load_model
    self.model = get_model(
                 ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/__init__.py", line 22, in get_model
    return loader.load_model(
           ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 467, in load_model
    self.load_weights_and_postprocess(
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 475, in load_weights_and_postprocess
    model.load_weights(weights)
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2692, in load_weights
    self.post_load_weights(is_nextn=is_nextn, weight_names=weight_names)
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2394, in post_load_weights
    self._weight_requant_ue8m0(is_nextn)
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2420, in _weight_requant_ue8m0
    requant_weight_ue8m0_inplace(
  File "/sgl-workspace/sglang/python/sglang/srt/layers/quantization/fp8_utils.py", line 430, in requant_weight_ue8m0_inplace
    weight.data, weight_scale_inv.data = _requant_weight_ue8m0(
                                         ^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/quantization/fp8_utils.py", line 465, in _requant_weight_ue8m0
    out_s = _transform_scale(out_s, mn=out_w.shape[-2])
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/quantization/fp8_utils.py", line 462, in _transform_scale
    sf = deep_gemm.utils.layout.get_col_major_tma_aligned_packed_tensor(sf)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'deep_gemm.utils.layout' has no attribute 'get_col_major_tma_aligned_packed_tensor'
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
