### PR TITLE
[router] move grpc client from router to worker and builder

### DIFF
--- a/sgl-router/src/core/worker_builder.rs
+++ b/sgl-router/src/core/worker_builder.rs
@@ -100,7 +100,7 @@ impl BasicWorkerBuilder {
             atomic::{AtomicBool, AtomicUsize},
             Arc,
         };
-        use tokio::sync::Mutex;
+        use tokio::sync::{Mutex, RwLock};
 
         let metadata = WorkerMetadata {
             url: self.url.clone(),
@@ -111,6 +111,10 @@ impl BasicWorkerBuilder {
             health_config: self.health_config,
         };
 
+        let grpc_client = Arc::new(RwLock::new(
+            self.grpc_client.map(|client| Arc::new(Mutex::new(client))),
+        ));
+
         BasicWorker {
             metadata,
             load_counter: Arc::new(AtomicUsize::new(0)),
@@ -119,7 +123,7 @@ impl BasicWorkerBuilder {
             consecutive_failures: Arc::new(AtomicUsize::new(0)),
             consecutive_successes: Arc::new(AtomicUsize::new(0)),
             circuit_breaker: CircuitBreaker::with_config(self.circuit_breaker_config),
-            grpc_client: self.grpc_client.map(|client| Arc::new(Mutex::new(client))),
+            grpc_client,
         }
     }
 }


### PR DESCRIPTION
moving both grpc client to builder and worker itself

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
