### PR TITLE
fix(qwen2/3): tie-weights sending hangs, and make it work on tp_size>1

### DIFF
--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -438,14 +438,12 @@ class Qwen2ForCausalLM(nn.Module):
         # perform weight tying for PP
         if self.pp_group.world_size > 1 and config.tie_word_embeddings:
             if self.pp_group.is_first_rank:
-                self.pp_group.send(
-                    self.model.embed_tokens.weight, dst=self.pp_group.last_rank
-                )
+                self.pp_group.send(self.model.embed_tokens.weight, dst=-1)
             elif self.pp_group.is_last_rank:
                 emb_token_weight = self.pp_group.recv(
-                    size=(config.vocab_size, config.hidden_size),
+                    size=self.lm_head.weight.size(),
                     dtype=next(self.model.parameters()).dtype,
-                    src=self.pp_group.first_rank,
+                    src=0,
                 )
                 self.lm_head.weight.copy_(emb_token_weight)
 

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -441,7 +441,7 @@ class Qwen2ForCausalLM(nn.Module):
                 self.pp_group.send(
                     self.model.embed_tokens.weight, dst=self.pp_group.last_rank
                 )
-            else:
+            elif self.pp_group.is_last_rank:
                 emb_token_weight = self.pp_group.recv(
                     size=(config.vocab_size, config.hidden_size),
                     dtype=next(self.model.parameters()).dtype,

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -313,14 +313,12 @@ class Qwen3ForCausalLM(nn.Module):
         # perform weight tying for PP
         if self.pp_group.world_size > 1 and config.tie_word_embeddings:
             if self.pp_group.is_first_rank:
-                self.pp_group.send(
-                    self.model.embed_tokens.weight, dst=self.pp_group.last_rank
-                )
+                self.pp_group.send(self.model.embed_tokens.weight, dst=-1)
             elif self.pp_group.is_last_rank:
                 emb_token_weight = self.pp_group.recv(
-                    size=(config.vocab_size, config.hidden_size),
+                    size=self.lm_head.weight.size(),
                     dtype=next(self.model.parameters()).dtype,
-                    src=self.pp_group.first_rank,
+                    src=0,
                 )
                 self.lm_head.weight.copy_(emb_token_weight)
 

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -316,7 +316,7 @@ class Qwen3ForCausalLM(nn.Module):
                 self.pp_group.send(
                     self.model.embed_tokens.weight, dst=self.pp_group.last_rank
                 )
-            else:
+            elif self.pp_group.is_last_rank:
                 emb_token_weight = self.pp_group.recv(
                     size=(config.vocab_size, config.hidden_size),
                     dtype=next(self.model.parameters()).dtype,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Following #6546, Qwen2/3 will hang when `tie_word_embeddings` is true and `pp_size` is larger than 2. Also, #6546 fails when `tp_size` is larger than 1.

## Modifications

<!-- Detail the changes made in this pull request. -->

+ Add logic that only the last pp_rank will receive the weights.
+ Fix the `send/recv` arguments `src/dst` that receive local ranks instead of global ones.
+ Fix the shape of transferred weights when `tp_size>1`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
