### PR TITLE
[RFC][feat] Attention-FFN Disaggregation (AFD)

### DIFF
--- a/python/sglang/srt/afd/afd_model.py
+++ b/python/sglang/srt/afd/afd_model.py
@@ -1,0 +1,29 @@
+# AF disaggregation model
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========
+
+import torch
+from torch import nn
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class AFDProxyAttention(nn.Module):
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        return hidden_states

--- a/python/sglang/srt/afd/afd_type.py
+++ b/python/sglang/srt/afd/afd_type.py
@@ -1,0 +1,41 @@
+# AF disaggregation type
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =========
+
+import argparse
+from enum import Enum
+from typing import Optional
+
+
+class AFDRole(Enum):
+    AFD_ROLE_ATTN = "attn"
+    AFD_ROLE_FFN = "ffn"
+
+    def __str__(self):
+        return self.value
+
+
+def get_afd_role() -> Optional[AFDRole]:
+    from sglang.srt.managers.schedule_batch import global_server_args_dict
+
+    afd_role = global_server_args_dict.get("afd_role")
+    return afd_role
+
+
+def afd_is_attn():
+    return get_afd_role() == AFDRole.AFD_ROLE_ATTN
+
+
+def afd_is_ffn():
+    return get_afd_role() == AFDRole.AFD_ROLE_FFN

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -47,6 +47,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 
+from sglang.srt.afd.afd_type import AFDRole
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.entrypoints.engine import _launch_subprocesses
 from sglang.srt.entrypoints.openai.protocol import (
@@ -1437,14 +1438,14 @@ def _wait_and_warmup(
     pipe_finish_writer: Optional[multiprocessing.connection.Connection],
     launch_callback: Optional[Callable[[], None]] = None,
 ):
-    if not server_args.skip_server_warmup:
+    if server_args.skip_server_warmup or server_args.afd_role == AFDRole.AFD_ROLE_FFN:
+        _global_state.tokenizer_manager.server_status = ServerStatus.Up
+    else:
         if not _execute_server_warmup(
             server_args,
             pipe_finish_writer,
         ):
             return
-    else:
-        _global_state.tokenizer_manager.server_status = ServerStatus.Up
 
     logger.info("The server is fired up and ready to roll!")
 

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -136,6 +136,7 @@ class LayerScatterModes:
                 if (
                     # Token dispatch/combine will be handled outside of LayerCommunicator for these modes.
                     not get_moe_a2a_backend().is_none()
+                    or get_afd_role()
                     or should_use_flashinfer_cutlass_moe_fp4_allgather()
                 )
                 else ScatterMode.FULL

--- a/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
@@ -20,6 +20,7 @@ from sglang.srt.layers.moe.token_dispatcher.standard import (
     StandardCombineInput,
     StandardDispatchOutput,
 )
+from sglang.srt.layers.moe.token_dispatcher.stepmesh import StepMeshATTN, StepMeshFFN
 
 __all__ = [
     "BaseDispatcher",
@@ -38,4 +39,6 @@ __all__ = [
     "DeepEPLLOutput",
     "DeepEPLLCombineInput",
     "DeepEPNormalCombineInput",
+    "StepMeshATTN",
+    "StepMeshFFN",
 ]

--- a/python/sglang/srt/layers/moe/token_dispatcher/stepmesh.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/stepmesh.py
@@ -1,0 +1,447 @@
+import json
+import logging
+import os
+import sys
+import time
+
+import torch
+import torch.distributed as dist
+import zmq
+
+from sglang.srt.afd.afd_type import afd_is_attn, get_afd_role
+from sglang.srt.distributed.parallel_state import GroupCoordinator
+from sglang.srt.managers.schedule_batch import global_server_args_dict
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+
+logger = logging.getLogger(__name__)
+
+dtype_map = [
+    torch.float16,  # torch.half
+    torch.float32,  # torch.float
+    torch.float64,  # torch.double
+    torch.bfloat16,  # Brain floating point
+    torch.complex32,
+    torch.complex64,
+    torch.complex128,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,  # torch.int
+    torch.int64,  # torch.long
+    torch.bool,
+    torch.quint8,  # Quantized unsigned int8
+    torch.qint8,  # Quantized int8
+    torch.qint32,  # Quantized int32
+    torch.quint4x2,  # 4-bit quantized (packed)
+    torch.quint2x4,  # 2-bit quantized (packed)
+]
+
+push_cache = None
+initialized = False
+fserver = None
+global_tokens_num = None
+
+
+def stepmesh_scheduler():
+    os.environ["DMLC_ROLE"] = "scheduler"
+
+    import fserver_lib as f
+
+    f.init()
+
+    # let the scheduler to sleep forever
+    while True:
+        time.sleep(30 * 24 * 3600)
+
+
+def env_def(env, v):
+    if os.environ.get(env) == None:
+        os.environ[env] = v
+
+
+def start_stepmesh_scheduler(world: GroupCoordinator):
+    if os.environ["DMLC_ROLE"] != "server":
+        return
+
+    if world.rank_in_group != 0:
+        return
+
+    if os.environ.get("STEPMESH_SCHEDULER_STARTED") == "1":
+        return
+
+    os.environ["STEPMESH_SCHEDULER_STARTED"] = "1"
+
+    import multiprocessing
+
+    p = multiprocessing.Process(target=stepmesh_scheduler)
+    p.daemon = True
+    p.start()
+
+
+def stepmesh_config(world: GroupCoordinator, local_group: GroupCoordinator):
+    rank = world.rank_in_group
+    local_size = local_group.world_size
+
+    node_rank = rank // local_size
+
+    # Users do not care about these:
+    env_def("DMLC_GROUP_SIZE", f"{local_size}")
+    env_def("DMLC_NODE_RANK", f"{node_rank}")
+    env_def("STEPMESH_GPU", f"{torch.cuda.current_device()}")
+    env_def("DMLC_ENABLE_RDMA", "ibverbs")
+
+
+def att_ffn_exchange_conf(world: GroupCoordinator, local_group: GroupCoordinator):
+    rank = world.rank_in_group
+
+    nodes_n = world.world_size // local_group.world_size
+
+    addr = global_server_args_dict.get("afd_ffn_addr")
+    ffn_ip, port = addr.split(":")
+
+    port = int(port) + 10
+
+    if rank > 0:
+        x = torch.tensor([0])
+        # wait that rank0 connects to the peer(attn or ffn)
+        x = world.all_gather(x)
+    else:
+        context = zmq.Context()
+
+        if afd_is_attn():
+            assert nodes_n == 1, "Only support one attention node"
+
+            socket = context.socket(zmq.REQ)
+            socket.connect(f"tcp://{ffn_ip}:{port}")
+
+            msg = {"attn_nodes_n": nodes_n, "scheduler_ip": ffn_ip}
+
+            socket.send_string(json.dumps(msg))
+            reply = socket.recv_string()
+
+            reply = json.loads(reply)
+
+            peer_nodes_n = reply["ffn_nodes_n"]
+        else:
+            assert nodes_n == 1, "Only support one FFN node"
+
+            socket = context.socket(zmq.REP)
+            socket.bind(f"tcp://*:{port}")
+
+            msg = socket.recv_string()
+
+            msg = json.loads(msg)
+            peer_nodes_n = msg["attn_nodes_n"]
+            ffn_ip = msg["scheduler_ip"]
+
+            reply = {"ffn_nodes_n": nodes_n}
+
+            socket.send_string(json.dumps(reply))
+
+        x = torch.tensor([peer_nodes_n])
+        x = world.all_gather(x)
+
+    peer_nodes_n = x[0]
+
+    if afd_is_attn():
+        os.environ["DMLC_NUM_WORKER"] = f"{nodes_n}"
+        os.environ["DMLC_NUM_SERVER"] = f"{peer_nodes_n}"
+        os.environ["DMLC_ROLE"] = "worker"
+    else:
+        os.environ["DMLC_NUM_WORKER"] = f"{peer_nodes_n}"
+        os.environ["DMLC_NUM_SERVER"] = f"{nodes_n}"
+        os.environ["DMLC_ROLE"] = "server"
+
+    os.environ["DMLC_PS_ROOT_URI"] = ffn_ip
+    env_def("DMLC_PS_ROOT_PORT", "8123")
+
+
+def stepmesh_init(local_group: GroupCoordinator):
+    global initialized
+
+    if initialized:
+        return
+
+    initialized = True
+
+    from sglang.srt.distributed import get_world_group
+
+    world = get_world_group()
+
+    global push_cache
+    push_cache = PushTensorCache(world.rank_in_group)
+
+    att_ffn_exchange_conf(world, local_group)
+    stepmesh_config(world, local_group)
+
+    import fserver_lib as f
+
+    start_stepmesh_scheduler(world)
+
+    logger.info("stepmesh for %s init..." % get_afd_role())
+    f.init()
+    logger.info("stepmesh for %s init done." % get_afd_role())
+
+    global fserver
+    fserver = f
+
+
+class StepMeshTensorCache:
+    def __init__(self):
+        self.push = []
+        self.pull = []
+
+        self.push_keys = []
+        self.pull_keys = []
+        self.shape = None
+
+        self.h = None
+
+
+class PushTensorCache:
+    def __init__(self, rank):
+        self.cache = {}
+        self.key = rank << 24
+
+    def copy(self, p: PPProxyTensors):
+        x = p["hidden_states"]
+        topk_weights = p["topk_weights"]
+        topk_ids = p["topk_ids"]
+        router_logits = p["router_logits"]
+
+        free = self.cache.get(x.shape)
+        if free == None:
+            self.cache[x.shape] = []
+            free = self.cache[x.shape]
+
+        if x.shape[0] == 0:
+            l = []
+            for t in [x, topk_weights, topk_ids, router_logits]:
+                l.append(t.shape[1])
+                l.append(dtype_map.index(t.dtype))
+
+            y = torch.tensor(l)
+
+        if len(free) == 0:
+            t = StepMeshTensorCache()
+            t.shape = x.shape
+            t.dtype = x.dtype
+            t.device = x.device
+
+            if x.shape[0] == 0:
+                x = torch.empty(y.shape[0], dtype=torch.int)
+                t.push.append(x)
+                t.pull = [torch.empty_like(x)]
+
+            else:
+                t.push.append(torch.empty_like(x))
+                t.push.append(torch.empty_like(topk_weights))
+                t.push.append(torch.empty_like(topk_ids))
+                t.push.append(torch.empty_like(router_logits))
+
+                t.pull = [torch.empty_like(x)]
+
+            t.push_keys = range(self.key, self.key + len(t.push))
+            self.key += len(t.push)
+            t.pull_keys = range(self.key, self.key + len(t.pull))
+            self.key += len(t.pull)
+
+        else:
+            t = free.pop(0)
+
+        if len(t.push) > 2:
+            t.push[0].copy_(x)
+            t.push[1].copy_(topk_weights)
+            t.push[2].copy_(topk_ids)
+            t.push[3].copy_(router_logits)
+        else:
+            t.push[0].copy_(y)
+
+        return t
+
+    def put(self, t):
+        self.cache[t.shape].append(t)
+
+
+class FFNSendCache:
+    def __init__(self):
+        self.free_tensors = {}
+        self.inflight = []
+
+    def copy(self, x: torch.Tensor):
+        if len(self.inflight) > 100:
+            t = self.inflight.pop(0)
+            self.free_tensors[t.shape].append(t)
+
+        free = self.free_tensors.get(x.shape)
+        if free == None:
+            self.free_tensors[x.shape] = []
+            free = self.free_tensors[x.shape]
+
+        if len(free) == 0:
+            t = torch.empty_like(x)
+        else:
+            t = free.pop(0)
+
+        t.copy_(x)
+
+        self.inflight.append(t)
+
+        return t
+
+
+ffn_cache = FFNSendCache()
+
+
+class StepMeshATTN:
+    def __init__(
+        self,
+        layer_id: int,
+        group: GroupCoordinator,
+    ):
+        stepmesh_init(group)
+
+        self.waits = []
+        self.f = fserver
+        self.layer_id = layer_id
+
+    def send(self, p: PPProxyTensors):
+
+        t = push_cache.copy(p)
+
+        h = self.f.push_pull(t.push, t.push_keys, t.pull, t.pull_keys)
+
+        t.h = h
+
+        self.waits.append(t)
+
+    def recv(self):
+        t = self.waits.pop(0)
+
+        self.f.wait(t.h)
+
+        push_cache.put(t)
+
+        if t.shape[0] == 0:
+            return torch.empty(0, t.shape[1], dtype=t.dtype, device=t.device)
+
+        return t.pull[0].clone()
+
+
+def all_gathter_global_tokens(x: torch.Tensor, layer_id: int, group: GroupCoordinator):
+    global global_tokens_num
+    if layer_id > 0:
+        return global_tokens_num
+
+    tensor = torch.tensor([x.shape[0]], dtype=torch.int, device=x.device)
+
+    tensor = group.all_gather(tensor, dim=0)
+
+    global_tokens_num = tensor.tolist()
+
+    return global_tokens_num
+
+
+class FFNCTX:
+    def __init__(self):
+        self.id = None
+        self.token_n = 0
+        self.token_s = 0
+        self.token_e = 0
+        self.zero_x = None
+
+
+def all_gather_partial(ctx: FFNCTX, x: torch.Tensor, group: GroupCoordinator):
+    dim = x.shape[1]
+
+    t = torch.zeros(ctx.token_n, dim, device=x.device, dtype=x.dtype)
+    t[ctx.token_s : ctx.token_e] = x
+
+    torch.ops.sglang.inplace_all_reduce(t, group_name=group.unique_name)
+
+    return t
+
+
+class StepMeshFFN:
+    def __init__(
+        self,
+        layer_id: int,
+        group: GroupCoordinator,
+    ):
+        stepmesh_init(group)
+
+        self.layer_id = layer_id
+        self.comms = []
+        self.peek_tensor = None
+
+        self.f = fserver
+
+        self.group = group
+
+    def send(self, x: torch.Tensor):
+        x = self.group.all_reduce(x)
+
+        ctx = self.comms.pop(0)
+
+        if ctx.zero_x == None:
+            x = x[ctx.token_s : ctx.token_e]
+
+            t = ffn_cache.copy(x)
+        else:
+            t = ffn_cache.copy(ctx.zero_x)
+
+        self.f.respond([t], ctx.id, True)
+
+    def recv(self):
+        batches = self.f.get_batch()
+        if len(batches) == 0:
+            return None
+
+        from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+        ctx = FFNCTX()
+        ctx.id = batches[0][0]
+
+        self.comms.append(ctx)
+
+        # attn send tensor(0, dim)
+        if len(batches[0][1]) == 1:
+            x = batches[0][1][0]
+            ctx.zero_x = x
+            y = x.tolist()
+
+            ts = []
+
+            for i in range(0, 4):
+                dim = y.pop(0)
+                dtype = dtype_map[y.pop(0)]
+                ts.append(torch.empty(0, dim, device=x.device, dtype=dtype))
+
+            x, topk_weights, topk_idx, router_logits = ts
+
+        else:
+            x, topk_weights, topk_idx, router_logits = batches[0][1]
+
+        g_tokens = all_gathter_global_tokens(x, self.layer_id, self.group)
+
+        ctx.token_s = sum(g_tokens[0 : self.group.rank_in_group])
+        ctx.token_e = sum(g_tokens[0 : self.group.rank_in_group + 1])
+
+        if set(g_tokens) == 1:  # tokens number is eq
+            x = self.group.all_gather(x, dim=0)
+            topk_weights = self.group.all_gather(topk_weights, dim=0)
+            topk_idx = self.group.all_gather(topk_idx, dim=0)
+            router_logits = self.group.all_gather(router_logits, dim=0)
+        else:
+            tk = sum(g_tokens)
+
+            ctx.token_n = tk
+
+            x = all_gather_partial(ctx, x, self.group)
+            topk_weights = all_gather_partial(ctx, topk_weights, self.group)
+            topk_idx = all_gather_partial(ctx, topk_idx, self.group)
+            router_logits = all_gather_partial(ctx, router_logits, self.group)
+
+        topk_output = StandardTopKOutput(topk_weights, topk_idx, router_logits)
+
+        return x, topk_output

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1416,3 +1416,8 @@ class GetLoadReqOutput:
 @dataclass
 class WatchLoadUpdateReq:
     loads: List[GetLoadReqOutput]
+
+
+@dataclass
+class AFSyncReq:
+    pass

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -112,6 +112,9 @@ GLOBAL_SERVER_ARGS_KEYS = [
     "enable_custom_logit_processor",
     "disaggregation_mode",
     "enable_deterministic_inference",
+    "afd_role",
+    "afd_ffn_addr",
+    "afd_transfer_backend",
 ]
 
 # Put some global args for easy access

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -31,6 +31,7 @@ import requests
 import torch
 import torch.distributed as dist
 
+from sglang.srt.afd.afd_type import AFDRole
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.configs.model_config import AttentionArch, ModelConfig
@@ -2019,6 +2020,23 @@ class ModelRunner:
             forward_batch.post_forward_mlp_sync_batch(ret)
 
         return ret, can_run_graph
+
+    def afd_forward_ffn(self):
+        assert self.server_args.afd_role == AFDRole.AFD_ROLE_FFN
+
+        # forward_batch fields like input_ids are needed in forwarding
+        placeholder = torch.zeros(0).to(self.device, non_blocking=True)
+        forward_batch = ForwardBatch(
+            forward_mode=0,
+            batch_size=0,
+            input_ids=placeholder,
+            req_pool_indices=placeholder,
+            seq_lens=placeholder,
+            out_cache_loc=placeholder,
+            seq_lens_sum=0,
+        )
+
+        self.model.forward(forward_batch.input_ids, None, forward_batch, None)
 
     def _preprocess_logits(
         self, logits_output: LogitsProcessorOutput, sampling_info: SamplingBatchInfo

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -43,6 +43,7 @@ from sglang.srt.distributed import (
     get_tp_group,
     get_world_group,
     init_distributed_environment,
+    initialize_local_group,
     initialize_model_parallel,
     set_custom_all_reduce,
     set_mscclpp_all_reduce,
@@ -682,6 +683,11 @@ class ModelRunner:
                 pipeline_model_parallel_size=self.pp_size,
                 expert_model_parallel_size=self.moe_ep_size,
                 duplicate_tp_group=self.server_args.enable_pdmux,
+            )
+            initialize_local_group(
+                self.server_args.nnodes,
+                self.server_args.pp_size,
+                self.server_args.tp_size,
             )
             initialize_dp_attention(
                 server_args=self.server_args,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -24,6 +24,7 @@ import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
 
+from sglang.srt.afd.afd_type import afd_is_ffn
 from sglang.srt.distributed import (
     get_moe_expert_parallel_world_size,
     get_pp_group,
@@ -522,7 +523,8 @@ class Qwen2MoeModel(nn.Module):
         self.vocab_size = config.vocab_size
         self.pp_group = get_pp_group()
 
-        if self.pp_group.is_first_rank:
+        # AFD: always skip embed for ffn
+        if not afd_is_ffn() and self.pp_group.is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -22,6 +22,7 @@ import random
 import tempfile
 from typing import List, Literal, Optional, Union
 
+from sglang.srt.afd.afd_type import AFDRole
 from sglang.srt.connector import ConnectorType
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.hf_transformers_utils import check_gguf_file, get_config
@@ -435,6 +436,24 @@ class ServerArgs:
     # For PD-Multiplexing
     enable_pdmux: bool = False
     sm_group_num: int = 3
+
+    # Mamba cache
+    max_mamba_cache_size: Optional[int] = None
+    mamba_ssm_dtype: str = "float32"
+
+    # For AFD
+    afd_role: Optional[AFDRole] = None
+    afd_transfer_backend: Literal["stepmesh"] = "stepmesh"
+    afd_ffn_addr: Optional[str] = None
+
+    # Deprecated arguments
+    enable_ep_moe: bool = False
+    enable_deepep_moe: bool = False
+    enable_flashinfer_cutlass_moe: bool = False
+    enable_flashinfer_cutedsl_moe: bool = False
+    enable_flashinfer_trtllm_moe: bool = False
+    enable_triton_kernel_moe: bool = False
+    enable_flashinfer_mxfp4_moe: bool = False
 
     def __post_init__(self):
         """
@@ -2622,6 +2641,30 @@ class ServerArgs:
             help="Enable deterministic inference mode with batch invariant ops.",
         )
 
+        # For AFD
+        parser.add_argument(
+            "--afd-role",
+            type=AFDRole,
+            choices=list(AFDRole),
+            default=ServerArgs.afd_role,
+            help="AFD role, i.e., `attn` or `ffn`.",
+        )
+
+        parser.add_argument(
+            "--afd-transfer-backend",
+            type=str,
+            choices=["stepmesh"],
+            default=ServerArgs.afd_transfer_backend,
+            help="Backend for AFD.",
+        )
+
+        parser.add_argument(
+            "--afd-ffn-addr",
+            type=str,
+            default=ServerArgs.afd_ffn_addr,
+            help="The host address (ip:port) for FFN (e.g., `192.168.0.2:25000`).",
+        )
+
         # Deprecated arguments
         parser.add_argument(
             "--enable-ep-moe",
@@ -2751,6 +2794,9 @@ class ServerArgs:
                 "lof",
             ], f"To use priority scheduling, schedule_policy must be 'fcfs' or 'lof'. '{self.schedule_policy}' is not supported."
 
+        # Check AFD
+        self.check_afd_server_args()
+
     def check_lora_server_args(self):
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"
 
@@ -2839,6 +2885,31 @@ class ServerArgs:
                     16 <= self.max_lora_chunk_size <= 128
                     and (self.max_lora_chunk_size & (self.max_lora_chunk_size - 1)) == 0
                 ), "--max-lora-chunk-size must be a power of 2 between 16 and 128."
+
+    def check_afd_server_args(self):
+        if self.afd_role is None:
+            return
+
+        # Either not compatible or temporarily unsupported.
+        assert self.disable_cuda_graph, "Cuda graph is not supported for AFD."
+        assert (
+            self.disable_overlap_schedule
+        ), "Overlap schedule is not supported for AFD."
+
+        assert self.nnodes == 1, "Multi-node distribution is not supported for AFD."
+        assert (
+            self.disaggregation_mode == "null"
+        ), "Disaggregation mode is not supported for AFD."
+        assert self.pp_size == 1, "PP is not supported for AFD."
+        if self.tp_size > 1:
+            assert (
+                self.enable_dp_attention
+            ), "DP attention must be enabled if tp_size > 1 for AFD"
+
+        assert self.moe_a2a_backend == "none", "MoE A2A is not compatible with AFD."
+        assert (
+            not self.enable_two_batch_overlap
+        ), "Two batch overlap is not compatible with AFD."
 
     def validate_disagg_tp_size(self, prefill_tp: int, decode_tp: int):
         larger_tp = max(decode_tp, prefill_tp)
@@ -2997,6 +3068,9 @@ class PortArgs:
     # The ipc filename for Tokenizer and worker tokenizer
     tokenizer_worker_ipc_name: Optional[str]
 
+    # The ipc filename for Attn-to-FFN forwarding
+    afd_ipc_name: Optional[str]
+
     @staticmethod
     def init_new(server_args, dp_rank: Optional[int] = None) -> "PortArgs":
         if server_args.nccl_port is None:
@@ -3011,6 +3085,24 @@ class PortArgs:
         else:
             nccl_port = server_args.nccl_port
 
+        # always use TCP for AFD
+        afd_ipc_name = None
+        if server_args.afd_role is not None:
+            assert (
+                server_args.afd_ffn_addr is not None
+            ), "Please provide --afd-ffn-addr for AFD"
+            if server_args.afd_ffn_addr.startswith("["):  # ipv6 address
+                port_num, host = configure_ipv6(server_args.afd_ffn_addr)
+                afd_ffn_addr = (host, str(port_num))
+            else:
+                afd_ffn_addr = server_args.afd_ffn_addr.split(":")
+
+            assert (
+                len(afd_ffn_addr) == 2
+            ), "Please provide --afd-ffn-addr as host:port of FFN node"
+            afd_ffn_host, afd_ffn_port = afd_ffn_addr
+            afd_ipc_name = f"tcp://{afd_ffn_host}:{afd_ffn_port}"
+
         if not server_args.enable_dp_attention:
             # Normal case, use IPC within a single node
             return PortArgs(
@@ -3021,6 +3113,7 @@ class PortArgs:
                 rpc_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",
                 metrics_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",
                 tokenizer_worker_ipc_name=None,
+                afd_ipc_name=afd_ipc_name,
             )
         else:
             # DP attention. Use TCP + port to handle both single-node and multi-node.
@@ -3055,6 +3148,7 @@ class PortArgs:
                 rpc_ipc_name=f"tcp://{dist_init_host}:{rpc_port}",
                 metrics_ipc_name=f"tcp://{dist_init_host}:{metrics_ipc_name}",
                 tokenizer_worker_ipc_name=None,
+                afd_ipc_name=afd_ipc_name,
             )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This is a request for comments, not a complete version, but a runnable one with necessary parts.

AFD (Attention FFN Disaggregation) is a deployment method for LLM that separates the attention and FFN/expert layers onto distinct sets of GPUs. See #9401 for more details.

To directly show [our design](https://docs.google.com/document/d/1mxAGznAxLIfsYQblAEea6OjCXbritiaCDDtRY9U7D6A/edit?usp=sharing), advanced features like microbatch overlapping are not included. So this is not ready for speed benchmarking, but enough for review and discussion.

## Modifications

<!-- Detail the changes made in this pull request. -->

In comparison with the previous [POC](https://github.com/LPhgh/sglang/tree/afd):
  ✅ More elegant implementation
  ✅ Support attn dp with moe tp/ep
  ❌ No microbatch overlapping

Major modifications:
* Scheduler: Sync ATTN and FFN forwarding with AFDSyncReq.
* Model: Separate expert computing into FFN, only support Qwen3-moe.
* AFDMoE: A new expert class, equipped with AFD backend, only support StepMesh.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Test with Qwen3-30B-A3B-Thinking-2507: 
```
# python -m sglang.test.few_shot_gsm8k --num-questions 200
Accuracy: 0.885
Invalid: 0.000
Latency: 53.722 s
Output throughput: 795.035 token/s
```

```shell
# attn
python -m sglang.launch_server --model-path <Qwen3-30B-A3B-Thinking-2507> --disable-overlap-schedule --disable-cuda-graph --afd-role attn --afd-ffn-addr <ffn_ip:port1> --tp 4 --ep-size 4 --enable-dp-attention --dp-size 4

# ffn
python -m sglang.launch_server --model-path <Qwen3-30B-A3B-Thinking-2507> --disable-overlap-schedule --disable-cuda-graph --afd-role ffn --afd-ffn-addr <ffn_ip:port1> --port <port2> --tp 4 --ep-size 4 --enable-dp-attention --dp-size 4
```

Note: Currently there are StepMesh bugs that may break our implementation, so it's recommended to use this branch: https://github.com/fengidri/StepMesh/tree/erdma

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
