### PR TITLE
[router] fix axum default body limit

### DIFF
--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -477,6 +477,7 @@ pub fn build_app(
         .merge(public_routes)
         .merge(admin_routes)
         .merge(worker_routes)
+        .layer(axum::extract::DefaultBodyLimit::max(max_payload_size))
         .layer(tower_http::limit::RequestBodyLimitLayer::new(
             max_payload_size,
         ))


### PR DESCRIPTION
## Motivation

Fixes #10800 

See: By default the limit of request body sizes that [Bytes::from_request](https://docs.rs/bytes/1.10.1/x86_64-unknown-linux-gnu/bytes/bytes/struct.Bytes.html) (and other extractors built on top of it such as String, [Json](https://docs.rs/axum/0.8/axum/struct.Json.html), and [Form](https://docs.rs/axum/0.8/axum/struct.Form.html)) is 2MB.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
