### PR TITLE
The allreduce-rmsnorm-fusion operator based on multimem

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -262,6 +262,7 @@ endif()
 set(SOURCES
     "csrc/allreduce/custom_all_reduce.cu"
     "csrc/allreduce/mscclpp_allreduce.cu"
+    "csrc/allreduce_rmsnorm_fusion/fused_kernels.cu"
     "csrc/attention/cascade.cu"
     "csrc/attention/cutlass_mla_kernel.cu"
     "csrc/attention/lightning_attention_decode_kernel.cu"

--- a/sgl-kernel/csrc/allreduce_rmsnorm_fusion/dispatch_utils.h
+++ b/sgl-kernel/csrc/allreduce_rmsnorm_fusion/dispatch_utils.h
@@ -1,0 +1,76 @@
+/*
+ * Adapted from
+ * https://github.com/pytorch/pytorch/blob/v2.0.1/aten/src/ATen/Dispatch.h
+ */
+#pragma once
+
+#include <torch/all.h>
+
+// Need a special dispatch case macro since we will nest the FP8 dispatch.
+// Instead of the usual 'scalar_t', this names the dispatched type 'fp8_t'.
+#define AT_DISPATCH_FP8_CASE(enum_type, ...) \
+  AT_PRIVATE_CASE_TYPE_USING_HINT(enum_type, fp8_t, __VA_ARGS__)
+
+#define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)         \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
+
+#define VLLM_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, VLLM_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__))
+
+
+#define VLLM_BF16_DISPATCH_CASE_FLOATING_TYPES(...)         \
+  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
+
+#define VLLM_BF16_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, VLLM_BF16_DISPATCH_CASE_FLOATING_TYPES(__VA_ARGS__))
+
+// ROCm devices might use either fn or fnuz, so set up dispatch table for both.
+// A host-based check at runtime will create a preferred FP8 type for ROCm
+// such that the correct kernel is dispatched.
+#ifdef USE_ROCM
+  #define VLLM_DISPATCH_CASE_FP8_TYPES(...)                          \
+    AT_DISPATCH_FP8_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__) \
+    AT_DISPATCH_FP8_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__)
+
+  #define VLLM_DISPATCH_CASE_QUANT_TYPES(...)                      \
+    AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__)   \
+    AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fnuz, __VA_ARGS__) \
+    AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)
+#else
+  #define VLLM_DISPATCH_CASE_FP8_TYPES(...) \
+    AT_DISPATCH_FP8_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__)
+
+  #define VLLM_DISPATCH_CASE_QUANT_TYPES(...)                    \
+    AT_DISPATCH_CASE(at::ScalarType::Float8_e4m3fn, __VA_ARGS__) \
+    AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)
+#endif
+
+// When using this dispatch macro, the type is 'fp8_t' not 'scalar_t'.
+// See AT_DISPATCH_FP8_CASE above.
+#define VLLM_DISPATCH_FP8_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, VLLM_DISPATCH_CASE_FP8_TYPES(__VA_ARGS__))
+
+#define VLLM_DISPATCH_QUANT_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, VLLM_DISPATCH_CASE_QUANT_TYPES(__VA_ARGS__))
+
+#define VLLM_DISPATCH_CASE_FLOATING_AND_BYTE_TYPES(...)   \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)    \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)     \
+  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__)
+
+#define VLLM_DISPATCH_FLOATING_AND_BYTE_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME,                               \
+                     VLLM_DISPATCH_CASE_FLOATING_AND_BYTE_TYPES(__VA_ARGS__))
+
+#define VLLM_DISPATCH_CASE_INTEGRAL_TYPES(...)         \
+  AT_DISPATCH_CASE(at::ScalarType::Byte, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::Char, __VA_ARGS__)  \
+  AT_DISPATCH_CASE(at::ScalarType::Short, __VA_ARGS__) \
+  AT_DISPATCH_CASE(at::ScalarType::Int, __VA_ARGS__)   \
+  AT_DISPATCH_CASE(at::ScalarType::Long, __VA_ARGS__)
+
+#define VLLM_DISPATCH_INTEGRAL_TYPES(TYPE, NAME, ...) \
+  AT_DISPATCH_SWITCH(TYPE, NAME, VLLM_DISPATCH_CASE_INTEGRAL_TYPES(__VA_ARGS__))

--- a/sgl-kernel/csrc/allreduce_rmsnorm_fusion/fused_kernels.cu
+++ b/sgl-kernel/csrc/allreduce_rmsnorm_fusion/fused_kernels.cu
@@ -1,0 +1,202 @@
+#include "type_convert.cuh"
+#include "dispatch_utils.h"
+
+#include <torch/cuda.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#ifndef USE_ROCM
+#include <cub/cub.cuh>
+#else
+#include <hipcub/hipcub.hpp>
+#endif
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/all.h>
+#include <cmath>
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && CUDART_VERSION >= 12010
+#define NVCC_SUPPORTS_MULTICAST 1
+#endif
+
+#include <ATen/ATen.h>
+#if !defined(USE_ROCM)
+#include <cuda_bf16.h>
+#endif
+
+#include "multimem_utils.cuh"
+#include <cassert>
+
+
+//copy from https://github.com/microsoft/tokenweave/blob/main/csrc/tokenweave_fused_kernels.cu
+
+
+/* 
+* ********************************************************* *
+* FUSED RS + RESIDUAL ADD + RMS NORM + AG CTA-BASED KERNEL  *
+* Function specialization in the case of BF16/FP16 tensors. *
+* ********************************************************* *
+*/
+namespace vllm
+{
+template <typename scalar_t, int width>
+__global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
+fused_rs_ln_ag_cta_kernel(
+    scalar_t *__restrict__ input,        // [..., hidden_size]
+    scalar_t *__restrict__ mcptr,        // [..., hidden_size] multimem_ptr
+    scalar_t *__restrict__ residual,     // [..., hidden_size]
+    const scalar_t *__restrict__ weight, // [hidden_size]
+    uint32_t **signal_pads,
+    size_t rank,
+    size_t world_size,
+    const float epsilon,
+    const int num_tokens,
+    const int hidden_size)
+{
+
+  // Check vectorization assumptions
+  static_assert(std::is_pod_v<_f16Vec<scalar_t, width>>);
+  static_assert(sizeof(_f16Vec<scalar_t, width>) == sizeof(scalar_t) * width);
+
+  const int vec_hidden_size = hidden_size / width;
+  using vec_t = _f16Vec<scalar_t, width>;
+
+  // Type-punned vector pointers
+  auto *__restrict__ input_v = reinterpret_cast<vec_t *>(input);
+  auto *__restrict__ residual_v = reinterpret_cast<vec_t *>(residual);
+  auto *__restrict__ weight_v = reinterpret_cast<const vec_t *>(weight);
+  int tokens_per_iter = (num_tokens + gridDim.x - 1) / gridDim.x;
+
+  sync_remote_blocks<MemOpSem::Relaxed>(signal_pads, rank, world_size);
+  __syncthreads();
+
+  #pragma unroll
+  for (int iter = 0; iter < tokens_per_iter; iter++)
+  {
+    int token_id = blockIdx.x + iter * gridDim.x;
+    if (token_id >= num_tokens)
+      continue;
+    float variance[1] = {0.0f};
+    const int tid = threadIdx.x;
+    const int bdimx = blockDim.x;
+
+    __shared__ float s_variance;
+    int offset = token_id * vec_hidden_size;
+    int offset_scalar = token_id * hidden_size;
+    auto input_o = input_v + offset;
+    auto residual_o = residual_v + offset;
+
+    for (int idx = tid; idx < vec_hidden_size; idx += bdimx)
+    {
+      auto mtemp = multimem_ld_reduce_add<16>(mcptr + offset_scalar + idx * width);
+      vec_t temp = *(reinterpret_cast<vec_t *>(&mtemp));
+      temp += residual_o[idx];
+      variance[0] += temp.sum_squares(); // FP32 accumulation
+      residual_o[idx] = temp;
+      // multimem_st<16>(residual_mcptr + offset_scalar + idx * width, 
+      //                *(reinterpret_cast<Vec<16> *>(&temp)));
+    }
+
+    blockReduceSum<float, 1>(variance);
+    if (threadIdx.x == 0)
+    {
+      s_variance = rsqrtf(variance[0] / hidden_size + epsilon);
+    }
+    __syncthreads();
+
+    // Second pass: normalize and apply weight
+    for (int idx = tid; idx < vec_hidden_size; idx += bdimx)
+    {
+      vec_t shared_weight = weight_v[idx];
+      vec_t temp = residual_o[idx];
+      temp *= s_variance;
+      temp *= shared_weight;
+      multimem_st<16>(mcptr + offset_scalar + idx * width, *(reinterpret_cast<Vec<16> *>(&temp)));
+    }
+  }
+  __syncthreads();
+  sync_remote_blocks<MemOpSem::AcqRel>(signal_pads, rank, world_size);
+}
+
+/* 
+* ********************************************************* *
+* FUSED RS + RESIDUAL ADD + RMS NORM + AG CTA-BASED KERNEL  *
+* GENERIC NOT SUPPORTED                                     *
+* ********************************************************* *
+*/
+template <typename scalar_t, int width>
+__global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
+fused_rs_ln_ag_cta_kernel(
+    scalar_t *__restrict__ input,        // [..., hidden_size]
+    scalar_t *__restrict__ mcptr,        // [..., hidden_size] multimem_ptr
+    scalar_t *__restrict__ residual,     // [..., hidden_size]
+    const scalar_t *__restrict__ weight, // [hidden_size]
+    uint32_t **signal_pads,
+    size_t rank,
+    size_t world_size,
+    const float epsilon,
+    const int num_tokens,
+    const int hidden_size)
+{
+  /* Not supported */
+  assert(false && "TokenWeave currently only supports bf16/fp16 with width 8.");
+}
+} //namespace vllm
+
+/* 
+* ******************************************************************* *
+* Fused ReduceScatter plus Fused(Residual, RMSNorm) plus AllGather    *
+* ******************************************************************* *
+*/
+#define LAUNCH_FUSED_RS_LN_AG_CTA(width)                                                                                                   \
+  VLLM_BF16_DISPATCH_FLOATING_TYPES(                                                                                                       \
+      input.scalar_type(), "fused_rs_ln_ag_cta_kernel", [&] { vllm::fused_rs_ln_ag_cta_kernel<scalar_t, width>                             \
+                                                                  <<<grid, block, 0, stream>>>(input.data_ptr<scalar_t>(),                 \
+                                                                                               reinterpret_cast<scalar_t *>(mcptr),        \
+                                                                                               residual.data_ptr<scalar_t>(),              \
+                                                                                               weight.data_ptr<scalar_t>(),                \
+                                                                                               reinterpret_cast<uint32_t **>(signal_pads), \
+                                                                                               static_cast<size_t>(rank),                  \
+                                                                                               static_cast<size_t>(world_size),            \
+                                                                                               epsilon, num_tokens, hidden_size); });
+void fused_rs_ln_ag_cta(torch::Tensor &input,    // [..., hidden_size]
+                        torch::Tensor &residual, // [..., hidden_size]
+                        torch::Tensor &weight,   // [hidden_size]
+                        int64_t mcptr,           // [..., hidden_size] multimem_ptr
+                        int64_t signal_pads,     // [..., hidden_size] signal pads
+                        int64_t rank,
+                        int64_t world_size,
+                        int64_t MAX_CTAS,
+                        double epsilon)
+{
+  int hidden_size = input.size(-1);
+  int num_tokens = input.numel() / hidden_size;
+
+  dim3 grid(MAX_CTAS);                                          // full coverage
+  dim3 block(std::min(1024, (hidden_size / 8 + 31) / 32 * 32)); // match kernel assumptions
+  /* This kernel is memory-latency bound in many scenarios.
+     When num_tokens is large, a smaller block size allows
+     for increased block occupancy on CUs and better latency
+     hiding on global mem ops. */
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  /*If the tensor types are FP16/BF16, try to use the optimized kernel
+    with packed + vectorized ops.
+    Max optimization is achieved with a width-8 vector of FP16/BF16s
+    since we can load at most 128 bits at once in a global memory op.
+    However, this requires each tensor's data to be aligned to 16
+    bytes.
+   */
+  auto inp_ptr = reinterpret_cast<std::uintptr_t>(input.data_ptr());
+  auto res_ptr = reinterpret_cast<std::uintptr_t>(residual.data_ptr());
+  auto wt_ptr = reinterpret_cast<std::uintptr_t>(weight.data_ptr());
+  bool ptrs_are_aligned =
+      inp_ptr % 16 == 0 && res_ptr % 16 == 0 && wt_ptr % 16 == 0;
+  if (ptrs_are_aligned && hidden_size % 8 == 0)
+  {
+    LAUNCH_FUSED_RS_LN_AG_CTA(8);
+  }
+  else
+  {
+    TORCH_CHECK(false, "Input, residual, and weight tensors must be 16-byte aligned and hidden_size must be divisible by 8 for optimized kernel.");
+  }
+}

--- a/sgl-kernel/csrc/allreduce_rmsnorm_fusion/multimem_utils.cuh
+++ b/sgl-kernel/csrc/allreduce_rmsnorm_fusion/multimem_utils.cuh
@@ -1,0 +1,402 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+namespace vllm {
+
+/* 
+* ********************************************************** *
+* Code copied from Pytorch codebase:                         *
+* https://github.com/pytorch/pytorch/blob/f6275bf0fe198f7f27569776ec221eb040a4cfa2/torch/csrc/distributed/c10d/CUDASymmetricMemoryOps.cu#L129                     *
+* Multimem All Reduce Meta kernel                            *
+* ********************************************************** *
+*/
+template <typename T>
+__inline__ size_t get_alignment(T ptr_or_size)
+{
+  auto val = reinterpret_cast<uintptr_t>(ptr_or_size);
+  if (val % 16 == 0)
+  {
+    return 16;
+  }
+  else if (val % 8 == 0)
+  {
+    return 8;
+  }
+  else if (val % 4 == 0)
+  {
+    return 4;
+  }
+  else if (val % 2 == 0)
+  {
+    return 2;
+  }
+  else
+  {
+    return 1;
+  }
+}
+
+template <>
+__inline__ size_t get_alignment<size_t>(size_t size)
+{
+  return get_alignment(reinterpret_cast<void *>(size));
+}
+
+template <bool Value, class... Args>
+inline constexpr bool dependent_bool_value = Value;
+
+template <class... Args>
+inline constexpr bool dependent_false = dependent_bool_value<false, Args...>;
+
+template <auto... Args>
+inline constexpr bool dependent_false_nt =
+    dependent_bool_value<false, decltype(Args)...>;
+
+enum class MemOpSem
+{
+  Relaxed,
+  Acquire,
+  Release,
+  AcqRel,
+};
+
+#define CAS_ASM(addr, compare, val, old_val, sem)                 \
+asm volatile("atom.global" sem ".sys.cas.b32 %0, [%1], %2, %3;" \
+              : "=r"(old_val)                                    \
+              : "l"(addr), "r"(compare), "r"(val)                \
+              : "memory");
+
+template <MemOpSem Sem>
+__device__ __forceinline__ uint32_t
+cas(uint32_t *addr, uint32_t compare, uint32_t val)
+{
+#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+  CUDA_KERNEL_ASSERT(false);
+  return 0;
+#else
+  uint32_t old_val;
+  if constexpr (Sem == MemOpSem::Relaxed)
+  {
+    CAS_ASM(addr, compare, val, old_val, ".relaxed");
+  }
+  else if constexpr (Sem == MemOpSem::Acquire)
+  {
+    CAS_ASM(addr, compare, val, old_val, ".acquire");
+  }
+  else if constexpr (Sem == MemOpSem::Release)
+  {
+    CAS_ASM(addr, compare, val, old_val, ".release");
+  }
+  else
+  {
+    static_assert(dependent_false_nt<Sem>);
+  }
+  return old_val;
+#endif
+}
+
+__device__ __forceinline__ void trap()
+{
+#if defined(USE_ROCM)
+  assert(0);
+#else
+  __trap();
+#endif
+}
+
+__device__ __forceinline__ size_t global_timer_ns()
+{
+#if defined(USE_ROCM)
+  CUDA_KERNEL_ASSERT(false);
+  return 0;
+#else
+  size_t val;
+  asm volatile("mov.u64 %0, %globaltimer;" : "=l"(val) : : "memory");
+  return val;
+#endif
+}
+
+constexpr size_t ns_per_ms = 1e6;
+
+template <MemOpSem Sem>
+__device__ __forceinline__ bool try_put_signal(
+    uint32_t *addr,
+    size_t timeout_ms)
+{
+  size_t deadline = global_timer_ns() + timeout_ms * ns_per_ms;
+  while (cas<Sem>(addr, 0, 1) != 0)
+  {
+    if (timeout_ms != 0 && global_timer_ns() > deadline)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <MemOpSem Sem>
+__device__ __forceinline__ bool try_wait_signal(
+    uint32_t *addr,
+    size_t timeout_ms)
+{
+  size_t deadline = global_timer_ns() + timeout_ms * ns_per_ms;
+  while (cas<Sem>(addr, 1, 0) != 1)
+  {
+    if (timeout_ms != 0 && global_timer_ns() > deadline)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <MemOpSem Sem>
+__device__ __forceinline__ void put_signal(uint32_t *addr)
+{
+  while (cas<Sem>(addr, 0, 1) != 0)
+    ;
+}
+
+template <MemOpSem Sem>
+__device__ __forceinline__ void wait_signal(uint32_t *addr)
+{
+  while (cas<Sem>(addr, 1, 0) != 1)
+    ;
+}
+
+template <MemOpSem Sem>
+__device__ __forceinline__ void sync_remote_blocks(
+    uint32_t **signal_pads,
+    size_t rank,
+    size_t world_size);
+
+template <>
+__device__ __forceinline__ void sync_remote_blocks<MemOpSem::Relaxed>(
+    uint32_t **signal_pads,
+    size_t rank,
+    size_t world_size)
+{
+  if (threadIdx.x < world_size)
+  {
+    auto target_rank = threadIdx.x;
+    put_signal<MemOpSem::Relaxed>(
+        signal_pads[target_rank] + blockIdx.x * world_size + rank);
+    wait_signal<MemOpSem::Relaxed>(
+        signal_pads[rank] + blockIdx.x * world_size + target_rank);
+  }
+}
+
+template <>
+__device__ __forceinline__ void sync_remote_blocks<MemOpSem::AcqRel>(
+    uint32_t **signal_pads,
+    size_t rank,
+    size_t world_size)
+{
+  if (threadIdx.x < world_size)
+  {
+    auto target_rank = threadIdx.x;
+    put_signal<MemOpSem::Release>(
+        signal_pads[target_rank] + blockIdx.x * world_size + rank);
+    wait_signal<MemOpSem::Acquire>(
+        signal_pads[rank] + blockIdx.x * world_size + target_rank);
+  }
+}
+
+template <int Size>
+union Vec;
+
+template <>
+union Vec<4>
+{
+  uint16_t u16[2];
+  uint32_t u32, as_scalar;
+  float f32;
+};
+
+template <>
+union Vec<8>
+{
+  uint16_t u16[4];
+  uint32_t u32[2];
+  uint64_t u64, as_scalar;
+  float f32[2];
+};
+
+template <>
+union alignas(16) Vec<16>
+{
+  uint16_t u16[8];
+  uint32_t u32[4];
+  uint64_t u64[2];
+  uint4 u128, as_scalar;
+  float f32[4];
+};
+
+template <typename T>
+struct MultimemLdReduce
+{
+  template <int Alignment>
+  __device__ __inline__ Vec<Alignment> operator()(T *mc_ptr)
+  {
+    static_assert(dependent_false<T>);
+  }
+};
+
+template <int Alignment, typename T>
+__device__ __inline__ Vec<Alignment> multimem_ld_reduce_add(T *mc_ptr)
+{
+  MultimemLdReduce<T> functor;
+  return functor.template operator()<Alignment>(mc_ptr);
+}
+
+#if defined(USE_ROCM) || !defined(NVCC_SUPPORTS_MULTICAST)
+#define SPECIALIZE_MULTIMEM_LD_REDUCE_VEC_32(type, asm_type, acc_prec) \
+  template <>                                                          \
+  struct MultimemLdReduce<type>                                        \
+  {                                                                    \
+    template <int Alignment>                                           \
+    __device__ __inline__ Vec<Alignment> operator()(type *mc_ptr)      \
+    {                                                                  \
+      CUDA_KERNEL_ASSERT(false);                                       \
+    }                                                                  \
+  };
+#else
+#define SPECIALIZE_MULTIMEM_LD_REDUCE_VEC_32(type, asm_type, acc_prec)    \
+  template <>                                                             \
+  struct MultimemLdReduce<type>                                           \
+  {                                                                       \
+    template <int Alignment>                                              \
+    __device__ __inline__ Vec<Alignment> operator()(type *mc_ptr)         \
+    {                                                                     \
+      Vec<Alignment> vec;                                                 \
+      if constexpr (Alignment == 16)                                      \
+      {                                                                   \
+        asm("multimem.ld_reduce.relaxed.sys.global.add" acc_prec          \
+            ".v4" asm_type " {%0,%1,%2,%3}, [%4];"                        \
+            : "=r"(vec.u32[0]),                                           \
+              "=r"(vec.u32[1]),                                           \
+              "=r"(vec.u32[2]),                                           \
+              "=r"(vec.u32[3])                                            \
+            : "l"(mc_ptr)                                                 \
+            : "memory");                                                  \
+      }                                                                   \
+      else if constexpr (Alignment == 8)                                  \
+      {                                                                   \
+        asm("multimem.ld_reduce.relaxed.sys.global.add" acc_prec          \
+            ".v2" asm_type " {%0,%1}, [%2];"                              \
+            : "=r"(vec.u32[0]), "=r"(vec.u32[1])                          \
+            : "l"(mc_ptr)                                                 \
+            : "memory");                                                  \
+      }                                                                   \
+      else if constexpr (Alignment == 4)                                  \
+      {                                                                   \
+        asm("multimem.ld_reduce.relaxed.sys.global.add" acc_prec asm_type \
+            " %0, [%1];"                                                  \
+            : "=r"(vec.u32)                                               \
+            : "l"(mc_ptr)                                                 \
+            : "memory");                                                  \
+      }                                                                   \
+      return vec;                                                         \
+    }                                                                     \
+  };
+#endif
+
+  SPECIALIZE_MULTIMEM_LD_REDUCE_VEC_32(at::BFloat16, ".bf16x2", ".acc::f32");
+  SPECIALIZE_MULTIMEM_LD_REDUCE_VEC_32(c10::Half, ".f16x2", ".acc::f32");
+  SPECIALIZE_MULTIMEM_LD_REDUCE_VEC_32(float, ".f32", "");
+
+  template <int Alignment, typename T>
+  __device__ __inline__ void multimem_st(T *mc_ptr, Vec<Alignment> &vec)
+  {
+#if defined(USE_ROCM) || !defined(NVCC_SUPPORTS_MULTICAST)
+    CUDA_KERNEL_ASSERT(false);
+#else
+    if constexpr (Alignment == 16)
+    {
+      asm("multimem.st.relaxed.sys.global.v4.f32 [%0], {%1,%2,%3,%4};"
+          :
+          : "l"(mc_ptr),
+            "r"(vec.u32[0]),
+            "r"(vec.u32[1]),
+            "r"(vec.u32[2]),
+            "r"(vec.u32[3])
+          : "memory");
+    }
+    else if constexpr (Alignment == 8)
+    {
+      asm("multimem.st.relaxed.sys.global.v2.f32 [%0], {%1,%2};"
+          :
+          : "l"(mc_ptr), "r"(vec.u32[0]), "r"(vec.u32[1])
+          : "memory");
+    }
+    else if constexpr (Alignment == 4)
+    {
+      asm("multimem.st.relaxed.sys.global.f32 [%0], %1;"
+          :
+          : "l"(mc_ptr), "r"(vec.u32)
+          : "memory");
+    }
+    else
+    {
+      static_assert(dependent_false<T>);
+    }
+#endif
+  }
+/* 
+* ********************************************************** *
+* Code copied from Pytorch codebase                          *
+* End:: Multimem All Reduce Meta kernel                      *
+* ********************************************************** *
+*/
+
+/* 
+* ********************************************************* *
+* BLOCK REDUCE SUM                                          *
+* ********************************************************* *
+*/
+template <typename T, int NUM>
+__inline__ __device__ T warpReduceSum(T *val)
+{
+#pragma unroll
+  for (int i = 0; i < NUM; i++)
+  {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+      val[i] += __shfl_xor_sync(0xffffffff, val[i], mask, 32);
+  }
+  return (T)(0.0f);
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T blockReduceSum(T *val)
+{
+  __shared__ T shared[NUM][33];
+  int lane = threadIdx.x & 0x1f;
+  int wid = threadIdx.x >> 5;
+
+  warpReduceSum<T, NUM>(val);
+
+  if (lane == 0)
+  {
+#pragma unroll
+    for (int i = 0; i < NUM; i++)
+    {
+      shared[i][wid] = val[i];
+    }
+  }
+
+  __syncthreads();
+
+  bool is_mask = threadIdx.x < (blockDim.x / 32.f);
+#pragma unroll
+  for (int i = 0; i < NUM; i++)
+  {
+    val[i] = is_mask ? shared[i][lane] : (T)(0.0f);
+  }
+  warpReduceSum<T, NUM>(val);
+  return (T)0.0f;
+}
+}  // namespace vllm

--- a/sgl-kernel/csrc/allreduce_rmsnorm_fusion/type_convert.cuh
+++ b/sgl-kernel/csrc/allreduce_rmsnorm_fusion/type_convert.cuh
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <torch/all.h>
+
+#ifndef USE_ROCM
+  #include <cuda_bf16.h>
+  #include <cuda_fp16.h>
+#else
+  #include <hip/hip_bf16.h>
+  #include <hip/hip_fp16.h>
+
+using __nv_bfloat16 = __hip_bfloat16;
+using __nv_bfloat162 = __hip_bfloat162;
+#endif
+
+namespace vllm {
+/* Converter structs for the conversion from torch types to HIP/CUDA types,
+   and the associated type conversions within HIP/CUDA. These helpers need
+   to be implemented for now because the relevant type conversion
+   operators/constructors are not consistently implemented by HIP/CUDA, so
+   a generic conversion via type casts cannot be implemented.
+
+   Each struct should have the member static constexpr bool `exists`:
+   If false, the optimized kernel is not used for the corresponding torch type.
+   If true, the struct should be fully defined as shown in the examples below.
+ */
+template <typename torch_type>
+struct _typeConvert {
+  static constexpr bool exists = false;
+};
+
+#if defined(USE_ROCM) || (defined(CUDA_VERSION) && (CUDA_VERSION >= 12000))
+// CUDA < 12.0 runs into issues with packed type conversion
+template <>
+struct _typeConvert<c10::Half> {
+  static constexpr bool exists = true;
+  using hip_type = __half;
+  using packed_hip_type = __half2;
+
+  __device__ static inline float convert(hip_type x) { return __half2float(x); }
+  __device__ static inline float2 convert(packed_hip_type x) {
+    return __half22float2(x);
+  }
+  __device__ static inline hip_type convert(float x) {
+    return __float2half_rn(x);
+  }
+  __device__ static inline packed_hip_type convert(float2 x) {
+    return __float22half2_rn(x);
+  }
+};
+
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+// CUDA_ARCH < 800 does not have BF16 support
+// TODO: Add in ROCm support once public headers handle bf16 maturely
+template <>
+struct _typeConvert<c10::BFloat16> {
+  static constexpr bool exists = true;
+  using hip_type = __nv_bfloat16;
+  using packed_hip_type = __nv_bfloat162;
+
+  __device__ static inline float convert(hip_type x) {
+    return __bfloat162float(x);
+  }
+  __device__ static inline float2 convert(packed_hip_type x) {
+    return __bfloat1622float2(x);
+  }
+  __device__ static inline hip_type convert(float x) {
+    return __float2bfloat16(x);
+  }
+  __device__ static inline packed_hip_type convert(float2 x) {
+    return __float22bfloat162_rn(x);
+  }
+};
+  #endif  // defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#endif    // defined(USE_ROCM) || (defined(CUDA_VERSION) && (CUDA_VERSION >=
+          // 12000))
+
+/* Vector POD struct to generate vectorized and packed FP16/BF16 ops
+   for appropriate specializations of fused_add_rms_norm_kernel.
+   Only functions that are necessary in that kernel are implemented.
+   Alignment to 16 bytes is required to use 128-bit global memory ops.
+ */
+template <typename scalar_t, int width>
+struct alignas(16) _f16Vec {
+  /* Not theoretically necessary that width is a power of 2 but should
+     almost always be the case for optimization purposes */
+  static_assert(width > 0 && (width & (width - 1)) == 0,
+                "Width is not a positive power of 2!");
+  using Converter = _typeConvert<scalar_t>;
+  using T1 = typename Converter::hip_type;
+  using T2 = typename Converter::packed_hip_type;
+  T1 data[width];
+
+  __device__ _f16Vec& operator+=(const _f16Vec<scalar_t, width>& other) {
+    if constexpr (width % 2 == 0) {
+#pragma unroll
+      for (int i = 0; i < width; i += 2) {
+        T2 temp{data[i], data[i + 1]};
+        temp += T2{other.data[i], other.data[i + 1]};
+        data[i] = temp.x;
+        data[i + 1] = temp.y;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < width; ++i) data[i] += other.data[i];
+    }
+    return *this;
+  }
+
+  __device__ _f16Vec& operator*=(const _f16Vec<scalar_t, width>& other) {
+    if constexpr (width % 2 == 0) {
+#pragma unroll
+      for (int i = 0; i < width; i += 2) {
+        T2 temp{data[i], data[i + 1]};
+        temp *= T2{other.data[i], other.data[i + 1]};
+        data[i] = temp.x;
+        data[i + 1] = temp.y;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < width; ++i) data[i] *= other.data[i];
+    }
+    return *this;
+  }
+
+  __device__ _f16Vec& operator*=(const float scale) {
+    if constexpr (width % 2 == 0) {
+#pragma unroll
+      for (int i = 0; i < width; i += 2) {
+        float2 temp_f = Converter::convert(T2{data[i], data[i + 1]});
+        temp_f.x *= scale;
+        temp_f.y *= scale;
+        T2 temp = Converter::convert(temp_f);
+        data[i] = temp.x;
+        data[i + 1] = temp.y;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < width; ++i) {
+        float temp = Converter::convert(data[i]) * scale;
+        data[i] = Converter::convert(temp);
+      }
+    }
+    return *this;
+  }
+
+  __device__ float sum_squares() const {
+    float result = 0.0f;
+    if constexpr (width % 2 == 0) {
+#pragma unroll
+      for (int i = 0; i < width; i += 2) {
+        float2 z = Converter::convert(T2{data[i], data[i + 1]});
+        result += z.x * z.x + z.y * z.y;
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < width; ++i) {
+        float x = Converter::convert(data[i]);
+        result += x * x;
+      }
+    }
+    return result;
+  }
+};
+}  // namespace vllm

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -479,6 +479,16 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "bool silu_activation,"
       "int pad_slot_id) -> ()");
   m.impl("causal_conv1d_fwd", torch::kCUDA, &causal_conv1d_fwd);
+
+  /*
+   * From csrc/allreduce_rmsnorm_fusion
+   */
+  m.def(
+      "fused_rs_ln_ag_cta(Tensor! input, Tensor! residual, Tensor weight, "
+      "int mcptr, int signal_pads, int rank, int world_size, int MAX_CTAS, "
+      "float epsilon) -> ()");
+  m.impl("fused_rs_ln_ag_cta", torch::kCUDA,
+             &fused_rs_ln_ag_cta);
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -770,3 +770,16 @@ void causal_conv1d_fwd(
     const std::optional<at::Tensor>& has_initial_state,
     bool silu_activation,
     int64_t pad_slot_id);
+
+/*
+ * From csrc/allreduce_rmsnorm_fusion
+ */
+void fused_rs_ln_ag_cta(torch::Tensor& input,     // [..., hidden_size]
+    torch::Tensor& residual,  // [..., hidden_size]
+    torch::Tensor& weight,    // [hidden_size]
+    int64_t mcptr,      // [..., hidden_size] multimem_ptr
+    int64_t signal_pads, // [..., hidden_size] signal pads
+    int64_t rank,
+    int64_t world_size,
+    int64_t MAX_CTAS,
+    double epsilon) ;

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -98,6 +98,9 @@ from sgl_kernel.speculative import (
     tree_speculative_sampling_target_only,
     verify_tree_greedy,
 )
+from sgl_kernel.allreduce_rmsnorm import (
+    fused_rs_ln_ag_cta
+)
 from sgl_kernel.top_k import fast_topk
 from sgl_kernel.version import __version__
 

--- a/sgl-kernel/python/sgl_kernel/allreduce_rmsnorm.py
+++ b/sgl-kernel/python/sgl_kernel/allreduce_rmsnorm.py
@@ -1,0 +1,19 @@
+from typing import Optional
+import torch
+
+
+def fused_rs_ln_ag_cta(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    mcptr: int,
+    signal_pads: int,
+    rank: int,
+    world_size: int,
+    MAX_CTAS: int,
+    epsilon: float,
+) -> None:
+    """Fused ReduceScatter + RMSNorm + AllGather CTA-based kernel"""
+    torch.ops.sgl_kernel.fused_rs_ln_ag_cta.default(
+        input, residual, weight, mcptr, signal_pads, rank, world_size, MAX_CTAS, epsilon
+    )

--- a/sgl-kernel/tests/test_allreduce_rmsnorm.py
+++ b/sgl-kernel/tests/test_allreduce_rmsnorm.py
@@ -1,0 +1,320 @@
+import ctypes
+import multiprocessing as mp
+import random
+import socket
+import unittest
+from typing import Any, List, Optional
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch.distributed import ProcessGroup
+
+from sglang.srt.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+from sglang.srt.managers.schedule_batch import global_server_args_dict
+import sgl_kernel
+
+
+def _run_allreduce_rmsnorm_worker(world_size, rank, distributed_init_port, test_configs):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    distributed_init_method = f"tcp://localhost:{distributed_init_port}"
+    dist.init_process_group(
+        backend="nccl",
+        init_method=distributed_init_method,
+        rank=rank,
+        world_size=world_size,
+        device_id=rank,
+    )
+    group = dist.group.WORLD
+
+    try:
+        # Initialize global server args
+        global_server_args_dict.update({
+            "chunked_prefill_size": 2048,
+            "enable_flashinfer_allreduce_fusion": True
+        })
+
+        for config in test_configs:
+            batch_size, hidden_size, dtype, variance_epsilon = config
+            print(f"Rank {rank}: Testing batch_size={batch_size}, hidden_size={hidden_size}, dtype={dtype}")
+
+            # Create symmetric memory buffers
+            CHUNK_SIZE = batch_size + 512
+            staging_buffer = symm_mem.empty(
+                (CHUNK_SIZE, hidden_size),
+                device=device,
+                dtype=dtype
+            )
+
+            try:
+                symm_mem_hdl = symm_mem.rendezvous(staging_buffer, group)
+            except Exception as e:
+                print(f"Rank {rank}: Symmetric memory rendezvous failed: {e}")
+                raise
+
+            residual_buffer = torch.empty_like(staging_buffer)
+            MAX_CTAS = 16
+
+            # Use same seed to ensure data consistency across ranks
+            torch.manual_seed(42)
+            base_input = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+            base_residual = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+            base_weight = torch.randn(hidden_size, dtype=dtype, device=device)
+
+            # Set up data according to distributed training scenario
+            input_tensor = base_input + rank * 0.1  # Different input per rank
+            residual_tensor = base_residual  # Same residual across all ranks
+            weight = base_weight  # Same weight across all ranks
+
+            # Save original residual for comparison
+            original_residual = residual_tensor.clone()
+
+            # Prepare fusion operator data
+            staging_buffer[:batch_size].copy_(input_tensor)
+            residual_buffer[:batch_size].copy_(residual_tensor)
+
+            # =============== Fusion operator computation ===============
+            tokens_per_rank = (batch_size + world_size - 1) // world_size
+            start_idx = rank * tokens_per_rank
+            end_idx = min((rank + 1) * tokens_per_rank, batch_size)
+            offset = start_idx * hidden_size * input_tensor.element_size()
+
+            try:
+                # Call fusion operator
+                sgl_kernel.fused_rs_ln_ag_cta(
+                    staging_buffer[start_idx:end_idx],
+                    residual_buffer[start_idx:end_idx], 
+                    weight,
+                    symm_mem_hdl.multicast_ptr + offset,
+                    symm_mem_hdl.signal_pad_ptrs_dev,
+                    rank,
+                    world_size,
+                    MAX_CTAS,
+                    variance_epsilon
+                )
+            except Exception as e:
+                print(f"Rank {rank}: Fusion operator failed: {e}")
+                raise
+
+            # Wait for all ranks to complete kernel execution
+            torch.cuda.synchronize()
+            dist.barrier(group=group)
+
+            fused_output = staging_buffer[:batch_size].clone()
+            fused_residual = residual_buffer[:batch_size].clone()
+
+            # =============== Reference computation ===============
+            # Collect input data from all ranks
+            all_inputs = [torch.zeros_like(input_tensor) for _ in range(world_size)]
+            dist.all_gather(all_inputs, input_tensor, group=group)
+
+            # AllReduce all inputs
+            total_input = torch.stack(all_inputs).sum(dim=0)  # [batch_size, hidden_size]
+
+            # ReduceScatter + LayerNorm + AllGather semantics:
+            # 1. Each rank processes a portion of tokens in the batch
+            tokens_per_rank = (batch_size + world_size - 1) // world_size
+            start_idx = rank * tokens_per_rank
+            end_idx = min((rank + 1) * tokens_per_rank, batch_size)
+
+            # 2. Each rank uses allreduced input and its own residual to compute this portion
+            my_combined = total_input[start_idx:end_idx] + original_residual[start_idx:end_idx]
+
+            # 3. LayerNorm on my slice
+            orig_dtype = my_combined.dtype
+            x = my_combined.float()
+            variance = x.pow(2).mean(dim=-1, keepdim=True)
+            normalized = x * torch.rsqrt(variance + variance_epsilon)
+            my_output_slice = (normalized * weight.float()).to(orig_dtype)
+            my_residual_slice = my_combined
+
+            # 4. AllGather results from all ranks
+            all_output_slices = [torch.zeros(tokens_per_rank, hidden_size, dtype=dtype, device=device) 
+                               for _ in range(world_size)]
+            all_residual_slices = [torch.zeros(tokens_per_rank, hidden_size, dtype=dtype, device=device) 
+                                 for _ in range(world_size)]
+
+            # Handle case where last rank may have different slice size
+            my_actual_slice_size = end_idx - start_idx
+            padded_output_slice = torch.zeros(tokens_per_rank, hidden_size, dtype=dtype, device=device)
+            padded_residual_slice = torch.zeros(tokens_per_rank, hidden_size, dtype=dtype, device=device)
+            padded_output_slice[:my_actual_slice_size] = my_output_slice
+            padded_residual_slice[:my_actual_slice_size] = my_residual_slice
+
+            dist.all_gather(all_output_slices, padded_output_slice, group=group)
+            dist.all_gather(all_residual_slices, padded_residual_slice, group=group)
+
+            # Reconstruct complete output and residual
+            ref_output_parts = []
+            ref_residual_parts = []
+            for i in range(world_size):
+                start_i = i * tokens_per_rank
+                end_i = min((i + 1) * tokens_per_rank, batch_size)
+                actual_size_i = end_i - start_i
+                ref_output_parts.append(all_output_slices[i][:actual_size_i])
+                ref_residual_parts.append(all_residual_slices[i][:actual_size_i])
+
+            ref_output = torch.cat(ref_output_parts, dim=0)
+            ref_residual = torch.cat(ref_residual_parts, dim=0)
+
+            # =============== Compare results ===============
+            try:
+                # Test output (should be same across all ranks)
+                torch.testing.assert_close(
+                    fused_output, ref_output, 
+                    rtol=1e-2, atol=1e-3,
+                    msg=f"Rank {rank}: Output mismatch for config {config}"
+                )
+
+                # Only test residual slice that each rank is responsible for
+                my_fused_residual_slice = fused_residual[start_idx:end_idx]
+                my_ref_residual_slice = ref_residual[start_idx:end_idx]
+
+                # Handle empty slice case
+                if my_fused_residual_slice.numel() > 0 and my_ref_residual_slice.numel() > 0:
+                    torch.testing.assert_close(
+                        my_fused_residual_slice, my_ref_residual_slice,
+                        rtol=1e-2, atol=1e-3,
+                        msg=f"Rank {rank}: My residual slice mismatch for config {config}"
+                    )
+
+                print(f"Rank {rank}: Test passed for config {config}")
+
+            except Exception as e:
+                print(f"Rank {rank}: Test failed for config {config}: {e}")
+
+                # Only report differences within slice
+                if start_idx < end_idx:  # Ensure slice is not empty
+                    my_fused_output_slice = fused_output[start_idx:end_idx]
+                    my_ref_output_slice = ref_output[start_idx:end_idx]
+                    slice_output_diff = (my_fused_output_slice - my_ref_output_slice).abs().max().item()
+                    print(f"Rank {rank}: My output slice max diff: {slice_output_diff}")
+
+                    my_fused_residual_slice = fused_residual[start_idx:end_idx]  
+                    my_ref_residual_slice = ref_residual[start_idx:end_idx]
+                    slice_residual_diff = (my_fused_residual_slice - my_ref_residual_slice).abs().max().item()
+                    print(f"Rank {rank}: My residual slice max diff: {slice_residual_diff}")
+
+                raise
+
+        print(f"Rank {rank}: All tests completed successfully")
+
+    except Exception as e:
+        print(f"Rank {rank}: Exception occurred: {e}")
+        import traceback
+        traceback.print_exc()
+        raise
+    finally:
+        try:
+            dist.destroy_process_group()
+        except Exception as e:
+            print(f"Rank {rank}: Cleanup failed: {e}")
+
+
+def get_open_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+    except OSError:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return s.getsockname()[1]
+
+
+def multi_process_parallel(
+    world_size: int, test_target: Any, target_args: tuple = ()
+) -> None:
+    mp.set_start_method("spawn", force=True)
+
+    procs = []
+    distributed_init_port = get_open_port()
+    for i in range(world_size):
+        proc_args = (world_size, i, distributed_init_port) + target_args
+        proc = mp.Process(target=test_target, args=proc_args, name=f"Worker-{i}")
+        proc.start()
+        procs.append(proc)
+
+    for i in range(world_size):
+        procs[i].join()
+        assert (
+            procs[i].exitcode == 0
+        ), f"Process {i} failed with exit code {procs[i].exitcode}"
+
+
+class TestAllReduceRMSNorm(unittest.TestCase):
+    # Test configurations: (batch_size, hidden_size, dtype, variance_epsilon)
+    test_configs = [
+        (32, 512, torch.bfloat16, 1e-6),
+        (64, 1024, torch.bfloat16, 1e-5),
+        (128, 2048, torch.bfloat16, 1e-6),
+    ]
+
+    world_sizes = [2, 4]  # Test different GPU counts
+
+    def test_allreduce_rmsnorm_correctness(self):
+        for world_size in self.world_sizes:
+            available_gpus = torch.cuda.device_count()
+            if world_size > available_gpus:
+                print(
+                    f"Skipping world_size={world_size}, requires {world_size} GPUs, found {available_gpus}"
+                )
+                continue
+
+            print(f"Running allreduce_rmsnorm test for world_size={world_size}")
+            multi_process_parallel(
+                world_size, 
+                _run_allreduce_rmsnorm_worker, 
+                target_args=(self.test_configs,)
+            )
+            print(f"AllReduce RMSNorm fusion test with world_size={world_size}: PASSED")
+
+    def test_different_batch_sizes(self):
+        """Test different batch sizes, including cases where batch_size is not divisible by world_size"""
+        world_size = 2
+        available_gpus = torch.cuda.device_count()
+        if world_size > available_gpus:
+            print(f"Skipping batch size test, requires {world_size} GPUs, found {available_gpus}")
+            return
+
+        # Test batch_sizes that are not divisible by world_size
+        special_configs = [
+            (33, 512, torch.bfloat16, 1e-6),   # 33 % 2 != 0
+            (127, 1024, torch.bfloat16, 1e-6), # 127 % 2 != 0
+            (255, 2048, torch.bfloat16, 1e-6), # 255 % 2 != 0
+        ]
+
+        print("Running allreduce_rmsnorm test for uneven batch sizes")
+        multi_process_parallel(
+            world_size,
+            _run_allreduce_rmsnorm_worker,
+            target_args=(special_configs,)
+        )
+        print("AllReduce RMSNorm fusion test with uneven batch sizes: PASSED")
+
+    def test_small_batch_sizes(self):
+        """Test small batch sizes"""
+        world_size = 2
+        available_gpus = torch.cuda.device_count()
+        if world_size > available_gpus:
+            print(f"Skipping small batch test, requires {world_size} GPUs, found {available_gpus}")
+            return
+
+        small_configs = [
+            (1, 512, torch.bfloat16, 1e-6),    # Very small batch
+            (2, 1024, torch.bfloat16, 1e-6),   # 1 token per rank
+            (4, 2048, torch.bfloat16, 1e-6),   # 2 tokens per rank
+        ]
+
+        print("Running allreduce_rmsnorm test for small batch sizes")
+        multi_process_parallel(
+            world_size,
+            _run_allreduce_rmsnorm_worker,
+            target_args=(small_configs,)
+        )
+        print("AllReduce RMSNorm fusion test with small batch sizes: PASSED")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The allreduce-rmsnorm-fusion operator based on multimem has been extended. On the H800, its performance on Llama3.1-70B surpasses that of the flashinfer-trtllm-allreduce-fusion operator, as shown in the test results below. This operator is copied from the Tokenweave project: https://github.com/microsoft/tokenweave/blob/main/csrc/tokenweave_fused_kernels.cu.


## Modifications

Added the implementation of allreduce-rmsnorm-fusion and its related tests in sgl-kernel.

## Accuracy Tests


## Benchmarking and Profiling
```bash
python3 -m sglang.bench_one_batch --model /model/meta-llama/Meta-Llama-3.1-70B-Instruct/main --batch 1 --input-len 8192 --output-len 128 --tensor-parallel-size 4 --disable-cuda-graph --disable-radix-cache
```

Llama3.1-70B-H800-TP4 | fused_rs_ln_ag_cta | flashinfer_trtllm_fuse | sglang052
-- | -- | -- | --
input=2k,output=128 | Prefill. latency: 0.15513 s, throughput:  13202.02 token/s <br>Decode.  median latency: 0.02847 s, median throughput:     35.13 token/s <br>Total. latency:  3.792 s, throughput:    573.91 token/s | Prefill. latency: 0.17303 s, throughput:  11836.31 token/s <br>Decode.  median latency: 0.02984 s, median throughput:     33.51 token/s <br>Total. latency:  4.014 s, throughput:    542.12 token/s | Prefill. latency: 0.16455 s, throughput:  12445.83 token/s <br>Decode.  median latency: 0.03114 s, median throughput:     32.11 token/sTotal. latency:  4.150 s, throughput:    524.29 token/s
input=8k,output=128 | Prefill. latency: 0.63125 s, throughput:  12977.51 token/s <br>Decode.  median latency: 0.02882 s, median throughput:     34.70 token/s <br>Total. latency:  4.326 s, throughput:   1923.27 token/s | Prefill. latency: 0.68563 s, throughput:  11948.08 token/s <br>Decode.  median latency: 0.02983 s, median throughput:     33.52 token/s <br>Total. latency:  4.530 s, throughput:   1836.75 token/s | Prefill. latency: 0.65892 s, throughput:  12432.40 token/s <br>Decode.  median latency: 0.03105 s, median throughput:     32.21 token/s <br>Total. latency:  4.614 s, throughput:   1803.30 token/s

<span citadel-meta="{&quot;isCut&quot;:false,&quot;dataset&quot;:{&quot;from-citadel&quot;:true}}"></span>


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
