### PR TITLE
[ROCm] Update aiter to v0.1.5.post3

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -31,7 +31,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT="v0.1.5.post2"
+ENV AITER_COMMIT="v0.1.5.post3"
 ENV NO_DEPS_FLAG=""
 
 # ===============================
@@ -42,7 +42,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT="v0.1.5.post2"
+ENV AITER_COMMIT="v0.1.5.post3"
 ENV NO_DEPS_FLAG="--no-deps"
 
 # ===============================


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

With aiter update to v0.1.5post2, the prebult image will hit DSv3 abort.

## Modifications

Update aiter to v0.1.5post3. (related tickets: https://github.com/ROCm/aiter/issues/1042)

## Accuracy Tests

After rrebuilding the image with prebuilt aiter, verifing the accuracy on MI30x and MI35x:

=== Summary ===
DeepSeek-R1+DP: PASS [OK]
DeepSeek-R1: PASS [OK]
GROK1-IN4: PASS [OK]
GROK1-FP8: PASS [OK]
GROK2.5: PASS [OK]
GPT-OSS-120B: PASS [OK]
QWEN-30B: PASS [OK]

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
