### PR TITLE
[PoC] make radix cache deterministic

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -137,10 +137,10 @@ class FlashInferAttnBackend(AttentionBackend):
         if self.enable_deterministic:
             self.decode_use_tensor_cores = True
             self.prefill_split_tile_size = get_int_env_var(
-                "SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 4096
+                "SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 1024
             )
             self.decode_split_tile_size = get_int_env_var(
-                "SGLANG_FLASHINFER_DECODE_SPLIT_TILE_SIZE", 2048
+                "SGLANG_FLASHINFER_DECODE_SPLIT_TILE_SIZE", 1024
             )
             self.disable_cuda_graph_kv_split = True
             global_config.flashinfer_workspace_size = 2048 * 1024 * 1024

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -994,11 +994,11 @@ class ServerArgs:
                 "Sampling backend is set to pytorch for deterministic inference."
             )
             # Currently, only FA3 supports radix cache. Support for other backends is in progress
-            if self.attention_backend != "fa3":
-                self.disable_radix_cache = True
-                logger.warning(
-                    "Currently radix cache is disabled for deterministic inference. It will be supported in the future."
-                )
+            # if self.attention_backend != "fa3":
+            #     self.disable_radix_cache = True
+            #     logger.warning(
+            #         "Currently radix cache is disabled for deterministic inference. It will be supported in the future."
+            #     )
             if self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
                 raise ValueError(
                     f"Currently only {DETERMINISTIC_ATTENTION_BACKEND_CHOICES} attention backends are supported for deterministic inference."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This patch is based on https://github.com/sgl-project/sglang/pull/10678.

The patch (tries) adding determinism to the radix cache. I overrode the split size with 1024 so that the model fits into my GPU.

```
python3 -m sglang.launch_server --model-path Qwen/Qwen3-0.6B --attention-backend flashinfer --enable-deterministic-inference
python3 -m sglang.test.test_deterministic --test-mode prefix --temperature 0.7 --n-trials 12
```

Before:

```
Prompt 0 with prefix length 1: total samples: 18, Unique samples: 1
Prompt 1 with prefix length 511: total samples: 17, Unique samples: 3
Prompt 2 with prefix length 2048: total samples: 17, Unique samples: 5
Prompt 3 with prefix length 4097: total samples: 26, Unique samples: 4
```

After:

```
Prompt 0 with prefix length 1: total samples: 20, Unique samples: 1
Prompt 1 with prefix length 511: total samples: 18, Unique samples: 1
Prompt 2 with prefix length 2048: total samples: 22, Unique samples: 1
Prompt 3 with prefix length 4097: total samples: 18, Unique samples: 1
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

The patch mainly modifies the match_prefix logic:

- If it's called from the scheduler, always return the value to the multiply of SPLIT_SIZE.
- Otherwise, insert into the tree as normal.

The algorithm is two-pass:

- In the first pass, do the prefix matching as before.
- If we need to align to the split size, in the second pass, we use the nodes we collected from the previous pass to split exactly at the split size and return the node.

Note that this would do two splits in one match_prefix: one during the normal match to split at any prefix match, and another during we split at the split_size point; but it seems to work as desired. Please let me know if this doesn't work (memory leak?)

We can also do this in one pass and I don’t have a strong preference of which approach to take — feel free to suggest.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
