### PR TITLE
Refactor(prefix_cache): refactor init prefix cache, server args

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional, Tuple
 
 import torch
@@ -26,6 +27,23 @@ class MatchResult(NamedTuple):
     last_device_node: Any
     last_host_node: Any
     host_hit_length: int = 0
+
+
+class PrefixCacheBackend(Enum):
+    radix = "radix"
+    radix_cpp = "radix_cpp"
+    chunk = "chunk"
+    hierarchical = "hierarchical"
+    hierarchical_cpp = "hierarchical_cpp"
+    lora = "lora"
+    lmcache = "lmcache"
+    swa_radix = "swa_radix"
+    swa_chunk = "swa_chunk"
+    none = "none"
+
+
+def get_prefix_cache_backend(backend: str) -> PrefixCacheBackend:
+    return PrefixCacheBackend(backend)
 
 
 class BasePrefixCache(ABC):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -893,7 +893,7 @@ class ServerArgs:
             "1" if self.disable_outlines_disk_cache else "0"
         )
 
-        if self.schedule_policy and self.prefix_cache_backend == "lora":
+        if self.prefix_cache_backend == "lora" and self.schedule_policy != "fcfs":
             raise ValueError("LoRA radix cache only supports FCFS policy")
 
     @staticmethod


### PR DESCRIPTION
## Motivation

there are too many args and prefix cache implementation.

some of them are confilict.

too many if-else for `disable_radix_cache` and `enable_hicache`
and check between `enable_lmcache` and `disable_radix_cache` is forgot

use `prefix_cache_backend` and discard `disable_radix_cache` and `enable_hicache`

## Modifications

introduce new arg: --prefix-cache-backend

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
