### PR TITLE
[router] fix FunctionCallResponse proto, support arguments is null

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -1565,7 +1565,8 @@ pub enum FunctionCall {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FunctionCallResponse {
     pub name: String,
-    pub arguments: String, // JSON string
+    #[serde(default)]
+    pub arguments: Option<String>, // JSON string
 }
 
 // ============= Usage Tracking =============


### PR DESCRIPTION
## Motivation

I meet some online request, which like following
```
               "tool_calls": [{
                    "id": "chatcmpl-tool-dc755656-7036-44f5-9956-2c094bd08973",
                    "type": "function",
                    "function": {
                        "name": "read_file",
                        "arguments": null
                    }
                }]
 ```
 and router returns `Failed to deserialize the JSON body into the target type: messages[15]: data did not match any variant of untagged enum ChatMessage`
 I finally find it's because FunctionCallResponse proto does not support null arguments.
 I could reproduce it in the 0.5.1 released image

## Modifications

fix FunctionCallResponse proto to be compatible with null

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
