### PR TITLE
Disable radix cache in test_lora_update.py for better stability

### DIFF
--- a/test/srt/lora/test_lora_update.py
+++ b/test/srt/lora/test_lora_update.py
@@ -824,6 +824,7 @@ class LoRAUpdateEngineTestSession(LoRAUpdateTestSessionBase):
             disable_cuda_graph=self.disable_cuda_graph,
             cuda_graph_max_bs=self.cuda_graph_max_bs,
             enable_lora=self.enable_lora,
+            disable_radix_cache=True,
         )
         self.handle.__enter__()
         return self
@@ -958,6 +959,7 @@ class LoRAUpdateServerTestSession(LoRAUpdateTestSessionBase):
             "1",
             "--mem-fraction-static",
             str(MEM_FRACTION_STATIC),
+            "--disable-radix-cache",
         ]
         if self.enable_lora:
             other_args.append("--enable-lora")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently in `test_lora_update.py`, radix cache is enabled by default since #7216. Despite passing CI, this test is not stable due to the randomness introduced by radix cache.

For example, this test might pass on H100, while failing on H200 with same environment setting.

To make it more stable, we want to disable the radix cache feature for this test . Correctness of radix cache in lora can be covered by other tests.

cc @lifuhuang 

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
