### PR TITLE
[router] basic mcp support for openai router response api

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -668,6 +668,33 @@ pub struct CompletionStreamChoice {
 pub struct ResponseTool {
     #[serde(rename = "type")]
     pub r#type: ResponseToolType,
+    // MCP-specific fields (used when type == "mcp")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub require_approval: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+}
+
+impl Default for ResponseTool {
+    fn default() -> Self {
+        Self {
+            r#type: ResponseToolType::WebSearchPreview,
+            server_url: None,
+            authorization: None,
+            server_label: None,
+            server_description: None,
+            require_approval: None,
+            allowed_tools: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -675,6 +702,7 @@ pub struct ResponseTool {
 pub enum ResponseToolType {
     WebSearchPreview,
     CodeInterpreter,
+    Mcp,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -1133,11 +1133,11 @@ impl OpenAIRouter {
             "role": "user",
             "content": args.original_body.input.clone()
         });
-
+        // temp system message since currently only support 1 turn of mcp function call
         let system_item = serde_json::json!({
             "type": "message",
             "role": "system",
-            "content": "please resume with the following tool result, and answer user's question directly"
+            "content": "please resume with the following tool result, and answer user's question directly, don't trigger any more tool calls"
         });
 
         let func_item = serde_json::json!({
@@ -1192,6 +1192,9 @@ impl OpenAIRouter {
         }
         // After resume, mask tools as MCP if request used MCP
         Self::mask_tools_as_mcp(&mut v, args.original_body);
+        if let Some(obj) = v.as_object_mut() {
+            obj.insert("store".to_string(), Value::Bool(args.original_body.store));
+        }
         Ok(v)
     }
 }

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -1149,12 +1149,7 @@ impl OpenAIRouter {
 
         obj.insert(
             "input".to_string(),
-            Value::Array(vec![
-                Value::Object(user_item.as_object().cloned().unwrap()),
-                Value::Object(system_item.as_object().cloned().unwrap()),
-                Value::Object(func_item.as_object().cloned().unwrap()),
-                Value::Object(tool_item.as_object().cloned().unwrap()),
-            ]),
+            Value::Array(vec![user_item, system_item, func_item, tool_item]),
         );
 
         // Ensure non-streaming and no store to upstream

--- a/sgl-router/tests/common/mock_worker.rs
+++ b/sgl-router/tests/common/mock_worker.rs
@@ -646,7 +646,18 @@ async fn responses_handler(
     } else {
         // If tools are provided and this is the first call (no previous_response_id),
         // emit a single function_tool_call to trigger the router's MCP flow.
-        let has_tools = payload.get("tools").is_some();
+        let has_tools = payload
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter().any(|tool| {
+                    tool.get("type")
+                        .and_then(|t| t.as_str())
+                        .map(|t| t == "function")
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
         let has_function_output = payload
             .get("input")
             .and_then(|v| v.as_array())

--- a/sgl-router/tests/common/mock_worker.rs
+++ b/sgl-router/tests/common/mock_worker.rs
@@ -644,27 +644,78 @@ async fn responses_handler(
         }))
         .into_response()
     } else {
-        Json(json!({
-            "id": format!("resp-{}", Uuid::new_v4()),
-            "object": "response",
-            "created_at": timestamp,
-            "model": "mock-model",
-            "output": [{
-                "type": "message",
-                "role": "assistant",
-                "content": [{
-                    "type": "output_text",
-                    "text": "This is a mock responses output."
-                }]
-            }],
-            "status": "completed",
-            "usage": {
-                "input_tokens": 10,
-                "output_tokens": 5,
-                "total_tokens": 15
-            }
-        }))
-        .into_response()
+        // If tools are provided and this is the first call (no previous_response_id),
+        // emit a single function_tool_call to trigger the router's MCP flow.
+        let has_tools = payload.get("tools").is_some();
+        let has_prev = payload
+            .get("previous_response_id")
+            .and_then(|v| v.as_str())
+            .is_some();
+
+        if has_tools && !has_prev {
+            let rid = format!("resp-{}", Uuid::new_v4());
+            Json(json!({
+                "id": rid,
+                "object": "response",
+                "created_at": timestamp,
+                "model": "mock-model",
+                "output": [{
+                    "type": "function_tool_call",
+                    "id": "call_1",
+                    "name": "brave_web_search",
+                    "arguments": "{\"query\":\"SGLang router MCP integration\"}",
+                    "status": "in_progress"
+                }],
+                "status": "in_progress",
+                "usage": null
+            }))
+            .into_response()
+        } else if has_prev {
+            // Second call after tool_result injection: return a completed assistant message
+            Json(json!({
+                "id": format!("resp-{}", Uuid::new_v4()),
+                "object": "response",
+                "created_at": timestamp,
+                "model": "mock-model",
+                "output": [{
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "Tool result consumed; here is the final answer."
+                    }]
+                }],
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 12,
+                    "output_tokens": 7,
+                    "total_tokens": 19
+                }
+            }))
+            .into_response()
+        } else {
+            Json(json!({
+                "id": format!("resp-{}", Uuid::new_v4()),
+                "object": "response",
+                "created_at": timestamp,
+                "model": "mock-model",
+                "output": [{
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "This is a mock responses output."
+                    }]
+                }],
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15
+                }
+            }))
+            .into_response()
+        }
     }
 }
 

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -131,8 +131,6 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
 
     assert_eq!(resp.status(), axum::http::StatusCode::OK);
 
-
-
     // Cleanup
     worker.stop().await;
     mcp.stop().await;

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -130,14 +130,8 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         .await;
 
     assert_eq!(resp.status(), axum::http::StatusCode::OK);
-    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    // Validate metadata.mcp is present
-    let mcp_meta = json.get("metadata").and_then(|m| m.get("mcp"));
-    assert!(mcp_meta.is_some(), "metadata.mcp should be present");
+
 
     // Cleanup
     worker.stop().await;

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -6,6 +6,137 @@ use sglang_router_rs::protocols::spec::{
     ToolChoiceValue, Truncation, UsageInfo,
 };
 
+mod common;
+use common::mock_mcp_server::MockMCPServer;
+use common::mock_worker::{MockWorker, MockWorkerConfig, WorkerType, HealthStatus};
+use sglang_router_rs::routers::RouterFactory;
+use sglang_router_rs::server::AppContext;
+use sglang_router_rs::config::{RoutingMode, RouterConfig, ConnectionMode, PolicyConfig, HealthCheckConfig, RetryConfig, CircuitBreakerConfig, MetricsConfig};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
+    // Start mock MCP server
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    // Write a temp MCP config file
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    // Start mock OpenAI worker
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    // Build router config (HTTP OpenAI mode)
+    let router_cfg = RouterConfig {
+        mode: RoutingMode::OpenAI { worker_urls: vec![worker_url] },
+        connection_mode: ConnectionMode::Http,
+        policy: PolicyConfig::Random,
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        max_payload_size: 8 * 1024 * 1024,
+        request_timeout_secs: 60,
+        worker_startup_timeout_secs: 5,
+        worker_startup_check_interval_secs: 1,
+        dp_aware: false,
+        api_key: None,
+        discovery: None,
+        metrics: None,
+        log_dir: None,
+        log_level: Some("warn".to_string()),
+        request_id_headers: None,
+        max_concurrent_requests: 32,
+        queue_size: 0,
+        queue_timeout_secs: 5,
+        rate_limit_tokens_per_second: None,
+        cors_allowed_origins: vec![],
+        retry: RetryConfig::default(),
+        circuit_breaker: CircuitBreakerConfig::default(),
+        disable_retries: false,
+        disable_circuit_breaker: false,
+        health_check: HealthCheckConfig::default(),
+        enable_igw: false,
+        model_path: None,
+        tokenizer_path: None,
+        history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+        oracle: None,
+    };
+
+    // Create router and context
+    let ctx = AppContext::new(router_cfg, reqwest::Client::new(), 64, None).expect("ctx");
+    let router = RouterFactory::create_router(&Arc::new(ctx)).await.expect("router");
+
+    // Build a simple ResponsesRequest that will trigger the tool call
+    let req = ResponsesRequest {
+        background: false,
+        include: None,
+        input: ResponseInput::Text("search something".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: Some("mock-model".to_string()),
+        parallel_tool_calls: true,
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: sglang_router_rs::protocols::spec::ServiceTier::Auto,
+        store: true,
+        stream: false,
+        temperature: Some(0.2),
+        tool_choice: sglang_router_rs::protocols::spec::ToolChoice::default(),
+        tools: vec![ResponseTool {
+            r#type: ResponseToolType::Mcp,
+            server_url: Some(mcp.url()),
+            authorization: None,
+            server_label: Some("mock".to_string()),
+            server_description: None,
+            require_approval: None,
+            allowed_tools: None,
+        }],
+        top_logprobs: 0,
+        top_p: None,
+        truncation: sglang_router_rs::protocols::spec::Truncation::Disabled,
+        user: None,
+        request_id: "resp_test_mcp_e2e".to_string(),
+        priority: 0,
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+    };
+
+    let resp = router
+        .route_responses(None, &req, req.model.as_deref())
+        .await;
+
+    assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Validate metadata.mcp is present
+    let mcp_meta = json.get("metadata").and_then(|m| m.get("mcp"));
+    assert!(mcp_meta.is_some(), "metadata.mcp should be present");
+
+    // Cleanup
+    worker.stop().await;
+    mcp.stop().await;
+}
+
 #[test]
 fn test_responses_request_creation() {
     let request = ResponsesRequest {
@@ -27,9 +158,7 @@ fn test_responses_request_creation() {
         stream: false,
         temperature: Some(0.7),
         tool_choice: ToolChoice::Value(ToolChoiceValue::Auto),
-        tools: vec![ResponseTool {
-            r#type: ResponseToolType::WebSearchPreview,
-        }],
+        tools: vec![ResponseTool { r#type: ResponseToolType::WebSearchPreview, ..Default::default() }],
         top_logprobs: 5,
         top_p: Some(0.9),
         truncation: Truncation::Disabled,
@@ -177,9 +306,7 @@ fn test_json_serialization() {
         stream: true,
         temperature: Some(0.9),
         tool_choice: ToolChoice::Value(ToolChoiceValue::Required),
-        tools: vec![ResponseTool {
-            r#type: ResponseToolType::CodeInterpreter,
-        }],
+        tools: vec![ResponseTool { r#type: ResponseToolType::CodeInterpreter, ..Default::default() }],
         top_logprobs: 10,
         top_p: Some(0.8),
         truncation: Truncation::Auto,

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -10,8 +10,8 @@ mod common;
 use common::mock_mcp_server::MockMCPServer;
 use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType};
 use sglang_router_rs::config::{
-    CircuitBreakerConfig, ConnectionMode, HealthCheckConfig, PolicyConfig,
-    RetryConfig, RouterConfig, RoutingMode,
+    CircuitBreakerConfig, ConnectionMode, HealthCheckConfig, PolicyConfig, RetryConfig,
+    RouterConfig, RoutingMode,
 };
 use sglang_router_rs::routers::RouterFactory;
 use sglang_router_rs::server::AppContext;

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -8,10 +8,13 @@ use sglang_router_rs::protocols::spec::{
 
 mod common;
 use common::mock_mcp_server::MockMCPServer;
-use common::mock_worker::{MockWorker, MockWorkerConfig, WorkerType, HealthStatus};
+use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType};
+use sglang_router_rs::config::{
+    CircuitBreakerConfig, ConnectionMode, HealthCheckConfig, PolicyConfig,
+    RetryConfig, RouterConfig, RoutingMode,
+};
 use sglang_router_rs::routers::RouterFactory;
 use sglang_router_rs::server::AppContext;
-use sglang_router_rs::config::{RoutingMode, RouterConfig, ConnectionMode, PolicyConfig, HealthCheckConfig, RetryConfig, CircuitBreakerConfig, MetricsConfig};
 use std::sync::Arc;
 
 #[tokio::test]
@@ -40,7 +43,9 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
 
     // Build router config (HTTP OpenAI mode)
     let router_cfg = RouterConfig {
-        mode: RoutingMode::OpenAI { worker_urls: vec![worker_url] },
+        mode: RoutingMode::OpenAI {
+            worker_urls: vec![worker_url],
+        },
         connection_mode: ConnectionMode::Http,
         policy: PolicyConfig::Random,
         host: "127.0.0.1".to_string(),
@@ -75,7 +80,9 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
 
     // Create router and context
     let ctx = AppContext::new(router_cfg, reqwest::Client::new(), 64, None).expect("ctx");
-    let router = RouterFactory::create_router(&Arc::new(ctx)).await.expect("router");
+    let router = RouterFactory::create_router(&Arc::new(ctx))
+        .await
+        .expect("router");
 
     // Build a simple ResponsesRequest that will trigger the tool call
     let req = ResponsesRequest {
@@ -158,7 +165,10 @@ fn test_responses_request_creation() {
         stream: false,
         temperature: Some(0.7),
         tool_choice: ToolChoice::Value(ToolChoiceValue::Auto),
-        tools: vec![ResponseTool { r#type: ResponseToolType::WebSearchPreview, ..Default::default() }],
+        tools: vec![ResponseTool {
+            r#type: ResponseToolType::WebSearchPreview,
+            ..Default::default()
+        }],
         top_logprobs: 5,
         top_p: Some(0.9),
         truncation: Truncation::Disabled,
@@ -306,7 +316,10 @@ fn test_json_serialization() {
         stream: true,
         temperature: Some(0.9),
         tool_choice: ToolChoice::Value(ToolChoiceValue::Required),
-        tools: vec![ResponseTool { r#type: ResponseToolType::CodeInterpreter, ..Default::default() }],
+        tools: vec![ResponseTool {
+            r#type: ResponseToolType::CodeInterpreter,
+            ..Default::default()
+        }],
         top_logprobs: 10,
         top_p: Some(0.8),
         truncation: Truncation::Auto,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Implement basic mcp support for openai router response api. The current request flow is:
```
Client
  |
  |  POST /responses (contains MCP tool block)
  v
OpenAIRouter::route_responses
  |
  |-- check/transform request history
  |-- set store=false for upstream call
  |-- mcp_manager_from_request_tools()  ──► builds one-off MCP client (if MCP tool present)
  v
OpenAIRouter::handle_non_streaming_response
  |
  |-- rewrite payload.tools -> function descriptors
  |-- forward request to upstream /v1/responses
  v
Upstream Model
  |
  |-- streams / returns response
  |-- may emit function_call item
  v
router.extract_function_call()
  |
  |-- if function_call:
  |     execute_mcp_call() ──► run MCP tool via McpClientManager
  |     capture output/error & telemetry
  |     resume_with_tool_result()
  |         ├─ wrap original user input
  |         ├─ add temporary system hint (no more tool calls)
  |         ├─ include function_call + function_call_output
  |         └─ POST back to /v1/responses (stream=false, store=false)
  |     receive resumed response JSON
  |     mask_tools_as_mcp() ──► convert function tool artifacts back to MCP block
  |     restore client store flag & annotate errors (if any)
  |
  |-- else: skip MCP handling
  v
OpenAIRouter::store_response_internal()  (if store=true)
  |
  v
Final Response -> Client
  |
  ` tools array reverts to original MCP shape; model output included
```
**Out of this PR's Scope**
- Streaming; 
- Multiple tool calls; 
- LLM loops;
- MCP client cache 
- MCP Metadata persistence; 
- Auth

will do in the following PRs

<!-- Describe the purpose and goals of this pull request. -->

## Tests
Started a brave mcp server in local
```
docker run -d --rm \
-p 8001:8080 \
-e BRAVE_API_KEY="BS****rFr" \
--name brave-search-server \
shoofio/brave-search-mcp-sse:latest
```
Started openai router
```
cargo run --bin sglang-router --  --worker-urls https://api.openai.com/ --backend openai --prometheus-port 30002
```

Request
```
curl http://localhost:30000/v1/responses \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $OPENAI_API_KEY" \
-d '{
  "model": "gpt-5",
  "tools": [
    {
      "type": "mcp",
      "server_label": "brave",
      "server_description": "A Tool to do web serch",
      "server_url": "http://localhost:8001/sse",
      "require_approval": "never"
    }
  ],
  "input": "could you tell me Sep 25 2025 oracle stock price at close"
}'
```

Response
```
{
    "id": "resp_68d75693cfc481998cefb9a8e949cf830effef77ac5bc552",
    "object": "response",
    "created_at": 1758942867,
    "status": "completed",
    "background": false,
    "billing": {
        "payer": "developer"
    },
    "error": null,
    "incomplete_details": null,
    "instructions": null,
    "max_output_tokens": null,
    "max_tool_calls": null,
    "model": "gpt-5-2025-08-07",
    "output": [
        {
            "id": "rs_68d756946b3c8199ab33ffc14e88176f0effef77ac5bc552",
            "type": "reasoning",
            "summary": []
        },
        {
            "id": "msg_68d756970cb08199839616309f062f340effef77ac5bc552",
            "type": "message",
            "status": "completed",
            "content": [
                {
                    "type": "output_text",
                    "annotations": [],
                    "logprobs": [],
                    "text": "Oracle (ORCL) closed at $291.20 on September 25, 2025."
                }
            ],
            "role": "assistant"
        }
    ],
    "parallel_tool_calls": true,
    "previous_response_id": null,
    "prompt_cache_key": null,
    "reasoning": {
        "effort": "medium",
        "summary": null
    },
    "safety_identifier": null,
    "service_tier": "default",
    "store": true,
    "temperature": 1.0,
    "text": {
        "format": {
            "type": "text"
        },
        "verbosity": "medium"
    },
    "tool_choice": "auto",
    "tools": [
        {
            "type": "mcp",
            "server_label": "brave",
            "server_url": "http://localhost:8001/sse",
            "server_description": "A Tool to do web serch",
            "require_approval": "never"
        }
    ],
    "top_logprobs": 0,
    "top_p": 1.0,
    "truncation": "disabled",
    "usage": {
        "input_tokens": 863,
        "input_tokens_details": {
            "cached_tokens": 0
        },
        "output_tokens": 282,
        "output_tokens_details": {
            "reasoning_tokens": 256
        },
        "total_tokens": 1145
    },
    "user": null,
    "metadata": {}
}
```


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
