### PR TITLE
Opt tp: tp attn support tp reduce scattered input

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -394,6 +394,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--enable-return-hidden-states` | Enable returning hidden states with responses. | `False` | bool flag (set to enable) |
 | `--scheduler-recv-interval` | The interval to poll requests in scheduler. Can be set to >1 to reduce the overhead of this. | `1` | Type: int |
 | `--numa-node` | Sets the numa node for the subprocesses. i-th element corresponds to i-th subprocess. | `None` | List[int] |
+| `--enable-attn-tp-input-scattered` | Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent.                                                                                                      | `False`  | bool flag (set to enable) |
 
 ## Debug tensor dumps
 | Argument | Description | Defaults | Options |

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -154,6 +154,7 @@ class AttnTpContext:
             and not is_dp_attention_enabled()
             and not get_moe_a2a_backend().is_deepep()
             and not enable_moe_dense_fully_dp()
+            and not get_global_server_args().enable_piecewise_cuda_graph
         )
 
     def use_input_scattered(self, forward_batch: ForwardBatch):

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -18,6 +18,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
 from sglang.srt.layers.amx_utils import PackWeightMethod
+from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
 from sglang.srt.layers.parameter import BasevLLMParameter
 from sglang.srt.layers.quantization.base_config import (
@@ -459,7 +460,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
         param[loaded_weight.shape[0] :].data.fill_(0)
 
-    def forward(self, input_, reduce_results=True):
+    def forward(self, input_):
         if self.tp_size > 1:
             # Build the mask.
             masked_input, input_mask = get_masked_input_and_mask(
@@ -478,7 +479,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         # Mask the output embedding.
         if self.tp_size > 1:
             output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
-            if reduce_results:
+            if not get_attn_tp_context().input_scattered:
                 # Reduce across all the model parallel GPUs.
                 output_parallel = tensor_model_parallel_all_reduce(output_parallel)
         return output_parallel

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -38,7 +38,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.distributed.parallel_state import get_moe_expert_parallel_world_size
+from sglang.srt.distributed.parallel_state import (
+    get_moe_expert_parallel_world_size,
+    get_tensor_model_parallel_world_size,
+)
 from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
@@ -767,6 +770,13 @@ class ForwardBatch:
                     bs = self.batch_size = num_tokens
 
         # padding
+        self._pad_inputs_to_size(model_runner, num_tokens, bs)
+        self.global_num_tokens_cpu = global_num_tokens
+        global_num_tokens_pinned = torch.tensor(global_num_tokens, pin_memory=True)
+        self.global_num_tokens_gpu.copy_(global_num_tokens_pinned, non_blocking=True)
+
+    def _pad_inputs_to_size(self, model_runner: ModelRunner, num_tokens, bs):
+        # padding
         self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
         self.req_pool_indices = self._pad_tensor_to_size(self.req_pool_indices, bs)
 
@@ -788,9 +798,6 @@ class ForwardBatch:
         if self.encoder_lens is not None:
             self.encoder_lens = self._pad_tensor_to_size(self.encoder_lens, bs)
         self.positions = self._pad_tensor_to_size(self.positions, num_tokens)
-        self.global_num_tokens_cpu = global_num_tokens
-        global_num_tokens_pinned = torch.tensor(global_num_tokens, pin_memory=True)
-        self.global_num_tokens_gpu.copy_(global_num_tokens_pinned, non_blocking=True)
 
         if self.mrope_positions is not None:
             self.mrope_positions = self._pad_tensor_to_size(self.mrope_positions, bs)
@@ -817,6 +824,19 @@ class ForwardBatch:
             spec_info.hidden_states = self._pad_tensor_to_size(
                 spec_info.hidden_states, num_tokens
             )
+
+    def prepare_attn_tp_scatter_input(self, model_runner: ModelRunner):
+        from sglang.srt.layers.communicator import get_attn_tp_context
+
+        attn_tp_context = get_attn_tp_context()
+        input_scattered = attn_tp_context.use_input_scattered(self)
+        if not input_scattered:
+            return
+        assert self.forward_mode.is_extend()
+        tokens = self.input_ids.shape[0]
+        rank_size = get_tensor_model_parallel_world_size()
+        tokens_padded = (tokens + rank_size - 1) // rank_size * rank_size
+        self._pad_inputs_to_size(model_runner, tokens_padded, self.batch_size)
 
     def post_forward_mlp_sync_batch(self, logits_output: LogitsProcessorOutput):
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -336,9 +336,6 @@ class ForwardBatch:
     # For matryoshka embeddings
     dimensions: Optional[list[int]] = None
 
-    # For attention tp scattered
-    attn_input_tp_scattered: Optional[bool] = None
-
     @classmethod
     def init_new(
         cls,
@@ -383,11 +380,6 @@ class ForwardBatch:
             dimensions=batch.dimensions,
         )
         device = model_runner.device
-
-        attn_input_tp_scattered = hasattr(
-            model_runner.model, "attn_input_tp_scattered"
-        ) and model_runner.model.attn_input_tp_scattered(ret)
-        ret.attn_input_tp_scattered = attn_input_tp_scattered
 
         if batch.extend_input_logprob_token_ids is not None:
             ret.extend_input_logprob_token_ids_gpu = (

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -336,6 +336,9 @@ class ForwardBatch:
     # For matryoshka embeddings
     dimensions: Optional[list[int]] = None
 
+    # For attention tp scattered
+    attn_input_tp_scattered: Optional[bool] = None
+
     @classmethod
     def init_new(
         cls,
@@ -380,6 +383,11 @@ class ForwardBatch:
             dimensions=batch.dimensions,
         )
         device = model_runner.device
+
+        attn_input_tp_scattered = hasattr(
+            model_runner.model, "attn_input_tp_scattered"
+        ) and model_runner.model.attn_input_tp_scattered(ret)
+        ret.attn_input_tp_scattered = attn_input_tp_scattered
 
         if batch.extend_input_logprob_token_ids is not None:
             ret.extend_input_logprob_token_ids_gpu = (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2200,6 +2200,8 @@ class ModelRunner:
         # For MLP sync
         if forward_batch.global_num_tokens_cpu is not None:
             forward_batch.prepare_mlp_sync_batch(self)
+        else:
+            forward_batch.prepare_attn_tp_scatter_input(self)
 
         if forward_batch.forward_mode.is_decode():
             ret = self.forward_decode(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -523,6 +523,7 @@ class ServerArgs:
     numa_node: Optional[List[int]] = None
     enable_deterministic_inference: bool = False
     rl_on_policy_target: Optional[str] = None
+    enable_attn_tp_input_scattered: bool = False
 
     # Dynamic batch tokenizer
     enable_dynamic_batch_tokenizer: bool = False
@@ -3473,6 +3474,11 @@ class ServerArgs:
             default=ServerArgs.rl_on_policy_target,
             choices=RL_ON_POLICY_TARGET_CHOICES,
             help="The training system that SGLang needs to match for true on-policy.",
+        )
+        parser.add_argument(
+            "--enable-attn-tp-input-scattered",
+            action="store_true",
+            help="Enable input of attention to be scattered when only tensor parallelism is used.",
         )
 
         # Dynamic batch tokenizer

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3478,7 +3478,7 @@ class ServerArgs:
         parser.add_argument(
             "--enable-attn-tp-input-scattered",
             action="store_true",
-            help="Enable input of attention to be scattered when only tensor parallelism is used.",
+            help="Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent.",
         )
 
         # Dynamic batch tokenizer

--- a/python/sglang/srt/two_batch_overlap.py
+++ b/python/sglang/srt/two_batch_overlap.py
@@ -732,6 +732,7 @@ class TboForwardBatchPreparer:
                 top_logprobs_nums=None,
                 token_ids_logprobs=None,
                 next_token_logits_buffer=None,
+                attn_input_tp_scattered=None,
             )
         )
 

--- a/python/sglang/srt/two_batch_overlap.py
+++ b/python/sglang/srt/two_batch_overlap.py
@@ -732,7 +732,6 @@ class TboForwardBatchPreparer:
                 top_logprobs_nums=None,
                 token_ids_logprobs=None,
                 next_token_logits_buffer=None,
-                attn_input_tp_scattered=None,
             )
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

In H20(96GB) TP8 prefill, optimize the original combined operation:
`embed/mlp all reduce + RMSNorm + fused_qkv_a_proj_with_mqa`
into:
`embed/mlp reduce scatter + RMSNorm + fused_qkv_a_proj_with_mqa + all gather`

Use switch `--enable-attn-tp-input-scattered` to enable this feature.

<img width="1796" height="1216" alt="image" src="https://github.com/user-attachments/assets/1ae0cfe7-ed7c-46d4-b771-63876cd39df4" />


This optimization primarily brings the following improvements:
1. Computation and Memory Reduction: The amount of data that `RMSNorm` and `fused_qkv_a_proj_with_mqa` need to process is reduced to **1/8** of the original.
2. Communication Pattern Optimization: The `all reduce` communication is decomposed into `reduce scatter` + `all gather`. During the `all gather` phase, after `fused_qkv_a_proj_with_mqa`, the last dimension is reduced from `7168` to `(1536 + 512 + 64)`, significantly reducing the communication data volume.

Based on the performance sampling data for 16K chunked prefill, the effects after optimization are as follows:

- The latency offused_qkv_a_proj_with_mqa decreased from 205.1 ms to 26.14 ms.

- The total latency of communication has decreased from 267.1 ms to 249.63 ms.

- The total latency of RMSNorm has decreased from 82.303 ms to 43.398 ms.

After:

<img width="2022" height="1058" alt="image" src="https://github.com/user-attachments/assets/9393e53d-4f33-4cfc-a01e-42ba26b8d901" />

Before:

<img width="2000" height="980" alt="image" src="https://github.com/user-attachments/assets/6b28d3fe-9e87-4069-9a3e-0d8a0fbcdd16" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
#gsm8k
Accuracy: 0.955
Invalid: 0.000
Latency: 271.702 s
Output throughput: 467.895 token/s
```

```
#mmlu
subject: abstract_algebra, #q:100, acc: 0.760
subject: anatomy, #q:135, acc: 0.844
subject: astronomy, #q:152, acc: 0.934
subject: business_ethics, #q:100, acc: 0.890
subject: clinical_knowledge, #q:265, acc: 0.928
subject: college_biology, #q:144, acc: 0.965
subject: college_chemistry, #q:100, acc: 0.620
subject: college_computer_science, #q:100, acc: 0.830
subject: college_mathematics, #q:100, acc: 0.760
subject: college_medicine, #q:173, acc: 0.873
subject: college_physics, #q:102, acc: 0.804
subject: computer_security, #q:100, acc: 0.890
subject: conceptual_physics, #q:235, acc: 0.936
subject: econometrics, #q:114, acc: 0.763
subject: electrical_engineering, #q:145, acc: 0.869
subject: elementary_mathematics, #q:378, acc: 0.939
subject: formal_logic, #q:126, acc: 0.802
subject: global_facts, #q:100, acc: 0.670
subject: high_school_biology, #q:310, acc: 0.952
subject: high_school_chemistry, #q:203, acc: 0.857
subject: high_school_computer_science, #q:100, acc: 0.940
subject: high_school_european_history, #q:165, acc: 0.885
subject: high_school_geography, #q:198, acc: 0.965
subject: high_school_government_and_politics, #q:193, acc: 0.984
subject: high_school_macroeconomics, #q:390, acc: 0.926
subject: high_school_mathematics, #q:270, acc: 0.748
subject: high_school_microeconomics, #q:238, acc: 0.962
subject: high_school_physics, #q:151, acc: 0.834
subject: high_school_psychology, #q:545, acc: 0.971
subject: high_school_statistics, #q:216, acc: 0.861
subject: high_school_us_history, #q:204, acc: 0.961
subject: high_school_world_history, #q:237, acc: 0.949
subject: human_aging, #q:223, acc: 0.852
subject: human_sexuality, #q:131, acc: 0.939
subject: international_law, #q:121, acc: 0.942
subject: jurisprudence, #q:108, acc: 0.907
subject: logical_fallacies, #q:163, acc: 0.933
subject: machine_learning, #q:112, acc: 0.786
subject: management, #q:103, acc: 0.932
subject: marketing, #q:234, acc: 0.944
subject: medical_genetics, #q:100, acc: 0.940
subject: miscellaneous, #q:783, acc: 0.951
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
```
export SGL_ENABLE_JIT_DEEPGEMM=1
export TORCHINDUCTOR_CACHE_DIR=/home/admin/inductor_root_cache
export SGLANG_TORCH_PROFILER_DIR=/home/admin/torch_profiler
export SGL_CHUNKED_PREFIX_CACHE_USE_TUNED=1
model_path=/home/deepseek-ai__DeepSeek-R1

python3 -m sglang.launch_server --model-path $model_path \
--host 0.0.0.0 --port 8000 --trust-remote-code \
--enable-cache-report --quantization fp8 --log-level info --max-running-requests 32 \
--mem-fraction-static 0.92 --chunked-prefill-size 16384 --context-length 65535 --chat-template /home/r1.jinja \
--attention-backend fa3 \
--disable-radix-cache \
--tp-size 8 --enable-metrics --cuda-graph-max-bs 32
```

```
input_len=1000  # 2000, 4000
python3 -m sglang.bench_serving --backend sglang --dataset-name random \
--random-input ${input_len} --random-output 1 --request-rate 1000 \
--num-prompt 500 --random-range-ratio 1 --max-concurrency 16  --port 8000 
--dataset-path /home/ShareGPT_V3_unfiltered_cleaned_split.json
```

Request throughput (req/s) :
| Input Length | Before PR | After PR|
|--------------|------------------------|-----------------------|
| 1000         | 12.82                  | 14.22                 | 
| 2000         | 6.52                   | 7.33                  | 
| 4000         | 2.49                   | 2.72                  | 
| 4096         | 2.41                   | 2.63                  | 

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for tensor-parallel scattered attention, enabling more efficient multi-GPU attention workflows.
  - Introduced a fused QKV projection path with automatic gathering when required.
  - Added an option to skip reduction in vocab-parallel embeddings for advanced workflows.

- Performance
  - Reduced communication overhead in attention and embedding stages, improving scalability on tensor-parallel setups.

- Bug Fixes
  - Prevented potential hangs in fused paths when processing empty micro-batches.

- Refactor
  - Exposed additional runtime context to better coordinate tensor-parallel operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->