### PR TITLE
Fix sgl_kernel import failure on devices other than CUDA

### DIFF
--- a/docs/platforms/cpu_server.md
+++ b/docs/platforms/cpu_server.md
@@ -63,7 +63,7 @@ is required to enable SGLang service with CPU engine.
 conda create -n sgl-cpu python=3.12 -y
 conda activate sgl-cpu
 
-# Optional: Set PyTorch CPU as primary pip install channel to avoid installing CUDA version
+# Set PyTorch CPU as primary pip install channel to avoid installing CUDA version
 pip config set global.index-url https://download.pytorch.org/whl/cpu
 pip config set global.extra-index-url https://pypi.org/simple
 

--- a/docs/platforms/cpu_server.md
+++ b/docs/platforms/cpu_server.md
@@ -63,7 +63,7 @@ is required to enable SGLang service with CPU engine.
 conda create -n sgl-cpu python=3.12 -y
 conda activate sgl-cpu
 
-# Set PyTorch CPU as primary pip install channel to avoid installing CUDA version
+# Set PyTorch CPU as primary pip install channel to avoid installing the larger CUDA-enabled version and prevent potential runtime issues.
 pip config set global.index-url https://download.pytorch.org/whl/cpu
 pip config set global.extra-index-url https://pypi.org/simple
 

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -23,7 +23,7 @@ def _find_cuda_home():
     return cuda_home
 
 
-if torch.version.hip is None:
+if torch.version.cuda is not None:
     cuda_home = Path(_find_cuda_home())
 
     if (cuda_home / "lib").is_dir():


### PR DESCRIPTION
## Motivation

Fix #10602 

## Modifications

Change `if` logic as cuda libs should only be retrieved for cuda backend.

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [X] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
