### PR TITLE
[POC] Support deterministic inference

### DIFF
--- a/python/sglang/srt/custom_op.py
+++ b/python/sglang/srt/custom_op.py
@@ -88,15 +88,16 @@ class CustomOp(nn.Module):
         return self.forward_native(*args, **kwargs)
 
     def dispatch_forward(self):
-        if _is_cuda:
-            return self.forward_cuda
-        elif _is_hip:
-            return self.forward_hip
-        elif _is_cpu and _is_cpu_amx_available:
-            return self.forward_cpu
-        elif _is_npu:
-            return self.forward_npu
-        elif _is_xpu:
-            return self.forward_xpu
-        else:
-            return self.forward_native
+        # if _is_cuda:
+        #     return self.forward_cuda
+        # elif _is_hip:
+        #     return self.forward_hip
+        # elif _is_cpu and _is_cpu_amx_available:
+        #     return self.forward_cpu
+        # elif _is_npu:
+        #     return self.forward_npu
+        # elif _is_xpu:
+        #     return self.forward_xpu
+        # else:
+        #     return self.forward_native
+        return self.forward_native

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -129,7 +129,7 @@ class FlashInferAttnBackend(AttentionBackend):
         if global_workspace_buffer is None:
             # different from flashinfer zero_init_global_workspace_buffer
             global_workspace_buffer = torch.empty(
-                1024 * 1024 * 1024,
+                2048 * 1024 * 1024,
                 dtype=torch.uint8,
                 device=model_runner.device,
             )

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -239,7 +239,6 @@ def multinomial_with_seed(inputs: torch.Tensor, seed: torch.Tensor) -> torch.Ten
         A tensor of shape (n,) where the i-th element is an index sampled
         from the distribution in `inputs[i]` using `seed[i]`.
     """
-    print(f"inputs.shape: {inputs.shape}, seed.shape: {seed.shape}")
     device = inputs.device
     seed = seed.to(device)
 

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -241,25 +241,15 @@ def multinomial_with_seed(inputs: torch.Tensor, seed: torch.Tensor) -> torch.Ten
     """
     device = inputs.device
     seed = seed.to(device)
-
     n, m = inputs.shape
-
     col_indices = torch.arange(m, device=device).unsqueeze(0)
-
     seed_expanded = seed.unsqueeze(-1)
-
     hashed = seed_expanded * 73856093 ^ col_indices * 19349663
-
     uniform_samples = (hashed % (2**24)).float() / (2**24)
-
     epsilon = 1e-9
-
     gumbel_noise = -torch.log(-torch.log(uniform_samples + epsilon) + epsilon)
-
     log_probs = torch.log(inputs + epsilon)
-
     perturbed_log_probs = log_probs + gumbel_noise
-
     return torch.argmax(perturbed_log_probs, dim=1, keepdim=True)
 
 

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -108,12 +108,15 @@ class Sampler(nn.Module):
                         )
                 elif global_server_args_dict["sampling_backend"] == "pytorch":
                     # A slower fallback implementation with torch native operations.
-                    batch_next_token_ids = top_k_top_p_min_p_sampling_from_probs_torch(
-                        probs,
-                        sampling_info.top_ks,
-                        sampling_info.top_ps,
-                        sampling_info.min_ps,
-                        sampling_info.need_min_p_sampling,
+                    batch_next_token_ids = (
+                        top_k_top_p_min_p_sampling_from_probs_torch_deterministic(
+                            probs,
+                            sampling_info.top_ks,
+                            sampling_info.top_ps,
+                            sampling_info.min_ps,
+                            sampling_info.need_min_p_sampling,
+                            sampling_info.sampling_seed,
+                        )
                     )
                 else:
                     raise ValueError(
@@ -190,6 +193,75 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
     probs_idx = probs_idx.to(torch.int32)
     batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
     return batch_next_token_ids
+
+
+def top_k_top_p_min_p_sampling_from_probs_torch_deterministic(
+    probs: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_ps: torch.Tensor,
+    min_ps: torch.Tensor,
+    need_min_p_sampling: bool,
+    sampling_seed: torch.Tensor,
+):
+    """A top-k, top-p and min-p sampling implementation with native pytorch operations."""
+    probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    probs_sort[
+        torch.arange(0, probs.shape[-1], device=probs.device).view(1, -1)
+        >= top_ks.view(-1, 1)
+    ] = 0.0
+    probs_sort[(probs_sum - probs_sort) > top_ps.view(-1, 1)] = 0.0
+
+    if need_min_p_sampling:
+        min_p_thresholds = probs_sort[:, 0] * min_ps
+        probs_sort[probs_sort < min_p_thresholds.view(-1, 1)] = 0.0
+    sampled_index = multinomial_with_seed(probs_sort, sampling_seed)
+    # int32 range is enough to represent the token ids
+    probs_idx = probs_idx.to(torch.int32)
+    batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
+    return batch_next_token_ids
+
+
+def multinomial_with_seed(inputs: torch.Tensor, seed: torch.Tensor) -> torch.Tensor:
+    """
+    Samples n elements from an input tensor `inputs` of shape (n, m) using
+    a unique random seed for each row. This is a deterministic batched alternative to
+    `torch.multinomial`.
+
+    Args:
+        inputs: A float tensor of shape (n, m) representing n categorical
+                distributions with m categories each. The values are treated
+                as weights and do not need to sum to 1.
+        seed:   An integer tensor of shape (n,) containing the random seed
+                for each corresponding row in `inputs`.
+
+    Returns:
+        A tensor of shape (n,) where the i-th element is an index sampled
+        from the distribution in `inputs[i]` using `seed[i]`.
+    """
+    print(f"inputs.shape: {inputs.shape}, seed.shape: {seed.shape}")
+    device = inputs.device
+    seed = seed.to(device)
+
+    n, m = inputs.shape
+
+    col_indices = torch.arange(m, device=device).unsqueeze(0)
+
+    seed_expanded = seed.unsqueeze(-1)
+
+    hashed = seed_expanded * 73856093 ^ col_indices * 19349663
+
+    uniform_samples = (hashed % (2**24)).float() / (2**24)
+
+    epsilon = 1e-9
+
+    gumbel_noise = -torch.log(-torch.log(uniform_samples + epsilon) + epsilon)
+
+    log_probs = torch.log(inputs + epsilon)
+
+    perturbed_log_probs = log_probs + gumbel_noise
+
+    return torch.argmax(perturbed_log_probs, dim=1, keepdim=True)
 
 
 def sampling_from_probs_torch(probs: torch.Tensor):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -66,7 +66,7 @@ from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, Forw
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import flatten_nested_list, support_triton
+from sglang.srt.utils import flatten_nested_list, hash_string_to_int, support_triton
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -450,6 +450,9 @@ class Req:
         self.fill_ids = []
         self.session_id = session_id
         self.input_embeds = input_embeds
+
+        # Used for deterministic sampling
+        self.sampling_seed = hash_string_to_int(self.origin_input_text)
 
         # for corss-endoder model
         self.token_type_ids = token_type_ids

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -554,6 +554,15 @@ class PrefillAdder:
                 if trunc_len <= 0:
                     return AddReqResult.OTHER
 
+                # Split-kv size for prefill is hard-coded to 4096 here
+                # Also we want to assert that chunked prefill size is multiple of split-kv-size
+                # Cut trunc_len to the nearest multiple of split_kv_size
+                split_kv_size = 4096
+                if trunc_len < split_kv_size:
+                    return AddReqResult.OTHER
+                else:
+                    trunc_len = split_kv_size * (trunc_len // split_kv_size)
+
                 # Chunked prefill
                 req.extend_input_len = trunc_len
                 req.fill_ids = req.fill_ids[: len(req.prefix_indices) + trunc_len]

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 import requests
 import torch
 import torch.distributed as dist
+from batch_invariant_ops import enable_batch_invariant_mode
 
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
@@ -266,6 +267,8 @@ class ModelRunner:
         # For weight updates
         self._model_update_group = {}
         self._weights_send_group = {}
+
+        enable_batch_invariant_mode()
 
     def initialize(self, min_per_gpu_memory: float):
         server_args = self.server_args

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -268,8 +268,6 @@ class ModelRunner:
         self._model_update_group = {}
         self._weights_send_group = {}
 
-        enable_batch_invariant_mode()
-
     def initialize(self, min_per_gpu_memory: float):
         server_args = self.server_args
 
@@ -386,6 +384,9 @@ class ModelRunner:
                     "Please specify the heavy channel type for double sparsity optimization."
                 )
             self.init_double_sparsity_channel_config(server_args.ds_heavy_channel_type)
+
+        # Enable batch invariant mode
+        enable_batch_invariant_mode()
 
         # Init memory pool and attention backends
         self.init_memory_pool(

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -26,6 +26,9 @@ class SamplingBatchInfo:
     top_ks: torch.Tensor
     min_ps: torch.Tensor
 
+    # Used for deterministic sampling
+    sampling_seed: torch.Tensor
+
     # Whether all requests use greedy sampling
     is_all_greedy: bool
 
@@ -92,6 +95,9 @@ class SamplingBatchInfo:
         min_ps = torch.tensor(
             [r.sampling_params.min_p for r in reqs], dtype=torch.float, device=device
         )
+        sampling_seed = torch.tensor(
+            [r.sampling_seed for r in reqs], dtype=torch.int32, device=device
+        )
 
         logit_bias = None
         if any(r.sampling_params.logit_bias is not None for r in reqs):
@@ -157,6 +163,7 @@ class SamplingBatchInfo:
             top_ps=top_ps,
             top_ks=top_ks,
             min_ps=min_ps,
+            sampling_seed=sampling_seed,
             is_all_greedy=all(r.sampling_params.top_k <= 1 for r in reqs),
             need_top_p_sampling=any(r.sampling_params.top_p != 1.0 for r in reqs),
             need_top_k_sampling=any(r.sampling_params.top_k != TOP_K_ALL for r in reqs),
@@ -238,6 +245,7 @@ class SamplingBatchInfo:
             "top_ps",
             "top_ks",
             "min_ps",
+            "sampling_seed",
         ]:
             value = getattr(self, item, None)
             setattr(self, item, value[keep_indices_device])
@@ -342,6 +350,7 @@ class SamplingBatchInfo:
             "top_ps",
             "top_ks",
             "min_ps",
+            "sampling_seed",
         ]:
             self_val = getattr(self, item, None)
             other_val = getattr(other, item, None)

--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -21,6 +21,7 @@ import builtins
 import ctypes
 import dataclasses
 import functools
+import hashlib
 import importlib
 import io
 import ipaddress
@@ -519,6 +520,12 @@ def set_random_seed(seed: int) -> None:
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
+
+
+def hash_string_to_int(s: str) -> int:
+    """Generate hash value from string and convert it to an integer."""
+    h = hashlib.sha256(s.encode("utf-8")).digest()
+    return np.uint32(int.from_bytes(h, "big") & 0xFFFFFFFF).astype(np.int32)
 
 
 def find_process_using_port(port: int) -> Optional[psutil.Process]:

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -105,7 +105,7 @@ def send_single(args, batch_size: int):
 
 
 def send_mixed(args, batch_size: int):
-    num_long_prompt = 0 if batch_size < 10 else random.randint(1, 10)
+    num_long_prompt = 0 if batch_size <= 10 else random.randint(1, 10)
     num_prompt_1 = random.randint(1, batch_size - num_long_prompt)
     num_prompt_2 = batch_size - num_prompt_1 - num_long_prompt
 

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -52,10 +52,9 @@ class BenchArgs:
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
 
-def send_one_prompt(args):
+def send_one_prompt(args, batch_size: int):
 
     prompt = args.prompt
-    batch_size = random.randint(1, 256)
     prompt = [prompt] * batch_size
 
     json_data = {
@@ -92,17 +91,18 @@ def send_one_prompt(args):
         print(ret)
         return 0, 0
 
-    return ret["text"], batch_size
+    return ret["text"]
 
 
 def test_deterministic(args):
     # First do some warmups
     for i in range(3):
-        send_one_prompt(args)
+        send_one_prompt(args, 16)
 
     texts = []
-    for i in range(args.n_trials):
-        text, batch_size = send_one_prompt(args)
+    for i in range(1, args.n_trials + 1):
+        batch_size = i
+        text = send_one_prompt(args, batch_size)
         text = text.replace("\n", " ")
         print(f"Trial {i} with batch size {batch_size}: {text}")
         texts.append(text)

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -1,0 +1,118 @@
+"""
+Batch the same prompt in random batch sizes, and test if the results are consistent across different trials.
+
+Usage:
+python3 -m sglang.test.test_deterministic --n-trials <numer_of_trials>
+"""
+
+import argparse
+import dataclasses
+import json
+import random
+
+import numpy as np
+import requests
+
+
+@dataclasses.dataclass
+class BenchArgs:
+    host: str = "localhost"
+    port: int = 30000
+    batch_size: int = 1
+    temperature: float = 0.0
+    max_new_tokens: int = 100
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    return_logprob: bool = False
+    prompt: str = "Tell me about Richard Feynman: "
+    stream: bool = False
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser):
+        parser.add_argument("--host", type=str, default=BenchArgs.host)
+        parser.add_argument("--port", type=int, default=BenchArgs.port)
+        parser.add_argument("--n-trials", type=int, default=50)
+        parser.add_argument("--temperature", type=float, default=BenchArgs.temperature)
+        parser.add_argument(
+            "--max-new-tokens", type=int, default=BenchArgs.max_new_tokens
+        )
+        parser.add_argument(
+            "--frequency-penalty", type=float, default=BenchArgs.frequency_penalty
+        )
+        parser.add_argument(
+            "--presence-penalty", type=float, default=BenchArgs.presence_penalty
+        )
+        parser.add_argument("--return-logprob", action="store_true")
+        parser.add_argument("--prompt", type=str, default=BenchArgs.prompt)
+        parser.add_argument("--stream", action="store_true")
+
+    @classmethod
+    def from_cli_args(cls, args: argparse.Namespace):
+        attrs = [attr.name for attr in dataclasses.fields(cls)]
+        return cls(**{attr: getattr(args, attr) for attr in attrs})
+
+
+def send_one_prompt(args):
+
+    prompt = args.prompt
+    batch_size = random.randint(1, 256)
+    prompt = [prompt] * batch_size
+
+    json_data = {
+        "text": prompt,
+        "sampling_params": {
+            "temperature": args.temperature,
+            "max_new_tokens": args.max_new_tokens,
+            "frequency_penalty": args.frequency_penalty,
+            "presence_penalty": args.presence_penalty,
+        },
+        "return_logprob": args.return_logprob,
+        "stream": args.stream,
+    }
+
+    response = requests.post(
+        f"http://{args.host}:{args.port}/generate",
+        json=json_data,
+        stream=args.stream,
+    )
+
+    if args.stream:
+        for chunk in response.iter_lines(decode_unicode=False):
+            chunk = chunk.decode("utf-8")
+            if chunk and chunk.startswith("data:"):
+                if chunk == "data: [DONE]":
+                    break
+                ret = json.loads(chunk[5:].strip("\n"))
+    else:
+        ret = response.json()
+
+    ret = ret[0]
+
+    if response.status_code != 200:
+        print(ret)
+        return 0, 0
+
+    return ret["text"], batch_size
+
+
+def test_deterministic(args):
+    # First do some warmups
+    for i in range(3):
+        send_one_prompt(args)
+
+    texts = []
+    for i in range(args.n_trials):
+        text, batch_size = send_one_prompt(args)
+        text = text.replace("\n", " ")
+        print(f"Trial {i} with batch size {batch_size}: {text}")
+        texts.append(text)
+
+    print(f"Total samples: {len(texts)}, Unique samples: {len(set(texts))}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    BenchArgs.add_cli_args(parser)
+    args = parser.parse_args()
+
+    test_deterministic(args)

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -188,8 +188,6 @@ def test_deterministic(args):
         print(
             f"Long prompt: total samples: {len(output_long_prompt)}, Unique samples: {len(set(output_long_prompt))}"
         )
-        x = list(set(output_long_prompt))
-        print(x[0], x[1])
 
     else:
         raise ValueError(f"Invalid test mode: {args.test_mode}")

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -2,7 +2,7 @@
 Batch the same prompt in random batch sizes, and test if the results are consistent across different trials.
 
 Usage:
-python3 -m sglang.test.test_deterministic --n-trials <numer_of_trials> --test-mode <single|mixed> --profile
+python3 -m sglang.test.test_deterministic --n-trials <numer_of_trials> --test-mode <single|mixed|prefix> --profile
 """
 
 import argparse


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->
co-author: @hebiao064 , @Qiaolin-Yu

## Motivation

#10278

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. (Flashinfer) Apply the batch invariant attention kernels from https://github.com/flashinfer-ai/flashinfer/pull/1675 
2. (Flashinfer) Only use BatchPrefillWithPagedKVCacheWrapper for prefilling (even when there is no prefix). Fix size of split-kv to 2048 for decode and 4096 for prefill.
3. Use forward_native for norm kernels
4. Enable batch invariant mode from https://github.com/thinking-machines-lab/batch_invariant_ops/tree/main
5. To handle chunked prefill batches,we choose to truncate sequence at multiple of split size. So that the edges of blocks are always aligned with split size.
6. Support cuda graph by disabling split-kv during graph capturing and graph replay for flashinfer
7. Generate a fixed sampling seed for each prompt, so temperature > 0 can also achieve determinism

## Reproduction

Environment: H200, Cuda12.6, sglang 0.5.2, torch 2.8.0, Python 3.12.11

1. For flashinfer, we need to install its latest main branch from source, under the instruction of https://github.com/flashinfer-ai/flashinfer?tab=readme-ov-file#install-from-source
2. Batch invariant ops needs to be built from https://github.com/thinking-machines-lab/batch_invariant_ops/tree/main
3. Apply the modification in this PR


Launch qwen3-8b:
```python3
python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --attention-backend flashinfer --disable-radix-cache 
```

Test determinism with single prompt and different batch sizes:
```bash
python3 -m sglang.test.test_deterministic --test-mode single

# Main branch
Total samples: 50, Unique samples: 6

# This PR
Total samples: 50, Unique samples: 1
```

Test determinism with mixture of short prompts and long prompts in each batch:
```bash
# Requires running multiple times
python3 -m sglang.test.test_deterministic --test-mode mixed

Prompt 1: total samples: 644, Unique samples: 1
Prompt 2: total samples: 423, Unique samples: 1
Long prompt: total samples: 208, Unique samples: 1
```

Test determinism with multiple prompts with different lengths of common prefix:
```bash
python3 -m sglang.test.test_deterministic --test-mode prefix

Prompt 0 with prefix length 1: total samples: 327, Unique samples: 1
Prompt 1 with prefix length 511: total samples: 316, Unique samples: 1
Prompt 2 with prefix length 2048: total samples: 326, Unique samples: 1
Prompt 3 with prefix length 4097: total samples: 306, Unique samples: 1
```



<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

GSM8K

```bash
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319

# Main Branch
Accuracy: 0.902
Invalid: 0.000
Latency: 105.043 s
Output throughput: 1631.791 token/s

# This PR
Accuracy: 0.901
Invalid: 0.000
Latency: 125.780 s
Output throughput: 1366.029 token/s
```

GPQA
```bash
python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 4096

# Main Branch
'score:std': np.float64(0.40881022918884974), 'score': np.float64(0.21212121212121213)

# This PR
'score:std': np.float64(0.40520665017240837), 'score': np.float64(0.20707070707070707)
```


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Temperature > 0
For launching, we need to specify pytorch sampling backend temporarily
```
python3 -m sglang.launch_server --model-path Qwen/Qwen3-8B --attention-backend flashinfer --disable-radix-cache --sampling-backend pytorch
```

For testing, we set temperature to a value greater than 0
```
python3 -m sglang.test.test_deterministic --test-mode mixed --temperature 0.2

# Results
Prompt 1: total samples: 530, Unique samples: 1
Prompt 2: total samples: 527, Unique samples: 1
Long prompt: total samples: 218, Unique samples: 1
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
