### PR TITLE
Garbage collector regression in the online server

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -100,6 +100,7 @@ def freeze_gc(enable_cudagraph_gc: bool):
     finally:
         if should_freeze:
             gc.unfreeze()
+            gc.collect()
 
 
 def _to_torch(model: torch.nn.Module, reverse: bool, num_tokens: int):


### PR DESCRIPTION
We encountered a regression in the online server, where freezing Python’s GC during graph capture reduced serving throughput at larger batch sizes (we saw no measurable difference at the concurrency=1 case). Freezing GC shows a measurable drop (~3%). We found that calling `gc.collect()` after unfreeze resolves this issue.

<details>
<summary>With <code>--enable-cudagraph-gc</code></summary>

**Launch server**
```bash
python -m sglang.launch_server \
  --model-path nvidia/Llama-3.1-405B-Instruct-FP4 \
  --mem-fraction 0.8 \
  --cuda-graph-max-bs 512 \
  --tp 8 \
  --attention-backend flashinfer \
  --quantization modelopt_fp4 \
  --kv-cache-dtype fp8_e4m3 \
  --trust-remote-code \
  --load-format dummy \
  --enable-cudagraph-gc

for i in {1..5}; do
  python3 -m sglang.bench_serving \
    --backend sglang \
    --dataset-name random \
    --random-input-len 128 \
    --random-output-len 128 \
    --num-prompts 1024 \
    --max-concurrency 256 \
    --flush-cache
done
```

**Result**
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 256       
Successful requests:                     1024      
Benchmark duration (s):                  66.44     
Total input tokens:                      65160     
Total generated tokens:                  65088     
Total generated tokens (retokenized):    66773     
Request throughput (req/s):              15.41     
Input token throughput (tok/s):          980.67    
Output token throughput (tok/s):         979.58    
Total token throughput (tok/s):          1960.25   
Concurrency:                             247.95    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16088.97  
Median E2E Latency (ms):                 13323.98  
---------------Time to First Token----------------
Mean TTFT (ms):                          1127.59   
Median TTFT (ms):                        940.00    
P99 TTFT (ms):                           2708.67   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           239.17    
Median ITL (ms):                         100.19    
P95 ITL (ms):                            902.95    
P99 ITL (ms):                            1095.33   
Max ITL (ms):                            1757.36   
==================================================
```
</details>

<details>
<summary>Without <code>--enable-cudagraph-gc</code></summary>

**Launch server**
```bash
python -m sglang.launch_server \
  --model-path nvidia/Llama-3.1-405B-Instruct-FP4 \
  --mem-fraction 0.8 \
  --cuda-graph-max-bs 512 \
  --tp 8 \
  --attention-backend flashinfer \
  --quantization modelopt_fp4 \
  --kv-cache-dtype fp8_e4m3 \
  --trust-remote-code \
  --load-format dummy

for i in {1..5}; do
  python3 -m sglang.bench_serving \
    --backend sglang \
    --dataset-name random \
    --random-input-len 128 \
    --random-output-len 128 \
    --num-prompts 1024 \
    --max-concurrency 256 \
    --flush-cache
done
```

**Result**
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 256       
Successful requests:                     1024      
Benchmark duration (s):                  68.47     
Total input tokens:                      65160     
Total generated tokens:                  65088     
Total generated tokens (retokenized):    66773     
Request throughput (req/s):              14.96     
Input token throughput (tok/s):          951.72    
Output token throughput (tok/s):         950.67    
Total token throughput (tok/s):          1902.39   
Concurrency:                             248.21    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16595.17  
Median E2E Latency (ms):                 15988.25  
---------------Time to First Token----------------
Mean TTFT (ms):                          1217.03   
Median TTFT (ms):                        995.36    
P99 TTFT (ms):                           2717.34   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           245.83    
Median ITL (ms):                         100.18    
P95 ITL (ms):                            1054.01   
P99 ITL (ms):                            1787.13   
Max ITL (ms):                            1792.46   
==================================================
```
</details>

| Condition                       | Req/s | Total tok/s | Δ vs baseline |
|---------------------------------|-------|-------------|---------------|
| With `--enable-cudagraph-gc`    | 15.41 | 1960.25     | baseline      |
| Without `--enable-cudagraph-gc` | 14.96 | 1902.39     | -2.95%        |

It appears Python’s GC during graph capture introduces a throughput regression by delaying the memory reclamation, but if we force the collection at the end, we don't see this issue anymore.