### PR TITLE
Fuse write kv buffer into rope for qwen3 moe & bailing moe

### DIFF
--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -72,6 +72,10 @@ from sglang.srt.managers.schedule_batch import global_server_args_dict
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.utils import (
+    create_fused_set_kv_buffer_arg,
+    enable_fused_set_kv_buffer,
+)
 from sglang.srt.utils import add_prefix, is_cuda, is_non_idle_and_non_empty, make_layers
 
 LoraConfig = None
@@ -555,8 +559,27 @@ class BailingMoEAttention(nn.Module):
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         if self.use_qk_norm:
             q, k = self._apply_qk_norm(q, k)
-        q, k = self.rotary_emb(positions, q, k)
-        context_layer = self.attn(q, k, v, forward_batch)
+        q, k = self.rotary_emb(
+            positions,
+            q,
+            k,
+            fused_set_kv_buffer_arg=(
+                create_fused_set_kv_buffer_arg(
+                    value=v,
+                    layer=self.attn,
+                    forward_batch=forward_batch,
+                )
+                if enable_fused_set_kv_buffer(forward_batch)
+                else None
+            ),
+        )
+        context_layer = self.attn(
+            q,
+            k,
+            v,
+            forward_batch,
+            save_kv_cache=not enable_fused_set_kv_buffer(forward_batch),
+        )
         attn_output, _ = self.dense(context_layer)
         return attn_output
 

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -1,0 +1,51 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import torch
+
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.utils import is_cuda
+
+_is_cuda = is_cuda()
+
+
+if _is_cuda:
+    from sgl_kernel import FusedSetKVBufferArg
+
+
+def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
+    """Enable fused set_kv_buffer only on CUDA with bfloat16 KV cache."""
+    return _is_cuda and forward_batch.token_to_kv_pool.dtype == torch.bfloat16
+
+
+def create_fused_set_kv_buffer_arg(
+    value: torch.Tensor,
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+):
+    layer_id = layer.layer_id
+    token_to_kv_pool = forward_batch.token_to_kv_pool
+
+    k_buffer = token_to_kv_pool.get_key_buffer(layer_id)
+    v_buffer = token_to_kv_pool.get_value_buffer(layer_id)
+
+    return FusedSetKVBufferArg(
+        value=value,
+        k_buffer=k_buffer.view(k_buffer.shape[0], -1),
+        v_buffer=v_buffer.view(v_buffer.shape[0], -1),
+        k_scale=layer.k_scale,
+        v_scale=layer.v_scale,
+        cache_loc=forward_batch.out_cache_loc,
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fused write kv buffer into rope for qwen3 moe and bailing moe models. Got minor e2e speedup.
Inspired by https://github.com/sgl-project/sglang/pull/9014

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

```
python3 -m sglang.launch_server --model Qwen/Qwen3-30B-A3B --tp-size 8 --port 30010 --disable-radix-cache

python3 -m sglang.bench_serving \
    --backend sglang-oai-chat \
    --dataset-name mmmu \
    --num-prompts 1000 \
    --apply-chat-template --port 30010

python3 -m sglang.bench_serving     --backend sglang     --dataset-name random     --num-prompts 100     --random-input-len 4000     --random-output-len 1     --random-range-ratio 1 --port 30010


PR:
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     100
Benchmark duration (s):                  4.24
Total input tokens:                      400000
Total generated tokens:                  100
Total generated tokens (retokenized):    100
Request throughput (req/s):              23.60
Input token throughput (tok/s):          94401.10
Output token throughput (tok/s):         23.60
Total token throughput (tok/s):          94424.70
Concurrency:                             60.63
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2569.20
Median E2E Latency (ms):                 2611.22
---------------Time to First Token----------------
Mean TTFT (ms):                          2569.19
Median TTFT (ms):                        2611.21
P99 TTFT (ms):                           4159.26
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P95 ITL (ms):                            0.00
P99 ITL (ms):                            0.00
Max ITL (ms):                            0.00
==================================================

MAIN:
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     100
Benchmark duration (s):                  4.35
Total input tokens:                      400000
Total generated tokens:                  100
Total generated tokens (retokenized):    100
Request throughput (req/s):              22.99
Input token throughput (tok/s):          91961.44
Output token throughput (tok/s):         22.99
Total token throughput (tok/s):          91984.43
Concurrency:                             61.32
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2667.41
Median E2E Latency (ms):                 2682.19
---------------Time to First Token----------------
Mean TTFT (ms):                          2667.40
Median TTFT (ms):                        2682.18
P99 TTFT (ms):                           4290.75
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P95 ITL (ms):                            0.00
P99 ITL (ms):                            0.00
Max ITL (ms):                            0.00
==================================================
```

gsm8k result:
```
➜  sglang_dev2 git:(qwen_fuse_wr_kvbuf_into_rope2) ✗ CUDA_VISIBLE_DEVICES=4,5,6,7 python3 -m sglang.launch_server --model inclusionAI/Ling-mini-2.0 --tp-size 4 --port 30010 --disable-radix-cache --trust-remote-code

PR:
➜  sglang git:(main) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30010
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:08<00:00, 23.64it/s]
Accuracy: 0.925
Invalid: 0.000
Latency: 8.550 s
Output throughput: 3998.265 token/s

Main:
➜  sglang git:(main) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30010
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:09<00:00, 21.89it/s]
Accuracy: 0.905
Invalid: 0.000
Latency: 9.270 s
Output throughput: 3715.624 token/s

```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
