### PR TITLE
add proctitle for tokenizers

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -29,6 +29,8 @@ import time
 from http import HTTPStatus
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
+import setproctitle
+
 # Fix a bug of Python threading
 setattr(threading, "_register_atexit", lambda *args, **kwargs: None)
 
@@ -1165,6 +1167,7 @@ def launch_server(
     1. The HTTP server, Engine, and TokenizerManager both run in the main process.
     2. Inter-process communication is done through IPC (each process uses a different port) via the ZMQ library.
     """
+    setproctitle.setproctitle(f"sglang::http_server/tokenizer_manager")
     if server_args.tokenizer_worker_num > 1:
         port_args = PortArgs.init_new(server_args)
         port_args.tokenizer_worker_ipc_name = (

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1167,8 +1167,8 @@ def launch_server(
     1. The HTTP server, Engine, and TokenizerManager both run in the main process.
     2. Inter-process communication is done through IPC (each process uses a different port) via the ZMQ library.
     """
-    setproctitle.setproctitle(f"sglang::http_server/tokenizer_manager")
     if server_args.tokenizer_worker_num > 1:
+        setproctitle.setproctitle(f"sglang::http_server/multi_tokenizer_router")
         port_args = PortArgs.init_new(server_args)
         port_args.tokenizer_worker_ipc_name = (
             f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}"
@@ -1177,6 +1177,7 @@ def launch_server(
             server_args=server_args, port_args=port_args
         )
     else:
+        setproctitle.setproctitle(f"sglang::http_server/tokenizer_manager")
         tokenizer_manager, template_manager, scheduler_info = _launch_subprocesses(
             server_args=server_args,
         )

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -477,7 +477,9 @@ class MultiTokenizerManager(TokenizerManager, MultiTokenizerMixin):
         server_args: ServerArgs,
         port_args: PortArgs,
     ):
-        setproctitle.setproctitle(f"sglang::http_server/multi_tokenizer_manager:{os.getpid()}")
+        setproctitle.setproctitle(
+            f"sglang::http_server/multi_tokenizer_manager:{os.getpid()}"
+        )
         # prevent init prefill bootstrapserver again
         disaggregation_mode = server_args.disaggregation_mode
         server_args.disaggregation_mode = "null"

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -23,6 +23,7 @@ import threading
 from multiprocessing import shared_memory
 from typing import Dict
 
+import setproctitle
 import zmq
 import zmq.asyncio
 
@@ -476,6 +477,7 @@ class MultiTokenizerManager(TokenizerManager, MultiTokenizerMixin):
         server_args: ServerArgs,
         port_args: PortArgs,
     ):
+        setproctitle.setproctitle("sglang::multi_tokenizer_manager")
         # prevent init prefill bootstrapserver again
         disaggregation_mode = server_args.disaggregation_mode
         server_args.disaggregation_mode = "null"

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -477,7 +477,7 @@ class MultiTokenizerManager(TokenizerManager, MultiTokenizerMixin):
         server_args: ServerArgs,
         port_args: PortArgs,
     ):
-        setproctitle.setproctitle("sglang::multi_tokenizer_manager")
+        setproctitle.setproctitle(f"sglang::http_server/multi_tokenizer_manager:{os.getpid()}")
         # prevent init prefill bootstrapserver again
         disaggregation_mode = server_args.disaggregation_mode
         server_args.disaggregation_mode = "null"


### PR DESCRIPTION
After setting proc title for each process, we can easily get the PID from `pgrep -a sglang` to get each proc's PID, which is useful when debugging with `py-spy`

```
pgrep sglang -a
95990 sglang::http_server/multi_tokenizer_router
96354 sglang::data_parallel_controller
96355 sglang::detokenizer
97728 sglang::scheduler_DP0_TP0
97729 sglang::scheduler_DP1_TP1
97730 sglang::scheduler_DP2_TP2
97731 sglang::scheduler_DP3_TP3
100529 sglang::http_server/multi_tokenizer_manager:100529
100530 sglang::http_server/multi_tokenizer_manager:100530
100531 sglang::http_server/multi_tokenizer_manager:100531
102312 sglang::http_server/multi_tokenizer_manager:102312
```