### PR TITLE
Add script for testing deterministic

### DIFF
--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -1,5 +1,5 @@
 """
-Send the same prompt for multiple times and test if the results are deterministic.
+Batch the same prompt in random batch sizes, and test if the results are consistent across different trials.
 
 Usage:
 python3 -m sglang.test.test_deterministic --n-trials <numer_of_trials>
@@ -24,9 +24,7 @@ class BenchArgs:
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
     return_logprob: bool = False
-    prompt: str = (
-        "Generate 1000 random numbers. Go directly into it, don't say Sure and don't say here are numbers. Just start with a number. /no_think"
-    )
+    prompt: str = "Tell me about Richard Feynman: "
     stream: bool = False
 
     @staticmethod
@@ -94,7 +92,7 @@ def send_one_prompt(args):
         print(ret)
         return 0, 0
 
-    return ret["text"]
+    return ret["text"], batch_size
 
 
 def test_deterministic(args):
@@ -104,9 +102,9 @@ def test_deterministic(args):
 
     texts = []
     for i in range(args.n_trials):
-        text = send_one_prompt(args)
+        text, batch_size = send_one_prompt(args)
         text = text.replace("\n", " ")
-        print(f"Trial {i}: {text}")
+        print(f"Trial {i} with batch size {batch_size}: {text}")
         texts.append(text)
 
     print(f"Total samples: {len(texts)}, Unique samples: {len(set(texts))}")

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -100,6 +100,10 @@ def send_one_prompt(args):
 
 
 def test_deterministic(args):
+    # First do some warmups
+    for i in range(3):
+        send_one_prompt(args)
+
     speeds = []
     texts = []
     for i in range(args.n_trials):

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -7,9 +7,9 @@ python3 -m sglang.test.test_deterministic --n-trials <numer_of_trials>
 
 import argparse
 import dataclasses
-import numpy as np
 import json
 
+import numpy as np
 import requests
 
 
@@ -23,9 +23,7 @@ class BenchArgs:
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
     return_logprob: bool = False
-    prompt: str = (
-        "Tell me about Richard Feynman: "
-    )
+    prompt: str = "Tell me about Richard Feynman: "
     stream: bool = False
 
     @staticmethod
@@ -115,13 +113,16 @@ def test_deterministic(args):
     for i in range(len(texts)):
         text = texts[i]
         if text != texts[0]:
-            print(f"Test failed: Output of trial 0: {texts[0][:50]}\n Output of trial {i}: {text[:50]}\n")
+            print(
+                f"Test failed: Output of trial 0: {texts[0][:50]}\n Output of trial {i}: {text[:50]}\n"
+            )
             pass_test = False
             break
 
     if pass_test:
         print("Test passed for all trials")
     print(f"Average speed: {np.mean(speeds)=:.2f} token/s")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -105,7 +105,8 @@ def test_deterministic(args):
     texts = []
     for i in range(args.n_trials):
         text = send_one_prompt(args)
-        print(f"Trial {i}: {text.replace('\n', ' ')}")
+        text = text.replace("\n", " ")
+        print(f"Trial {i}: {text}")
         texts.append(text)
 
     print(f"Total samples: {len(texts)}, Unique samples: {len(set(texts))}")

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -1,0 +1,131 @@
+"""
+Send the same prompt for multiple times and test if the results are deterministic.
+
+Usage:
+python3 -m sglang.test.test_deterministic --n-trials <numer_of_trials>
+"""
+
+import argparse
+import dataclasses
+import numpy as np
+import json
+
+import requests
+
+
+@dataclasses.dataclass
+class BenchArgs:
+    host: str = "localhost"
+    port: int = 30000
+    batch_size: int = 1
+    temperature: float = 0.0
+    max_new_tokens: int = 512
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    return_logprob: bool = False
+    prompt: str = (
+        "Tell me about Richard Feynman: "
+    )
+    stream: bool = False
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser):
+        parser.add_argument("--host", type=str, default=BenchArgs.host)
+        parser.add_argument("--port", type=int, default=BenchArgs.port)
+        parser.add_argument("--n-trials", type=int, default=50)
+        parser.add_argument("--batch-size", type=int, default=BenchArgs.batch_size)
+        parser.add_argument("--temperature", type=float, default=BenchArgs.temperature)
+        parser.add_argument(
+            "--max-new-tokens", type=int, default=BenchArgs.max_new_tokens
+        )
+        parser.add_argument(
+            "--frequency-penalty", type=float, default=BenchArgs.frequency_penalty
+        )
+        parser.add_argument(
+            "--presence-penalty", type=float, default=BenchArgs.presence_penalty
+        )
+        parser.add_argument("--return-logprob", action="store_true")
+        parser.add_argument("--prompt", type=str, default=BenchArgs.prompt)
+        parser.add_argument("--stream", action="store_true")
+
+    @classmethod
+    def from_cli_args(cls, args: argparse.Namespace):
+        attrs = [attr.name for attr in dataclasses.fields(cls)]
+        return cls(**{attr: getattr(args, attr) for attr in attrs})
+
+
+def send_one_prompt(args):
+
+    prompt = args.prompt
+    if args.batch_size > 1:
+        prompt = [prompt] * args.batch_size
+
+    json_data = {
+        "text": prompt,
+        "sampling_params": {
+            "temperature": args.temperature,
+            "max_new_tokens": args.max_new_tokens,
+            "frequency_penalty": args.frequency_penalty,
+            "presence_penalty": args.presence_penalty,
+            "stop": ["Question", "Assistant:", "<|separator|>", "<|eos|>"],
+        },
+        "return_logprob": args.return_logprob,
+        "stream": args.stream,
+    }
+
+    response = requests.post(
+        f"http://{args.host}:{args.port}/generate",
+        json=json_data,
+        stream=args.stream,
+    )
+
+    if args.stream:
+        for chunk in response.iter_lines(decode_unicode=False):
+            chunk = chunk.decode("utf-8")
+            if chunk and chunk.startswith("data:"):
+                if chunk == "data: [DONE]":
+                    break
+                ret = json.loads(chunk[5:].strip("\n"))
+    else:
+        ret = response.json()
+
+    if args.batch_size > 1:
+        ret = ret[0]
+
+    if response.status_code != 200:
+        print(ret)
+        return 0, 0
+
+    latency = ret["meta_info"]["e2e_latency"]
+    speed = ret["meta_info"]["completion_tokens"] / latency
+
+    return ret["text"], speed
+
+
+def test_deterministic(args):
+    speeds = []
+    texts = []
+    for i in range(args.n_trials):
+        text, speed = send_one_prompt(args)
+        print(f"Trial {i}: {speed=:.2f} token/s, {text[:50]}")
+        speeds.append(speed)
+        texts.append(text)
+
+    pass_test = True
+    for i in range(len(texts)):
+        text = texts[i]
+        if text != texts[0]:
+            print(f"Test failed: Output of trial 0: {texts[0][:50]}\n Output of trial {i}: {text[:50]}\n")
+            pass_test = False
+            break
+
+    if pass_test:
+        print("Test passed for all trials")
+    print(f"Average speed: {np.mean(speeds)=:.2f} token/s")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    BenchArgs.add_cli_args(parser)
+    args = parser.parse_args()
+
+    test_deterministic(args)

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -65,7 +65,6 @@ def send_one_prompt(args):
             "max_new_tokens": args.max_new_tokens,
             "frequency_penalty": args.frequency_penalty,
             "presence_penalty": args.presence_penalty,
-            "stop": ["Question", "Assistant:", "<|separator|>", "<|eos|>"],
         },
         "return_logprob": args.return_logprob,
         "stream": args.stream,
@@ -105,7 +104,7 @@ def test_deterministic(args):
     texts = []
     for i in range(args.n_trials):
         text, speed = send_one_prompt(args)
-        print(f"Trial {i}: {speed=:.2f} token/s, {text[:50]}")
+        print(f"Trial {i}: {speed=:.2f} token/s \n Last 50 characters: {text[-50:]}")
         speeds.append(speed)
         texts.append(text)
 

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -19,11 +19,13 @@ class BenchArgs:
     port: int = 30000
     batch_size: int = 1
     temperature: float = 0.0
-    max_new_tokens: int = 512
+    max_new_tokens: int = 100
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
     return_logprob: bool = False
-    prompt: str = "Tell me about Richard Feynman: "
+    prompt: str = (
+        "Generate 1000 random numbers. Go directly into it, don't say Sure and don't say here are numbers. Just start with a number. /no_think"
+    )
     stream: bool = False
 
     @staticmethod
@@ -108,23 +110,12 @@ def test_deterministic(args):
     texts = []
     for i in range(args.n_trials):
         text, speed = send_one_prompt(args)
-        print(f"Trial {i}: {speed=:.2f} token/s \n Last 50 characters: {text[-50:]}")
+        print(f"Trial {i}: {speed=:.2f} token/s \nLast 50 characters: {text[-50:]}")
         speeds.append(speed)
         texts.append(text)
 
-    pass_test = True
-    for i in range(len(texts)):
-        text = texts[i]
-        if text != texts[0]:
-            print(
-                f"Test failed: Output of trial 0: {texts[0][:50]}\n Output of trial {i}: {text[:50]}\n"
-            )
-            pass_test = False
-            break
-
-    if pass_test:
-        print("Test passed for all trials")
-    print(f"Average speed: {np.mean(speeds)=:.2f} token/s")
+    print(f"Total samples: {len(texts)}, Unique samples: {len(set(texts))}")
+    print(f"Average speed: {np.mean(speeds):.2f} token/s")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Modified based on `send_one.py`

This PR is merged into #10417

Usage:

First launch server
```bash
python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --disable-radix-cache
```

Then run script 
```bash
python3 -m sglang.test.test_deterministic --n-trials 100
```

Currently the number of unique samples is more than 1. After supporting batch invariant ops, the number of unique samples should be equal to 1.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
