### PR TITLE
[bugfix]hicache bench_long_context.py run failed

### DIFF
--- a/benchmark/hicache/bench_long_context.py
+++ b/benchmark/hicache/bench_long_context.py
@@ -65,6 +65,7 @@ class ContextWorkloadGenerator(WorkloadGenerator):
 
         self.max_parallel = args.max_parallel
         self.logfile = args.log_file
+        self.enable_round_barrier = False
 
     def response_handler(self):
         while True:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

fix hicache bench_long_context.py failure
```
Traceback (most recent call last):
  File "/home/zhangchen50/sglang-main/benchmark/hicache/bench_long_context.py", line 104, in <module>
    performance_data = ContextWorkloadGenerator(args).run()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zhangchen50/sglang-main/benchmark/hicache/bench_multiturn.py", line 513, in run
    if self.enable_round_barrier:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ContextWorkloadGenerator' object has no attribute 'enable_round_barrier'
```

introduced by #10203

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
