### PR TITLE
[Test] Fix XPU pytest crashes by initializing mem_fraction_static and setting profiler env

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -126,6 +126,7 @@ class Envs:
     SGLANG_DISABLE_REQUEST_LOGGING = EnvBool(False)
     SGLANG_SIMULATE_ACC_LEN = EnvFloat(-1)
     SGLANG_SIMULATE_ACC_METHOD = EnvStr("multinomial")
+    SGLANG_TORCH_PROFILER_DIR = EnvStr("/tmp")
 
     # Model Parallel
     SGLANG_USE_MESSAGE_QUEUE_BROADCASTER = EnvBool(True)

--- a/test/srt/models/test_vlm_models.py
+++ b/test/srt/models/test_vlm_models.py
@@ -27,6 +27,9 @@ MODELS = [
     SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4),
 ]
 
+# Set default mem_fraction_static to 0.8
+DEFAULT_MEM_FRACTION_STATIC = 0.8
+
 
 class TestVLMModels(CustomTestCase):
     parsed_args = None  # Class variable to store args
@@ -37,6 +40,11 @@ class TestVLMModels(CustomTestCase):
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.api_key = "sk-123456"
         cls.time_out = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+        if cls.parsed_args is None:
+            cls.parsed_args = SimpleNamespace(
+                mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC
+            )
 
         # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
         os.environ["OPENAI_API_KEY"] = cls.api_key
@@ -302,7 +310,7 @@ if __name__ == "__main__":
         "--mem-fraction-static",
         type=float,
         help="Static memory fraction for the model",
-        default=0.8,
+        default=DEFAULT_MEM_FRACTION_STATIC,
     )
 
     # Parse args intended for unittest

--- a/test/srt/test_start_profile.py
+++ b/test/srt/test_start_profile.py
@@ -9,6 +9,7 @@ import unittest
 
 import requests
 
+from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.test_utils import (
     DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
@@ -25,6 +26,7 @@ class TestStartProfile(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
+        envs.SGLANG_TORCH_PROFILER_DIR.set(OUTPUT_DIR)
         cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
@@ -111,5 +113,4 @@ class TestStartProfile(CustomTestCase):
 
 
 if __name__ == "__main__":
-    os.environ["SGLANG_TORCH_PROFILER_DIR"] = OUTPUT_DIR
     unittest.main()


### PR DESCRIPTION
… test crashes.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Added a safe fallback initialization of mem_fraction_static in setUpClass using SimpleNamespace to ensure tests can access it correctly in both pytest and unittest. Additionally, ensured that SGLANG_TORCH_PROFILER_DIR is properly set during pytest runs, preventing missing profiler output directories and fixing test crashes on XPU. These changes are limited to test setup and do not affect actual model evaluation logic.
<!-- Describe the purpose and goals of this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
No changes to model accuracy expected.
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
