### PR TITLE
fix OOM issue when update weight from trainer.

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1191,18 +1191,11 @@ class ModelRunner:
                 target_dtype = (
                     dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
                 )
-                weight = torch.empty(shape, dtype=target_dtype, device=self.device)
-                handles.append(
-                    torch.distributed.broadcast(
-                        weight,
-                        src=0,
-                        group=self._model_update_group[group_name],
-                        async_op=True,
-                    )
-                )
+                weight = torch.empty(1, dtype=target_dtype, device=self.device)
+                weight._fake = True
+                weight._original_shape = shape
+                weight._group = self._model_update_group[group_name]
                 weights.append((name, weight))
-            for handle in handles:
-                handle.wait()
 
             self.model.load_weights(weights)
             return True, "Succeeded to update parameter online."

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -130,7 +130,15 @@ from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
 )
 from sglang.srt.model_loader import get_model
 from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
-from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
+from sglang.srt.model_loader.utils import set_default_torch_dtype
+from sglang.srt.model_loader.weight_utils import default_weight_loader, broadcast_weight
+from sglang.srt.offloader import (
+    create_offloader_from_server_args,
+    get_offloader,
+    set_offloader,
+)
+from sglang.srt.patch_torch import monkey_patch_torch_reductions
+from sglang.srt.remote_instance_weight_loader_utils import (
     trigger_init_weights_send_group_for_remote_instance_request,
 )
 from sglang.srt.model_loader.utils import set_default_torch_dtype

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -130,11 +130,11 @@ from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
 )
 from sglang.srt.model_loader import get_model
 from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
-from sglang.srt.model_loader.utils import set_default_torch_dtype
-from sglang.srt.model_loader.weight_utils import broadcast_weight, default_weight_loader
-from sglang.srt.remote_instance_weight_loader_utils import (
+from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     trigger_init_weights_send_group_for_remote_instance_request,
 )
+from sglang.srt.model_loader.utils import set_default_torch_dtype
+from sglang.srt.model_loader.weight_utils import broadcast_weight, default_weight_loader
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import (
     ServerArgs,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -131,18 +131,10 @@ from sglang.srt.model_executor.piecewise_cuda_graph_runner import (
 from sglang.srt.model_loader import get_model
 from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
 from sglang.srt.model_loader.utils import set_default_torch_dtype
-from sglang.srt.model_loader.weight_utils import default_weight_loader, broadcast_weight
-from sglang.srt.offloader import (
-    create_offloader_from_server_args,
-    get_offloader,
-    set_offloader,
-)
-from sglang.srt.patch_torch import monkey_patch_torch_reductions
+from sglang.srt.model_loader.weight_utils import broadcast_weight, default_weight_loader
 from sglang.srt.remote_instance_weight_loader_utils import (
     trigger_init_weights_send_group_for_remote_instance_request,
 )
-from sglang.srt.model_loader.utils import set_default_torch_dtype
-from sglang.srt.model_loader.weight_utils import default_weight_loader, broadcast_weight
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import (
     ServerArgs,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -134,7 +134,7 @@ from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     trigger_init_weights_send_group_for_remote_instance_request,
 )
 from sglang.srt.model_loader.utils import set_default_torch_dtype
-from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.model_loader.weight_utils import default_weight_loader, broadcast_weight
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.server_args import (
     ServerArgs,
@@ -1195,6 +1195,7 @@ class ModelRunner:
                 weight._fake = True
                 weight._original_shape = shape
                 weight._group = self._model_update_group[group_name]
+                weight._hook_func = broadcast_weight.__get__(weight, torch.Tensor)
                 weights.append((name, weight))
 
             self.model.load_weights(weights)

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -873,6 +873,8 @@ def weight_loader_hook(loader):
     def loader_wrapper(param: torch.Tensor, loaded_weight: torch.Tensor):
         if hasattr(loaded_weight, "_hook_func") and callable(loaded_weight._hook_func):
             weight = loaded_weight._hook_func()
+        else:
+            weight = loaded_weight
         return loader(param, weight)
 
     return loader_wrapper


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

I encountered an out-of-memory (OOM) issue while running the grpo_gsm8k example in AReal. The error message said: "Failed to update parameter online: OOM ...". After investigating, I found that the model weight update process in sglang—specifically in `model_runner.py->ModelRunner-> update_weights_from_distributed`—may be causing the OOM.

The current implementation creates a full copy of the model weights and uses an NCCL broadcast call to load weights from the trainer. This approach significantly increases memory usage, potentially leading to OOM errors.


https://github.com/sgl-project/sglang/blob/a13dd1e492a303bba4f8ceb2e6d476797ffb052a/python/sglang/srt/model_executor/model_runner.py#L1047-L1074

To address this, I propose introducing a fake tensor with a _fake attribute to indicate when a tensor is not yet loaded. The weight loader should then load the actual weights only when the fake tensor is encountered. This change would reduce memory overhead during weight updates.
 
## Modifications

I have drafted a preliminary implementation for the default weight loader but would appreciate community assistance to finalize this pull request.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

@zhuzilin @zhaochenyang20 CC.