### PR TITLE
Tests/fix attributeerror streaming moe

### DIFF
--- a/test/srt/test_forward_split_prefill.py
+++ b/test/srt/test_forward_split_prefill.py
@@ -59,6 +59,8 @@ class TestForwardSplitPrefill(CustomTestCase):
             tp_size=cls.tp_size,
             pp_rank=0,
             pp_size=1,
+            moe_ep_rank=0,
+            moe_ep_size=1,
             nccl_port=cls.port_args.nccl_port,
             server_args=cls.server_args,
         )
@@ -105,7 +107,6 @@ class TestForwardSplitPrefill(CustomTestCase):
             model_config=self.model_config,
             enable_overlap=False,
             spec_algorithm=SpeculativeAlgorithm.NONE,
-            enable_custom_logit_processor=False,
         )
         if is_split_prefill:
             batch.prepare_for_split_prefill()

--- a/test/srt/test_sagemaker_server.py
+++ b/test/srt/test_sagemaker_server.py
@@ -128,6 +128,10 @@ class TestSageMakerServer(CustomTestCase):
                 is_firsts[index] = False
                 continue
 
+            # Skip chunks that are just empty placeholders, usually at stream end/stop
+            if data.get("content") is None:
+                continue
+
             if logprobs:
                 assert line.get("choices")[0].get("logprobs")
                 assert isinstance(

--- a/test/srt/test_vision_openai_server_common.py
+++ b/test/srt/test_vision_openai_server_common.py
@@ -33,7 +33,8 @@ class TestOpenAIOmniServerBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        if cls.process is not None:
+            kill_process_tree(cls.process.pid)
 
     def get_vision_request_kwargs(self):
         return self.get_request_kwargs()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This branch addresses multiple test-related issues to improve test reliability and fix streaming-related errors:

AttributeError Fixes:

Handle AttributeError when process is None in vision OpenAI server tests
Handle streaming chunks with null content at stream end in SageMaker server tests
MoE Expert Parallelism Updates:

Update TestForwardSplitPrefill test with proper MoE EP (Expert Parallelism) parameters
## Modifications

<!-- Detail the changes made in this pull request. -->
test/srt/test_vision_openai_server_common.py - Fixed AttributeError handling
test/srt/test_sagemaker_server.py - Added null content handling for streaming
test/srt/test_forward_split_prefill.py - Updated MoE EP parameters
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A - This PR only contains test fixes and does not affect model outputs or inference logic.
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A - This PR only contains test improvements and does not impact inference performance.

Claude Sonnet 4 • 1x
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
