### PR TITLE
[router] add auth middleware for api key auth

### DIFF
--- a/sgl-router/Cargo.toml
+++ b/sgl-router/Cargo.toml
@@ -69,6 +69,7 @@ rmcp = { version = "0.6.3", features = ["client", "server",
     "reqwest",
     "auth"] }
 serde_yaml = "0.9"
+subtle = "2.6"
 
 # gRPC and Protobuf dependencies
 tonic = { version = "0.12", features = ["tls", "gzip", "transport"] }

--- a/sgl-router/README.md
+++ b/sgl-router/README.md
@@ -363,7 +363,7 @@ python -m sglang_router.launch_router \
 curl -X POST http://localhost:8080/add_worker?url=http://worker3:8000
 # WARNING: This worker has NO API key even though router has one!
 
-# Adding workers with specific API keys dynamically  
+# Adding workers with specific API keys dynamically
 curl -X POST http://localhost:8080/add_worker?url=http://worker3:8000&api_key=worker3-specific-key
 ```
 
@@ -391,7 +391,7 @@ curl -X POST http://localhost:8080/add_worker?url=http://worker3:8000&api_key=wo
    ```bash
    # Start router with its key
    python -m sglang_router.launch_router --api-key "router-key"
-   
+
    # Add workers with their keys
    curl -H "Authorization: Bearer router-key" \
         -X POST http://localhost:8080/add_worker?url=http://worker:8000&api_key=worker-key

--- a/sgl-router/README.md
+++ b/sgl-router/README.md
@@ -331,6 +331,79 @@ python -m sglang_router.launch_router \
     --prometheus-port 9090
 ```
 
+### API Key Authentication
+
+The router supports multi-level API key authentication for both the router itself and individual workers:
+
+#### Router API Key
+Protect access to the router endpoints:
+
+```bash
+python -m sglang_router.launch_router \
+    --api-key "your-router-api-key" \
+    --worker-urls http://worker1:8000 http://worker2:8000
+```
+
+When router API key is set, clients must include the Bearer token:
+```bash
+curl -H "Authorization: Bearer your-router-api-key" http://localhost:8080/v1/chat/completions
+```
+
+#### Worker API Keys
+Workers can have their own API keys for authentication:
+
+```bash
+# Workers specified in --worker-urls automatically inherit the router's API key
+python -m sglang_router.launch_router \
+    --api-key "shared-api-key" \
+    --worker-urls http://worker1:8000 http://worker2:8000
+# Both workers will use "shared-api-key" for authentication
+
+# Adding workers dynamically WITHOUT inheriting router's key
+curl -X POST http://localhost:8080/add_worker?url=http://worker3:8000
+# WARNING: This worker has NO API key even though router has one!
+
+# Adding workers with specific API keys dynamically  
+curl -X POST http://localhost:8080/add_worker?url=http://worker3:8000&api_key=worker3-specific-key
+```
+
+#### Security Configurations
+
+1. **No Authentication** (default):
+   - Router and workers accessible without keys
+   - Suitable for trusted environments
+
+2. **Router-only Authentication**:
+   - Clients need key to access router
+   - Router can access workers freely
+
+3. **Worker-only Authentication**:
+   - Router accessible without key
+   - Each worker requires authentication
+   ```bash
+   # Add workers with their API keys
+   curl -X POST http://localhost:8080/add_worker?url=http://worker:8000&api_key=worker-key
+   ```
+
+4. **Full Authentication**:
+   - Router requires key from clients
+   - Each worker requires its own key
+   ```bash
+   # Start router with its key
+   python -m sglang_router.launch_router --api-key "router-key"
+   
+   # Add workers with their keys
+   curl -H "Authorization: Bearer router-key" \
+        -X POST http://localhost:8080/add_worker?url=http://worker:8000&api_key=worker-key
+   ```
+
+#### Important Notes
+
+- **Initial Workers**: Workers specified in `--worker-urls` automatically inherit the router's API key
+- **Dynamic Workers**: When adding workers via API, you must explicitly specify their API keys - they do NOT inherit the router's key
+- **Security Warning**: When adding workers without API keys while the router has one configured, a warning will be logged
+- **Common Pitfall**: If router and workers use the same API key, you must still specify the key when adding workers dynamically
+
 ### Command Line Arguments Reference
 
 #### Service Discovery
@@ -348,6 +421,9 @@ python -m sglang_router.launch_router \
 - `--policy`: Routing policy (`cache_aware`, `random`, `power_of_two`, `round_robin`)
 - `--prefill-policy`: Separate routing policy for prefill nodes (optional, overrides `--policy` for prefill)
 - `--decode-policy`: Separate routing policy for decode nodes (optional, overrides `--policy` for decode)
+
+#### Authentication
+- `--api-key`: API key for router authentication (clients must provide this as Bearer token)
 
 ## Development
 

--- a/sgl-router/py_test/e2e/test_regular_router.py
+++ b/sgl-router/py_test/e2e/test_regular_router.py
@@ -141,21 +141,14 @@ def test_dp_aware_worker_expansion_and_api_key(
     assert len(urls) == 2
     assert set(urls) == {f"{worker_url}@0", f"{worker_url}@1"}
 
-    # TODO: Router currently doesn't enforce API key authentication on incoming requests.
-    # It only adds the API key to outgoing requests to workers.
-    # Need to implement auth middleware to properly protect router endpoints.
-    # For now, both requests succeed (200) regardless of client authentication.
-
-    # Verify API key enforcement path-through
-    # 1) Without Authorization -> Currently 200 (should be 401 after auth middleware added)
+    # Verify API key enforcement
+    # 1) Without Authorization -> Should get 401 Unauthorized
     r = requests.post(
         f"{router_url}/v1/completions",
         json={"model": e2e_model, "prompt": "hi", "max_tokens": 1},
         timeout=60,
     )
-    assert (
-        r.status_code == 200
-    )  # TODO: Change to 401 after auth middleware implementation
+    assert r.status_code == 401
 
     # 2) With correct Authorization -> 200
     r = requests.post(

--- a/sgl-router/py_test/e2e/test_regular_router.py
+++ b/sgl-router/py_test/e2e/test_regular_router.py
@@ -131,11 +131,16 @@ def test_dp_aware_worker_expansion_and_api_key(
     r = requests.post(
         f"{router_url}/add_worker",
         params={"url": worker_url, "api_key": api_key},
+        headers={"Authorization": f"Bearer {api_key}"},
         timeout=180,
     )
     r.raise_for_status()
 
-    r = requests.get(f"{router_url}/list_workers", timeout=30)
+    r = requests.get(
+        f"{router_url}/list_workers",
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=30,
+    )
     r.raise_for_status()
     urls = r.json().get("urls", [])
     assert len(urls) == 2

--- a/sgl-router/tests/common/test_app.rs
+++ b/sgl-router/tests/common/test_app.rs
@@ -2,6 +2,7 @@ use axum::Router;
 use reqwest::Client;
 use sglang_router_rs::{
     config::RouterConfig,
+    middleware::AuthConfig,
     routers::RouterTrait,
     server::{build_app, AppContext, AppState},
 };
@@ -43,9 +44,15 @@ pub fn create_test_app(
         ]
     });
 
+    // Create auth config from router config
+    let auth_config = AuthConfig {
+        api_key: router_config.api_key.clone(),
+    };
+
     // Use the actual server's build_app function
     build_app(
         app_state,
+        auth_config,
         router_config.max_payload_size,
         request_id_headers,
         router_config.cors_allowed_origins.clone(),
@@ -79,9 +86,15 @@ pub fn create_test_app_with_context(
         ]
     });
 
+    // Create auth config from router config
+    let auth_config = AuthConfig {
+        api_key: router_config.api_key.clone(),
+    };
+
     // Use the actual server's build_app function
     build_app(
         app_state,
+        auth_config,
         router_config.max_payload_size,
         request_id_headers,
         router_config.cors_allowed_origins.clone(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR adds API key authentication support to the SGLang router, enabling multi-level security for both router endpoints and individual workers.

## Changes
### 1. Authentication Middleware
- Added `AuthConfig` struct and `auth_middleware` function in `middleware.rs`
- Uses constant-time comparison (`subtle` crate) to prevent timing attacks
- Validates Bearer tokens in Authorization headers
- Returns 401 Unauthorized for invalid/missing tokens when auth is enabled

### 2. Middleware Integration
- Applied auth middleware to all protected route groups:
  - API endpoints (`/generate`, `/v1/chat/completions`, etc.)
  - Admin endpoints (`/add_worker`, `/flush_cache`, etc.)
  - Worker management endpoints (`/workers/*`)
- Public endpoints remain accessible without authentication (`/health`, `/liveness`, `/readiness`)

### 3. Security Warnings
- Added warning logs when adding workers without API keys while router has one configured
- Helps prevent common misconfiguration where users expect router's key to be inherited by dynamically added workers

### 4. Documentation
- Updated README.md with comprehensive API key usage guide
- Clarified the difference between initial workers (inherit router's key) and dynamic workers (require explicit key)
- Added examples for all common security configurations

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
