### PR TITLE
[improvement] add average input/output token length for hicache benchmark stats output

### DIFF
--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -479,10 +479,18 @@ class WorkloadGenerator:
             "summary": {
                 "total_requests": len(self.performance_metrics["ttft"]),
                 "request_rate": self.request_rate,
-                "average_prompt_len": sum(self.performance_metrics["prompt_len"])
-                / len(self.performance_metrics["prompt_len"]),
-                "average_output_len": sum(self.performance_metrics["generated_len"])
-                / len(self.performance_metrics["generated_len"]),
+                "average_prompt_len": (
+                    sum(self.performance_metrics["prompt_len"])
+                    / len(self.performance_metrics["prompt_len"])
+                    if self.performance_metrics["prompt_len"]
+                    else 0.0
+                ),
+                "average_output_len": (
+                    sum(self.performance_metrics["generated_len"])
+                    / len(self.performance_metrics["generated_len"])
+                    if self.performance_metrics["generated_len"]
+                    else 0.0
+                ),
                 "average_ttft": sum(self.performance_metrics["ttft"])
                 / len(self.performance_metrics["ttft"]),
                 "p90_ttft": sorted(self.performance_metrics["ttft"])[

--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -479,6 +479,10 @@ class WorkloadGenerator:
             "summary": {
                 "total_requests": len(self.performance_metrics["ttft"]),
                 "request_rate": self.request_rate,
+                "average_prompt_len": sum(self.performance_metrics["prompt_len"])
+                / len(self.performance_metrics["prompt_len"]),
+                "average_output_len": sum(self.performance_metrics["generated_len"])
+                / len(self.performance_metrics["generated_len"]),
                 "average_ttft": sum(self.performance_metrics["ttft"])
                 / len(self.performance_metrics["ttft"]),
                 "p90_ttft": sorted(self.performance_metrics["ttft"])[
@@ -533,6 +537,12 @@ class WorkloadGenerator:
         print("Performance metrics summary:")
         print(
             f"  Total requests: {performance_data['summary']['total_requests']} at {performance_data['summary']['request_rate']} requests per second"
+        )
+        print(
+            f"  Average Prompt Length: {performance_data['summary']['average_prompt_len']:.2f} tokens"
+        )
+        print(
+            f"  Average Output Length: {performance_data['summary']['average_output_len']:.2f} tokens"
         )
         print(f"  Average TTFT: {performance_data['summary']['average_ttft']:.2f}")
         print(f"  P90 TTFT: {performance_data['summary']['p90_ttft']:.2f}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

average input token length affects TTFT a lot, we should print the input/output length in the final report of hicache benchmarks

## Modifications

Performance metrics summary:
  Total requests: 256 at 24 requests per second
  **Average Prompt Length: 20260.29 tokens
  Average Output Length: 15.34 tokens**
  Average TTFT: 7.53
  P90 TTFT: 11.20
  Median TTFT: 3.62
  Average latency: 24.88
  P90 latency: 72.42
  Median latency: 11.45
  Input token throughput: 19306.06 tokens per second
  Output token throughput: 14.62 tokens per second
  Request Throughput: 0.95 requests per second
  Cache Hit Rate: 0.716130

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
