### PR TITLE
[router][tool call] Support normal content extraction before tool call (streaming)

### DIFF
--- a/sgl-router/src/tool_parser/parsers/deepseek_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/deepseek_parser.rs
@@ -154,8 +154,20 @@ impl ToolParser for DeepSeekParser {
 
         // Check for tool markers
         if !self.has_tool_markers(&state.buffer) {
-            // No markers found, return as incomplete
-            return Ok(StreamResult::Incomplete);
+            // No tool markers detected - return all buffered content as normal text
+            let normal_text = state.buffer.clone();
+            state.buffer.clear();
+            return Ok(StreamResult::NormalText(normal_text));
+        }
+
+        // Check for text before tool markers and extract it as normal text
+        if let Some(marker_pos) = state.buffer.find("<｜tool▁calls▁begin｜>") {
+            if marker_pos > 0 {
+                // We have text before the tool marker - extract it as normal text
+                let normal_text = state.buffer[..marker_pos].to_string();
+                state.buffer = state.buffer[marker_pos..].to_string();
+                return Ok(StreamResult::NormalText(normal_text));
+            }
         }
 
         // Look for start of tool calls
@@ -220,7 +232,7 @@ impl ToolParser for DeepSeekParser {
                                             });
                                         }
                                         Err(_) => {
-                                            // Can't parse yet, keep buffering
+                                            // Can't parse yet, continue waiting for more data
                                         }
                                     }
                                 }

--- a/sgl-router/src/tool_parser/parsers/deepseek_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/deepseek_parser.rs
@@ -155,8 +155,7 @@ impl ToolParser for DeepSeekParser {
         // Check for tool markers
         if !self.has_tool_markers(&state.buffer) {
             // No tool markers detected - return all buffered content as normal text
-            let normal_text = state.buffer.clone();
-            state.buffer.clear();
+            let normal_text = std::mem::take(&mut state.buffer);
             return Ok(StreamResult::NormalText(normal_text));
         }
 
@@ -164,8 +163,7 @@ impl ToolParser for DeepSeekParser {
         if let Some(marker_pos) = state.buffer.find("<｜tool▁calls▁begin｜>") {
             if marker_pos > 0 {
                 // We have text before the tool marker - extract it as normal text
-                let normal_text = state.buffer[..marker_pos].to_string();
-                state.buffer = state.buffer[marker_pos..].to_string();
+                let normal_text: String = state.buffer.drain(..marker_pos).collect();
                 return Ok(StreamResult::NormalText(normal_text));
             }
         }

--- a/sgl-router/src/tool_parser/parsers/glm4_moe_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/glm4_moe_parser.rs
@@ -178,8 +178,7 @@ impl ToolParser for Glm4MoeParser {
         // Check for tool markers
         if !self.has_tool_markers(&state.buffer) {
             // No tool markers detected - return all buffered content as normal text
-            let normal_text = state.buffer.clone();
-            state.buffer.clear();
+            let normal_text = std::mem::take(&mut state.buffer);
             return Ok(StreamResult::NormalText(normal_text));
         }
 
@@ -187,8 +186,7 @@ impl ToolParser for Glm4MoeParser {
         if let Some(marker_pos) = state.buffer.find("<tool_call>") {
             if marker_pos > 0 {
                 // We have text before the tool marker - extract it as normal text
-                let normal_text = state.buffer[..marker_pos].to_string();
-                state.buffer = state.buffer[marker_pos..].to_string();
+                let normal_text: String = state.buffer.drain(..marker_pos).collect();
                 return Ok(StreamResult::NormalText(normal_text));
             }
         }

--- a/sgl-router/src/tool_parser/parsers/glm4_moe_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/glm4_moe_parser.rs
@@ -177,8 +177,20 @@ impl ToolParser for Glm4MoeParser {
 
         // Check for tool markers
         if !self.has_tool_markers(&state.buffer) {
-            // No markers found, return as incomplete
-            return Ok(StreamResult::Incomplete);
+            // No tool markers detected - return all buffered content as normal text
+            let normal_text = state.buffer.clone();
+            state.buffer.clear();
+            return Ok(StreamResult::NormalText(normal_text));
+        }
+
+        // Check for text before tool markers and extract it as normal text
+        if let Some(marker_pos) = state.buffer.find("<tool_call>") {
+            if marker_pos > 0 {
+                // We have text before the tool marker - extract it as normal text
+                let normal_text = state.buffer[..marker_pos].to_string();
+                state.buffer = state.buffer[marker_pos..].to_string();
+                return Ok(StreamResult::NormalText(normal_text));
+            }
         }
 
         // Look for start of tool call

--- a/sgl-router/src/tool_parser/parsers/mistral_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/mistral_parser.rs
@@ -196,8 +196,7 @@ impl ToolParser for MistralParser {
         // Check if we have the start marker
         if !self.has_tool_markers(&state.buffer) {
             // No tool markers detected - return all buffered content as normal text
-            let normal_text = state.buffer.clone();
-            state.buffer.clear();
+            let normal_text = std::mem::take(&mut state.buffer);
             return Ok(StreamResult::NormalText(normal_text));
         }
 
@@ -205,8 +204,7 @@ impl ToolParser for MistralParser {
         if let Some(marker_pos) = state.buffer.find("[TOOL_CALLS]") {
             if marker_pos > 0 {
                 // We have text before the tool marker - extract it as normal text
-                let normal_text = state.buffer[..marker_pos].to_string();
-                state.buffer = state.buffer[marker_pos..].to_string();
+                let normal_text: String = state.buffer.drain(..marker_pos).collect();
                 return Ok(StreamResult::NormalText(normal_text));
             }
         }

--- a/sgl-router/src/tool_parser/parsers/step3_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/step3_parser.rs
@@ -210,8 +210,7 @@ impl ToolParser for Step3Parser {
         // Check for tool markers
         if !self.has_tool_markers(&state.buffer) {
             // No tool markers detected - return all buffered content as normal text
-            let normal_text = state.buffer.clone();
-            state.buffer.clear();
+            let normal_text = std::mem::take(&mut state.buffer);
             return Ok(StreamResult::NormalText(normal_text));
         }
 
@@ -219,8 +218,7 @@ impl ToolParser for Step3Parser {
         if let Some(marker_pos) = state.buffer.find("<｜tool_calls_begin｜>") {
             if marker_pos > 0 {
                 // We have text before the tool marker - extract it as normal text
-                let normal_text = state.buffer[..marker_pos].to_string();
-                state.buffer = state.buffer[marker_pos..].to_string();
+                let normal_text: String = state.buffer.drain(..marker_pos).collect();
                 return Ok(StreamResult::NormalText(normal_text));
             }
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR adds the extraction of normal content before tool call in tool-call parsers 

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- gpt-oss-parser is ignored. By design
- pythonic parser uses parse_complete. So we can ignore it.
- For other parsers: add check for normal texts before the tool call. Return as `StreamResult::NormalText`

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
