### PR TITLE
[Do not merge] Add pass manager to unify kernel fusion pattens

### DIFF
--- a/python/sglang/srt/fx_pass_manager.py
+++ b/python/sglang/srt/fx_pass_manager.py
@@ -1,123 +1,15 @@
-# Copyright 2023-2024 SGLang Team
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
-"""
-SGLang FX Pass Manager - torch.fx based kernel fusion pass manager
-"""
-
 import logging
-import operator
-from typing import Optional
 
-import sgl_kernel
 import torch
 import torch.fx as fx
 import torch.nn as nn
-from torch.fx.node import Node
+
+from sglang.srt.passes import SiLUMulFusionPass
 
 logger = logging.getLogger(__name__)
 
 
-class SiLUMulFusionPass:
-    def __init__(self):
-        self.name = "SiLUMulFusionPass"
-
-    def is_applicable(self, graph: fx.Graph) -> bool:
-        for node in graph.nodes:
-            if self._is_silu_node(node):
-                return True
-        return False
-
-    def apply(self, graph: fx.Graph) -> bool:
-        modified = False
-
-        for node in list(graph.nodes):
-            if self._is_silu_node(node):
-                for user in list(node.users):
-                    if self._is_mul_node(user) and self._can_fuse_silu_mul(node, user):
-                        self._create_fused_silu_mul(graph, node, user)
-                        modified = True
-                        logger.debug(f"Fused SiLU * x: {node.name} -> {user.name}")
-        return modified
-
-    def _is_silu_node(self, node: Node) -> bool:
-        if node.op == "call_function":
-            return node.target in [
-                torch.nn.functional.silu,
-                torch.ops.aten.silu.default,
-            ]
-        elif node.op == "call_module":
-            return "silu" in str(node.target).lower()
-        return False
-
-    def _is_mul_node(self, node: Node) -> bool:
-        if node.op == "call_function":
-            mul_targets = [
-                torch.mul,
-                torch.ops.aten.mul.Tensor,
-                torch.ops.aten.mul.default,
-                operator.mul,
-            ]
-            return node.target in mul_targets
-        elif node.op == "call_method":
-            return "mul" in str(node.target).lower()
-        return False
-
-    def _can_fuse_silu_mul(self, silu_node: Node, mul_node: Node) -> bool:
-        return silu_node in mul_node.args
-
-    def _create_fused_silu_mul(self, graph: fx.Graph, silu_node: Node, mul_node: Node):
-        silu_input = silu_node.args[0]  # This should be x[..., :dim]
-
-        # Find the mul's other operand (should be x[..., dim:])
-        other_arg = None
-        for arg in mul_node.args:
-            if arg != silu_node:
-                other_arg = arg
-                break
-
-        if (
-            hasattr(silu_input, "op")
-            and hasattr(other_arg, "op")
-            and silu_input.op == "call_function"
-            and other_arg.op == "call_function"
-            and silu_input.target == operator.getitem
-            and other_arg.target == operator.getitem
-            and len(silu_input.args) > 0
-            and len(other_arg.args) > 0
-            and silu_input.args[0] == other_arg.args[0]
-        ):
-
-            base_tensor = silu_input.args[0]
-
-            with graph.inserting_after(mul_node):
-                fused_node = graph.call_function(
-                    self._get_fused_silu_mul_op(), args=(base_tensor,), kwargs={}
-                )
-
-        mul_node.replace_all_uses_with(fused_node)
-
-        graph.erase_node(mul_node)
-        if len(silu_node.users) == 0:
-            graph.erase_node(silu_node)
-
-    def _get_fused_silu_mul_op(self):
-        return sgl_kernel.silu_and_mul
-
-
 class SGLangFXPassManager:
-    """SGLang FX Pass Manager for SiLU and Mul fusion"""
-
     def __init__(self):
         self.passes = [SiLUMulFusionPass()]
 

--- a/python/sglang/srt/fx_pass_manager.py
+++ b/python/sglang/srt/fx_pass_manager.py
@@ -1,0 +1,157 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+SGLang FX Pass Manager - torch.fx based kernel fusion pass manager
+"""
+
+import logging
+import operator
+from typing import Optional
+
+import sgl_kernel
+import torch
+import torch.fx as fx
+import torch.nn as nn
+from torch.fx.node import Node
+
+logger = logging.getLogger(__name__)
+
+
+class SiLUMulFusionPass:
+    def __init__(self):
+        self.name = "SiLUMulFusionPass"
+
+    def is_applicable(self, graph: fx.Graph) -> bool:
+        for node in graph.nodes:
+            if self._is_silu_node(node):
+                return True
+        return False
+
+    def apply(self, graph: fx.Graph) -> bool:
+        modified = False
+
+        for node in list(graph.nodes):
+            if self._is_silu_node(node):
+                for user in list(node.users):
+                    if self._is_mul_node(user) and self._can_fuse_silu_mul(node, user):
+                        self._create_fused_silu_mul(graph, node, user)
+                        modified = True
+                        logger.debug(f"Fused SiLU * x: {node.name} -> {user.name}")
+        return modified
+
+    def _is_silu_node(self, node: Node) -> bool:
+        if node.op == "call_function":
+            return node.target in [
+                torch.nn.functional.silu,
+                torch.ops.aten.silu.default,
+            ]
+        elif node.op == "call_module":
+            return "silu" in str(node.target).lower()
+        return False
+
+    def _is_mul_node(self, node: Node) -> bool:
+        if node.op == "call_function":
+            mul_targets = [
+                torch.mul,
+                torch.ops.aten.mul.Tensor,
+                torch.ops.aten.mul.default,
+                operator.mul,
+            ]
+            return node.target in mul_targets
+        elif node.op == "call_method":
+            return "mul" in str(node.target).lower()
+        return False
+
+    def _can_fuse_silu_mul(self, silu_node: Node, mul_node: Node) -> bool:
+        return silu_node in mul_node.args
+
+    def _create_fused_silu_mul(self, graph: fx.Graph, silu_node: Node, mul_node: Node):
+        silu_input = silu_node.args[0]  # This should be x[..., :dim]
+
+        # Find the mul's other operand (should be x[..., dim:])
+        other_arg = None
+        for arg in mul_node.args:
+            if arg != silu_node:
+                other_arg = arg
+                break
+
+        if (
+            hasattr(silu_input, "op")
+            and hasattr(other_arg, "op")
+            and silu_input.op == "call_function"
+            and other_arg.op == "call_function"
+            and silu_input.target == operator.getitem
+            and other_arg.target == operator.getitem
+            and len(silu_input.args) > 0
+            and len(other_arg.args) > 0
+            and silu_input.args[0] == other_arg.args[0]
+        ):
+
+            base_tensor = silu_input.args[0]
+
+            with graph.inserting_after(mul_node):
+                fused_node = graph.call_function(
+                    self._get_fused_silu_mul_op(), args=(base_tensor,), kwargs={}
+                )
+
+        mul_node.replace_all_uses_with(fused_node)
+
+        graph.erase_node(mul_node)
+        if len(silu_node.users) == 0:
+            graph.erase_node(silu_node)
+
+    def _get_fused_silu_mul_op(self):
+        return sgl_kernel.silu_and_mul
+
+
+class SGLangFXPassManager:
+    """SGLang FX Pass Manager for SiLU and Mul fusion"""
+
+    def __init__(self):
+        self.passes = [SiLUMulFusionPass()]
+
+    def apply_passes(self, model: nn.Module) -> nn.Module:
+        logger.info("Starting SGLang FX Pass optimization...")
+
+        try:
+            tracer = fx.Tracer()
+            graph = tracer.trace(model)
+            fx_model = fx.GraphModule(model, graph)
+
+            total_modifications = 0
+            for pass_instance in self.passes:
+                if pass_instance.is_applicable(graph):
+                    logger.info(f"Applying {pass_instance.name}...")
+                    modified = pass_instance.apply(graph)
+                    if modified:
+                        total_modifications += 1
+                        logger.info(f"{pass_instance.name} applied successfully")
+                else:
+                    logger.debug(f"Skipping {pass_instance.name} (not applicable)")
+
+            fx_model.recompile()
+
+            logger.info(
+                f"FX Pass optimization completed. Applied {total_modifications} passes."
+            )
+            return fx_model
+
+        except Exception as e:
+            logger.warning(f"FX Pass optimization failed: {e}")
+            return model
+
+
+def apply_sglang_fx_optimization(model: nn.Module) -> nn.Module:
+    pass_manager = SGLangFXPassManager()
+    return pass_manager.apply_passes(model)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -88,6 +88,7 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "enable_dp_lm_head",
     "flashinfer_mxfp4_moe_precision",
     "enable_flashinfer_allreduce_fusion",
+    "enable_torch_fx_passes",
     "moe_dense_tp_size",
     "ep_dispatch_algorithm",
     "ep_num_redundant_experts",

--- a/python/sglang/srt/passes/__init__.py
+++ b/python/sglang/srt/passes/__init__.py
@@ -1,0 +1,7 @@
+from .base_pass import BaseFXPass
+from .silu_mul_fusion_pass import SiLUMulFusionPass
+
+__all__ = [
+    "BaseFXPass",
+    "SiLUMulFusionPass",
+]

--- a/python/sglang/srt/passes/base_pass.py
+++ b/python/sglang/srt/passes/base_pass.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+import torch.fx as fx
+
+
+class BaseFXPass(ABC):
+    def __init__(self):
+        self.name = self.__class__.__name__
+    
+    @abstractmethod
+    def is_applicable(self, graph: fx.Graph) -> bool:
+        pass
+    
+    @abstractmethod
+    def apply(self, graph: fx.Graph) -> bool:
+        pass

--- a/python/sglang/srt/passes/silu_mul_fusion_pass.py
+++ b/python/sglang/srt/passes/silu_mul_fusion_pass.py
@@ -1,0 +1,86 @@
+import logging
+import operator
+import torch
+import torch.fx as fx
+from torch.fx.node import Node
+import sgl_kernel
+
+from .base_pass import BaseFXPass
+
+logger = logging.getLogger(__name__)
+
+
+class SiLUMulFusionPass(BaseFXPass):
+    def __init__(self):
+        super().__init__()
+    
+    def is_applicable(self, graph: fx.Graph) -> bool:
+        for node in graph.nodes:
+            if self._is_silu_node(node):
+                return True
+        return False
+    
+    def apply(self, graph: fx.Graph) -> bool:
+        modified = False
+        
+        for node in list(graph.nodes):
+            if self._is_silu_node(node):
+                for user in list(node.users):
+                    if self._is_mul_node(user) and self._can_fuse_silu_mul(node, user):
+                        self._create_fused_silu_mul(graph, node, user)
+                        modified = True
+                        logger.debug(f"Fused SiLU * x: {node.name} -> {user.name}")
+        return modified
+    
+    def _is_silu_node(self, node: Node) -> bool:
+        if node.op == 'call_function':
+            return node.target in [torch.nn.functional.silu, torch.ops.aten.silu.default]
+        elif node.op == 'call_module':
+            return 'silu' in str(node.target).lower()
+        return False
+    
+    def _is_mul_node(self, node: Node) -> bool:
+        if node.op == 'call_function':
+            mul_targets = [
+                torch.mul,
+                operator.mul,
+            ]
+            return node.target in mul_targets
+        elif node.op == 'call_method':
+            return 'mul' in str(node.target).lower()
+        return False
+    
+    def _can_fuse_silu_mul(self, silu_node: Node, mul_node: Node) -> bool:
+        return silu_node in mul_node.args
+    
+    def _create_fused_silu_mul(self, graph: fx.Graph, silu_node: Node, mul_node: Node):
+        silu_input = silu_node.args[0]
+        
+        other_arg = None
+        for arg in mul_node.args:
+            if arg != silu_node:
+                other_arg = arg
+                break
+        
+        if (hasattr(silu_input, 'op') and hasattr(other_arg, 'op') and
+            silu_input.op == 'call_function' and other_arg.op == 'call_function' and
+            silu_input.target == operator.getitem and other_arg.target == operator.getitem and
+            silu_input.args[0] == other_arg.args[0]):
+            
+            base_tensor = silu_input.args[0]
+            
+            with graph.inserting_after(mul_node):
+                fused_node = graph.call_function(
+                    self._get_fused_silu_mul_op(),
+                    args=(base_tensor,),
+                    kwargs={}
+                )
+        
+        mul_node.replace_all_uses_with(fused_node)
+        
+        graph.erase_node(mul_node)
+        if len(silu_node.users) == 0:
+            graph.erase_node(silu_node)
+    
+    def _get_fused_silu_mul_op(self):
+        return sgl_kernel.silu_and_mul

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -181,6 +181,7 @@ class ServerArgs:
     base_gpu_id: int = 0
     gpu_id_step: int = 1
     sleep_on_idle: bool = False
+    enable_torch_fx_passes: bool = False
 
     # Logging
     log_level: str = "info"
@@ -1160,6 +1161,11 @@ class ServerArgs:
             "--sleep-on-idle",
             action="store_true",
             help="Reduce CPU usage when sglang is idle.",
+        )
+        parser.add_argument(
+            "--enable-torch-fx-passes",
+            action="store_true",
+            help="Enable torch.fx do kernel fusion passes for model optimization.",
         )
 
         # Logging

--- a/python/sglang/test/kernel_fusion_passes/test_silu_mul_fusion.py
+++ b/python/sglang/test/kernel_fusion_passes/test_silu_mul_fusion.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../srt"))
+
+import torch
+import torch.nn as nn
+from fx_pass_manager import apply_sglang_fx_optimization
+
+
+class TestModel(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.silu = nn.SiLU()
+        self.dim = dim
+
+    def forward(self, x):
+        x1 = x[..., : self.dim]
+        x2 = x[..., self.dim :]
+        activated = self.silu(x1)
+        result = activated * x2
+        return result
+
+
+class TestSiLUMulFusion(unittest.TestCase):
+    DTYPES = [torch.float32, torch.half]
+    BATCH_SIZES = [1, 4, 16]
+    DIMS = [64, 128, 256]
+    SEEDS = [0]
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        torch.set_default_device("cuda")
+
+    def _run_fusion_test(self, batch_size, dim, dtype, seed):
+        torch.manual_seed(seed)
+
+        model = TestModel(dim).to(dtype=dtype)
+        x = torch.randn(batch_size, 2 * dim, dtype=dtype)
+
+        with torch.inference_mode():
+            original_output = model(x)
+            optimized_model = apply_sglang_fx_optimization(model)
+            optimized_output = optimized_model(x)
+
+        self.assertTrue(
+            torch.allclose(original_output, optimized_output, atol=1e-3, rtol=1e-3)
+        )
+
+    def test_silu_mul_fusion(self):
+        for batch_size in self.BATCH_SIZES:
+            for dim in self.DIMS:
+                for dtype in self.DTYPES:
+                    for seed in self.SEEDS:
+                        with self.subTest(
+                            batch_size=batch_size,
+                            dim=dim,
+                            dtype=dtype,
+                            seed=seed,
+                        ):
+                            self._run_fusion_test(batch_size, dim, dtype, seed)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

I think we’ve reached the point where this abstraction is necessary. For example, the `fused_allreduce_residual_rmsnorm`(It can also handle `fp8/fp4` quant) pattern has already required duplicate logic implementations for three different models. Moreover, models like DeepSeek V3 and GPT-OSS now contain numerous kernel fusion patterns. The worst part is that many of these patterns could be reused across similar model architectures, yet we’re currently forced to repeatedly modify Python code for each model implementation.

We can manage kernel fuse pattern by `torch.fx`, this pr implement a `torch.fx` Pass Manager to do `silu_mul` kernel fuse. Please keep the discussion going.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
