### PR TITLE
Remove repeatedly lists adding in `init_incremental_detokenization`

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -684,9 +684,17 @@ class Req:
             self.surr_offset = max(
                 self.read_offset - INIT_INCREMENTAL_DETOKENIZATION_OFFSET, 0
             )
+            self.surr_and_decode_ids = (
+                self.origin_input_ids_unpadded[self.surr_offset :] + self.output_ids
+            )
+            self.cur_decode_ids_len = len(self.output_ids)
 
-        all_ids = self.origin_input_ids_unpadded + self.output_ids
-        return all_ids[self.surr_offset :], self.read_offset - self.surr_offset
+        extend_len = len(self.output_ids) - self.cur_decode_ids_len
+        if extend_len > 0:
+            self.surr_and_decode_ids.extend(self.output_ids[-extend_len:])
+            self.cur_decode_ids_len = len(self.output_ids)
+
+        return self.surr_and_decode_ids, self.read_offset - self.surr_offset
 
     def check_finished(self):
         if self.finished():

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -688,10 +688,8 @@ class Req:
                 self.origin_input_ids_unpadded[self.surr_offset :] + self.output_ids
             )
             self.cur_decode_ids_len = len(self.output_ids)
-
-        extend_len = len(self.output_ids) - self.cur_decode_ids_len
-        if extend_len > 0:
-            self.surr_and_decode_ids.extend(self.output_ids[-extend_len:])
+        else:
+            self.surr_and_decode_ids.extend(self.output_ids[self.cur_decode_ids_len :])
             self.cur_decode_ids_len = len(self.output_ids)
 
         return self.surr_and_decode_ids, self.read_offset - self.surr_offset


### PR DESCRIPTION
Since incremental detokenization has been removed (see issue #10384), the old-fashioned method of calculating data for incremental detokenization is no longer necessary, which results in repeatedly adding lists and causing significant CPU overhead.

<img width="1262" height="211" alt="image" src="https://github.com/user-attachments/assets/b3adc9df-4b4b-4f7e-80c0-6ea3daed0622" />
