### PR TITLE
[router] fix logger type mismatch

### DIFF
--- a/sgl-router/py_src/sglang_router/router.py
+++ b/sgl-router/py_src/sglang_router/router.py
@@ -53,7 +53,7 @@ class Router:
             Useful when the dp aware scheduling strategy is enabled.
             Default: None
         log_dir: Directory to store log files. If None, logs are only output to console. Default: None
-        log_level: Logging level. Options: 'debug', 'info', 'warning', 'error', 'critical'.
+        log_level: Logging level. Options: 'debug', 'info', 'warn', 'error'.
         service_discovery: Enable Kubernetes service discovery. When enabled, the router will
             automatically discover worker pods based on the selector. Default: False
         selector: Dictionary mapping of label keys to values for Kubernetes pod selection.

--- a/sgl-router/py_src/sglang_router/router_args.py
+++ b/sgl-router/py_src/sglang_router/router_args.py
@@ -249,7 +249,7 @@ class RouterArgs:
             f"--{prefix}log-level",
             type=str,
             default="info",
-            choices=["debug", "info", "warning", "error", "critical"],
+            choices=["debug", "info", "warn", "error"],
             help="Set the logging level. If not specified, defaults to INFO.",
         )
         parser.add_argument(


### PR DESCRIPTION
fix logger from warning to warn, since rust expects `warn` instead of `warning`

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
