### PR TITLE
[router] fix logger ordering git ctx

### DIFF
--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -525,11 +525,12 @@ pub fn build_app(
         .layer(tower_http::limit::RequestBodyLimitLayer::new(
             max_payload_size,
         ))
-        // Request ID layer - must be added AFTER logging layer in the code
-        // so it executes BEFORE logging layer at runtime (layers execute bottom-up)
-        .layer(crate::middleware::RequestIdLayer::new(request_id_headers))
-        // Custom logging layer that can now see request IDs from extensions
+        // Logging layer - must be added BEFORE request ID layer in the code
+        // so it executes AFTER request ID layer at runtime (layers execute bottom-up)
+        // This way the TraceLayer can see the request ID that was added to extensions
         .layer(crate::middleware::create_logging_layer())
+        // Request ID layer - adds request ID to extensions first
+        .layer(crate::middleware::RequestIdLayer::new(request_id_headers))
         // CORS (should be outermost)
         .layer(create_cors_layer(cors_allowed_origins))
         // Fallback


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The router's HTTP request logging was showing incorrect source locations (`src/middleware.rs:180`) for all requests instead of providing useful context about which handler was processing the request. Additionally, request IDs were not being properly included in log spans.


## Modifications

### `src/server.rs`
- Reordered middleware layers to ensure RequestIdLayer runs before TraceLayer at runtime

### `src/middleware.rs`
- Removed duplicated logging code from RequestIdMiddleware
- RequestLogger and ResponseLogger now handle all actual logging with proper request ID context


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
