### PR TITLE
[Feature] Mamba SSM state supports selecting the data type (fp32 or bf16) via environment variables

### DIFF
--- a/python/sglang/srt/configs/qwen3_next.py
+++ b/python/sglang/srt/configs/qwen3_next.py
@@ -15,6 +15,7 @@
 """Qwen3Hybrid model configuration"""
 
 import enum
+import os
 
 import numpy as np
 import torch
@@ -24,7 +25,6 @@ from transformers.utils import logging
 
 from sglang.srt.distributed.utils import divide
 from sglang.srt.layers.dp_attention import get_attention_tp_size
-import os
 
 logger = logging.get_logger(__name__)
 

--- a/python/sglang/srt/configs/qwen3_next.py
+++ b/python/sglang/srt/configs/qwen3_next.py
@@ -24,6 +24,7 @@ from transformers.utils import logging
 
 from sglang.srt.distributed.utils import divide
 from sglang.srt.layers.dp_attention import get_attention_tp_size
+import os
 
 logger = logging.get_logger(__name__)
 
@@ -298,7 +299,11 @@ class Qwen3NextConfig(PretrainedConfig):
             self.linear_value_head_dim,
         )
         conv_dtype = torch.bfloat16
-        ssm_dtype = torch.float32
+        dtype_map = {
+            "float32": torch.float32,
+            "bfloat16": torch.bfloat16,
+        }
+        ssm_dtype = dtype_map[os.environ["SGLANG_MAMBA_SSM_DTYPE"]]
         mamba_layers = self.linear_layer_ids
         return (
             conv_state_shape,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -393,6 +393,7 @@ class ServerArgs:
 
     # Mamba cache
     max_mamba_cache_size: Optional[int] = None
+    mamba_ssm_dtype: str = "float32"
 
     # Deprecated arguments
     enable_ep_moe: bool = False
@@ -837,6 +838,8 @@ class ServerArgs:
         os.environ["SGLANG_ENABLE_TORCH_COMPILE"] = (
             "1" if self.enable_torch_compile else "0"
         )
+        os.environ["SGLANG_MAMBA_SSM_DTYPE"] = self.mamba_ssm_dtype
+
         # Set env var before grammar backends init
         os.environ["SGLANG_DISABLE_OUTLINES_DISK_CACHE"] = (
             "1" if self.disable_outlines_disk_cache else "0"
@@ -1721,6 +1724,13 @@ class ServerArgs:
             type=int,
             default=ServerArgs.max_mamba_cache_size,
             help="It is used for mamba cache memory static allocation.",
+        )
+        parser.add_argument(
+            "--mamba-ssm-dtype",
+            type=str,
+            default=ServerArgs.mamba_ssm_dtype,
+            choices=["float32", "bfloat16"],
+            help="It is used to tune mamba ssm dtype",
         )
         # Hierarchical cache
         parser.add_argument(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Close https://github.com/Qwen-SGLang/sglang-qwen3.5/issues/55

## Modifications

```
import sys
from sglang.srt.entrypoints.http_server import launch_server
from sglang.srt.server_args import prepare_server_args

if __name__ == "__main__":
    # Simulate CLI arguments (excluding the script name)
    args = [
        "--model-path",
        "/shared/public/sharing/sglanglearning/Qwen-SGlang/Qwen3-Next-80B-A3B-Instruct",
        "--tp",
        "8",
        "--attention-backend",
        "hybrid_linear_attn",
        "--trust-remote-code",
        "--mamba-ssm-dtype",
        "bfloat16"
    ]
    server_args = prepare_server_args(args)
    launch_server(server_args)
```
## Accuracy Tests

GSM8k:

| Setup              | Accuracy |
|--------------------|----------|
| TP8; float32       | 0.955    |
| TP8; bfloat16      | 0.945    |
| TP8; MTP; float32  | 0.945    |
| TP8; MTP; bfloat16 | 0.950    |


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
