### PR TITLE
[metrics][EPLB]: Support selected count of physical experts on each GPU

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -6,14 +6,15 @@ SGLang supports various environment variables that can be used to configure its 
 
 ## General Configuration
 
-| Environment Variable | Description | Default Value |
-| --- | --- | --- |
-| `SGLANG_USE_MODELSCOPE` | Enable using models from ModelScope | `false` |
-| `SGLANG_HOST_IP` | Host IP address for the server | `0.0.0.0` |
-| `SGLANG_PORT` | Port for the server | auto-detected |
-| `SGLANG_LOGGING_CONFIG_PATH` | Custom logging configuration path | Not set |
-| `SGLANG_DISABLE_REQUEST_LOGGING` | Disable request logging | `false` |
-| `SGLANG_HEALTH_CHECK_TIMEOUT` | Timeout for health check in seconds | `20` |
+| Environment Variable                      | Description                                                                                                                      | Default Value |
+|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `SGLANG_USE_MODELSCOPE`                   | Enable using models from ModelScope                                                                                              | `false`       |
+| `SGLANG_HOST_IP`                          | Host IP address for the server                                                                                                   | `0.0.0.0`     |
+| `SGLANG_PORT`                             | Port for the server                                                                                                              | auto-detected |
+| `SGLANG_LOGGING_CONFIG_PATH`              | Custom logging configuration path                                                                                                | Not set       |
+| `SGLANG_DISABLE_REQUEST_LOGGING`          | Disable request logging                                                                                                          | `false`       |
+| `SGLANG_HEALTH_CHECK_TIMEOUT`             | Timeout for health check in seconds                                                                                              | `20`          |
+| `SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL` | The interval of passes to collect the metric of selected count of physical experts on each layer and GPU rank. 0 means disabled. | `0`           |
 
 ## Performance Tuning
 

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import time
 from abc import ABC
 from collections import deque

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
 # --------------------------------------- Entrypoint -----------------------------------------
 
 _OutputMode = Literal["file", "object"]

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -29,6 +29,7 @@ import torch
 import torch.distributed
 
 from sglang.srt.environ import envs
+from sglang.srt.metrics.collector import ExpertDispatchCollector
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import Withable, is_npu
@@ -669,7 +670,7 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
             self._expert_dispatch_collector = ExpertDispatchCollector(
                 self._expert_location_metadata.ep_size
             )
-            self.collection_counter = 0
+            self._collection_counter = 0
 
     def append(
         self,
@@ -722,7 +723,7 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
         # sglang:eplb_gpu_physical_count metric is disabled if SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL <= 0
         if (
             SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL > 0
-            and self.collection_counter % SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL == 0
+            and self._collection_counter % SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL == 0
         ):
             for layer_idx in range(self._expert_location_metadata.num_layers):
                 count_of_layer = (
@@ -740,7 +741,7 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
                     if count > 0:
                         count_of_layer._sum.inc(count * gpu_rank)
                         count_of_layer._buckets[gpu_rank].inc(count)
-        self.collection_counter += 1
+        self._collection_counter += 1
 
 
 class _DequeCollection:

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import logging
 import math
-import os
 import time
 from abc import ABC
 from collections import deque
@@ -41,9 +40,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL = int(
-    os.getenv("SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL", 0)
-)
 
 # --------------------------------------- Entrypoint -----------------------------------------
 
@@ -722,8 +718,9 @@ class _UtilizationRateAccumulatorMixin(_Accumulator):
     def _collect_metrics_if_needed(self, gpu_physical_count: torch.Tensor):
         # sglang:eplb_gpu_physical_count metric is disabled if SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL <= 0
         if (
-            SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL > 0
-            and self._collection_counter % SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL == 0
+            envs.SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL > 0
+            and self._collection_counter % envs.SGLANG_EPLB_HEATMAP_COLLECTION_INTERVAL
+            == 0
         ):
             for layer_idx in range(self._expert_location_metadata.num_layers):
                 count_of_layer = (

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -999,3 +999,16 @@ class StorageMetricsCollector:
             self._log_histogram(self.histogram_prefetch_bandwidth, v)
         for v in storage_metrics.backup_bandwidth:
             self._log_histogram(self.histogram_backup_bandwidth, v)
+
+
+class ExpertDispatchCollector:
+    def __init__(self, ep_size: int) -> None:
+        from prometheus_client import Histogram
+
+        ep_size_buckets = [i for i in range(ep_size)]
+        self.eplb_gpu_physical_count = Histogram(
+            name="sglang:eplb_gpu_physical_count",
+            documentation="The selected count of physical experts on each layer and GPU rank.",
+            labelnames={"layer"},
+            buckets=ep_size_buckets,
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
EPLB is very important in large scale EP, but now it's not convenient to monitor the balancedness.

## Modifications

<!-- Detail the changes made in this pull request. -->
Introduce a new histogram metric `sglang:eplb_gpu_physical_count` to reflect the selected count of physical expert count on each layer and each gpu rank. It is enabled when `--enable-expert-distribution-metrics` is enbled.

Then we can get metrics like:
- `layer` label: the layer of the model
- `le` buckets: the GPU rank
```
...
sglang:eplb_gpu_physical_count_count{layer="26"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="0.0"} 0.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="1.0"} 16.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="2.0"} 16.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="3.0"} 16.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="4.0"} 48.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="5.0"} 48.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="6.0"} 64.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="7.0"} 80.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="8.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="9.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="10.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="11.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="12.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="13.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="14.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="15.0"} 128.0
sglang:eplb_gpu_physical_count_bucket{layer="27",le="+Inf"} 128.0
...
```

We can use this metric to draw a heatmap on Grafana, for example, using PromQL:
```
increase(sum(sglang:eplb_gpu_physical_count_bucket{le!="+Inf", pod=~".*decode.*"}) by (le)[5m])
```
to draw a heatmap on the sum of all layers:
<img width="3818" height="1848" alt="image" src="https://github.com/user-attachments/assets/acee2133-7a7b-418e-881b-c7552c201e86" />

Of course, it's easy to draw the heatmap on a specify layer label in PromQL.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
