### PR TITLE
[router] move tokenizer, reasoning, tool initialization to server

### DIFF
--- a/sgl-router/src/core/worker.rs
+++ b/sgl-router/src/core/worker.rs
@@ -986,7 +986,7 @@ pub fn start_health_checker(
 
             // Periodically reset load counters to prevent drift
             // Only do this when we believe all workers should be idle
-            if check_count.is_multiple_of(LOAD_RESET_INTERVAL) {
+            if check_count % LOAD_RESET_INTERVAL == 0 {
                 let max_load = workers_to_check.iter().map(|w| w.load()).max().unwrap_or(0);
                 // Only reset if load appears to be very low (likely drift)
                 if max_load <= 2 {

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -12,7 +12,7 @@ use crate::metrics::RouterMetrics;
 use crate::policies::LoadBalancingPolicy;
 use crate::reasoning_parser::ParserFactory;
 use crate::routers::{RouterTrait, WorkerManagement};
-use crate::tokenizer::{factory, traits::Tokenizer};
+use crate::tokenizer::traits::Tokenizer;
 use crate::tool_parser::ParserRegistry;
 use async_trait::async_trait;
 use axum::{
@@ -74,20 +74,12 @@ impl GrpcPDRouter {
         retry_config: RetryConfig,
         circuit_breaker_config: ConfigCircuitBreakerConfig,
         health_check_config: ConfigHealthCheckConfig,
-        tokenizer_path_or_model: String,
+        tokenizer: Arc<dyn Tokenizer>,
+        reasoning_parser_factory: ParserFactory,
+        tool_parser_registry: &'static ParserRegistry,
     ) -> Result<Self, String> {
         // Update metrics
         RouterMetrics::set_active_workers(prefill_urls.len() + decode_urls.len());
-
-        // Initialize tokenizer
-        let tokenizer = factory::create_tokenizer(&tokenizer_path_or_model)
-            .map_err(|e| format!("Failed to create tokenizer: {}", e))?;
-
-        // Initialize reasoning parser factory
-        let reasoning_parser_factory = ParserFactory::new();
-
-        // Get tool parser registry
-        let tool_parser_registry = ParserRegistry::new();
 
         // Convert config CircuitBreakerConfig to core CircuitBreakerConfig
         let core_cb_config = CircuitBreakerConfig {

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -12,7 +12,7 @@ use crate::metrics::RouterMetrics;
 use crate::policies::LoadBalancingPolicy;
 use crate::reasoning_parser::ParserFactory;
 use crate::routers::{RouterTrait, WorkerManagement};
-use crate::tokenizer::{factory, traits::Tokenizer};
+use crate::tokenizer::traits::Tokenizer;
 use crate::tool_parser::ParserRegistry;
 use async_trait::async_trait;
 use axum::{
@@ -65,20 +65,12 @@ impl GrpcRouter {
         retry_config: RetryConfig,
         circuit_breaker_config: ConfigCircuitBreakerConfig,
         health_check_config: ConfigHealthCheckConfig,
-        tokenizer_path_or_model: String,
+        tokenizer: Arc<dyn Tokenizer>,
+        reasoning_parser_factory: ParserFactory,
+        tool_parser_registry: &'static ParserRegistry,
     ) -> Result<Self, String> {
         // Update metrics
         RouterMetrics::set_active_workers(worker_urls.len());
-
-        // Initialize tokenizer
-        let tokenizer = factory::create_tokenizer(&tokenizer_path_or_model)
-            .map_err(|e| format!("Failed to create tokenizer: {}", e))?;
-
-        // Initialize reasoning parser factory
-        let reasoning_parser_factory = ParserFactory::new();
-
-        // Get tool parser registry
-        let tool_parser_registry = ParserRegistry::new();
 
         // Convert config CircuitBreakerConfig to core CircuitBreakerConfig
         let core_cb_config = CircuitBreakerConfig {

--- a/sgl-router/tests/common/mod.rs
+++ b/sgl-router/tests/common/mod.rs
@@ -13,12 +13,15 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 /// Helper function to create AppContext for tests
 pub fn create_test_context(config: RouterConfig) -> Arc<AppContext> {
-    Arc::new(AppContext::new(
-        config.clone(),
-        reqwest::Client::new(),
-        config.max_concurrent_requests,
-        config.rate_limit_tokens_per_second,
-    ))
+    Arc::new(
+        AppContext::new(
+            config.clone(),
+            reqwest::Client::new(),
+            config.max_concurrent_requests,
+            config.rate_limit_tokens_per_second,
+        )
+        .expect("Failed to create AppContext in test"),
+    )
 }
 
 // Tokenizer download configuration

--- a/sgl-router/tests/common/test_app.rs
+++ b/sgl-router/tests/common/test_app.rs
@@ -15,12 +15,15 @@ pub fn create_test_app(
     router_config: &RouterConfig,
 ) -> Router {
     // Create AppContext
-    let app_context = Arc::new(AppContext::new(
-        router_config.clone(),
-        client,
-        router_config.max_concurrent_requests,
-        router_config.rate_limit_tokens_per_second,
-    ));
+    let app_context = Arc::new(
+        AppContext::new(
+            router_config.clone(),
+            client,
+            router_config.max_concurrent_requests,
+            router_config.rate_limit_tokens_per_second,
+        )
+        .expect("Failed to create AppContext in test"),
+    );
 
     // Create AppState with the test router and context
     let app_state = Arc::new(AppState {

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -195,7 +195,8 @@ mod test_pd_routing {
 
             // Router creation will fail due to health checks, but config should be valid
             let app_context =
-                sglang_router_rs::server::AppContext::new(config, reqwest::Client::new(), 64, None);
+                sglang_router_rs::server::AppContext::new(config, reqwest::Client::new(), 64, None)
+                    .expect("Failed to create AppContext");
             let app_context = std::sync::Arc::new(app_context);
             let result = RouterFactory::create_router(&app_context).await;
             assert!(result.is_err());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

all dependencies should be initialized in the server

## Modifications

1. move tokenizer to app context
2. move reasoning parser to app context
3. move tool parser to app context

```python3 -m sglang_router.launch_router --worker-urls grpc://0.0.0.0:50052 --log-level debug --model-path deepseek-ai/DeepSeek-R1
2025-09-04 02:19:14  INFO sglang_router_rs::server: src/server.rs:305: Starting router on 127.0.0.1:30000 | mode: Regular { worker_urls: ["grpc://0.0.0.0:50052"] } | policy: CacheAware { cache_threshold: 0.3, balance_abs_threshold: 64, balance_rel_threshold: 1.5, eviction_interval_secs: 120, max_tree_size: 67108864 } | max_payload: 512MB
tokenizer.json [00:00:01] [████████████████████████████████████████████████████████████████████████████] 7.48 MiB/7.48 MiB 6.11 MiB/s (0s)tokenizer_config.json [00:00:00] [████████████████████████████████████████████████████████████████████] 3.51 KiB/3.51 KiB 81.62 KiB/s (0s)2025-09-04 02:19:16 DEBUG sglang_router_rs::grpc::client: src/grpc/client.rs:21: Connecting to SGLang scheduler at grpc://0.0.0.0:50052
2025-09-04 02:19:16  INFO sglang_router_rs::routers::grpc::router: src/routers/grpc/router.rs:89: Connected to gRPC worker at grpc://0.0.0.0:50052
2025-09-04 02:19:16  INFO sglang_router_rs::middleware: src/middleware.rs:366: Starting concurrency queue processor
2025-09-04 02:19:16  INFO sglang_router_rs::server: src/server.rs:345: Started request queue with size: 100, timeout: 60s
2025-09-04 02:19:16  INFO sglang_router_rs::server: src/server.rs:380: Router ready | workers: ["grpc://0.0.0.0:50052"]
2025-09-04 02:19:16 DEBUG sglang_router_rs::grpc::client: src/grpc/client.rs:69: Sending health check request
2025-09-04 02:19:16  INFO sglang_router_rs::server: src/server.rs:408: Starting server on 127.0.0.1:30000
2025-09-04 02:19:16  WARN sglang_router_rs::core::worker: src/core/worker.rs:404: gRPC health check RPC failed for grpc://0.0.0.0:50052: Status { code: Unknown, message: "h2 protocol error: http2 error", source: Some(tonic::transport::Error(Transport, hyper::Error(Http2, Error { kind: GoAway(b"", FRAME_SIZE_ERROR, Library) }))) }
2025-09-04 02:19:16  WARN sglang_router_rs::core::worker: src/core/worker.rs:1017: Worker grpc://0.0.0.0:50052 health check failed: Health check failed for worker grpc://0.0.0.0:50052: Health check failed (consecutive failures: 1)
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
