### PR TITLE
[router] Add get and cancel method for response api

### DIFF
--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -297,6 +297,14 @@ impl RouterTrait for GrpcPDRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
+    async fn get_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+
+    async fn cancel_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -230,6 +230,14 @@ impl RouterTrait for GrpcRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
+    async fn get_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+
+    async fn cancel_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (StatusCode::NOT_IMPLEMENTED).into_response()
+    }
+
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -345,6 +345,22 @@ impl super::super::RouterTrait for OpenAIRouter {
             .into_response()
     }
 
+    async fn get_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses retrieve endpoint not implemented for OpenAI router",
+        )
+            .into_response()
+    }
+
+    async fn cancel_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses cancel endpoint not implemented for OpenAI router",
+        )
+            .into_response()
+    }
+
     async fn flush_cache(&self) -> Response {
         (
             StatusCode::NOT_IMPLEMENTED,

--- a/sgl-router/src/routers/http/pd_router.rs
+++ b/sgl-router/src/routers/http/pd_router.rs
@@ -1942,6 +1942,22 @@ impl RouterTrait for PDRouter {
             .into_response()
     }
 
+    async fn get_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses retrieve endpoint not implemented for PD router",
+        )
+            .into_response()
+    }
+
+    async fn cancel_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses cancel endpoint not implemented for PD router",
+        )
+            .into_response()
+    }
+
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {
         todo!()
     }

--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -13,7 +13,9 @@ use crate::routers::{RouterTrait, WorkerManagement};
 use axum::{
     body::Body,
     extract::Request,
-    http::{header::CONTENT_LENGTH, header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode},
+    http::{
+        header::CONTENT_LENGTH, header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode,
+    },
     response::{IntoResponse, Response},
     Json,
 };
@@ -551,6 +553,112 @@ impl Router {
         }
 
         response
+    }
+
+    // Helper: return base worker URL (strips DP suffix when enabled)
+    fn worker_base_url(&self, worker_url: &str) -> String {
+        if self.dp_aware {
+            if let Ok((prefix, _)) = Self::extract_dp_rank(worker_url) {
+                return prefix.to_string();
+            }
+        }
+        worker_url.to_string()
+    }
+
+    // Generic simple routing for GET/POST without JSON body
+    async fn route_simple_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        endpoint: &str,
+        method: Method,
+    ) -> Response {
+        let worker_urls = self.get_worker_urls();
+        if worker_urls.is_empty() {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No available workers").into_response();
+        }
+
+        let mut last_response: Option<Response> = None;
+        for worker_url in worker_urls {
+            let base = self.worker_base_url(&worker_url);
+
+            let url = format!("{}/{}", base, endpoint);
+            let mut request_builder = match method {
+                Method::GET => self.client.get(url),
+                Method::POST => self.client.post(url),
+                _ => {
+                    return (
+                        StatusCode::METHOD_NOT_ALLOWED,
+                        "Unsupported method for simple routing",
+                    )
+                        .into_response()
+                }
+            };
+
+            if let Some(hdrs) = headers {
+                for (name, value) in hdrs {
+                    let name_lc = name.as_str().to_lowercase();
+                    if name_lc != "content-type" && name_lc != "content-length" {
+                        request_builder = request_builder.header(name, value);
+                    }
+                }
+            }
+
+            match request_builder.send().await {
+                Ok(res) => {
+                    let status = StatusCode::from_u16(res.status().as_u16())
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    let response_headers = header_utils::preserve_response_headers(res.headers());
+                    match res.bytes().await {
+                        Ok(body) => {
+                            let mut response = Response::new(axum::body::Body::from(body));
+                            *response.status_mut() = status;
+                            *response.headers_mut() = response_headers;
+                            if status.is_success() {
+                                return response;
+                            }
+                            last_response = Some(response);
+                        }
+                        Err(e) => {
+                            last_response = Some(
+                                (
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    format!("Failed to read response: {}", e),
+                                )
+                                    .into_response(),
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    last_response = Some(
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Request failed: {}", e),
+                        )
+                            .into_response(),
+                    );
+                }
+            }
+        }
+
+        last_response
+            .unwrap_or_else(|| (StatusCode::BAD_GATEWAY, "No worker response").into_response())
+    }
+
+    // Route a GET request with provided headers to a specific endpoint
+    async fn route_get_request(&self, headers: Option<&HeaderMap>, endpoint: &str) -> Response {
+        self.route_simple_request(headers, endpoint, Method::GET)
+            .await
+    }
+
+    // Route a POST request with empty body to a specific endpoint
+    async fn route_post_empty_request(
+        &self,
+        headers: Option<&HeaderMap>,
+        endpoint: &str,
+    ) -> Response {
+        self.route_simple_request(headers, endpoint, Method::POST)
+            .await
     }
 
     // TODO (rui): Better accommodate to the Worker abstraction
@@ -1217,6 +1325,16 @@ impl RouterTrait for Router {
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/responses")
             .await
+    }
+
+    async fn get_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response {
+        let endpoint = format!("v1/responses/{}", response_id);
+        self.route_get_request(headers, &endpoint).await
+    }
+
+    async fn cancel_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response {
+        let endpoint = format!("v1/responses/{}/cancel", response_id);
+        self.route_post_empty_request(headers, &endpoint).await
     }
 
     async fn route_embeddings(&self, _headers: Option<&HeaderMap>, _body: Body) -> Response {

--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -574,6 +574,8 @@ impl Router {
         endpoint: &str,
         method: Method,
     ) -> Response {
+        // TODO: currently the sglang worker is using in-memory state management, so this implementation has to fan out to all workers.
+        // Eventually, we need to have router to manage the chat history with a proper database, will update this implementation accordingly.
         let worker_urls = self.get_worker_urls();
         if worker_urls.is_empty() {
             return (StatusCode::SERVICE_UNAVAILABLE, "No available workers").into_response();

--- a/sgl-router/src/routers/mod.rs
+++ b/sgl-router/src/routers/mod.rs
@@ -87,6 +87,34 @@ pub trait RouterTrait: Send + Sync + Debug + WorkerManagement {
         body: &ResponsesRequest,
     ) -> Response;
 
+    /// Retrieve a stored/background response by id
+    async fn get_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response;
+
+    /// Cancel a background response by id
+    async fn cancel_response(&self, headers: Option<&HeaderMap>, response_id: &str) -> Response;
+
+    /// Delete a response by id
+    async fn delete_response(&self, _headers: Option<&HeaderMap>, _response_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses delete endpoint not implemented",
+        )
+            .into_response()
+    }
+
+    /// List input items of a response by id
+    async fn list_response_input_items(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _response_id: &str,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Responses list input items endpoint not implemented",
+        )
+            .into_response()
+    }
+
     async fn route_embeddings(&self, headers: Option<&HeaderMap>, body: Body) -> Response;
 
     async fn route_rerank(&self, headers: Option<&HeaderMap>, body: Body) -> Response;

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -11,10 +11,10 @@ use crate::service_discovery::{start_service_discovery, ServiceDiscoveryConfig};
 use crate::tokenizer::{factory as tokenizer_factory, traits::Tokenizer};
 use crate::tool_parser::ParserRegistry;
 use axum::{
-    extract::{Query, Request, State},
+    extract::{Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use reqwest::Client;
@@ -160,6 +160,52 @@ async fn v1_responses(
     state.router.route_responses(Some(&headers), &body).await
 }
 
+async fn v1_responses_get(
+    State(state): State<Arc<AppState>>,
+    Path(response_id): Path<String>,
+    headers: http::HeaderMap,
+) -> Response {
+    state
+        .router
+        .get_response(Some(&headers), &response_id)
+        .await
+}
+
+async fn v1_responses_cancel(
+    State(state): State<Arc<AppState>>,
+    Path(response_id): Path<String>,
+    headers: http::HeaderMap,
+) -> Response {
+    state
+        .router
+        .cancel_response(Some(&headers), &response_id)
+        .await
+}
+
+async fn v1_responses_delete(
+    State(state): State<Arc<AppState>>,
+    Path(response_id): Path<String>,
+    headers: http::HeaderMap,
+) -> Response {
+    // Python server does not support this yet
+    state
+        .router
+        .delete_response(Some(&headers), &response_id)
+        .await
+}
+
+async fn v1_responses_list_input_items(
+    State(state): State<Arc<AppState>>,
+    Path(response_id): Path<String>,
+    headers: http::HeaderMap,
+) -> Response {
+    // Python server does not support this yet
+    state
+        .router
+        .list_response_input_items(Some(&headers), &response_id)
+        .await
+}
+
 // Worker management endpoints
 async fn add_worker(
     State(state): State<Arc<AppState>>,
@@ -238,6 +284,16 @@ pub fn build_app(
         .route("/v1/chat/completions", post(v1_chat_completions))
         .route("/v1/completions", post(v1_completions))
         .route("/v1/responses", post(v1_responses))
+        .route("/v1/responses/{response_id}", get(v1_responses_get))
+        .route(
+            "/v1/responses/{response_id}/cancel",
+            post(v1_responses_cancel),
+        )
+        .route("/v1/responses/{response_id}", delete(v1_responses_delete))
+        .route(
+            "/v1/responses/{response_id}/input",
+            get(v1_responses_list_input_items),
+        )
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
             crate::middleware::concurrency_limit_middleware,

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -994,6 +994,7 @@ mod router_policy_tests {
 #[cfg(test)]
 mod responses_endpoint_tests {
     use super::*;
+    use reqwest::Client as HttpClient;
 
     #[tokio::test]
     async fn test_v1_responses_non_streaming() {
@@ -1072,6 +1073,207 @@ mod responses_endpoint_tests {
         assert!(ct.contains("text/event-stream"));
 
         // We don't fully consume the stream in this test harness.
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_get() {
+        let ctx = TestContext::new(vec![MockWorkerConfig {
+            port: 18952,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        // First create a response to obtain an id
+        let payload = json!({
+            "input": "Hello Responses API",
+            "model": "mock-model",
+            "stream": false
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let resp_id = body_json["id"].as_str().unwrap().to_string();
+
+        // Retrieve the response
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/v1/responses/{}", resp_id))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let get_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(get_json["object"], "response");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_cancel() {
+        let ctx = TestContext::new(vec![MockWorkerConfig {
+            port: 18953,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        // First create a response to obtain an id
+        let payload = json!({
+            "input": "Hello Responses API",
+            "model": "mock-model",
+            "stream": false
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let resp_id = body_json["id"].as_str().unwrap().to_string();
+
+        // Cancel the response
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/v1/responses/{}/cancel", resp_id))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let cancel_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(cancel_json["status"], "cancelled");
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_delete_and_list_not_implemented() {
+        let ctx = TestContext::new(vec![MockWorkerConfig {
+            port: 18954,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        // Use an arbitrary id for delete/list
+        let resp_id = "resp-test-123";
+
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(format!("/v1/responses/{}", resp_id))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/v1/responses/{}/input", resp_id))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_v1_responses_get_multi_worker_fanout() {
+        // Start two mock workers
+        let ctx = TestContext::new(vec![
+            MockWorkerConfig {
+                port: 18960,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+            MockWorkerConfig {
+                port: 18961,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            },
+        ])
+        .await;
+
+        let app = ctx.create_app().await;
+
+        // Create a background response with a known id
+        let rid = format!("resp_{}", 18960); // arbitrary unique id
+        let payload = json!({
+            "input": "Hello Responses API",
+            "model": "mock-model",
+            "background": true,
+            "store": true,
+            "request_id": rid,
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Using the router, GET should succeed by fanning out across workers
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/v1/responses/{}", rid))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Validate only one worker holds the metadata: direct calls
+        let client = HttpClient::new();
+        let mut ok_count = 0usize;
+        for url in ctx.router.get_worker_urls() {
+            let get_url = format!("{}/v1/responses/{}", url, rid);
+            let res = client.get(get_url).send().await.unwrap();
+            if res.status() == StatusCode::OK {
+                ok_count += 1;
+            }
+        }
+        assert_eq!(ok_count, 1, "exactly one worker should store the response");
+
         ctx.shutdown().await;
     }
 }

--- a/sgl-router/tests/common/mock_worker.rs
+++ b/sgl-router/tests/common/mock_worker.rs
@@ -799,9 +799,7 @@ fn get_store() -> &'static Mutex<HashMap<u16, HashSet<String>>> {
 
 fn store_response_for_port(port: u16, response_id: &str) {
     let mut map = get_store().lock().unwrap();
-    map.entry(port)
-        .or_default()
-        .insert(response_id.to_string());
+    map.entry(port).or_default().insert(response_id.to_string());
 }
 
 fn response_exists_for_port(port: u16, response_id: &str) -> bool {

--- a/sgl-router/tests/common/mock_worker.rs
+++ b/sgl-router/tests/common/mock_worker.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 use axum::{
-    extract::{Json, State},
+    extract::{Json, Path, State},
     http::StatusCode,
     response::sse::{Event, KeepAlive},
     response::{IntoResponse, Response, Sse},
@@ -11,8 +11,9 @@ use axum::{
 };
 use futures_util::stream::{self, StreamExt};
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -82,6 +83,11 @@ impl MockWorker {
             .route("/v1/chat/completions", post(chat_completions_handler))
             .route("/v1/completions", post(completions_handler))
             .route("/v1/responses", post(responses_handler))
+            .route("/v1/responses/{response_id}", get(responses_get_handler))
+            .route(
+                "/v1/responses/{response_id}/cancel",
+                post(responses_cancel_handler),
+            )
             .route("/flush_cache", post(flush_cache_handler))
             .route("/v1/models", get(v1_models_handler))
             .with_state(config);
@@ -583,6 +589,21 @@ async fn responses_handler(
         .unwrap()
         .as_secs() as i64;
 
+    // Background storage simulation
+    let is_background = payload
+        .get("background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let req_id = payload
+        .get("request_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    if is_background {
+        if let Some(id) = &req_id {
+            store_response_for_port(config.port, id);
+        }
+    }
+
     if is_stream {
         let request_id = format!("resp-{}", Uuid::new_v4());
 
@@ -609,6 +630,18 @@ async fn responses_handler(
         Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response()
+    } else if is_background {
+        let rid = req_id.unwrap_or_else(|| format!("resp-{}", Uuid::new_v4()));
+        Json(json!({
+            "id": rid,
+            "object": "response",
+            "created_at": timestamp,
+            "model": "mock-model",
+            "output": [],
+            "status": "queued",
+            "usage": null
+        }))
+        .into_response()
     } else {
         Json(json!({
             "id": format!("resp-{}", Uuid::new_v4()),
@@ -685,6 +718,96 @@ async fn v1_models_handler(State(config): State<Arc<RwLock<MockWorkerConfig>>>) 
         }]
     }))
     .into_response()
+}
+
+async fn responses_get_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    Path(response_id): Path<String>,
+) -> Response {
+    let config = config.read().await;
+    if should_fail(&config).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "Random failure for testing" })),
+        )
+            .into_response();
+    }
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    // Only return 200 if this worker "stores" the response id
+    if response_exists_for_port(config.port, &response_id) {
+        Json(json!({
+            "id": response_id,
+            "object": "response",
+            "created_at": timestamp,
+            "model": "mock-model",
+            "output": [],
+            "status": "completed",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0
+            }
+        }))
+        .into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+async fn responses_cancel_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    Path(response_id): Path<String>,
+) -> Response {
+    let config = config.read().await;
+    if should_fail(&config).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "Random failure for testing" })),
+        )
+            .into_response();
+    }
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    if response_exists_for_port(config.port, &response_id) {
+        Json(json!({
+            "id": response_id,
+            "object": "response",
+            "created_at": timestamp,
+            "model": "mock-model",
+            "output": [],
+            "status": "cancelled",
+            "usage": null
+        }))
+        .into_response()
+    } else {
+        StatusCode::NOT_FOUND.into_response()
+    }
+}
+
+// --- Simple in-memory response store per worker port (for tests) ---
+static RESP_STORE: OnceLock<Mutex<HashMap<u16, HashSet<String>>>> = OnceLock::new();
+
+fn get_store() -> &'static Mutex<HashMap<u16, HashSet<String>>> {
+    RESP_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn store_response_for_port(port: u16, response_id: &str) {
+    let mut map = get_store().lock().unwrap();
+    map.entry(port)
+        .or_default()
+        .insert(response_id.to_string());
+}
+
+fn response_exists_for_port(port: u16, response_id: &str) -> bool {
+    let map = get_store().lock().unwrap();
+    map.get(&port)
+        .map(|set| set.contains(response_id))
+        .unwrap_or(false)
 }
 
 impl Default for MockWorkerConfig {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
make the http regular router response api support get/cancel/delete/list method
delete and list input items methods are not implemented yet in sglang python, so we just add a placeholder in router
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- implement the get and cancel response api
- since the sglang python server store the response state in memory, the response state is not shared across workers. fan out the request to all the workers during get/cancel response call
- added integration test
<!-- Detail the changes made in this pull request. -->

## Tests
<details>
  <summary>test script</summary>
<code>
#!/usr/bin/env bash
set -euo pipefail

BASE_URL=${BASE_URL:-http://localhost:30000}
MODEL=${MODEL:-meta-llama/Llama-3.1-8B-Instruct}
API_KEY=${API_KEY:-}
DO_STREAM=${STREAM:-0}

while [[ $# -gt 0 ]]; do
  case "$1" in
    --base-url)
      BASE_URL="$2"; shift 2 ;;
    --model)
      MODEL="$2"; shift 2 ;;
    --api-key)
      API_KEY="$2"; shift 2 ;;
    --stream)
      DO_STREAM=1; shift 1 ;;
    -h|--help)
      echo "Usage: $0 [--base-url URL] [--model MODEL] [--api-key KEY] [--stream]"; exit 0 ;;
    *) echo "Unknown arg: $1" >&2; exit 2 ;;
  esac
done

auth_header=()
if [[ -n "$API_KEY" ]]; then
  auth_header+=( -H "Authorization: Bearer $API_KEY" )
fi

printf "Responses API smoke tests\n"
printf -- "- BASE_URL: %s\n" "$BASE_URL"
printf -- "- MODEL:    %s\n" "$MODEL"
[[ -n "$API_KEY" ]] && printf -- "- Auth:     Bearer <redacted>\n" || true

fail() { echo "[FAIL] $*" >&2; exit 1; }

has_jq=0
if command -v jq >/dev/null 2>&1; then has_jq=1; fi

printf "\n[1/5] Create (synchronous)\n\n"
create_sync_payload=$(cat <<JSON
{ "input": "Hello Responses API", "model": "$MODEL", "stream": false, "store": true }
JSON
)
sync_out=$(curl -sS -X POST "$BASE_URL/v1/responses" \
  -H "Content-Type: application/json" "${auth_header[@]}" \
  -d "$create_sync_payload" ) || fail "create (sync) request failed"

echo "$sync_out" | grep -q '"object"\s*:\s*"response"' || fail "sync create: unexpected body"
printf "[OK] Created sync response\n"

printf "\n[2/5] Create (background)\n\n"
# Use an explicit response id with the required prefix
RID="resp_$(date +%s%3N)"
create_bg_payload=$(cat <<JSON
{ "input": "Run in background", "model": "$MODEL", "background": true, "store": true, "request_id": "$RID" }
JSON
)
bg_out=$(curl -sS -X POST "$BASE_URL/v1/responses" \
  -H "Content-Type: application/json" "${auth_header[@]}" \
  -d "$create_bg_payload" ) || fail "create (background) request failed"

if [[ $has_jq -eq 1 ]]; then
  rid_from_resp=$(echo "$bg_out" | jq -r '.id // empty')
else
  rid_from_resp=$(echo "$bg_out" | sed -n 's/.*"id"\s*:\s*"\([^"]\+\)".*/\1/p')
fi

[[ -n "$rid_from_resp" ]] || fail "background create: missing id in response"

printf "[OK] Created background response: id=%s\n" "$rid_from_resp"

printf "\n[3/5] Get (retrieve)\n\n"
get_out=$(curl -sS "$BASE_URL/v1/responses/$rid_from_resp" "${auth_header[@]}" ) || fail "get response failed"
echo "$get_out" | grep -q '"object"\s*:\s*"response"' || fail "get: unexpected body"
echo "$get_out"
printf "[OK] Retrieved response\n"

printf "\n[4/5] Cancel (background)\n\n"
cancel_out=$(curl -sS -X POST "$BASE_URL/v1/responses/$rid_from_resp/cancel" "${auth_header[@]}" ) || fail "cancel failed"
echo "$cancel_out" | grep -q '"status"\s*:\s*"cancelled"' || echo "[WARN] cancel response did not contain status=cancelled"
echo "$cancel_out"
printf "[OK] Cancelled (or attempted cancel)\n"

printf "\n[5/5] Get (after cancel)\n\n"
get_after_cancel=$(curl -sS "$BASE_URL/v1/responses/$rid_from_resp" "${auth_header[@]}") || fail "get after cancel failed"
echo "$get_after_cancel" | grep -q '"object"\s*:\s*"response"' || fail "get after cancel: unexpected body"
echo "$get_after_cancel"
if echo "$get_after_cancel" | grep -q '"status"\s*:\s*"cancelled"'; then
  printf "[OK] Retrieved cancelled response\n"
else
  echo "[WARN] response status is not 'cancelled' after cancel"
fi

if [[ "$DO_STREAM" -eq 1 ]]; then
  printf "\n[Optional] Create (streaming)\n"
  stream_payload=$(cat <<JSON
{ "input": "Stream test", "model": "$MODEL", "stream": true }
JSON
  )
  printf "Streaming events (press Ctrl+C to stop):\n"
  curl -sS -N -X POST "$BASE_URL/v1/responses" \
    -H "Content-Type: application/json" -H "Accept: text/event-stream" \
    "${auth_header[@]}" -d "$stream_payload" || echo "[WARN] streaming request ended"
fi

printf "\nAll done.\n"
</code>
</details>

result:
```
Responses API smoke tests
- BASE_URL: http://localhost:30000
- MODEL:    meta-llama/Llama-3.1-8B-Instruct

[1/5] Create (synchronous)[OK] Created sync response

[2/5] Create (background)[OK] Created background response: id=resp_1757700099322

[3/5] Get (retrieve){"id":"resp_1757700099322","object":"response","created_at":1757700099,"model":"meta-llama/Llama-3.1-8B-Instruct","output":[],"status":"in_progress","usage":null,"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}
[OK] Retrieved response

[4/5] Cancel (background){"id":"resp_1757700099322","object":"response","created_at":1757700099,"model":"meta-llama/Llama-3.1-8B-Instruct","output":[],"status":"cancelled","usage":null,"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}
[OK] Cancelled (or attempted cancel)

[5/5] Get (after cancel){"id":"resp_1757700099322","object":"response","created_at":1757700099,"model":"meta-llama/Llama-3.1-8B-Instruct","output":[],"status":"cancelled","usage":null,"parallel_tool_calls":true,"tool_choice":"auto","tools":[]}
[OK] Retrieved cancelled response

All done.

```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
