### PR TITLE
[Bugfix] GPT-OSS + torch.compile + --moe-runner-backend triton compatibility

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -152,9 +152,10 @@ class RotaryEmbedding(CustomOp):
         fused_set_kv_buffer_arg: Optional[FusedSetKVBufferArg] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """A PyTorch-native implementation of forward()."""
-        assert (
-            fused_set_kv_buffer_arg is None
-        ), "fused_set_kv_buffer_arg is not supported for native implementation"
+
+        # fused_set_kv_buffer_arg is not used in the PyTorch-native forward,
+        # however, it is required to match the signature of the forward method
+        # to avoid errors in the fallback of torch.compile.
 
         if offsets is not None:
             positions = positions + offsets


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

After https://github.com/sgl-project/sglang/pull/9014 was merged, when we enable torch.compile and call RotaryEmbedding it defaults to forward_native() which always passes in fused_set_kv_buffer_arg.

As well, https://github.com/sgl-project/sglang/issues/8833#issuecomment-3219286773

```
TypeError: RotaryEmbedding.forward_native() got an unexpected keyword argument 'fused_set_kv_buffer_arg'
```

```python
q, k = self.rotary_emb(
    positions, q, k,
    fused_set_kv_buffer_arg=_create_fused_set_kv_buffer_arg(...)
)
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Add it

<!-- Detail the changes made in this pull request. -->

## Benchmarking and Profiling

`python3 -m sglang.launch_server --model openai/gpt-oss-20b --enable-torch-compile --moe-runner-backend triton`

```
...
[2025-08-30 17:35:53] max_total_num_tokens=644795, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=2518, context_len=131072, available_gpu_mem=7.92 GB
[2025-08-30 17:35:54] INFO:     Started server process [1529]
[2025-08-30 17:35:54] INFO:     Waiting for application startup.
[2025-08-30 17:35:54] INFO:     Application startup complete.
[2025-08-30 17:35:54] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2025-08-30 17:35:55] INFO:     127.0.0.1:46299 - "GET /get_model_info HTTP/1.1" 200 OK
[2025-08-30 17:35:55] Prefill batch. #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-08-30 17:36:03] INFO:     127.0.0.1:37720 - "POST /generate HTTP/1.1" 200 OK
[2025-08-30 17:36:03] The server is fired up and ready to roll!
```

> Actually there is a separate compatibility issue with torch compile with the default triton_kernel moe runner backend so I'll raise that issue separately.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

```
torch.compile ON (Triton normal backend)
#Input tokens: 32768
#Output tokens: 16384
batch size: 32
input_len: 1024
output_len: 512
latency: 8.03 s
ttft: 1.76 s
last generation throughput: 2734.27 tok/s
input throughput: 18595.85 tok/s
output throughput: 2612.41 tok/s
#Input tokens: 262144
#Output tokens: 16384
batch size: 32
input_len: 8192
output_len: 512
latency: 14.40 s
ttft: 6.82 s
last generation throughput: 2173.17 tok/s
input throughput: 38440.53 tok/s
output throughput: 2162.51 tok/s

Results are saved to result.jsonl

Input lens: (1024, 8192). Output lens: (512,).
|   batch size |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) | acc length   |   ITL (ms) |   input cost ($/1M) |   output cost ($/1M) |
|--------------|---------------|----------------------------|-----------------------------|--------------|------------|---------------------|----------------------|
|           32 |          8.03 |                   18595.85 |                     2612.41 | n/a          |      12.25 |                0.04 |                 0.21 |
|           32 |         14.40 |                   38440.53 |                     2162.51 | n/a          |      14.80 |                0.02 |                 0.26 |


torch.compile OFF (Triton normal backend)
#Input tokens: 32768
#Output tokens: 16384
batch size: 32
input_len: 1024
output_len: 512
latency: 9.51 s
ttft: 2.13 s
last generation throughput: 2219.48 tok/s
input throughput: 15408.52 tok/s
output throughput: 2217.56 tok/s
#Input tokens: 262144
#Output tokens: 16384
batch size: 32
input_len: 8192
output_len: 512
latency: 15.42 s
ttft: 6.83 s
last generation throughput: 1871.07 tok/s
input throughput: 38400.35 tok/s
output throughput: 1905.66 tok/s

Results are saved to result.jsonl

Input lens: (1024, 8192). Output lens: (512,).
|   batch size |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) | acc length   |   ITL (ms) |   input cost ($/1M) |   output cost ($/1M) |
|--------------|---------------|----------------------------|-----------------------------|--------------|------------|---------------------|----------------------|
|           32 |          9.51 |                   15408.52 |                     2217.56 | n/a          |      14.43 |                0.05 |                 0.25 |
|           32 |         15.42 |                   38400.35 |                     1905.66 | n/a          |      16.79 |                0.02 |                 0.29 |


MoE runner backend: triton_kernel
#Input tokens: 32768
#Output tokens: 16384
batch size: 32
input_len: 1024
output_len: 512
latency: 5.35 s
ttft: 1.35 s
last generation throughput: 4070.47 tok/s
input throughput: 24188.40 tok/s
output throughput: 4101.52 tok/s
#Input tokens: 262144
#Output tokens: 16384
batch size: 32
input_len: 8192
output_len: 512
latency: 9.28 s
ttft: 4.15 s
last generation throughput: 3165.20 tok/s
input throughput: 63188.29 tok/s
output throughput: 3195.47 tok/s

Results are saved to result.jsonl

Input lens: (1024, 8192). Output lens: (512,).
|   batch size |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) | acc length   |   ITL (ms) |   input cost ($/1M) |   output cost ($/1M) |
|--------------|---------------|----------------------------|-----------------------------|--------------|------------|---------------------|----------------------|
|           32 |          5.35 |                   24188.40 |                     4101.52 | n/a          |       7.80 |                0.03 |                 0.14 |
|           32 |          9.28 |                   63188.29 |                     3195.47 | n/a          |      10.01 |                0.01 |                 0.17 |
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
