### PR TITLE
[router] grpc router generate endpoint support

### DIFF
--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -224,7 +224,7 @@ impl GrpcRouter {
 
         debug!("Selected worker: {}", worker.url());
 
-        // Step 2: Get gRPC client from worker
+        // Step 3: Get gRPC client from worker
         let client = match Self::get_grpc_client_from_worker(&worker).await {
             Ok(client) => client,
             Err(response) => return response,

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -257,7 +257,7 @@ impl GrpcRouter {
             .cloned()
             .unwrap_or_else(|| "default".to_string());
 
-        // Step 5: Handle streaming vs non-streaming
+        // Step 6: Handle streaming vs non-streaming
         if body.stream {
             // TODO: Implement streaming support for generate endpoint
             return (

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -213,7 +213,7 @@ impl GrpcRouter {
 
         debug!("Resolved input with {} tokens", token_ids.len());
 
-        // Step 4: Select worker (fail fast if no workers available)
+        // Step 2: Select worker (fail fast if no workers available)
         let worker = match self.select_worker_for_request(model_id, original_text.as_deref()) {
             Some(w) => w,
             None => {

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -249,7 +249,7 @@ impl GrpcRouter {
             }
         };
 
-        // Step 4: Get weight version for response metadata
+        // Step 5: Get weight version for response metadata
         let weight_version = worker
             .metadata()
             .labels

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -230,7 +230,7 @@ impl GrpcRouter {
             Err(response) => return response,
         };
 
-        // Step 3: Build the gRPC request
+        // Step 4: Build the gRPC request
         let request_id = body
             .rid
             .clone()


### PR DESCRIPTION
## Changes
Added end-to-end /generate support to the Rust gRPC router. 
- The router now mirrors the Python flow: it resolves `text/prompt/input_ids` through the router's tokenizer, 
- builds a `proto::GenerateRequest` via the new plain-generate helper, 
- selects a gRPC worker
- streams back the scheduler’s completion payload. 
- Responses preserve the scheduler’s metadata (finish reason, token counts, matched stops, logprob/hidden-state blocks, weight version, latency, request id) without router-side rewrites, and decoding errors are handled through shared helpers.

## Tests
### Start Router
```
python3 -m sglang_router.launch_router \
  --host 0.0.0.0 \
  --port 8080 \
  --worker-urls grpc://localhost:30000 \
  --model-path meta-llama/Llama-3.1-8B-Instruct \
  --log-level debug
```

### Start gRPC Server
```
python3 -m sglang.srt.entrypoints.grpc_server --model /raid/models/meta-llama/Llama-3.1-8B-Instruct --port=30000 --tp-size=1
```

### Screnn Shot
<img width="1915" height="1205" alt="Screenshot 2025-09-29 at 9 35 22 AM" src="https://github.com/user-attachments/assets/02dfdd2b-f755-4b02-a3a8-2521e383c09c" />

  
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
