### PR TITLE
fix: support GPT OSS tool calls ending with `<|return|>`

### DIFF
--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -32,7 +32,7 @@ class GptOssDetector(BaseFormatDetector):
 
         # Pattern to extract function name and JSON from tool_call event content
         self.tool_extract_pattern = re.compile(
-            r"to=([a-zA-Z_][a-zA-Z0-9_.-]*)\s*<\|constrain\|>json<\|message\|>(.*?)(?:<\|call\|>|$)",
+            r"to=([a-zA-Z_][a-zA-Z0-9_.-]*)\s*<\|constrain\|>json<\|message\|>(.*?)(?:<\|call\|>|<\|return\|>|$)",
             re.DOTALL,
         )
 

--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -32,7 +32,7 @@ class GptOssDetector(BaseFormatDetector):
 
         # Pattern to extract function name and JSON from tool_call event content
         self.tool_extract_pattern = re.compile(
-            r"to=([a-zA-Z_][a-zA-Z0-9_.-]*)\s*<\|constrain\|>json<\|message\|>(.*?)(?:<\|call\|>|<\|return\|>|$)",
+            r"to=([a-zA-Z_][a-zA-Z0-9_.-]*)\s*(?:<\|constrain\|>json)?<\|message\|>(.*?)(?:<\|call\|>|<\|return\|>|$)",
             re.DOTALL,
         )
 

--- a/python/sglang/srt/function_call/gpt_oss_detector.py
+++ b/python/sglang/srt/function_call/gpt_oss_detector.py
@@ -30,6 +30,11 @@ class GptOssDetector(BaseFormatDetector):
         self.bot_token = "<|start|>assistant<|channel|>commentary"
         self.eot_token = "<|call|>"
 
+        self.tool_start_pattern = re.compile(
+            r"<|start|>assistant<|channel|>(analysis|commentary)",
+            re.DOTALL,
+        )
+
         # Pattern to extract function name and JSON from tool_call event content
         self.tool_extract_pattern = re.compile(
             r"to=([a-zA-Z_][a-zA-Z0-9_.-]*)\s*(?:<\|constrain\|>json)?<\|message\|>(.*?)(?:<\|call\|>|<\|return\|>|$)",
@@ -38,7 +43,7 @@ class GptOssDetector(BaseFormatDetector):
 
     def has_tool_call(self, text: str) -> bool:
         """Check if text contains TypeScript-style function call markers."""
-        return self.bot_token in text
+        return bool(self.tool_start_pattern.search(text))
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         """Parse TypeScript-style function calls from complete text."""

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -137,8 +137,8 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
 
         # Trim stop token.
         if isinstance(matched, int) and isinstance(output, list):
-            # 200012 <|call|> is the tool call token and one of eos tokens for gpt-oss model
-            if output[-1] == 200012 and self.is_tool_call_parser_gpt_oss:
+            # HarmonyParser used for gpt-oss model relies on end tokens to detect if events are complete
+            if self.is_tool_call_parser_gpt_oss:
                 return output
             assert len(output) > 0
             # NOTE: We can always assume the last token is the matched stop token

--- a/python/sglang/srt/parser/harmony_parser.py
+++ b/python/sglang/srt/parser/harmony_parser.py
@@ -134,7 +134,7 @@ class CanonicalStrategy:
             "<|return|>",
         ]
         self.tool_extract_pattern = re.compile(
-            r"commentary to=([a-zA-Z_][a-zA-Z0-9_.]*)\s*(<\|constrain\|>json)?$",
+            r"(analysis|commentary) to=([a-zA-Z_][a-zA-Z0-9_.]*)\s*(<\|constrain\|>json)?$",
             re.DOTALL,
         )
 
@@ -349,7 +349,7 @@ class CanonicalStrategy:
 
         # Create event based on channel and end token
         if channel_type == "analysis":
-            if end_token.type == "CALL":
+            if self.tool_extract_pattern.match(channel_header):
                 # Built-in tools (browser, python) use analysis channel with <|call|>
                 raw_text = text[tokens[start_pos].start : end_token.end]
                 return Event("tool_call", content.strip(), raw_text), end_pos + 1

--- a/test/srt/openai_server/basic/test_serving_chat.py
+++ b/test/srt/openai_server/basic/test_serving_chat.py
@@ -14,9 +14,9 @@ from typing import Optional
 from unittest.mock import Mock, patch
 
 from fastapi import Request
-
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
+    ChatCompletionResponse,
     MessageProcessingResult,
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
@@ -69,6 +69,7 @@ class _MockTemplateManager:
         self.chat_template_name: Optional[str] = "llama-3"
         self.jinja_template_content_format: Optional[str] = None
         self.completion_template_name: Optional[str] = None
+        self.force_reasoning: bool = True
 
 
 class ServingChatTestCase(unittest.TestCase):
@@ -99,9 +100,12 @@ class ServingChatTestCase(unittest.TestCase):
 
     # ------------- conversion tests -------------
     def test_convert_to_internal_request_single(self):
-        with patch(
-            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
-        ) as conv_mock, patch.object(self.chat, "_process_messages") as proc_mock:
+        with (
+            patch(
+                "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            ) as conv_mock,
+            patch.object(self.chat, "_process_messages") as proc_mock,
+        ):
             conv_ins = Mock()
             conv_ins.get_prompt.return_value = "Test prompt"
             conv_ins.image_data = conv_ins.audio_data = None
@@ -572,6 +576,93 @@ class ServingChatTestCase(unittest.TestCase):
             payload = json.loads(line[len("data: ") :])
             tool_calls = payload["choices"][0]["delta"]["tool_calls"]
             self.assertEqual(tool_calls[0]["id"], "functions.get_weather:1")
+
+    def test_gpt_oss_reasoning_and_tool_call(self):
+        """Ensure a GPT OSS style response with both reasoning and tool_call is handled correctly."""
+
+        self.chat.tool_call_parser = "gpt-oss"
+        self.chat.tokenizer_manager.server_args.reasoning_parser = "gpt-oss"
+
+        # Prepare request with tools
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            stream=False,
+        )
+
+        ret = [
+            {
+                "meta_info": {
+                    "id": "chatcmpl-test",
+                    "finish_reason": {"type": "stop", "matched": None},
+                    "prompt_tokens": 100,
+                    "completion_tokens": 42,
+                    "weight_version": "1.0",
+                },
+                "text": (
+                    "<|channel|>analysis<|message|>Need to use function get_weather.<|end|>"
+                    "<|start|>assistant<|channel|>"
+                    'commentary to=functions.get_weather<|constrain|>json<|message|>{"location": "SF"}<|return|>'
+                ),
+            }
+        ]
+
+        result = self.chat._build_chat_response(req, ret, 0)
+
+        self.assertIsInstance(result, ChatCompletionResponse)
+        self.assertEqual(len(result.choices), 1)
+        self.assertEqual(result.choices[0].message.role, "assistant")
+        self.assertIsNone(result.choices[0].message.content)
+        self.assertEqual(
+            result.choices[0].message.reasoning_content,
+            "Need to use function get_weather.",
+        )
+        self.assertEqual(len(result.choices[0].message.tool_calls), 1)
+        self.assertEqual(result.choices[0].finish_reason, "tool_calls")
+
+    def test_gpt_oss_reasoning_no_tool_call(self):
+        """Ensure a GPT OSS style response with reasoning and no tool_call is handled correctly."""
+
+        self.chat.tool_call_parser = "gpt-oss"
+        self.chat.tokenizer_manager.server_args.reasoning_parser = "gpt-oss"
+
+        # Prepare request with tools
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            stream=False,
+        )
+
+        ret = [
+            {
+                "meta_info": {
+                    "id": "chatcmpl-test",
+                    "finish_reason": {"type": "stop", "matched": None},
+                    "prompt_tokens": 100,
+                    "completion_tokens": 42,
+                    "weight_version": "1.0",
+                },
+                "text": (
+                    "<|channel|>analysis<|message|>Say hi back.<|end|>"
+                    "<|start|>assistant<|channel|>final<|message|>Hi!<|return|>"
+                ),
+            }
+        ]
+
+        result = self.chat._build_chat_response(req, ret, 0)
+
+        self.assertIsInstance(result, ChatCompletionResponse)
+        self.assertEqual(len(result.choices), 1)
+        self.assertEqual(result.choices[0].message.role, "assistant")
+        self.assertEqual(result.choices[0].message.content, "Hi!")  # no return tag
+        self.assertEqual(
+            result.choices[0].message.reasoning_content,
+            "Say hi back.",
+        )
+        self.assertIsNone(result.choices[0].message.tool_calls)
+        self.assertEqual(result.choices[0].finish_reason, "stop")
 
 
 if __name__ == "__main__":

--- a/test/srt/test_harmony_parser.py
+++ b/test/srt/test_harmony_parser.py
@@ -204,6 +204,16 @@ class TestCanonicalStrategy(CustomTestCase):
         self.assertEqual(events[0].content, '{"location": "SF"}')
         self.assertEqual(remaining, "")
 
+    def test_parse_tool_call_ending_with_return(self):
+        """Test parsing tool call block ending with <|return|>."""
+        text = '<|channel|>commentary to=functions.get_weather<|message|>{"location": "SF"}<|return|>'
+        events, remaining = self.strategy.parse(text)
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_type, "tool_call")
+        self.assertEqual(events[0].content, '{"location": "SF"}')
+        self.assertEqual(remaining, "")
+
     def test_parse_tool_call_analysis(self):
         """Test parsing built-in tool call on analysis channel."""
         text = '<|channel|>analysis to=browser.search<|message|>{"query": "SGLang"}<|call|>'


### PR DESCRIPTION
## Motivation

When using gpt-oss-120b with SGLang with the Chat Completion API and tools, I often get an empty response containing only `reasoning_content` (no `content` nor `tool_calls`).

When looking at what is returned by the model, the tool call is followed by the `<|return|>` end token rather than  expected `<|call|>`.

When parsing this output with OpenAI's harmony library, this is parsed as a tool call so I think this should be supported.

## Modifications

* Keep all end tokens (not only `<|call|>`) since they are used by `HarmonyParser`
* Use a tool regex rather than the `<|call|>` end token in `HarmonyParser` to determine if an `Event` should be considered as a tool call or as text
* Update the tool call regex to accept `<|return|>` as a valid end token for tool calls

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

## Additional information

The [tool parser](https://docs.sglang.ai/advanced_features/tool_parser.html) documentation states that:

> The gpt-oss tool parser filters out analysis channel events and only preserves normal text. This can cause the content to be empty when explanations are in the analysis channel. To work around this, complete the tool round by returning tool results as role="tool" messages, which enables the model to generate the final content.

I did not understand this comment so I'm unclear how this is related.