### PR TITLE
[router] preserve order of json params using preserve_order feature

### DIFF
--- a/sgl-router/Cargo.toml
+++ b/sgl-router/Cargo.toml
@@ -24,7 +24,10 @@ axum = { version = "0.8.4", features = ["macros", "ws", "tracing"] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "limit", "request-id", "util"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", default-features = false, features = [
+    "std",
+    "preserve_order",
+] }
 bytes = "1.8.0"
 rand = "0.9.2"
 reqwest = { version = "0.12.8", features = ["stream", "blocking", "json"] }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This change was found to the be fix to a problem we identified when using tool calling together with the sglang rust router. The symptoms of the issue are degraded performance in the quality of the outputs of the models (deepseek in this case, but I assume it does not matter).
Consider the following prompt body which would be sent to the sglang router

<details>

<summary>Example prompt body snipped</summary>

```python
body = {
    "messages": [
        {
            "content": "You are a helpful assistant ...",
            "role": "system",
        },
        {"role": "user", "content": "How to build a paper plane?"},
    ],
    "model": model,
    "tool_choice": "required",
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "intent_analysis",
                "description": "...",
                "parameters": {
                    "properties": {
                        "true_intent": {
                            "description": "baa",
                            "type": "string",
                        },
                        "primary_objective": {
                            "description": "baz",
                            "type": "string",
                        },
                        "hidden_complexities": {
                            "description": "baz",
                            "items": {"type": "string"},
                            "type": "array",
                        },
                        "clarifications": {
                            "description": "baa",
                            "items": {"type": "string"},
                            "type": "array",
                        },
                    },
                    "required": [
                        "true_intent",
                        "primary_objective",
                        "hidden_complexities",
                        "clarifications",
                    ],
                    "type": "object",
                    "additionalProperties": False,
                    "$defs": {
                        "Constraint": {
                            "description": "baz",
                            "properties": {
                                "temporal": {
                                    "description": "...",
                                    "anyOf": [{"type": "string"}, {"type": "null"}],
                                },
                                "geographical": {
                                    "description": "...",
                                    "anyOf": [{"type": "string"}, {"type": "null"}],
                                },
                                "depth": {
                                    "description": "...",
                                    "type": "string",
                                },
                            },
                            "type": "object",
                            "additionalProperties": False,
                            "required": [
                                "temporal",
                                "geographical",
                                "depth",
                            ],
                        }
                    },
                },
                "strict": True,
            },
        }
    ],
}
```
</details>

Without the change in this PR, the order of elements (in the above example: `["true_intent", "primary_objective", "hidden_complexities", "clarifications"]`) in the json payload generated from `serde_json` would not be preserved but rather sorted alphabetically. We found this to have undesired effects on the output quality of the LLM, as the input would be different. 

On a side note; the JSON standard does not preserve order of elements in a set like this. Hence one could argue that JSON might not be the best option for this purpose, but this is yet another discussion. The problem however, stems from the fact that `serde_json` does apply ordering to the input given by the user. To prevent this (alphabetical) ordering we propose to enable the `preserve_order` feature of `serde_json`. Doing so we achieved the desired output quality, which is in line with the output of sglang without the rust router. 

Let me know what you think. Happy to discuss!

## Modifications

I'm changing the `cargo.toml` of the sglang router only to enable the `preserve_order` feature of `serde_json`.

## Accuracy Tests

I did not (yet) touch any tests at all. Let me know what you think about testing this change.

## Benchmarking and Profiling

No benchmarking performed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
~~- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).~~
~~- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).~~