### PR TITLE
[router] Support Oracle DB(ATP) Data Connector

### DIFF
--- a/sgl-router/Cargo.toml
+++ b/sgl-router/Cargo.toml
@@ -19,7 +19,7 @@ name = "sglang-router"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 axum = { version = "0.8.4", features = ["macros", "ws", "tracing"] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "limit", "request-id", "util"] }
@@ -69,6 +69,7 @@ rmcp = { version = "0.6.3", features = ["client", "server",
     "reqwest",
     "auth"] }
 serde_yaml = "0.9"
+oracle = { version = "0.6.3", features = ["chrono"] }
 
 # gRPC and Protobuf dependencies
 tonic = { version = "0.12", features = ["tls", "gzip", "transport"] }

--- a/sgl-router/src/config/types.rs
+++ b/sgl-router/src/config/types.rs
@@ -94,10 +94,11 @@ pub enum HistoryBackend {
 /// Oracle history backend configuration
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct OracleHistoryConfig {
-    /// Directory containing the ATP wallet files (tnsnames.ora, cwallet.sso, etc.)
-    pub wallet_path: String,
-    /// TNS alias from the wallet to use for connections (e.g. `<db_name>_low`)
-    pub tns_alias: String,
+    /// Directory containing the ATP wallet or TLS config files (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wallet_path: Option<String>,
+    /// Connection descriptor / DSN (e.g. `tcps://host:port/service`)
+    pub connect_descriptor: String,
     /// Database username
     pub username: String,
     /// Database password
@@ -143,7 +144,7 @@ impl std::fmt::Debug for OracleHistoryConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OracleHistoryConfig")
             .field("wallet_path", &self.wallet_path)
-            .field("tns_alias", &self.tns_alias)
+            .field("connect_descriptor", &self.connect_descriptor)
             .field("username", &self.username)
             .field("pool_min", &self.pool_min)
             .field("pool_max", &self.pool_max)

--- a/sgl-router/src/config/types.rs
+++ b/sgl-router/src/config/types.rs
@@ -72,7 +72,7 @@ pub struct RouterConfig {
     pub history_backend: HistoryBackend,
     /// Oracle history backend configuration (required when `history_backend` = "oracle")
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub oracle_history: Option<OracleHistoryConfig>,
+    pub oracle: Option<OracleConfig>,
 }
 
 fn default_history_backend() -> HistoryBackend {
@@ -93,7 +93,7 @@ pub enum HistoryBackend {
 
 /// Oracle history backend configuration
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
-pub struct OracleHistoryConfig {
+pub struct OracleConfig {
     /// Directory containing the ATP wallet or TLS config files (optional)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wallet_path: Option<String>,
@@ -114,7 +114,7 @@ pub struct OracleHistoryConfig {
     pub pool_timeout_secs: u64,
 }
 
-impl OracleHistoryConfig {
+impl OracleConfig {
     pub fn default_pool_min() -> usize {
         default_pool_min()
     }
@@ -140,9 +140,9 @@ fn default_pool_timeout_secs() -> u64 {
     30
 }
 
-impl std::fmt::Debug for OracleHistoryConfig {
+impl std::fmt::Debug for OracleConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OracleHistoryConfig")
+        f.debug_struct("OracleConfig")
             .field("wallet_path", &self.wallet_path)
             .field("connect_descriptor", &self.connect_descriptor)
             .field("username", &self.username)
@@ -448,7 +448,7 @@ impl Default for RouterConfig {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
-            oracle_history: None,
+            oracle: None,
         }
     }
 }
@@ -1016,7 +1016,7 @@ mod tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
-            oracle_history: None,
+            oracle: None,
         };
 
         assert!(config.mode.is_pd_mode());
@@ -1081,7 +1081,7 @@ mod tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
-            oracle_history: None,
+            oracle: None,
         };
 
         assert!(!config.mode.is_pd_mode());
@@ -1142,7 +1142,7 @@ mod tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
-            oracle_history: None,
+            oracle: None,
         };
 
         assert!(config.has_service_discovery());

--- a/sgl-router/src/config/types.rs
+++ b/sgl-router/src/config/types.rs
@@ -1015,6 +1015,7 @@ mod tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
+            oracle_history: None,
         };
 
         assert!(config.mode.is_pd_mode());
@@ -1079,6 +1080,7 @@ mod tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
+            oracle_history: None,
         };
 
         assert!(!config.mode.is_pd_mode());
@@ -1139,6 +1141,7 @@ mod tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: default_history_backend(),
+            oracle_history: None,
         };
 
         assert!(config.has_service_discovery());

--- a/sgl-router/src/config/validation.rs
+++ b/sgl-router/src/config/validation.rs
@@ -29,6 +29,12 @@ impl ConfigValidator {
         Self::validate_retry(&retry_cfg)?;
         Self::validate_circuit_breaker(&cb_cfg)?;
 
+        if config.history_backend == HistoryBackend::Oracle && config.oracle.is_none() {
+            return Err(ConfigError::MissingRequired {
+                field: "oracle".to_string(),
+            });
+        }
+
         Ok(())
     }
 

--- a/sgl-router/src/data_connector/mod.rs
+++ b/sgl-router/src/data_connector/mod.rs
@@ -1,10 +1,12 @@
 // Data connector module for response storage
 pub mod response_memory_store;
 pub mod response_noop_store;
+pub mod response_oracle_store;
 pub mod responses;
 
 pub use response_memory_store::MemoryResponseStorage;
 pub use response_noop_store::NoOpResponseStorage;
+pub use response_oracle_store::OracleResponseStorage;
 pub use responses::{
     ResponseChain, ResponseId, ResponseStorage, ResponseStorageError, SharedResponseStorage,
     StoredResponse,

--- a/sgl-router/src/data_connector/response_oracle_store.rs
+++ b/sgl-router/src/data_connector/response_oracle_store.rs
@@ -1,4 +1,4 @@
-use crate::config::OracleHistoryConfig;
+use crate::config::OracleConfig;
 use crate::data_connector::responses::{
     ResponseChain, ResponseId, ResponseStorage, ResponseStorageError, Result as StorageResult,
     StoredResponse,
@@ -21,7 +21,7 @@ pub struct OracleResponseStorage {
 }
 
 impl OracleResponseStorage {
-    pub fn new(config: OracleHistoryConfig) -> StorageResult<Self> {
+    pub fn new(config: OracleConfig) -> StorageResult<Self> {
         let config = Arc::new(config);
         configure_oracle_client(&config)?;
         initialize_schema(&config)?;
@@ -285,7 +285,7 @@ struct OracleConnectionManager {
 }
 
 impl OracleConnectionManager {
-    fn new(config: Arc<OracleHistoryConfig>) -> Self {
+    fn new(config: Arc<OracleConfig>) -> Self {
         let params = OracleConnectParams {
             username: config.username.clone(),
             password: config.password.clone(),
@@ -353,7 +353,7 @@ impl Manager for OracleConnectionManager {
     }
 }
 
-fn configure_oracle_client(config: &OracleHistoryConfig) -> StorageResult<()> {
+fn configure_oracle_client(config: &OracleConfig) -> StorageResult<()> {
     if let Some(wallet_path) = &config.wallet_path {
         let wallet_path = Path::new(wallet_path);
         if !wallet_path.is_dir() {
@@ -375,7 +375,7 @@ fn configure_oracle_client(config: &OracleHistoryConfig) -> StorageResult<()> {
     Ok(())
 }
 
-fn initialize_schema(config: &OracleHistoryConfig) -> StorageResult<()> {
+fn initialize_schema(config: &OracleConfig) -> StorageResult<()> {
     let conn = Connection::connect(
         &config.username,
         &config.password,

--- a/sgl-router/src/data_connector/response_oracle_store.rs
+++ b/sgl-router/src/data_connector/response_oracle_store.rs
@@ -255,7 +255,7 @@ impl ResponseStorage for OracleResponseStorage {
             let mut rows = stmt.query(&[&user]).map_err(map_oracle_error)?;
             let mut results = Vec::new();
 
-            while let Some(row) = rows.next() {
+            for row in &mut rows {
                 let row = row.map_err(map_oracle_error)?;
                 results.push(OracleResponseStorage::build_response_from_row(&row)?);
             }
@@ -343,6 +343,7 @@ impl Manager for OracleConnectionManager {
         }
     }
 
+    #[allow(clippy::manual_async_fn)]
     fn recycle(
         &self,
         conn: &mut Connection,

--- a/sgl-router/src/data_connector/response_oracle_store.rs
+++ b/sgl-router/src/data_connector/response_oracle_store.rs
@@ -1,0 +1,541 @@
+use crate::config::OracleHistoryConfig;
+use crate::data_connector::responses::{
+    ResponseChain, ResponseId, ResponseStorage, ResponseStorageError, Result as StorageResult,
+    StoredResponse,
+};
+use async_trait::async_trait;
+use deadpool::managed::{Manager, Metrics, Pool, PoolError, RecycleError, RecycleResult};
+use oracle::{Connection, Row};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+const SELECT_BASE: &str = "SELECT id, previous_response_id, input, instructions, output, \
+    tool_calls, metadata, created_at, user_id, model, raw_response FROM responses";
+
+#[derive(Clone)]
+pub struct OracleResponseStorage {
+    pool: Pool<OracleConnectionManager>,
+}
+
+impl OracleResponseStorage {
+    pub fn new(config: OracleHistoryConfig) -> StorageResult<Self> {
+        let config = Arc::new(config);
+        ensure_wallet(&config)?;
+        initialize_schema(&config)?;
+
+        let manager = OracleConnectionManager::new(config.clone());
+        let mut builder = Pool::builder(manager)
+            .max_size(config.pool_max)
+            .runtime(deadpool::Runtime::Tokio1);
+
+        if config.pool_timeout_secs > 0 {
+            builder = builder.wait_timeout(Some(Duration::from_secs(config.pool_timeout_secs)));
+        }
+
+        let pool = builder.build().map_err(|err| {
+            ResponseStorageError::StorageError(format!(
+                "failed to build Oracle connection pool: {err}"
+            ))
+        })?;
+
+        Ok(Self { pool })
+    }
+
+    async fn with_connection<F, T>(&self, func: F) -> StorageResult<T>
+    where
+        F: FnOnce(&Connection) -> StorageResult<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let connection = self.pool.get().await.map_err(map_pool_error)?;
+
+        tokio::task::spawn_blocking(move || {
+            let result = func(&connection);
+            drop(connection);
+            result
+        })
+        .await
+        .map_err(|err| {
+            ResponseStorageError::StorageError(format!(
+                "failed to execute Oracle query task: {err}"
+            ))
+        })?
+    }
+
+    fn build_response_from_row(row: &Row) -> StorageResult<StoredResponse> {
+        let id: String = row
+            .get(0)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch id"))?;
+        let previous: Option<String> = row.get(1).map_err(|err| {
+            map_oracle_error(err).into_storage_error("fetch previous_response_id")
+        })?;
+        let input: String = row
+            .get(2)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch input"))?;
+        let instructions: Option<String> = row
+            .get(3)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch instructions"))?;
+        let output: String = row
+            .get(4)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch output"))?;
+        let tool_calls_json: Option<String> = row
+            .get(5)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch tool_calls"))?;
+        let metadata_json: Option<String> = row
+            .get(6)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch metadata"))?;
+        let created_at: chrono::DateTime<chrono::Utc> = row
+            .get(7)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch created_at"))?;
+        let user_id: Option<String> = row
+            .get(8)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch user_id"))?;
+        let model: Option<String> = row
+            .get(9)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch model"))?;
+        let raw_response_json: Option<String> = row
+            .get(10)
+            .map_err(|err| map_oracle_error(err).into_storage_error("fetch raw_response"))?;
+
+        let previous_response_id = previous.map(ResponseId);
+        let tool_calls = parse_tool_calls(tool_calls_json)?;
+        let metadata = parse_metadata(metadata_json)?;
+        let raw_response = parse_raw_response(raw_response_json)?;
+
+        Ok(StoredResponse {
+            id: ResponseId(id),
+            previous_response_id,
+            input,
+            instructions,
+            output,
+            tool_calls,
+            metadata,
+            created_at,
+            user: user_id,
+            model,
+            raw_response,
+        })
+    }
+}
+
+#[async_trait]
+impl ResponseStorage for OracleResponseStorage {
+    async fn store_response(&self, response: StoredResponse) -> StorageResult<ResponseId> {
+        let StoredResponse {
+            id,
+            previous_response_id,
+            input,
+            instructions,
+            output,
+            tool_calls,
+            metadata,
+            created_at,
+            user,
+            model,
+            raw_response,
+        } = response;
+
+        let response_id = id.clone();
+        let response_id_str = response_id.0.clone();
+        let previous_id = previous_response_id.map(|r| r.0);
+        let json_tool_calls = serde_json::to_string(&tool_calls)?;
+        let json_metadata = serde_json::to_string(&metadata)?;
+        let json_raw_response = serde_json::to_string(&raw_response)?;
+
+        self.with_connection(move |conn| {
+            conn.execute(
+                "INSERT INTO responses (id, previous_response_id, input, instructions, output, \
+                    tool_calls, metadata, created_at, user_id, model, raw_response) \
+                 VALUES (:1, :2, :3, :4, :5, :6, :7, :8, :9, :10, :11)",
+                &[
+                    &response_id_str,
+                    &previous_id,
+                    &input,
+                    &instructions,
+                    &output,
+                    &json_tool_calls,
+                    &json_metadata,
+                    &created_at,
+                    &user,
+                    &model,
+                    &json_raw_response,
+                ],
+            )
+            .map(|_| ())
+            .map_err(map_oracle_error)
+        })
+        .await?;
+
+        Ok(response_id)
+    }
+
+    async fn get_response(
+        &self,
+        response_id: &ResponseId,
+    ) -> StorageResult<Option<StoredResponse>> {
+        let id = response_id.0.clone();
+        self.with_connection(move |conn| {
+            let mut stmt = conn
+                .statement(&format!("{} WHERE id = :1", SELECT_BASE))
+                .build()
+                .map_err(map_oracle_error)?;
+            let mut rows = stmt.query(&[&id]).map_err(map_oracle_error)?;
+            match rows.next() {
+                Some(row) => {
+                    let row = row.map_err(map_oracle_error)?;
+                    OracleResponseStorage::build_response_from_row(&row).map(Some)
+                }
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
+    async fn delete_response(&self, response_id: &ResponseId) -> StorageResult<()> {
+        let id = response_id.0.clone();
+        self.with_connection(move |conn| {
+            conn.execute("DELETE FROM responses WHERE id = :1", &[&id])
+                .map(|_| ())
+                .map_err(map_oracle_error)
+        })
+        .await
+    }
+
+    async fn get_response_chain(
+        &self,
+        response_id: &ResponseId,
+        max_depth: Option<usize>,
+    ) -> StorageResult<ResponseChain> {
+        let mut chain = ResponseChain::new();
+        let mut current_id = Some(response_id.clone());
+        let mut visited = 0usize;
+
+        while let Some(ref lookup_id) = current_id {
+            if let Some(limit) = max_depth {
+                if visited >= limit {
+                    break;
+                }
+            }
+
+            let fetched = self.get_response(lookup_id).await?;
+            match fetched {
+                Some(response) => {
+                    current_id = response.previous_response_id.clone();
+                    chain.responses.push(response);
+                    visited += 1;
+                }
+                None => break,
+            }
+        }
+
+        chain.responses.reverse();
+        Ok(chain)
+    }
+
+    async fn list_user_responses(
+        &self,
+        user: &str,
+        limit: Option<usize>,
+    ) -> StorageResult<Vec<StoredResponse>> {
+        let user = user.to_string();
+
+        self.with_connection(move |conn| {
+            let sql = if let Some(limit) = limit {
+                format!(
+                    "SELECT * FROM ({} WHERE user_id = :1 ORDER BY created_at DESC) WHERE ROWNUM <= {}",
+                    SELECT_BASE, limit
+                )
+            } else {
+                format!("{} WHERE user_id = :1 ORDER BY created_at DESC", SELECT_BASE)
+            };
+
+            let mut stmt = conn.statement(&sql).build().map_err(map_oracle_error)?;
+            let mut rows = stmt.query(&[&user]).map_err(map_oracle_error)?;
+            let mut results = Vec::new();
+
+            while let Some(row) = rows.next() {
+                let row = row.map_err(map_oracle_error)?;
+                results.push(OracleResponseStorage::build_response_from_row(&row)?);
+            }
+
+            Ok(results)
+        })
+        .await
+    }
+
+    async fn delete_user_responses(&self, user: &str) -> StorageResult<usize> {
+        let user = user.to_string();
+        let affected = self
+            .with_connection(move |conn| {
+                conn.execute("DELETE FROM responses WHERE user_id = :1", &[&user])
+                    .map_err(map_oracle_error)
+            })
+            .await?;
+
+        let deleted = affected.row_count().map_err(map_oracle_error)? as usize;
+        Ok(deleted)
+    }
+}
+
+#[derive(Clone)]
+struct OracleConnectionManager {
+    params: Arc<OracleConnectParams>,
+}
+
+impl OracleConnectionManager {
+    fn new(config: Arc<OracleHistoryConfig>) -> Self {
+        let params = OracleConnectParams {
+            username: config.username.clone(),
+            password: config.password.clone(),
+            connect_descriptor: config.tns_alias.clone(),
+        };
+
+        Self {
+            params: Arc::new(params),
+        }
+    }
+}
+
+impl std::fmt::Debug for OracleConnectionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OracleConnectionManager")
+            .field("username", &self.params.username)
+            .field("connect_descriptor", &self.params.connect_descriptor)
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+struct OracleConnectParams {
+    username: String,
+    password: String,
+    connect_descriptor: String,
+}
+
+impl std::fmt::Debug for OracleConnectParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OracleConnectParams")
+            .field("username", &self.username)
+            .field("connect_descriptor", &self.connect_descriptor)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl Manager for OracleConnectionManager {
+    type Type = Connection;
+    type Error = oracle::Error;
+
+    fn create(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Connection, oracle::Error>> + Send {
+        let params = self.params.clone();
+        async move {
+            let mut conn = Connection::connect(
+                &params.username,
+                &params.password,
+                &params.connect_descriptor,
+            )?;
+            conn.set_autocommit(true);
+            Ok(conn)
+        }
+    }
+
+    fn recycle(
+        &self,
+        conn: &mut Connection,
+        _: &Metrics,
+    ) -> impl std::future::Future<Output = RecycleResult<Self::Error>> + Send {
+        async move { conn.ping().map_err(RecycleError::Backend) }
+    }
+}
+
+fn ensure_wallet(config: &OracleHistoryConfig) -> StorageResult<()> {
+    let wallet_path = Path::new(&config.wallet_path);
+    if !wallet_path.is_dir() {
+        return Err(ResponseStorageError::StorageError(format!(
+            "Oracle wallet path '{}' is not a directory",
+            wallet_path.display()
+        )));
+    }
+
+    if !wallet_path.join("tnsnames.ora").exists() {
+        return Err(ResponseStorageError::StorageError(format!(
+            "Oracle wallet path '{}' does not contain tnsnames.ora",
+            wallet_path.display()
+        )));
+    }
+
+    std::env::set_var("TNS_ADMIN", wallet_path);
+    Ok(())
+}
+
+fn initialize_schema(config: &OracleHistoryConfig) -> StorageResult<()> {
+    let conn = Connection::connect(&config.username, &config.password, &config.tns_alias)
+        .map_err(map_oracle_error)?;
+
+    let exists: i64 = conn
+        .query_row_as(
+            "SELECT COUNT(*) FROM user_tables WHERE table_name = 'RESPONSES'",
+            &[],
+        )
+        .map_err(map_oracle_error)?;
+
+    if exists == 0 {
+        conn.execute(
+            "CREATE TABLE responses (
+                id VARCHAR2(64) PRIMARY KEY,
+                previous_response_id VARCHAR2(64),
+                input CLOB,
+                instructions CLOB,
+                output CLOB,
+                tool_calls CLOB,
+                metadata CLOB,
+                created_at TIMESTAMP WITH TIME ZONE,
+                user_id VARCHAR2(128),
+                model VARCHAR2(128),
+                raw_response CLOB
+            )",
+            &[],
+        )
+        .map_err(map_oracle_error)?;
+    }
+
+    create_index_if_missing(
+        &conn,
+        "RESPONSES_PREV_IDX",
+        "CREATE INDEX responses_prev_idx ON responses(previous_response_id)",
+    )?;
+    create_index_if_missing(
+        &conn,
+        "RESPONSES_USER_IDX",
+        "CREATE INDEX responses_user_idx ON responses(user_id)",
+    )?;
+
+    Ok(())
+}
+
+fn create_index_if_missing(conn: &Connection, index_name: &str, ddl: &str) -> StorageResult<()> {
+    let count: i64 = conn
+        .query_row_as(
+            "SELECT COUNT(*) FROM user_indexes WHERE table_name = 'RESPONSES' AND index_name = :1",
+            &[&index_name],
+        )
+        .map_err(map_oracle_error)?;
+
+    if count == 0 {
+        if let Err(err) = conn.execute(ddl, &[]) {
+            if err.db_error().map(|db| db.code()) != Some(1408) {
+                return Err(map_oracle_error(err));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_tool_calls(raw: Option<String>) -> StorageResult<Vec<Value>> {
+    match raw {
+        Some(s) if !s.is_empty() => {
+            serde_json::from_str(&s).map_err(ResponseStorageError::SerializationError)
+        }
+        _ => Ok(Vec::new()),
+    }
+}
+
+fn parse_metadata(raw: Option<String>) -> StorageResult<HashMap<String, Value>> {
+    match raw {
+        Some(s) if !s.is_empty() => {
+            serde_json::from_str(&s).map_err(ResponseStorageError::SerializationError)
+        }
+        _ => Ok(HashMap::new()),
+    }
+}
+
+fn parse_raw_response(raw: Option<String>) -> StorageResult<Value> {
+    match raw {
+        Some(s) if !s.is_empty() => {
+            serde_json::from_str(&s).map_err(ResponseStorageError::SerializationError)
+        }
+        _ => Ok(Value::Null),
+    }
+}
+
+fn map_pool_error(err: PoolError<oracle::Error>) -> ResponseStorageError {
+    match err {
+        PoolError::Backend(e) => map_oracle_error(e),
+        other => ResponseStorageError::StorageError(format!(
+            "failed to obtain Oracle connection: {other}"
+        )),
+    }
+}
+
+fn map_oracle_error(err: oracle::Error) -> ResponseStorageError {
+    if let Some(db_err) = err.db_error() {
+        ResponseStorageError::StorageError(format!(
+            "Oracle error (code {}): {}",
+            db_err.code(),
+            db_err.message()
+        ))
+    } else {
+        ResponseStorageError::StorageError(err.to_string())
+    }
+}
+
+trait OracleErrorExt {
+    fn into_storage_error(self, context: &str) -> ResponseStorageError;
+}
+
+impl OracleErrorExt for ResponseStorageError {
+    fn into_storage_error(self, context: &str) -> ResponseStorageError {
+        ResponseStorageError::StorageError(format!("{context}: {self}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_tool_calls_handles_empty_input() {
+        assert!(parse_tool_calls(None).unwrap().is_empty());
+        assert!(parse_tool_calls(Some(String::new())).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_tool_calls_round_trips() {
+        let payload = json!([{ "type": "test", "value": 1 }]).to_string();
+        let parsed = parse_tool_calls(Some(payload)).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["type"], "test");
+        assert_eq!(parsed[0]["value"], 1);
+    }
+
+    #[test]
+    fn parse_metadata_defaults_to_empty_map() {
+        assert!(parse_metadata(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_metadata_round_trips() {
+        let payload = json!({"key": "value", "nested": {"bool": true}}).to_string();
+        let parsed = parse_metadata(Some(payload)).unwrap();
+        assert_eq!(parsed.get("key").unwrap(), "value");
+        assert_eq!(parsed["nested"]["bool"], true);
+    }
+
+    #[test]
+    fn parse_raw_response_handles_null() {
+        assert_eq!(parse_raw_response(None).unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn parse_raw_response_round_trips() {
+        let payload = json!({"id": "abc"}).to_string();
+        let parsed = parse_raw_response(Some(payload)).unwrap();
+        assert_eq!(parsed["id"], "abc");
+    }
+}

--- a/sgl-router/src/lib.rs
+++ b/sgl-router/src/lib.rs
@@ -231,6 +231,7 @@ impl Router {
             model_path: self.model_path.clone(),
             tokenizer_path: self.tokenizer_path.clone(),
             history_backend: config::HistoryBackend::Memory,
+            oracle_history: None,
         })
     }
 }

--- a/sgl-router/src/lib.rs
+++ b/sgl-router/src/lib.rs
@@ -231,7 +231,7 @@ impl Router {
             model_path: self.model_path.clone(),
             tokenizer_path: self.tokenizer_path.clone(),
             history_backend: config::HistoryBackend::Memory,
-            oracle_history: None,
+            oracle: None,
         })
     }
 }

--- a/sgl-router/src/main.rs
+++ b/sgl-router/src/main.rs
@@ -1,8 +1,8 @@
 use clap::{ArgAction, Parser, ValueEnum};
 use sglang_router_rs::config::{
     CircuitBreakerConfig, ConfigError, ConfigResult, ConnectionMode, DiscoveryConfig,
-    HealthCheckConfig, HistoryBackend, MetricsConfig, OracleHistoryConfig, PolicyConfig,
-    RetryConfig, RouterConfig, RoutingMode,
+    HealthCheckConfig, HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig,
+    RouterConfig, RoutingMode,
 };
 use sglang_router_rs::metrics::PrometheusConfig;
 use sglang_router_rs::server::{self, ServerConfig};
@@ -396,7 +396,7 @@ impl CliArgs {
         }
     }
 
-    fn build_oracle_history_config(&self) -> ConfigResult<OracleHistoryConfig> {
+    fn build_oracle_config(&self) -> ConfigResult<OracleConfig> {
         let wallet_path = self.oracle_wallet_path.clone();
         let connect_descriptor = if let Some(dsn) = self.oracle_dsn.clone() {
             dsn
@@ -422,10 +422,10 @@ impl CliArgs {
 
         let pool_min = self
             .oracle_pool_min
-            .unwrap_or_else(OracleHistoryConfig::default_pool_min);
+            .unwrap_or_else(OracleConfig::default_pool_min);
         let pool_max = self
             .oracle_pool_max
-            .unwrap_or_else(OracleHistoryConfig::default_pool_max);
+            .unwrap_or_else(OracleConfig::default_pool_max);
 
         if pool_min == 0 {
             return Err(ConfigError::InvalidValue {
@@ -445,9 +445,9 @@ impl CliArgs {
 
         let pool_timeout_secs = self
             .oracle_pool_timeout_secs
-            .unwrap_or_else(OracleHistoryConfig::default_pool_timeout_secs);
+            .unwrap_or_else(OracleConfig::default_pool_timeout_secs);
 
-        Ok(OracleHistoryConfig {
+        Ok(OracleConfig {
             wallet_path,
             connect_descriptor,
             username,
@@ -559,8 +559,8 @@ impl CliArgs {
             _ => HistoryBackend::Memory,
         };
 
-        let oracle_history = if history_backend == HistoryBackend::Oracle {
-            Some(self.build_oracle_history_config()?)
+        let oracle = if history_backend == HistoryBackend::Oracle {
+            Some(self.build_oracle_config()?)
         } else {
             None
         };
@@ -618,7 +618,7 @@ impl CliArgs {
             model_path: self.model_path.clone(),
             tokenizer_path: self.tokenizer_path.clone(),
             history_backend,
-            oracle_history,
+            oracle,
         })
     }
 

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -95,9 +95,8 @@ impl AppContext {
             HistoryBackend::Memory => Arc::new(MemoryResponseStorage::new()),
             HistoryBackend::None => Arc::new(NoOpResponseStorage::new()),
             HistoryBackend::Oracle => {
-                let oracle_cfg = router_config.oracle_history.clone().ok_or_else(|| {
-                    "oracle_history configuration is required when history_backend=oracle"
-                        .to_string()
+                let oracle_cfg = router_config.oracle.clone().ok_or_else(|| {
+                    "oracle configuration is required when history_backend=oracle".to_string()
                 })?;
 
                 let storage = OracleResponseStorage::new(oracle_cfg).map_err(|err| {

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -1,7 +1,9 @@
 use crate::{
     config::{ConnectionMode, HistoryBackend, RouterConfig},
     core::{WorkerManager, WorkerRegistry, WorkerType},
-    data_connector::{MemoryResponseStorage, NoOpResponseStorage, SharedResponseStorage},
+    data_connector::{
+        MemoryResponseStorage, NoOpResponseStorage, OracleResponseStorage, SharedResponseStorage,
+    },
     logging::{self, LoggingConfig},
     metrics::{self, PrometheusConfig},
     middleware::{self, QueuedRequest, TokenBucket},
@@ -92,6 +94,18 @@ impl AppContext {
         let response_storage: SharedResponseStorage = match router_config.history_backend {
             HistoryBackend::Memory => Arc::new(MemoryResponseStorage::new()),
             HistoryBackend::None => Arc::new(NoOpResponseStorage::new()),
+            HistoryBackend::Oracle => {
+                let oracle_cfg = router_config.oracle_history.clone().ok_or_else(|| {
+                    "oracle_history configuration is required when history_backend=oracle"
+                        .to_string()
+                })?;
+
+                let storage = OracleResponseStorage::new(oracle_cfg).map_err(|err| {
+                    format!("failed to initialize Oracle response storage: {err}")
+                })?;
+
+                Arc::new(storage)
+            }
         };
 
         Ok(Self {

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -62,7 +62,7 @@ impl TestContext {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
-            oracle_history: None,
+            oracle: None,
         };
 
         Self::new_with_config(config, worker_configs).await
@@ -1409,7 +1409,7 @@ mod error_tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
-            oracle_history: None,
+            oracle: None,
         };
 
         let ctx = TestContext::new_with_config(
@@ -1769,7 +1769,7 @@ mod pd_mode_tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
-            oracle_history: None,
+            oracle: None,
         };
 
         // Create app context
@@ -1933,7 +1933,7 @@ mod request_id_tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
-            oracle_history: None,
+            oracle: None,
         };
 
         let ctx = TestContext::new_with_config(

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -62,6 +62,7 @@ impl TestContext {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+            oracle_history: None,
         };
 
         Self::new_with_config(config, worker_configs).await
@@ -1408,6 +1409,7 @@ mod error_tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+            oracle_history: None,
         };
 
         let ctx = TestContext::new_with_config(
@@ -1767,6 +1769,7 @@ mod pd_mode_tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+            oracle_history: None,
         };
 
         // Create app context
@@ -1930,6 +1933,7 @@ mod request_id_tests {
             model_path: None,
             tokenizer_path: None,
             history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+            oracle_history: None,
         };
 
         let ctx = TestContext::new_with_config(

--- a/sgl-router/tests/test_openai_routing.rs
+++ b/sgl-router/tests/test_openai_routing.rs
@@ -849,12 +849,14 @@ async fn test_openai_router_models_auth_forwarding() {
 
 #[test]
 fn oracle_config_validation_requires_config_when_enabled() {
-    let mut config = RouterConfig::default();
-    config.mode = RoutingMode::OpenAI {
-        worker_urls: vec!["https://api.openai.com".to_string()],
+    let config = RouterConfig {
+        mode: RoutingMode::OpenAI {
+            worker_urls: vec!["https://api.openai.com".to_string()],
+        },
+        history_backend: HistoryBackend::Oracle,
+        oracle: None,
+        ..Default::default()
     };
-    config.history_backend = HistoryBackend::Oracle;
-    config.oracle = None;
 
     let err =
         ConfigValidator::validate(&config).expect_err("config should fail without oracle details");
@@ -869,40 +871,44 @@ fn oracle_config_validation_requires_config_when_enabled() {
 
 #[test]
 fn oracle_config_validation_accepts_dsn_only() {
-    let mut config = RouterConfig::default();
-    config.mode = RoutingMode::OpenAI {
-        worker_urls: vec!["https://api.openai.com".to_string()],
+    let config = RouterConfig {
+        mode: RoutingMode::OpenAI {
+            worker_urls: vec!["https://api.openai.com".to_string()],
+        },
+        history_backend: HistoryBackend::Oracle,
+        oracle: Some(OracleConfig {
+            wallet_path: None,
+            connect_descriptor: "tcps://db.example.com:1522/service".to_string(),
+            username: "scott".to_string(),
+            password: "tiger".to_string(),
+            pool_min: 1,
+            pool_max: 4,
+            pool_timeout_secs: 30,
+        }),
+        ..Default::default()
     };
-    config.history_backend = HistoryBackend::Oracle;
-    config.oracle = Some(OracleConfig {
-        wallet_path: None,
-        connect_descriptor: "tcps://db.example.com:1522/service".to_string(),
-        username: "scott".to_string(),
-        password: "tiger".to_string(),
-        pool_min: 1,
-        pool_max: 4,
-        pool_timeout_secs: 30,
-    });
 
     ConfigValidator::validate(&config).expect("dsn-based config should validate");
 }
 
 #[test]
 fn oracle_config_validation_accepts_wallet_alias() {
-    let mut config = RouterConfig::default();
-    config.mode = RoutingMode::OpenAI {
-        worker_urls: vec!["https://api.openai.com".to_string()],
+    let config = RouterConfig {
+        mode: RoutingMode::OpenAI {
+            worker_urls: vec!["https://api.openai.com".to_string()],
+        },
+        history_backend: HistoryBackend::Oracle,
+        oracle: Some(OracleConfig {
+            wallet_path: Some("/etc/sglang/oracle-wallet".to_string()),
+            connect_descriptor: "db_low".to_string(),
+            username: "app_user".to_string(),
+            password: "secret".to_string(),
+            pool_min: 1,
+            pool_max: 8,
+            pool_timeout_secs: 45,
+        }),
+        ..Default::default()
     };
-    config.history_backend = HistoryBackend::Oracle;
-    config.oracle = Some(OracleConfig {
-        wallet_path: Some("/etc/sglang/oracle-wallet".to_string()),
-        connect_descriptor: "db_low".to_string(),
-        username: "app_user".to_string(),
-        password: "secret".to_string(),
-        pool_min: 1,
-        pool_max: 8,
-        pool_timeout_secs: 45,
-    });
 
     ConfigValidator::validate(&config).expect("wallet-based config should validate");
 }

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -208,6 +208,7 @@ mod test_pd_routing {
                 model_path: None,
                 tokenizer_path: None,
                 history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+                oracle_history: None,
             };
 
             let app_context =

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -208,7 +208,7 @@ mod test_pd_routing {
                 model_path: None,
                 tokenizer_path: None,
                 history_backend: sglang_router_rs::config::HistoryBackend::Memory,
-                oracle_history: None,
+                oracle: None,
             };
 
             let app_context =


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Add Oracle Autonomous Transaction Processing (ATP) as a concrete implementation of `ResponseStorage` so persisted responses survive router restarts and can be shared across instances.
<!-- Describe the purpose and goals of this pull request. -->

## Tests
0. create ATP: sglroutertestatp in oci console
1. create a sgl user in db
```
CREATE USER SGL_USER IDENTIFIED BY "M***7";
GRANT CREATE SESSION, CREATE TABLE TO SGL_USER;
```
2. download oracle instant client: https://download.oracle.com/otn_software/linux/instantclient/2390000/instantclient-basic-linux.x64-23.9.0.25.07.zip
Note: make sure using 23.9, 21.x has some bugs
3. unzip the zip file and Set Env variable
```
export LD_LIBRARY_PATH=/home/ubuntu/instant-client/instantclient_23_9
```
4. downloaded atp wallet file and export atp env variables:
```
export ATP_WALLET_PATH=/home/ubuntu/wallet/Wallet_sglroutertestatp
export ATP_TNS_ALIAS=sglroutertestatp_low
export ATP_USER=sgl_user
export ATP_PASSWORD=M***7
export ATP_POOL_MIN=1
export ATP_POOL_MAX=8
export ATP_POOL_TIMEOUT_SECS=30
```
5. start a openai router using oracle history backend
```
cargo run --bin sglang-router --  --worker-urls https://api.openai.com/ --backend openai --history-backend oracle --prometheus-port 30002
```
6. test post response api

**request**
```
curl http://localhost:30000/v1/responses \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $OPENAI_API_KEY" \
-d '{
"model": "gpt-5-nano",
"input": "Tell me a 3 sentence bedtime story about a unicorn."
}'
```
**response**
```
{"id":"resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa","object":"response","created_at":1758685917,"status":"completed","background":false,"billing":{"payer":"developer"},"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-nano-2025-08-07","output":[{"id":"rs_68d36ade9c28819a906e9efbef91b8610a4591916469f4fa","type":"reasoning","summary":[]},{"id":"msg_68d36ae093a4819a81c62c5845a9022d0a4591916469f4fa","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"In a quiet glade under a silver moon, a gentle unicorn named Luma watched fireflies drift like tiny stars.  \nShe hummed a lullaby of starlight, and the breeze carried her song to every sleepy leaf.  \nThen Luma tucked herself into the soft moss and dreamt of dawn, knowing the world would wake to a kinder day."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"medium","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens":463,"output_tokens_details":{"reasoning_tokens":384},"total_tokens":481},"user":null,"metadata":{}}
```
9. test Get response API thru router endpoint

**request**
```
curl http://localhost:30000/v1/responses/resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa -H "Authorization: Bearer $OPENAI_API_KEY"
```
**response**
```
{"id":"resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa","object":"response","created_at":1758685917,"status":"completed","background":false,"billing":{"payer":"developer"},"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-nano-2025-08-07","output":[{"id":"rs_68d36ade9c28819a906e9efbef91b8610a4591916469f4fa","type":"reasoning","summary":[]},{"id":"msg_68d36ae093a4819a81c62c5845a9022d0a4591916469f4fa","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"In a quiet glade under a silver moon, a gentle unicorn named Luma watched fireflies drift like tiny stars.  \nShe hummed a lullaby of starlight, and the breeze carried her song to every sleepy leaf.  \nThen Luma tucked herself into the soft moss and dreamt of dawn, knowing the world would wake to a kinder day."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"medium","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens":463,"output_tokens_details":{"reasoning_tokens":384},"total_tokens":481},"user":null,"metadata":{}}
```
10. test Get response API thru openai endpoint

**request**
```
curl https://api.openai.com/v1/responses/resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa -H "Authorization: Bearer $OPENAI_API_KEY"
```
**response**
```
{
  "error": {
    "message": "Response with id 'resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa' not found.",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
```
Confirmed it's not storing in OPENAI server

11. Checked record in db
<img width="1035" height="365" alt="Screenshot 2025-09-23 at 9 00 20 PM" src="https://github.com/user-attachments/assets/a622fd2d-a55b-4cc8-8b00-99ee5fb1d322" />

12. Post response api with previous response id

**Request**
```
curl http://localhost:30000/v1/responses \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $OPENAI_API_KEY" \
-d '{
"model": "gpt-5-nano",
"input": "write a summary about what you mentioned",
"previous_response_id": "resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa"
}'
```
**Response**
```
{"id":"resp_68d36d4aae2c819aa9a2ba3c3526447d0a4591916469f4fa","object":"response","created_at":1758686539,"status":"completed","background":false,"billing":{"payer":"developer"},"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-nano-2025-08-07","output":[{"id":"rs_68d36d4bf6c0819abbe4dcfff559e8e30a4591916469f4fa","type":"reasoning","summary":[]},{"id":"msg_68d36d4e1cf0819abeb302bc9e7103b50a4591916469f4fa","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The story centers on a gentle unicorn named Luma in a moonlit glade. She hums a lullaby that rides the breeze to every sleepy leaf, then settles into soft moss to dream of dawn and a kinder day ahead."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_68d36add9bc8819a8c05ca6721964e340a4591916469f4fa","prompt_cache_key":null,"reasoning":{"effort":"medium","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":108,"input_tokens_details":{"cached_tokens":0},"output_tokens":373,"output_tokens_details":{"reasoning_tokens":320},"total_tokens":481},"user":null,"metadata":{}}
```

13. Checked record in db
<img width="982" height="347" alt="Screenshot 2025-09-23 at 9 04 04 PM" src="https://github.com/user-attachments/assets/ee64c4f4-b465-4bf7-a1f5-459e8493fb27" />
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

