### PR TITLE
[metrics] instrument fastapi for tracing

### DIFF
--- a/docs/references/production_request_trace.md
+++ b/docs/references/production_request_trace.md
@@ -12,7 +12,7 @@ This section explains how to configure the request tracing and export the trace 
     pip install -e "python[tracing]"
 
     # or manually install the dependencies using pip
-    pip install opentelemetry-sdk opentelemetry-api opentelemetry-exporter-otlp opentelemetry-exporter-otlp-proto-grpc
+    pip install opentelemetry-sdk opentelemetry-api opentelemetry-exporter-otlp opentelemetry-exporter-otlp-proto-grpc opentelemetry-instrumentation-fastapi
     ```
 
 2. launch opentelemetry collector and jaeger

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -88,6 +88,7 @@ tracing = [
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",
     "opentelemetry-exporter-otlp-proto-grpc",
+    "opentelemetry-instrumentation-fastapi",
 ]
 all = ["sglang[test]", "sglang[decord]"]
 blackwell = ["sglang[test]", "sglang[decord]"]

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -29,7 +29,11 @@ import time
 from http import HTTPStatus
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Union
 
-from sglang.srt.tracing.trace import process_tracing_init, trace_set_thread_info
+from sglang.srt.tracing.trace import (
+    instrument_fastapi,
+    process_tracing_init,
+    trace_set_thread_info,
+)
 
 # Fix a bug of Python threading
 setattr(threading, "_register_atexit", lambda *args, **kwargs: None)
@@ -1181,6 +1185,9 @@ async def vertex_generate(vertex_req: VertexGenerateReqInput, raw_request: Reque
     if isinstance(ret, Response):
         return ret
     return ORJSONResponse({"predictions": ret})
+
+
+instrument_fastapi(app)
 
 
 def _update_weight_version_if_provided(weight_version: Optional[str]) -> None:

--- a/python/sglang/srt/tracing/trace.py
+++ b/python/sglang/srt/tracing/trace.py
@@ -25,6 +25,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from fastapi import FastAPI
+
 logger = logging.getLogger(__name__)
 opentelemetry_imported = False
 tracing_enabled = False
@@ -32,6 +34,7 @@ tracing_enabled = False
 try:
     from opentelemetry import context, propagate, trace
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.trace import TracerProvider, id_generator
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -550,3 +553,10 @@ def trace_slice_add_attr(rid: str, attrs: Dict[str, Any]):
 
     slice_info = thread_context.cur_slice_stack[-1]
     slice_info.span.set_attributes(attrs)
+
+
+def instrument_fastapi(app: FastAPI):
+    if not opentelemetry_imported:
+        return
+
+    FastAPIInstrumentor.instrument_app(app)


### PR DESCRIPTION
## Motivation

I was checking tracing for our setup and noticed that fastapi is not instrumented: https://github.com/sgl-project/sglang/pull/10804#issuecomment-3347340226, this leads to being unable to use sglang in other services that do use specific conventions for tracing (such as w3c's trace context, also used by opentelemetry, see comment for references). this was tested manually in our go `net/http` + `otelhttp.Transport` calling the sglang deployment.

## Modifications

- add instrumentation for fastapi for optional tracing

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
   - N/A? 
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
    - N/A 
