### PR TITLE
[router] Basic OAI Response api

### DIFF
--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -289,6 +289,14 @@ impl RouterTrait for GrpcPDRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
+    async fn route_responses(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::ResponsesRequest,
+    ) -> Response {
+        (StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -222,6 +222,14 @@ impl RouterTrait for GrpcRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
+    async fn route_responses(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::ResponsesRequest,
+    ) -> Response {
+        (StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -333,6 +333,18 @@ impl super::super::RouterTrait for OpenAIRouter {
             .into_response()
     }
 
+    async fn route_responses(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &crate::protocols::spec::ResponsesRequest,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses endpoint not implemented for OpenAI router",
+        )
+            .into_response()
+    }
+
     async fn flush_cache(&self) -> Response {
         (
             StatusCode::NOT_IMPLEMENTED,

--- a/sgl-router/src/routers/http/pd_router.rs
+++ b/sgl-router/src/routers/http/pd_router.rs
@@ -9,8 +9,8 @@ use crate::core::{
 use crate::metrics::RouterMetrics;
 use crate::policies::LoadBalancingPolicy;
 use crate::protocols::spec::{
-    ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateRequest, StringOrArray,
-    UserMessageContent,
+    ChatCompletionRequest, ChatMessage, CompletionRequest, GenerateRequest, ResponsesRequest,
+    StringOrArray, UserMessageContent,
 };
 use crate::routers::header_utils;
 use crate::routers::{RouterTrait, WorkerManagement};
@@ -1928,6 +1928,18 @@ impl RouterTrait for PDRouter {
 
         // Execute with retry and bootstrap injection
         self.execute_dual_dispatch(headers, body, context).await
+    }
+
+    async fn route_responses(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &ResponsesRequest,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses endpoint not implemented for PD router",
+        )
+            .into_response()
     }
 
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {

--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -7,6 +7,7 @@ use crate::metrics::RouterMetrics;
 use crate::policies::LoadBalancingPolicy;
 use crate::protocols::spec::{
     ChatCompletionRequest, CompletionRequest, GenerateRequest, GenerationRequest,
+    ResponsesRequest,
 };
 use crate::routers::header_utils;
 use crate::routers::{RouterTrait, WorkerManagement};
@@ -1208,6 +1209,14 @@ impl RouterTrait for Router {
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/completions")
             .await
+    }
+
+    async fn route_responses(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &ResponsesRequest,
+    ) -> Response {
+        self.route_typed_request(headers, body, "/v1/responses").await
     }
 
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {

--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -6,8 +6,7 @@ use crate::core::{
 use crate::metrics::RouterMetrics;
 use crate::policies::LoadBalancingPolicy;
 use crate::protocols::spec::{
-    ChatCompletionRequest, CompletionRequest, GenerateRequest, GenerationRequest,
-    ResponsesRequest,
+    ChatCompletionRequest, CompletionRequest, GenerateRequest, GenerationRequest, ResponsesRequest,
 };
 use crate::routers::header_utils;
 use crate::routers::{RouterTrait, WorkerManagement};
@@ -1216,7 +1215,8 @@ impl RouterTrait for Router {
         headers: Option<&HeaderMap>,
         body: &ResponsesRequest,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/responses").await
+        self.route_typed_request(headers, body, "/v1/responses")
+            .await
     }
 
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {

--- a/sgl-router/src/routers/mod.rs
+++ b/sgl-router/src/routers/mod.rs
@@ -9,7 +9,9 @@ use axum::{
 };
 use std::fmt::Debug;
 
-use crate::protocols::spec::{ChatCompletionRequest, CompletionRequest, GenerateRequest};
+use crate::protocols::spec::{
+    ChatCompletionRequest, CompletionRequest, GenerateRequest, ResponsesRequest,
+};
 
 pub mod factory;
 pub mod grpc;
@@ -76,6 +78,13 @@ pub trait RouterTrait: Send + Sync + Debug + WorkerManagement {
         &self,
         headers: Option<&HeaderMap>,
         body: &CompletionRequest,
+    ) -> Response;
+
+    /// Route a responses request
+    async fn route_responses(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &ResponsesRequest,
     ) -> Response;
 
     async fn route_embeddings(&self, headers: Option<&HeaderMap>, body: Body) -> Response;

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -1024,7 +1024,9 @@ mod responses_endpoint_tests {
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(body_json["object"], "response");
         assert_eq!(body_json["status"], "completed");
@@ -1063,7 +1065,10 @@ mod responses_endpoint_tests {
 
         // Check that content-type indicates SSE
         let headers = resp.headers().clone();
-        let ct = headers.get("content-type").and_then(|v| v.to_str().ok()).unwrap_or("");
+        let ct = headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
         assert!(ct.contains("text/event-stream"));
 
         // We don't fully consume the stream in this test harness.

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -992,6 +992,86 @@ mod router_policy_tests {
 }
 
 #[cfg(test)]
+mod responses_endpoint_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_v1_responses_non_streaming() {
+        let ctx = TestContext::new(vec![MockWorkerConfig {
+            port: 18950,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "input": "Hello Responses API",
+            "model": "mock-model",
+            "stream": false
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["object"], "response");
+        assert_eq!(body_json["status"], "completed");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_streaming() {
+        let ctx = TestContext::new(vec![MockWorkerConfig {
+            port: 18951,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        let payload = json!({
+            "input": "Hello Responses API",
+            "model": "mock-model",
+            "stream": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Check that content-type indicates SSE
+        let headers = resp.headers().clone();
+        let ct = headers.get("content-type").and_then(|v| v.to_str().ok()).unwrap_or("");
+        assert!(ct.contains("text/event-stream"));
+
+        // We don't fully consume the stream in this test harness.
+        ctx.shutdown().await;
+    }
+}
+
+#[cfg(test)]
 mod error_tests {
     use super::*;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
- Support basic response api for regular router. Support to pd and openai router will do later
- mcp integration and state management will be done in seperate pr
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Add route_responses to RouterTrait (imports ResponsesRequest).
  - Server (src/server.rs): add v1/responses handler and route.
  - Regular router (routers/http/router.rs): implement route_responses via route_typed_request(..., "/v1/responses").
  - PD/OpenAI/gRPC routers: add simple route_responses stubs returning 501.
  - Mock worker (tests/common/mock_worker.rs): add /v1/responses (JSON + SSE).
  - Tests (tests/api_endpoints_test.rs): add non-streaming and streaming tests for /v1/responses.
<!-- Detail the changes made in this pull request. -->

## Tests
setup command
```
python3 -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --port 8001

python3 -m sglang_router.launch_router --worker-urls http://127.0.0.1:8001/  --port 3002 --prometheus-port 29001
```

Non-stream
```
curl -sS -X POST http://localhost:3002/v1/responses -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" -d '{"model":"meta-llama/Llama-3.1-8B-Instruct","input":"Write a short haiku about Rust.","instructions":"Be concise and poetic.","stream":false,"max_output_tokens":128,"temperature":0.7}'rite a short haiku about Rust.","instructions":"Be concise and poetic.","stream":false,"max_output_tokens":128,"temperature":0.7}'


{"id":"resp_ece027be5dd44ff19d30c1cb942d90de","object":"response","created_at":1757637423,"model":"meta-llama/Llama-3.1-8B-Instruct","output":[{"id":"msg_29e31cfbe1154ff4972be3e222c89d97","content":[{"annotations":[],"text":"Safe systems rise\nMemory's gentle whisper\nCode's careful dance","type":"output_text","logprobs":null}],"role":"assistant","status":"completed","type":"message"}],"status":"completed","usage":{"prompt_tokens":0,"total_tokens":0,"completion_tokens":0,"prompt_tokens_details":null,"reasoning_tokens":0},"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}

```
Stream
```
curl -sS -N http://localhost:3002/v1/responses -H "Content-Type: application/json" -H "Authorization: Bearer $API_KEY" -d '{"model":"meta-llama/Llama-3.1-8B-Instruct","input":"Write a short haiku about Rust.","stream":true,"max_output_tokens":128,"temperature":0.7}'

event: response.created
data: {"response":{"id":"resp_42ce3d6c9cc84bf9b6b16bd6e003e14a","created_at":1757637496.0,"error":null,"incomplete_details":null,"instructions":null,"metadata":null,"model":"meta-llama/Llama-3.1-8B-Instruct","object":"response","output":[],"parallel_tool_calls":true,"temperature":null,"tool_choice":"auto","tools":[],"top_p":null,"background":null,"max_output_tokens":null,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"prompt_cache_key":null,"reasoning":null,"safety_identifier":null,"service_tier":null,"status":"in_progress","text":null,"top_logprobs":null,"truncation":null,"usage":null,"user":null},"sequence_number":0,"type":"response.created"}

event: response.in_progress
data: {"response":{"id":"resp_42ce3d6c9cc84bf9b6b16bd6e003e14a","created_at":1757637496.0,"error":null,"incomplete_details":null,"instructions":null,"metadata":null,"model":"meta-llama/Llama-3.1-8B-Instruct","object":"response","output":[],"parallel_tool_calls":true,"temperature":null,"tool_choice":"auto","tools":[],"top_p":null,"background":null,"max_output_tokens":null,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"prompt_cache_key":null,"reasoning":null,"safety_identifier":null,"service_tier":null,"status":"in_progress","text":null,"top_logprobs":null,"truncation":null,"usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}

curl: (18) transfer closed with outstanding read data remaining
```
Note: curl: (18) transfer closed with outstanding read data remaining this error is from the sglang server.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
