### PR TITLE
[CI] fix ambiguous argument in testing hybrid attentions.

### DIFF
--- a/test/srt/test_hybrid_attn_backend.py
+++ b/test/srt/test_hybrid_attn_backend.py
@@ -142,7 +142,7 @@ class TestHybridAttnBackendSpeculativeDecodingPrefillBackend(TestHybridAttnBacke
         return DEFAULT_SERVER_ARGS + [
             "--speculative-algorithm",
             "EAGLE",
-            "--speculative-draft",
+            "--speculative-draft-model-path",
             DEFAULT_EAGLE_DRAFT_MODEL_FOR_TEST,
             "--speculative-num-steps",
             "3",
@@ -165,7 +165,7 @@ class TestHybridAttnBackendSpeculativeDecodingDecodeBackend(TestHybridAttnBacken
         return DEFAULT_SERVER_ARGS + [
             "--speculative-algorithm",
             "EAGLE",
-            "--speculative-draft",
+            "--speculative-draft-model-path",
             DEFAULT_EAGLE_DRAFT_MODEL_FOR_TEST,
             "--speculative-num-steps",
             "3",


### PR DESCRIPTION
Clarify `--speculative-draft` to `--speculative-draft-model-path` as there are two arguments (`--speculative-draft-model-path`, `--speculative-draft-model-revision`) that share the same prefix.