### PR TITLE
perf: Avoid unnecessary data type conversions for DeepSeek-V3 on Blackwell

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -655,7 +655,8 @@ def _set_envs_and_config(server_args: ServerArgs):
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "4"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
     # flashinfer uses this environment variable for various kernels from MoE to quant kernels
-    os.environ["TRTLLM_ENABLE_PDL"] = "1"
+    if os.environ.get("TRTLLM_ENABLE_PDL", "1") != "0":
+        os.environ["TRTLLM_ENABLE_PDL"] = "1"
 
     # Can also be passed as argument
     os.environ["SGLANG_RUN_ID"] = (

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -67,7 +67,10 @@ from sglang.srt.layers.moe import (
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
-from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.moe.fused_moe_triton.layer import (
+    FusedMoE,
+    _is_fp4_quantization_enabled,
+)
 from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.quantization import deep_gemm_wrapper
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -299,7 +302,9 @@ class MoEGate(nn.Module):
             and _device_sm >= 90
         ):
             # router gemm output float32
-            logits = dsv3_router_gemm(hidden_states, self.weight)
+            logits = dsv3_router_gemm(
+                hidden_states, self.weight, out_dtype=torch.float32
+            )
         elif _use_aiter_gfx95 and hidden_states.shape[0] <= 256:
             logits = aiter_dsv3_router_gemm(
                 hidden_states, self.weight, gemm_output_zero_allocator
@@ -364,6 +369,9 @@ class DeepseekV2MoE(nn.Module):
             prefix=add_prefix("experts", prefix),
         )
 
+        correction_bias = self.gate.e_score_correction_bias
+        if _is_fp4_quantization_enabled():
+            correction_bias = correction_bias.to(torch.bfloat16)
         self.topk = TopK(
             top_k=config.num_experts_per_tok + self.num_fused_shared_experts,
             renormalize=config.norm_topk_prob,
@@ -371,7 +379,7 @@ class DeepseekV2MoE(nn.Module):
             num_expert_group=config.n_group,
             num_fused_shared_experts=self.num_fused_shared_experts,
             topk_group=config.topk_group,
-            correction_bias=self.gate.e_score_correction_bias,
+            correction_bias=correction_bias,
             routed_scaling_factor=self.routed_scaling_factor,
             apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk(),
             force_topk=quant_config is None,


### PR DESCRIPTION
Optimize the performance of DeepSeek-V3 on Blackwell for small batch sizes by

- Change the output data type of router GEMM to FP32
- Convert the data type of `correction_bias` in the object initialization
- ~~Use the `cutlass` backend for the first GEMM in shared experts~~ (only benefits small batches)

The performance has been tested on B200 using the following commands.
```
python3 -m sglang.launch_server \
    --model-path ${path_model} \
    --trust-remote-code \
    --quantization modelopt_fp4 \
    --tp 8 \
    --moe-runner-backend flashinfer_trtllm \
    --attention-backend trtllm_mla \
    --enable-flashinfer-allreduce-fusion

for batch_size in 1 2 4 8 16 32 64 128 256; do
    python3 -m sglang.bench_serving \
        --model ${path_model} \
        --dataset-name random \
        --backend sglang-oai \
        --random-range-ratio 1 \
        --random-input-len 1200 \
        --random-output-len 256 \
        --max-concurrency ${batch_size} \
        --num-prompts $(( batch_size * 10 ))
done
```

The tested median TTFT and median ITL are listed below. Because TTFT has very large variance (comparing it is not very meaningful), the performance is assessed using ITL.

<table>
    <thead>
        <tr>
            <th rowspan=3>Batch Size</th>
            <th rowspan=2, colspan=2>Original</th>
            <th colspan=6>Avoid Dtype Conversion</th>
        </tr>
        <tr>
            <th colspan=2>cuDNN, cuDNN</th>
            <th colspan=2>CUTLASS, cuDNN</th>
            <th colspan=2>CUTLASS, CUTLASS</th>
        </tr>
        <tr>
            <th>TTFT (ms)</th>
            <th>ITL (ms)</th>
            <th>TTFT (ms)</th>
            <th>ITL (ms)</th>
            <th>TTFT (ms)</th>
            <th>ITL (ms)</th>
            <th>TTFT (ms)</th>
            <th>ITL (ms)</th>
        </tr>
    </thead>
    <tbody>
<tr><td align=center>1</td> <td align=center>72.63</td> <td align=center>7.41</td> <td align=center>72.21</td> <td align=center>7.15</td> <td align=center>74.54</td> <th align=center>7.07</th> <td align=center>69.93</td> <td align=center>7.15</td></tr>
<tr><td align=center>2</td> <td align=center>144.49</td> <td align=center>7.41</td> <td align=center>119.35</td> <th align=center>7.12</th> <td align=center>84.18</td> <th align=center>7.12</th> <td align=center>136.82</td> <td align=center>7.14</td></tr>
<tr><td align=center>4</td> <td align=center>159.16</td> <td align=center>7.93</td> <td align=center>156.64</td> <td align=center>7.70</td> <td align=center>173.00</td> <th align=center>7.62</th> <td align=center>151.52</td> <td align=center>7.73</td></tr>
<tr><td align=center>8</td> <td align=center>271.39</td> <td align=center>8.92</td> <td align=center>308.45</td> <th align=center>8.57</th> <td align=center>273.02</td> <td align=center>8.70</td> <td align=center>260.27</td> <td align=center>8.79</td></tr>
<tr><td align=center>16</td> <td align=center>472.31</td> <td align=center>11.70</td> <td align=center>474.21</td> <td align=center>11.41</td> <td align=center>481.33</td> <th align=center>11.23</th> <td align=center>466.03</td> <td align=center>11.33</td></tr>
<tr><td align=center>32</td> <td align=center>808.20</td> <td align=center>14.24</td> <td align=center>561.89</td> <th align=center>14.08</th> <td align=center>559.31</td> <td align=center>14.23</td> <td align=center>544.00</td> <td align=center>14.19</td></tr>
<tr><td align=center>64</td> <td align=center>1515.34</td> <td align=center>18.05</td> <td align=center>1611.65</td> <th align=center>17.89</th> <td align=center>1012.22</td> <td align=center>18.00</td> <td align=center>967.13</td> <td align=center>17.97</td></tr>
<tr><td align=center>128</td> <td align=center>2074.25</td> <td align=center>23.11</td> <td align=center>1890.56</td> <th align=center>22.97</th> <td align=center>1513.91</td> <td align=center>23.05</td> <td align=center>1155.98</td> <td align=center>23.06</td></tr>
<tr><td align=center>256</td> <td align=center>4009.33</td> <td align=center>31.33</td> <td align=center>3878.77</td> <th align=center>31.18</th> <td align=center>3866.18</td> <th align=center>31.18</th> <td align=center>3882.10</td> <td align=center>31.21</td></tr>
    </tbody>
</table>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
