### PR TITLE
Benchmark: Improve path of check_chat_template

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1930,9 +1930,9 @@ async def benchmark(
     return result | result_details
 
 
-def check_chat_template(model_path):
+def check_chat_template(tokenizer_id):
     try:
-        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_id, trust_remote_code=True)
         return "chat_template" in tokenizer.init_kwargs
     except Exception as e:
         print(f"Fail to load tokenizer config with error={e}")
@@ -2071,7 +2071,8 @@ def run_benchmark(args_: argparse.Namespace):
         print("No model specified or found. Please provide a model using `--model`.")
         sys.exit(1)
 
-    if not check_chat_template(args.model):
+    tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
+    if not check_chat_template(tokenizer_id):
         print(
             "\nWARNING It is recommended to use the `Chat` or `Instruct` model for benchmarking.\n"
             "Because when the tokenizer counts the output tokens, if there is gibberish, it might count incorrectly.\n"
@@ -2082,7 +2083,6 @@ def run_benchmark(args_: argparse.Namespace):
     # Read dataset
     backend = args.backend
     model_id = args.model
-    tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
     tokenizer = get_tokenizer(tokenizer_id)
     input_requests = get_dataset(args, tokenizer)
 

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1930,9 +1930,11 @@ async def benchmark(
     return result | result_details
 
 
-def check_chat_template(tokenizer_id):
+def check_chat_template(tokenizer_path):
     try:
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer_id, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_path, trust_remote_code=True
+        )
         return "chat_template" in tokenizer.init_kwargs
     except Exception as e:
         print(f"Fail to load tokenizer config with error={e}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When using `base_url` to request remote servers, users typically provide a **tokenizer path** to handle prompt tokenization and ensure prompt length. However, the current `check_chat_template` checks the **model path** from the HTTP request, which may not match the official model identifier (e.g., just `"DeepSeek-V3"`), leading to lookup errors.

Since the `chat_template` is usually defined in the **tokenizer path**, it makes more sense to prioritize checking the tokenizer path provided by the user. This way, users don’t need to explicitly pass model arguments, making the experience simpler and more intuitive.

## Modifications
1. Move `tokenizer_id` earlier in the workflow so it can be used by `check_chat_template`.
2. Rename the argument in `check_chat_template` for clarity and consistency.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
