### PR TITLE
[router] fix worker registration in multi model mode

### DIFF
--- a/sgl-router/src/core/worker.rs
+++ b/sgl-router/src/core/worker.rs
@@ -804,6 +804,37 @@ impl WorkerFactory {
         Box::new(worker)
     }
 
+    /// Create a prefill worker with labels
+    pub fn create_prefill_with_labels(
+        url: String,
+        bootstrap_port: Option<u16>,
+        labels: std::collections::HashMap<String, String>,
+        circuit_breaker_config: CircuitBreakerConfig,
+    ) -> Box<dyn Worker> {
+        let mut worker = BasicWorker::new(url.clone(), WorkerType::Prefill { bootstrap_port })
+            .with_circuit_breaker_config(circuit_breaker_config);
+
+        // Add labels to metadata
+        worker.metadata.labels = labels;
+
+        Box::new(worker)
+    }
+
+    /// Create a decode worker with labels
+    pub fn create_decode_with_labels(
+        url: String,
+        labels: std::collections::HashMap<String, String>,
+        circuit_breaker_config: CircuitBreakerConfig,
+    ) -> Box<dyn Worker> {
+        let mut worker = BasicWorker::new(url.clone(), WorkerType::Decode)
+            .with_circuit_breaker_config(circuit_breaker_config);
+
+        // Add labels to metadata
+        worker.metadata.labels = labels;
+
+        Box::new(worker)
+    }
+
     /// Create a DP-aware worker of specified type
     pub fn create_dp_aware(
         base_url: String,

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -211,18 +211,21 @@ impl RouterManager {
         }
 
         // Create worker based on type
-        // Note: For prefill and decode workers, we can't easily add labels after creation
-        // since they return Box<dyn Worker>. We'll need to enhance WorkerFactory in the future.
         let worker = match config.worker_type.as_deref() {
             Some("prefill") => {
-                // For now, prefill workers won't have custom labels
-                // TODO: Enhance WorkerFactory to accept labels for prefill workers
-                WorkerFactory::create_prefill(config.url.clone(), config.bootstrap_port)
+                WorkerFactory::create_prefill_with_labels(
+                    config.url.clone(),
+                    config.bootstrap_port,
+                    labels.clone(),
+                    CircuitBreakerConfig::default(),
+                )
             }
             Some("decode") => {
-                // For now, decode workers won't have custom labels
-                // TODO: Enhance WorkerFactory to accept labels for decode workers
-                WorkerFactory::create_decode(config.url.clone())
+                WorkerFactory::create_decode_with_labels(
+                    config.url.clone(),
+                    labels.clone(),
+                    CircuitBreakerConfig::default(),
+                )
             }
             _ => {
                 // Regular workers can have labels

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -41,7 +41,6 @@ impl RouterId {
 }
 
 /// Router Manager - Central coordinator for routers and workers
-/// Only created when enable_igw=true
 pub struct RouterManager {
     /// Worker registry (single source of truth in multi-router mode)
     worker_registry: Arc<WorkerRegistry>,
@@ -49,7 +48,7 @@ pub struct RouterManager {
     /// Policy registry for managing model-to-policy mappings
     policy_registry: Arc<crate::policies::PolicyRegistry>,
 
-    /// All routers managed by this manager (max 4 routers in Phase 2)
+    /// All routers managed by this manager
     /// RouterId examples: "http-regular", "http-pd", "grpc-regular", "grpc-pd"
     routers: Arc<DashMap<RouterId, Arc<dyn RouterTrait>>>,
 
@@ -83,12 +82,7 @@ impl RouterManager {
     }
 
     /// Register a router with the manager
-    pub fn register_router(
-        &mut self,
-        id: RouterId,
-        router: Arc<dyn RouterTrait>,
-        _models: Vec<String>, // Keep parameter for backward compatibility but ignore it
-    ) {
+    pub fn register_router(&mut self, id: RouterId, router: Arc<dyn RouterTrait>) {
         // Store router
         self.routers.insert(id.clone(), router);
 
@@ -210,35 +204,28 @@ impl RouterManager {
             labels.insert("chat_template".to_string(), chat_template);
         }
 
-        // Create worker based on type
         let worker = match config.worker_type.as_deref() {
-            Some("prefill") => {
-                WorkerFactory::create_prefill_with_labels(
-                    config.url.clone(),
-                    config.bootstrap_port,
-                    labels.clone(),
-                    CircuitBreakerConfig::default(),
-                )
-            }
-            Some("decode") => {
-                WorkerFactory::create_decode_with_labels(
-                    config.url.clone(),
-                    labels.clone(),
-                    CircuitBreakerConfig::default(),
-                )
-            }
-            _ => {
-                // Regular workers can have labels
-                WorkerFactory::create_regular_with_labels(
-                    config.url.clone(),
-                    labels.clone(),
-                    CircuitBreakerConfig::default(),
-                )
-            }
+            Some("prefill") => WorkerFactory::create_prefill_with_labels(
+                config.url.clone(),
+                config.bootstrap_port,
+                labels.clone(),
+                CircuitBreakerConfig::default(),
+            ),
+            Some("decode") => WorkerFactory::create_decode_with_labels(
+                config.url.clone(),
+                labels.clone(),
+                CircuitBreakerConfig::default(),
+            ),
+            _ => WorkerFactory::create_regular_with_labels(
+                config.url.clone(),
+                labels.clone(),
+                CircuitBreakerConfig::default(),
+            ),
         };
 
         // Register worker
-        let worker_id = self.worker_registry.register(Arc::from(worker));
+        let worker_arc: Arc<dyn Worker> = Arc::from(worker);
+        let worker_id = self.worker_registry.register(worker_arc.clone());
 
         // Notify PolicyRegistry about the new worker
         // Extract policy hint from labels if provided
@@ -265,7 +252,6 @@ impl RouterManager {
         );
 
         // Return worker info
-        let worker_arc = self.worker_registry.get(&worker_id).unwrap();
         let worker_info = self.worker_to_info(worker_id.as_str(), &worker_arc);
 
         Ok(WorkerApiResponse {
@@ -378,7 +364,11 @@ impl RouterManager {
             model_id: worker.model_id().to_string(),
             priority: worker.priority(),
             cost: worker.cost(),
-            worker_type: format!("{:?}", worker.worker_type()),
+            worker_type: match worker.worker_type() {
+                WorkerType::Regular => "regular".to_string(),
+                WorkerType::Prefill { .. } => "prefill".to_string(),
+                WorkerType::Decode => "decode".to_string(),
+            },
             is_healthy: worker.is_healthy(),
             load: worker.load(),
             connection_mode: format!("{:?}", worker.connection_mode()),
@@ -389,11 +379,6 @@ impl RouterManager {
             metadata: metadata.labels.clone(),
         }
     }
-
-    // Note: calculate_stats removed - using WorkerRegistry::stats() instead
-
-    // === Phase 2: Router Management ===
-    // Note: Dynamic router creation removed - routers are created and registered externally
 
     /// Get the appropriate router for a request based on headers and request content
     pub fn select_router_for_request(
@@ -476,11 +461,6 @@ impl RouterManager {
         best_router
     }
 }
-
-// Note: Default implementation removed as RouterManager now requires AppContext
-// which cannot be defaulted. RouterManager must be created with explicit context.
-
-// === Phase 2: RouterManager as RouterTrait ===
 
 /// RouterManager implements RouterTrait to act as a meta-router
 /// that delegates requests to the appropriate underlying router


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When using the SGLang router in multi-router mode (`--enable-igw`), PD (`Prefill-Decode`) workers were being registered as "Regular" type instead of their specified types ("`prefill`" or "`decode`"), causing incorrect routing behavior.

  1. `AppContext.router_manager` was always initialized as `None` and never updated
  2. The worker management endpoints were checking `state.context.router_manager` which was always None
  3. This caused the code to fall back to the `RouterTrait::add_worker(&str)` method which only accepts a URL string
  4. The trait method creates a new `WorkerConfigRequest` with all fields set to None, discarding the `worker_type` field


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
