### PR TITLE
[router][tool parser] Modify tool parser to return both normal text and tool calls (non-stream)

### DIFF
--- a/sgl-router/benches/tool_parser_benchmark.rs
+++ b/sgl-router/benches/tool_parser_benchmark.rs
@@ -409,7 +409,7 @@ fn bench_concurrent_parsing(c: &mut Criterion) {
                                     let result =
                                         rt.block_on(async { parser.parse_complete(input).await });
 
-                                    if let Ok(tools) = result {
+                                    if let Ok((_normal_text, tools)) = result {
                                         total_p.fetch_add(tools.len() as u64, Ordering::Relaxed);
                                     }
                                 }

--- a/sgl-router/src/reasoning_parser/traits.rs
+++ b/sgl-router/src/reasoning_parser/traits.rs
@@ -3,7 +3,7 @@ use std::fmt;
 /// Result of parsing text for reasoning content.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ParserResult {
-    /// The normal text outside of reasoning blocks.
+    /// The normal text outside reasoning blocks.
     pub normal_text: String,
 
     /// The extracted reasoning text from within reasoning blocks.

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -804,7 +804,7 @@ impl GrpcRouter {
                 .get_parser(&original_request.model)
             {
                 match parser.parse_complete(&processed_text).await {
-                    Ok(parsed_tool_calls) => {
+                    Ok((normal_text, parsed_tool_calls)) => {
                         if !parsed_tool_calls.is_empty() {
                             let spec_tool_calls = parsed_tool_calls
                                 .into_iter()
@@ -821,7 +821,7 @@ impl GrpcRouter {
                                 })
                                 .collect();
                             tool_calls = Some(spec_tool_calls);
-                            processed_text = String::new();
+                            processed_text = normal_text;
                         }
                     }
                     Err(e) => {

--- a/sgl-router/src/tool_parser/parsers/glm4_moe_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/glm4_moe_parser.rs
@@ -130,21 +130,42 @@ impl Default for Glm4MoeParser {
 
 #[async_trait]
 impl ToolParser for Glm4MoeParser {
-    async fn parse_complete(&self, text: &str) -> ToolParserResult<Vec<ToolCall>> {
+    async fn parse_complete(&self, text: &str) -> ToolParserResult<(String, Vec<ToolCall>)> {
         // Check if text contains GLM-4 MoE format
         if !self.has_tool_markers(text) {
-            return Ok(vec![]);
+            return Ok((text.to_string(), vec![]));
         }
 
-        // Extract all tool call blocks
+        // Collect matches with positions and parse tools in one pass
+        let matches: Vec<_> = self.tool_call_extractor.find_iter(text).collect();
         let mut tools = Vec::new();
-        for mat in self.tool_call_extractor.find_iter(text) {
+
+        for mat in matches.iter() {
             if let Some(tool) = self.parse_tool_call(mat.as_str())? {
                 tools.push(tool);
             }
         }
 
-        Ok(tools)
+        // Extract normal text using first and last match positions
+        let normal_text = if tools.is_empty() {
+            text.to_string()
+        } else {
+            let first_start = matches[0].start();
+            let last_end = matches.last().unwrap().end();
+            let before = if first_start > 0 {
+                &text[..first_start]
+            } else {
+                ""
+            };
+            let after = if last_end < text.len() {
+                &text[last_end..]
+            } else {
+                ""
+            };
+            format!("{}{}", before, after)
+        };
+
+        Ok((normal_text, tools))
     }
 
     async fn parse_incremental(
@@ -232,11 +253,12 @@ mod tests {
 <arg_value>2024-06-27</arg_value>
 </tool_call>More text"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_weather");
-        assert!(result[0].function.arguments.contains("Beijing"));
-        assert!(result[0].function.arguments.contains("2024-06-27"));
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert!(tools[0].function.arguments.contains("Beijing"));
+        assert!(tools[0].function.arguments.contains("2024-06-27"));
+        assert_eq!(normal_text, "Some text\nMore text"); // Text before and after tool call
     }
 
     #[tokio::test]
@@ -251,12 +273,13 @@ mod tests {
 <arg_value>Shanghai</arg_value>
 </tool_call>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].function.name, "get_weather");
-        assert_eq!(result[1].function.name, "get_weather");
-        assert!(result[0].function.arguments.contains("Beijing"));
-        assert!(result[1].function.arguments.contains("Shanghai"));
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert_eq!(tools[1].function.name, "get_weather");
+        assert!(tools[0].function.arguments.contains("Beijing"));
+        assert!(tools[1].function.arguments.contains("Shanghai"));
+        assert_eq!(normal_text, ""); // Pure tool calls, no normal text
     }
 
     #[tokio::test]
@@ -271,12 +294,13 @@ mod tests {
 <arg_value>test</arg_value>
 </tool_call>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "process_data");
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(normal_text, ""); // Pure tool call, no normal text
+        assert_eq!(tools[0].function.name, "process_data");
 
         // Parse arguments to check types
-        let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+        let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
         assert_eq!(args["count"], 42);
         assert_eq!(args["active"], true);
         assert_eq!(args["name"], "test");

--- a/sgl-router/src/tool_parser/parsers/json_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/json_parser.rs
@@ -317,14 +317,16 @@ impl ToolParser for JsonParser {
                     && json_content.trim().ends_with('}')
                 {
                     let mut all_tools = Vec::new();
-                    let mut all_normal_text = String::new();
 
                     // Split by separator and try to parse each part
                     let parts: Vec<&str> =
                         json_content.split(&self.token_config.separator).collect();
+                    let mut normal_parts = Vec::new();
+
                     for part in parts {
                         let trimmed = part.trim();
                         if trimmed.is_empty() {
+                            normal_parts.push(trimmed.to_string());
                             continue;
                         }
 
@@ -333,6 +335,7 @@ impl ToolParser for JsonParser {
                             if let Ok(tools) = self.parse_json_value(&value) {
                                 all_tools.extend(tools);
                             }
+                            normal_parts.push(trimmed.to_string());
                         } else if let Some((extracted, part_normal_text)) =
                             self.extract_json_from_text(trimmed)
                         {
@@ -342,11 +345,14 @@ impl ToolParser for JsonParser {
                                     all_tools.extend(tools);
                                 }
                             }
-                            all_normal_text.push_str(&part_normal_text);
+                            normal_parts.push(part_normal_text);
                         } else {
-                            all_normal_text.push_str(trimmed);
+                            normal_parts.push(trimmed.to_string());
                         }
                     }
+
+                    // Rejoin with the original separator to preserve it
+                    let all_normal_text = normal_parts.join(&self.token_config.separator);
 
                     return Ok((all_normal_text, all_tools));
                 }

--- a/sgl-router/src/tool_parser/parsers/json_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/json_parser.rs
@@ -367,8 +367,8 @@ impl ToolParser for JsonParser {
                     }
                 }
 
-                // No valid JSON found, return content as normal text
-                Ok((json_content.to_string(), vec![]))
+                // No valid JSON found, return original text as normal text
+                Ok((text.to_string(), vec![]))
             }
         }
     }
@@ -645,6 +645,20 @@ mod tests {
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].function.name, "test");
         assert_eq!(normal_text, ""); // Wrapper tokens with no extra text
+    }
+
+    #[tokio::test]
+    async fn test_parse_with_start_token_invalid_json() {
+        let parser = JsonParser::with_config(TokenConfig {
+            start_tokens: vec!["<|python_tag|>".to_string()],
+            end_tokens: vec!["".to_string()],
+            separator: ";".to_string(),
+        });
+
+        let input = r#"Hello world <|python_tag|>this is not valid json at all"#;
+        let (normal_text, tool_calls) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tool_calls.len(), 0);
+        assert_eq!(normal_text, input); // Should return entire original text when JSON parsing fails
     }
 
     #[tokio::test]

--- a/sgl-router/src/tool_parser/parsers/kimik2_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/kimik2_parser.rs
@@ -79,16 +79,18 @@ impl Default for KimiK2Parser {
 
 #[async_trait]
 impl ToolParser for KimiK2Parser {
-    async fn parse_complete(&self, text: &str) -> ToolParserResult<Vec<ToolCall>> {
+    async fn parse_complete(&self, text: &str) -> ToolParserResult<(String, Vec<ToolCall>)> {
         // Check if text contains Kimi K2 format
         if !self.has_tool_markers(text) {
-            return Ok(vec![]);
+            return Ok((text.to_string(), vec![]));
         }
 
+        // Collect matches with positions and parse tools in one pass
+        let matches: Vec<_> = self.tool_call_extractor.captures_iter(text).collect();
         let mut tools = Vec::new();
 
-        // Extract all tool calls
-        for captures in self.tool_call_extractor.captures_iter(text) {
+        // Extract all tool calls using collected matches
+        for captures in matches.iter() {
             if let (Some(id_match), Some(args_match)) = (
                 captures.name("tool_call_id"),
                 captures.name("function_arguments"),
@@ -116,7 +118,26 @@ impl ToolParser for KimiK2Parser {
             }
         }
 
-        Ok(tools)
+        // Extract normal text using first and last match positions
+        let normal_text = if tools.is_empty() || matches.is_empty() {
+            text.to_string()
+        } else {
+            let first_start = matches[0].get(0).unwrap().start();
+            let last_end = matches.last().unwrap().get(0).unwrap().end();
+            let before = if first_start > 0 {
+                &text[..first_start]
+            } else {
+                ""
+            };
+            let after = if last_end < text.len() {
+                &text[last_end..]
+            } else {
+                ""
+            };
+            format!("{}{}", before, after)
+        };
+
+        Ok((normal_text, tools))
     }
 
     async fn parse_incremental(
@@ -227,10 +248,10 @@ mod tests {
 <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location": "Tokyo", "units": "celsius"}<|tool_call_end|>
 <|tool_calls_section_end|>More text"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_weather");
-        assert!(result[0].function.arguments.contains("Tokyo"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert!(tools[0].function.arguments.contains("Tokyo"));
     }
 
     #[tokio::test]
@@ -241,10 +262,10 @@ mod tests {
 <|tool_call_begin|>functions.calculate:1<|tool_call_argument_begin|>{"expression": "2+2"}<|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].function.name, "search");
-        assert_eq!(result[1].function.name, "calculate");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].function.name, "search");
+        assert_eq!(tools[1].function.name, "calculate");
     }
 
     #[tokio::test]
@@ -254,9 +275,9 @@ mod tests {
 <|tool_call_begin|> functions.test:0 <|tool_call_argument_begin|> {"key": "value"} <|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test");
     }
 
     #[test]

--- a/sgl-router/src/tool_parser/parsers/llama_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/llama_parser.rs
@@ -48,6 +48,7 @@ impl ToolParser for LlamaParser {
 
         if !tools.is_empty() {
             // Extract normal text before the python tag
+            // JsonParser doesn't preserve normal text for single start tokens, so we do it manually
             let normal_text = if let Some(tag_pos) = text.find("<|python_tag|>") {
                 text[..tag_pos].to_string()
             } else {

--- a/sgl-router/src/tool_parser/parsers/llama_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/llama_parser.rs
@@ -42,22 +42,31 @@ impl Default for LlamaParser {
 
 #[async_trait]
 impl ToolParser for LlamaParser {
-    async fn parse_complete(&self, text: &str) -> ToolParserResult<Vec<ToolCall>> {
+    async fn parse_complete(&self, text: &str) -> ToolParserResult<(String, Vec<ToolCall>)> {
         // First try with the configured python_tag parser
-        let result = self.json_parser.parse_complete(text).await?;
+        let (_json_normal_text, tools) = self.json_parser.parse_complete(text).await?;
 
-        if !result.is_empty() {
-            return Ok(result);
+        if !tools.is_empty() {
+            // Extract normal text before the python tag
+            let normal_text = if let Some(tag_pos) = text.find("<|python_tag|>") {
+                text[..tag_pos].to_string()
+            } else {
+                String::new()
+            };
+            return Ok((normal_text, tools));
         }
 
         // If no results and text starts with '{', try plain JSON
         if text.trim_start().starts_with('{') {
             // Create a temporary plain JSON parser
             let plain_parser = JsonParser::new();
-            return plain_parser.parse_complete(text).await;
+            let (_json_normal_text, tools) = plain_parser.parse_complete(text).await?;
+            // For plain JSON, don't extract normal text (consistent with JsonParser behavior)
+            return Ok((String::new(), tools));
         }
 
-        Ok(vec![])
+        // No tool calls found, return original text as normal text
+        Ok((text.to_string(), vec![]))
     }
 
     async fn parse_incremental(
@@ -99,10 +108,11 @@ mod tests {
         let parser = LlamaParser::new();
         let input = r#"<|python_tag|>{"name": "search", "arguments": {"query": "weather"}}"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "search");
-        assert!(result[0].function.arguments.contains("weather"));
+        let (normal_text, tool_calls) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "search");
+        assert!(tool_calls[0].function.arguments.contains("weather"));
+        assert_eq!(normal_text, ""); // Pure python_tag with JSON should have no normal text
     }
 
     #[tokio::test]
@@ -110,9 +120,10 @@ mod tests {
         let parser = LlamaParser::new();
         let input = r#"{"name": "calculate", "arguments": {"x": 5, "y": 10}}"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "calculate");
+        let (normal_text, tool_calls) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "calculate");
+        assert_eq!(normal_text, ""); // Pure JSON should have no normal text
     }
 
     #[tokio::test]
@@ -120,9 +131,10 @@ mod tests {
         let parser = LlamaParser::new();
         let input = r#"Let me help you with that. <|python_tag|>{"name": "get_time", "arguments": {"timezone": "UTC"}}"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_time");
+        let (normal_text, tool_calls) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].function.name, "get_time");
+        assert_eq!(normal_text, "Let me help you with that. ");
     }
 
     #[test]
@@ -141,15 +153,15 @@ mod tests {
         // Note: Llama 3.2 doesn't handle multiple calls well
         let input = r#"<|python_tag|>{"name": "func1", "arguments": {"x": 1}};"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
+        let (_normal_text, tool_calls) = parser.parse_complete(input).await.unwrap();
 
         // We expect this to either parse the first JSON object or fail gracefully
         // Since the semicolon makes it invalid JSON, it will likely return empty
         // This is acceptable as Llama 3.2 doesn't reliably support parallel calls
 
         // If it parses anything, it should be func1
-        if !result.is_empty() {
-            assert_eq!(result[0].function.name, "func1");
+        if !tool_calls.is_empty() {
+            assert_eq!(tool_calls[0].function.name, "func1");
         }
     }
 }

--- a/sgl-router/src/tool_parser/parsers/mistral_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/mistral_parser.rs
@@ -38,6 +38,10 @@ impl MistralParser {
     /// - Escape sequences
     /// - Bracket depth
     fn extract_json_array<'a>(&self, text: &'a str) -> Option<&'a str> {
+        self.extract_json_array_with_pos(text).map(|(_, json)| json)
+    }
+
+    fn extract_json_array_with_pos<'a>(&self, text: &'a str) -> Option<(usize, &'a str)> {
         const BOT_TOKEN: &str = "[TOOL_CALLS] [";
 
         // Find the start of the token
@@ -78,7 +82,7 @@ impl MistralParser {
                     bracket_count -= 1;
                     if bracket_count == 0 {
                         // Found the matching closing bracket
-                        return Some(&text[json_start..=i]);
+                        return Some((start_idx, &text[json_start..=i]));
                     }
                 }
             }
@@ -154,18 +158,26 @@ impl Default for MistralParser {
 
 #[async_trait]
 impl ToolParser for MistralParser {
-    async fn parse_complete(&self, text: &str) -> ToolParserResult<Vec<ToolCall>> {
+    async fn parse_complete(&self, text: &str) -> ToolParserResult<(String, Vec<ToolCall>)> {
         // Check if text contains Mistral format
         if !self.has_tool_markers(text) {
-            return Ok(vec![]);
+            return Ok((text.to_string(), vec![]));
         }
 
-        // Extract JSON array from Mistral format
-        if let Some(json_array) = self.extract_json_array(text) {
-            self.parse_json_array(json_array)
+        // Extract JSON array from Mistral format with position
+        if let Some((start_idx, json_array)) = self.extract_json_array_with_pos(text) {
+            // Extract normal text before BOT_TOKEN
+            let normal_text_before = if start_idx > 0 {
+                text[..start_idx].to_string()
+            } else {
+                String::new()
+            };
+
+            let tools = self.parse_json_array(json_array)?;
+            Ok((normal_text_before, tools))
         } else {
             // Markers present but no complete array found
-            Ok(vec![])
+            Ok((text.to_string(), vec![]))
         }
     }
 
@@ -291,10 +303,10 @@ mod tests {
         let parser = MistralParser::new();
         let input = r#"[TOOL_CALLS] [{"name": "get_weather", "arguments": {"location": "Paris", "units": "celsius"}}]"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_weather");
-        assert!(result[0].function.arguments.contains("Paris"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert!(tools[0].function.arguments.contains("Paris"));
     }
 
     #[tokio::test]
@@ -305,10 +317,10 @@ mod tests {
             {"name": "calculate", "arguments": {"expression": "2 + 2"}}
         ]"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].function.name, "search");
-        assert_eq!(result[1].function.name, "calculate");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].function.name, "search");
+        assert_eq!(tools[1].function.name, "calculate");
     }
 
     #[tokio::test]
@@ -316,11 +328,11 @@ mod tests {
         let parser = MistralParser::new();
         let input = r#"[TOOL_CALLS] [{"name": "process", "arguments": {"data": [1, 2, [3, 4]], "config": {"nested": [5, 6]}}}]"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "process");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "process");
         // JSON serialization removes spaces, so check for [3,4] without spaces
-        assert!(result[0].function.arguments.contains("[3,4]"));
+        assert!(tools[0].function.arguments.contains("[3,4]"));
     }
 
     #[tokio::test]
@@ -328,9 +340,9 @@ mod tests {
         let parser = MistralParser::new();
         let input = r#"[TOOL_CALLS] [{"name": "echo", "arguments": {"message": "He said \"Hello [World]\""}}]"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "echo");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "echo");
     }
 
     #[test]

--- a/sgl-router/src/tool_parser/parsers/mistral_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/mistral_parser.rs
@@ -173,8 +173,13 @@ impl ToolParser for MistralParser {
                 String::new()
             };
 
-            let tools = self.parse_json_array(json_array)?;
-            Ok((normal_text_before, tools))
+            match self.parse_json_array(json_array) {
+                Ok(tools) => Ok((normal_text_before, tools)),
+                Err(_) => {
+                    // If JSON parsing fails, return the original text as normal text
+                    Ok((text.to_string(), vec![]))
+                }
+            }
         } else {
             // Markers present but no complete array found
             Ok((text.to_string(), vec![]))

--- a/sgl-router/src/tool_parser/parsers/pythonic_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/pythonic_parser.rs
@@ -45,7 +45,8 @@ impl PythonicParser {
     }
 
     /// Extract tool calls using bracket counting (similar to MistralParser)
-    fn extract_tool_calls(&self, text: &str) -> Option<String> {
+    /// Returns extracted tool call group with [] and normal content
+    fn extract_tool_calls(&self, text: &str) -> Option<(String, String)> {
         // Find the start of a tool call list - look for [ followed by a function name
         let chars: Vec<char> = text.chars().collect();
 
@@ -103,7 +104,11 @@ impl PythonicParser {
                                 // Found the matching bracket
                                 let extracted: String = chars[start_idx..=i].iter().collect();
                                 if extracted.contains('(') && extracted.contains(')') {
-                                    return Some(extracted);
+                                    // Calculate normal text by removing the tool call portion
+                                    let before = &text[..start_idx];
+                                    let after = &text[(i + 1)..];
+                                    let normal_text = format!("{}{}", before, after);
+                                    return Some((extracted, normal_text));
                                 }
                             }
                         }
@@ -264,7 +269,7 @@ impl ToolParser for PythonicParser {
         let cleaned = Self::strip_special_tokens(text);
 
         // Extract tool calls using bracket counting
-        if let Some(tool_calls_text) = self.extract_tool_calls(&cleaned) {
+        if let Some((tool_calls_text, normal_text)) = self.extract_tool_calls(&cleaned) {
             // Remove the outer brackets
             let tool_calls_str = &tool_calls_text[1..tool_calls_text.len() - 1];
 
@@ -318,7 +323,7 @@ impl ToolParser for PythonicParser {
                 }
             }
 
-            Ok((String::new(), calls)) // TODO: Implement proper normal text extraction
+            Ok((normal_text, calls))
         } else {
             Ok((text.to_string(), vec![]))
         }
@@ -429,5 +434,34 @@ mod tests {
         let args: Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
         assert_eq!(args["city"], "London");
         assert_eq!(args["units"], "celsius");
+    }
+
+    #[tokio::test]
+    async fn test_normal_text_extraction() {
+        let parser = PythonicParser::new();
+
+        // Test with text before and after
+        let input = r#"Please check the weather [get_weather(city="Tokyo")] and let me know."#;
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert_eq!(normal_text, "Please check the weather  and let me know.");
+
+        // Test with only normal text (no tool calls)
+        let input_no_tools = "This is just normal text without any tool calls.";
+        let (normal_text, tools) = parser.parse_complete(input_no_tools).await.unwrap();
+
+        assert_eq!(tools.len(), 0);
+        assert_eq!(normal_text, input_no_tools);
+
+        // Test with multiple tool calls in single bracket group and normal text
+        let input_multiple = r#"First, [search(query="rust"), calculate(x=5, y=10)] please."#;
+        let (normal_text, tools) = parser.parse_complete(input_multiple).await.unwrap();
+
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].function.name, "search");
+        assert_eq!(tools[1].function.name, "calculate");
+        assert_eq!(normal_text, "First,  please.");
     }
 }

--- a/sgl-router/src/tool_parser/parsers/qwen_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/qwen_parser.rs
@@ -140,9 +140,14 @@ impl ToolParser for QwenParser {
 
         for (index, captures) in matches.iter().enumerate() {
             if let Some(json_str) = captures.get(1) {
-                if let Ok(value) = serde_json::from_str::<Value>(json_str.as_str().trim()) {
-                    if let Some(tool) = self.parse_single_object(&value, index)? {
-                        tools.push(tool);
+                match serde_json::from_str::<Value>(json_str.as_str().trim()) {
+                    Ok(value) => {
+                        if let Some(tool) = self.parse_single_object(&value, index)? {
+                            tools.push(tool);
+                        }
+                    }
+                    Err(_) => {
+                        // JSON parsing failed, might be incomplete
                     }
                 }
             }

--- a/sgl-router/src/tool_parser/parsers/qwen_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/qwen_parser.rs
@@ -128,32 +128,46 @@ impl Default for QwenParser {
 
 #[async_trait]
 impl ToolParser for QwenParser {
-    async fn parse_complete(&self, text: &str) -> ToolParserResult<Vec<ToolCall>> {
+    async fn parse_complete(&self, text: &str) -> ToolParserResult<(String, Vec<ToolCall>)> {
         // Check if text contains Qwen format
         if !self.has_tool_markers(text) {
-            return Ok(vec![]);
+            return Ok((text.to_string(), vec![]));
         }
 
-        // Extract all tool call blocks
-        let tool_blocks = self.extract_tool_calls(text);
+        // Collect matches with positions and parse tools in one pass
+        let matches: Vec<_> = self.extractor.captures_iter(text).collect();
         let mut tools = Vec::new();
 
-        for (index, json_str) in tool_blocks.iter().enumerate() {
-            // Parse each JSON block
-            match serde_json::from_str::<Value>(json_str.trim()) {
-                Ok(value) => {
+        for (index, captures) in matches.iter().enumerate() {
+            if let Some(json_str) = captures.get(1) {
+                if let Ok(value) = serde_json::from_str::<Value>(json_str.as_str().trim()) {
                     if let Some(tool) = self.parse_single_object(&value, index)? {
                         tools.push(tool);
                     }
                 }
-                Err(_) => {
-                    // Skip malformed JSON blocks
-                    continue;
-                }
             }
         }
 
-        Ok(tools)
+        // Extract normal text using first and last match positions
+        let normal_text = if tools.is_empty() {
+            text.to_string()
+        } else {
+            let first_start = matches[0].get(0).unwrap().start();
+            let last_end = matches.last().unwrap().get(0).unwrap().end();
+            let before = if first_start > 0 {
+                &text[..first_start]
+            } else {
+                ""
+            };
+            let after = if last_end < text.len() {
+                &text[last_end..]
+            } else {
+                ""
+            };
+            format!("{}{}", before, after)
+        };
+
+        Ok((normal_text, tools))
     }
 
     async fn parse_incremental(
@@ -276,10 +290,11 @@ mod tests {
 {"name": "get_weather", "arguments": {"location": "Beijing", "units": "celsius"}}
 </tool_call>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_weather");
-        assert!(result[0].function.arguments.contains("Beijing"));
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert!(tools[0].function.arguments.contains("Beijing"));
+        assert_eq!(normal_text, ""); // Pure tool call, no normal text
     }
 
     #[tokio::test]
@@ -292,10 +307,11 @@ mod tests {
 {"name": "calculate", "arguments": {"expression": "2 + 2"}}
 </tool_call>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].function.name, "search");
-        assert_eq!(result[1].function.name, "calculate");
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].function.name, "search");
+        assert_eq!(tools[1].function.name, "calculate");
+        assert_eq!(normal_text, ""); // Pure tool calls, no normal text
     }
 
     #[tokio::test]
@@ -307,9 +323,13 @@ mod tests {
 </tool_call>
 Here are the results."#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_info");
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_info");
+        assert_eq!(
+            normal_text,
+            "Let me help you with that.\n\nHere are the results."
+        );
     }
 
     #[tokio::test]
@@ -329,10 +349,11 @@ Here are the results."#;
 }
 </tool_call>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "process_data");
-        assert!(result[0].function.arguments.contains("nested"));
+        let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "process_data");
+        assert!(tools[0].function.arguments.contains("nested"));
+        assert_eq!(normal_text, ""); // Pure tool call, no normal text
     }
 
     #[test]

--- a/sgl-router/src/tool_parser/parsers/step3_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/step3_parser.rs
@@ -157,10 +157,10 @@ impl Default for Step3Parser {
 
 #[async_trait]
 impl ToolParser for Step3Parser {
-    async fn parse_complete(&self, text: &str) -> ToolParserResult<Vec<ToolCall>> {
+    async fn parse_complete(&self, text: &str) -> ToolParserResult<(String, Vec<ToolCall>)> {
         // Check if text contains Step3 format
         if !self.has_tool_markers(text) {
-            return Ok(vec![]);
+            return Ok((text.to_string(), vec![]));
         }
 
         // Find the tool calls section
@@ -170,6 +170,7 @@ impl ToolParser for Step3Parser {
             // Find the end of tool calls section
             if let Some(end_pos) = text[search_from..].find("<｜tool_calls_end｜>") {
                 let tool_section = &text[search_from..search_from + end_pos];
+                let end_abs = search_from + end_pos + "<｜tool_calls_end｜>".len();
 
                 // Extract all tool call blocks
                 let mut tools = Vec::new();
@@ -179,11 +180,24 @@ impl ToolParser for Step3Parser {
                     }
                 }
 
-                return Ok(tools);
+                // Extract normal text before start and after end
+                let before = if start_pos > 0 {
+                    &text[..start_pos]
+                } else {
+                    ""
+                };
+                let after = if end_abs < text.len() {
+                    &text[end_abs..]
+                } else {
+                    ""
+                };
+                let normal_text = format!("{}{}", before, after);
+
+                return Ok((normal_text, tools));
             }
         }
 
-        Ok(vec![])
+        Ok((text.to_string(), vec![]))
     }
 
     async fn parse_incremental(
@@ -289,11 +303,11 @@ mod tests {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>More text"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "get_weather");
-        assert!(result[0].function.arguments.contains("Tokyo"));
-        assert!(result[0].function.arguments.contains("celsius"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "get_weather");
+        assert!(tools[0].function.arguments.contains("Tokyo"));
+        assert!(tools[0].function.arguments.contains("celsius"));
     }
 
     #[tokio::test]
@@ -308,10 +322,10 @@ mod tests {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].function.name, "search");
-        assert_eq!(result[1].function.name, "calculate");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].function.name, "search");
+        assert_eq!(tools[1].function.name, "calculate");
     }
 
     #[tokio::test]
@@ -326,12 +340,12 @@ mod tests {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "process_data");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "process_data");
 
         // Parse arguments to check types
-        let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+        let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
         assert_eq!(args["count"], 42);
         assert_eq!(args["active"], true);
         assert_eq!(args["rate"], 1.5);

--- a/sgl-router/src/tool_parser/tests.rs
+++ b/sgl-router/src/tool_parser/tests.rs
@@ -242,12 +242,12 @@ async fn test_json_parser_complete_single() {
     let parser = JsonParser::new();
 
     let input = r#"{"name": "get_weather", "arguments": {"location": "San Francisco", "units": "celsius"}}"#;
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
 
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
-    assert!(result[0].function.arguments.contains("San Francisco"));
-    assert!(result[0].function.arguments.contains("celsius"));
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert!(tools[0].function.arguments.contains("San Francisco"));
+    assert!(tools[0].function.arguments.contains("celsius"));
 }
 
 #[tokio::test]
@@ -259,11 +259,11 @@ async fn test_json_parser_complete_array() {
         {"name": "get_news", "arguments": {"query": "technology"}}
     ]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
 
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "get_weather");
-    assert_eq!(result[1].function.name, "get_news");
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert_eq!(tools[1].function.name, "get_news");
 }
 
 #[tokio::test]
@@ -271,13 +271,13 @@ async fn test_json_parser_with_parameters() {
     let parser = JsonParser::new();
 
     let input = r#"{"name": "calculate", "parameters": {"x": 10, "y": 20, "operation": "add"}}"#;
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
 
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "calculate");
-    assert!(result[0].function.arguments.contains("10"));
-    assert!(result[0].function.arguments.contains("20"));
-    assert!(result[0].function.arguments.contains("add"));
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "calculate");
+    assert!(tools[0].function.arguments.contains("10"));
+    assert!(tools[0].function.arguments.contains("20"));
+    assert!(tools[0].function.arguments.contains("add"));
 }
 
 #[tokio::test]
@@ -289,10 +289,10 @@ async fn test_json_parser_with_tokens() {
     });
 
     let input = r#"[TOOL_CALLS] [{"name": "search", "arguments": {"query": "rust programming"}}]"#;
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
 
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
 }
 
 #[tokio::test]
@@ -313,12 +313,12 @@ async fn test_multiline_json_with_tokens() {
     }
 }</tool>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
-    assert!(result[0].function.arguments.contains("San Francisco"));
-    assert!(result[0].function.arguments.contains("celsius"));
-    assert!(result[0].function.arguments.contains("true"));
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert!(tools[0].function.arguments.contains("San Francisco"));
+    assert!(tools[0].function.arguments.contains("celsius"));
+    assert!(tools[0].function.arguments.contains("true"));
 }
 
 #[tokio::test]
@@ -342,12 +342,12 @@ async fn test_multiline_json_array() {
     }
 ]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "function1");
-    assert_eq!(result[1].function.name, "function2");
-    assert!(result[0].function.arguments.contains("value1"));
-    assert!(result[1].function.arguments.contains("[1,2,3]"));
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "function1");
+    assert_eq!(tools[1].function.name, "function2");
+    assert!(tools[0].function.arguments.contains("value1"));
+    assert!(tools[1].function.arguments.contains("[1,2,3]"));
 }
 
 #[test]
@@ -397,9 +397,9 @@ async fn test_registry_with_json_parser() {
     let parser = registry.get_parser("gpt-4-turbo").unwrap();
 
     let input = r#"{"name": "test", "arguments": {"x": 1}}"#;
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 }
 
 #[tokio::test]
@@ -407,9 +407,9 @@ async fn test_json_parser_invalid_input() {
     let parser = JsonParser::new();
 
     // Invalid JSON should return empty results
-    assert_eq!(parser.parse_complete("not json").await.unwrap().len(), 0);
-    assert_eq!(parser.parse_complete("{invalid}").await.unwrap().len(), 0);
-    assert_eq!(parser.parse_complete("").await.unwrap().len(), 0);
+    assert_eq!(parser.parse_complete("not json").await.unwrap().1.len(), 0);
+    assert_eq!(parser.parse_complete("{invalid}").await.unwrap().1.len(), 0);
+    assert_eq!(parser.parse_complete("").await.unwrap().1.len(), 0);
 }
 
 #[tokio::test]
@@ -418,11 +418,11 @@ async fn test_json_parser_empty_arguments() {
 
     // Tool call with no arguments
     let input = r#"{"name": "get_time"}"#;
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
 
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_time");
-    assert_eq!(result[0].function.arguments, "{}");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_time");
+    assert_eq!(tools[0].function.arguments, "{}");
 }
 
 #[cfg(test)]
@@ -435,14 +435,14 @@ mod failure_cases {
 
         // Missing name field
         let input = r#"{"arguments": {"x": 1}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 0, "Should return empty for tool without name");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 0, "Should return empty for tool without name");
 
         // Empty name
         let input = r#"{"name": "", "arguments": {"x": 1}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1, "Should accept empty name string");
-        assert_eq!(result[0].function.name, "");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1, "Should accept empty name string");
+        assert_eq!(tools[0].function.name, "");
     }
 
     #[tokio::test]
@@ -451,22 +451,22 @@ mod failure_cases {
 
         // Arguments is a string instead of object
         let input = r#"{"name": "test", "arguments": "not an object"}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
         // Should serialize the string as JSON
-        assert!(result[0].function.arguments.contains("not an object"));
+        assert!(tools[0].function.arguments.contains("not an object"));
 
         // Arguments is a number
         let input = r#"{"name": "test", "arguments": 42}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.arguments, "42");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.arguments, "42");
 
         // Arguments is null
         let input = r#"{"name": "test", "arguments": null}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.arguments, "null");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.arguments, "null");
     }
 
     #[tokio::test]
@@ -479,26 +479,26 @@ mod failure_cases {
 
         // Missing end token
         let input = r#"<tool>{"name": "test", "arguments": {}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
         assert_eq!(
-            result.len(),
+            tools.len(),
             0,
             "Should fail to parse without complete wrapper"
         );
 
         // Missing start token - parser looks for complete wrapper, so this won't parse
         let input = r#"{"name": "test", "arguments": {}}</tool>"#;
-        let result = parser.parse_complete(input).await.unwrap();
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
         assert_eq!(
-            result.len(),
+            tools.len(),
             0,
             "Should not parse JSON with incomplete wrapper"
         );
 
         // Mismatched tokens
         let input = r#"<tool>{"name": "test", "arguments": {}}</wrong>"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 0, "Should fail with mismatched tokens");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 0, "Should fail with mismatched tokens");
     }
 
     #[tokio::test]
@@ -507,18 +507,18 @@ mod failure_cases {
 
         // Trailing comma
         let input = r#"{"name": "test", "arguments": {"x": 1,}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 0, "Should reject JSON with trailing comma");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 0, "Should reject JSON with trailing comma");
 
         // Missing quotes on keys
         let input = r#"{name: "test", arguments: {}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 0, "Should reject invalid JSON syntax");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 0, "Should reject invalid JSON syntax");
 
         // Unclosed object
         let input = r#"{"name": "test", "arguments": {"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 0, "Should reject incomplete JSON");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 0, "Should reject incomplete JSON");
     }
 }
 
@@ -532,17 +532,17 @@ mod edge_cases {
 
         // Unicode in function name
         let input = r#"{"name": "获取天气", "arguments": {"location": "北京"}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "获取天气");
-        assert!(result[0].function.arguments.contains("北京"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "获取天气");
+        assert!(tools[0].function.arguments.contains("北京"));
 
         // Emoji in arguments
         let input = r#"{"name": "send_message", "arguments": {"text": "Hello 👋 World 🌍"}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("👋"));
-        assert!(result[0].function.arguments.contains("🌍"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("👋"));
+        assert!(tools[0].function.arguments.contains("🌍"));
     }
 
     #[tokio::test]
@@ -551,22 +551,22 @@ mod edge_cases {
 
         // Escaped quotes in arguments
         let input = r#"{"name": "echo", "arguments": {"text": "He said \"hello\""}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains(r#"\"hello\""#));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains(r#"\"hello\""#));
 
         // Escaped backslashes
         let input = r#"{"name": "path", "arguments": {"dir": "C:\\Users\\test"}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("\\\\"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("\\\\"));
 
         // Newlines and tabs
         let input = r#"{"name": "format", "arguments": {"text": "line1\nline2\ttabbed"}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("\\n"));
-        assert!(result[0].function.arguments.contains("\\t"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("\\n"));
+        assert!(tools[0].function.arguments.contains("\\t"));
     }
 
     #[tokio::test]
@@ -580,10 +580,10 @@ mod edge_cases {
         }
         large_args.push_str(r#""final": "value"}}"#);
 
-        let result = parser.parse_complete(&large_args).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "process");
-        assert!(result[0].function.arguments.contains("field_999"));
+        let (_normal_text, tools) = parser.parse_complete(&large_args).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "process");
+        assert!(tools[0].function.arguments.contains("field_999"));
 
         // Large array of tool calls
         let mut large_array = "[".to_string();
@@ -595,9 +595,9 @@ mod edge_cases {
         }
         large_array.push(']');
 
-        let result = parser.parse_complete(&large_array).await.unwrap();
-        assert_eq!(result.len(), 100);
-        assert_eq!(result[99].function.name, "func_99");
+        let (_normal_text, tools) = parser.parse_complete(&large_array).await.unwrap();
+        assert_eq!(tools.len(), 100);
+        assert_eq!(tools[99].function.name, "func_99");
     }
 
     #[tokio::test]
@@ -612,10 +612,10 @@ mod edge_cases {
             {"key": "value", "another": "field"}
         ]"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 2, "Should only parse valid tool calls");
-        assert_eq!(result[0].function.name, "tool1");
-        assert_eq!(result[1].function.name, "tool2");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 2, "Should only parse valid tool calls");
+        assert_eq!(tools[0].function.name, "tool1");
+        assert_eq!(tools[1].function.name, "tool2");
     }
 
     #[tokio::test]
@@ -624,14 +624,14 @@ mod edge_cases {
 
         // JSON with duplicate keys (last one wins in most parsers)
         let input = r#"{"name": "first", "name": "second", "arguments": {"x": 1, "x": 2}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
         assert_eq!(
-            result[0].function.name, "second",
+            tools[0].function.name, "second",
             "Last duplicate key should win"
         );
         assert!(
-            result[0].function.arguments.contains("2"),
+            tools[0].function.arguments.contains("2"),
             "Last duplicate value should win"
         );
     }
@@ -642,15 +642,15 @@ mod edge_cases {
 
         // Null values in arguments
         let input = r#"{"name": "test", "arguments": {"required": "value", "optional": null}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("null"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("null"));
 
         // Array with null
         let input = r#"{"name": "test", "arguments": {"items": [1, null, "three"]}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("null"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("null"));
     }
 
     #[tokio::test]
@@ -663,22 +663,22 @@ mod edge_cases {
 
         // First pattern
         let input = r#"<<{"name": "test1", "arguments": {}}>>"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test1");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test1");
 
         // Second pattern
         let input = r#"<tool>{"name": "test2", "arguments": {}}</tool>"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test2");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test2");
 
         // Nested patterns (should use first match)
         let input = r#"<<tool>{"name": "test3", "arguments": {}}</tool>>"#;
-        let result = parser.parse_complete(input).await.unwrap();
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
         // This is tricky - depends on regex behavior
         // The parser should handle this gracefully
-        assert!(result.len() <= 1, "Should not parse multiple times");
+        assert!(tools.len() <= 1, "Should not parse multiple times");
     }
 
     #[tokio::test]
@@ -743,25 +743,25 @@ mod edge_cases {
 
         // Boolean values
         let input = r#"{"name": "toggle", "arguments": {"enabled": true, "disabled": false}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("true"));
-        assert!(result[0].function.arguments.contains("false"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("true"));
+        assert!(tools[0].function.arguments.contains("false"));
 
         // Numbers (including float and negative)
         let input = r#"{"name": "calc", "arguments": {"int": 42, "float": 3.14, "negative": -17}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("42"));
-        assert!(result[0].function.arguments.contains("3.14"));
-        assert!(result[0].function.arguments.contains("-17"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("42"));
+        assert!(tools[0].function.arguments.contains("3.14"));
+        assert!(tools[0].function.arguments.contains("-17"));
 
         // Empty arrays and objects
         let input = r#"{"name": "test", "arguments": {"empty_arr": [], "empty_obj": {}}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("[]"));
-        assert!(result[0].function.arguments.contains("{}"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("[]"));
+        assert!(tools[0].function.arguments.contains("{}"));
     }
 
     #[tokio::test]
@@ -770,15 +770,15 @@ mod edge_cases {
 
         // Using "function" instead of "name"
         let input = r#"{"function": "test_func", "arguments": {"x": 1}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test_func");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test_func");
 
         // Both "name" and "function" present (name should take precedence)
         let input = r#"{"name": "primary", "function": "secondary", "arguments": {}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "primary");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "primary");
     }
 
     #[tokio::test]
@@ -792,15 +792,15 @@ mod edge_cases {
                 "key"   :   "value"
             }
         }  "#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test");
 
         // Minified JSON (no whitespace)
         let input = r#"{"name":"compact","arguments":{"a":1,"b":2}}"#;
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "compact");
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "compact");
     }
 }
 
@@ -830,9 +830,9 @@ mod stress_tests {
             }
         }"#;
 
-        let result = parser.parse_complete(input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].function.arguments.contains("deep"));
+        let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert!(tools[0].function.arguments.contains("deep"));
     }
 
     #[tokio::test]
@@ -845,9 +845,9 @@ mod stress_tests {
             let parser_clone = parser.clone();
             let handle = tokio::spawn(async move {
                 let input = format!(r#"{{"name": "func_{}", "arguments": {{}}}}"#, i);
-                let result = parser_clone.parse_complete(&input).await.unwrap();
-                assert_eq!(result.len(), 1);
-                assert_eq!(result[0].function.name, format!("func_{}", i));
+                let (_normal_text, tools) = parser_clone.parse_complete(&input).await.unwrap();
+                assert_eq!(tools.len(), 1);
+                assert_eq!(tools[0].function.name, format!("func_{}", i));
             });
             handles.push(handle);
         }

--- a/sgl-router/src/tool_parser/traits.rs
+++ b/sgl-router/src/tool_parser/traits.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait ToolParser: Send + Sync {
     /// Parse complete tool calls from final output
-    async fn parse_complete(&self, output: &str) -> ToolParserResult<Vec<ToolCall>>;
+    /// Returns (remaining_normal_text, tool_calls) tuple
+    async fn parse_complete(&self, output: &str) -> ToolParserResult<(String, Vec<ToolCall>)>;
 
     /// Parse tool calls from model output (streaming)
     async fn parse_incremental(

--- a/sgl-router/tests/tool_parser_deepseek.rs
+++ b/sgl-router/tests/tool_parser_deepseek.rs
@@ -13,11 +13,11 @@ async fn test_deepseek_complete_parsing() {
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
 The weather in Tokyo is..."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["location"], "Tokyo");
     assert_eq!(args["units"], "celsius");
 }
@@ -37,10 +37,10 @@ async fn test_deepseek_multiple_tools() {
 ```<｜tool▁call▁end｜>
 <｜tool▁calls▁end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search");
-    assert_eq!(result[1].function.name, "translate");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
 }
 
 #[tokio::test]
@@ -96,11 +96,11 @@ async fn test_deepseek_nested_json() {
 }
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "process");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["data"]["nested"]["deep"].is_array());
 }
 
@@ -134,10 +134,10 @@ async fn test_deepseek_malformed_json_handling() {
 ```<｜tool▁call▁end｜>
 <｜tool▁calls▁end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
     // Only the valid tool call should be parsed
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "valid");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "valid");
 }
 
 #[tokio::test]
@@ -151,9 +151,9 @@ async fn test_normal_text_extraction() {
 {"location": "Tokyo"}
 ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
     // TODO: Verify normal text extraction when parser returns it
     // In Python: normal_text = "Let me help you with that."
@@ -174,8 +174,8 @@ async fn test_multiple_tool_calls() {
 ```<｜tool▁call▁end｜>
 <｜tool▁calls▁end｜><｜end▁of▁sentence｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "get_weather");
-    assert_eq!(result[1].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert_eq!(tools[1].function.name, "get_weather");
 }

--- a/sgl-router/tests/tool_parser_edge_cases.rs
+++ b/sgl-router/tests/tool_parser_edge_cases.rs
@@ -16,9 +16,9 @@ async fn test_empty_input() {
         let parser = registry
             .get_parser(&format!("test-{}", parser_name))
             .unwrap();
-        let result = parser.parse_complete("").await.unwrap();
+        let (_normal_text, tools) = parser.parse_complete("").await.unwrap();
         assert_eq!(
-            result.len(),
+            tools.len(),
             0,
             "Parser {} should return empty for empty input",
             parser_name
@@ -32,7 +32,12 @@ async fn test_plain_text_no_tools() {
 
     let json_parser = JsonParser::new();
     assert_eq!(
-        json_parser.parse_complete(plain_text).await.unwrap().len(),
+        json_parser
+            .parse_complete(plain_text)
+            .await
+            .unwrap()
+            .1
+            .len(),
         0
     );
 
@@ -42,13 +47,19 @@ async fn test_plain_text_no_tools() {
             .parse_complete(plain_text)
             .await
             .unwrap()
+            .1
             .len(),
         0
     );
 
     let qwen_parser = QwenParser::new();
     assert_eq!(
-        qwen_parser.parse_complete(plain_text).await.unwrap().len(),
+        qwen_parser
+            .parse_complete(plain_text)
+            .await
+            .unwrap()
+            .1
+            .len(),
         0
     );
 
@@ -58,6 +69,7 @@ async fn test_plain_text_no_tools() {
             .parse_complete(plain_text)
             .await
             .unwrap()
+            .1
             .len(),
         0
     );
@@ -74,9 +86,9 @@ async fn test_incomplete_json() {
     ];
 
     for input in incomplete_cases {
-        let result = json_parser.parse_complete(input).await.unwrap();
+        let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
         assert_eq!(
-            result.len(),
+            tools.len(),
             0,
             "Should not parse incomplete JSON: {}",
             input
@@ -106,9 +118,9 @@ async fn test_malformed_mistral() {
 
     for input in malformed_cases {
         // Parser might return error or empty vec for malformed input
-        if let Ok(result) = parser.parse_complete(input).await {
+        if let Ok((_normal_text, tools)) = parser.parse_complete(input).await {
             assert_eq!(
-                result.len(),
+                tools.len(),
                 0,
                 "Should not parse malformed Mistral: {}",
                 input
@@ -124,13 +136,13 @@ async fn test_missing_required_fields() {
 
     // Missing name field
     let input = r#"{"arguments": {"x": 1}}"#;
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0, "Should not parse without name field");
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0, "Should not parse without name field");
 
     // Name is not a string
     let input = r#"{"name": 123, "arguments": {}}"#;
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0, "Should not parse with non-string name");
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0, "Should not parse with non-string name");
 }
 
 #[tokio::test]
@@ -143,11 +155,11 @@ async fn test_very_long_strings() {
         long_string
     );
 
-    let result = json_parser.parse_complete(&input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = json_parser.parse_complete(&input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["data"].as_str().unwrap().len(), 10000);
 }
 
@@ -158,10 +170,10 @@ async fn test_unicode_edge_cases() {
     // Various Unicode characters including emojis, CJK, RTL text
     let input = r#"{"name": "translate", "arguments": {"text": "Hello 世界 🌍 مرحبا עולם"}}"#;
 
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["text"], "Hello 世界 🌍 مرحبا עולם");
 }
 
@@ -169,16 +181,16 @@ async fn test_unicode_edge_cases() {
 async fn test_nested_brackets_in_strings() {
     let mistral_parser = MistralParser::new();
     let input = r#"[TOOL_CALLS] [{"name": "echo", "arguments": {"text": "Array: [1, 2, 3]"}}]"#;
-    let result = mistral_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let (_normal_text, tools) = mistral_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["text"], "Array: [1, 2, 3]");
 
     let pythonic_parser = PythonicParser::new();
     let input = r#"[echo(text="List: [a, b, c]")]"#;
-    let result = pythonic_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let (_normal_text, tools) = pythonic_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["text"], "List: [a, b, c]");
 }
 
@@ -191,9 +203,9 @@ async fn test_multiple_formats_in_text() {
     And some more text with <tool_call> tags.
     "#;
 
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "actual_tool");
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "actual_tool");
 }
 
 #[tokio::test]
@@ -202,10 +214,10 @@ async fn test_escaped_characters() {
 
     let input = r#"{"name": "write", "arguments": {"content": "Line 1\nLine 2\r\nLine 3\tTabbed\\Backslash\"Quote"}}"#;
 
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     let content = args["content"].as_str().unwrap();
     assert!(content.contains('\n'));
     assert!(content.contains('\t'));
@@ -229,10 +241,10 @@ async fn test_numeric_edge_cases() {
         }
     }"#;
 
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["int"], 42);
     assert_eq!(args["float"], 123.456);
     assert_eq!(args["scientific"], 0.000123);
@@ -254,10 +266,10 @@ async fn test_null_and_boolean_values() {
         }
     }"#;
 
-    let result = json_parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = json_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["enabled"], true);
     assert_eq!(args["disabled"], false);
     assert_eq!(args["optional"], serde_json::Value::Null);

--- a/sgl-router/tests/tool_parser_fallback.rs
+++ b/sgl-router/tests/tool_parser_fallback.rs
@@ -1,0 +1,267 @@
+//! Tests for tool parser fallback behavior
+//!
+//! When tool call parsing fails, the original text should be preserved as normal text
+//! rather than being lost. This ensures graceful degradation.
+
+use sglang_router_rs::tool_parser::{
+    DeepSeekParser, JsonParser, LlamaParser, MistralParser, QwenParser, ToolParser,
+};
+
+#[tokio::test]
+async fn test_json_parser_invalid_json_returns_as_normal_text() {
+    let parser = JsonParser::new();
+
+    // Malformed JSON should be returned as normal text (note: commas may be processed)
+    let input = r#"{"name": "test", "arguments": invalid json here}"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(
+        normal_text,
+        r#"{"name": "test""arguments": invalid json here}"#
+    );
+
+    // Plain text with no JSON structure should be returned as normal text
+    let input = "This is just plain text that should not be parsed as a tool call";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input);
+
+    // Text that looks like it might have JSON but doesn't should be returned as normal text
+    let input = "The user said: {something} but it's not valid JSON";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input);
+}
+
+#[tokio::test]
+async fn test_qwen_parser_invalid_format_returns_as_normal_text() {
+    let parser = QwenParser::new();
+
+    // Missing closing tag
+    let input = r#"<tool_call>
+{"name": "test", "arguments": {}}
+This text is missing the closing tag"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should preserve original text when no valid tools found
+
+    // Malformed JSON inside valid tags
+    let input = r#"<tool_call>
+{"name": "test", "arguments": invalid}
+</tool_call>"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    // When JSON parsing fails but tags are present, it should preserve the original text
+    assert_eq!(normal_text, input);
+
+    // Plain text without any tool markers
+    let input = "This is a regular response without any tool calls.";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should return original text when no markers found
+}
+
+#[tokio::test]
+async fn test_llama_parser_invalid_format_returns_as_normal_text() {
+    let parser = LlamaParser::new();
+
+    // Invalid JSON after python_tag
+    let input = r#"<|python_tag|>{"name": "test", "arguments": invalid}"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should preserve original text when parsing fails
+
+    // Plain text without markers or JSON
+    let input = "Just explaining something without any function calls.";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should return original text
+
+    // Text with python_tag but completely invalid content
+    let input = r#"Here's my response <|python_tag|>not even close to JSON"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should preserve everything when parsing fails
+}
+
+#[tokio::test]
+async fn test_mistral_parser_invalid_format_returns_as_normal_text() {
+    let parser = MistralParser::new();
+
+    // Missing closing bracket
+    let input = r#"[TOOL_CALLS] [{"name": "test", "arguments": {}"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should preserve original text when parsing fails
+
+    // Invalid JSON in tool calls section
+    let input = r#"[TOOL_CALLS] [{"name": invalid json}]"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should preserve original text when parsing fails
+
+    // Plain text
+    let input = "No tool calls here, just regular text.";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should return original text
+}
+
+#[tokio::test]
+async fn test_deepseek_parser_invalid_format_returns_as_normal_text() {
+    let parser = DeepSeekParser::new();
+
+    // Invalid JSON after emoji marker
+    let input = r#"🤔[{"name": "test", "arguments": malformed}]"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should preserve original text when parsing fails
+
+    // Emoji but no JSON array
+    let input = "🤔 Just thinking about this problem...";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should return original text
+
+    // No emoji marker at all
+    let input = "Regular response without any special markers.";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Should return original text
+}
+
+#[tokio::test]
+async fn test_mixed_valid_and_invalid_content() {
+    let parser = QwenParser::new();
+
+    // Text with one valid tool call and one invalid
+    let input = r#"Let me help you with that.
+<tool_call>
+{"name": "valid_tool", "arguments": {"x": 1}}
+</tool_call>
+And here's another one:
+<tool_call>
+{"name": "invalid_tool", "arguments": malformed}
+</tool_call>
+That's all!"#;
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1); // Should extract the valid tool
+    assert_eq!(tools[0].function.name, "valid_tool");
+    // Normal text should contain the text around the valid tool call
+    assert!(normal_text.contains("Let me help you"));
+    assert!(normal_text.contains("That's all!"));
+}
+
+#[tokio::test]
+async fn test_partial_tool_markers() {
+    // Test cases where tool markers are incomplete or cut off
+
+    let parser = QwenParser::new();
+    let input = "<tool_call>\nThis looks like it might be a tool call but it's not";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input);
+
+    let parser = MistralParser::new();
+    let input = "[TOOL_CALLS] But then nothing follows...";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input);
+
+    let parser = LlamaParser::new();
+    let input = "Starting a response <|python_tag|> but no JSON";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input);
+}
+
+#[tokio::test]
+async fn test_escaped_json_like_content() {
+    // Test that JSON-like content in regular text doesn't get parsed as tools
+
+    let parser = JsonParser::new();
+    let input = r#"The user typed: {"name": "example"} but this is just quoted text"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    // JsonParser should extract the valid JSON and return normal text
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "example");
+    assert_eq!(normal_text, "The user typed:  but this is just quoted text");
+
+    let parser = QwenParser::new();
+    let input = r#"The syntax is: <tool_call>
+{"name": "example"}
+</tool_call> - that's how you format it"#;
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    // This actually contains valid tool call syntax, so it should parse
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "example");
+}
+
+#[tokio::test]
+async fn test_unicode_and_special_chars_in_failed_parsing() {
+    let parser = QwenParser::new();
+
+    // Unicode in malformed tool calls
+    let input = r#"<tool_call>
+{"name": "测试", "arguments": 🚀 invalid}
+</tool_call>"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    // Should handle Unicode properly in the fallback text
+    assert!(!normal_text.is_empty() || normal_text == input);
+
+    // Special characters that might confuse parsers
+    let input = r#"Response: <tool_call>{"name": "test\n\t", "arguments": {"]}"}</tool_call>"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    // This might or might not parse depending on JSON handling of escape sequences
+    if tools.is_empty() {
+        assert!(!normal_text.is_empty() || normal_text == input);
+    }
+}
+
+#[tokio::test]
+async fn test_very_long_invalid_input() {
+    let parser = JsonParser::new();
+
+    // Generate a very long string that looks like it might be JSON but isn't
+    let mut input = String::from("{\"name\": \"test\", \"arguments\": {");
+    for i in 0..1000 {
+        input.push_str(&format!("\"field{}\": \"value{}\", ", i, i));
+    }
+    input.push_str("\"final\": incomplete"); // Don't close the JSON properly
+
+    let (normal_text, tools) = parser.parse_complete(&input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(normal_text, input); // Invalid JSON should be returned as normal text
+}
+
+#[tokio::test]
+async fn test_almost_valid_tool_calls() {
+    // Test tool calls that are almost valid but have small issues
+
+    let parser = JsonParser::new();
+
+    // Missing closing quote should be returned as normal text
+    let input = r#"{"name": "test", "arguments": {"key": "value}}"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
+    assert_eq!(
+        normal_text,
+        r#"{"name": "test""arguments": {"key": "value}}"#
+    );
+
+    // Extra comma
+    let input = r#"{"name": "test", "arguments": {},}"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    // Some JSON parsers might accept trailing commas
+    if tools.is_empty() {
+        assert_eq!(normal_text, r#"{"name": "test""arguments": ,}"#);
+    }
+
+    // Wrong quote types
+    let input = r#"{'name': 'test', 'arguments': {}}"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0); // Standard JSON requires double quotes
+    assert_eq!(normal_text, r#"{'name': 'test''arguments': }"#);
+}

--- a/sgl-router/tests/tool_parser_fallback.rs
+++ b/sgl-router/tests/tool_parser_fallback.rs
@@ -17,7 +17,7 @@ async fn test_json_parser_invalid_json_returns_as_normal_text() {
     assert_eq!(tools.len(), 0);
     assert_eq!(
         normal_text,
-        r#"{"name": "test""arguments": invalid json here}"#
+        r#"{"name": "test", "arguments": invalid json here}"#
     );
 
     // Plain text with no JSON structure should be returned as normal text
@@ -248,7 +248,7 @@ async fn test_almost_valid_tool_calls() {
     assert_eq!(tools.len(), 0);
     assert_eq!(
         normal_text,
-        r#"{"name": "test""arguments": {"key": "value}}"#
+        r#"{"name": "test", "arguments": {"key": "value}}"#
     );
 
     // Extra comma
@@ -256,12 +256,12 @@ async fn test_almost_valid_tool_calls() {
     let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
     // Some JSON parsers might accept trailing commas
     if tools.is_empty() {
-        assert_eq!(normal_text, r#"{"name": "test""arguments": ,}"#);
+        assert_eq!(normal_text, r#"{"name": "test", "arguments": ,}"#);
     }
 
     // Wrong quote types
     let input = r#"{'name': 'test', 'arguments': {}}"#;
     let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
     assert_eq!(tools.len(), 0); // Standard JSON requires double quotes
-    assert_eq!(normal_text, r#"{'name': 'test''arguments': }"#);
+    assert_eq!(normal_text, r#"{'name': 'test', 'arguments': }"#);
 }

--- a/sgl-router/tests/tool_parser_glm4_moe.rs
+++ b/sgl-router/tests/tool_parser_glm4_moe.rs
@@ -15,11 +15,11 @@ async fn test_glm4_complete_parsing() {
 </tool_call>
 The weather will be..."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["city"], "Beijing");
     assert_eq!(args["date"], "2024-12-25");
 }
@@ -39,10 +39,10 @@ async fn test_glm4_multiple_tools() {
 <arg_value>zh</arg_value>
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search");
-    assert_eq!(result[1].function.name, "translate");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
 }
 
 #[tokio::test]
@@ -62,10 +62,10 @@ async fn test_glm4_type_conversion() {
 <arg_value>string value</arg_value>
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["count"], 42);
     assert_eq!(args["rate"], 1.5);
     assert_eq!(args["enabled"], true);
@@ -138,10 +138,10 @@ async fn test_glm4_python_literal_values() {
 <arg_value>None</arg_value>
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["debug"], true);
     assert_eq!(args["verbose"], false);
     assert_eq!(args["optional"], serde_json::Value::Null);
@@ -160,11 +160,11 @@ async fn test_python_literals() {
 <arg_value>None</arg_value>
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test_func");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test_func");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["bool_true"], true);
     assert_eq!(args["bool_false"], false);
     assert_eq!(args["none_val"], serde_json::Value::Null);
@@ -181,10 +181,10 @@ async fn test_nested_values() {
 <arg_value>[1, 2, 3]</arg_value>
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["data"].is_object());
     assert!(args["list"].is_array());
 }

--- a/sgl-router/tests/tool_parser_gpt_oss.rs
+++ b/sgl-router/tests/tool_parser_gpt_oss.rs
@@ -10,11 +10,11 @@ async fn test_gpt_oss_complete_parsing() {
 <|channel|>commentary to=functions.search<|constrain|>json<|message|>{"query": "rust programming", "limit": 10}<|call|>
 Here are the results..."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["query"], "rust programming");
     assert_eq!(args["limit"], 10);
 }
@@ -26,10 +26,10 @@ async fn test_gpt_oss_multiple_tools() {
     let input = r#"<|channel|>commentary to=functions.get_weather<|constrain|>json<|message|>{"location": "Paris"}<|call|>commentary
 <|channel|>commentary to=functions.search<|constrain|>json<|message|>{"query": "Paris tourism"}<|call|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "get_weather");
-    assert_eq!(result[1].function.name, "search");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert_eq!(tools[1].function.name, "search");
 }
 
 #[tokio::test]
@@ -39,10 +39,10 @@ async fn test_gpt_oss_with_namespace() {
     let input = r#"<|channel|>commentary to=api.users.create<|constrain|>json<|message|>{"name": "John", "email": "john@example.com"}<|call|>
 <|channel|>commentary to=tools.calculator.add<|constrain|>json<|message|>{"x": 10, "y": 20}<|call|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "create"); // Should extract last part
-    assert_eq!(result[1].function.name, "add");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "create"); // Should extract last part
+    assert_eq!(tools[1].function.name, "add");
 }
 
 #[tokio::test]
@@ -51,9 +51,9 @@ async fn test_gpt_oss_with_assistant_prefix() {
 
     let input = r#"<|start|>assistant<|channel|>commentary to=functions.test<|constrain|>json<|message|>{"key": "value"}<|call|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 }
 
 #[tokio::test]
@@ -63,10 +63,10 @@ async fn test_gpt_oss_empty_args() {
     let input =
         r#"<|channel|>commentary to=functions.get_time<|constrain|>json<|message|>{}<|call|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_time");
-    assert_eq!(result[0].function.arguments, "{}");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_time");
+    assert_eq!(tools[0].function.arguments, "{}");
 }
 
 #[tokio::test]
@@ -127,9 +127,9 @@ async fn test_gpt_oss_with_whitespace() {
 
     let input = r#"<|channel|>commentary to=functions.test  <|constrain|>json<|message|>{"key": "value"}<|call|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 }
 
 #[tokio::test]
@@ -145,11 +145,11 @@ async fn test_gpt_oss_complex_json() {
     }
 }<|call|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "process");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["nested"]["data"].is_array());
     assert_eq!(args["nested"]["config"]["enabled"], true);
 }
@@ -161,9 +161,9 @@ async fn test_commentary_without_function() {
     // Python should extract commentary as normal text
     let input = r#"<|channel|>commentary<|message|>**Action plan**: 1. Do X 2. Do Y<|end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0); // No tool calls
-                                 // TODO: Verify normal text = "**Action plan**: 1. Do X 2. Do Y"
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0); // No tool calls
+                                // TODO: Verify normal text = "**Action plan**: 1. Do X 2. Do Y"
 }
 
 #[tokio::test]
@@ -173,9 +173,9 @@ async fn test_final_channel() {
     let input = r#"<|channel|>commentary to=functions.test<|constrain|>json<|message|>{"x": 1}<|call|>
 <|channel|>final<|message|>The result is calculated.<|return|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
     // TODO: Verify normal text = "The result is calculated."
 }
 
@@ -187,8 +187,8 @@ async fn test_mixed_commentary_and_calls() {
 <|channel|>commentary to=functions.calc<|constrain|>json<|message|>{"x": 5}<|call|>
 <|channel|>commentary<|message|>Processing...<|end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "calc");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "calc");
     // TODO: Verify normal text = "Let me think Processing..."
 }

--- a/sgl-router/tests/tool_parser_kimik2.rs
+++ b/sgl-router/tests/tool_parser_kimik2.rs
@@ -12,11 +12,11 @@ async fn test_kimik2_complete_parsing() {
 <|tool_calls_section_end|>
 The weather in Tokyo is..."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["location"], "Tokyo");
     assert_eq!(args["units"], "celsius");
 }
@@ -30,10 +30,10 @@ async fn test_kimik2_multiple_tools() {
 <|tool_call_begin|>functions.translate:1<|tool_call_argument_begin|>{"text": "Hello", "to": "ja"}<|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search");
-    assert_eq!(result[1].function.name, "translate");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
 }
 
 #[tokio::test]
@@ -44,11 +44,11 @@ async fn test_kimik2_with_whitespace() {
 <|tool_call_begin|> functions.test:0 <|tool_call_argument_begin|> {"key": "value", "num": 42} <|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["key"], "value");
     assert_eq!(args["num"], 42);
 }
@@ -117,11 +117,11 @@ async fn test_kimik2_sequential_indices() {
 <|tool_call_begin|>functions.third:2<|tool_call_argument_begin|>{"param": "c"}<|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 3);
-    assert_eq!(result[0].function.name, "first");
-    assert_eq!(result[1].function.name, "second");
-    assert_eq!(result[2].function.name, "third");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 3);
+    assert_eq!(tools[0].function.name, "first");
+    assert_eq!(tools[1].function.name, "second");
+    assert_eq!(tools[2].function.name, "third");
 }
 
 #[tokio::test]
@@ -134,10 +134,10 @@ async fn test_function_index_extraction() {
 <|tool_call_begin|>functions.calc:1<|tool_call_argument_begin|>{"x": 10}<|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search");
-    assert_eq!(result[1].function.name, "calc");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "calc");
     // TODO: Verify indices are preserved: 0 and 1
     // TODO: Verify normal text = "Text before tool calls."
 }
@@ -150,7 +150,7 @@ async fn test_namespace_extraction() {
 <|tool_call_begin|>api.tools.search:0<|tool_call_argument_begin|>{"q": "test"}<|tool_call_end|>
 <|tool_calls_section_end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search"); // Should extract after last dot
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search"); // Should extract after last dot
 }

--- a/sgl-router/tests/tool_parser_mistral.rs
+++ b/sgl-router/tests/tool_parser_mistral.rs
@@ -11,11 +11,11 @@ async fn test_mistral_single_tool() {
     let input = r#"Let me search for that.
 [TOOL_CALLS] [{"name": "search_web", "arguments": {"query": "latest news", "max_results": 5}}]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search_web");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search_web");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["query"], "latest news");
     assert_eq!(args["max_results"], 5);
 }
@@ -29,15 +29,15 @@ async fn test_mistral_multiple_tools() {
     {"name": "search_news", "arguments": {"query": "AI developments", "limit": 10}}
 ]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
 
-    assert_eq!(result[0].function.name, "get_weather");
-    let args0: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    assert_eq!(tools[0].function.name, "get_weather");
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args0["city"], "Tokyo");
 
-    assert_eq!(result[1].function.name, "search_news");
-    let args1: serde_json::Value = serde_json::from_str(&result[1].function.arguments).unwrap();
+    assert_eq!(tools[1].function.name, "search_news");
+    let args1: serde_json::Value = serde_json::from_str(&tools[1].function.arguments).unwrap();
     assert_eq!(args1["query"], "AI developments");
 }
 
@@ -47,10 +47,10 @@ async fn test_mistral_nested_json() {
     let input = r#"Processing complex data.
 [TOOL_CALLS] [{"name": "process_data", "arguments": {"config": {"nested": {"value": [1, 2, 3]}}, "enabled": true}}]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["config"]["nested"]["value"], json!([1, 2, 3]));
     assert_eq!(args["enabled"], true);
 }
@@ -62,9 +62,9 @@ async fn test_mistral_with_text_after() {
 
 And here's some text after the tool call that should be ignored."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 }
 
 #[tokio::test]
@@ -72,9 +72,9 @@ async fn test_mistral_empty_arguments() {
     let parser = MistralParser::new();
     let input = r#"[TOOL_CALLS] [{"name": "ping", "arguments": {}}]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "ping");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "ping");
 }
 
 #[tokio::test]
@@ -82,10 +82,10 @@ async fn test_mistral_with_brackets_in_strings() {
     let parser = MistralParser::new();
     let input = r#"[TOOL_CALLS] [{"name": "echo", "arguments": {"text": "Array notation: arr[0] = value[1]"}}]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["text"], "Array notation: arr[0] = value[1]");
 }
 
@@ -105,15 +105,15 @@ async fn test_mistral_malformed_json() {
 
     // Missing closing bracket
     let input = r#"[TOOL_CALLS] [{"name": "test", "arguments": {}"#;
-    if let Ok(result) = parser.parse_complete(input).await {
-        assert_eq!(result.len(), 0);
+    if let Ok((_normal_text, tools)) = parser.parse_complete(input).await {
+        assert_eq!(tools.len(), 0);
     }
     // Error is also acceptable for malformed input
 
     // Invalid JSON inside
     let input = r#"[TOOL_CALLS] [{"name": invalid}]"#;
-    if let Ok(result) = parser.parse_complete(input).await {
-        assert_eq!(result.len(), 0);
+    if let Ok((_normal_text, tools)) = parser.parse_complete(input).await {
+        assert_eq!(tools.len(), 0);
     }
     // Error is also acceptable for malformed input
 }
@@ -146,8 +146,8 @@ async fn test_mistral_real_world_output() {
 
 Let me execute these searches for you."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "web_search");
-    assert_eq!(result[1].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "web_search");
+    assert_eq!(tools[1].function.name, "get_weather");
 }

--- a/sgl-router/tests/tool_parser_pythonic.rs
+++ b/sgl-router/tests/tool_parser_pythonic.rs
@@ -10,11 +10,11 @@ async fn test_pythonic_single_function() {
     let parser = PythonicParser::new();
     let input = r#"[get_weather(city="London", units="celsius")]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["city"], "London");
     assert_eq!(args["units"], "celsius");
 }
@@ -25,12 +25,12 @@ async fn test_pythonic_multiple_functions() {
     let input =
         r#"[search_web(query="Rust programming", max_results=5), get_time(timezone="UTC")]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search_web");
-    assert_eq!(result[1].function.name, "get_time");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search_web");
+    assert_eq!(tools[1].function.name, "get_time");
 
-    let args0: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args0["query"], "Rust programming");
     assert_eq!(args0["max_results"], 5);
 }
@@ -40,10 +40,10 @@ async fn test_pythonic_with_python_literals() {
     let parser = PythonicParser::new();
     let input = r#"[configure(enabled=True, disabled=False, optional=None)]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["enabled"], true);
     assert_eq!(args["disabled"], false);
     assert_eq!(args["optional"], json!(null));
@@ -55,10 +55,10 @@ async fn test_pythonic_with_lists_and_dicts() {
     let input =
         r#"[process_data(items=[1, 2, 3], config={"key": "value", "nested": {"deep": True}})]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["items"], json!([1, 2, 3]));
     assert_eq!(args["config"]["key"], "value");
     assert_eq!(args["config"]["nested"]["deep"], true);
@@ -71,11 +71,11 @@ async fn test_pythonic_with_special_tokens() {
     // Llama 4 sometimes outputs these tokens
     let input = r#"<|python_start|>[calculate(x=10, y=20)]<|python_end|>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "calculate");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "calculate");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["x"], 10);
     assert_eq!(args["y"], 20);
 }
@@ -85,10 +85,10 @@ async fn test_pythonic_with_nested_parentheses() {
     let parser = PythonicParser::new();
     let input = r#"[math_eval(expression="(2 + 3) * (4 - 1)", round_to=2)]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["expression"], "(2 + 3) * (4 - 1)");
     assert_eq!(args["round_to"], 2);
 }
@@ -98,10 +98,10 @@ async fn test_pythonic_with_escaped_quotes() {
     let parser = PythonicParser::new();
     let input = r#"[echo(text="She said \"Hello\" to him")]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["text"], "She said \"Hello\" to him");
 }
 
@@ -110,11 +110,11 @@ async fn test_pythonic_empty_arguments() {
     let parser = PythonicParser::new();
     let input = r#"[ping()]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "ping");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "ping");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args, json!({}));
 }
 
@@ -135,8 +135,8 @@ async fn test_pythonic_invalid_syntax() {
 
     // Missing closing bracket
     let input = r#"[function(arg=value"#;
-    if let Ok(result) = parser.parse_complete(input).await {
-        assert_eq!(result.len(), 0);
+    if let Ok((_normal_text, tools)) = parser.parse_complete(input).await {
+        assert_eq!(tools.len(), 0);
     }
     // Error is also acceptable for invalid syntax
 
@@ -144,10 +144,10 @@ async fn test_pythonic_invalid_syntax() {
     // Note: The parser currently accepts this invalid syntax and returns a result
     // This is a known limitation of the current implementation
     let input = r#"[function(=value)]"#;
-    if let Ok(result) = parser.parse_complete(input).await {
+    if let Ok((_normal_text, tools)) = parser.parse_complete(input).await {
         // The parser incorrectly accepts this, returning 1 result
         // We'll accept this behavior for now but note it's not ideal
-        assert!(result.len() <= 1, "Should parse at most one function");
+        assert!(tools.len() <= 1, "Should parse at most one function");
     }
     // Error would be the correct behavior
 }
@@ -165,13 +165,13 @@ async fn test_pythonic_real_world_llama4() {
 
 These functions will provide the information you need."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 3);
-    assert_eq!(result[0].function.name, "web_search");
-    assert_eq!(result[1].function.name, "calculate");
-    assert_eq!(result[2].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 3);
+    assert_eq!(tools[0].function.name, "web_search");
+    assert_eq!(tools[1].function.name, "calculate");
+    assert_eq!(tools[2].function.name, "get_weather");
 
-    let args0: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args0["query"], "latest Rust features");
     assert_eq!(args0["safe_search"], true);
 }
@@ -182,11 +182,11 @@ async fn test_pythonic_nested_brackets_in_lists() {
 
     let input = r#"[process_matrix(data=[[1, 2], [3, 4]], labels=["row[0]", "row[1]"])]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "process_matrix");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process_matrix");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["data"], json!([[1, 2], [3, 4]]));
     assert_eq!(args["labels"], json!(["row[0]", "row[1]"]));
 }
@@ -198,11 +198,11 @@ async fn test_pythonic_nested_brackets_in_dicts() {
     let input =
         r#"[analyze(config={"patterns": ["[a-z]+", "[0-9]+"], "nested": {"list": [1, [2, 3]]}})]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "analyze");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "analyze");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["config"]["patterns"], json!(["[a-z]+", "[0-9]+"]));
     assert_eq!(args["config"]["nested"]["list"], json!([1, [2, 3]]));
 }
@@ -213,11 +213,11 @@ async fn test_pythonic_mixed_quotes() {
 
     let input = r#"[format_text(single='Hello', double="World", mixed="It's \"quoted\"")]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "format_text");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "format_text");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["single"], "Hello");
     assert_eq!(args["double"], "World");
     assert_eq!(args["mixed"], "It's \"quoted\"");
@@ -233,11 +233,11 @@ async fn test_pythonic_complex_nesting() {
         metadata={"tags": ["nested[0]", "nested[1]"], "config": {"depth": [1, 2, 3]}}
     )]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "transform");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "transform");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["matrix"].is_array());
     assert!(args["operations"].is_array());
     assert_eq!(args["operations"][0]["type"], "scale");
@@ -530,12 +530,12 @@ async fn test_detect_and_parse_with_python_start_and_end_token() {
     let parser = PythonicParser::new();
 
     let text = "User wants to get the weather in Mars. <|python_start|>[get_weather(location='Mars', unit='celsius')]<|python_end|> In this way we will get the weather in Mars.";
-    let result = parser.parse_complete(text).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(text).await.unwrap();
 
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["location"], "Mars");
     assert_eq!(args["unit"], "celsius");
 }

--- a/sgl-router/tests/tool_parser_qwen.rs
+++ b/sgl-router/tests/tool_parser_qwen.rs
@@ -12,11 +12,11 @@ async fn test_qwen_single_tool() {
 {"name": "get_weather", "arguments": {"city": "Beijing", "units": "celsius"}}
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["city"], "Beijing");
     assert_eq!(args["units"], "celsius");
 }
@@ -32,10 +32,10 @@ async fn test_qwen_multiple_sequential_tools() {
 {"name": "translate", "arguments": {"text": "Hello", "to": "zh"}}
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search");
-    assert_eq!(result[1].function.name, "translate");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
 }
 
 #[tokio::test]
@@ -55,11 +55,11 @@ async fn test_qwen_pretty_printed_json() {
 }
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "create_document");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "create_document");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["metadata"]["author"], "Qwen");
     assert_eq!(args["metadata"]["tags"], json!(["test", "example"]));
 }
@@ -79,10 +79,10 @@ Now I'll translate something.
 </tool_call>
 Done!"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "search");
-    assert_eq!(result[1].function.name, "translate");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
 }
 
 #[tokio::test]
@@ -92,9 +92,9 @@ async fn test_qwen_empty_arguments() {
 {"name": "get_time", "arguments": {}}
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_time");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_time");
 }
 
 #[tokio::test]
@@ -104,10 +104,10 @@ async fn test_qwen_with_newlines_in_strings() {
 {"name": "write_file", "arguments": {"content": "Line 1\nLine 2\nLine 3", "path": "/tmp/test.txt"}}
 </tool_call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["content"], "Line 1\nLine 2\nLine 3");
 }
 
@@ -128,14 +128,14 @@ async fn test_qwen_incomplete_tags() {
     // Missing closing tag
     let input = r#"<tool_call>
 {"name": "test", "arguments": {}}"#;
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
 
     // Missing opening tag
     let input = r#"{"name": "test", "arguments": {}}
 </tool_call>"#;
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0);
 }
 
 #[tokio::test]
@@ -171,12 +171,12 @@ Let me also calculate something for you:
 
 These tools will provide the information you need."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "web_search");
-    assert_eq!(result[1].function.name, "calculator");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "web_search");
+    assert_eq!(tools[1].function.name, "calculator");
 
-    let args0: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args0["query"], "quantum computing breakthroughs 2024");
     assert_eq!(args0["safe_search"], true);
 }

--- a/sgl-router/tests/tool_parser_registry.rs
+++ b/sgl-router/tests/tool_parser_registry.rs
@@ -24,9 +24,9 @@ async fn test_openai_models_use_json() {
     for model in models {
         let parser = registry.get_parser(model).unwrap();
         let test_input = r#"{"name": "test", "arguments": {}}"#;
-        let result = parser.parse_complete(test_input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test");
+        let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test");
     }
 }
 
@@ -38,8 +38,8 @@ async fn test_anthropic_models_use_json() {
     for model in models {
         let parser = registry.get_parser(model).unwrap();
         let test_input = r#"{"name": "test", "arguments": {}}"#;
-        let result = parser.parse_complete(test_input).await.unwrap();
-        assert_eq!(result.len(), 1);
+        let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+        assert_eq!(tools.len(), 1);
     }
 }
 
@@ -51,9 +51,9 @@ async fn test_mistral_models() {
     for model in models {
         let parser = registry.get_parser(model).unwrap();
         let test_input = r#"[TOOL_CALLS] [{"name": "test", "arguments": {}}]"#;
-        let result = parser.parse_complete(test_input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test");
+        let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test");
     }
 }
 
@@ -67,9 +67,9 @@ async fn test_qwen_models() {
         let test_input = r#"<tool_call>
 {"name": "test", "arguments": {}}
 </tool_call>"#;
-        let result = parser.parse_complete(test_input).await.unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].function.name, "test");
+        let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "test");
     }
 }
 
@@ -80,22 +80,22 @@ async fn test_llama_model_variants() {
     // Llama 4 uses pythonic
     let parser = registry.get_parser("llama-4-70b").unwrap();
     let test_input = r#"[get_weather(city="NYC")]"#;
-    let result = parser.parse_complete(test_input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "get_weather");
+    let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
 
     // Llama 3.2 uses python_tag
     let parser = registry.get_parser("llama-3.2-8b").unwrap();
     let test_input = r#"<|python_tag|>{"name": "test", "arguments": {}}"#;
-    let result = parser.parse_complete(test_input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 
     // Other Llama models use JSON
     let parser = registry.get_parser("llama-2-70b").unwrap();
     let test_input = r#"{"name": "test", "arguments": {}}"#;
-    let result = parser.parse_complete(test_input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 }
 
 #[tokio::test]
@@ -105,9 +105,9 @@ async fn test_deepseek_models() {
     // DeepSeek uses pythonic format (simplified, v3 would need custom parser)
     let parser = registry.get_parser("deepseek-coder").unwrap();
     let test_input = r#"[function(arg="value")]"#;
-    let result = parser.parse_complete(test_input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "function");
+    let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "function");
 }
 
 #[tokio::test]
@@ -117,9 +117,9 @@ async fn test_unknown_model_fallback() {
     // Unknown models should fall back to JSON parser
     let parser = registry.get_parser("unknown-model-xyz").unwrap();
     let test_input = r#"{"name": "fallback", "arguments": {}}"#;
-    let result = parser.parse_complete(test_input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "fallback");
+    let (_normal_text, tools) = parser.parse_complete(test_input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "fallback");
 }
 
 #[tokio::test]
@@ -181,10 +181,10 @@ The weather information has been requested."#,
 
     for (model, output, expected_name) in test_cases {
         let parser = registry.get_parser(model).unwrap();
-        let result = parser.parse_complete(output).await.unwrap();
-        assert!(!result.is_empty(), "No tools parsed for model {}", model);
+        let (_normal_text, tools) = parser.parse_complete(output).await.unwrap();
+        assert!(!tools.is_empty(), "No tools parsed for model {}", model);
         assert_eq!(
-            result[0].function.name, expected_name,
+            tools[0].function.name, expected_name,
             "Wrong function name for model {}",
             model
         );

--- a/sgl-router/tests/tool_parser_step3.rs
+++ b/sgl-router/tests/tool_parser_step3.rs
@@ -15,11 +15,11 @@ async fn test_step3_complete_parsing() {
 <｜tool_calls_end｜>
 Here are the results..."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["query"], "rust programming");
     assert_eq!(args["limit"], 10);
 }
@@ -38,10 +38,10 @@ async fn test_step3_multiple_tools() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "get_weather");
-    assert_eq!(result[1].function.name, "get_news");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "get_weather");
+    assert_eq!(tools[1].function.name, "get_news");
 }
 
 #[tokio::test]
@@ -58,10 +58,10 @@ async fn test_step3_type_conversion() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["count"], 100);
     assert_eq!(args["rate"], 2.5);
     assert_eq!(args["active"], true);
@@ -132,11 +132,11 @@ async fn test_step3_nested_steptml() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "config");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "config");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["settings"].is_object());
     assert!(args["array"].is_array());
 }
@@ -153,10 +153,10 @@ async fn test_step3_python_literals() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["bool_true"], true);
     assert_eq!(args["bool_false"], false);
     assert_eq!(args["none_value"], serde_json::Value::Null);
@@ -174,11 +174,11 @@ async fn test_steptml_format() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>Text after."#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["query"], "rust lang");
     assert_eq!(args["limit"], 10);
     // TODO: Verify normal text extraction
@@ -195,10 +195,10 @@ async fn test_json_parameter_values() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["settings"].is_object());
     assert!(args["items"].is_array());
 }
@@ -214,11 +214,11 @@ async fn test_step3_parameter_with_angle_brackets() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "compare");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "compare");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["expression"], "a < b && b > c");
     assert_eq!(args["context"], "comparison test");
 }
@@ -233,6 +233,6 @@ async fn test_step3_empty_function_name() {
 </steptml:invoke><｜tool_call_end｜>
 <｜tool_calls_end｜>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0); // Should reject empty function name
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0); // Should reject empty function name
 }

--- a/sgl-router/tests/tool_parser_wrapper_tokens.rs
+++ b/sgl-router/tests/tool_parser_wrapper_tokens.rs
@@ -15,11 +15,11 @@ async fn test_json_with_xml_style_wrapper() {
     let input =
         r#"Some text before <tool>{"name": "test", "arguments": {"x": 1}}</tool> and after"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["x"], 1);
 }
 
@@ -32,14 +32,14 @@ async fn test_json_with_multiple_wrapper_pairs() {
     });
 
     let input1 = r#"<tool>{"name": "tool1", "arguments": {}}</tool>"#;
-    let result1 = parser.parse_complete(input1).await.unwrap();
-    assert_eq!(result1.len(), 1);
-    assert_eq!(result1[0].function.name, "tool1");
+    let (_normal_text, tools1) = parser.parse_complete(input1).await.unwrap();
+    assert_eq!(tools1.len(), 1);
+    assert_eq!(tools1[0].function.name, "tool1");
 
     let input2 = r#"<<TOOL>>{"name": "tool2", "arguments": {}}<</TOOL>>"#;
-    let result2 = parser.parse_complete(input2).await.unwrap();
-    assert_eq!(result2.len(), 1);
-    assert_eq!(result2[0].function.name, "tool2");
+    let (_normal_text, tools2) = parser.parse_complete(input2).await.unwrap();
+    assert_eq!(tools2.len(), 1);
+    assert_eq!(tools2[0].function.name, "tool2");
 }
 
 #[tokio::test]
@@ -52,9 +52,9 @@ async fn test_json_with_only_start_token() {
 
     let input = r#"Some preamble >>>FUNCTION:{"name": "execute", "arguments": {"cmd": "ls"}}"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "execute");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "execute");
 }
 
 #[tokio::test]
@@ -68,9 +68,9 @@ async fn test_json_with_custom_separator() {
     // Though we're not testing multiple tools here, the separator is configured
     let input = r#"[FUNC]{"name": "test", "arguments": {}}[/FUNC]"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 }
 
 #[tokio::test]
@@ -88,21 +88,21 @@ async fn test_json_with_nested_wrapper_tokens_in_content() {
     let input =
         r#"<call>{"name": "echo", "arguments": {"text": "Use <call> and </call> tags"}}</call>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
 
     // This is a known limitation - the parser may fail when end tokens appear in content
     // For now, we accept this behavior
-    if result.is_empty() {
+    if tools.is_empty() {
         // Parser failed due to nested tokens - this is expected
         assert_eq!(
-            result.len(),
+            tools.len(),
             0,
             "Known limitation: nested wrapper tokens in content"
         );
     } else {
         // If it does parse, verify it's correct
-        assert_eq!(result[0].function.name, "echo");
-        let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+        assert_eq!(tools[0].function.name, "echo");
+        let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
         assert_eq!(args["text"], "Use <call> and </call> tags");
     }
 }
@@ -118,9 +118,9 @@ async fn test_json_extraction_without_wrapper_tokens() {
     And here is some text after.
     "#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "search");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
 }
 
 #[tokio::test]
@@ -143,9 +143,9 @@ async fn test_json_with_multiline_wrapper_content() {
 ```
 Done!"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "format_code");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "format_code");
 }
 
 #[tokio::test]
@@ -158,11 +158,11 @@ async fn test_json_with_special_chars_in_tokens() {
 
     let input = r#"{{FUNC[[{"name": "test", "arguments": {"special": "[]{}"}}]]FUNC}}"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 
-    let args: serde_json::Value = serde_json::from_str(&result[0].function.arguments).unwrap();
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["special"], "[]{}");
 }
 
@@ -183,9 +183,9 @@ async fn test_json_multiple_tools_with_wrapper() {
 
     // Current implementation might handle this as separate calls
     // Let's test that at least the first one is parsed
-    let result = parser.parse_complete(input).await.unwrap();
-    assert!(!result.is_empty(), "Should parse at least one tool");
-    assert_eq!(result[0].function.name, "tool1");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert!(!tools.is_empty(), "Should parse at least one tool");
+    assert_eq!(tools[0].function.name, "tool1");
 }
 
 #[tokio::test]
@@ -201,10 +201,10 @@ async fn test_json_wrapper_with_array() {
         {"name": "func2", "arguments": {"param": "value"}}
     ]</tools>"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 2);
-    assert_eq!(result[0].function.name, "func1");
-    assert_eq!(result[1].function.name, "func2");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "func1");
+    assert_eq!(tools[1].function.name, "func2");
 }
 
 #[tokio::test]
@@ -217,13 +217,13 @@ async fn test_json_incomplete_wrapper_tokens() {
 
     // Missing end token
     let input = r#"<tool>{"name": "test", "arguments": {}}"#;
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0, "Should not parse without closing token");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0, "Should not parse without closing token");
 
     // Missing start token
     let input = r#"{"name": "test", "arguments": {}}</tool>"#;
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 0, "Should not parse without opening token");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 0, "Should not parse without opening token");
 }
 
 #[tokio::test]
@@ -236,7 +236,7 @@ async fn test_json_empty_wrapper_tokens() {
 
     let input = r#"{"name": "test", "arguments": {"key": "value"}}"#;
 
-    let result = parser.parse_complete(input).await.unwrap();
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].function.name, "test");
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "test");
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Tool parsers should reserve any content before and after tool calls. Especially, when tool call parsing fails, the original text should be preserved as normal text.

The current behavior only returns a tool-calls list. When it is empty due to parsing failures, the user won't get any content. But completion tokens are still counted.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Fix typo in `reasoning_parser/traits.rs`

### Modify the tool parser system to return both normal text and tool calls

- Updated `ToolParser` trait signature - Changed parse_complete from returning `ToolParserResult<Vec<ToolCall>>` to `ToolParserResult<(String, Vec<ToolCall>)>`
- Updated all parser implementations with efficient normal text extraction:
  - JsonParser: Use stack approach in `extract_json_from_text` to return both normal text and json content
  - MistralParser: Implemented `extract_json_array_with_pos()` method to extract normal text before the tool calls. (**After is ignored**)
  - LlamaParser: Extracts text before `<|python_tag|>` markers
  - QwenParser: Uses `captures_iter()` with match positions for both tool calls and normal text
  - DeepSeekParser: Uses `find_iter()` with match positions
  - KimiK2Parser: Uses `captures_iter()` with match positions
  - PythonicParser: Extract normal texts around the tool call array
  - Step3Parser: Uses regex extractors with match positions
  - GptOssParser: **Ignored**
- Fixed router implementation - Use normal_text as processed_text
- Fixed all test cases - Updated 166+ test cases across multiple files to handle the new (String, Vec<ToolCall>) tuple format
- Add test for parser failure

### Proper error handling for parsing failures

- Capture `ParsingFailed` error in MistralParser
  - `parse_json_array` throws a `ToolParserError::ParsingFailed` error but it is not captured later. 
  - Tool Parser should handle parsing failure errors instead of bubbling up to router.
- Add similar handling in QwenParser
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

### JsonParser

This PR refactored `extract_json_from_text` to use a stack based approach to extract a valid JSON object from a mixed test. 

Here is a detailed comparison:

#### JSON Parser Implementation Comparison

  | Test Case                     | Description                                                                  | Old Implementation         | New Stack-Based            | Winner |
  |-------------------------------|------------------------------------------------------------------------------|----------------------------|----------------------------|--------|
  | Valid Tool Cases              |                                                                              |                            |                            |        |
  | Valid single tool             | {"name": "test", "arguments": {"x": 1}}                                      | ✅ 1 tool (test)            | ✅ 1 tool (test)            | 🤝 Tie |
  | Tool in mixed text            | prefix {"name": "tool1", "arguments": {}} suffix                             | ✅ 1 tool (tool1)           | ✅ 1 tool (tool1)           | 🤝 Tie |
  | Array of tools                | [{"name": "tool1", "arguments": {}}, {"name": "tool2", "arguments": {}}]     | ✅ 2 tools (tool1, tool2)   | ✅ 2 tools (tool1, tool2)   | 🤝 Tie |
  | Array tool in text            | text [{"name": "arr_tool", "arguments": {"k": [3]}}] end                     | ✅ 1 tool (arr_tool)        | ✅ 1 tool (arr_tool)        | 🤝 Tie |
  | Escaped quotes                | {"name": "escape", "arguments": {"text": "quote \" here"}}                   | ✅ 1 tool (escape)          | ✅ 1 tool (escape)          | 🤝 Tie |
  | Nested data                   | before {"name": "nested", "arguments": {"data": {"deep": true}}} after       | ✅ 1 tool (nested)          | ✅ 1 tool (nested)          | 🤝 Tie |
  | Array parameter               | {"name": "array_param", "arguments": {"list": [1,2,3]}}                      | ✅ 1 tool (array_param)     | ✅ 1 tool (array_param)     | 🤝 Tie |
  | Brackets in strings           | {"name": "string_brackets", "arguments": {"msg": "array [1] and obj {x:1}"}} | ✅ 1 tool (string_brackets) | ✅ 1 tool (string_brackets) | 🤝 Tie |
  | Edge Cases                    |                                                                              |                            |                            |        |
  | Stray closer before           | nonsense} {"name": "after_stray", "arguments": {}} end                       | ✅ 1 tool (after_stray)     | ✅ 1 tool (after_stray)     | 🤝 Tie |
  | Fake tool in string           | text "fake {name: tool}" {"name": "real", "arguments": {}} end               | ❌ 0 tools                  | ✅ 1 tool (real)            | 🏆 New |
  | Priority Cases                |                                                                              |                            |                            |        |
  | Array vs object               | [{"name": "first", "arguments": {}}] {"name": "second", "arguments": {}}     | ✅ 1 tool (first)           | ✅ 1 tool (first)           | 🤝 Tie |
  | Malformed Cases (Should Fail) |                                                                              |                            |                            |        |
  | Malformed brackets            | garbage { "name": "bad", "arguments": [1,2} } more                           | ✅ 0 tools (correct)        | ✅ 0 tools (correct)        | 🤝 Tie |
  | Incomplete JSON               | {"name": "incomplete", "arguments": {"x": [1,2}                              | ✅ 0 tools (correct)        | ✅ 0 tools (correct)        | 🤝 Tie |
  | Mismatched brackets           | pre { "name": "mismatch", "arguments": [1,2} then after                      | ✅ 0 tools (correct)        | ✅ 0 tools (correct)        | 🤝 Tie |

#### Detailed Edge Case Analysis

  | Case            | Input                                                                    | Old Result           | New Result           | Analysis                             |
  |-----------------|--------------------------------------------------------------------------|----------------------|----------------------|--------------------------------------|
  | Stray Closer    | stray} {"name": "tool", "arguments": {}}                                 | ✅ Found tool         | ✅ Found tool         | Both correctly ignore stray }        |
  | String Content  | text "fake {name: tool}" {"name": "real", "arguments": {}}               | ❌ No tools found     | ✅ Found real         | New correctly ignores string content |
  | Malformed Inner | bad{ "name": "tool", "arguments": [1,2} good                             | ✅ No tools (correct) | ✅ No tools (correct) | Both correctly reject malformed JSON |
  | Array Priority  | [{"name": "first", "arguments": {}}] {"name": "second", "arguments": {}} | ✅ Found first        | ✅ Found first        | Both correctly extract array first   |

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
