### PR TITLE
Fix Llama 4 with MXFP4 dynamic quant on MI35x

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -816,7 +816,10 @@ class Mxfp4DynamicQuantMoEMethod(FusedMoEMethodBase):
         moe_runner_config: MoeRunnerConfig,
     ) -> torch.Tensor:
         topk_weights, topk_ids, _ = topk_output
-
+        if _is_hip:
+            topk_weights = topk_weights.to(
+                torch.float32
+            )  # aiter's moe_sorting requires topk_weights to be FP32
         return fused_moe(
             x,
             layer.w13_weight,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2336,7 +2336,8 @@ class ServerArgs:
             assert self.attention_backend in {
                 "fa3",
                 "aiter",
-            }, "fa3 or aiter is required for Llama4 model"
+                "triton",  # ROCm bf16 or mxfp4 dynamic quantization
+            }, "fa3, aiter, or triton is required for Llama4 model"
         elif model_arch in [
             "Gemma2ForCausalLM",
             "Gemma3ForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2336,7 +2336,7 @@ class ServerArgs:
             assert self.attention_backend in {
                 "fa3",
                 "aiter",
-                "triton",  # ROCm bf16 or mxfp4 dynamic quantization
+                "triton",
             }, "fa3, aiter, or triton is required for Llama4 model"
         elif model_arch in [
             "Gemma2ForCausalLM",


### PR DESCRIPTION
Server command
```
SGLANG_USE_AITER=1 python -m sglang.launch_server --model-path meta-llama/Llama-4-Maverick-17B-128E-Instruct --quantization mxfp4 --tp 8 --port 8000 --attention-backend aiter
# Or
SGLANG_USE_AITER=1 python -m sglang.launch_server --model-path meta-llama/Llama-4-Maverick-17B-128E-Instruct --quantization mxfp4 --tp 8 --port 8000 --attention-backend triton
```
Client command
```
python benchmark/gsm8k/bench_sglang.py --num-questions 1400 --port 8000
-------
Accuracy: 0.933
Invalid: 0.000
```



## Motivation

As title.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

CC: @HaiShaw @sogalin 
