### PR TITLE
fix xeon ci check

### DIFF
--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -67,7 +67,6 @@ jobs:
         run: |
           docker exec -w /sglang-checkout/ ci_sglang_xeon \
             bash -c "python3 -c 'import torch; import sgl_kernel; assert torch._C._cpu._is_amx_tile_supported(); assert hasattr(torch.ops.sgl_kernel, \"convert_weight_packed\"); '"
-        continue-on-error: true
 
       - name: Run unit tests
         if: steps.check_amx.outcome == 'success'


### PR DESCRIPTION
Previously, the CI script would continue even if the AMX detection failed on Xeon machines, which could lead to incorrect execution flow. Since our CI machines support AMX, a failure in this check should be treated as a real error.

This change makes the script fail fast when AMX detection fails, ensuring we catch potential issues early instead of proceeding with potentially incorrect assumptions.