### PR TITLE
[Bugfix] fix the issue with the default reasoning mode # 

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -124,7 +124,7 @@ class CacheEntry:
 class BaseGrammarBackend:
     def __init__(self):
         self.executor = ThreadPoolExecutor()
-        self.cache: Dict[Tuple[str, str], CacheEntry] = {}
+        self.cache: Dict[Tuple[str, str, bool], CacheEntry] = {}
 
     def _not_supported(self, key_type: str, key_string: str) -> None:
         logger.warning(f"Skip unsupported {key_type=}, {key_string=}")
@@ -149,9 +149,9 @@ class BaseGrammarBackend:
     def dispatch_structural_tag(self, key_string: str) -> Optional[BaseGrammarObject]:
         return self._not_supported("structural_tag", key_string)
 
-    def _init_value_dispatch(self, key: Tuple[str, str]) -> Optional[BaseGrammarObject]:
+    def _init_value_dispatch(self, key: Tuple[str, str, bool]) -> Optional[BaseGrammarObject]:
         s = time.perf_counter()
-        key_type, key_string = key
+        key_type, key_string, may_can_reasoning = key
         if key_type == "json":
             grammar = self.dispatch_json(key_string)
         elif key_type == "regex":
@@ -171,16 +171,14 @@ class BaseGrammarBackend:
             grammar.grammar_stats.compilation_time = time.perf_counter() - s
         return grammar
 
-    def get_cached_or_future_value(
-        self, key: Tuple[str, str]
-    ) -> Optional[BaseGrammarObject]:
+    def get_cached_or_future_value(self, key):
         value = self.cache.get(key)
         if value:
             return value.copy(), True
         value = self.executor.submit(self._init_value_dispatch, key)
         return value, False
 
-    def set_cache(self, key: Tuple[str, str], value: BaseGrammarObject):
+    def set_cache(self, key, value: BaseGrammarObject):
         self.cache[key] = value
 
     def reset(self):

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -21,11 +21,11 @@ from .base_grammar_backend import BaseGrammarBackend, BaseGrammarObject
 
 
 class ReasonerGrammarObject(BaseGrammarObject):
-    def __init__(self, grammar: BaseGrammarObject, think_end_id):
+    def __init__(self, grammar: BaseGrammarObject, think_end_id, may_can_reasoning):
         super().__init__()
         self.grammar = grammar
         self.think_end_id = think_end_id
-        self.is_in_reasoning = True
+        self.is_in_reasoning = may_can_reasoning
 
     def accept_token(self, token: int):
         if token == self.think_end_id:
@@ -34,10 +34,16 @@ class ReasonerGrammarObject(BaseGrammarObject):
         if not self.is_in_reasoning and token != self.think_end_id:
             self.grammar.accept_token(token)
 
+    def rollback(self, k: int):
+        self.grammar.rollback(k)
+
     def allocate_vocab_mask(
         self, vocab_size: int, batch_size: int, device
     ) -> torch.Tensor:
         return self.grammar.allocate_vocab_mask(vocab_size, batch_size, device)
+
+    def is_terminated(self):
+        return self.grammar.is_terminated()
 
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
         if not self.is_in_reasoning:
@@ -51,7 +57,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
         return self.grammar.apply_vocab_mask
 
     def copy(self) -> BaseGrammarObject:
-        return ReasonerGrammarObject(self.grammar.copy(), self.think_end_id)
+        return ReasonerGrammarObject(self.grammar.copy(), self.think_end_id, self.is_in_reasoning)
 
     @property
     def finished(self):
@@ -82,9 +88,10 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
         self.think_end_id = think_end_id
 
     def _init_value_dispatch(
-        self, key: Tuple[str, str]
+        self, key: Tuple[str, str, bool]
     ) -> Optional[ReasonerGrammarObject]:
         ret = self.grammar_backend._init_value_dispatch(key)
         if ret is None:
             return None
-        return ReasonerGrammarObject(ret, self.think_end_id)
+        may_can_reasoning = key[2]
+        return ReasonerGrammarObject(ret, self.think_end_id, may_can_reasoning)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1369,6 +1369,10 @@ class Scheduler(
             elif req.sampling_params.structural_tag:
                 key = ("structural_tag", req.sampling_params.structural_tag)
 
+            may_can_reasoning = not getattr(self.tokenizer, "think_end_id", None) in getattr(req, "origin_input_ids", [])
+            key = (key[0], key[1], may_can_reasoning)
+            req._may_can_reasoning = may_can_reasoning
+
             value, cache_hit = self.grammar_backend.get_cached_or_future_value(key)
             req.grammar = value
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
When we start a hybrid reasoning model on the server side, such as DeepSeek V3.1 or Qwen-14B, and enable both the reasoning parser and speculative decoding, then on the client side disable “thinking mode” in `chat_template_kwargs` while also enabling JSON-constrained decoding, we observe that SGLang produces abnormal results.
https://github.com/sgl-project/sglang/issues/10789



<!-- Describe the purpose and goals of this pull request.a-->

## Modifications
We found that this may be related to the `ReasonerGrammarBackend`, where the `ReasonerGrammarObject` defaults to `is_in_reasoning = true`. Therefore, we are considering some actions to take when “thinking mode” is disabled in `chat_template_kwargs`.


https://github.com/sgl-project/sglang/blob/d21c35224d64c0badaedb1c6d1d71819f5b0578f/python/sglang/srt/constrained/reasoner_grammar_backend.py#L28



<!-- Detail the changes made in this pull request. -->

script
```
import json
from openai import OpenAI

def main(model_name="Qwen3-14B", thinking=False, use_json_schema=None):

    niogpt_base_url = "http://0.0.0.0:30000/v1"
    niogpt_api_key = "sk-no-api-key-needed"
    client = OpenAI(
        api_key=niogpt_api_key,
        base_url=niogpt_base_url
    )
    json_schema = {
        "type": "object",
        "properties": {
            "population": {"type": "integer"},
            "name": {"type": "string", "pattern": "^[\\w]+$"},
        },
        "required": ["name", "population"],
    }
    
    chat_kwargs = {"enable_thinking": thinking}

    # 基础请求参数
    request_params = dict(
        model=model_name,
        messages=[
            {
                "role": "user",
                "content": "show me the information of the capital of China in the JSON format.",
            }
        ],
        temperature=0,
        max_tokens=512,
        extra_body={"chat_template_kwargs": chat_kwargs}
    )
    if use_json_schema is True:
        request_params["response_format"] = {
            "type": "json_schema",
            "json_schema": {"name": "foo", "schema": json_schema}
        }

    response = client.chat.completions.create(**request_params)

    print("========== completion_tokens ==========")
    print(response.usage.completion_tokens)

    print("========== content ==========")
    for choice in response.choices:
        print(choice.message.content if choice.message.content is not None else "None")

    print("========== reasoning_content ==========")
    for choice in response.choices:
        print(choice.message.reasoning_content if choice.message.reasoning_content is not None else "None")
        print("=" * 50 + "\n")


if __name__ == "__main__":
    main(model_name="Qwen3-14B", thinking=True, use_json_schema=True)

```


- before
```
========== completion_tokens ==========
512
========== content ==========
```!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========== reasoning_content ==========
None
==================================================
```

- After PR

```
========== completion_tokens ==========
22
========== content ==========
{"population": 215423946, "name": "Beijing"}
========== reasoning_content ==========
None
==================================================
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
