### PR TITLE
[Benchmark] Minor improve for profiling: add output_dir to start_profile in requests

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -596,7 +596,12 @@ async def async_request_profile(api_url: str) -> RequestFuncOutput:
     async with _create_bench_client_session() as session:
         output = RequestFuncOutput()
         try:
-            async with session.post(url=api_url) as response:
+            payload = {
+                "output_dir": os.getenv("SGLANG_TORCH_PROFILER_DIR"),
+            }
+            async with session.post(
+                url=api_url, json=payload, headers=get_auth_headers()
+            ) as response:
                 if response.status == 200:
                     output.success = True
                 else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Currently, users need to set the environment variable `SGLANG_TORCH_PROFILER_DIR` on both the client and server sides based on [SGLang Doc](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html#profile-a-server-with-sglang-bench-serving). This PR decouples the settings in `bench_serving.py`, allowing users to set the variable on either side. When both are set, the client-side setting takes priority, which aligns with expected behavior.

## Modifications

Add output_dir from env in the `bench_serving.py`, then send it to server.

## Accuracy Tests

## Benchmarking and Profiling

Manually tested locally; the script behaves as expected.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
