### PR TITLE
[MUSA][1/N] sglang.check_env

### DIFF
--- a/docs/platforms/mthreads_gpu.md
+++ b/docs/platforms/mthreads_gpu.md
@@ -1,0 +1,15 @@
+# Moore Threads GPUs
+
+This document describes how run SGLang on Moore Threads GPUs. If you encounter issues or have questions, please [open an issue](https://github.com/sgl-project/sglang/issues).
+
+## Install SGLang
+
+You can install SGLang using one of the methods below.
+
+### Install from Source
+
+```bash
+# Install sglang python package
+rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml
+pip install -e "python[all_musa]"
+```

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -90,6 +90,14 @@ srt_npu = ["sglang[runtime_common]"]
 # https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html
 srt_hpu = ["sglang[runtime_common]"]
 
+# MUSA (Meta-computing Unified System Architecture) for Moore Threads
+# => base docker mthreads/vllm-dev:20251024, not from public vllm whl
+srt_musa = [
+    "sglang[runtime_common]",
+    "torch",
+    "torch_musa",
+]
+
 test = [
   "accelerate",
   "expecttest",
@@ -105,10 +113,12 @@ test = [
 all_hip = ["sglang[srt_hip]"]
 all_npu = ["sglang[srt_npu]"]
 all_hpu = ["sglang[srt_hpu]"]
+all_musa = ["sglang[srt_musa]"]
 
 dev_hip = ["sglang[all_hip]", "sglang[test]"]
 dev_npu = ["sglang[all_npu]", "sglang[test]"]
 dev_hpu = ["sglang[all_hpu]", "sglang[test]"]
+dev_musa = ["sglang[all_musa]", "sglang[test]"]
 
 [project.urls]
 "Homepage" = "https://github.com/sgl-project/sglang"

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -149,6 +149,24 @@ def is_cpu() -> bool:
     return os.getenv("SGLANG_USE_CPU_ENGINE", "0") == "1" and is_host_cpu_x86()
 
 
+def is_musa() -> bool:
+    if getattr(is_musa, "_patched", False):
+        return hasattr(torch, "musa") and torch.cuda.is_available()
+
+    try:
+        import torch_musa
+    except ImportError:
+        setattr(is_musa, "_patched", False)
+        return False
+
+    torch.cuda.device_count = torch.musa.device_count
+    torch.cuda.get_device_capability = torch.musa.get_device_capability
+    torch.cuda.get_device_name = torch.musa.get_device_name
+    torch.cuda.is_available = torch.musa.is_available
+    setattr(is_musa, "_patched", True)
+    return hasattr(torch, "musa") and torch.cuda.is_available()
+
+
 def get_cuda_version():
     if torch.version.cuda:
         return tuple(map(int, torch.version.cuda.split(".")))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is the first in a series of pull requests to add full support for [Moore Threads](https://en.mthreads.com/) GPUs, leveraging MUSA (Meta-computing Unified System Architecture) to accelerate LLM inference.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. Added `is_musa` to check the basic runtime environment
2. Updated `check_env.py` to fetch the device info, driver version, topology, etc.

### Testing Done

```bash
root@worker39094:/ws# python3 -m sglang.check_env
Python: 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0]
MUSA available: True
GPU 0,1,2,3,4,5,6,7: MTT S4000
GPU 0,1,2,3,4,5,6,7 Compute Capability: 2.2
MUSA_HOME: /usr/local/musa
MCC: mcc version 4.3.1
MUSA Driver Version: 3.3.1-server
PyTorch: 2.5.0
sglang: 0.5.3.post3
sgl_kernel: Module Not Found
flashinfer_python: Module Not Found
triton: 3.1.0
transformers: 4.52.4
torchao: 0.9.0
numpy: 1.26.1
aiohttp: 3.12.15
fastapi: 0.116.1
hf_transfer: 0.1.9
huggingface_hub: 0.34.4
interegular: 0.3.3
modelscope: 1.29.2
orjson: 3.11.3
outlines: 0.1.11
packaging: 25.0
psutil: 7.0.0
pydantic: 2.11.7
python-multipart: 0.0.20
pyzmq: 27.0.1
uvicorn: 0.35.0
uvloop: 0.21.0
vllm: 0.9.3.dev0+ga5dd03c1e.d20250904.empty
xgrammar: 0.1.24
openai: 1.90.0
tiktoken: 0.11.0
anthropic: 0.66.0
litellm: Module Not Found
decord: 0.6.0
MTHREADS Topology: 
         GPU0     GPU1     GPU2     GPU3     GPU4     GPU5     GPU6     GPU7     NIC0     NIC1     NIC2     NIC3     NIC4     NIC5     NIC6     NIC7     NIC8     NIC9     NIC10    CPU Affinity   NUMA Affinity  
GPU0     X        MT2      MT2      MT2      MT2      MT2      MT2      MT2      MPB      MPB      NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU1     MT2      X        MT2      MT2      MT2      MT2      MT2      MT2      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU2     MT2      MT2      X        MT2      MT2      MT2      MT2      MT2      NODE     NODE     MPB      MPB      SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU3     MT2      MT2      MT2      X        MT2      MT2      MT2      MT2      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     0-31,64-95     0              
GPU4     MT2      MT2      MT2      MT2      X        MT2      MT2      MT2      SYS      SYS      SYS      SYS      NODE     NODE     MPB      MPB      NODE     NODE     SYS      32-63,96-127   1              
GPU5     MT2      MT2      MT2      MT2      MT2      X        MT2      MT2      SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     NODE     NODE     SYS      32-63,96-127   1              
GPU6     MT2      MT2      MT2      MT2      MT2      MT2      X        MT2      SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     MPB      MPB      SYS      32-63,96-127   1              
GPU7     MT2      MT2      MT2      MT2      MT2      MT2      MT2      X        SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     NODE     NODE     SYS      32-63,96-127   1              
NIC0     MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      X        SPB      NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC1     MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      SPB      X        NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC2     NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     X        SPB      SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC3     NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     SPB      X        SYS      SYS      SYS      SYS      SYS      SYS      NODE     
NIC4     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      X        SPB      NODE     NODE     NODE     NODE     SYS      
NIC5     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SPB      X        NODE     NODE     NODE     NODE     SYS      
NIC6     SYS      SYS      SYS      SYS      MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      NODE     NODE     X        SPB      NODE     NODE     SYS      
NIC7     SYS      SYS      SYS      SYS      MPB      NODE     NODE     NODE     SYS      SYS      SYS      SYS      NODE     NODE     SPB      X        NODE     NODE     SYS      
NIC8     SYS      SYS      SYS      SYS      NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     X        SPB      SYS      
NIC9     SYS      SYS      SYS      SYS      NODE     NODE     MPB      NODE     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SPB      X        SYS      
NIC10    NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      NODE     NODE     NODE     NODE     SYS      SYS      SYS      SYS      SYS      SYS      X        

Legend:
    X = Self
  SYS = Topology path that contains PCIe switches/bridges as well as multiple host bridges across NUMA nodes.
 NODE = Topology path that contains PCIe switches/bridges as well as multiple host bridges within a NUMA node.
  HPB = Topology path that contains PCIe switches/bridges as well as a single host bridge.
  MPB = Topology path that contains multiple PCIe switches/bridges (but no host bridge).
  SPB = Topology path that contains at most one PCIe switch/bridge.
  INT = Topology path that is created internally, for example 2 devices on a single S2000 card.
  MTx = Topology path that is a bonded set of x MTLinks.

NIC Legend:
  NIC0: mlx5_0
  NIC1: mlx5_1
  NIC2: mlx5_2
  NIC3: mlx5_3
  NIC4: mlx5_4
  NIC5: mlx5_5
  NIC6: mlx5_6
  NIC7: mlx5_7
  NIC8: mlx5_8
  NIC9: mlx5_9
 NIC10: mlx5_bond_0


ulimit soft: 1048576
root@worker39094:/ws# 
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
