### PR TITLE
[WIP] External shared experts 

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -108,6 +108,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "quantization",
     "enable_custom_logit_processor",
     "disaggregation_mode",
+    "moe_shared_expert_rank_num",
 ]
 
 # Put some global args for easy access

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -352,6 +352,18 @@ class DeepseekV2MoE(nn.Module):
         self.shared_experts_is_int8 = False
         self.shared_experts_is_fp8 = False
         self.shared_experts_weight_block_size = None
+        self.rank = torch.distributed.get_rank()
+        self.moe_shared_expert_rank_num = global_server_args_dict[
+            "moe_shared_expert_rank_num"
+        ]
+        self.num_experts = (
+            config.n_routed_experts
+            + self.num_fused_shared_experts
+            + global_server_args_dict["ep_num_redundant_experts"]
+        )
+        self.num_local_experts = self.num_experts // (
+            self.tp_size - self.moe_shared_expert_rank_num
+        )
         if config.n_shared_experts is not None and self.num_fused_shared_experts == 0:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
             # disable tp for shared experts when enable deepep moe, or with fp4 allgather

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -282,6 +282,9 @@ class ServerArgs:
     deepep_config: Optional[str] = None
     moe_dense_tp_size: Optional[int] = None
 
+    # Moe external shared expert
+    moe_shared_expert_rank_num: int = 0
+
     # Hierarchical cache
     enable_hierarchical_cache: bool = False
     hicache_ratio: float = 2.0
@@ -653,6 +656,9 @@ class ServerArgs:
             logger.warning(
                 "EPLB is enabled. The expert_distribution_recorder_mode is automatically set."
             )
+
+        if self.enable_deepep_moe and self.moe_shared_expert_rank_num > 0:
+            logger.info("Moe shared expert externalization is enabled.")
 
         if (self.enable_eplb or (self.init_expert_location is not None)) and (
             self.ep_dispatch_algorithm is None
@@ -1611,6 +1617,12 @@ class ServerArgs:
             "--enable-expert-distribution-metrics",
             action="store_true",
             help="Enable logging metrics for expert balancedness",
+        )
+        parser.add_argument(
+            "--moe-shared-expert-rank-num",
+            type=int,
+            default=0,
+            help="The number of moe shared expert-ranks",
         )
         parser.add_argument(
             "--deepep-config",


### PR DESCRIPTION
**Co-authored-by:** raindaywhu raindaywhu@163.com
releated issue #9438 
## Motivation

In MoE inference under ​**Expert Parallelism (EP)**​, each device executes both the shared experts and the routed experts **sequentially** on the same device, which increases per-device load and end-to-end latency. To address this, we **externalize shared experts** by placing them on dedicated ranks/devices and aggregating the outputs of shared and routed experts via ​dispatch/combine, thereby eliminating on-device serialization and reducing load and latency.

## Overview

Empirically, shared-expert demand is much lower; with **top-8** gating (DeepSeek-style), we observe roughly an **8:1** ratio of routed-expert compute to shared-expert usage. By separating shared experts and routed experts onto different ranks and using the **`dispatch`** operator to route tokens (then **`combine`** to aggregate results), the shared-expert cost is largely overlapped/hidden behind routed-expert computation. This reduces end-to-end latency and eases per-rank load.

![external_moe_shared_experts](https://github.com/user-attachments/assets/56930df9-6dab-4ec8-bdb7-a61a33857d7b)

## Changes

#### 1) New parameter

* `moe_shared_expert_rank_num`: the number of ranks dedicated to shared experts (externalized).

#### 2) Inference adaptation

We leverage Ascend NPU **`dispatch`/`combine`** operators. By configuring the number of externalized shared experts, forwarding and aggregation are handled automatically, so the **top-k** logic remains unchanged. The only requirement during inference is to divide the shared-expert outputs by the coefficient `routed_scaling_factor`.

#### 3) Weight-loading adaptation

The existing `num_fused_shared_experts` path already supports loading shared experts as routed experts. Here we only adjust the expert map so that **shared-expert ranks** load only shared experts, and **routed-expert ranks** load only routed experts.

## Experimental results

On ​**Ascend NPU**​, with ​**EP = 64**​, we observe a performance improvement of ​**over 5 ms**​.## Advantages and Limitations
We will present additional experimental results in subsequent updates.

## Advantages and Limitations

* **Advantages.** With minimal code changes, we enable ​**externalized shared experts**​, improving inference performance.
* **Limitations.** This relies on  token dispatch/combine with external shared experts. Currently  supported by Ascend NPU  on A3.

**Update pending:** The code adapted for EPLB is done and will be supplemented later.
