### PR TITLE
[FIX] Fix Prometheus multiproc metrics cleanup

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1446,7 +1446,7 @@ def set_prometheus_multiproc_dir():
         )
     else:
         prometheus_multiproc_dir = tempfile.TemporaryDirectory()
-        os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
     logger.debug(f"PROMETHEUS_MULTIPROC_DIR: {os.environ['PROMETHEUS_MULTIPROC_DIR']}")
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When using SGLang with the environment variable PROMETHEUS_MULTIPROC_DIR pre-set, I noticed that
```python
prometheus_multiproc_dir = tempfile.TemporaryDirectory(
    dir=os.environ["PROMETHEUS_MULTIPROC_DIR"]
)
``` 
does not work as expected. 

The Prometheus client still writes data directly into the directory specified by PROMETHEUS_MULTIPROC_DIR, and this data is not cleaned up when the program exits. 

For example, when PROMETHEUS_MULTIPROC_DIR is set to /tmp/test,
<img width="1722" height="202" alt="image" src="https://github.com/user-attachments/assets/95639404-6e8e-48f5-a833-adb8a81ea577" />

A new subdirectory is created under /tmp/test, but the data is still written directly to /tmp/test instead of into the subdirectory. 

<img width="1162" height="280" alt="image" src="https://github.com/user-attachments/assets/c6c63276-8e54-4fba-85b6-db36b7e783e4" />

Furthermore, when the main process exits, although the subdirectory is removed, the data is still not cleaned up, which is not the expected behavior.

<img width="982" height="138" alt="image" src="https://github.com/user-attachments/assets/a7460ef1-a4f6-4105-b62e-7ff580e8f1fb" />

## Modifications

To fix this, I made some modifications to ensure that the data generated by the Prometheus client is stored in a temporary subdirectory under PROMETHEUS_MULTIPROC_DIR, 

<img width="996" height="322" alt="image" src="https://github.com/user-attachments/assets/5302c0b5-5387-486b-8977-e63180ed9bc8" />

and that this data is automatically cleaned up when the engine shuts down.
<img width="844" height="190" alt="image" src="https://github.com/user-attachments/assets/4d85f0c9-7a93-47b3-adff-0e15a5cd9cf0" />

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
