### PR TITLE
accomendate json schema in the "schema" field, not in "json_schema" field of response_format

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -460,6 +460,38 @@ class ChatCompletionRequest(BaseModel):
                 values["tool_choice"] = "auto"
         return values
 
+    @model_validator(mode="before")
+    @classmethod
+    def set_json_schema(cls, values):
+        response_format = values.get("response_format")
+        if not response_format:
+            return values
+
+        if response_format.get("type") != "json_schema":
+            return values
+
+        schema = response_format.pop("schema", None)
+        json_schema = response_format.get("json_schema")
+
+        if json_schema:
+            return values
+
+        if schema:
+            name_ = schema.get("title", "Schema")
+            strict_ = False
+            if "properties" in schema and "strict" in schema["properties"]:
+                item = schema["properties"].pop("strict", None)
+                if item and item.get("default", False):
+                    strict_ = True
+
+            response_format["json_schema"] = {
+                "name": name_,
+                "schema": schema,
+                "strict": strict_,
+            }
+
+        return values
+
     # Extra parameters for SRT backend only and will be ignored by OpenAI models.
     top_k: int = -1
     min_p: float = 0.0

--- a/test/srt/openai_server/basic/test_protocol.py
+++ b/test/srt/openai_server/basic/test_protocol.py
@@ -18,7 +18,7 @@ import time
 import unittest
 from typing import Dict, List, Optional
 
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from sglang.srt.entrypoints.openai.protocol import (
     BatchRequest,
@@ -191,6 +191,81 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.separate_reasoning)
         self.assertFalse(request.stream_reasoning)
         self.assertEqual(request.chat_template_kwargs, {"custom_param": "value"})
+
+    def test_chat_completion_json_format(self):
+        """Test chat completion json format"""
+        transcript = "Good morning! It's 7:00 AM, and I'm just waking up. Today is going to be a busy day, "
+        "so let's get started. First, I need to make a quick breakfast. I think I'll have some "
+        "scrambled eggs and toast with a cup of coffee. While I'm cooking, I'll also check my "
+        "emails to see if there's anything urgent."
+
+        messages = [
+            {
+                "role": "system",
+                "content": "The following is a voice message transcript. Only answer in JSON.",
+            },
+            {
+                "role": "user",
+                "content": transcript,
+            },
+        ]
+
+        class VoiceNote(BaseModel):
+            title: str = Field(description="A title for the voice note")
+            summary: str = Field(
+                description="A short one sentence summary of the voice note."
+            )
+            strict: Optional[bool] = True
+            actionItems: List[str] = Field(
+                description="A list of action items from the voice note"
+            )
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            top_k=40,
+            min_p=0.05,
+            separate_reasoning=False,
+            stream_reasoning=False,
+            chat_template_kwargs={"custom_param": "value"},
+            response_format={
+                "type": "json_schema",
+                "schema": VoiceNote.model_json_schema(),
+            },
+        )
+        res_format = request.response_format
+        json_format = res_format.json_schema
+        name = json_format.name
+        schema = json_format.schema_
+        strict = json_format.strict
+        self.assertEqual(name, "VoiceNote")
+        self.assertEqual(strict, True)
+        self.assertNotIn("strict", schema["properties"])
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=messages,
+            top_k=40,
+            min_p=0.05,
+            separate_reasoning=False,
+            stream_reasoning=False,
+            chat_template_kwargs={"custom_param": "value"},
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "VoiceNote",
+                    "schema": VoiceNote.model_json_schema(),
+                    "strict": True,
+                },
+            },
+        )
+        res_format = request.response_format
+        json_format = res_format.json_schema
+        name = json_format.name
+        schema = json_format.schema_
+        strict = json_format.strict
+        self.assertEqual(name, "VoiceNote")
+        self.assertEqual(strict, True)
 
 
 class TestModelSerialization(unittest.TestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
currently it woun't take if write as bellow:

```
class VoiceNote(BaseModel):
    title: str = Field(description="A title for the voice note")
    summary: str = Field(description="A short one sentence summary of the voice note.")
    strict: Optional[bool] = True
    actionItems: List[str] = Field(
        description="A list of action items from the voice note"
    )

    transcript = (
        "Good morning! It's 7:00 AM, and I'm just waking up. Today is going to be a busy day, "
        "so let's get started. First, I need to make a quick breakfast. I think I'll have some "
        "scrambled eggs and toast with a cup of coffee. While I'm cooking, I'll also check my "
        "emails to see if there's anything urgent."
    )

    try:
        extract = client.chat.completions.create(
            messages=[
                {
                    "role": "system",
                    "content": "The following is a voice message transcript. Only answer in JSON.",
                },
                {
                    "role": "user",
                    "content": transcript,
                },
            ],
            model=model,
            response_format={
                "type": "json_schema",
                "schema": VoiceNote.model_json_schema(),
            },
        )
```

UT passed:

```
root@research-common-b200-05:/sgl-workspace/sglang# python3 /sgl-workspace/sglang/test/srt/openai_server/basic/test_protocol.py
test_basic_chat_completion_request (__main__.TestChatCompletionRequest.test_basic_chat_completion_request)
Test basic chat completion request ... ok
test_chat_completion_json_format (__main__.TestChatCompletionRequest.test_chat_completion_json_format)
Test chat completion json format ... ok
test_chat_completion_sglang_extensions (__main__.TestChatCompletionRequest.test_chat_completion_sglang_extensions)
Test chat completion with SGLang extensions ... ok
test_chat_completion_tool_choice_validation (__main__.TestChatCompletionRequest.test_chat_completion_tool_choice_validation)
Test tool choice validation logic ... ok
test_basic_completion_request (__main__.TestCompletionRequest.test_basic_completion_request)
Test basic completion request ... ok
test_completion_request_sglang_extensions (__main__.TestCompletionRequest.test_completion_request_sglang_extensions)
Test completion request with SGLang-specific extensions ... ok
test_completion_request_validation_errors (__main__.TestCompletionRequest.test_completion_request_validation_errors)
Test completion request validation errors ... ok
test_model_card_serialization (__main__.TestModelCard.test_model_card_serialization)
Test model card JSON serialization ... ok
test_empty_model_list (__main__.TestModelList.test_empty_model_list)
Test empty model list creation ... ok
test_model_list_with_cards (__main__.TestModelList.test_model_list_with_cards)
Test model list with model cards ... ok
test_hidden_states_excluded_when_none (__main__.TestModelSerialization.test_hidden_states_excluded_when_none)
Test that None hidden_states are excluded with exclude_none=True ... ok
test_hidden_states_included_when_not_none (__main__.TestModelSerialization.test_hidden_states_included_when_not_none)
Test that non-None hidden_states are included ... ok
test_invalid_tool_choice_type (__main__.TestValidationEdgeCases.test_invalid_tool_choice_type)
Test invalid tool choice type ... ok
test_model_serialization_roundtrip (__main__.TestValidationEdgeCases.test_model_serialization_roundtrip)
Test that models can be serialized and deserialized ... /sgl-workspace/sglang/test/srt/openai_server/basic/test_protocol.py:350: DeprecationWarning: max_tokens is deprecated in favor of the max_completion_tokens field
  self.assertEqual(restored_request.max_tokens, original_request.max_tokens)
ok
test_negative_token_limits (__main__.TestValidationEdgeCases.test_negative_token_limits)
Test negative token limits ... ok
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
