### PR TITLE
[Hack] Add pd-disaggregation decode polling interval

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -389,6 +389,9 @@ class ServerArgs:
     disaggregation_ib_device: Optional[str] = None
     num_reserved_decode_tokens: int = 512  # used for decode kv cache offload in PD
 
+    # FIXME: hack to reduce ITL when decode bs is small
+    disaggregation_decode_polling_interval: int = 1
+
     # For model weight update
     custom_weight_loader: Optional[List[str]] = None
     weight_loader_disable_mmap: bool = False
@@ -2215,6 +2218,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.num_reserved_decode_tokens,
             help="Number of decode tokens that will have memory reserved when adding new request to the running batch.",
+        )
+        parser.add_argument(
+            "--disaggregation-decode-polling-interval",
+            type=int,
+            default=ServerArgs.disaggregation_decode_polling_interval,
+            help="The interval to poll requests in decode server. Can be set to >1 to reduce the overhead of this.",
         )
 
         # Custom weight loader


### PR DESCRIPTION
The `poll_and_all_reduce` in pd-disaggregation decode mode would cause a lot of CPU overhead when there are always new incoming requests or transferring requests.

<img width="720" height="327" alt="image" src="https://github.com/user-attachments/assets/b1e5dcb8-08e2-47e2-b6cd-0479ea6eca7c" />

Adding a polling interval would reduce the ITL when decoding bs is small.

> [!WARNING]
> This is only a hack and will be removed once overlapping is fully supported. Also, this config  would cause an increase in TTFT
