### PR TITLE
[Router] Include logprob metrics in the response

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -1791,6 +1791,18 @@ pub struct GenerateRequest {
     #[serde(default)]
     pub return_logprob: bool,
 
+    /// Start position for computing input logprobs (SGLang extension)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprob_start_len: Option<i32>,
+
+    /// Number of top input logprobs to return (SGLang extension)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_logprobs_num: Option<i32>,
+
+    /// Specific token IDs to compute input logprobs for (SGLang extension)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_ids_logprob: Option<Vec<i32>>,
+
     // ============= SGLang Extensions =============
     /// Path to LoRA adapter(s) for model customization
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1807,6 +1819,10 @@ pub struct GenerateRequest {
     /// Request ID for tracking
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rid: Option<String>,
+
+    /// Additional passthrough fields to maintain forward-compatibility
+    #[serde(default, flatten)]
+    pub other: serde_json::Map<String, serde_json::Value>,
 }
 
 impl GenerationRequest for GenerateRequest {

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -300,7 +300,13 @@ mod generation_tests {
 
         let payload = json!({
             "text": "Hello, world!",
-            "stream": false
+            "stream": false,
+            "return_logprob": true,
+            "logprob_start_len": 0,
+            "top_logprobs_num": 3,
+            "sampling_params": {
+                "max_new_tokens": 4
+            }
         });
 
         let req = Request::builder()
@@ -323,6 +329,20 @@ mod generation_tests {
         assert!(meta_info.get("finish_reason").is_some());
         assert_eq!(meta_info["finish_reason"]["type"], "stop");
 
+        assert!(meta_info.get("input_token_logprobs").is_some());
+        assert!(meta_info.get("output_token_logprobs").is_some());
+
+        let echo = body_json.get("echo_request").unwrap();
+        assert_eq!(echo.get("return_logprob").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(echo.get("logprob_start_len").and_then(|v| v.as_i64()), Some(0));
+        assert_eq!(echo.get("top_logprobs_num").and_then(|v| v.as_i64()), Some(3));
+        assert_eq!(
+            echo.get("sampling_params")
+                .and_then(|sp| sp.get("max_new_tokens"))
+                .and_then(|v| v.as_i64()),
+            Some(4)
+        );
+
         ctx.shutdown().await;
     }
 
@@ -341,7 +361,11 @@ mod generation_tests {
 
         let payload = json!({
             "text": "Stream test",
-            "stream": true
+            "stream": true,
+            "return_logprob": true,
+            "logprob_start_len": 0,
+            "top_logprobs_num": 2,
+            "sampling_params": {"max_new_tokens": 3}
         });
 
         let req = Request::builder()

--- a/sgl-router/tests/common/mock_worker.rs
+++ b/sgl-router/tests/common/mock_worker.rs
@@ -387,7 +387,8 @@ async fn generate_handler(
                     "type": "stop",
                     "reason": "length"
                 }
-            }
+            },
+            "echo_request": payload
         }))
         .into_response()
     }

--- a/sgl-router/tests/streaming_tests.rs
+++ b/sgl-router/tests/streaming_tests.rs
@@ -152,6 +152,9 @@ mod streaming_tests {
         let payload = json!({
             "text": "Stream test",
             "stream": true,
+            "return_logprob": true,
+            "logprob_start_len": 0,
+            "top_logprobs_num": 2,
             "sampling_params": {
                 "temperature": 0.7,
                 "max_new_tokens": 10


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When using the router, some of the log probs related fields in the response are not returned. Using a simple payload such as
```python
sampling_params = {"max_new_tokens": 1, "temperature":0}
    payload = {
        "sampling_params": sampling_params,        
        "input_ids": [[128000, 3923, 892, 374, 433, 30]],
        "return_logprob": True,
        "logprob_start_len": 0,
        "top_logprobs_num": 1,
    } 
```
We expect to get the logprobs for all the input tokens and output tokens along with the top log probs.


Using server (i.e. launching using `sglang.laucnch_server`):
```bash
$python test.py 

output=[{'text': ' (', 'output_ids': [3923, 892, 374, 433, 30, 320], 'meta_info': {'id': '4bafc0ac88ad4c48acf29b4ca3faf2f7', 'finish_reason': {'type': 'length', 'length': 1}, 'prompt_tokens': 6, 'weight_version': 'default', 'input_token_logprobs': [[None, 128000, None], [-6.5678887367248535, 3923, None], [-6.764453411102295, 892, None], [-1.626485824584961, 374, None], [-1.8728961944580078, 433, None], [-1.4933363199234009, 30, None]], 'output_token_logprobs': [[-2.0437331199645996, 320, None]], 'input_top_logprobs': [None, [[-4.0366387367248535, 791, None]], [[-1.3269532918930054, 374, None]], [[-1.251485824584961, 1587, None]], [[-0.6853961944580078, 279, None]], [[-1.2433363199234009, 304, None]]], 'output_top_logprobs': [[[-2.0437331199645996, 320, None]]], 'completion_tokens': 1, 'cached_tokens': 0, 'e2e_latency': 0.05393624305725098}}]
payload={'sampling_params': {'max_new_tokens': 1, 'temperature': 0}, 'input_ids': [[128000, 3923, 892, 374, 433, 30]], 'return_logprob': True, 'logprob_start_len': 0, 'top_logprobs_num': 1}
```

Using current router (using `sgl_router.launch_router`):
```bash
$ python test.py 

output=[{'text': ' (', 'output_ids': [3923, 892, 374, 433, 30, 320], 'meta_info': {'id': 'e76b502c30c34b05bc2521ec34401d72', 'finish_reason': {'type': 'length', 'length': 1}, 'prompt_tokens': 6, 'weight_version': 'default', 'input_token_logprobs': [[None, 30, None]], 'output_token_logprobs': [[-2.0437331199645996, 320, None]], 'completion_tokens': 1, 'cached_tokens': 1, 'e2e_latency': 0.034102678298950195}}]
payload={'sampling_params': {'max_new_tokens': 1, 'temperature': 0}, 'input_ids': [[128000, 3923, 892, 374, 433, 30]], 'return_logprob': True, 'logprob_start_len': 0, 'top_logprobs_num': 1}
```
After this PR:
```bash
$ python test.py 
output=[{'text': ' (', 'output_ids': [3923, 892, 374, 433, 30, 320], 'meta_info': {'id': 'a49ea86431874447b9b3a74dcb6fc456', 'finish_reason': {'type': 'length', 'length': 1}, 'prompt_tokens': 6, 'weight_version': 'default', 'input_token_logprobs': [[None, 128000, None], [-6.5678887367248535, 3923, None], [-6.764453411102295, 892, None], [-1.626485824584961, 374, None], [-1.8728961944580078, 433, None], [-1.4933363199234009, 30, None]], 'output_token_logprobs': [[-2.0437331199645996, 320, None]], 'input_top_logprobs': [None, [[-4.0366387367248535, 791, None]], [[-1.3269532918930054, 374, None]], [[-1.251485824584961, 1587, None]], [[-0.6853961944580078, 279, None]], [[-1.2433363199234009, 304, None]]], 'output_top_logprobs': [[[-2.0437331199645996, 320, None]]], 'completion_tokens': 1, 'cached_tokens': 0, 'e2e_latency': 0.125931978225708}}]
payload={'sampling_params': {'max_new_tokens': 1, 'temperature': 0}, 'input_ids': [[128000, 3923, 892, 374, 433, 30]], 'return_logprob': True, 'logprob_start_len': 0, 'top_logprobs_num': 1}
```

As it can be seen, with these changes, we can see the correct number of log probs for the input and output tokens as well the top log probs for all the tokens.

Simple script to reproduce:

```python
import httpx
import asyncio


async def post(url, payload, max_retries=60):
    _http_client = httpx.AsyncClient(
            limits=httpx.Limits(max_connections=1),
            timeout=httpx.Timeout(None, connect=5.0),
        )
    try:
        response = await _http_client.post(url, json=payload or {})
        response.raise_for_status()
        try:
            output = response.json()
        except:
            output = response.text
    except Exception as e:
        raise e
    return output

if __name__ == "__main__":
    sampling_params = {"max_new_tokens": 1, "temperature":0}
    payload = {
        "sampling_params": sampling_params,        
        "input_ids": [[128000, 3923, 892, 374, 433, 30]],
        "return_logprob": True,
        "logprob_start_len": 0,
        "top_logprobs_num": 1,
    }    

    url = "http://127.0.0.1:30000/generate"
    output = asyncio.run(post(url, payload))
    print(f"{output=}")
    print(f"{payload=}")
```
## Modifications

Update the router to include the logprob related metrics.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
