### PR TITLE
Add Node priority calculation for hicache offloading 

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -473,7 +473,7 @@ class HiCacheController:
         if len(self.write_queue) == 0:
             return
 
-        op = CacheOperation.merge_ops(self.write_queue)        
+        op = CacheOperation.merge_ops(self.write_queue)
         host_indices, device_indices = self.move_indices(op)
         self.write_queue.clear()
 

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -472,7 +472,7 @@ class HiCacheController:
     def start_writing(self) -> None:
         if len(self.write_queue) == 0:
             return
-
+        print(f"The length of write_queue {len(self.write_queue)}")
         op = CacheOperation.merge_ops(self.write_queue)
         host_indices, device_indices = self.move_indices(op)
         self.write_queue.clear()

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -473,7 +473,7 @@ class HiCacheController:
         if len(self.write_queue) == 0:
             return
 
-        op = CacheOperation.merge_ops(self.write_queue)
+        op = CacheOperation.merge_ops(self.write_queue)        
         host_indices, device_indices = self.move_indices(op)
         self.write_queue.clear()
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -714,6 +714,7 @@ class Scheduler(
                     hicache_storage_prefetch_policy=server_args.hicache_storage_prefetch_policy,
                     model_name=server_args.served_model_name,
                     storage_backend_extra_config=server_args.hicache_storage_backend_extra_config,
+                    enable_backup_priority=server_args.enable_backup_priority,
                 )
                 self.tp_worker.register_hicache_layer_transfer_counter(
                     self.tree_cache.cache_controller.layer_done_counter
@@ -753,6 +754,7 @@ class Scheduler(
                     disable=server_args.disable_radix_cache,
                     enable_kv_cache_events=self.enable_kv_cache_events,
                     eviction_policy=server_args.radix_eviction_policy,
+                    enable_backup_priority=server_args.enable_backup_priority,
                 )
 
         self.decode_mem_cache_buf_multiplier = (

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -165,17 +165,17 @@ class HiRadixCache(RadixCache):
             return False
         
     def calculate_node_value(self, node: TreeNode):
-        # 基于访问频率和最近访问时间
+        
         recency = time.monotonic() - node.last_access_time
         frequency = node.hit_count
 
-        # 价值公式：高频 + 近期 = 高价值
+        # high value = big size Node which is frequently & recently accessed
         value = frequency / (recency + 1)  # +1 避免除零
 
-        # 大节点价值更高（节省更多内存）
+        
         value *= len(node.value) 
-
-        return value 
+        # High value node should have small priority which can be process firstly
+        return -1 * value 
 
     def write_backup(self, node: TreeNode, priority=None, write_back=False):
         host_indices = self.cache_controller.write(

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -163,19 +163,17 @@ class HiRadixCache(RadixCache):
         else:
             logger.warning("Hierarchical cache storage backend is not enabled.")
             return False
-        
+
     def calculate_node_value(self, node: TreeNode):
-        
+
         recency = time.monotonic() - node.last_access_time
         frequency = node.hit_count
 
         # high value = big size Node which is frequently & recently accessed
-        value = frequency / (recency + 1)  # +1 avoid dividing by 0
-
-        
-        value *= len(node.value) 
+        value = frequency / (recency + 1)
+        value *= len(node.value)
         # High value node should have small priority which can be process firstly
-        return -1 * value 
+        return -1 * value
 
     def write_backup(self, node: TreeNode, priority=None, write_back=False):
         host_indices = self.cache_controller.write(

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -170,7 +170,7 @@ class HiRadixCache(RadixCache):
         frequency = node.hit_count
 
         # high value = big size Node which is frequently & recently accessed
-        value = frequency / (recency + 1)  # +1 避免除零
+        value = frequency / (recency + 1)  # +1 avoid dividing by 0
 
         
         value *= len(node.value) 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -168,6 +168,7 @@ class RadixCache(BasePrefixCache):
         disable: bool = False,
         enable_kv_cache_events: bool = False,
         eviction_policy: str = "lru",
+        enable_backup_priority = False,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -175,6 +176,7 @@ class RadixCache(BasePrefixCache):
         self.disable = disable
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue = []
+        self.enable_backup_priority = enable_backup_priority
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -340,6 +340,7 @@ class ServerArgs:
     hicache_storage_backend: Optional[str] = None
     hicache_storage_prefetch_policy: str = "best_effort"
     hicache_storage_backend_extra_config: Optional[str] = None
+    enable_backup_priority: bool = False
     # LMCache
     enable_lmcache: bool = False
 
@@ -2170,6 +2171,12 @@ class ServerArgs:
             type=str,
             default=ServerArgs.hicache_storage_backend_extra_config,
             help="A dictionary in JSON string format containing extra configuration for the storage backend.",
+        )
+        parser.add_argument(
+            "--enable-backup-priority",
+            action="store_true",
+            default=ServerArgs.enable_backup_priority,
+            help="Enable priority calculation when node is write to host memory",
         )
         # LMCache
         parser.add_argument(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

We notice that in merge_ops(), the CacheOperations in List will be concatenated to form a larger CacheOperation which use the minimal priority in these CacheOperations represent the collective priority. When change writing queue to PriorityQueue[CacheOperation] rather List[CacheOperation], the node with large value(frequently & recently accessed with big size) will be processed firstly. 

## Modifications

1. Add --enable-backup-priority as a server parameter
2. Add priority calculation function which consider frequency, recency and size of the node


## Accuracy Tests

By testing on benchmark/bench_multiturn.py, the performance is listed below
<img width="760" height="540" alt="image" src="https://github.com/user-attachments/assets/b29436dd-a2a6-4cf7-a2a9-899ab2517b54" />



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
