### PR TITLE
[router] multi model registration fix

### DIFF
--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -5,7 +5,7 @@
 //! - Multi-Router Mode (enable_igw=true): RouterManager coordinates everything
 
 use crate::config::RouterConfig;
-use crate::core::{CircuitBreakerConfig, Worker, WorkerFactory, WorkerRegistry};
+use crate::core::{CircuitBreakerConfig, Worker, WorkerFactory, WorkerRegistry, WorkerType};
 use crate::protocols::spec::{
     ChatCompletionRequest, CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest,
     ResponsesRequest,
@@ -56,10 +56,6 @@ pub struct RouterManager {
     /// Default router for requests without specific routing
     default_router: Option<RouterId>,
 
-    /// Model to router mapping for model-aware routing
-    /// Multiple models can be served by the same router
-    model_routers: Arc<DashMap<String, Vec<RouterId>>>,
-
     /// HTTP client for querying worker info
     client: reqwest::Client,
 
@@ -81,7 +77,6 @@ impl RouterManager {
             policy_registry,
             routers: Arc::new(DashMap::new()),
             default_router: None,
-            model_routers: Arc::new(DashMap::new()),
             client,
             config,
         }
@@ -92,18 +87,10 @@ impl RouterManager {
         &mut self,
         id: RouterId,
         router: Arc<dyn RouterTrait>,
-        models: Vec<String>,
+        _models: Vec<String>, // Keep parameter for backward compatibility but ignore it
     ) {
         // Store router
         self.routers.insert(id.clone(), router);
-
-        // Update model mappings
-        for model in models {
-            self.model_routers
-                .entry(model)
-                .or_default()
-                .push(id.clone());
-        }
 
         // Set as default if first router
         if self.default_router.is_none() {
@@ -122,14 +109,29 @@ impl RouterManager {
         self.routers.len()
     }
 
-    /// Get router for a specific model
+    /// Get router for a specific model based on worker types
     pub fn get_router_for_model(&self, model_id: &str) -> Option<Arc<dyn RouterTrait>> {
-        // First try model-specific routers
-        if let Some(router_ids) = self.model_routers.get(model_id) {
-            if let Some(router_id) = router_ids.first() {
-                if let Some(router) = self.routers.get(router_id) {
-                    return Some(router.clone());
-                }
+        // Query workers for this model from registry
+        let workers = self.worker_registry.get_by_model(model_id);
+
+        if !workers.is_empty() {
+            // Determine router based on worker types
+            let has_pd_workers = workers.iter().any(|w| {
+                matches!(
+                    w.worker_type(),
+                    WorkerType::Prefill { .. } | WorkerType::Decode
+                )
+            });
+
+            let router_id = if has_pd_workers {
+                RouterId::new("http-pd".to_string())
+            } else {
+                RouterId::new("http-regular".to_string())
+            };
+
+            // Return the router if it exists
+            if let Some(router) = self.routers.get(&router_id) {
+                return Some(router.clone());
             }
         }
 
@@ -240,38 +242,16 @@ impl RouterManager {
         let policy_hint = labels.get("policy").map(|s| s.as_str());
         let policy = self.policy_registry.on_worker_added(&model_id, policy_hint);
 
-        // Update model_routers mapping based on worker type
-        // Determine which router should handle this worker
-        let router_id = match config.worker_type.as_deref() {
-            Some("prefill") | Some("decode") => {
-                // PD workers should be handled by http-pd router
-                RouterId::new("http-pd".to_string())
-            }
-            _ => {
-                // Regular workers should be handled by http-regular router
-                RouterId::new("http-regular".to_string())
-            }
+        // Log which type of router would handle this worker (for debugging)
+        let expected_router = match config.worker_type.as_deref() {
+            Some("prefill") | Some("decode") => "http-pd",
+            _ => "http-regular",
         };
 
-        // Add model to router mapping if router exists
-        if self.routers.contains_key(&router_id) {
-            self.model_routers
-                .entry(model_id.clone())
-                .or_default()
-                .push(router_id.clone());
-
-            info!(
-                "Added model '{}' to router '{}' mapping",
-                model_id,
-                router_id.as_str()
-            );
-        } else {
-            warn!(
-                "Router '{}' not found for model '{}', worker will be in registry but not routable",
-                router_id.as_str(),
-                model_id
-            );
-        }
+        info!(
+            "Worker for model '{}' would be handled by '{}' router based on type",
+            model_id, expected_router
+        );
 
         info!(
             "Added worker {} with URL {} for model {} using policy {}",
@@ -307,21 +287,6 @@ impl RouterManager {
             // Notify PolicyRegistry about worker removal
             if let Some(ref model_id) = model_id {
                 self.policy_registry.on_worker_removed(model_id);
-
-                // Remove model from model_routers if no other workers serve it
-                let workers_for_model = self
-                    .worker_registry
-                    .get_all()
-                    .iter()
-                    .any(|w| w.model_id() == model_id);
-
-                if !workers_for_model {
-                    self.model_routers.remove(model_id);
-                    info!(
-                        "Removed model '{}' from router mappings (no remaining workers)",
-                        model_id
-                    );
-                }
 
                 info!("Removed worker with URL {} for model {}", url, model_id);
             } else {
@@ -455,16 +420,34 @@ impl RouterManager {
             })
             .unwrap_or(false);
 
-        // If model specified, find routers serving that model
+        // If model specified, determine router based on worker types
         let candidate_routers = if let Some(model) = model_id {
-            // Get routers for specific model
-            if let Some(router_ids) = self.model_routers.get(model) {
-                router_ids
-                    .iter()
-                    .filter_map(|id| self.routers.get(id).map(|r| r.clone()))
-                    .collect::<Vec<_>>()
-            } else {
+            // Query workers for this model
+            let workers = self.worker_registry.get_by_model(model);
+
+            if workers.is_empty() {
                 Vec::new()
+            } else {
+                // Determine router based on worker types
+                let has_pd_workers = workers.iter().any(|w| {
+                    matches!(
+                        w.worker_type(),
+                        WorkerType::Prefill { .. } | WorkerType::Decode
+                    )
+                });
+
+                let router_id = if has_pd_workers {
+                    RouterId::new("http-pd".to_string())
+                } else {
+                    RouterId::new("http-regular".to_string())
+                };
+
+                // Get the appropriate router
+                if let Some(router) = self.routers.get(&router_id) {
+                    vec![router.clone()]
+                } else {
+                    Vec::new()
+                }
             }
         } else {
             // No model specified, consider all routers
@@ -596,14 +579,10 @@ impl RouterTrait for RouterManager {
             .into_response()
     }
 
-    /// Get available models - aggregate from all routers
+    /// Get available models - query from worker registry
     async fn get_models(&self, _req: Request<Body>) -> Response {
-        // Return models that have registered routers
-        let models = self
-            .model_routers
-            .iter()
-            .map(|entry| entry.key().clone())
-            .collect::<Vec<_>>();
+        // Get models from worker registry
+        let models = self.worker_registry.get_models();
 
         if models.is_empty() {
             (StatusCode::SERVICE_UNAVAILABLE, "No models available").into_response()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Fix multi model registration bug where the model and router mapping is not updated in router manager.
Why do we remove model to router mapping internally?
eventually, we need to sync the data such as radix tree, worker registry and policy registry across different replicas of routers when service discovery is not an option.
Thus keeping router stateless is critical and only allow registries and trees to be stateful to reduce network I/O

## Changes
remove internal maps in router and use workers' characteristics to find its matching router
## Tests

1. Running 4 Models in a single GPU
```
📊 Summary:
   Launched: 4 servers
   Healthy: 4 servers

✅ Multi-model servers are running!

📡 Server endpoints:
   llama3.1-8b: http://localhost:30001
   gpt-oss-20b: http://localhost:30003
   sarashina2.2-3b-instruct-v0.1: http://localhost:30004
   qwen3-8b: **http://localhost:30002
```
2. Spin up router without any workers with IGW mode
```
python3 -m sglang_router.launch_router --enable-igw --host 0.0.0.0 --port 8000
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:553: Starting router on 0.0.0.0:8000 | mode: Regular { worker_urls: [] } | policy: CacheAware { cache_threshold: 0.3, balance_abs_threshold: 64, balance_rel_threshold: 1.5, eviction_interval_secs: 120, max_tree_size: 67108864 } | max_payload: 512MB
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:584: Multi-router mode enabled (enable_igw=true)
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:602: Created HTTP Regular router
2025-09-15 21:12:31  INFO sglang_router_rs::routers::router_manager: src/routers/router_manager.rs:98: Set default router to http-regular
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:626: Created HTTP PD router
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:640: RouterManager initialized with 2 routers
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:655: Started health checker for workers with 60s interval
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:670: Started request queue with size: 100, timeout: 60s
2025-09-15 21:12:31  INFO sglang_router_rs::routers::http::pd_router: src/routers/http/pd_router.rs:493: Prefill drain coordinator started
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:705: Router ready | workers: []
2025-09-15 21:12:31  INFO sglang_router_rs::middleware: src/middleware.rs:335: Starting concurrency queue processor
2025-09-15 21:12:31  INFO sglang_router_rs::server: src/server.rs:729: Starting server on 0.0.0.0:8000
```

3. Add workers individually
```
# Add Qwen3 8B worker
curl -X POST http://localhost:8000/workers \
  -H "Content-Type: application/json" \
  -d '{
    "url": "http://localhost:30002",
    "model_id": "Qwen/Qwen3-8B",
    "labels": {
      "policy": "cache_aware"
    }
  }'

# Add GPT-OSS 20B worker
curl -X POST http://localhost:8000/workers \
  -H "Content-Type: application/json" \
  -d '{
    "url": "http://localhost:30003",
    "model_id": "openai/gpt-oss-20b",
    "labels": {
      "policy": "cache_aware"
    }
  }'

# Add Sarashina 2.2 3B worker
curl -X POST http://localhost:8000/workers \
  -H "Content-Type: application/json" \
  -d '{
    "url": "http://localhost:30004",
    "model_id": "sbintuitions/sarashina2.2-3b-instruct-v0.1",
    "labels": {
      "policy": "cache_aware"
    }
  }'

curl -X POST http://localhost:8000/workers \
    -H "Content-Type: application/json" \
    -d '{
      "url": "http://localhost:30001",
      "model_id": "meta-llama/Llama-3.1-8B-Instruct",
      "labels": {
        "policy": "cache_aware"
      }
    }'
```
This essentially makes the router with 4 workers and 4 radix trees

```
curl http://0.0.0.0:8000/workers
{
  "stats": {
    "decode_count": 0,
    "prefill_count": 0,
    "regular_count": 4
  },
  "total": 4,
  "workers": [
    {
      "connection_mode": "Http",
      "cost": 1,
      "is_healthy": true,
      "load": 0,
      "model_id": "Qwen3-8B",
      "priority": 50,
      "url": "http://localhost:30002",
      "worker_type": "Regular"
    },
    {
      "connection_mode": "Http",
      "cost": 1,
      "is_healthy": true,
      "load": 0,
      "model_id": "sarashina2.2-3b-instruct-v0.1",
      "priority": 50,
      "url": "http://localhost:30004",
      "worker_type": "Regular"
    },
    {
      "connection_mode": "Http",
      "cost": 1,
      "is_healthy": true,
      "load": 0,
      "model_id": "gpt-oss-20b",
      "priority": 50,
      "url": "http://localhost:30003",
      "worker_type": "Regular"
    },
    {
      "connection_mode": "Http",
      "cost": 1,
      "is_healthy": true,
      "load": 0,
      "model_id": "Llama-3.1-8B-Instruct",
      "priority": 50,
      "url": "http://localhost:30001",
      "worker_type": "Regular"
    }
  ]
}
```

curl test
```
curl -s -X POST "http://localhost:8000/v1/chat/completions" \
            -H "Content-Type: application/json" \
            -H "Authorization: Bearer test-token" \
            -d '{
              "model": "Llama-3.1-8B-Instruct",
              "messages": [
                {"role": "user", "content": "Write a Python function to calculate fibonacci numbers recursively"}
              ],
              "stream": false,
              "max_tokens": 100
            }'
{"id":"5645f05cf2d2402b907d6e82e8548e3d","object":"chat.completion","created":1757971410,"model":"Llama-3.1-8B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"**Recursive Fibonacci Function in Python**\n=====================================================\n\nBelow is an example of a recursive function in Python to calculate Fibonacci numbers.\n\n```python\ndef fibonacci(n):\n    \"\"\"\n    Calculate the nth Fibonacci number using recursion.\n\n    Args:\n        n (int): The position of the Fibonacci number to calculate.\n\n    Returns:\n        int: The nth Fibonacci number.\n\n    Raises:\n        ValueError: If n is a negative integer.\n    \"\"\"\n\n    # Check if n is a non-negative integer\n    if not","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null}],"usage":{"prompt_tokens":44,"total_tokens":144,"completion_tokens":100,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
```

## TODO
- [ ] PD and regular priority are still pending implementation
- [ ] model ID is incorrect, the actual registered ID is based on `/get_server_info` instead of the request payload from client



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
