### PR TITLE
[router] consolidate worker get loads

### DIFF
--- a/sgl-router/src/protocols/worker_spec.rs
+++ b/sgl-router/src/protocols/worker_spec.rs
@@ -215,3 +215,28 @@ pub struct FlushCacheResult {
     /// Human-readable summary message
     pub message: String,
 }
+
+/// Result from getting worker loads
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WorkerLoadsResult {
+    /// Worker URL and load pairs
+    pub loads: Vec<WorkerLoadInfo>,
+    /// Total number of workers
+    pub total_workers: usize,
+    /// Number of workers with successful load fetches
+    pub successful: usize,
+    /// Number of workers with failed load fetches
+    pub failed: usize,
+}
+
+/// Individual worker load information
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WorkerLoadInfo {
+    /// Worker URL
+    pub worker: String,
+    /// Worker type (regular, prefill, decode)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worker_type: Option<String>,
+    /// Current load (-1 indicates failure to fetch)
+    pub load: isize,
+}

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -340,10 +340,6 @@ impl RouterTrait for GrpcPDRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
-    async fn get_worker_loads(&self) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-
     fn router_type(&self) -> &'static str {
         "grpc_pd"
     }

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -787,10 +787,6 @@ impl RouterTrait for GrpcRouter {
         (StatusCode::NOT_IMPLEMENTED).into_response()
     }
 
-    async fn get_worker_loads(&self) -> Response {
-        (StatusCode::NOT_IMPLEMENTED).into_response()
-    }
-
     fn router_type(&self) -> &'static str {
         "grpc"
     }

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -1296,14 +1296,6 @@ impl super::super::RouterTrait for OpenAIRouter {
         }
     }
 
-    async fn get_worker_loads(&self) -> Response {
-        (
-            StatusCode::FORBIDDEN,
-            "get_worker_loads not supported for OpenAI router",
-        )
-            .into_response()
-    }
-
     fn router_type(&self) -> &'static str {
         "openai"
     }

--- a/sgl-router/src/routers/mod.rs
+++ b/sgl-router/src/routers/mod.rs
@@ -126,9 +126,6 @@ pub trait RouterTrait: Send + Sync + Debug {
         model_id: Option<&str>,
     ) -> Response;
 
-    /// Get worker loads (for monitoring)
-    async fn get_worker_loads(&self) -> Response;
-
     /// Get router type name
     fn router_type(&self) -> &'static str;
 

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -508,30 +508,6 @@ impl RouterTrait for RouterManager {
         }
     }
 
-    async fn get_worker_loads(&self) -> Response {
-        let workers = self.worker_registry.get_all();
-        let loads: Vec<serde_json::Value> = workers
-            .iter()
-            .map(|w| {
-                serde_json::json!({
-                    "url": w.url(),
-                    "model": w.model_id(),
-                    "load": w.load(),
-                    "is_healthy": w.is_healthy()
-                })
-            })
-            .collect();
-
-        (
-            StatusCode::OK,
-            serde_json::json!({
-                "workers": loads
-            })
-            .to_string(),
-        )
-            .into_response()
-    }
-
     fn router_type(&self) -> &'static str {
         "manager"
     }


### PR DESCRIPTION
1. removed all get loads implementation across routers
2. deleted the interface signature
3. centralized get load implementation in worker manager
4. updated get load handler to use worker manager

future improvmenet
1. create get load service which runs async in background and updates 
2. move worker load monitoring out of routers for power of two
3. use worker loads for proper rate limiting

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
