### PR TITLE
[NVIDIA] disable chunked prefix cache when dp is used

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -522,10 +522,11 @@ class ModelRunner:
 
         if not self.use_mla_backend:
             server_args.disable_chunked_prefix_cache = True
-
-        if self.dp_size > 1:
-            logger.info("Disable chunked prefix cache when dp size > 1.")
-            server_args.disable_chunked_prefix_cache = True
+        # TODO(kaixih@nvidia): remove this once we have a better solution for DP attention.
+        #  For more details, see: https://github.com/sgl-project/sglang/issues/8616
+        elif self.dp_size > 1 and is_sm100_supported() and server_args.attention_backend != "triton":
+           logger.info("Disable chunked prefix cache when dp size > 1 and attention backend is not triton.")
+           server_args.disable_chunked_prefix_cache = True
 
         if not server_args.disable_chunked_prefix_cache:
             logger.info("Chunked prefix cache is turned on.")

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -523,6 +523,10 @@ class ModelRunner:
         if not self.use_mla_backend:
             server_args.disable_chunked_prefix_cache = True
 
+        if self.dp_size > 1:
+            logger.info("Disable chunked prefix cache when dp size > 1.")
+            server_args.disable_chunked_prefix_cache = True
+
         if not server_args.disable_chunked_prefix_cache:
             logger.info("Chunked prefix cache is turned on.")
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -524,9 +524,15 @@ class ModelRunner:
             server_args.disable_chunked_prefix_cache = True
         # TODO(kaixih@nvidia): remove this once we have a better solution for DP attention.
         #  For more details, see: https://github.com/sgl-project/sglang/issues/8616
-        elif self.dp_size > 1 and is_sm100_supported() and server_args.attention_backend != "triton":
-           logger.info("Disable chunked prefix cache when dp size > 1 and attention backend is not triton.")
-           server_args.disable_chunked_prefix_cache = True
+        elif (
+            self.dp_size > 1
+            and is_sm100_supported()
+            and server_args.attention_backend != "triton"
+        ):
+            logger.info(
+                "Disable chunked prefix cache when dp size > 1 and attention backend is not triton."
+            )
+            server_args.disable_chunked_prefix_cache = True
 
         if not server_args.disable_chunked_prefix_cache:
             logger.info("Chunked prefix cache is turned on.")


### PR DESCRIPTION
This PR is to work around an accuracy issue found in https://github.com/sgl-project/sglang/issues/9806.

It seems the chunked prefix cache doesn't work well with the DP. So, we disable it for now to recover the accuracy.

cc @trevor-m @kushanam @zhyncs 