### PR TITLE
Fix(SRT): Correctly initialize kv_head_num for MLA backend

### DIFF
--- a/python/sglang/test/attention/test_kv_head_initialization.py
+++ b/python/sglang/test/attention/test_kv_head_initialization.py
@@ -1,0 +1,264 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue
+from sglang.srt.disaggregation.utils import TransferBackend
+from sglang.test.test_utils import CustomTestCase
+
+
+class MockTokenToKVPool:
+    """Mock for token_to_kv_pool with configurable head_num."""
+
+    def __init__(self, head_num=32, page_size=1):
+        self.head_num = head_num
+        self.page_size = page_size
+        self.start_layer = 0
+
+    def get_contiguous_buf_infos(self):
+        """Mock method for getting buffer info."""
+        return [], [], []
+
+
+class MockMLATokenToKVPool:
+    """Mock for MLA token_to_kv_pool (no head_num attribute)."""
+
+    def __init__(self, page_size=1):
+        self.page_size = page_size
+        self.start_layer = 0
+
+    def get_contiguous_buf_infos(self):
+        """Mock method for getting buffer info."""
+        return [], [], []
+
+
+class MockModelConfig:
+    """Mock for model config with num_attention_heads."""
+
+    def __init__(self, num_attention_heads=64):
+        self.num_attention_heads = num_attention_heads
+
+
+class MockScheduler:
+    """Mock for scheduler with model config and other attributes."""
+
+    def __init__(self, model_config, dp_rank=0, gpu_id=0):
+        self.model_config = model_config
+        self.dp_rank = dp_rank
+        self.gpu_id = gpu_id
+        self.server_args = Mock()
+        self.server_args.disaggregation_ib_device = "mlx5_roce0"
+
+
+class MockMetadataBuffers:
+    """Mock for metadata buffers."""
+
+    def get_buf_infos(self):
+        return [], [], []
+
+
+class MockReqToMetadataIdxAllocator:
+    """Mock for request to metadata index allocator."""
+
+    pass
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestKvHeadInitialization(CustomTestCase):
+    """Test kv_head_num initialization logic in PrefillBootstrapQueue."""
+
+    def setUp(self):
+        """Set up common test data."""
+        self.tp_rank = 0
+        self.tp_size = 1
+        self.gpu_id = 0
+        self.bootstrap_port = 8000
+        self.max_total_num_tokens = 1000
+        self.decode_tp_size = 1
+        self.decode_dp_size = 1
+        self.pp_rank = 0
+        self.pp_size = 1
+        self.transfer_backend = TransferBackend.FAKE
+
+        # Mock gloo group
+        self.gloo_group = Mock()
+
+        # Mock metadata buffers
+        self.metadata_buffers = MockMetadataBuffers()
+
+        # Mock request to metadata index allocator
+        self.req_to_metadata_buffer_idx_allocator = MockReqToMetadataIdxAllocator()
+
+    def _create_prefill_bootstrap_queue(
+        self, token_to_kv_pool, model_config, draft_token_to_kv_pool=None
+    ):
+        """Helper method to create PrefillBootstrapQueue instance."""
+        scheduler = MockScheduler(model_config)
+
+        return PrefillBootstrapQueue(
+            token_to_kv_pool=token_to_kv_pool,
+            draft_token_to_kv_pool=draft_token_to_kv_pool,
+            req_to_metadata_buffer_idx_allocator=self.req_to_metadata_buffer_idx_allocator,
+            metadata_buffers=self.metadata_buffers,
+            tp_rank=self.tp_rank,
+            tp_size=self.tp_size,
+            gpu_id=self.gpu_id,
+            bootstrap_port=self.bootstrap_port,
+            gloo_group=self.gloo_group,
+            max_total_num_tokens=self.max_total_num_tokens,
+            decode_tp_size=self.decode_tp_size,
+            decode_dp_size=self.decode_dp_size,
+            scheduler=scheduler,
+            pp_rank=self.pp_rank,
+            pp_size=self.pp_size,
+            transfer_backend=self.transfer_backend,
+        )
+
+    @patch("sglang.srt.disaggregation.prefill.get_kv_class")
+    def test_mha_backend_initialization(self, mock_get_kv_class):
+        """Test that kv_head_num is correctly set from token_to_kv_pool for MHA backend."""
+        # Given: MHA backend (non-MLA) with specific head_num
+        expected_head_num = 32
+        token_to_kv_pool = MockTokenToKVPool(head_num=expected_head_num)
+        model_config = MockModelConfig(num_attention_heads=64)
+
+        # Mock the kv_args class and instance
+        mock_kv_args_class = Mock()
+        mock_kv_args = Mock()
+        mock_kv_args_class.return_value = mock_kv_args
+        mock_get_kv_class.return_value = mock_kv_args_class
+
+        # When: Creating PrefillBootstrapQueue (which calls _init_kv_manager)
+        prefill_queue = self._create_prefill_bootstrap_queue(
+            token_to_kv_pool, model_config
+        )
+
+        # Then: kv_head_num should be set from token_to_kv_pool.head_num
+        self.assertEqual(mock_kv_args.kv_head_num, expected_head_num)
+
+        # Verify that is_mla_backend is False
+        self.assertFalse(prefill_queue.is_mla_backend)
+
+    @patch("sglang.srt.disaggregation.prefill.get_kv_class")
+    @patch("sglang.srt.utils.get_attention_tp_size")
+    def test_mla_backend_initialization(
+        self, mock_get_attention_tp_size, mock_get_kv_class
+    ):
+        """Test that kv_head_num is correctly calculated for MLA backend."""
+        # Given: MLA backend with specific attention heads and TP size
+        num_attention_heads = 64
+        tp_size = 2
+        expected_head_num = num_attention_heads // tp_size  # 32
+
+        token_to_kv_pool = MockMLATokenToKVPool()  # MLA pool has no head_num
+        model_config = MockModelConfig(num_attention_heads=num_attention_heads)
+
+        # Mock get_attention_tp_size to return tp_size
+        mock_get_attention_tp_size.return_value = tp_size
+
+        # Mock the kv_args class and instance
+        mock_kv_args_class = Mock()
+        mock_kv_args = Mock()
+        mock_kv_args_class.return_value = mock_kv_args
+        mock_get_kv_class.return_value = mock_kv_args_class
+
+        # When: Creating PrefillBootstrapQueue (which calls _init_kv_manager)
+        prefill_queue = self._create_prefill_bootstrap_queue(
+            token_to_kv_pool, model_config
+        )
+
+        # Then: kv_head_num should be calculated from model config
+        self.assertEqual(mock_kv_args.kv_head_num, expected_head_num)
+
+        # Verify that is_mla_backend is True
+        self.assertTrue(prefill_queue.is_mla_backend)
+
+        # Verify that get_attention_tp_size was called
+        mock_get_attention_tp_size.assert_called_once()
+
+    @patch("sglang.srt.disaggregation.prefill.get_kv_class")
+    def test_mla_backend_with_different_tp_sizes(self, mock_get_kv_class):
+        """Test MLA backend initialization with different tensor parallelism sizes."""
+        # Given: MLA backend with different TP sizes
+        test_cases = [
+            (64, 1, 64),  # 64 heads, TP=1 -> 64 heads per rank
+            (64, 2, 32),  # 64 heads, TP=2 -> 32 heads per rank
+            (64, 4, 16),  # 64 heads, TP=4 -> 16 heads per rank
+            (32, 2, 16),  # 32 heads, TP=2 -> 16 heads per rank
+        ]
+
+        for num_attention_heads, tp_size, expected_head_num in test_cases:
+            with self.subTest(
+                num_attention_heads=num_attention_heads,
+                tp_size=tp_size,
+                expected_head_num=expected_head_num,
+            ):
+                token_to_kv_pool = MockMLATokenToKVPool()
+                model_config = MockModelConfig(num_attention_heads=num_attention_heads)
+
+                # Mock get_attention_tp_size
+                with patch(
+                    "sglang.srt.utils.get_attention_tp_size", return_value=tp_size
+                ):
+                    # Mock the kv_args class and instance
+                    mock_kv_args_class = Mock()
+                    mock_kv_args = Mock()
+                    mock_kv_args_class.return_value = mock_kv_args
+                    mock_get_kv_class.return_value = mock_kv_args_class
+
+                    # When: Creating PrefillBootstrapQueue
+                    prefill_queue = self._create_prefill_bootstrap_queue(
+                        token_to_kv_pool, model_config
+                    )
+
+                    # Then: kv_head_num should be calculated correctly
+                    self.assertEqual(mock_kv_args.kv_head_num, expected_head_num)
+                    self.assertTrue(prefill_queue.is_mla_backend)
+
+    @patch("sglang.srt.disaggregation.prefill.get_kv_class")
+    def test_mha_backend_with_different_head_nums(self, mock_get_kv_class):
+        """Test MHA backend initialization with different head_num values."""
+        # Given: MHA backend with different head_num values
+        test_cases = [16, 32, 64, 128]
+
+        for head_num in test_cases:
+            with self.subTest(head_num=head_num):
+                token_to_kv_pool = MockTokenToKVPool(head_num=head_num)
+                model_config = MockModelConfig(num_attention_heads=64)
+
+                # Mock the kv_args class and instance
+                mock_kv_args_class = Mock()
+                mock_kv_args = Mock()
+                mock_kv_args_class.return_value = mock_kv_args
+                mock_get_kv_class.return_value = mock_kv_args_class
+
+                # When: Creating PrefillBootstrapQueue
+                prefill_queue = self._create_prefill_bootstrap_queue(
+                    token_to_kv_pool, model_config
+                )
+
+                # Then: kv_head_num should be set from token_to_kv_pool
+                self.assertEqual(mock_kv_args.kv_head_num, head_num)
+                self.assertFalse(prefill_queue.is_mla_backend)
+
+    def test_is_mla_backend_detection(self):
+        """Test that is_mla_backend is correctly detected based on token_to_kv_pool type."""
+        # Test MHA backend detection
+        mha_pool = MockTokenToKVPool()
+        model_config = MockModelConfig()
+
+        with patch("sglang.srt.disaggregation.prefill.get_kv_class"):
+            prefill_queue = self._create_prefill_bootstrap_queue(mha_pool, model_config)
+            self.assertFalse(prefill_queue.is_mla_backend)
+
+        # Test MLA backend detection
+        mla_pool = MockMLATokenToKVPool()
+
+        with patch("sglang.srt.disaggregation.prefill.get_kv_class"):
+            prefill_queue = self._create_prefill_bootstrap_queue(mla_pool, model_config)
+            self.assertTrue(prefill_queue.is_mla_backend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/test_disaggregation_kv_head_fix.py
+++ b/test/srt/test_disaggregation_kv_head_fix.py
@@ -1,0 +1,285 @@
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+import requests
+
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_disaggregation_utils import TestDisaggregationBase
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    popen_launch_pd_server,
+)
+
+
+class TestDisaggregationKvHeadFix(TestDisaggregationBase):
+    """Test that kv_head_num initialization fix works in disaggregation mode."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up disaggregation servers for testing."""
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        parsed_url = urlparse(DEFAULT_URL_FOR_TEST)
+        cls.base_host = parsed_url.hostname
+        base_port = str(parsed_url.port)
+        cls.lb_port = base_port
+        cls.prefill_port = f"{int(base_port) + 100}"
+        cls.decode_port = f"{int(base_port) + 200}"
+        cls.prefill_url = f"http://{cls.base_host}:{cls.prefill_port}"
+        cls.decode_url = f"http://{cls.base_host}:{cls.decode_port}"
+        cls.lb_url = f"http://{cls.base_host}:{cls.lb_port}"
+        print(f"{cls.base_host=} {cls.lb_port=} {cls.prefill_port=} {cls.decode_port=}")
+
+        # Non blocking start servers
+        cls.start_prefill()
+        cls.start_decode()
+
+        # Block until both servers are ready
+        cls.wait_server_ready(cls.prefill_url + "/health")
+        cls.wait_server_ready(cls.decode_url + "/health")
+
+        cls.launch_lb()
+
+    @classmethod
+    def start_prefill(cls):
+        """Start prefill server with disaggregation mode."""
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--tp",
+            "1",
+            "--disaggregation-ib-device",
+            "mlx5_roce0",
+        ]
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        """Start decode server with disaggregation mode."""
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--tp",
+            "1",
+            "--base-gpu-id",
+            "1",
+            "--disaggregation-ib-device",
+            "mlx5_roce1",
+        ]
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def test_basic_generation_works(self):
+        """Test that basic text generation works without kv_head_num errors."""
+        prompt = "The capital of France is"
+
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0.0,
+                    "max_new_tokens": 10,
+                },
+            },
+            timeout=30,
+        )
+
+        # Verify the request was successful
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertIn("text", result)
+        self.assertIsInstance(result["text"], str)
+        self.assertGreater(len(result["text"]), len(prompt))
+
+        print(f"Generated text: {result['text']}")
+
+    def test_structured_output_works(self):
+        """Test that structured output generation works without kv_head_num errors."""
+        import json
+
+        json_schema = json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "country": {"type": "string"},
+                },
+                "required": ["city", "country"],
+            }
+        )
+
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "Tell me about the capital of France in JSON format.",
+                "sampling_params": {
+                    "temperature": 0.0,
+                    "max_new_tokens": 50,
+                    "json_schema": json_schema,
+                },
+            },
+            timeout=30,
+        )
+
+        # Verify the request was successful
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertIn("text", result)
+
+        # Verify the output is valid JSON
+        try:
+            parsed_output = json.loads(result["text"])
+            self.assertIn("city", parsed_output)
+            self.assertIn("country", parsed_output)
+        except json.JSONDecodeError:
+            self.fail("Generated output is not valid JSON")
+
+        print(f"Generated JSON: {result['text']}")
+
+    def test_logprob_generation_works(self):
+        """Test that logprob generation works without kv_head_num errors."""
+        prompt = "The capital of France is"
+
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": prompt,
+                "sampling_params": {
+                    "temperature": 0.0,
+                    "max_new_tokens": 5,
+                },
+                "return_logprob": True,
+                "return_input_logprob": True,
+                "logprob_start_len": 0,
+            },
+            timeout=30,
+        )
+
+        # Verify the request was successful
+        self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertIn("text", result)
+        self.assertIn("meta_info", result)
+
+        meta_info = result["meta_info"]
+        self.assertIn("completion_tokens", meta_info)
+        self.assertIn("input_token_logprobs", meta_info)
+        self.assertIn("output_token_logprobs", meta_info)
+
+        # Verify logprobs are present
+        self.assertGreater(len(meta_info["input_token_logprobs"]), 0)
+        self.assertGreater(len(meta_info["output_token_logprobs"]), 0)
+
+        print(f"Generated with logprobs: {result['text']}")
+
+    def test_gsm8k_evaluation_works(self):
+        """Test that GSM8K evaluation works without kv_head_num errors."""
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=10,  # Reduced for faster testing
+            max_new_tokens=512,
+            parallel=4,  # Reduced for faster testing
+            host=f"http://{self.base_host}",
+            port=int(self.lb_port),
+        )
+
+        try:
+            metrics = run_eval_few_shot_gsm8k(args)
+            print(f"GSM8K evaluation metrics: {metrics}")
+
+            # Verify we got some accuracy (even if low due to reduced test size)
+            self.assertIn("accuracy", metrics)
+            self.assertGreaterEqual(metrics["accuracy"], 0.0)
+
+        except Exception as e:
+            # If evaluation fails, check if it's due to kv_head_num error
+            error_msg = str(e).lower()
+            if "attributeerror" in error_msg and "kv_head_num" in error_msg:
+                self.fail(f"kv_head_num AttributeError still present: {e}")
+            else:
+                # Other errors are acceptable for this test
+                print(f"GSM8K evaluation failed with non-kv_head_num error: {e}")
+
+    def test_multiple_requests_work(self):
+        """Test that multiple sequential requests work without kv_head_num errors."""
+        prompts = [
+            "What is the capital of France?",
+            "What is 2+2?",
+            "Name a programming language.",
+        ]
+
+        for i, prompt in enumerate(prompts):
+            with self.subTest(prompt_index=i, prompt=prompt):
+                response = requests.post(
+                    self.lb_url + "/generate",
+                    json={
+                        "text": prompt,
+                        "sampling_params": {
+                            "temperature": 0.0,
+                            "max_new_tokens": 5,
+                        },
+                    },
+                    timeout=30,
+                )
+
+                # Verify each request was successful
+                self.assertEqual(response.status_code, 200)
+
+                result = response.json()
+                self.assertIn("text", result)
+                self.assertIsInstance(result["text"], str)
+
+                print(f"Request {i+1} generated: {result['text']}")
+
+    def test_server_health_after_requests(self):
+        """Test that servers remain healthy after processing requests."""
+        # Make a few requests first
+        for _ in range(3):
+            response = requests.post(
+                self.lb_url + "/generate",
+                json={
+                    "text": "Test request",
+                    "sampling_params": {
+                        "temperature": 0.0,
+                        "max_new_tokens": 1,
+                    },
+                },
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200)
+
+        # Check that servers are still healthy
+        try:
+            prefill_health = requests.get(self.prefill_url + "/health", timeout=5)
+            self.assertEqual(prefill_health.status_code, 200)
+
+            decode_health = requests.get(self.decode_url + "/health", timeout=5)
+            self.assertEqual(decode_health.status_code, 200)
+
+            lb_health = requests.get(self.lb_url + "/health", timeout=5)
+            self.assertEqual(lb_health.status_code, 200)
+
+        except Exception as e:
+            self.fail(f"Server health check failed: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves AttributeError in disaggregation by ensuring kv_head_num is always initialized in KVArgs for both MHA and MLA backends.

- For MHA, kv_head_num is derived from token_to_kv_pool.head_num.
- For MLA, it is calculated from model_config.num_attention_heads and tensor parallel size, as MLATokenToKVPool lacks a head_num attribute.

Adds unit and integration tests to verify the fix and prevent regressions. Closes #10381

## Motivation

This pull request fixes a critical `AttributeError` bug that occurs when using the disaggregation feature with the MLA backend. The goal is to improve the stability and reliability of the runtime by ensuring that the `KVArgs` object is always correctly initialized, preventing server crashes.

## Modifications
`
python/sglang/srt/disaggregation/prefill.py`: Modified the `_init_kv_manager` method to add conditional logic. It now correctly initializes the `kv_head_num` attribute for both MHA and MLA backends, addressing the root cause of the bug.

`python/sglang/test/attention/test_kv_head_initialization.py`: Added a new unit test to verify the initialization logic in isolation for both MHA and MLA backends.

`test/srt/test_disaggregation_kv_head_fix.py`: Added a new integration test to ensure the fix works within the full disaggregation runtime and prevents the original crash.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
