### PR TITLE
Optimize Qwen3-moe model by using flashinfer fused allreduce 

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -42,9 +42,15 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.utils import is_cuda, is_flashinfer_available, is_sm100_supported
+from sglang.srt.utils import (
+    is_cuda,
+    is_flashinfer_available,
+    is_sm90_supported,
+    is_sm100_supported,
+)
 
 _is_flashinfer_available = is_flashinfer_available()
+_is_sm90_supported = is_cuda() and is_sm90_supported()
 _is_sm100_supported = is_cuda() and is_sm100_supported()
 
 FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
@@ -484,11 +490,11 @@ class CommunicateWithAllReduceAndLayerNormFn:
             # According to the discussion in https://github.com/flashinfer-ai/flashinfer/issues/1223#issuecomment-3047256465
             # We set the max token num to 128 for allreduce fusion with min-latency case(use_oneshot=True).
             if (
-                _is_sm100_supported
+                (_is_sm100_supported or _is_sm90_supported)
                 and _is_flashinfer_available
                 and hasattr(layernorm, "forward_with_allreduce_fusion")
                 and global_server_args_dict["enable_flashinfer_allreduce_fusion"]
-                and hidden_states.shape[0] <= 2048
+                and hidden_states.shape[0] <= 4096
             ):
                 hidden_states, residual = layernorm.forward_with_allreduce_fusion(
                     hidden_states, residual

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -105,11 +105,14 @@ class Qwen2MoeMLP(nn.Module):
     def forward(
         self,
         x,
+        should_allreduce_fusion: bool = False,
         use_reduce_scatter: bool = False,
     ):
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x, skip_all_reduce=use_reduce_scatter)
+        x, _ = self.down_proj(
+            x, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter
+        )
         return x
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to make qwen moe model leverage FlashInfer fused_allreduce to fuse allreduce+rmsnorm+residual_add. 
The E2E input throughput improved 2.2%. Currently use a small MoE model so the speedup is slightly, larger 235B model can gain better performance. Will try and update the report.

Before fusion:
The AllReduce 13.26% + FusedNormAdd 6.45% == 19.71%
<img width="2994" height="1456" alt="image" src="https://github.com/user-attachments/assets/418dd21a-3b40-4f83-9919-ad4285b2ba4f" />

<img width="2964" height="1400" alt="image" src="https://github.com/user-attachments/assets/c518ceec-f049-4924-901c-cca8f7a4dd4a" />

This PR:
Fused AllReduce_Norm_Residual == 12.98%

<img width="2988" height="1384" alt="image" src="https://github.com/user-attachments/assets/14fbe855-2d65-41b8-af02-afe69051abb5" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
gsm8k result:
```
PR:
$python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000 --data-path ./test.jsonl
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:11<00:00, 17.89it/s]
Accuracy: 0.730
Invalid: 0.000
Latency: 11.408 s
Output throughput: 4582.656 token/s

Main:
$python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000 --data-path ./test.jsonl
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:11<00:00, 16.71it/s]
Accuracy: 0.695
Invalid: 0.000
Latency: 12.098 s
Output throughput: 4544.950 token/s

```

```
$python test_openai.py 
ChatCompletion(id='ab6d5c2a3da74d58908895b51a64ebd2', choices=[Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content="<think>\nOkay, the user asked for three countries and their capitals, and then how I rank them. Let me start by picking three countries. Maybe the US, Japan, and Brazil. Their capitals are Washington, D.C., Tokyo, and Brasília. Now, how to rank them? The user didn't specify the criteria, so I need to think of possible ways. Maybe by population, economic size, or cultural influence. Let me check the population. The US has around 330 million, Japan about 125 million, Brazil 215 million. So US first, Brazil second, Japan third. But if I consider GDP, the US is the largest, then Japan, then Brazil. Alternatively, cultural influence: Japan has a strong cultural impact, maybe higher than Brazil. But the user might not have a specific criteria. I should mention that the ranking depends on the criteria. Maybe list different rankings based on different factors. That way, the answer is comprehensive", refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None, reasoning_content=None), matched_stop=None)], created=1756901402, model='default', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=200, prompt_tokens=33, total_tokens=233, completion_tokens_details=None, prompt_tokens_details=None, reasoning_tokens=0), metadata={'weight_version': 'default'})
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

```
==========This PR==========
Server run:
python3 -m sglang.launch_server --model-path /home/admin/Qwen3-30B-A3B --attention-backend flashinfer --trust-remote-code --tp-size=8 --disable-radix-cache --enable-flashinfer-allreduce-fusion

Benchmark command:
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 20 --max-concurrency 1 --output-file opt_ar.jsonl --port 30000 --warmup-requests 10
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 200 --max-concurrency 32 --output-file opt_ar.jsonl --port 30000 --warmup-requests 10
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 300 --max-concurrency 64 --output-file opt_ar.jsonl --port 30000 --warmup-requests 10
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 400 --max-concurrency 128 --output-file opt_ar.jsonl --port 30000 --warmup-requests 10

$python test/srt/parse_results.py opt_ar.jsonl 

+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+====================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |          51354.780 |              12.839 |         77.302 |           76.660 |        83.727 |          0.000 |            0.000 |         0.000 |                12.839 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |            32.000 |          66705.620 |              16.676 |       1781.711 |         1930.559 |      1981.094 |          0.000 |            0.000 |         0.000 |                 0.521 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |            64.000 |          66678.729 |              16.670 |       3459.219 |         3800.498 |      3954.309 |          0.000 |            0.000 |         0.000 |                 0.260 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  3 |           128.000 |          66709.728 |              16.677 |       6488.294 |         7597.425 |      7767.646 |          0.000 |            0.000 |         0.000 |                 0.130 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+


Main:

python3 -m sglang.launch_server --model-path /home/admin/Qwen3-30B-A3B --attention-backend flashinfer --trust-remote-code --tp-size=8 --disable-radix-cache

curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 20 --max-concurrency 1 --output-file main_ar.jsonl --port 30000 --warmup-requests 10
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 200 --max-concurrency 32 --output-file main_ar.jsonl --port 30000 --warmup-requests 10
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 300 --max-concurrency 64 --output-file main_ar.jsonl --port 30000 --warmup-requests 10
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --backend sglang-oai  --dataset-name random --random-input-len 4000 --random-output-len 1 --random-range-ratio 1 --num-prompts 400 --max-concurrency 128 --output-file main_ar.jsonl --port 30000 --warmup-requests 10

$python test/srt/parse_results.py main.jsonl 

+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+====================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |          50351.713 |              12.588 |         78.854 |           77.447 |        95.848 |          0.000 |            0.000 |         0.000 |                12.588 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |            32.000 |          66295.272 |              16.574 |       1791.414 |         1933.183 |      1988.196 |          0.000 |            0.000 |         0.000 |                 0.518 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |            64.000 |          66609.521 |              16.652 |       3462.091 |         3804.271 |      3949.396 |          0.000 |            0.000 |         0.000 |                 0.260 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  3 |           128.000 |          66046.912 |              16.512 |       6551.049 |         7585.682 |      7768.804 |          0.000 |            0.000 |         0.000 |                 0.129 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
