### PR TITLE
add the metrics info into output meta data

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -36,6 +36,29 @@ else:
 
 
 @dataclass
+class Metrics:
+    """Timing metrics for a request."""
+
+    arrival_time: float
+    first_token_time: float
+    finished_time: float
+
+    def __post_init__(self):
+        """Ensure all times are valid."""
+        if self.first_token_time == 0.0:
+            # If first_token_time is not set, use finished_time
+            self.first_token_time = self.finished_time
+
+    def to_dict(self):
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "arrival_time": self.arrival_time,
+            "first_token_time": self.first_token_time,
+            "finished_time": self.finished_time,
+        }
+
+
+@dataclass
 class SessionParams:
     id: Optional[str] = None
     rid: Optional[str] = None
@@ -1268,6 +1291,12 @@ class OpenSessionReqOutput:
 @dataclass
 class HealthCheckOutput:
     pass
+
+
+@dataclass
+class FirstTokenTimeUpdate:
+    rid: str
+    first_token_time: float
 
 
 class ExpertDistributionReq(Enum):

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -9,7 +9,12 @@ import torch
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.managers.io_struct import AbortReq, BatchEmbeddingOut, BatchTokenIDOut
+from sglang.srt.managers.io_struct import (
+    AbortReq,
+    BatchEmbeddingOut,
+    BatchTokenIDOut,
+    FirstTokenTimeUpdate,
+)
 from sglang.srt.managers.schedule_batch import BaseFinishReason, Req, ScheduleBatch
 
 if TYPE_CHECKING:
@@ -88,6 +93,14 @@ class SchedulerOutputProcessorMixin:
                     # req output_ids are set here
                     req.output_ids.append(next_token_id)
                     req.check_finished()
+
+                    # send first token time to tokenizer
+                    if len(req.output_ids) == 1:
+                        self.send_to_tokenizer.send_pyobj(
+                            FirstTokenTimeUpdate(
+                                rid=req.rid, first_token_time=time.time()
+                            )
+                        )
 
                     if req.finished():
                         self.tree_cache.cache_finished_req(req)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1757,6 +1757,13 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             recv_obj.session_id if recv_obj.success else None
         )
 
+    def _handle_first_token_time_update(self, recv_obj: FirstTokenTimeUpdate):
+        """Handle first token time update from scheduler."""
+        if recv_obj.rid in self.rid_to_state:
+            state = self.rid_to_state[recv_obj.rid]
+            if state.first_token_time == 0.0:  # Only update if not already set
+                state.first_token_time = recv_obj.first_token_time
+
     def _handle_update_weights_from_disk_req_output(self, recv_obj):
         if self.server_args.dp_size == 1:
             self.model_update_result.set_result(recv_obj)


### PR DESCRIPTION
Add the metrics info into the metadata of the output 

## Motivation

Some 3rd benchmark framework can be integrated with sglang easily, be similar with vllm.

## Modifications
```python
{
            "arrival_time": self.arrival_time,
            "first_token_time": self.first_token_time,
            "finished_time": self.finished_time
}
```

## Accuracy Tests
no impact on the accuracy

## Benchmarking and Profiling
```python
  if engine_name == "VLLM":
      # vllm
      arrivals = [o.metrics.arrival_time for o in outputs]
      firsts = [o.metrics.first_token_time for o in outputs]
      finishes = [o.metrics.finished_time for o in outputs]
  else:
      # sglang
      arrivals = [o['metrics']['arrival_time'] for o in outputs]
      firsts = [o['metrics']['first_token_time'] for o in outputs]
      finishes = [o['metrics']['finished_time'] for o in outputs]
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
