### PR TITLE
Fix FA4 import cause moe_fused_gate output be illegal memory

### DIFF
--- a/sgl-kernel/python/sgl_kernel/flash_attn.py
+++ b/sgl-kernel/python/sgl_kernel/flash_attn.py
@@ -9,11 +9,6 @@ try:
 except:
     raise ImportError("Can not import sgl_kernel. Please check your installation.")
 
-try:
-    from ._fa4_interface import flash_attn_varlen_func as flash_attn_varlen_func_v4
-except ImportError:
-    flash_attn_varlen_func_v4 = None
-
 
 @lru_cache(maxsize=1)
 def is_fa3_supported(device=None) -> bool:
@@ -249,9 +244,8 @@ def flash_attn_varlen_func(
     ver=3,
 ):
     if ver == 4:
-        assert (
-            flash_attn_varlen_func_v4 is not None
-        ), "FA4 is not available, please check your installation."
+        from ._fa4_interface import flash_attn_varlen_func as flash_attn_varlen_func_v4
+
         # Using `(-1, -1)` as no sliding window causes correctness issues for FA4.
         if window_size == (-1, -1):
             window_size = (None, None)


### PR DESCRIPTION
## Motivation

before fix: error, cannot use sglang in my scenario

<details>

```
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-6.8165, device='cuda:3') gating_output.max()=tensor(0.3788, device='cuda:3') gating_output.mean()=tensor(-3.9311, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[128,  53, 185,  55, 183, 171,  76, 145]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-6.3357, device='cuda:3') gating_output.max()=tensor(0.0242, device='cuda:3') gating_output.mean()=tensor(-3.5893, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[ 38, 190,  75,  32,  36,   8,   6,  81]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-6.3394, device='cuda:3') gating_output.max()=tensor(0.6184, device='cuda:3') gating_output.mean()=tensor(-2.7144, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[128, 107, 105,   0, 241, 127,   7,  27]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-6.1605, device='cuda:3') gating_output.max()=tensor(0.5922, device='cuda:3') gating_output.mean()=tensor(-2.8778, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[128,  78,  66,  50, 104, 111, 145,  47]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-4.8919, device='cuda:3') gating_output.max()=tensor(1.4478, device='cuda:3') gating_output.mean()=tensor(-2.6520, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[128,  88, 130, 161, 187, 174, 241,  68]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-7.1304, device='cuda:3') gating_output.max()=tensor(2.2765, device='cuda:3') gating_output.mean()=tensor(-4.1431, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[128, 184, 182, 180,  83,  70,  10,   2]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-3.6963, device='cuda:3') gating_output.max()=tensor(1.9460, device='cuda:3') gating_output.mean()=tensor(-1.8894, device='cuda:3')
[11] hi going to call _biased_grouped_topk_postprocess topk_ids=tensor([[128, 189, 196, 165, 138, 166,  54,  32]], device='cuda:3',
       dtype=torch.int32) num_token_non_padded=tensor(1, device='cuda:3', dtype=torch.int32)
[11] hi going to call moe_fused_gate gating_output.min()=tensor(-5.1756, device='cuda:3') gating_output.max()=tensor(1.8946, device='cuda:3') gating_output.mean()=tensor(-2.1670, device='cuda:3')
[2025-09-12 09:31:11 DP11 TP11 EP11] TpModelWorkerClient hit an exception: Traceback (most recent call last):
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 141, in forward_thread_func
    self.forward_thread_func_()
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/managers/tp_worker_overlap_thread.py", line 174, in forward_thread_func_
    self.worker.forward_batch_generation(
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/managers/tp_worker.py", line 251, in forward_batch_generation
    logits_output, can_run_cuda_graph = self.model_runner.forward(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/model_executor/model_runner.py", line 1901, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/model_executor/model_runner.py", line 1946, in _forward_raw
    ret = self.forward_decode(
          ^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/model_executor/model_runner.py", line 1823, in forward_decode
    return self.model.forward(
           ^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/models/deepseek_v2.py", line 2448, in forward
    hidden_states = self.model(
                    ^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/models/deepseek_v2.py", line 2312, in forward
    hidden_states, residual = layer(
                              ^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/models/deepseek_v2.py", line 2073, in forward
    hidden_states = self.mlp(
                    ^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/models/deepseek_v2.py", line 506, in forward
    return self.forward_deepep(hidden_states, forward_batch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/models/deepseek_v2.py", line 654, in forward_deepep
    topk_weights, topk_idx, _ = self.topk(
                                ^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/custom_op.py", line 67, in forward
    return self._forward_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/layers/moe/topk.py", line 272, in forward_cuda
    return select_experts(
           ^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/layers/moe/topk.py", line 826, in select_experts
    topk_weights, topk_ids = biased_grouped_topk(
                             ^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/primary_synced/sglang/python/sglang/srt/layers/moe/topk.py", line 688, in biased_grouped_topk_gpu
    print(f"[{torch.distributed.get_rank()}] hi going to call _biased_grouped_topk_postprocess {topk_ids=} {num_token_non_padded=}")
                                                                                               ^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/_tensor.py", line 590, in __repr__
    return torch._tensor_str._str(self, tensor_contents=tensor_contents)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/_tensor_str.py", line 726, in _str
    return _str_intern(self, tensor_contents=tensor_contents)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/_tensor_str.py", line 647, in _str_intern
    tensor_str = _tensor_str(self, indent)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/_tensor_str.py", line 379, in _tensor_str
    formatter = _Formatter(get_summarized_data(self) if summarize else self)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/_tensor_str.py", line 142, in __init__
    value_str = f"{value}"
                  ^^^^^^^
  File "/data/numa0/tom/venvs/sgl/lib/python3.12/site-packages/torch/_tensor.py", line 1129, in __format__
    return self.detach().item().__format__(format_spec)
           ^^^^^^^^^^^^^^^^^^^^
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.


(sgl) (base) ubuntu@expedition-carbon-cn01-worker:/data/numa0/tom/primary_synced/tom_sglang
_server/misc$
```

</details>

after fix: no error

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
