### PR TITLE
[router] Add complete embedding API specification

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -2869,7 +2869,7 @@ mod tests {
     fn test_embedding_request_serialization() {
         let request = EmbeddingRequest {
             input: EmbeddingInput::Text("test text".to_string()),
-            model: "text-embedding-ada-002".to_string(),
+            model: "text-embedding-model".to_string(),
             encoding_format: "float".to_string(),
             dimensions: Some(1536),
             user: Some("user-123".to_string()),
@@ -3132,7 +3132,7 @@ mod tests {
                     object: "embedding".to_string(),
                 },
             ],
-            model: "text-embedding-ada-002".to_string(),
+            model: "text-embedding-model".to_string(),
             object: "list".to_string(),
             usage: Some(UsageInfo {
                 prompt_tokens: 10,
@@ -3151,7 +3151,7 @@ mod tests {
         assert_eq!(deserialized.data[0].index, 0);
         assert_eq!(deserialized.data[1].embedding, vec![0.4, 0.5, 0.6]);
         assert_eq!(deserialized.data[1].index, 1);
-        assert_eq!(deserialized.model, "text-embedding-ada-002");
+        assert_eq!(deserialized.model, "text-embedding-model");
         assert_eq!(deserialized.object, "list");
         assert!(deserialized.usage.is_some());
     }


### PR DESCRIPTION
## Motivation

This PR implements the complete embedding API specification for the Rust router to address issue #9762. Currently, the Python backend supports embedding requests, but the Rust router lacks the necessary data structures to parse, validate, and route embedding requests. This PR aims to fill that gap.

## Modifications

- **Core Data Structures**: Added `EmbeddingRequest`, `EmbeddingResponse`, `EmbeddingObject`, and `MultimodalEmbeddingInput` structs with OpenAI API compatibility
- **Input Type Support**: Implemented `EmbeddingInput` enum supporting text, text arrays, integer tokens, nested tokens, and multimodal inputs
- **Router Integration**: Implemented `GenerationRequest` trait for `EmbeddingRequest` and created `OpenAIServingRequest` union type for endpoint dispatch
- **SGLang Extensions**: Added support for request ID tracking (`rid` field) and multimodal embedding inputs (text + image)
- **Validation & Helpers**: Included validation methods for encoding formats and dimensions, and input normalization helpers
- **Comprehensive Testing**: Added 20 unit tests covering serialization/deserialization, validation, router integration, and OpenAI compatibility

## Accuracy Tests

This PR only adds protocol specification data structures, it does not affect model outputs or inference logic. No accuracy tests required.

## Benchmarking and Profiling

This PR does not impact inference speed as it only adds data structures for request parsing. No performance impact is expected.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

Fixes #9762