### PR TITLE
[Bugfix] dp-attention split error

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1522,6 +1522,7 @@ class Scheduler(
             self.tree_cache.cache_unfinished_req(self.chunked_req, chunked=True)
             # chunked request keeps its rid but will get a new req_pool_idx
             self.req_to_token_pool.free(self.chunked_req.req_pool_idx)
+
         if self.last_batch and self.last_batch.forward_mode.is_extend():
             if self.last_batch.chunked_req is not None:
                 # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked_req.
@@ -1558,6 +1559,7 @@ class Scheduler(
         if new_batch is not None:
             # Run prefill first if possible
             ret = new_batch
+
         else:
             # Run decode
             if not self.running_batch.is_empty():

--- a/python/sglang/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sglang/srt/managers/tp_worker_overlap_thread.py
@@ -180,6 +180,7 @@ class TpModelWorkerClient:
 
             # Update the future token ids map
             bs = len(model_worker_batch.seq_lens)
+
             self.future_token_ids_map[
                 future_token_ids_ct + 1 : future_token_ids_ct + bs + 1
             ] = next_token_ids

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1784,9 +1784,16 @@ class ModelRunner:
             )
             return ret, can_run_cuda_graph
 
+        #logger.info( f"[GW DEBUG] LOC2 {forward_batch.batch_size=} {forward_batch.input_ids.shape=}, {forward_batch.seq_lens=}, {forward_batch.seq_lens_sum=}, {forward_batch.orig_seq_lens=}, "
+        #            f"{forward_batch.extend_num_tokens=}, {forward_batch.extend_seq_lens=}, {forward_batch.extend_seq_lens_cpu=}, {forward_batch.extend_prefix_lens_cpu=}"
+        #)
         # For MLP sync
         if forward_batch.global_num_tokens_cpu is not None:
             forward_batch.prepare_mlp_sync_batch(self)
+
+        #logger.info( f"[GW DEBUG] LOC3 {forward_batch.batch_size=} {forward_batch.input_ids.shape=}, {forward_batch.seq_lens=}, {forward_batch.seq_lens_sum=}, {forward_batch.orig_seq_lens=}, "
+        #            f"{forward_batch.extend_num_tokens=}, {forward_batch.extend_seq_lens=}, {forward_batch.extend_seq_lens_cpu=}, {forward_batch.extend_prefix_lens_cpu=}"
+        #)
 
         if forward_batch.forward_mode.is_decode():
             ret = self.forward_decode(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
#9896 
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
<!-- Detail the changes made in this pull request. -->
#### `prepare_mlp_sync_batch()`
1. `batch_size` is sharing across the all DP ranks and select the global batch size as the maximum one.
2.  Proper padding applied to tensors prefixed `extend_` using both `global_batch_size` and `globlal_num_tokens`

#### Others
- Changed certain data types for stability and safety.

#### Limitation of current changes
1. Only supports the case where TP-size = DP-size.
2. A new tensor is created when calling `prepare_mlp_sync_batch()` which may affect to cuda-graph capturing.
3. Only support `global_batch_size - local_batch_size <= 1` case.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
