### PR TITLE
Bug: hidden_states shape mismatch in pd disaggregation when eagle3 is enabled

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -421,9 +421,20 @@ class SchedulerDisaggregationPrefillMixin:
                     last_hidden_index = (
                         hidden_state_offset + extend_input_len_per_req[i] - 1
                     )
-                    req.hidden_states_tensor = (
-                        logits_output.hidden_states[last_hidden_index].cpu().clone()
-                    )
+                    if self.spec_algorithm.is_eagle3():
+                        hidden_size = self.model_config.hf_text_config.hidden_size
+                        hidden_states_for_transfer = (
+                            logits_output.hidden_states[last_hidden_index][
+                                -hidden_size:
+                            ]
+                            .cpu()
+                            .clone()
+                        )
+                    else:
+                        hidden_states_for_transfer = (
+                            logits_output.hidden_states[last_hidden_index].cpu().clone()
+                        )
+                    req.hidden_states_tensor = hidden_states_for_transfer
                     hidden_state_offset += extend_input_len_per_req[i]
                 else:
                     req.hidden_states_tensor = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

A bug is found when I enable eagle3 and pd disaggregation at the same time.
<img width="2098" height="516" alt="image" src="https://github.com/user-attachments/assets/c99e7cae-7dd0-4c58-b03b-1dee0aa15029" />


## Modifications

truncate hidden_states captured during eagle3 before p->d transfer

## Accuracy Tests

After fix, eagle3 configuration with 3,3,8 gets a reasonable accept rate:
<img width="812" height="1052" alt="image" src="https://github.com/user-attachments/assets/10bd3a05-deaa-4b9a-a1b1-31654e52ddb9" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
