### PR TITLE
[Feature][1/n] Custom pin memory allocation (numa supported)

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -22,6 +22,24 @@ enable_language(CUDA)
 find_package(CUDAToolkit REQUIRED)
 set_property(GLOBAL PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
+# NUMA
+if(DEFINED ENV{CONDA_PREFIX})
+    set(CONDA_LIB_DIR "$ENV{CONDA_PREFIX}/lib")
+    message(STATUS "Using Conda lib dir: ${CONDA_LIB_DIR}")
+    link_directories(${CONDA_LIB_DIR})
+    set(CONDA_INCLUDE_DIR "$ENV{CONDA_PREFIX}/include")
+    include_directories(${CONDA_INCLUDE_DIR})
+
+    # Look for libnuma in Conda's lib directory
+    find_library(NUMA_LIB numa HINTS "${CONDA_LIB_DIR}")
+    if(NUMA_LIB)
+        message(STATUS "Found libnuma: ${NUMA_LIB}")
+    else()
+        message(FATAL_ERROR "libnuma not found in Conda environment at ${CONDA_LIB_DIR}\n"
+                            "Please install it using: conda install libnuma numactl\n")
+    endif()
+endif()
+
 message(STATUS "Detected CUDA_VERSION=${CUDA_VERSION}")
 if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
     message("CUDA_VERSION ${CUDA_VERSION} >= 13.0")
@@ -315,6 +333,7 @@ set(SOURCES
     "csrc/moe/prepare_moe_input.cu"
 
     "csrc/memory/store.cu"
+    "csrc/memory/numa_pin_memory.cu"
     "csrc/kvcacheio/transfer.cu"
 
     "csrc/speculative/eagle_utils.cu"
@@ -365,7 +384,7 @@ add_subdirectory(
     ${repo-mscclpp_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/mscclpp-build
 )
-target_link_libraries(common_ops PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt mscclpp_static)
+target_link_libraries(common_ops PRIVATE ${TORCH_LIBRARIES} ${NUMA_LIB} c10 cuda cublas cublasLt mscclpp_static)
 
 # flash attention
 target_compile_definitions(common_ops PRIVATE

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -358,6 +358,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
    */
   m.def("store_kv_cache(Tensor k_cache, Tensor v_cache, Tensor out_loc, Tensor k, Tensor v) -> ()");
   m.impl("store_kv_cache", &store_kv_cache);
+  m.def("allocate_pin_memory(int size, ScalarType dtype, bool write_combined, int? numa_affinity) -> Tensor");
+  m.impl("allocate_pin_memory", &allocate_pin_memory);
 
   /*
    * From FlashInfer

--- a/sgl-kernel/csrc/memory/numa_pin_memory.cu
+++ b/sgl-kernel/csrc/memory/numa_pin_memory.cu
@@ -1,0 +1,58 @@
+#include <ATen/core/TensorBody.h>
+#include <ATen/ops/from_blob.h>
+#include <c10/core/ScalarType.h>
+#include <c10/core/ScalarTypeToTypeMeta.h>
+#include <c10/core/TensorOptions.h>
+#include <cuda_runtime.h>
+#include <numa.h>
+
+#include <cstdlib>
+#include <optional>
+
+auto allocate_pin_memory(
+    const int64_t size,
+    const at::ScalarType dtype,
+    const bool write_combined,
+    const std::optional<int64_t> numa_affinity) -> at::Tensor {
+  const auto size_bytes = size * at::elementSize(dtype);
+  void* data_ptr;
+  const auto options = at::TensorOptions(at::kCPU).dtype(dtype).pinned_memory(true);
+  if (numa_affinity.has_value()) {
+    // only initialize once
+    static const int kNumaCount = ::numa_max_node() + 1;
+    const auto node = static_cast<int>(numa_affinity.value());
+    TORCH_CHECK(node >= 0 && node < kNumaCount, "Invalid NUMA node: ", node);
+    TORCH_CHECK(!write_combined, "Write-combine is not compatible with NUMA allocation");
+    // allocate on the specified NUMA node
+    data_ptr = ::numa_alloc_onnode(size_bytes, node);
+    TORCH_CHECK(data_ptr != nullptr, "Failed to allocate memory on NUMA node: ", node);
+    const auto result = ::cudaHostRegister(data_ptr, size_bytes, cudaHostRegisterDefault);
+    if (result != ::cudaSuccess) {
+      ::numa_free(data_ptr, size_bytes);
+      TORCH_CHECK(false, "Failed to register pinned memory: ", ::cudaGetErrorString(result));
+    }
+    return at::from_blob(
+        data_ptr,
+        {size},
+        [size](void* data_ptr) {
+          const auto result = ::cudaHostUnregister(data_ptr);
+          ::numa_free(data_ptr, size);
+          TORCH_CHECK(result == ::cudaSuccess, "Failed to unregister pinned memory: ", ::cudaGetErrorString(result));
+        },
+        options,
+        at::kCPU);
+  } else {
+    const auto flags = write_combined ? cudaHostAllocWriteCombined : cudaHostAllocDefault;
+    const auto result = ::cudaHostAlloc(&data_ptr, size_bytes, flags);
+    TORCH_CHECK(result == ::cudaSuccess, "Failed to allocate pinned memory: ", ::cudaGetErrorString(result));
+    return at::from_blob(
+        data_ptr,
+        {size},
+        [](void* data_ptr) {
+          const auto result = ::cudaFreeHost(data_ptr);
+          TORCH_CHECK(result == ::cudaSuccess, "Failed to free pinned memory: ", ::cudaGetErrorString(result));
+        },
+        options,
+        at::kCPU);
+  }
+}

--- a/sgl-kernel/csrc/memory/numa_pin_memory.cu
+++ b/sgl-kernel/csrc/memory/numa_pin_memory.cu
@@ -34,9 +34,9 @@ auto allocate_pin_memory(
     return at::from_blob(
         data_ptr,
         {size},
-        [size](void* data_ptr) {
+        [size_bytes](void* data_ptr) {
           const auto result = ::cudaHostUnregister(data_ptr);
-          ::numa_free(data_ptr, size);
+          ::numa_free(data_ptr, size_bytes);
           TORCH_CHECK(result == ::cudaSuccess, "Failed to unregister pinned memory: ", ::cudaGetErrorString(result));
         },
         options,

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -770,3 +770,6 @@ void causal_conv1d_fwd(
     const std::optional<at::Tensor>& has_initial_state,
     bool silu_activation,
     int64_t pad_slot_id);
+
+at::Tensor
+allocate_pin_memory(int64_t size, at::ScalarType dtype, bool write_combined, std::optional<int64_t> numa_affinity);

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -747,6 +747,9 @@ std::vector<int64_t> create_greenctx_stream_by_value(int64_t smA, int64_t smB, i
  */
 void store_kv_cache(at::Tensor k_cache, at::Tensor v_cache, at::Tensor out_loc, at::Tensor k, at::Tensor v);
 
+at::Tensor
+allocate_pin_memory(int64_t size, at::ScalarType dtype, bool write_combined, std::optional<int64_t> numa_affinity);
+
 /*
  * From csrc/mamba
  */
@@ -770,6 +773,3 @@ void causal_conv1d_fwd(
     const std::optional<at::Tensor>& has_initial_state,
     bool silu_activation,
     int64_t pad_slot_id);
-
-at::Tensor
-allocate_pin_memory(int64_t size, at::ScalarType dtype, bool write_combined, std::optional<int64_t> numa_affinity);

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -73,7 +73,7 @@ from sgl_kernel.marlin import (
     awq_marlin_repack,
     gptq_marlin_repack,
 )
-from sgl_kernel.memory import set_kv_buffer_kernel
+from sgl_kernel.memory import allocate_pin_memory, set_kv_buffer_kernel
 from sgl_kernel.moe import (
     apply_shuffle_mul_sum,
     cutlass_fp4_group_mm,

--- a/sgl-kernel/python/sgl_kernel/memory.py
+++ b/sgl-kernel/python/sgl_kernel/memory.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 import torch
 
 
@@ -16,3 +18,19 @@ def set_kv_buffer_kernel(
     except RuntimeError:  # ok, fallback to torch implementation
         k_cache[loc] = k
         v_cache[loc] = v
+
+
+def allocate_pin_memory(
+    shape: Iterable[int],
+    dtype: torch.dtype,
+    write_combined: bool = False,
+    numa_affinity: int | None = None,
+) -> torch.Tensor:
+    shape_tuple = tuple(shape)
+    size = 1
+    for dim in shape_tuple:
+        size *= dim
+    t: torch.Tensor = torch.ops.sgl_kernel.allocate_pin_memory(
+        size, dtype, write_combined, numa_affinity
+    )
+    return t.view(shape_tuple)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
`torch`'s pin_memory allocator aligns large allocations (e.g., 65 GiB) to the next power of 2 (e.g., 128 GiB), introducing substantial memory overhead. This is particularly problematic when hierarchical KVCache is enabled, as we allocate large pinned host buffers. Furthermore, on NUMA systems, accessing pinned memory from a mismatched NUMA node incurs significant latency, exacerbating performance penalties when host memory is not properly aligned with the GPU's locality.

Reference:  [Where does torch align the allocation](https://github.com/pytorch/pytorch/blob/b994f6e3b331faeac693970bd1e14972f3fc9d4a/aten/src/ATen/core/CachingHostAllocator.h#L203)

## Modifications

<!-- Detail the changes made in this pull request. -->
Add a pin memory allocation function in `sgl_kernel`, supporting optional NUMA allocation.

TODO: Integrate this into `HiRadixCache`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
