### PR TITLE
[fix CI] Fix logical condition in fused MoE layer for compressed tensor quantization

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -613,8 +613,8 @@ class FusedMoE(torch.nn.Module):
             loaded_weight = loaded_weight.to(param.data.device)
 
             if (
-                "compressed" in self.quant_method.__class__.__name__.lower()
-                or "w4afp8" in self.quant_config.get_name()
+                ("compressed" in self.quant_method.__class__.__name__.lower()
+                or "w4afp8" in self.quant_config.get_name())
                 and (param.data[expert_id] != 1).any()
                 and ((param.data[expert_id] - loaded_weight).abs() > 1e-5).any()
             ):

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -613,8 +613,10 @@ class FusedMoE(torch.nn.Module):
             loaded_weight = loaded_weight.to(param.data.device)
 
             if (
-                ("compressed" in self.quant_method.__class__.__name__.lower()
-                or "w4afp8" in self.quant_config.get_name())
+                (
+                    "compressed" in self.quant_method.__class__.__name__.lower()
+                    or "w4afp8" in self.quant_config.get_name()
+                )
                 and (param.data[expert_id] != 1).any()
                 and ((param.data[expert_id] - loaded_weight).abs() > 1e-5).any()
             ):


### PR DESCRIPTION
### Background

The bug is caused by https://github.com/sgl-project/sglang/pull/8118 cc @chenxijun1029 

The current code in `fused_moe_triton/layer.py` has a logical operator precedence issue in the condition check for input scales validation (lines 615-620). The problematic condition was:

```python
if (
    "compressed" in self.quant_method.__class__.__name__.lower()
    or "w4afp8" in self.quant_config.get_name()
    and (param.data[expert_id] != 1).any()
    and ((param.data[expert_id] - loaded_weight).abs() > 1e-5).any()
):
```

Due to operator precedence (`and` has higher precedence than `or`), this condition is actually parsed as:

```python
if (
    "compressed" in self.quant_method.__class__.__name__.lower()
    or (
        "w4afp8" in self.quant_config.get_name()
        and (param.data[expert_id] != 1).any()
        and ((param.data[expert_id] - loaded_weight).abs() > 1e-5).any()
    )
):
```

This means that **any** model using compressed tensors quantization will unconditionally trigger the ValueError, regardless of whether the input scales are actually equal or not.

### Error Observed

When loading models with compressed tensors quantization (e.g., `neuralmagic/Mixtral-8x7B-Instruct-v0.1-FP8`), the following error occurs:

```
ValueError: input_scales of w1 and w3 of a layer must be equal. But got 1.0 vs. tensor([0.1011], device='cuda:1', dtype=torch.bfloat16)
```

### Solution

Add parentheses to ensure correct operator precedence:

```python
if (
    ("compressed" in self.quant_method.__class__.__name__.lower()
    or "w4afp8" in self.quant_config.get_name())
    and (param.data[expert_id] != 1).any()
    and ((param.data[expert_id] - loaded_weight).abs() > 1e-5).any()
):
```

Now the condition correctly checks:
- The quantization method is either `compressed` OR `w4afp8` 
- AND the parameter data is not equal to 1
- AND the difference between existing and loaded weights exceeds the threshold

This ensures the validation only runs when appropriate and doesn't incorrectly fail for valid compressed tensor models.

### Testing

This fix resolves the model loading failure for compressed tensor quantized models like `neuralmagic/Mixtral-8x7B-Instruct-v0.1-FP8` in the nightly GSM8K evaluation tests.


