### PR TITLE
Update vision.py

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -141,7 +141,7 @@ class VisionSdpaAttention(nn.Module):
     def generate_patch_attention_mask(
         self,
         s: int,
-        cu_seqlens: Optional[torch.Tensor],
+        cu_seqlens: Optional[Union[SingletonCache, torch.Tensor]],
         flatten_batch: bool = False,
     ) -> Optional[torch.Tensor]:
         r"""
@@ -155,7 +155,10 @@ class VisionSdpaAttention(nn.Module):
         """
         if cu_seqlens is None:
             return None
-
+        if isinstance(cu_seqlens, SingletonCache):
+            if cu_seqlens.empty():
+                return None
+            cu_seqlens = cu_seqlens.get_data()
         cu_seqlens_tuple = tuple(cu_seqlens.cpu().tolist())
 
         return self._generate_mask_cache(s, flatten_batch, cu_seqlens_tuple)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

fixing "SingletonCache" has no attribute "cpu" when serving InternVL-3.5 with --enable-multimodal and --mm-attention-backend sdpa

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

add simple code to check type of cu_seqlens, which could either be torch.Tensor and SingletonCache

        if isinstance(cu_seqlens, SingletonCache):
            if cu_seqlens.empty():
                return None
            cu_seqlens = cu_seqlens.get_data() 

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
