### PR TITLE
mm: rename triton_attn to just triton

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -389,7 +389,7 @@ class VisionAscendAttention(nn.Module):
 
 
 QKV_BACKEND_IMPL = {
-    "triton_attn": VisionTritonAttention,
+    "triton": VisionTritonAttention,
     "sdpa": VisionSdpaAttention,
     "fa3": VisionFlash3Attention,
     "ascend_attn": VisionAscendAttention,
@@ -525,7 +525,7 @@ class VisionAttention(nn.Module):
         Priority: server args override > constructor arg > platform default.
 
         Platform defaults:
-        - CUDA: "triton_attn"
+        - CUDA: "triton"
         - Non-CUDA: "sdpa"
         """
         override_backend = global_server_args_dict["mm_attention_backend"]
@@ -538,7 +538,7 @@ class VisionAttention(nn.Module):
             if major == 9:
                 backend = "fa3"
             else:
-                backend = "triton_attn"
+                backend = "triton"
         else:
             backend = "sdpa"
         if backend == "fa3" and is_blackwell():

--- a/python/sglang/srt/models/clip.py
+++ b/python/sglang/srt/models/clip.py
@@ -154,7 +154,7 @@ class CLIPEncoderLayer(nn.Module):
             qkv_backend = "sdpa"
             softmax_in_single_precision = False
         elif attn_implementation == "flash_attention_2":
-            qkv_backend = "triton_attn"
+            qkv_backend = "triton"
             softmax_in_single_precision = False
         elif attn_implementation == "eager":
             qkv_backend = "sdpa"

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -131,7 +131,7 @@ class Qwen2_5_VisionBlock(nn.Module):
             flatten_batch = True
         elif attn_implementation == "flash_attention_2":
             softmax_in_single_precision = False
-            qkv_backend = "triton_attn"
+            qkv_backend = "triton"
             flatten_batch = True
         elif attn_implementation == "eager":
             softmax_in_single_precision = True

--- a/python/sglang/srt/models/qwen2_vl.py
+++ b/python/sglang/srt/models/qwen2_vl.py
@@ -142,7 +142,7 @@ class Qwen2VisionBlock(nn.Module):
             qkv_backend = "sdpa"
             softmax_in_single_precision = False
         elif attn_implementation == "flash_attention_2":
-            qkv_backend = "triton_attn"
+            qkv_backend = "triton"
             softmax_in_single_precision = False
         elif attn_implementation == "eager":
             qkv_backend = "sdpa"

--- a/python/sglang/srt/models/siglip.py
+++ b/python/sglang/srt/models/siglip.py
@@ -110,7 +110,7 @@ class SiglipEncoderLayer(nn.Module):
             qkv_backend = "sdpa"
             softmax_in_single_precision = False
         elif attn_implementation == "flash_attention_2":
-            qkv_backend = "triton_attn"
+            qkv_backend = "triton"
             softmax_in_single_precision = False
         elif attn_implementation == "eager":
             qkv_backend = "sdpa"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1840,7 +1840,7 @@ class ServerArgs:
         parser.add_argument(
             "--mm-attention-backend",
             type=str,
-            choices=["sdpa", "fa3", "triton_attn", "ascend_attn"],
+            choices=["sdpa", "fa3", "triton", "ascend_attn"],
             default=ServerArgs.mm_attention_backend,
             help="Set multimodal attention backend.",
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

There doesn't seem to be a reason for the naming. Since it's `mm-attention-backend` it's clear enough that it's attention. The prefix matching for the argument doesn't seem to match either.

> launch_server.py: error: argument --mm-attention-backend: invalid choice: 'triton' (choose from 'sdpa', 'fa3', 'triton_attn', 'ascend_attn')

## Motivation

Cleanup

## Modifications

Change it