### PR TITLE
[router] clean up dependency injector to use ctx

### DIFF
--- a/sgl-router/src/routers/factory.rs
+++ b/sgl-router/src/routers/factory.rs
@@ -83,20 +83,8 @@ impl RouterFactory {
         // Create policy
         let policy = PolicyFactory::create_from_config(policy_config);
 
-        // Create regular router with injected policy and client
-        let router = Router::new(
-            worker_urls.to_vec(),
-            policy,
-            ctx.client.clone(),
-            ctx.router_config.worker_startup_timeout_secs,
-            ctx.router_config.worker_startup_check_interval_secs,
-            ctx.router_config.dp_aware,
-            ctx.router_config.api_key.clone(),
-            ctx.router_config.retry.clone(),
-            ctx.router_config.circuit_breaker.clone(),
-            ctx.router_config.health_check.clone(),
-        )
-        .await?;
+        // Create regular router with injected policy and context
+        let router = Router::new(worker_urls.to_vec(), policy, ctx).await?;
 
         Ok(Box::new(router))
     }
@@ -116,19 +104,13 @@ impl RouterFactory {
         let decode_policy =
             PolicyFactory::create_from_config(decode_policy_config.unwrap_or(main_policy_config));
 
-        // Create PD router with separate policies and client
+        // Create PD router with separate policies and context
         let router = PDRouter::new(
             prefill_urls.to_vec(),
             decode_urls.to_vec(),
             prefill_policy,
             decode_policy,
-            ctx.client.clone(),
-            ctx.router_config.request_timeout_secs,
-            ctx.router_config.worker_startup_timeout_secs,
-            ctx.router_config.worker_startup_check_interval_secs,
-            ctx.router_config.retry.clone(),
-            ctx.router_config.circuit_breaker.clone(),
-            ctx.router_config.health_check.clone(),
+            ctx,
         )
         .await?;
 
@@ -146,46 +128,8 @@ impl RouterFactory {
         // Create policy
         let policy = PolicyFactory::create_from_config(policy_config);
 
-        // Get tokenizer from context
-        let tokenizer = ctx
-            .tokenizer
-            .as_ref()
-            .ok_or_else(|| {
-                "gRPC router requires tokenizer to be initialized in AppContext".to_string()
-            })?
-            .clone();
-
-        // Get reasoning parser factory from context
-        let reasoning_parser_factory = ctx
-            .reasoning_parser_factory
-            .as_ref()
-            .ok_or_else(|| {
-                "gRPC router requires reasoning parser factory to be initialized in AppContext"
-                    .to_string()
-            })?
-            .clone();
-
-        // Get tool parser registry from context
-        let tool_parser_registry = ctx.tool_parser_registry.ok_or_else(|| {
-            "gRPC router requires tool parser registry to be initialized in AppContext".to_string()
-        })?;
-
-        // Create gRPC router
-        let router = GrpcRouter::new(
-            worker_urls.to_vec(),
-            policy,
-            ctx.router_config.worker_startup_timeout_secs,
-            ctx.router_config.worker_startup_check_interval_secs,
-            ctx.router_config.dp_aware,
-            ctx.router_config.api_key.clone(),
-            ctx.router_config.effective_retry_config(),
-            ctx.router_config.effective_circuit_breaker_config(),
-            ctx.router_config.health_check.clone(),
-            tokenizer,
-            reasoning_parser_factory,
-            tool_parser_registry,
-        )
-        .await?;
+        // Create gRPC router with context
+        let router = GrpcRouter::new(worker_urls.to_vec(), policy, ctx).await?;
 
         Ok(Box::new(router))
     }
@@ -207,47 +151,13 @@ impl RouterFactory {
         let decode_policy =
             PolicyFactory::create_from_config(decode_policy_config.unwrap_or(main_policy_config));
 
-        // Get tokenizer from context
-        let tokenizer = ctx
-            .tokenizer
-            .as_ref()
-            .ok_or_else(|| {
-                "gRPC PD router requires tokenizer to be initialized in AppContext".to_string()
-            })?
-            .clone();
-
-        // Get reasoning parser factory from context
-        let reasoning_parser_factory = ctx
-            .reasoning_parser_factory
-            .as_ref()
-            .ok_or_else(|| {
-                "gRPC PD router requires reasoning parser factory to be initialized in AppContext"
-                    .to_string()
-            })?
-            .clone();
-
-        // Get tool parser registry from context
-        let tool_parser_registry = ctx.tool_parser_registry.ok_or_else(|| {
-            "gRPC PD router requires tool parser registry to be initialized in AppContext"
-                .to_string()
-        })?;
-
-        // Create gRPC PD router
+        // Create gRPC PD router with context
         let router = GrpcPDRouter::new(
             prefill_urls.to_vec(),
             decode_urls.to_vec(),
             prefill_policy,
             decode_policy,
-            ctx.router_config.worker_startup_timeout_secs,
-            ctx.router_config.worker_startup_check_interval_secs,
-            ctx.router_config.dp_aware,
-            ctx.router_config.api_key.clone(),
-            ctx.router_config.effective_retry_config(),
-            ctx.router_config.effective_circuit_breaker_config(),
-            ctx.router_config.health_check.clone(),
-            tokenizer,
-            reasoning_parser_factory,
-            tool_parser_registry,
+            ctx,
         )
         .await?;
 

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -1,9 +1,6 @@
 // PD (Prefill-Decode) gRPC Router Implementation
 
-use crate::config::types::{
-    CircuitBreakerConfig as ConfigCircuitBreakerConfig,
-    HealthCheckConfig as ConfigHealthCheckConfig, RetryConfig,
-};
+use crate::config::types::RetryConfig;
 use crate::core::{
     BasicWorker, CircuitBreakerConfig, HealthChecker, HealthConfig, Worker, WorkerType,
 };
@@ -61,27 +58,33 @@ pub struct GrpcPDRouter {
 
 impl GrpcPDRouter {
     /// Create a new gRPC PD router
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         prefill_urls: Vec<(String, Option<u16>)>,
         decode_urls: Vec<String>,
         prefill_policy: Arc<dyn LoadBalancingPolicy>,
         decode_policy: Arc<dyn LoadBalancingPolicy>,
-        timeout_secs: u64,
-        interval_secs: u64,
-        dp_aware: bool,
-        api_key: Option<String>,
-        retry_config: RetryConfig,
-        circuit_breaker_config: ConfigCircuitBreakerConfig,
-        health_check_config: ConfigHealthCheckConfig,
-        tokenizer: Arc<dyn Tokenizer>,
-        reasoning_parser_factory: ParserFactory,
-        tool_parser_registry: &'static ParserRegistry,
+        ctx: &Arc<crate::server::AppContext>,
     ) -> Result<Self, String> {
         // Update metrics
         RouterMetrics::set_active_workers(prefill_urls.len() + decode_urls.len());
 
+        // Extract necessary components from context
+        let tokenizer = ctx
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| "gRPC PD router requires tokenizer".to_string())?
+            .clone();
+        let reasoning_parser_factory = ctx
+            .reasoning_parser_factory
+            .as_ref()
+            .ok_or_else(|| "gRPC PD router requires reasoning parser factory".to_string())?
+            .clone();
+        let tool_parser_registry = ctx
+            .tool_parser_registry
+            .ok_or_else(|| "gRPC PD router requires tool parser registry".to_string())?;
+
         // Convert config CircuitBreakerConfig to core CircuitBreakerConfig
+        let circuit_breaker_config = ctx.router_config.effective_circuit_breaker_config();
         let core_cb_config = CircuitBreakerConfig {
             failure_threshold: circuit_breaker_config.failure_threshold,
             success_threshold: circuit_breaker_config.success_threshold,
@@ -138,11 +141,11 @@ impl GrpcPDRouter {
                 )
                 .with_circuit_breaker_config(core_cb_config.clone())
                 .with_health_config(HealthConfig {
-                    timeout_secs: health_check_config.timeout_secs,
-                    check_interval_secs: health_check_config.check_interval_secs,
-                    endpoint: health_check_config.endpoint.clone(),
-                    failure_threshold: health_check_config.failure_threshold,
-                    success_threshold: health_check_config.success_threshold,
+                    timeout_secs: ctx.router_config.health_check.timeout_secs,
+                    check_interval_secs: ctx.router_config.health_check.check_interval_secs,
+                    endpoint: ctx.router_config.health_check.endpoint.clone(),
+                    failure_threshold: ctx.router_config.health_check.failure_threshold,
+                    success_threshold: ctx.router_config.health_check.success_threshold,
                 });
                 Box::new(worker) as Box<dyn Worker>
             })
@@ -159,11 +162,11 @@ impl GrpcPDRouter {
                 )
                 .with_circuit_breaker_config(core_cb_config.clone())
                 .with_health_config(HealthConfig {
-                    timeout_secs: health_check_config.timeout_secs,
-                    check_interval_secs: health_check_config.check_interval_secs,
-                    endpoint: health_check_config.endpoint.clone(),
-                    failure_threshold: health_check_config.failure_threshold,
-                    success_threshold: health_check_config.success_threshold,
+                    timeout_secs: ctx.router_config.health_check.timeout_secs,
+                    check_interval_secs: ctx.router_config.health_check.check_interval_secs,
+                    endpoint: ctx.router_config.health_check.endpoint.clone(),
+                    failure_threshold: ctx.router_config.health_check.failure_threshold,
+                    success_threshold: ctx.router_config.health_check.success_threshold,
                 });
                 Box::new(worker) as Box<dyn Worker>
             })
@@ -187,10 +190,14 @@ impl GrpcPDRouter {
         let prefill_workers = Arc::new(RwLock::new(prefill_workers));
         let decode_workers = Arc::new(RwLock::new(decode_workers));
 
-        let prefill_health_checker =
-            crate::core::start_health_checker(Arc::clone(&prefill_workers), interval_secs);
-        let decode_health_checker =
-            crate::core::start_health_checker(Arc::clone(&decode_workers), interval_secs);
+        let prefill_health_checker = crate::core::start_health_checker(
+            Arc::clone(&prefill_workers),
+            ctx.router_config.worker_startup_check_interval_secs,
+        );
+        let decode_health_checker = crate::core::start_health_checker(
+            Arc::clone(&decode_workers),
+            ctx.router_config.worker_startup_check_interval_secs,
+        );
 
         Ok(GrpcPDRouter {
             prefill_workers,
@@ -204,11 +211,11 @@ impl GrpcPDRouter {
             tool_parser_registry,
             _prefill_health_checker: Some(prefill_health_checker),
             _decode_health_checker: Some(decode_health_checker),
-            timeout_secs,
-            interval_secs,
-            dp_aware,
-            api_key,
-            retry_config,
+            timeout_secs: ctx.router_config.worker_startup_timeout_secs,
+            interval_secs: ctx.router_config.worker_startup_check_interval_secs,
+            dp_aware: ctx.router_config.dp_aware,
+            api_key: ctx.router_config.api_key.clone(),
+            retry_config: ctx.router_config.effective_retry_config(),
             circuit_breaker_config: core_cb_config,
         })
     }

--- a/sgl-router/src/service_discovery.rs
+++ b/sgl-router/src/service_discovery.rs
@@ -579,25 +579,27 @@ mod tests {
 
     // Helper to create a Router instance for testing event handlers
     async fn create_test_router() -> Arc<dyn RouterTrait> {
-        use crate::config::PolicyConfig;
+        use crate::config::{PolicyConfig, RouterConfig};
+        use crate::middleware::TokenBucket;
         use crate::policies::PolicyFactory;
         use crate::routers::http::router::Router;
+        use crate::server::AppContext;
+
+        // Create a minimal RouterConfig for testing
+        let router_config = RouterConfig::default();
+
+        // Create AppContext with minimal components
+        let app_context = Arc::new(AppContext {
+            client: reqwest::Client::new(),
+            router_config,
+            rate_limiter: Arc::new(TokenBucket::new(1000, 1000)),
+            tokenizer: None,                // HTTP mode doesn't need tokenizer
+            reasoning_parser_factory: None, // HTTP mode doesn't need reasoning parser
+            tool_parser_registry: None,     // HTTP mode doesn't need tool parser
+        });
 
         let policy = PolicyFactory::create_from_config(&PolicyConfig::Random);
-        let router = Router::new(
-            vec![],
-            policy,
-            reqwest::Client::new(),
-            5,
-            1,
-            false,
-            None,
-            crate::config::types::RetryConfig::default(),
-            crate::config::types::CircuitBreakerConfig::default(),
-            crate::config::types::HealthCheckConfig::default(),
-        )
-        .await
-        .unwrap();
+        let router = Router::new(vec![], policy, &app_context).await.unwrap();
         Arc::new(router) as Arc<dyn RouterTrait>
     }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
both http and grpc routers (pd or regular) takes considerable amount of input and configurations one by one, while those are all in `ctx` from `App`, we should just pass in `ctx` instead

## Modifications
1. modify grpc regular and PD router to accept ctx and use it to initialize router
2. modify http regular and PD router to accept ctx and use it to initialize router

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
