### PR TITLE
Optimize cutlass int8 gemm kernel for large M on SM89 Ada GPU

### DIFF
--- a/sgl-kernel/csrc/gemm/int8_gemm_kernel.cu
+++ b/sgl-kernel/csrc/gemm/int8_gemm_kernel.cu
@@ -409,8 +409,8 @@ void sm89_dispatch_shape(
     cutlass_int8_scaled_mm<
         ElementOutput,
         ArchTag,
-        cutlass::gemm::GemmShape<32, 64, 128>,
-        cutlass::gemm::GemmShape<16, 64, 64>,
+        cutlass::gemm::GemmShape<128, 128, 64>,
+        cutlass::gemm::GemmShape<64, 64, 64>,
         InstructionShape,
         5>(out, mat_a, mat_b, scales_a, scales_b, bias);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Inspired by [10502](https://github.com/sgl-project/sglang/pull/10502), we found that the int8 gemm kernel on SM89 GPU uses the wrong configuration when M>256: https://github.com/sgl-project/sglang/blob/fc3e54200932b653d359b206d7dcceffa0d76718/sgl-kernel/csrc/gemm/int8_gemm_kernel.cu#L409-L415

so we modified the default configuration to get better performance.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
sgl-kernel/csrc/gemm/int8_gemm_kernel.cu
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
Test on L40 GPU.
Baseline:
<img width="3456" height="2112" alt="int8_gemm_baseline" src="https://github.com/user-attachments/assets/8b316c89-2fac-4d84-9391-62b59734d568" />
Optimize:
<img width="3456" height="2112" alt="int8_gemm_optimize" src="https://github.com/user-attachments/assets/6fb17282-00e7-41fe-9b59-1ea7c4edbc03" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
