### PR TITLE
fix the cutlass moe tests

### DIFF
--- a/python/sglang/test/test_cutlass_moe.py
+++ b/python/sglang/test/test_cutlass_moe.py
@@ -22,7 +22,7 @@ def calc_diff(x, y):
 
 def get_model_config(tp_size: int):
     config = AutoConfig.from_pretrained(
-        "deepseek-ai/deepseek-R1", trust_remote_code=True
+        "deepseek-ai/Deepseek-R1", trust_remote_code=True
     )
     E = config.n_routed_experts
     topk = config.num_experts_per_tok
@@ -163,11 +163,10 @@ def run_test(tp_size, batch_size, model_config, check=False):
 
     moe_runner_config = MoeRunnerConfig(
         num_experts=E,
-        topk=topk,
+        top_k=topk,
         hidden_size=H,
-        shard_intermediate_size=I,
-        dtype=dtype,
-        block_shape=block_shape,
+        intermediate_size_per_partition=I,
+        params_dtype=dtype,
         activation="silu",
         inplace=False,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The cutlass moe test case is broken for long time. Try to fix it and make sure the result from cutlass moe is the same as triton moe with DeepSeek R1 model.

## Modifications

- fix the cutlass moe tests

## Accuracy Tests

```bash
➜  test git:(main) ✗ python test_cutlass_moe.py --batch-sizes 8 16 64 128 --check
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
All deep_gemm operations loaded successfully!
W0908 22:50:07.314000 3873737 torch/utils/cpp_extension.py:2425] TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
W0908 22:50:07.314000 3873737 torch/utils/cpp_extension.py:2425] If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'] to specific architectures.
WARNING:sglang.srt.layers.moe.utils:MOE_RUNNER_BACKEND is not initialized, using triton backend
Running benchmarks with TP size: 8
Testing batch sizes: [8, 16, 64, 128]
`torch_dtype` is deprecated! Use `dtype` instead!
Model Config: {'num_experts': 256, 'topk': 8, 'hidden_size': 7168, 'shard_intermediate_size': 512, 'dtype': torch.bfloat16, 'block_shape': [128, 128]}

--- Batch Size: 8 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 0.149 ms (median) [0.149 - 0.149]
Triton  fused_experts time: 0.099 ms (median) [0.099 - 0.099]
Running correctness check...
Diff: 0.000005
Correctness check passed.

--- Batch Size: 16 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 0.220 ms (median) [0.220 - 0.220]
Triton  fused_experts time: 0.143 ms (median) [0.143 - 0.143]
Running correctness check...
Diff: 0.000005
Correctness check passed.

--- Batch Size: 64 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 0.395 ms (median) [0.395 - 0.395]
Triton  fused_experts time: 0.270 ms (median) [0.270 - 0.270]
Running correctness check...
Diff: 0.000005
Correctness check passed.

--- Batch Size: 128 ---
Config: E=256, topk=8, H=7168, I_shard=512, dtype=torch.bfloat16, block_shape=[128, 128]
Warming up...
Benchmarking Cutlass fused_experts...
Benchmarking Triton fused_experts...
Cutlass fused_experts time: 0.444 ms (median) [0.444 - 0.444]
Triton  fused_experts time: 0.296 ms (median) [0.296 - 0.296]
Running correctness check...
Diff: 0.000005
Correctness check passed.
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
