### PR TITLE
Fix DSR1 accuracy for flashinfer_trtllm MoE with FP8 quantization

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -575,9 +575,9 @@ class FusedMoE(torch.nn.Module):
             )
 
         # Flashinfer assumes w31 format for w13_weight. Same for the scales.
-        if (
-            should_use_flashinfer_trtllm_moe()
-            and self.quant_method.__class__.__name__ == "ModelOptNvFp4FusedMoEMethod"
+        if should_use_flashinfer_trtllm_moe() and (
+            isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
+            or isinstance(self.quant_method, Fp8MoEMethod)
         ):
             shard_id = {"w1": "w3", "w3": "w1", "w2": "w2"}[shard_id]
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -912,7 +912,7 @@ class ServerArgs:
         if self.moe_runner_backend == "flashinfer_trtllm":
             assert (
                 self.quantization == "modelopt_fp4" or self.quantization == "fp8"
-            ), "modelopt_fp4 quantization is required for Flashinfer TRTLLM MoE"
+            ), "modelopt_fp4 or fp8 quantization is required for Flashinfer TRTLLM MoE"
             self.disable_shared_experts_fusion = True
             logger.warning(
                 "FlashInfer TRTLLM MoE is enabled. --disable-shared-experts-fusion is automatically set."


### PR DESCRIPTION
## Motivation

https://github.com/sgl-project/sglang/pull/10758 introduced a change to only apply w13 -> w31 weight mapping with flashinfer_trtllm for NVFP4 quantization, however FP8 quantization is also supported and needs this mapping too, otherwise GSM8K accuracy went to 0.

## Modifications

Apply w13 -> w31 for FP8 quantization also.

## Accuracy Tests

Command
```
python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-R1-0528  --trust-remote-code --tp 8 --moe-runner-backend flashinfer_trtllm --quantization fp8
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319 --port=30000
```

Before fix
```
Accuracy: 0.025
Invalid: 0.067
Latency: 73.347 s
Output throughput: 9207.244 token/s
```

After fix
```
Accuracy: 0.959
Invalid: 0.000
Latency: 25.951 s
Output throughput: 5488.445 token/s
```

## Benchmarking and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
