### PR TITLE
[Fix] Init mamba related memory pools with torch.zeros

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -127,7 +127,7 @@ class MambaPool:
         if speculative_num_draft_tokens is not None:
             # Cache intermediate SSM states per draft token during target verify
             # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
-            intermediate_ssm_state_cache = torch.empty(
+            intermediate_ssm_state_cache = torch.zeros(
                 size=(
                     num_mamba_layers,
                     size + 1,
@@ -141,7 +141,7 @@ class MambaPool:
             )
             # Cache intermediate conv windows (last K-1 inputs) per draft token during target verify
             # Shape: [num_layers, size + 1, speculative_num_draft_tokens, dim, K-1]
-            intermediate_conv_window_cache = torch.empty(
+            intermediate_conv_window_cache = torch.zeros(
                 size=(
                     num_mamba_layers,
                     size + 1,
@@ -240,7 +240,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layers)}
 
         self.device = device
-        self.req_index_to_mamba_index_mapping: torch.Tensor = torch.empty(
+        self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
             size, dtype=torch.int32, device=self.device
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This bug occurs when we try to online quantize qwen3-next model.
```
from sglang.srt.entrypoints.http_server import launch_server
from sglang.srt.server_args import prepare_server_args

if __name__ == "__main__":
    # Simulate CLI arguments (excluding the script name)
    args = [
        "--model-path",
        "/shared/public/sharing/sglanglearning/Qwen-SGlang/Qwen3-Next-80B-A3B-Instruct",
        "--tp",
        "4",
        "--attention-backend",
        "hybrid_linear_attn",
        "--quantization",
        "fp8"
    ]
    server_args = prepare_server_args(args)
    launch_server(server_args)
```

```
 File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 389, in __init__
    self.capture()
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 497, in capture
    ) = self.capture_one_batch_size(bs, forward)
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 673, in capture_one_batch_size
    run_once()
  File "/home/jobuser/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 662, in run_once
    logits_output_or_pp_proxy_tensors = forward(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/qwen3_next.py", line 904, in forward
    hidden_states = self.model(input_ids, positions, forward_batch, inputs_embeds)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/qwen3_next.py", line 843, in forward
    hidden_states, residual = layer(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/qwen3_next.py", line 545, in forward
    hidden_states = self.linear_attn(
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/models/qwen3_next.py", line 460, in forward
    core_attn_out = forward_batch.attn_backend.forward(
  File "/home/jobuser/sglang/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 509, in forward
    return self.forward_decode(
  File "/home/jobuser/sglang/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 470, in forward_decode
    return self.attn_backend_list[1].forward_decode(
  File "/home/jobuser/sglang/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 229, in forward_decode
    core_attn_out = fused_sigmoid_gating_delta_rule_update(
  File "/home/jobuser/sglang/python/sglang/srt/layers/attention/fla/utils.py", line 167, in wrapper
    return fn(*contiguous_args, **contiguous_kwargs)
  File "/home/jobuser/sglang/python/sglang/srt/layers/attention/fla/fused_sigmoid_gating_recurrent.py", line 204, in fused_sigmoid_gating_delta_rule_update
    fused_sigmoid_gating_delta_rule_update_kernel[grid](
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/triton/runtime/jit.py", line 390, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/triton/runtime/autotuner.py", line 453, in run
    return self.fn.run(*args, **kwargs)
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/triton/runtime/jit.py", line 617, in run
    kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/triton/compiler/compiler.py", line 498, in __getattribute__
    self._init_handles()
  File "/home/jobuser/sglang/venv/lib/python3.10/site-packages/triton/compiler/compiler.py", line 490, in _init_handles
    self.module, self.function, self.n_regs, self.n_spills, self.n_max_threads = driver.active.utils.load_binary(
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

## Modifications

After investigation, it is b/c `req_index_to_mamba_index_mapping` does not initialize as `torch.zeros` instead, it is initialized by `torch.empty` which can be any random value
<img width="984" height="269" alt="image" src="https://github.com/user-attachments/assets/80192c16-e2a8-4487-999b-d7b0f0075fb3" />

During cuda graph capture, memory pool does not go through `alloc` method so the mamba index returned from `req_index_to_mamba_index_mapping` can go out of range of mamba pool (if not initialized with torch.zeros) and then cause cuda graph capture error

<img width="721" height="774" alt="image" src="https://github.com/user-attachments/assets/3fc8b47e-70f8-4a6d-bd72-2e16843b690f" />
 

## Accuracy Tests
```
python3 benchmark/gsm8k/bench_sglang.py --num-questions 200
```

After:
```
TP4 MTP FP8
Accuracy: 0.943
Invalid: 0.000
Latency: 124.775 s
Output throughput: 1759.205 token/s

TP4 MTP 
Accuracy: 0.944
Invalid: 0.000
Latency: 129.534 s
Output throughput: 1710.309 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
