### PR TITLE
[bugfix] set is_prefill_only=false when mixed_chunk

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1371,6 +1371,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_num_tokens += running_bs
         # TODO (lianmin): Revisit this. It should be seq_len - 1
         self.extend_logprob_start_lens.extend([0] * running_bs)
+        self.is_prefill_only = False
 
     def new_page_count_next_decode(self):
         page_size = self.token_to_kv_pool_allocator.page_size


### PR DESCRIPTION
## Motivation

when I enanle mix_chunked, I do a bench_serving test but I meet a mem_leak bug
Then I find the root cause:
we meet some requests which could match is_prefill_only=True, 
but if we mix new_batch(extend) and running_batch(decode), we don't set is_prefill_only=False
after run_batch done, last_batch = new_batch(extend) and running_batch is Empty
then at next ground, in get_next_batch_to_run, last_batch just be skipped
then, the reqs in the former running_batch could not be exceuted(so mem could not be free)
then when we check memory at idle status, it raise mem_leak error
```
           if not self.last_batch.is_empty() and not self.last_batch.is_prefill_only:
                if self.running_batch.is_empty():
                    self.running_batch = self.last_batch
                else:
                    # Merge running_batch with prefill batch
                    self.running_batch.merge_batch(self.last_batch)
```

## Modifications

just set is_prefill_only = False in mix_with_running.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
