### PR TITLE
[Test] Initialize mem_fraction_static in setUpClass to fix pytest VLM test crashes.

### DIFF
--- a/test/srt/models/test_vlm_models.py
+++ b/test/srt/models/test_vlm_models.py
@@ -27,6 +27,8 @@ MODELS = [
     SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4),
 ]
 
+#Set default mem_fraction_static to 0.8
+DEFAULT_MEM_FRACTION_STATIC = 0.8
 
 class TestVLMModels(CustomTestCase):
     parsed_args = None  # Class variable to store args
@@ -37,6 +39,9 @@ class TestVLMModels(CustomTestCase):
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.api_key = "sk-123456"
         cls.time_out = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+        if cls.parsed_args is None:
+            cls.parsed_args = SimpleNamespace(mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC)
 
         # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
         os.environ["OPENAI_API_KEY"] = cls.api_key
@@ -302,7 +307,7 @@ if __name__ == "__main__":
         "--mem-fraction-static",
         type=float,
         help="Static memory fraction for the model",
-        default=0.8,
+        default=DEFAULT_MEM_FRACTION_STATIC,
     )
 
     # Parse args intended for unittest


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Added fallback initialization of parsed_args in setUpClass using SimpleNamespace(mem_fraction_static=0.8). Ensures both pytest and unittest executions can access mem_fraction_static safely. No changes to actual model evaluation logic; only test setup was modified.

## Accuracy Tests

No changes to model accuracy expected.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
