### PR TITLE
Pipeline parallel idle optimization

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -423,6 +423,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--enable-mscclpp` | Enable using mscclpp for small messages for all-reduce kernel and fall back to NCCL. | `False` | bool flag (set to enable) |
 | `--enable-torch-symm-mem` | Enable using torch symm mem for all-reduce kernel and fall back to NCCL. Only supports CUDA device SM90 and above. SM90 supports world size 4, 6, 8. SM10 supports world size 6, 8. | `False` | bool flag (set to enable) |
 | `--disable-overlap-schedule` | Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker. | `False` | bool flag (set to enable) |
+| `--enable-pp-sleep-on-idle` | Enable pipeline parallel sleep while idle, preventing costly GPU polling during idle periods. | `False` | bool flag (set to enable) |
 | `--enable-mixed-chunk` | Enabling mixing prefill and decode in a batch when using chunked prefill. | `False` | bool flag (set to enable) |
 | `--enable-dp-attention` | Enabling data parallelism for attention and tensor parallelism for FFN. The dp size should be equal to the tp size. Currently DeepSeek-V2 and Qwen 2/3 MoE models are supported. | `False` | bool flag (set to enable) |
 | `--enable-dp-lm-head` | Enable vocabulary parallel across the attention TP group to avoid all-gather across DP groups, optimizing performance under DP attention. | `False` | bool flag (set to enable) |

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -297,6 +297,7 @@ class Scheduler(
         self.max_loras_per_batch = server_args.max_loras_per_batch
         self.enable_overlap = not server_args.disable_overlap_schedule
         self.enable_pdmux = server_args.enable_pdmux
+        self.enable_pp_sleep_on_idle = server_args.enable_pp_sleep_on_idle
         self.skip_tokenizer_init = server_args.skip_tokenizer_init
         self.enable_metrics = server_args.enable_metrics
         self.enable_metrics_for_all_schedulers = (
@@ -450,6 +451,40 @@ class Scheduler(
             self.send_metrics_from_scheduler = get_zmq_socket(
                 context, zmq.PUSH, port_args.metrics_ipc_name, False
             )
+
+        self.pp_idle_wakeup_listener_socket = None
+        self.pp_idle_wakeup_notifier_socket = None
+
+        if self.enable_pp_sleep_on_idle:
+            # Listen for wake signals
+            if (
+                self.dp_rank,
+                self.pp_rank,
+            ) in port_args.pp_idle_wakeup_listeners_ipc_names:
+                self.pp_idle_wakeup_listener_socket = get_zmq_socket(
+                    context,
+                    zmq.PULL,
+                    port_args.pp_idle_wakeup_listeners_ipc_names[
+                        self.dp_rank, self.pp_rank
+                    ],
+                    True,
+                )
+                # Set 1-second timeout for periodic maintenance
+                self.pp_idle_wakeup_listener_socket.setsockopt(zmq.RCVTIMEO, 1000)
+
+            # Notify with wake signals
+            if (
+                self.dp_rank,
+                self.pp_rank,
+            ) in port_args.pp_idle_wakeup_notifiers_ipc_names:
+                self.pp_idle_wakeup_notifier_socket = get_zmq_socket(
+                    context,
+                    zmq.PUSH,
+                    port_args.pp_idle_wakeup_notifiers_ipc_names[
+                        self.dp_rank, self.pp_rank
+                    ],
+                    False,
+                )
 
     def init_tokenizer(self):
         server_args = self.server_args
@@ -1206,6 +1241,14 @@ class Scheduler(
                 recv_reqs = None
         else:
             if self.attn_tp_rank == 0:
+                # Wait for wake signal
+                if self.pp_idle_wakeup_listener_socket:
+                    try:
+                        self.pp_idle_wakeup_listener_socket.recv()
+                    except zmq.Again:
+                        return []
+
+                # There is work to be done now
                 dp_offset = self.attn_dp_rank * self.attn_tp_size
                 recv_reqs = point_to_point_pyobj(
                     [],

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -860,6 +860,10 @@ class SchedulerPPMixin:
     def _pp_send_pyobj_to_next_stage(self: Scheduler, data, async_send: bool = False):
         p2p_work = []
         if self.attn_tp_rank == 0:
+            # Send wake signal before reqs
+            if self.pp_idle_wakeup_notifier_socket:
+                self.pp_idle_wakeup_notifier_socket.send(b"WAKE")
+
             dp_offset = self.attn_dp_rank * self.attn_tp_size
             p2p_work = point_to_point_pyobj(
                 data,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -588,6 +588,7 @@ class ServerArgs:
     enable_mscclpp: bool = False
     enable_torch_symm_mem: bool = False
     disable_overlap_schedule: bool = False
+    enable_pp_sleep_on_idle: bool = False
     enable_mixed_chunk: bool = False
     enable_dp_attention: bool = False
     enable_dp_lm_head: bool = False
@@ -2192,6 +2193,14 @@ class ServerArgs:
             self.disable_overlap_schedule = True
             logger.warning(
                 "Pipeline parallelism is incompatible with overlap schedule."
+            )
+
+        if self.enable_pp_sleep_on_idle and (
+            (pp_size_per_node := max(self.pp_size // self.nnodes, 1)) <= 1
+        ):
+            self.enable_pp_sleep_on_idle = False
+            logger.warning(
+                "Pipeline parallelism sleep on idle is only compatible for pipeline parallelism occurring within nodes."
             )
 
     def _handle_hicache(self):
@@ -4436,6 +4445,11 @@ class ServerArgs:
             help="Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker.",
         )
         parser.add_argument(
+            "--enable-pp-sleep-on-idle",
+            action="store_true",
+            help="Enable pipeline parallel sleep while idle, preventing costly GPU polling during idle periods.",
+        )
+        parser.add_argument(
             "--enable-mixed-chunk",
             action="store_true",
             help="Enabling mixing prefill and decode in a batch when using chunked prefill.",
@@ -5495,6 +5509,15 @@ class PortArgs:
     # The ipc filename for Tokenizer and worker tokenizer
     tokenizer_worker_ipc_name: Optional[str]
 
+    # The ipc filenames for PP ranks succeeding other stages on same node (zmq)
+    pp_idle_wakeup_listeners_ipc_names: Optional[
+        dict[tuple[Optional[int], int], str]
+    ] = dataclasses.field(default_factory=dict)
+    # The ipc filenames for PP ranks preceding other stages on same node (zmq)
+    pp_idle_wakeup_notifiers_ipc_names: Optional[
+        dict[tuple[Optional[int], int], str]
+    ] = dataclasses.field(default_factory=dict)
+
     @staticmethod
     def init_new(
         server_args: ServerArgs,
@@ -5530,6 +5553,8 @@ class PortArgs:
                 rpc_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",
                 metrics_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",
                 tokenizer_worker_ipc_name=tokenizer_worker_ipc_name,
+                pp_idle_wakeup_listeners_ipc_names={},
+                pp_idle_wakeup_notifiers_ipc_names={},
             )
         else:
             # DP attention. Use TCP + port to handle both single-node and multi-node.
@@ -5584,6 +5609,8 @@ class PortArgs:
                 rpc_ipc_name=f"tcp://{dist_init_host}:{rpc_port}",
                 metrics_ipc_name=f"tcp://{dist_init_host}:{metrics_ipc_name}",
                 tokenizer_worker_ipc_name=tokenizer_worker_ipc_name,
+                pp_idle_wakeup_listeners_ipc_names={},
+                pp_idle_wakeup_notifiers_ipc_names={},
             )
 
 

--- a/test/registered/distributed/test_pp_single_node.py
+++ b/test/registered/distributed/test_pp_single_node.py
@@ -379,6 +379,31 @@ class TestFixedBugs(unittest.TestCase):
         )
 
 
+class TestPPSleepOnIdle(unittest.TestCase):
+    def test_pp_sleep_on_idle_basic(self):
+        """Test that PP sleep on idle doesn't break basic functionality"""
+        model = DEFAULT_MODEL_NAME_FOR_TEST
+        server_args = ServerArgs(model_path=model)
+        bench_args = OneBatchBenchArgs(
+            batch_size=(1,),
+            input_len=(10,),
+            output_len=(10,),
+            base_url=DEFAULT_URL_FOR_TEST,
+        )
+        other_server_args = [
+            "--pp-size",
+            2,
+            "--enable-pp-sleep-on-idle",
+        ]
+        run_bench_one_batch_server(
+            model,
+            DEFAULT_URL_FOR_TEST,
+            server_args,
+            bench_args,
+            other_server_args,
+        )
+
+
 @unittest.skipIf(
     is_in_ci(), "Skipping GLM41V PP accuracy test before it gets more stable"
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Online serving with pipeline parallelism currently suffers from a big problem where same-node GPUs with `pp_rank > 0` spin incessantly **while idle**, incurring near 100% utilization and wasting significant power. 

I first observe this on my 2x3090 single-node system with `--pp-size 2` and PP layer partition split 3:1. While idle, 2nd GPU (PP rank 1) draws constant 150W and 100% utilization.

This may not seem like a whole lot when compared to data center setups, but it leaves the gpu unusable for other tasks (despite only using ~8GB VRAM in my case), causes fans to whine nonstop, spikes my electricity bill, and overall contributes to avoidable wear and tear.

I traced this undesirable behavior down to how non-zero-rank PP stages poll recv which internally calls NCCL's `cudaStreamSynchronize`. Profiling with Nsys confirms this.

The solution proposed in this PR is actually quite simple and non-invasive. I discuss more in following section, but we can solve the problem by adding a touch of idle-friendly CPU sync via ZMQ.

This reducing power consumption while idle from ~150W to ~30W, enables GPU to enter proper sleep state, and generally frees it for other tasks since it's not stuck spinning at 100%.

The theoretical performance impact is truly negligible. In practice, I was actually happily surprised to observe modest performance **gains** of ~5% (discussed below).

I will stop rambling, but please advise if I can provide any more detail and/or if any revisions are needed.

CCing pipeline parallelism owner @Ying1123 for review as per contribution guide.
  
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

  - **Added `--enable-pp-sleep-on-idle` flag**: Opt-in feature for when `--pp-size > 1` and `pp_size_per_node > 1`. I personally don't see any reason not to just bake it in, but figured it's better to start defensively.
  - **Implemented CPU-only wake signaling**: Uses ZMQ PUSH/PULL sockets to coordinate PP stages without GPU involvement
    - PP rank N sends wake signal before sending work to PP rank N+1
    - PP rank N+1 waits on ZMQ socket instead of NCCL polling when idle
  - **Modified files**:
    - `scheduler.py`: Added wake socket initialization and idle wait logic
    - `server_args.py`: Added new flag and IPC mappings for wake sockets
    - `engine.py` & `data_parallel_controller.py`: Setup wake socket connections for same-node PP ranks
    - `docs/advanced_features/server_arguments.md`: Documented new flag
    - `test/srt/test_pp_single_node.py`: Added basic test
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

N/A -- no changes to anything that would affect model accuracy.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

I've run a slew of benchmarks and tests to catch any performance regressions or sync issues.

For this section, I show results comparing "flag" (`--enable-pp-sleep-on-idle` enabled) vs "baseline" (code without any of my changes).

For these tests, I use dense Qwen3-32B on single node and `--pp-size 2` with PP layer partition split 3:1.

I run benchmarks with following:
``` bash
docker compose --env-file .env -f docker-compose.sglang.yml run --rm \
    --entrypoint "python -m sglang.bench_serving" sglang \
    --backend sglang-oai \
    --host sglang \
    --port 8080 \
    --dataset-name random \
    --num-prompts 256 \
    --random-input-len 1024 \
    --random-output-len 512 \
    --random-range-ratio 0.2 \
    --max-concurrency 16 \
    --request-rate 16 \
    --warmup-requests 16 \
    --apply-chat-template \
    --extra-request-body '{"temperature":0.7,"top_p":0.8,"top_k":20,"min_p":0,"chat_template_kwargs":{"enable_thinking":false}}'
```

As this is running, I use `nvidia-smi` to collect data for analysis. Lets start by looking at results of one benchmark comparison:

<img width="2061" height="956" alt="pr-comparison-annotated-focused" src="https://github.com/user-attachments/assets/5027f122-11ee-4936-b932-7217eea97f56" />

I should have extended the window to cover more idle time, but take a close look before and after the benchmark runs. For GPU 1 (`pp_rank > 0`) note the distinct and unrelenting elevated plateau of power and utilization on the baseline (right). Now note how with the flag enabled, the usage and power actually drop to true idling state while idle (left).

Now let's check on performance, I was initially concerned that the solution might hurt performance due to sync overhead. Here are 3 trials (6 benchmarks) comparing baseline (without my changes) vs flag (include my changes and set `--enable-pp-sleep-on-idle`).

| Metric | Baseline 1 | Baseline 2 | Baseline 3 | **Baseline Avg** | Flag 1 | Flag 2 | Flag 3 | **Flag Avg** | **% Diff (Flag vs Baseline)** |
|--------|------------|------------|------------|------------------|---------|---------|---------|--------------|-------------------------------|
| **Benchmark duration (s)** | 596.03 | 613.21 | 562.59 | **590.61** | 609.87 | 542.24 | 527.16 | **559.76** | **-5.2%** |
| **Request throughput (req/s)** | 0.43 | 0.42 | 0.46 | **0.44** | 0.42 | 0.47 | 0.49 | **0.46** | **+4.5%** |
| **Input token throughput (tok/s)** | 261.14 | 253.82 | 276.66 | **263.87** | 255.21 | 287.04 | 295.25 | **279.17** | **+5.8%** |
| **Output token throughput (tok/s)** | 135.37 | 131.58 | 143.42 | **136.79** | 132.30 | 148.80 | 153.06 | **144.72** | **+5.8%** |
| **Total token throughput (tok/s)** | 396.51 | 385.40 | 420.07 | **400.66** | 387.51 | 435.84 | 448.31 | **423.89** | **+5.8%** |
| **Mean E2E Latency (ms)** | 36,130.29 | 37,106.19 | 33,928.42 | **35,721.63** | 36,987.83 | 32,748.57 | 31,817.27 | **33,851.22** | **-5.2%** |
| **Median E2E Latency (ms)** | 35,254.99 | 36,312.87 | 33,274.76 | **34,947.54** | 36,250.98 | 31,236.85 | 30,624.33 | **32,704.05** | **-6.4%** |
| **Mean TTFT (ms)** | 1,411.06 | 1,473.27 | 1,356.12 | **1,413.48** | 1,459.29 | 1,305.98 | 1,276.88 | **1,347.38** | **-4.7%** |
| **Median TTFT (ms)** | 1,085.16 | 1,126.55 | 1,058.60 | **1,090.10** | 1,152.60 | 985.95 | 937.75 | **1,025.43** | **-5.9%** |
| **P99 TTFT (ms)** | 6,593.62 | 6,557.62 | 6,396.49 | **6,515.91** | 6,469.77 | 6,282.74 | 6,403.28 | **6,385.26** | **-2.0%** |
| **Mean ITL (ms)** | 110.52 | 113.42 | 103.68 | **109.21** | 113.09 | 100.08 | 97.25 | **103.47** | **-5.3%** |
| **Median ITL (ms)** | 69.21 | 70.94 | 64.84 | **68.33** | 71.93 | 61.90 | 59.96 | **64.60** | **-5.5%** |
| **P95 ITL (ms)** | 217.64 | 214.15 | 183.85 | **205.21** | 214.90 | 176.12 | 173.14 | **188.05** | **-8.4%** |
| **P99 ITL (ms)** | 1,289.18 | 1,359.18 | 1,193.78 | **1,280.71** | 1,328.65 | 1,174.56 | 1,126.17 | **1,209.79** | **-5.5%** |

**Notable takeaways:**
- While idle (e.g. the time between sglang being ready and me actually starting the benchmark, and the time between benchmark completing and me killing the container) "flag" goes truly idle ~30W ~0% util whereas "baseline" eats 2nd GPU at constant ~150W and ~100% util.
- Benchmarks show increase in throughput by ~5.8%, and reduction to latency by 5-6% on average

I honestly wasn't expecting performance gains here, I'm mostly in this for the true idle. Thinking about it though, it Is plausible that less NCCL polling overhead makes everything more efficient with less context switching, or maybe it has something to do with avoiding thermal throttling caused by the unnecessary polling. Or maybe its not statistically significant. But in any case, the point here it to show this implementation does not hurt performance.

In any case, I'd argue this PR is huge for anyone wanting to run PP efficiently, especially with asymmetric partitioning and shared workloads. And as a ~100 LOC opt-in change without concessions, I look forward to this helping drive sglang even further ahead of the competition.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
