### PR TITLE
fix(disagg): fix sending KV cache in case of MLA for NIXL backend

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -547,7 +547,7 @@ class NixlKVManager(CommonKVManager):
             notif = "_".join([str(req.room), "kv", str(chunk_id), str(int(is_last))])
             decode_tp_size = self.decode_kv_args_table[req.agent_name].decode_tp_size
 
-            if decode_tp_size == self.attn_tp_size:
+            if self.is_mla_backend or (decode_tp_size == self.attn_tp_size):
                 kv_xfer_handle = self.send_kvcache(
                     req.agent_name,
                     kv_indices,


### PR DESCRIPTION
## Motivation

When running with the NIXL backend and MLA enabled, KV cache transfers were handled incorrectly.  
The logic only allowed transfers KV cache fully when `decode_tp_size == attn_tp_size`, which does not apply in the MLA case -- KV cache sent by slices.
This caused KV cache synchronization issues.

The correct behavior is consistent with the Mooncake backend implementation (see [mooncake/conn.py#L680](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/mooncake/conn.py#L680)), where MLA mode always enforces KV cache sending by not slicing.

Closes #10381

## Modifications

- Updated `python/sglang/srt/disaggregation/nixl/conn.py`:
  - Old condition:
    ```python
    if decode_tp_size == self.attn_tp_size:
    ```
  - New condition:
    ```python
    if self.is_mla_backend or (
        decode_tp_size == self.attn_tp_size
    ):
    ```
- This ensures KV cache is transferred correctly for MLA backends, aligning NIXL behavior with Mooncake.

## Accuracy Tests

- Verified that with NIXL backend for MAL, KV cache is now transferred correctly.
- Compared behavior with Mooncake backend – now consistent.

## Benchmarking and Profiling

- No additional overhead introduced; the fix only adjusts the conditional logic.
- Inference throughput and latency remain unaffected in benchmarking runs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
