### PR TITLE
fix: tool parse in large streaming chunk beginning with normal content

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -165,6 +165,10 @@ class BaseFormatDetector(ABC):
                 tool_call_pos = current_text.find(self.bot_token)
                 if tool_call_pos != -1:
                     start_idx = tool_call_pos + len(self.bot_token)
+                elif self.current_tool_id > 0 and current_text.startswith(
+                    self.tool_call_separator
+                ):
+                    start_idx = len(self.tool_call_separator)
                 else:
                     start_idx = 0
 

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -162,16 +162,9 @@ class BaseFormatDetector(ABC):
 
         try:
             try:
-                if current_text.startswith(self.bot_token):
-                    start_idx = len(self.bot_token)
-                elif self.current_tool_id > 0 and current_text.startswith(
-                    self.tool_call_separator + self.bot_token
-                ):
-                    start_idx = len(self.tool_call_separator + self.bot_token)
-                elif self.current_tool_id > 0 and current_text.startswith(
-                    self.tool_call_separator
-                ):
-                    start_idx = len(self.tool_call_separator)
+                tool_call_pos = current_text.find(self.bot_token)
+                if tool_call_pos != -1:
+                    start_idx = tool_call_pos + len(self.bot_token)
                 else:
                     start_idx = 0
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
This pull request addresses a bug in the base_format_detector where it would fail to parse streaming tool calls if there was any text in the buffer before the bot_token.

When processing **large streaming chunk** like `unit.\n\n<tool_call>\n`, current parser would fail in calculating the start id.

The previous implementation incorrectly assumed the bot_token would be at the beginning of the string, causing the JSON parser to fail with a JSONDecodeError when it encountered non-JSON text.

The fix replaces the faulty logic with a call to current_text.find(self.bot_token) to correctly locate the start of the tool call payload. This makes the parsing more robust and ensures that only the JSON portion of the buffer is processed, resolving the decoding errors.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
