### PR TITLE
fix:incorrect throughput calculation caused by a TTFT metric computation error in bench_one_batch_server

### DIFF
--- a/python/sglang/bench_one_batch_server.py
+++ b/python/sglang/bench_one_batch_server.py
@@ -190,6 +190,7 @@ def run_one_case(
 
     # The TTFT of the last request in the batch
     ttft = 0.0
+    last_time = tic
     for chunk in response.iter_lines(decode_unicode=False):
         chunk = chunk.decode("utf-8")
         if chunk and chunk.startswith("data:"):
@@ -204,7 +205,8 @@ def run_one_case(
                 or data["meta_info"]["finish_reason"]["type"] == "length"
             )
             if data["meta_info"]["completion_tokens"] == 1:
-                ttft = time.perf_counter() - tic
+                ttft += time.perf_counter() - last_time
+            last_time = time.perf_counter()
 
     latency = time.perf_counter() - tic
     input_throughput = batch_size * input_len / ttft


### PR DESCRIPTION




## Motivation

When KV cache capacity is small, long prompts cannot be fully prefetched in one shot, causing prefill–decode–prefill interleaving. The existing TTFT logic in bench_one_batch_server measured start → last first-token wall time and thus included decode time, inflating TTFT and skewing throughput metrics. This PR revises TTFT calculation so it only accumulates elapsed time segments that end at a first-token event, effectively excluding decode windows.
[#9967](https://github.com/sgl-project/sglang/issues/9967)

## Modifications

Scope: client-side benchmark script only (python/sglang/bench_one_batch_server.py). No runtime/server changes.

Logic change: instead of setting ttft = now - tic at the last “first-token” event, we accumulate the elapsed time only when a first-token event is observed, and reset the segment start.

## Accuracy Tests

N/A — This change does not affect model forward/evaluation logic or outputs.

## Benchmarking and Profiling

Model: Qwen3-8B

Batch size: 32

Input/Output: 2048 / 1024

## Repro Steps

Small KV pool (interleaving prefill/decode)
Server (reduced KV cache capacity):

```
python3 -m sglang.launch_server \
  --model-path /llm/HFModels/Qwen3-8B/ \
  --disable-radix-cache --trust-remote-code \
  --host 127.0.0.1 --port 30001 \
  --mem-fraction-static 0.3
```


Same benchmark command.

Before fix (incorrect TTFT):

```
latency: 35.14 s
ttft: 20.52 s
last generation throughput: 876.83 tok/s
input throughput: 3193.53 tok/s
output throughput: 2242.14 tok/s
```


After fix (decode excluded from TTFT):

```
latency: 35.08 s
ttft: 4.23 s
last generation throughput: 876.98 tok/s
input throughput: 15499.39 tok/s
output throughput: 1062.05 tok/s
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).


