### PR TITLE
[bugfix] add httpexception handle in stream case

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -481,6 +481,19 @@ async def generate_request(obj: GenerateReqInput, request: Request):
                 yield b"data: " + orjson.dumps(
                     out, option=orjson.OPT_NON_STR_KEYS
                 ) + b"\n\n"
+            except HTTPException as e:
+                out = {
+                    "error": {
+                        "message": str(e.detail),
+                        "type": str(e.status_code),
+                        "param": None,
+                        "code": e.status_code,
+                    }
+                }
+                logger.error(f"[http_server] http exception: {e}")
+                yield b"data: " + orjson.dumps(
+                    out, option=orjson.OPT_NON_STR_KEYS
+                ) + b"\n\n"
             yield b"data: [DONE]\n\n"
 
         return StreamingResponse(

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.protocol import (
@@ -663,7 +663,13 @@ class OpenAIServingChat(OpenAIServingBase):
         except ValueError as e:
             error = self.create_streaming_error_response(str(e))
             yield f"data: {error}\n\n"
-
+        except HTTPException as e:
+            error = self.create_streaming_error_response(
+                message=str(e.detail),
+                err_type=str(e.status_code),
+                status_code=e.status_code,
+            )
+            yield f"data: {error}\n\n"
         yield "data: [DONE]\n\n"
 
     async def _handle_non_streaming_request(


### PR DESCRIPTION
## Motivation

We find some http-exception online, and there is an unexpected response when streaming request meets 503(when request queue is full)
http server does not catch httpexception, so it will raise a total 503 unstream exception even this is a streaming request
and as a user, we expect a streaming error response

## Modifications

add httpexception handle in generate_request and v1/chat/completions

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
