### PR TITLE
[Bugfix]add hicache event check before mooncake transfer in pd case

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -52,6 +52,7 @@ class BaseKVManager(ABC):
         args: KVArgs,
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
+        tree_cache: RadixCache,
         is_mla_backend: Optional[bool] = False,
     ): ...
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -41,6 +41,7 @@ class CommonKVManager(BaseKVManager):
         args: KVArgs,
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
+        tree_cache: RadixCache,
         is_mla_backend: Optional[bool] = False,
     ):
         self.kv_args = args

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -223,6 +223,7 @@ class DecodePreallocQueue:
             kv_args,
             DisaggregationMode.DECODE,
             self.scheduler.server_args,
+            self.scheduler.tree_cache,
             self.is_mla_backend,
         )
         return kv_manager

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -167,12 +167,14 @@ class MooncakeKVManager(BaseKVManager):
         args: KVArgs,
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
+        tree_cache: RadixCache,
         is_mla_backend: Optional[bool] = False,
     ):
         self.kv_args = args
         self.local_ip = get_local_ip_auto()
         self.is_mla_backend = is_mla_backend
         self.disaggregation_mode = disaggregation_mode
+        self.tree_cache = tree_cache
         self.init_engine()
         # for p/d multi node infer
         self.bootstrap_port = server_args.disaggregation_bootstrap_port
@@ -697,6 +699,7 @@ class MooncakeKVManager(BaseKVManager):
                                 )
                                 break
 
+                        self.tree_cache.check_hicache_events()
                         chunked_dst_kv_indice = req.dst_kv_indices[kv_chunk.index_slice]
 
                         # NOTE: This is temporarily a workaround to deal with the case where the prefill_kv_indices

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -671,6 +671,8 @@ class MooncakeKVManager(BaseKVManager):
     ):
         while True:
             try:
+                if self.tree_cache.is_hiradix_cache:
+                    self.tree_cache.check_hicache_events()
                 kv_chunk: TransferKVChunk = queue.get()
                 reqs_to_be_processed = (
                     self.transfer_infos[kv_chunk.room].values()
@@ -699,7 +701,6 @@ class MooncakeKVManager(BaseKVManager):
                                 )
                                 break
 
-                        self.tree_cache.check_hicache_events()
                         chunked_dst_kv_indice = req.dst_kv_indices[kv_chunk.index_slice]
 
                         # NOTE: This is temporarily a workaround to deal with the case where the prefill_kv_indices

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -116,6 +116,7 @@ class NixlKVManager(CommonKVManager):
         args: KVArgs,
         disaggregation_mode: DisaggregationMode,
         server_args: ServerArgs,
+        tree_cache: RadixCache,
         is_mla_backend: Optional[bool] = False,
     ):
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -119,7 +119,7 @@ class NixlKVManager(CommonKVManager):
         tree_cache: RadixCache,
         is_mla_backend: Optional[bool] = False,
     ):
-        super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
+        super().__init__(args, disaggregation_mode, server_args, tree_cache, is_mla_backend)
         try:
             from nixl._api import nixl_agent
         except ImportError as e:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -145,6 +145,7 @@ class PrefillBootstrapQueue:
             kv_args,
             DisaggregationMode.PREFILL,
             self.scheduler.server_args,
+            self.scheduler.tree_cache,
             self.is_mla_backend,
         )
         return kv_manager

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -106,7 +106,11 @@ class HiRadixCache(RadixCache):
         )
         self.load_back_threshold = 10
         super().__init__(
-            req_to_token_pool, token_to_kv_pool_allocator, page_size, disable=False
+            req_to_token_pool,
+            token_to_kv_pool_allocator,
+            page_size,
+            disable=False,
+            is_hiradix_cache=True
         )
 
     def reset(self):

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -124,6 +124,7 @@ class RadixCache(BasePrefixCache):
         page_size: int,
         disable: bool = False,
         enable_kv_cache_events: bool = False,
+        is_hiradix_cache: bool = False,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -131,6 +132,7 @@ class RadixCache(BasePrefixCache):
         self.disable = disable
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue = []
+        self.is_hiradix_cache = is_hiradix_cache
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device


### PR DESCRIPTION
## Motivation

https://github.com/sgl-project/sglang/issues/9151
as this issue say, I find  it could trigger err error in prefill pod when using pd & hicache at the same time, and transferengine is mooncake.
so I try to fix it, I suspect it is a bug about sync between data movement of hicache and transferEngine.

## Modifications

just add self.tree_cache.check_hicache_events() before send_kvcache in MooncakeKVManager

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
