### PR TITLE
[BugFix] check port availability via socket connection

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -564,16 +564,31 @@ def wait_port_available(
 
 def is_port_available(port):
     """Return whether a port is available."""
+    is_port_available_flag = False
+
+    # Ask the OS if the port is ready to be binded
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         try:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind(("", port))
             s.listen(1)
-            return True
+            is_port_available_flag = True
         except socket.error:
-            return False
+            is_port_available_flag = False
         except OverflowError:
-            return False
+            is_port_available_flag = False
+
+    # Ask the OS if the port is really accessible
+    host = "localhost"
+    timeout = 1.0
+    if is_port_available_flag is True:
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                is_port_available_flag = True
+        except Exception as e:
+            is_port_available_flag = False
+
+    return is_port_available_flag
 
 
 def get_free_port():


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In certain environments (shared clusters / managed GPU nodes), our port-availability checks could return false positives, leading to flaky startup for distributed components (e.g., server launch, NCCL rendezvous). This PR hardens the `is_port_available` check by validating availability via a short-lived bind/listen as well as a follow-up TCP reachability probe, reducing cases where the OS reports a port as bindable but it’s not practically usable or immediately reachable due to transient states.

Thanks in advance for your time on reviewing this PR!

## Modifications

* Updated `python/sglang/srt/utils.py`:

  * Refactored `is_port_available(port)` to:

    1. Attempt a bind+listen on the target port (with `SO_REUSEADDR`) and set a local flag accordingly.
    2. Perform a quick TCP connect probe (`socket.create_connection`) to verify reachability semantics before returning.
  * Consolidated exception handling (`socket.error`, `OverflowError`) to robustly return a boolean instead of raising.
  * Added inline comments clarifying the two-phase check.


## Accuracy Tests

N/A — this change does not affect model outputs or kernels. It only impacts the reliability of networking setup prior to inference/training.

## Benchmarking and Profiling

Negligible impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

