### PR TITLE
Fix typo: oltp-traces-endpoint → otlp-traces-endpoint

### DIFF
--- a/docs/references/production_request_trace.md
+++ b/docs/references/production_request_trace.md
@@ -1,4 +1,4 @@
-SGlang exports request trace data based on the OpenTelemetry Collector. You can enable tracing by adding the `--enable-trace` and configure the OpenTelemetry Collector endpoint using `--oltp-traces-endpoint` when launching the server.
+SGlang exports request trace data based on the OpenTelemetry Collector. You can enable tracing by adding the `--enable-trace` and configure the OpenTelemetry Collector endpoint using `--otlp-traces-endpoint` when launching the server.
 
 You can find example screenshots of the visualization in https://github.com/sgl-project/sglang/issues/8965.
 
@@ -22,7 +22,7 @@ This section explains how to configure the request tracing and export the trace 
 
 3. start your SGLang server with tracing enabled
     ```bash
-    python -m sglang.launch_server --enable-trace --oltp-traces-endpoint 0.0.0.0:4317 <other option>
+    python -m sglang.launch_server --enable-trace --otlp-traces-endpoint 0.0.0.0:4317 <other option>
     ```
 
     Replace `0.0.0.0:4317` with the actual endpoint of the opentelemetry collector. If you launched the openTelemetry collector with tracing_compose.yaml, the default receiving port is 4317.
@@ -39,9 +39,9 @@ We have already inserted instrumentation points in the tokenizer and scheduler m
 
     Every process involved in tracing during the initialization phase should execute:
     ```python
-    process_tracing_init(oltp_traces_endpoint, server_name)
+    process_tracing_init(otlp_traces_endpoint, server_name)
     ```
-    The oltp_traces_endpoint is obtained from the arguments, and you can set server_name freely, but it should remain consistent across all processes.
+    The otlp_traces_endpoint is obtained from the arguments, and you can set server_name freely, but it should remain consistent across all processes.
 
     Every thread involved in tracing during the initialization phase should execute:
     ```python

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -142,7 +142,7 @@ class Engine(EngineBase):
         )
 
         if server_args.enable_trace:
-            process_tracing_init(server_args.oltp_traces_endpoint, "sglang")
+            process_tracing_init(server_args.otlp_traces_endpoint, "sglang")
             if server_args.disaggregation_mode == "null":
                 thread_label = "Tokenizer"
                 trace_set_thread_info(thread_label)

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -185,7 +185,7 @@ async def init_multi_tokenizer() -> ServerArgs:
     )
 
     if server_args.enable_trace:
-        process_tracing_init(server_args.oltp_traces_endpoint, "sglang")
+        process_tracing_init(server_args.otlp_traces_endpoint, "sglang")
         if server_args.disaggregation_mode == "null":
             thread_label = f"MultiTokenizer-{tokenizer_manager.worker_id}"
             trace_set_thread_info(thread_label)
@@ -1229,7 +1229,7 @@ def launch_server(
         )
 
         if server_args.enable_trace:
-            process_tracing_init(server_args.oltp_traces_endpoint, "sglang")
+            process_tracing_init(server_args.otlp_traces_endpoint, "sglang")
             if server_args.disaggregation_mode == "null":
                 thread_label = "Tokenizer"
                 trace_set_thread_info(thread_label)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2774,7 +2774,7 @@ def run_scheduler_process(
     balance_meta: Optional[DPBalanceMeta] = None,
 ):
     if server_args.enable_trace:
-        process_tracing_init(server_args.oltp_traces_endpoint, "sglang")
+        process_tracing_init(server_args.otlp_traces_endpoint, "sglang")
         if server_args.disaggregation_mode == "null":
             thread_label = "Scheduler"
             trace_set_thread_info(thread_label, tp_rank, dp_rank)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -226,7 +226,7 @@ class ServerArgs:
     kv_events_config: Optional[str] = None
     gc_warning_threshold_secs: float = 0.0
     enable_trace: bool = False
-    oltp_traces_endpoint: str = "localhost:4317"
+    otlp_traces_endpoint: str = "localhost:4317"
 
     # API related
     api_key: Optional[str] = None
@@ -1623,7 +1623,7 @@ class ServerArgs:
             help="Enable opentelemetry trace",
         )
         parser.add_argument(
-            "--oltp-traces-endpoint",
+            "--otlp-traces-endpoint",
             type=str,
             default="localhost:4317",
             help="Config opentelemetry collector endpoint if --enable-trace is set. format: <ip>:<port>",

--- a/test/srt/test_tracing.py
+++ b/test/srt/test_tracing.py
@@ -74,7 +74,7 @@ class TestTrace(CustomTestCase):
             DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--enable-trace", "--oltp-traces-endpoint", "0.0.0.0:4317"],
+            other_args=["--enable-trace", "--otlp-traces-endpoint", "0.0.0.0:4317"],
         )
 
         try:
@@ -121,7 +121,7 @@ class TestTrace(CustomTestCase):
             model_path=model_path,
             random_seed=42,
             enable_trace=True,
-            oltp_traces_endpoint="localhost:4317",
+            otlp_traces_endpoint="localhost:4317",
         )
 
         try:
@@ -148,7 +148,7 @@ class TestTrace(CustomTestCase):
             model_path=model_path,
             random_seed=42,
             enable_trace=True,
-            oltp_traces_endpoint="localhost:4317",
+            otlp_traces_endpoint="localhost:4317",
             is_embedding=True,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Rename 'oltp-traces-endpoint' to the correct 'otlp-traces-endpoint', where otlp stands for OpenTelemetry Protocol.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
