### PR TITLE
router-grpc: Add tools processing and other paramters for apply_chat_template

### DIFF
--- a/sgl-router/src/tokenizer/huggingface.rs
+++ b/sgl-router/src/tokenizer/huggingface.rs
@@ -4,7 +4,8 @@ use anyhow::{Error, Result};
 use tokenizers::tokenizer::Tokenizer as HfTokenizer;
 
 use super::chat_template::{
-    detect_chat_template_content_format, ChatTemplateContentFormat, ChatTemplateProcessor,
+    detect_chat_template_content_format, ChatTemplateContentFormat, ChatTemplateParams,
+    ChatTemplateProcessor,
 };
 use super::traits::{
     Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait,
@@ -165,16 +166,11 @@ impl HuggingFaceTokenizer {
     pub fn apply_chat_template(
         &self,
         messages: &[serde_json::Value],
-        add_generation_prompt: bool,
+        params: ChatTemplateParams,
     ) -> Result<String> {
         if let Some(ref template) = self.chat_template {
-            let processor = ChatTemplateProcessor::new(
-                template.clone(),
-                self.special_tokens.bos_token.clone(),
-                self.special_tokens.eos_token.clone(),
-            );
-
-            processor.apply_chat_template(messages, add_generation_prompt)
+            let processor = ChatTemplateProcessor::new(template.clone());
+            processor.apply_chat_template(messages, params)
         } else {
             Err(Error::msg(
                 "Cannot use chat template functions because tokenizer.chat_template is not set and no template \

--- a/sgl-router/tests/chat_template_loading.rs
+++ b/sgl-router/tests/chat_template_loading.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use sglang_router_rs::protocols::spec;
+    use sglang_router_rs::tokenizer::chat_template::ChatTemplateParams;
     use sglang_router_rs::tokenizer::huggingface::HuggingFaceTokenizer;
     use std::fs;
     use tempfile::TempDir;
@@ -79,7 +80,14 @@ mod tests {
             .map(|msg| serde_json::to_value(msg).unwrap())
             .collect();
 
-        let result = tokenizer.apply_chat_template(&json_messages, true).unwrap();
+        use sglang_router_rs::tokenizer::chat_template::ChatTemplateParams;
+        let params = ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+        let result = tokenizer
+            .apply_chat_template(&json_messages, params)
+            .unwrap();
 
         // Verify the custom template format
         assert!(result.contains("<|user|>Hello"));
@@ -150,7 +158,7 @@ mod tests {
             .collect();
 
         let result = tokenizer
-            .apply_chat_template(&json_messages, false)
+            .apply_chat_template(&json_messages, ChatTemplateParams::default())
             .unwrap();
 
         // Should use CUSTOM template, not built-in
@@ -219,7 +227,7 @@ mod tests {
             .collect();
 
         let result = tokenizer
-            .apply_chat_template(&json_messages, false)
+            .apply_chat_template(&json_messages, ChatTemplateParams::default())
             .unwrap();
 
         assert!(result.starts_with("NEW:"));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR serves as a follow-up of #10832 . It adds full support for Python's `tokenizer.apply_chat_template` functionality in the Rust router, including support for `tools`, `documents`, `continue_final_message`, and `**template_kwargs` parameter.

To achieve this in Rust (which lacks Python's flexible optional parameters), we introduced a `ChatTemplateParams` struct with the Default trait for clean API ergonomics.

Additionally, this PR implements proper `skip_special_tokens` handling when tools are present - setting it to `false` when tools are provided and tool_choice is not explicitly "none". 
> A TODO note has been added regarding the default tool_choice behavior, as the current spec.rs doesn't properly handle the OpenAI API semantics (where tool_choice defaults to "none" without tools and "auto" with tools).

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

### Core Changes

- Added `ChatTemplateParams` struct: Provides a clean API for optional parameters using Rust's Default trait, avoiding the need for multiple None parameters
- Enhanced `apply_chat_template`: Now supports all Python parity features including:
  - `tools` - for function/tool calling support
  - `documents` - for RAG context support
  - `continue_final_message` - for assistant message prefilling
  - `template_kwargs` - for additional template variables (e.g., reasoning_effort)

### Router Integration

- Tool call argument processing: Converts JSON string arguments to objects for Transformers compatibility (matching Python's behavior)
- Content format transformation: Processes messages based on detected chat template format (String vs OpenAI)
- Assistant prefix handling: Properly extracts and appends assistant content when `continue_final_message` is true
- Skip special tokens logic: Automatically sets `skip_special_tokens = false` when tools are present and active

### API Cleanup

- Simplified `ChatTemplateProcessor::new()`: Removed unused `bos_token` and `eos_token` parameters
- Consistent function naming: Renamed processing functions to `process_content_format` and `process_tool_call_arguments` for clarity
- Fixed `add_generation_prompt`: Always set to true in router context

### Testing

- Updated all existing chat template tests to use the new ChatTemplateParams struct
- All 22 chat template tests passing
- Full test suite (467 tests) passing 

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
