### PR TITLE
EPLB: prefer to use physical experts in the same gpu or node

### DIFF
--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -132,7 +132,7 @@ class ExpertLocationMetadata:
             server_args=server_args,
             physical_to_logical_map=physical_to_logical_map,
             num_logical_experts=model_config_for_expert_location.num_logical_experts,
-            num_gpus=common["ep_size"],
+            ep_size=common["ep_size"],
             moe_ep_rank=moe_ep_rank,
         )
 
@@ -313,7 +313,7 @@ def _compute_logical_to_all_physical_map(
     server_args: ServerArgs,
     physical_to_logical_map: torch.Tensor,
     num_logical_experts: int,
-    num_gpus: int,
+    ep_size: int,
     moe_ep_rank: int,
 ):
     # This is rarely called, so we use for loops for maximum clarity
@@ -337,7 +337,7 @@ def _compute_logical_to_all_physical_map(
     # Replace by the physical expert on local GPU or node if possible
     if moe_ep_rank is not None:
         num_gpus_per_node = server_args.ep_size // server_args.nnodes
-        num_local_gpu_physical_experts = num_physical_experts // num_gpus
+        num_local_gpu_physical_experts = num_physical_experts // ep_size
         num_local_node_physical_experts = (
             num_local_gpu_physical_experts * num_gpus_per_node
         )

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -85,7 +85,7 @@ class ExpertLocationMetadata:
     # -------------------------------- construction ------------------------------------
 
     @staticmethod
-    def init_trivial(server_args: ServerArgs, model_config: ModelConfig):
+    def init_trivial(server_args: ServerArgs, model_config: ModelConfig, gpu_id: int):
         """Trivial location - logical expert i corresponds to physical expert i"""
         common = ExpertLocationMetadata._init_common(server_args, model_config)
 
@@ -106,6 +106,7 @@ class ExpertLocationMetadata:
             server_args,
             model_config,
             physical_to_logical_map=physical_to_logical_map,
+            gpu_id=gpu_id,
         )
 
     @staticmethod
@@ -514,7 +515,7 @@ def compute_initial_expert_location_metadata(
 ) -> Optional[ExpertLocationMetadata]:
     data = server_args.init_expert_location
     if data == "trivial":
-        return ExpertLocationMetadata.init_trivial(server_args, model_config)
+        return ExpertLocationMetadata.init_trivial(server_args, model_config, gpu_id)
 
     # TODO unify with the utils function
     if data.endswith(".pt"):

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -457,6 +457,9 @@ def _find_nearest_expert(
     num_gpus_per_node: int,
     num_local_node_physical_experts: int,
 ) -> int:
+    if len(candidate_physical_expert_ids) == 1:
+        return candidate_physical_expert_ids[0]
+
     same_gpu_physical_expert_ids = [
         physical_expert_id
         for physical_expert_id in candidate_physical_expert_ids

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -348,7 +348,11 @@ class ModelRunner:
 
         if not self.is_draft_worker:
             set_global_expert_location_metadata(
-                compute_initial_expert_location_metadata(server_args, self.model_config)
+                compute_initial_expert_location_metadata(
+                    server_args=server_args,
+                    model_config=self.model_config,
+                    gpu_id=self.moe_ep_rank,
+                )
             )
             if self.tp_rank == 0 and get_bool_env_var(
                 "SGLANG_LOG_EXPERT_LOCATION_METADATA"

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -351,7 +351,7 @@ class ModelRunner:
                 compute_initial_expert_location_metadata(
                     server_args=server_args,
                     model_config=self.model_config,
-                    gpu_id=self.moe_ep_rank,
+                    moe_ep_rank=self.moe_ep_rank,
                 )
             )
             if self.tp_rank == 0 and get_bool_env_var(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Similar to https://github.com/sgl-project/sglang/pull/9849, when it's possible to use physical experts on the same node, we'd prefer to route to these GPU ranks in dynamic mode.

## Modifications

<!-- Detail the changes made in this pull request. -->
When setting `--ep-dispatch-algorithm dynamic`, select the experts on the same GPU at first if possible, then select experts on the same node if possible, at last, select the experts randomly as a fall back method.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
