### PR TITLE
[router] add router db connector for responses api

### DIFF
--- a/sgl-router/Cargo.toml
+++ b/sgl-router/Cargo.toml
@@ -45,6 +45,8 @@ k8s-openapi = { version = "0.25.0", features = ["v1_33"] }
 metrics = "0.24.2"
 metrics-exporter-prometheus = "0.17.0"
 uuid = { version = "1.10", features = ["v4", "serde"] }
+ulid = "1.2.1"
+parking_lot = "0.12.4"
 thiserror = "2.0.12"
 regex = "1.10"
 url = "2.5.4"

--- a/sgl-router/src/data_connector/mod.rs
+++ b/sgl-router/src/data_connector/mod.rs
@@ -1,0 +1,11 @@
+// Data connector module for response storage
+pub mod response_memory_store;
+pub mod response_noop_store;
+pub mod responses;
+
+pub use response_memory_store::MemoryResponseStorage;
+pub use response_noop_store::NoOpResponseStorage;
+pub use responses::{
+    ResponseChain, ResponseId, ResponseStorage, ResponseStorageError, SharedResponseStorage,
+    StoredResponse,
+};

--- a/sgl-router/src/data_connector/response_memory_store.rs
+++ b/sgl-router/src/data_connector/response_memory_store.rs
@@ -1,0 +1,308 @@
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::responses::{ResponseChain, ResponseId, ResponseStorage, Result, StoredResponse};
+
+/// In-memory implementation of response storage
+pub struct MemoryResponseStorage {
+    /// All stored responses indexed by ID
+    responses: Arc<RwLock<HashMap<ResponseId, StoredResponse>>>,
+    /// Index of responses by user
+    user_index: Arc<RwLock<HashMap<String, Vec<ResponseId>>>>,
+}
+
+impl MemoryResponseStorage {
+    pub fn new() -> Self {
+        Self {
+            responses: Arc::new(RwLock::new(HashMap::new())),
+            user_index: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get statistics about the store
+    pub fn stats(&self) -> MemoryStoreStats {
+        let responses = self.responses.read();
+        let user_index = self.user_index.read();
+
+        MemoryStoreStats {
+            response_count: responses.len(),
+            user_count: user_index.len(),
+        }
+    }
+
+    /// Clear all data (useful for testing)
+    pub fn clear(&self) {
+        self.responses.write().clear();
+        self.user_index.write().clear();
+    }
+}
+
+impl Default for MemoryResponseStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ResponseStorage for MemoryResponseStorage {
+    async fn store_response(&self, mut response: StoredResponse) -> Result<ResponseId> {
+        // Generate ID if not set
+        if response.id.0.is_empty() {
+            response.id = ResponseId::new();
+        }
+
+        let response_id = response.id.clone();
+
+        // Store the response
+        self.responses
+            .write()
+            .insert(response_id.clone(), response.clone());
+
+        // Update user index if user is specified
+        if let Some(ref user) = response.user {
+            self.user_index
+                .write()
+                .entry(user.clone())
+                .or_default()
+                .push(response_id.clone());
+        }
+
+        Ok(response_id)
+    }
+
+    async fn get_response(&self, response_id: &ResponseId) -> Result<Option<StoredResponse>> {
+        Ok(self.responses.read().get(response_id).cloned())
+    }
+
+    async fn delete_response(&self, response_id: &ResponseId) -> Result<()> {
+        let response = self.responses.write().remove(response_id);
+
+        // Remove from user index if it existed
+        if let Some(response) = response {
+            if let Some(ref user) = response.user {
+                if let Some(user_responses) = self.user_index.write().get_mut(user) {
+                    user_responses.retain(|id| id != response_id);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_response_chain(
+        &self,
+        response_id: &ResponseId,
+        max_depth: Option<usize>,
+    ) -> Result<ResponseChain> {
+        let mut chain = ResponseChain::new();
+        let mut current_id = Some(response_id.clone());
+        let mut depth = 0;
+        let max_depth = max_depth.unwrap_or(100); // Default max depth to prevent infinite loops
+
+        // Build the chain by following previous_response_id links
+        let mut responses_to_add = Vec::new();
+
+        while let Some(id) = current_id {
+            if depth >= max_depth {
+                break;
+            }
+
+            let responses = self.responses.read();
+            if let Some(response) = responses.get(&id) {
+                responses_to_add.push(response.clone());
+                current_id = response.previous_response_id.clone();
+                depth += 1;
+            } else {
+                break;
+            }
+        }
+
+        // Reverse to get chronological order (oldest first)
+        responses_to_add.reverse();
+        for response in responses_to_add {
+            chain.add_response(response);
+        }
+
+        Ok(chain)
+    }
+
+    async fn list_user_responses(
+        &self,
+        user: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<StoredResponse>> {
+        let user_index = self.user_index.read();
+        let responses = self.responses.read();
+
+        if let Some(user_response_ids) = user_index.get(user) {
+            let mut user_responses: Vec<StoredResponse> = user_response_ids
+                .iter()
+                .filter_map(|id| responses.get(id).cloned())
+                .collect();
+
+            // Sort by creation time (newest first)
+            user_responses.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+            // Apply limit if specified
+            if let Some(limit) = limit {
+                user_responses.truncate(limit);
+            }
+
+            Ok(user_responses)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    async fn delete_user_responses(&self, user: &str) -> Result<usize> {
+        let mut user_index = self.user_index.write();
+        let mut responses = self.responses.write();
+
+        if let Some(user_response_ids) = user_index.remove(user) {
+            let count = user_response_ids.len();
+            for id in user_response_ids {
+                responses.remove(&id);
+            }
+            Ok(count)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+/// Statistics for the memory store
+#[derive(Debug, Clone)]
+pub struct MemoryStoreStats {
+    pub response_count: usize,
+    pub user_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_memory_store_basic() {
+        let store = MemoryResponseStorage::new();
+
+        // Store a response
+        let response = StoredResponse::new("Hello".to_string(), "Hi there!".to_string(), None);
+        let response_id = store.store_response(response).await.unwrap();
+
+        // Retrieve it
+        let retrieved = store.get_response(&response_id).await.unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().input, "Hello");
+
+        // Delete it
+        store.delete_response(&response_id).await.unwrap();
+        let deleted = store.get_response(&response_id).await.unwrap();
+        assert!(deleted.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_response_chain() {
+        let store = MemoryResponseStorage::new();
+
+        // Create a chain of responses
+        let response1 =
+            StoredResponse::new("First".to_string(), "First response".to_string(), None);
+        let id1 = store.store_response(response1).await.unwrap();
+
+        let response2 = StoredResponse::new(
+            "Second".to_string(),
+            "Second response".to_string(),
+            Some(id1.clone()),
+        );
+        let id2 = store.store_response(response2).await.unwrap();
+
+        let response3 = StoredResponse::new(
+            "Third".to_string(),
+            "Third response".to_string(),
+            Some(id2.clone()),
+        );
+        let id3 = store.store_response(response3).await.unwrap();
+
+        // Get the chain
+        let chain = store.get_response_chain(&id3, None).await.unwrap();
+        assert_eq!(chain.responses.len(), 3);
+        assert_eq!(chain.responses[0].input, "First");
+        assert_eq!(chain.responses[1].input, "Second");
+        assert_eq!(chain.responses[2].input, "Third");
+
+        // Test with max_depth
+        let limited_chain = store.get_response_chain(&id3, Some(2)).await.unwrap();
+        assert_eq!(limited_chain.responses.len(), 2);
+        assert_eq!(limited_chain.responses[0].input, "Second");
+        assert_eq!(limited_chain.responses[1].input, "Third");
+    }
+
+    #[tokio::test]
+    async fn test_user_responses() {
+        let store = MemoryResponseStorage::new();
+
+        // Store responses for different users
+        let mut response1 = StoredResponse::new(
+            "User1 message".to_string(),
+            "Response to user1".to_string(),
+            None,
+        );
+        response1.user = Some("user1".to_string());
+        store.store_response(response1).await.unwrap();
+
+        let mut response2 = StoredResponse::new(
+            "Another user1 message".to_string(),
+            "Another response to user1".to_string(),
+            None,
+        );
+        response2.user = Some("user1".to_string());
+        store.store_response(response2).await.unwrap();
+
+        let mut response3 = StoredResponse::new(
+            "User2 message".to_string(),
+            "Response to user2".to_string(),
+            None,
+        );
+        response3.user = Some("user2".to_string());
+        store.store_response(response3).await.unwrap();
+
+        // List user1's responses
+        let user1_responses = store.list_user_responses("user1", None).await.unwrap();
+        assert_eq!(user1_responses.len(), 2);
+
+        // List user2's responses
+        let user2_responses = store.list_user_responses("user2", None).await.unwrap();
+        assert_eq!(user2_responses.len(), 1);
+
+        // Delete user1's responses
+        let deleted_count = store.delete_user_responses("user1").await.unwrap();
+        assert_eq!(deleted_count, 2);
+
+        // Verify they're gone
+        let user1_responses_after = store.list_user_responses("user1", None).await.unwrap();
+        assert_eq!(user1_responses_after.len(), 0);
+
+        // User2's responses should still be there
+        let user2_responses_after = store.list_user_responses("user2", None).await.unwrap();
+        assert_eq!(user2_responses_after.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_stats() {
+        let store = MemoryResponseStorage::new();
+
+        let mut response1 = StoredResponse::new("Test1".to_string(), "Reply1".to_string(), None);
+        response1.user = Some("user1".to_string());
+        store.store_response(response1).await.unwrap();
+
+        let mut response2 = StoredResponse::new("Test2".to_string(), "Reply2".to_string(), None);
+        response2.user = Some("user2".to_string());
+        store.store_response(response2).await.unwrap();
+
+        let stats = store.stats();
+        assert_eq!(stats.response_count, 2);
+        assert_eq!(stats.user_count, 2);
+    }
+}

--- a/sgl-router/src/data_connector/response_memory_store.rs
+++ b/sgl-router/src/data_connector/response_memory_store.rs
@@ -5,37 +5,42 @@ use std::sync::Arc;
 
 use super::responses::{ResponseChain, ResponseId, ResponseStorage, Result, StoredResponse};
 
+/// Internal store structure holding both maps together
+#[derive(Default)]
+struct InnerStore {
+    /// All stored responses indexed by ID
+    responses: HashMap<ResponseId, StoredResponse>,
+    /// Index of response IDs by user
+    user_index: HashMap<String, Vec<ResponseId>>,
+}
+
 /// In-memory implementation of response storage
 pub struct MemoryResponseStorage {
-    /// All stored responses indexed by ID
-    responses: Arc<RwLock<HashMap<ResponseId, StoredResponse>>>,
-    /// Index of responses by user
-    user_index: Arc<RwLock<HashMap<String, Vec<ResponseId>>>>,
+    /// Single lock wrapping both maps to prevent deadlocks and ensure atomic updates
+    store: Arc<RwLock<InnerStore>>,
 }
 
 impl MemoryResponseStorage {
     pub fn new() -> Self {
         Self {
-            responses: Arc::new(RwLock::new(HashMap::new())),
-            user_index: Arc::new(RwLock::new(HashMap::new())),
+            store: Arc::new(RwLock::new(InnerStore::default())),
         }
     }
 
     /// Get statistics about the store
     pub fn stats(&self) -> MemoryStoreStats {
-        let responses = self.responses.read();
-        let user_index = self.user_index.read();
-
+        let store = self.store.read();
         MemoryStoreStats {
-            response_count: responses.len(),
-            user_count: user_index.len(),
+            response_count: store.responses.len(),
+            user_count: store.user_index.len(),
         }
     }
 
     /// Clear all data (useful for testing)
     pub fn clear(&self) {
-        self.responses.write().clear();
-        self.user_index.write().clear();
+        let mut store = self.store.write();
+        store.responses.clear();
+        store.user_index.clear();
     }
 }
 
@@ -55,34 +60,36 @@ impl ResponseStorage for MemoryResponseStorage {
 
         let response_id = response.id.clone();
 
-        // Store the response
-        self.responses
-            .write()
-            .insert(response_id.clone(), response.clone());
+        // Single lock acquisition for atomic update
+        let mut store = self.store.write();
 
         // Update user index if user is specified
         if let Some(ref user) = response.user {
-            self.user_index
-                .write()
+            store
+                .user_index
                 .entry(user.clone())
                 .or_default()
                 .push(response_id.clone());
         }
 
+        // Store the response
+        store.responses.insert(response_id.clone(), response);
+
         Ok(response_id)
     }
 
     async fn get_response(&self, response_id: &ResponseId) -> Result<Option<StoredResponse>> {
-        Ok(self.responses.read().get(response_id).cloned())
+        let store = self.store.read();
+        Ok(store.responses.get(response_id).cloned())
     }
 
     async fn delete_response(&self, response_id: &ResponseId) -> Result<()> {
-        let response = self.responses.write().remove(response_id);
+        let mut store = self.store.write();
 
-        // Remove from user index if it existed
-        if let Some(response) = response {
+        // Remove the response and update user index if needed
+        if let Some(response) = store.responses.remove(response_id) {
             if let Some(ref user) = response.user {
-                if let Some(user_responses) = self.user_index.write().get_mut(user) {
+                if let Some(user_responses) = store.user_index.get_mut(user) {
                     user_responses.retain(|id| id != response_id);
                 }
             }
@@ -97,32 +104,40 @@ impl ResponseStorage for MemoryResponseStorage {
         max_depth: Option<usize>,
     ) -> Result<ResponseChain> {
         let mut chain = ResponseChain::new();
-        let mut current_id = Some(response_id.clone());
-        let mut depth = 0;
         let max_depth = max_depth.unwrap_or(100); // Default max depth to prevent infinite loops
 
-        // Build the chain by following previous_response_id links
-        let mut responses_to_add = Vec::new();
+        // Collect all response IDs first
+        let mut response_ids = Vec::new();
+        let mut current_id = Some(response_id.clone());
+        let mut depth = 0;
 
-        while let Some(id) = current_id {
-            if depth >= max_depth {
-                break;
-            }
+        // Single lock acquisition to collect the chain
+        {
+            let store = self.store.read();
+            while let Some(id) = current_id {
+                if depth >= max_depth {
+                    break;
+                }
 
-            let responses = self.responses.read();
-            if let Some(response) = responses.get(&id) {
-                responses_to_add.push(response.clone());
-                current_id = response.previous_response_id.clone();
-                depth += 1;
-            } else {
-                break;
+                if let Some(response) = store.responses.get(&id) {
+                    response_ids.push(id);
+                    current_id = response.previous_response_id.clone();
+                    depth += 1;
+                } else {
+                    break;
+                }
             }
         }
 
         // Reverse to get chronological order (oldest first)
-        responses_to_add.reverse();
-        for response in responses_to_add {
-            chain.add_response(response);
+        response_ids.reverse();
+
+        // Now collect the actual responses
+        let store = self.store.read();
+        for id in response_ids {
+            if let Some(response) = store.responses.get(&id) {
+                chain.add_response(response.clone());
+            }
         }
 
         Ok(chain)
@@ -133,22 +148,25 @@ impl ResponseStorage for MemoryResponseStorage {
         user: &str,
         limit: Option<usize>,
     ) -> Result<Vec<StoredResponse>> {
-        let user_index = self.user_index.read();
-        let responses = self.responses.read();
+        let store = self.store.read();
 
-        if let Some(user_response_ids) = user_index.get(user) {
-            let mut user_responses: Vec<StoredResponse> = user_response_ids
+        if let Some(user_response_ids) = store.user_index.get(user) {
+            // Collect responses with their timestamps for sorting
+            let mut responses_with_time: Vec<_> = user_response_ids
                 .iter()
-                .filter_map(|id| responses.get(id).cloned())
+                .filter_map(|id| store.responses.get(id).map(|r| (r.created_at, id)))
                 .collect();
 
             // Sort by creation time (newest first)
-            user_responses.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            responses_with_time.sort_by(|a, b| b.0.cmp(&a.0));
 
-            // Apply limit if specified
-            if let Some(limit) = limit {
-                user_responses.truncate(limit);
-            }
+            // Apply limit and collect the actual responses
+            let limit = limit.unwrap_or(responses_with_time.len());
+            let user_responses: Vec<StoredResponse> = responses_with_time
+                .into_iter()
+                .take(limit)
+                .filter_map(|(_, id)| store.responses.get(id).cloned())
+                .collect();
 
             Ok(user_responses)
         } else {
@@ -157,13 +175,12 @@ impl ResponseStorage for MemoryResponseStorage {
     }
 
     async fn delete_user_responses(&self, user: &str) -> Result<usize> {
-        let mut user_index = self.user_index.write();
-        let mut responses = self.responses.write();
+        let mut store = self.store.write();
 
-        if let Some(user_response_ids) = user_index.remove(user) {
+        if let Some(user_response_ids) = store.user_index.remove(user) {
             let count = user_response_ids.len();
             for id in user_response_ids {
-                responses.remove(&id);
+                store.responses.remove(&id);
             }
             Ok(count)
         } else {

--- a/sgl-router/src/data_connector/response_noop_store.rs
+++ b/sgl-router/src/data_connector/response_noop_store.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+
+use super::responses::{ResponseChain, ResponseId, ResponseStorage, Result, StoredResponse};
+
+/// No-op implementation of response storage (does nothing)
+pub struct NoOpResponseStorage;
+
+impl NoOpResponseStorage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NoOpResponseStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ResponseStorage for NoOpResponseStorage {
+    async fn store_response(&self, response: StoredResponse) -> Result<ResponseId> {
+        Ok(response.id)
+    }
+
+    async fn get_response(&self, _response_id: &ResponseId) -> Result<Option<StoredResponse>> {
+        Ok(None)
+    }
+
+    async fn delete_response(&self, _response_id: &ResponseId) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_response_chain(
+        &self,
+        _response_id: &ResponseId,
+        _max_depth: Option<usize>,
+    ) -> Result<ResponseChain> {
+        Ok(ResponseChain::new())
+    }
+
+    async fn list_user_responses(
+        &self,
+        _user: &str,
+        _limit: Option<usize>,
+    ) -> Result<Vec<StoredResponse>> {
+        Ok(Vec::new())
+    }
+
+    async fn delete_user_responses(&self, _user: &str) -> Result<usize> {
+        Ok(0)
+    }
+}

--- a/sgl-router/src/data_connector/responses.rs
+++ b/sgl-router/src/data_connector/responses.rs
@@ -1,0 +1,177 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Response identifier
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ResponseId(pub String);
+
+impl ResponseId {
+    pub fn new() -> Self {
+        Self(ulid::Ulid::new().to_string())
+    }
+
+    pub fn from_string(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl Default for ResponseId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Stored response data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredResponse {
+    /// Unique response ID
+    pub id: ResponseId,
+
+    /// ID of the previous response in the chain (if any)
+    pub previous_response_id: Option<ResponseId>,
+
+    /// The user input for this response
+    pub input: String,
+
+    /// System instructions used
+    pub instructions: Option<String>,
+
+    /// The model's output
+    pub output: String,
+
+    /// Tool calls made by the model (if any)
+    pub tool_calls: Vec<serde_json::Value>,
+
+    /// Custom metadata
+    pub metadata: HashMap<String, serde_json::Value>,
+
+    /// When this response was created
+    pub created_at: chrono::DateTime<chrono::Utc>,
+
+    /// User identifier (optional)
+    pub user: Option<String>,
+
+    /// Model used for generation
+    pub model: Option<String>,
+}
+
+impl StoredResponse {
+    pub fn new(input: String, output: String, previous_response_id: Option<ResponseId>) -> Self {
+        Self {
+            id: ResponseId::new(),
+            previous_response_id,
+            input,
+            instructions: None,
+            output,
+            tool_calls: Vec::new(),
+            metadata: HashMap::new(),
+            created_at: chrono::Utc::now(),
+            user: None,
+            model: None,
+        }
+    }
+}
+
+/// Response chain - a sequence of related responses
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseChain {
+    /// The responses in chronological order
+    pub responses: Vec<StoredResponse>,
+
+    /// Metadata about the chain
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl Default for ResponseChain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResponseChain {
+    pub fn new() -> Self {
+        Self {
+            responses: Vec::new(),
+            metadata: HashMap::new(),
+        }
+    }
+
+    /// Get the ID of the most recent response in the chain
+    pub fn latest_response_id(&self) -> Option<&ResponseId> {
+        self.responses.last().map(|r| &r.id)
+    }
+
+    /// Add a response to the chain
+    pub fn add_response(&mut self, response: StoredResponse) {
+        self.responses.push(response);
+    }
+
+    /// Build context from the chain for the next request
+    pub fn build_context(&self, max_responses: Option<usize>) -> Vec<(String, String)> {
+        let responses = if let Some(max) = max_responses {
+            let start = self.responses.len().saturating_sub(max);
+            &self.responses[start..]
+        } else {
+            &self.responses[..]
+        };
+
+        responses
+            .iter()
+            .map(|r| (r.input.clone(), r.output.clone()))
+            .collect()
+    }
+}
+
+/// Error type for response storage operations
+#[derive(Debug, thiserror::Error)]
+pub enum ResponseStorageError {
+    #[error("Response not found: {0}")]
+    ResponseNotFound(String),
+
+    #[error("Invalid chain: {0}")]
+    InvalidChain(String),
+
+    #[error("Storage error: {0}")]
+    StorageError(String),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+}
+
+pub type Result<T> = std::result::Result<T, ResponseStorageError>;
+
+/// Trait for response storage
+#[async_trait]
+pub trait ResponseStorage: Send + Sync {
+    /// Store a new response
+    async fn store_response(&self, response: StoredResponse) -> Result<ResponseId>;
+
+    /// Get a response by ID
+    async fn get_response(&self, response_id: &ResponseId) -> Result<Option<StoredResponse>>;
+
+    /// Delete a response
+    async fn delete_response(&self, response_id: &ResponseId) -> Result<()>;
+
+    /// Get the chain of responses leading to a given response
+    /// Returns responses in chronological order (oldest first)
+    async fn get_response_chain(
+        &self,
+        response_id: &ResponseId,
+        max_depth: Option<usize>,
+    ) -> Result<ResponseChain>;
+
+    /// List recent responses for a user
+    async fn list_user_responses(
+        &self,
+        user: &str,
+        limit: Option<usize>,
+    ) -> Result<Vec<StoredResponse>>;
+
+    /// Delete all responses for a user
+    async fn delete_user_responses(&self, user: &str) -> Result<usize>;
+}
+
+/// Type alias for shared storage
+pub type SharedResponseStorage = Arc<dyn ResponseStorage>;

--- a/sgl-router/src/lib.rs
+++ b/sgl-router/src/lib.rs
@@ -4,6 +4,7 @@ pub mod logging;
 use std::collections::HashMap;
 
 pub mod core;
+pub mod data_connector;
 #[cfg(feature = "grpc-client")]
 pub mod grpc;
 pub mod mcp;
@@ -229,6 +230,7 @@ impl Router {
             enable_igw: self.enable_igw,
             model_path: self.model_path.clone(),
             tokenizer_path: self.tokenizer_path.clone(),
+            history_backend: config::HistoryBackend::Memory,
         })
     }
 }

--- a/sgl-router/src/main.rs
+++ b/sgl-router/src/main.rs
@@ -1,7 +1,8 @@
 use clap::{ArgAction, Parser, ValueEnum};
 use sglang_router_rs::config::{
     CircuitBreakerConfig, ConfigError, ConfigResult, ConnectionMode, DiscoveryConfig,
-    HealthCheckConfig, MetricsConfig, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
+    HealthCheckConfig, HistoryBackend, MetricsConfig, PolicyConfig, RetryConfig, RouterConfig,
+    RoutingMode,
 };
 use sglang_router_rs::metrics::PrometheusConfig;
 use sglang_router_rs::server::{self, ServerConfig};
@@ -312,6 +313,10 @@ struct CliArgs {
     /// Explicit tokenizer path (overrides model_path tokenizer if provided)
     #[arg(long)]
     tokenizer_path: Option<String>,
+
+    /// History backend configuration (memory or none)
+    #[arg(long, default_value = "memory", value_parser = ["memory", "none"])]
+    history_backend: String,
 }
 
 impl CliArgs {
@@ -506,6 +511,10 @@ impl CliArgs {
             rate_limit_tokens_per_second: None,
             model_path: self.model_path.clone(),
             tokenizer_path: self.tokenizer_path.clone(),
+            history_backend: match self.history_backend.as_str() {
+                "none" => HistoryBackend::None,
+                _ => HistoryBackend::Memory,
+            },
         })
     }
 

--- a/sgl-router/src/service_discovery.rs
+++ b/sgl-router/src/service_discovery.rs
@@ -603,6 +603,7 @@ mod tests {
             reasoning_parser_factory: None, // HTTP mode doesn't need reasoning parser
             tool_parser_registry: None,     // HTTP mode doesn't need tool parser
             router_manager: None,           // Test doesn't need router manager
+            response_storage: Arc::new(crate::data_connector::MemoryResponseStorage::new()),
         });
 
         let router = Router::new(vec![], &app_context).await.unwrap();

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -58,6 +58,7 @@ impl TestContext {
             connection_mode: ConnectionMode::Http,
             model_path: None,
             tokenizer_path: None,
+            history_backend: sglang_router_rs::config::HistoryBackend::Memory,
         };
 
         Self::new_with_config(config, worker_configs).await
@@ -1392,6 +1393,7 @@ mod error_tests {
             connection_mode: ConnectionMode::Http,
             model_path: None,
             tokenizer_path: None,
+            history_backend: sglang_router_rs::config::HistoryBackend::Memory,
         };
 
         let ctx = TestContext::new_with_config(
@@ -1750,6 +1752,7 @@ mod pd_mode_tests {
             connection_mode: ConnectionMode::Http,
             model_path: None,
             tokenizer_path: None,
+            history_backend: sglang_router_rs::config::HistoryBackend::Memory,
         };
 
         // Create app context
@@ -1912,6 +1915,7 @@ mod request_id_tests {
             connection_mode: ConnectionMode::Http,
             model_path: None,
             tokenizer_path: None,
+            history_backend: sglang_router_rs::config::HistoryBackend::Memory,
         };
 
         let ctx = TestContext::new_with_config(

--- a/sgl-router/tests/request_formats_test.rs
+++ b/sgl-router/tests/request_formats_test.rs
@@ -3,9 +3,7 @@ mod common;
 use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType};
 use reqwest::Client;
 use serde_json::json;
-use sglang_router_rs::config::{
-    CircuitBreakerConfig, ConnectionMode, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
-};
+use sglang_router_rs::config::{RouterConfig, RoutingMode};
 use sglang_router_rs::routers::{RouterFactory, RouterTrait};
 use std::sync::Arc;
 
@@ -21,34 +19,10 @@ impl TestContext {
             mode: RoutingMode::Regular {
                 worker_urls: vec![],
             },
-            policy: PolicyConfig::Random,
-            host: "127.0.0.1".to_string(),
             port: 3003,
-            max_payload_size: 256 * 1024 * 1024,
-            request_timeout_secs: 600,
             worker_startup_timeout_secs: 1,
             worker_startup_check_interval_secs: 1,
-            dp_aware: false,
-            api_key: None,
-            discovery: None,
-            metrics: None,
-            log_dir: None,
-            log_level: None,
-            request_id_headers: None,
-            max_concurrent_requests: 64,
-            queue_size: 0,
-            queue_timeout_secs: 60,
-            rate_limit_tokens_per_second: None,
-            cors_allowed_origins: vec![],
-            retry: RetryConfig::default(),
-            circuit_breaker: CircuitBreakerConfig::default(),
-            disable_retries: false,
-            disable_circuit_breaker: false,
-            health_check: sglang_router_rs::config::HealthCheckConfig::default(),
-            enable_igw: false,
-            connection_mode: ConnectionMode::Http,
-            model_path: None,
-            tokenizer_path: None,
+            ..Default::default()
         };
 
         let mut workers = Vec::new();

--- a/sgl-router/tests/streaming_tests.rs
+++ b/sgl-router/tests/streaming_tests.rs
@@ -4,9 +4,7 @@ use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType
 use futures_util::StreamExt;
 use reqwest::Client;
 use serde_json::json;
-use sglang_router_rs::config::{
-    CircuitBreakerConfig, ConnectionMode, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
-};
+use sglang_router_rs::config::{RouterConfig, RoutingMode};
 use sglang_router_rs::routers::{RouterFactory, RouterTrait};
 use std::sync::Arc;
 
@@ -22,34 +20,10 @@ impl TestContext {
             mode: RoutingMode::Regular {
                 worker_urls: vec![],
             },
-            policy: PolicyConfig::Random,
-            host: "127.0.0.1".to_string(),
             port: 3004,
-            max_payload_size: 256 * 1024 * 1024,
-            request_timeout_secs: 600,
             worker_startup_timeout_secs: 1,
             worker_startup_check_interval_secs: 1,
-            dp_aware: false,
-            api_key: None,
-            discovery: None,
-            metrics: None,
-            log_dir: None,
-            log_level: None,
-            request_id_headers: None,
-            max_concurrent_requests: 64,
-            queue_size: 0,
-            queue_timeout_secs: 60,
-            rate_limit_tokens_per_second: None,
-            cors_allowed_origins: vec![],
-            retry: RetryConfig::default(),
-            circuit_breaker: CircuitBreakerConfig::default(),
-            disable_retries: false,
-            disable_circuit_breaker: false,
-            health_check: sglang_router_rs::config::HealthCheckConfig::default(),
-            enable_igw: false,
-            connection_mode: ConnectionMode::Http,
-            model_path: None,
-            tokenizer_path: None,
+            ..Default::default()
         };
 
         let mut workers = Vec::new();

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -191,6 +191,7 @@ mod test_pd_routing {
                 connection_mode: ConnectionMode::Http,
                 model_path: None,
                 tokenizer_path: None,
+                history_backend: sglang_router_rs::config::HistoryBackend::Memory,
             };
 
             // Router creation will fail due to health checks, but config should be valid


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Implements a interface for storage system for the OpenAI Responses API in the SGL Router. This PR provides local control over response persistence, enabling stateful conversation management independent of OpenAI's internal storage.

**Background**

The OpenAI Responses API uses a response chaining model where each response can reference a previous response via
 previous_response_id. This differs from the Chat Completions API (stateless with message arrays) We need our own storage layer to:
  - Control response persistence locally
  - Build conversation context from response chains
  - Support different storage backends


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
