### PR TITLE
bugfix: Fix `get_worker_urls_for_model` in http/router.rs

### DIFF
--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -38,6 +38,7 @@ pub struct Router {
     worker_startup_timeout_secs: u64,
     worker_startup_check_interval_secs: u64,
     dp_aware: bool,
+    #[allow(dead_code)]
     api_key: Option<String>,
     retry_config: RetryConfig,
     circuit_breaker_config: CircuitBreakerConfig,

--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -969,13 +969,12 @@ impl Router {
                                 self.policy_registry.on_worker_added(model_id, None);
 
                                 // Initialize cache-aware policy if applicable
-                                let model_workers =
-                                    self.worker_registry.get_workers_filtered(
-                                            Some(model_id),
-                                            Some(WorkerType::Regular),
-                                            Some(ConnectionMode::Http),
-                                            false,
-                                        );
+                                let model_workers = self.worker_registry.get_workers_filtered(
+                                    Some(model_id),
+                                    Some(WorkerType::Regular),
+                                    Some(ConnectionMode::Http),
+                                    false,
+                                );
                                 self.policy_registry
                                     .init_cache_aware_policy(model_id, &model_workers);
 
@@ -1011,11 +1010,11 @@ impl Router {
 
                             // Initialize cache-aware policy if applicable
                             let model_workers = self.worker_registry.get_workers_filtered(
-                                        Some(model_id),
-                                        Some(WorkerType::Regular),
-                                        Some(ConnectionMode::Http),
-                                        false,
-                                    );
+                                Some(model_id),
+                                Some(WorkerType::Regular),
+                                Some(ConnectionMode::Http),
+                                false,
+                            );
                             self.policy_registry
                                 .init_cache_aware_policy(model_id, &model_workers);
                         }

--- a/sgl-router/src/routers/http/router.rs
+++ b/sgl-router/src/routers/http/router.rs
@@ -38,7 +38,6 @@ pub struct Router {
     worker_startup_timeout_secs: u64,
     worker_startup_check_interval_secs: u64,
     dp_aware: bool,
-    #[allow(dead_code)]
     api_key: Option<String>,
     retry_config: RetryConfig,
     circuit_breaker_config: CircuitBreakerConfig,
@@ -133,10 +132,12 @@ impl Router {
 
     /// Get worker URLs for a specific model
     pub fn get_worker_urls_for_model(&self, model_id: Option<&str>) -> Vec<String> {
-        let workers = match model_id {
-            Some(model) => self.worker_registry.get_by_model_fast(model),
-            None => self.worker_registry.get_all(),
-        };
+        let workers = self.worker_registry.get_workers_filtered(
+            model_id,
+            Some(WorkerType::Regular),
+            Some(ConnectionMode::Http),
+            false, // get all workers
+        );
         workers.iter().map(|w| w.url().to_string()).collect()
     }
 
@@ -315,22 +316,6 @@ impl Router {
         }
     }
 
-    #[allow(dead_code)]
-    fn select_first_worker_for_model(&self, model_id: Option<&str>) -> Result<String, String> {
-        let workers = match model_id {
-            Some(model) => self.worker_registry.get_by_model_fast(model),
-            None => self.worker_registry.get_all(),
-        };
-        if workers.is_empty() {
-            Err(format!(
-                "No workers are available for model: {:?}",
-                model_id
-            ))
-        } else {
-            Ok(workers[0].url().to_string())
-        }
-    }
-
     pub async fn send_health_check(&self, worker_url: &str) -> Response {
         let health_url = if self.dp_aware {
             // Need to extract the URL from "http://host:port@dp_rank"
@@ -444,11 +429,13 @@ impl Router {
         model_id: Option<&str>,
         text: Option<&str>,
     ) -> Option<Arc<dyn Worker>> {
-        // Get workers for the specified model (O(1) lookup if model_id is provided)
-        let workers = match model_id {
-            Some(model) => self.worker_registry.get_by_model_fast(model),
-            None => self.worker_registry.get_all(),
-        };
+        // Get workers for the specified model O(1), filtered by connection mode
+        let workers = self.worker_registry.get_workers_filtered(
+            model_id,
+            Some(WorkerType::Regular),
+            Some(ConnectionMode::Http),
+            false, // get all workers, we'll filter by is_available() next
+        );
 
         let available: Vec<Arc<dyn Worker>> = workers
             .iter()
@@ -983,7 +970,12 @@ impl Router {
 
                                 // Initialize cache-aware policy if applicable
                                 let model_workers =
-                                    self.worker_registry.get_by_model_fast(model_id);
+                                    self.worker_registry.get_workers_filtered(
+                                            Some(model_id),
+                                            Some(WorkerType::Regular),
+                                            Some(ConnectionMode::Http),
+                                            false,
+                                        );
                                 self.policy_registry
                                     .init_cache_aware_policy(model_id, &model_workers);
 
@@ -1018,7 +1010,12 @@ impl Router {
                             self.policy_registry.on_worker_added(model_id, None);
 
                             // Initialize cache-aware policy if applicable
-                            let model_workers = self.worker_registry.get_by_model_fast(model_id);
+                            let model_workers = self.worker_registry.get_workers_filtered(
+                                        Some(model_id),
+                                        Some(WorkerType::Regular),
+                                        Some(ConnectionMode::Http),
+                                        false,
+                                    );
                             self.policy_registry
                                 .init_cache_aware_policy(model_id, &model_workers);
                         }


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The HTTP router's select_worker_for_model method uses get_by_model_fast() which returns ALL workers for a model, regardless of their connection mode. It then filters by is_available() (health + circuit breaker), but doesn't filter by connection mode.

This means the HTTP router could potentially select a gRPC worker when it should only select HTTP workers.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Use `get_workers_filtered` instead in get_worker_urls_for_model
- Update cross `http/router.rs` to use `get_workers_filtered`
- Remove deadcode `select_first_worker_for_model`

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
