### PR TITLE
[router] consolidate health endpoints and flush cache

### DIFF
--- a/sgl-router/src/protocols/worker_spec.rs
+++ b/sgl-router/src/protocols/worker_spec.rs
@@ -200,3 +200,18 @@ pub struct ServerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template: Option<String>,
 }
+
+/// Result from flush cache operations across workers
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FlushCacheResult {
+    /// URLs of workers where cache flush succeeded
+    pub successful: Vec<String>,
+    /// URLs and error messages for workers where cache flush failed
+    pub failed: Vec<(String, String)>,
+    /// Total number of workers attempted
+    pub total_workers: usize,
+    /// Number of HTTP workers (gRPC workers don't support flush cache)
+    pub http_workers: usize,
+    /// Human-readable summary message
+    pub message: String,
+}

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -252,12 +252,13 @@ impl RouterTrait for GrpcPDRouter {
         self
     }
 
-    async fn health(&self, _req: Request<Body>) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-
     async fn health_generate(&self, _req: Request<Body>) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
+        // TODO: Implement actual generation test for gRPC PD mode
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Health generate not yet implemented for gRPC PD",
+        )
+            .into_response()
     }
 
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
@@ -339,19 +340,11 @@ impl RouterTrait for GrpcPDRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
-    async fn flush_cache(&self) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-
     async fn get_worker_loads(&self) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
     fn router_type(&self) -> &'static str {
         "grpc_pd"
-    }
-
-    fn readiness(&self) -> Response {
-        (StatusCode::SERVICE_UNAVAILABLE).into_response()
     }
 }

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -568,12 +568,13 @@ impl RouterTrait for GrpcRouter {
         self
     }
 
-    async fn health(&self, _req: Request<Body>) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-
     async fn health_generate(&self, _req: Request<Body>) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
+        // TODO: Implement actual generation test for gRPC
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Health generate not yet implemented for gRPC",
+        )
+            .into_response()
     }
 
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
@@ -655,20 +656,12 @@ impl RouterTrait for GrpcRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
-    async fn flush_cache(&self) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-
     async fn get_worker_loads(&self) -> Response {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
     fn router_type(&self) -> &'static str {
         "grpc"
-    }
-
-    fn readiness(&self) -> Response {
-        (StatusCode::SERVICE_UNAVAILABLE).into_response()
     }
 }
 

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -20,13 +20,7 @@ use axum::{
 use bytes::Bytes;
 use futures_util::StreamExt;
 use serde_json::{json, to_value, Value};
-use std::{
-    any::Any,
-    borrow::Cow,
-    collections::HashMap,
-    io,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::{any::Any, borrow::Cow, collections::HashMap, io, sync::atomic::AtomicBool};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{error, info, warn};
@@ -777,7 +771,7 @@ impl super::super::RouterTrait for OpenAIRouter {
         self
     }
 
-    async fn health(&self, _req: Request<Body>) -> Response {
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
         // Simple upstream probe: GET {base}/v1/models without auth
         let url = format!("{}/v1/models", self.base_url);
         match self
@@ -806,11 +800,6 @@ impl super::super::RouterTrait for OpenAIRouter {
             )
                 .into_response(),
         }
-    }
-
-    async fn health_generate(&self, _req: Request<Body>) -> Response {
-        // For OpenAI, health_generate is the same as health
-        self.health(_req).await
     }
 
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
@@ -1307,14 +1296,6 @@ impl super::super::RouterTrait for OpenAIRouter {
         }
     }
 
-    async fn flush_cache(&self) -> Response {
-        (
-            StatusCode::FORBIDDEN,
-            "flush_cache not supported for OpenAI router",
-        )
-            .into_response()
-    }
-
     async fn get_worker_loads(&self) -> Response {
         (
             StatusCode::FORBIDDEN,
@@ -1325,14 +1306,6 @@ impl super::super::RouterTrait for OpenAIRouter {
 
     fn router_type(&self) -> &'static str {
         "openai"
-    }
-
-    fn readiness(&self) -> Response {
-        if self.healthy.load(Ordering::Acquire) && self.circuit_breaker.can_execute() {
-            (StatusCode::OK, "Ready").into_response()
-        } else {
-            (StatusCode::SERVICE_UNAVAILABLE, "Not ready").into_response()
-        }
     }
 
     async fn route_embeddings(

--- a/sgl-router/src/routers/mod.rs
+++ b/sgl-router/src/routers/mod.rs
@@ -34,9 +34,6 @@ pub trait RouterTrait: Send + Sync + Debug {
     /// Get a reference to self as Any for downcasting
     fn as_any(&self) -> &dyn std::any::Any;
 
-    /// Route a health check request
-    async fn health(&self, req: Request<Body>) -> Response;
-
     /// Route a health generate request
     async fn health_generate(&self, req: Request<Body>) -> Response;
 
@@ -129,9 +126,6 @@ pub trait RouterTrait: Send + Sync + Debug {
         model_id: Option<&str>,
     ) -> Response;
 
-    /// Flush cache on all workers
-    async fn flush_cache(&self) -> Response;
-
     /// Get worker loads (for monitoring)
     async fn get_worker_loads(&self) -> Response;
 
@@ -142,13 +136,4 @@ pub trait RouterTrait: Send + Sync + Debug {
     fn is_pd_mode(&self) -> bool {
         self.router_type() == "pd"
     }
-
-    /// Server liveness check - is the server process running
-    fn liveness(&self) -> Response {
-        // Simple liveness check - if we can respond, we're alive
-        (StatusCode::OK, "OK").into_response()
-    }
-
-    /// Server readiness check - is the server ready to handle requests
-    fn readiness(&self) -> Response;
 }

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -289,10 +289,6 @@ impl RouterTrait for RouterManager {
         self
     }
 
-    async fn health(&self, _req: Request<Body>) -> Response {
-        (StatusCode::OK, "RouterManager is healthy").into_response()
-    }
-
     async fn health_generate(&self, _req: Request<Body>) -> Response {
         // TODO: Should check if any router has healthy workers
         (
@@ -512,16 +508,6 @@ impl RouterTrait for RouterManager {
         }
     }
 
-    async fn flush_cache(&self) -> Response {
-        // TODO: Call flush_cache on all routers that have workers
-        if self.routers.is_empty() {
-            (StatusCode::SERVICE_UNAVAILABLE, "No routers configured").into_response()
-        } else {
-            // TODO: Actually flush cache on all routers
-            (StatusCode::OK, "Cache flush requested").into_response()
-        }
-    }
-
     async fn get_worker_loads(&self) -> Response {
         let workers = self.worker_registry.get_all();
         let loads: Vec<serde_json::Value> = workers
@@ -548,15 +534,6 @@ impl RouterTrait for RouterManager {
 
     fn router_type(&self) -> &'static str {
         "manager"
-    }
-
-    fn readiness(&self) -> Response {
-        if self.routers.is_empty() {
-            (StatusCode::SERVICE_UNAVAILABLE, "No routers configured").into_response()
-        } else {
-            // TODO: Check readiness of all routers
-            (StatusCode::OK, "Ready").into_response()
-        }
     }
 }
 

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -239,13 +239,6 @@ mod health_tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // The health endpoint returns plain text, not JSON
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let body_str = String::from_utf8_lossy(&body);
-        assert!(body_str.contains("All servers healthy"));
-
         ctx.shutdown().await;
     }
 

--- a/sgl-router/tests/test_openai_routing.rs
+++ b/sgl-router/tests/test_openai_routing.rs
@@ -101,27 +101,6 @@ async fn test_openai_router_creation() {
     assert!(!router.is_pd_mode());
 }
 
-/// Test health endpoints
-#[tokio::test]
-async fn test_openai_router_health() {
-    let router = OpenAIRouter::new(
-        "https://api.openai.com".to_string(),
-        None,
-        Arc::new(MemoryResponseStorage::new()),
-    )
-    .await
-    .unwrap();
-
-    let req = Request::builder()
-        .method(Method::GET)
-        .uri("/health")
-        .body(Body::empty())
-        .unwrap();
-
-    let response = router.health(req).await;
-    assert_eq!(response.status(), StatusCode::OK);
-}
-
 /// Test server info endpoint
 #[tokio::test]
 async fn test_openai_router_server_info() {


### PR DESCRIPTION
as we are consolidating worker management
1. maintaining health generate endpoint
2. remove liveness and readiness probe from all routers and interface
3. readiness in server now checks if at least one worker is available for regular routing or a pair of workers for PD routing
4. deleted all flush cache implementation across routers
5. consolidate flush cache implementation in worker manager

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
