### PR TITLE
fix: make inference deterministic for large TP

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1109,7 +1109,7 @@ class ServerArgs:
                 os.environ["NCCL_ALGO"] = "allreduce:tree"
                 self.disable_custom_all_reduce = True
                 logger.warning(
-                    "NCCL_ALGO is set to 'allreduce:tree' and custom all reduce is disabled for deterministic inference when TP size > 2."
+                    "NCCL_ALGO is set to 'allreduce:tree' and custom all reduce is disabled for deterministic inference when TP size > 1."
                 )
 
     def _handle_other_validations(self):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1106,14 +1106,11 @@ class ServerArgs:
 
             # Check TP size
             if self.tp_size > 1:
-                raise ValueError(
-                    "Currently only TP size 1 is supported for deterministic inference."
+                os.environ["NCCL_ALGO"] = "allreduce:tree"
+                self.disable_custom_all_reduce = True
+                logger.warning(
+                    "NCCL_ALGO is set to 'allreduce:tree' and custom all reduce is disabled for deterministic inference when TP size > 2."
                 )
-
-            # Warnings on MoE models
-            logger.warning(
-                "Currently deterministic inference is only tested on dense models. Please be cautious when using it on MoE models."
-            )
 
     def _handle_other_validations(self):
         pass

--- a/python/sglang/test/test_deterministic.py
+++ b/python/sglang/test/test_deterministic.py
@@ -19,7 +19,7 @@ from sglang.profiler import run_profile
 PROMPT_1 = "Tell me about Richard Feynman: "
 PROMPT_2 = "Generate 1000 random numbers. Go directly into it, don't say Sure and don't say here are numbers. Just start with a number."
 dirpath = os.path.dirname(__file__)
-with open("python/sglang/test/long_prompt.txt", "r") as f:
+with open(os.path.join(dirpath, "long_prompt.txt"), "r") as f:
     LONG_PROMPT = f.read()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Close #10785
This PR enables deterministic inference for models using TP > 1.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Set `NCCL_ALGO="allreduce:tree"` and disable custom all-reduce when TP > 1.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Model Type | TP size | Backend | Status
-- | -- | -- | --
Dense & MoE | 2, 4, 8 | FlashInfer | ✅ Passed
Dense & MoE | 2, 4, 8 | Triton | ✅ Passed
Dense & MoE | 4, 8 | FlashAttention-3 | ✅ Passed
Dense | 2 | FlashAttention-3 | ✅ Passed
MoE | 2 | FlashAttention-3 | ❌ Partial Failed (Corner Case)¹


Tests passed for both Dense/MoE models (TP=2,4,8) across all backends (fa3, flashinfer, triton) using `sglang.test.test_deterministic`.

However, we found one exception: the `prefix` test failed for ~~MoE~~Qwen3-30B-A3B with TP=2 and the fa3 backend, generating two unique outputs for prefix length 1.(But `mistralai/Mixtral-8x7B-v0.1` Could pass)

> We use `Qwen3-32B` for dense and `Qwen3-30B-A3B` for MoE
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Reproduce
1. Launch server:
  ```
  python3 -m sglang.launch_server \
      --model Qwen/Qwen3-30B-A3B \
      --port 30000 \
      --enable-deterministic-inference \
      --attention-backend fa3 \
      --tp-size 2
  ```
2. Run test:
```
python3 -m sglang.test.test_deterministic --test-mode prefix
```

You can see result like:
```
Prompt 0 with prefix length 1: total samples: xxx, Unique samples: 2
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
