### PR TITLE
Added memoization storage for logprobs detokenize

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -144,6 +144,13 @@ class ReqState:
     output_token_ids_logprobs_val: List = dataclasses.field(default_factory=list)
     output_token_ids_logprobs_idx: List = dataclasses.field(default_factory=list)
 
+    input_token_logprobs: List = dataclasses.field(default_factory=list)
+    input_token_ids_logprobs: List = dataclasses.field(default_factory=list)
+    input_top_logprobs: List = dataclasses.field(default_factory=list)
+    output_token_logprobs: List = dataclasses.field(default_factory=list)
+    output_token_ids_logprobs: List = dataclasses.field(default_factory=list)
+    output_top_logprobs: List = dataclasses.field(default_factory=list)
+
 
 class TokenizerManager(TokenizerCommunicatorMixin):
     """TokenizerManager is a process that tokenizes the text."""
@@ -1526,16 +1533,24 @@ class TokenizerManager(TokenizerCommunicatorMixin):
         state.output_token_logprobs_idx.extend(
             recv_obj.output_token_logprobs_idx[recv_obj_index]
         )
-        meta_info["input_token_logprobs"] = self.detokenize_logprob_tokens(
-            state.input_token_logprobs_val,
-            state.input_token_logprobs_idx,
+
+        delta_input_token_logprobs = self.detokenize_logprob_tokens(
+            recv_obj.input_token_logprobs_val[recv_obj_index],
+            recv_obj.input_token_logprobs_idx[recv_obj_index],
             return_text_in_logprobs,
         )
-        meta_info["output_token_logprobs"] = self.detokenize_logprob_tokens(
-            state.output_token_logprobs_val,
-            state.output_token_logprobs_idx,
+        state.input_token_logprobs.extend(delta_input_token_logprobs)
+
+        delta_output_token_logprobs = self.detokenize_logprob_tokens(
+            recv_obj.output_token_logprobs_val[recv_obj_index],
+            recv_obj.output_token_logprobs_idx[recv_obj_index],
             return_text_in_logprobs,
         )
+
+        state.output_token_logprobs.extend(delta_output_token_logprobs)
+
+        meta_info["input_token_logprobs"] = state.input_token_logprobs
+        meta_info["output_token_logprobs"] = state.output_token_logprobs
 
         if top_logprobs_num > 0:
             if len(recv_obj.input_top_logprobs_val) > 0:
@@ -1551,16 +1566,23 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             state.output_top_logprobs_idx.extend(
                 recv_obj.output_top_logprobs_idx[recv_obj_index]
             )
-            meta_info["input_top_logprobs"] = self.detokenize_top_logprobs_tokens(
-                state.input_top_logprobs_val,
-                state.input_top_logprobs_idx,
+
+            delta_input_top_logprobs = self.detokenize_top_logprobs_tokens(
+                recv_obj.input_top_logprobs_val[recv_obj_index],
+                recv_obj.input_top_logprobs_idx[recv_obj_index],
                 return_text_in_logprobs,
             )
-            meta_info["output_top_logprobs"] = self.detokenize_top_logprobs_tokens(
-                state.output_top_logprobs_val,
-                state.output_top_logprobs_idx,
+            state.input_top_logprobs.extend(delta_input_top_logprobs)
+
+            delta_output_top_logprobs = self.detokenize_top_logprobs_tokens(
+                recv_obj.output_top_logprobs_val[recv_obj_index],
+                recv_obj.output_top_logprobs_idx[recv_obj_index],
                 return_text_in_logprobs,
             )
+            state.output_top_logprobs.extend(delta_output_top_logprobs)
+
+            meta_info["input_top_logprobs"] = state.input_top_logprobs
+            meta_info["output_top_logprobs"] = state.output_top_logprobs
 
         if token_ids_logprob is not None:
             if len(recv_obj.input_token_ids_logprobs_val) > 0:
@@ -1576,18 +1598,23 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             state.output_token_ids_logprobs_idx.extend(
                 recv_obj.output_token_ids_logprobs_idx[recv_obj_index]
             )
-            meta_info["input_token_ids_logprobs"] = self.detokenize_top_logprobs_tokens(
-                state.input_token_ids_logprobs_val,
-                state.input_token_ids_logprobs_idx,
+
+            delta_input_token_ids_logprobs = self.detokenize_top_logprobs_tokens(
+                recv_obj.input_token_ids_logprobs_val[recv_obj_index],
+                recv_obj.input_token_ids_logprobs_idx[recv_obj_index],
                 return_text_in_logprobs,
             )
-            meta_info["output_token_ids_logprobs"] = (
-                self.detokenize_top_logprobs_tokens(
-                    state.output_token_ids_logprobs_val,
-                    state.output_token_ids_logprobs_idx,
-                    return_text_in_logprobs,
-                )
+            state.input_token_ids_logprobs.extend(delta_input_token_ids_logprobs)
+
+            delta_output_token_ids_logprobs = self.detokenize_top_logprobs_tokens(
+                recv_obj.output_token_ids_logprobs_val[recv_obj_index],
+                recv_obj.output_token_ids_logprobs_idx[recv_obj_index],
+                return_text_in_logprobs,
             )
+            state.output_token_ids_logprobs.extend(delta_output_token_ids_logprobs)
+
+            meta_info["input_token_ids_logprobs"] = state.input_token_ids_logprobs
+            meta_info["output_token_ids_logprobs"] = state.output_token_ids_logprobs
 
     def detokenize_logprob_tokens(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In the current top logprobs logic, all logprobs_val will be detokenized at the end of each decoding round. When the sequence length is long, it will cause excessive CPU load.And when the tokenizer uses a single-core CPU for parallel processing threads, the slower tokenizer processing process will block the processing of other parallel requests.Therefore, it is necessary to add a cache of detokenize logprobs to avoid repeated calculations and thus reduce the CPU load.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
1.  A new field is added to ReqState to store the logprobs that have been detokenized.
2. Modify the detokenize logic to change repeated detokenize to only use incremental logprobs for detokenize

<!-- Detail the changes made in this pull request. -->


## Benchmarking and Profiling
baseline benchmark
![20250923203935](https://github.com/user-attachments/assets/39b57f3a-8fed-4f4e-b6c8-261e0d7301b7)
After Added memoization storage for logprobs detokenize
![20250923203955](https://github.com/user-attachments/assets/e6a3dc04-43b3-4440-ab99-69838e609e2c)

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
