### PR TITLE
Fix [test]: Env:SGLANG_TORCH_PROFILER_DIR for pytest.

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -126,6 +126,7 @@ class Envs:
     SGLANG_DISABLE_REQUEST_LOGGING = EnvBool(False)
     SGLANG_SIMULATE_ACC_LEN = EnvFloat(-1)
     SGLANG_SIMULATE_ACC_METHOD = EnvStr("multinomial")
+    SGLANG_TORCH_PROFILER_DIR = EnvStr("/tmp")
 
     # Model Parallel
     SGLANG_USE_MESSAGE_QUEUE_BROADCASTER = EnvBool(True)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -126,7 +126,6 @@ class Envs:
     SGLANG_DISABLE_REQUEST_LOGGING = EnvBool(False)
     SGLANG_SIMULATE_ACC_LEN = EnvFloat(-1)
     SGLANG_SIMULATE_ACC_METHOD = EnvStr("multinomial")
-    SGLANG_TORCH_PROFILER_DIR = EnvStr("/tmp")
 
     # Model Parallel
     SGLANG_USE_MESSAGE_QUEUE_BROADCASTER = EnvBool(True)

--- a/test/srt/test_start_profile.py
+++ b/test/srt/test_start_profile.py
@@ -25,6 +25,7 @@ class TestStartProfile(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
+        os.environ["SGLANG_TORCH_PROFILER_DIR"] = OUTPUT_DIR
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
@@ -111,5 +112,4 @@ class TestStartProfile(CustomTestCase):
 
 
 if __name__ == "__main__":
-    os.environ["SGLANG_TORCH_PROFILER_DIR"] = OUTPUT_DIR
     unittest.main()

--- a/test/srt/test_start_profile.py
+++ b/test/srt/test_start_profile.py
@@ -9,8 +9,8 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
 from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,

--- a/test/srt/test_start_profile.py
+++ b/test/srt/test_start_profile.py
@@ -10,6 +10,7 @@ import unittest
 import requests
 
 from sglang.srt.utils import kill_process_tree
+from sglang.srt.environ import envs
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -25,7 +26,7 @@ class TestStartProfile(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        os.environ["SGLANG_TORCH_PROFILER_DIR"] = OUTPUT_DIR
+        envs.SGLANG_TORCH_PROFILER_DIR.set(OUTPUT_DIR)
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Running sglang unit tests on XPU currently fails under pytest because the SGLANG_TORCH_PROFILER_DIR environment variable is only set in the __main__ block. When executed via pytest, the __main__ block is not triggered, leading to missing profiler output directory setup. However, when running with unittest directly, the test passes since the variable is set in that execution path.
## Modifications

<!-- Detail the changes made in this pull request. -->
Moved the os.environ["SGLANG_TORCH_PROFILER_DIR"] = OUTPUT_DIR assignment into the setUpClass method of TestStartProfile.

Ensures the environment variable is always set, regardless of whether the test is executed via pytest or unittest.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Verified that the test now passes when executed with both pytest and unittest.
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
No accuracy or performance regressions introduced.

Only affects test setup to make profiling directory consistently available.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
