### PR TITLE
[router][tool call] Full support for ToolChoice

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -1491,6 +1491,7 @@ impl ResponsesResponse {
                 ToolChoice::Value(ToolChoiceValue::Required) => "required".to_string(),
                 ToolChoice::Value(ToolChoiceValue::None) => "none".to_string(),
                 ToolChoice::Function { .. } => "function".to_string(),
+                ToolChoice::AllowedTools { mode, .. } => mode.clone(),
             },
             tools: request.tools.clone(),
             top_p: request.top_p,
@@ -1718,6 +1719,12 @@ pub enum ToolChoice {
         tool_type: String, // "function"
         function: FunctionChoice,
     },
+    AllowedTools {
+        #[serde(rename = "type")]
+        tool_type: String, // "allowed_tools"
+        mode: String, // "auto" | "required" TODO: need validation
+        tools: Vec<ToolReference>,
+    },
 }
 
 impl Default for ToolChoice {
@@ -1729,6 +1736,14 @@ impl Default for ToolChoice {
 /// Function choice specification for ToolChoice::Function
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FunctionChoice {
+    pub name: String,
+}
+
+/// Tool reference for ToolChoice::AllowedTools
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ToolReference {
+    #[serde(rename = "type")]
+    pub tool_type: String, // "function"
     pub name: String,
 }
 

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -148,8 +148,39 @@ impl GrpcRouter {
             }
         };
 
-        // Step 3: Process messages and apply chat template
-        let processed_messages = match self.process_chat_messages(body) {
+        // Step 3: Filter tools if needed for allowed_tools or specific function
+        // Only clone body if we need to modify tools
+        let mut body_with_filtered_tools;
+        let body_ref = match &body.tool_choice {
+            Some(ToolChoice::AllowedTools { tools: allowed, .. }) if body.tools.is_some() => {
+                body_with_filtered_tools = body.clone();
+                let all_tools = body_with_filtered_tools.tools.as_ref().unwrap();
+                let allowed_names: std::collections::HashSet<&str> =
+                    allowed.iter().map(|t| t.name.as_str()).collect();
+                let filtered_tools: Vec<Tool> = all_tools
+                    .iter()
+                    .filter(|t| allowed_names.contains(t.function.name.as_str()))
+                    .cloned()
+                    .collect();
+                body_with_filtered_tools.tools = Some(filtered_tools);
+                &body_with_filtered_tools
+            }
+            Some(ToolChoice::Function { function, .. }) if body.tools.is_some() => {
+                body_with_filtered_tools = body.clone();
+                let all_tools = body_with_filtered_tools.tools.as_ref().unwrap();
+                let filtered_tools: Vec<Tool> = all_tools
+                    .iter()
+                    .filter(|t| t.function.name == function.name)
+                    .cloned()
+                    .collect();
+                body_with_filtered_tools.tools = Some(filtered_tools);
+                &body_with_filtered_tools
+            }
+            _ => body, // No filtering needed, use original
+        };
+
+        // Step 4: Process messages and apply chat template
+        let processed_messages = match self.process_chat_messages(body_ref) {
             Ok(msgs) => msgs,
             Err(e) => {
                 error!("Failed to process chat messages: {}", e);
@@ -157,7 +188,7 @@ impl GrpcRouter {
             }
         };
 
-        // Step 4: Tokenize the processed text
+        // Step 5: Tokenize the processed text
         let encoding = match self.tokenizer.encode(&processed_messages.text) {
             Ok(encoding) => encoding,
             Err(e) => {
@@ -173,18 +204,17 @@ impl GrpcRouter {
         let token_ids = encoding.token_ids().to_vec();
         debug!("Tokenized {} tokens from input", token_ids.len());
 
-        // Step 5: Build tool constraints if needed
-        let tool_call_constraint = if let Some(tools) = &body.tools {
+        // Step 6: Build tool constraints if needed
+        // body_ref already has filtered tools if needed
+        let tool_call_constraint = body_ref.tools.as_ref().and_then(|tools| {
             self.generate_tool_constraints(tools, &body.tool_choice, &body.model)
-        } else {
-            None
-        };
+        });
 
-        // Step 6: Build the base gRPC request
+        // Step 7: Build the base gRPC request (use body_ref with filtered tools if applicable)
         let request_id = format!("chatcmpl-{}", Uuid::new_v4());
         let request = match client.build_generate_request(
             request_id,
-            body,
+            body_ref,
             processed_messages.text.clone(),
             token_ids,
             processed_messages.multimodal_inputs,
@@ -471,16 +501,121 @@ impl GrpcRouter {
     }
 
     /// Generate tool constraints for structured generation
+    /// Note: tools should already be filtered if needed (by allowed_tools or specific function)
     fn generate_tool_constraints(
         &self,
-        _tools: &[Tool],
-        _tool_choice: &Option<ToolChoice>,
-        model: &str,
+        tools: &[Tool],
+        tool_choice: &Option<ToolChoice>,
+        _model: &str,
     ) -> Option<(String, String)> {
-        let _parser = self.tool_parser_registry.get_parser(model)?;
-        // TODO: Implement actual constraint generation logic
-        // For now, return None as this is placeholder implementation
-        None
+        use crate::protocols::spec::ToolChoiceValue;
+
+        let choice = tool_choice.as_ref()?;
+
+        match choice {
+            // Specific function: Return parameters schema directly
+            // tools should already be filtered to contain only the specific function
+            ToolChoice::Function { .. } => {
+                if tools.is_empty() {
+                    return None;
+                }
+                let tool = &tools[0];
+
+                // Return the tool's parameters schema directly (not wrapped in array)
+                let params_schema = serde_json::to_string(&tool.function.parameters).ok()?;
+                Some(("json_schema".to_string(), params_schema))
+            }
+
+            // Required: Array of tool calls with minItems: 1
+            ToolChoice::Value(ToolChoiceValue::Required) => {
+                let schema = self.build_required_array_schema(tools)?;
+                Some(("json_schema".to_string(), schema))
+            }
+
+            // AllowedTools with required mode: tools are already filtered
+            ToolChoice::AllowedTools { mode, .. } => {
+                if mode == "required" {
+                    if tools.is_empty() {
+                        return None;
+                    }
+                    let schema = self.build_required_array_schema(tools)?;
+                    Some(("json_schema".to_string(), schema))
+                } else {
+                    // "auto" mode - no constraint needed
+                    None
+                }
+            }
+
+            // "auto" or "none" - no constraint
+            _ => None,
+        }
+    }
+
+    /// Build JSON schema for required tool calls (array with minItems: 1)
+    /// Includes $defs consolidation from all tools (matching Python's behavior)
+    fn build_required_array_schema(&self, tools: &[Tool]) -> Option<String> {
+        use serde_json::{json, Map, Value};
+        use std::collections::HashMap;
+
+        // Build anyOf schemas for each tool
+        let mut any_of_schemas = Vec::new();
+        for tool in tools {
+            let tool_schema = json!({
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": [tool.function.name]
+                    },
+                    "parameters": tool.function.parameters
+                },
+                "required": ["name", "parameters"]
+            });
+            any_of_schemas.push(tool_schema);
+        }
+
+        // Consolidate $defs from all tools (matching Python's _get_tool_schema_defs)
+        let mut all_defs: HashMap<String, Value> = HashMap::new();
+        for tool in tools {
+            if let Value::Object(params) = &tool.function.parameters {
+                if let Some(Value::Object(defs)) = params.get("$defs") {
+                    for (def_name, def_schema) in defs {
+                        if let Some(existing) = all_defs.get(def_name) {
+                            // Check for conflicts
+                            if existing != def_schema {
+                                error!(
+                                    "Tool definition '{}' has multiple schemas, which is not supported",
+                                    def_name
+                                );
+                                return None;
+                            }
+                        } else {
+                            all_defs.insert(def_name.clone(), def_schema.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Build the full array schema
+        let mut array_schema = json!({
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "anyOf": any_of_schemas
+            }
+        });
+
+        // Add $defs if any were found (matching Python's behavior)
+        if !all_defs.is_empty() {
+            if let Value::Object(ref mut schema_obj) = array_schema {
+                let defs_value =
+                    Value::Object(all_defs.into_iter().collect::<Map<String, Value>>());
+                schema_obj.insert("$defs".to_string(), defs_value);
+            }
+        }
+
+        serde_json::to_string(&array_schema).ok()
     }
 
     /// Create a StopSequenceDecoder from the chat completion request
@@ -868,34 +1003,119 @@ impl GrpcRouter {
         );
 
         if tool_choice_enabled && original_request.tools.is_some() {
-            if let Some(parser) = self
-                .tool_parser_registry
-                .get_parser(&original_request.model)
-            {
-                match parser.parse_complete(&processed_text).await {
-                    Ok((normal_text, parsed_tool_calls)) => {
-                        if !parsed_tool_calls.is_empty() {
-                            let spec_tool_calls = parsed_tool_calls
-                                .into_iter()
-                                .map(|tc| crate::protocols::spec::ToolCall {
-                                    id: tc.id,
+            // Check if JSON schema constraint was used (specific function or required mode)
+            let used_json_schema = match &original_request.tool_choice {
+                Some(ToolChoice::Function { .. }) => true,
+                Some(ToolChoice::Value(crate::protocols::spec::ToolChoiceValue::Required)) => true,
+                Some(ToolChoice::AllowedTools { mode, .. }) => mode == "required",
+                _ => false,
+            };
+
+            if used_json_schema {
+                // JSON schema was used - parse response based on tool_choice type
+                match &original_request.tool_choice {
+                    Some(ToolChoice::Function { function, .. }) => {
+                        // Specific function: Parse parameters directly
+                        match serde_json::from_str::<serde_json::Value>(&processed_text) {
+                            Ok(params) => {
+                                let tool_call = crate::protocols::spec::ToolCall {
+                                    id: format!("call_{}", uuid::Uuid::new_v4()),
                                     tool_type: "function".to_string(),
                                     function: crate::protocols::spec::FunctionCallResponse {
-                                        name: tc.function.name,
+                                        name: function.name.clone(),
                                         arguments: Some(
-                                            serde_json::to_string(&tc.function.arguments)
+                                            serde_json::to_string(&params)
                                                 .unwrap_or_else(|_| "{}".to_string()),
                                         ),
                                     },
-                                })
-                                .collect();
-                            tool_calls = Some(spec_tool_calls);
-                            processed_text = normal_text;
+                                };
+                                tool_calls = Some(vec![tool_call]);
+                                processed_text = String::new(); // Tool call extracted
+                            }
+                            Err(e) => {
+                                error!("Failed to parse specific function parameters: {}", e);
+                            }
                         }
                     }
-                    Err(e) => {
-                        error!("Tool call parsing error: {}", e);
-                        // Continue without tool calls rather than failing
+                    Some(ToolChoice::Value(crate::protocols::spec::ToolChoiceValue::Required))
+                    | Some(ToolChoice::AllowedTools { .. }) => {
+                        // Required mode: Parse array of tool calls
+                        // JSON format: [{"name": "tool1", "parameters": {...}}, ...]
+                        // Note: AllowedTools only gets here if mode="required" (checked in used_json_schema)
+                        match serde_json::from_str::<Vec<serde_json::Value>>(&processed_text) {
+                            Ok(parsed_array) => {
+                                let spec_tool_calls: Vec<crate::protocols::spec::ToolCall> =
+                                    parsed_array
+                                        .into_iter()
+                                        .enumerate()
+                                        .filter_map(|(i, item)| {
+                                            let obj = item.as_object()?;
+                                            let name = obj.get("name")?.as_str()?.to_string();
+                                            let parameters = obj.get("parameters")?;
+
+                                            Some(crate::protocols::spec::ToolCall {
+                                                id: format!("call_{}_{}", i, uuid::Uuid::new_v4()),
+                                                tool_type: "function".to_string(),
+                                                function:
+                                                    crate::protocols::spec::FunctionCallResponse {
+                                                        name,
+                                                        arguments: Some(
+                                                            serde_json::to_string(parameters)
+                                                                .unwrap_or_else(|_| {
+                                                                    "{}".to_string()
+                                                                }),
+                                                        ),
+                                                    },
+                                            })
+                                        })
+                                        .collect();
+                                tool_calls = Some(spec_tool_calls);
+                                processed_text = String::new(); // Tool calls extracted
+                            }
+                            Err(e) => {
+                                error!("Failed to parse required tool call array: {}", e);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            } else {
+                // No JSON schema constraint - use model-specific parser
+                if let Some(parser) = self
+                    .tool_parser_registry
+                    .get_parser(&original_request.model)
+                {
+                    // Check if text contains tool calls before parsing
+                    if parser.detect_format(&processed_text) {
+                        match parser.parse_complete(&processed_text).await {
+                            Ok((normal_text, parsed_tool_calls)) => {
+                                if !parsed_tool_calls.is_empty() {
+                                    let spec_tool_calls = parsed_tool_calls
+                                        .into_iter()
+                                        .map(|tc| crate::protocols::spec::ToolCall {
+                                            id: tc.id,
+                                            tool_type: "function".to_string(),
+                                            function:
+                                                crate::protocols::spec::FunctionCallResponse {
+                                                    name: tc.function.name,
+                                                    arguments: Some(
+                                                        serde_json::to_string(
+                                                            &tc.function.arguments,
+                                                        )
+                                                        .unwrap_or_else(|_| "{}".to_string()),
+                                                    ),
+                                                },
+                                        })
+                                        .collect();
+                                    tool_calls = Some(spec_tool_calls);
+                                    processed_text = normal_text;
+                                }
+                            }
+                            Err(e) => {
+                                error!("Tool call parsing error: {}", e);
+                                // Continue without tool calls rather than failing
+                            }
+                        }
                     }
                 }
             }

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -1,5 +1,6 @@
 // gRPC Router Implementation
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -21,7 +21,7 @@ use crate::protocols::spec::ChatMessage;
 use crate::protocols::spec::{
     ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse,
     CompletionRequest, EmbeddingRequest, GenerateRequest, RerankRequest, ResponsesGetParams,
-    ResponsesRequest, StringOrArray, Tool, ToolChoice, Usage,
+    ResponsesRequest, StringOrArray, Tool, ToolChoice, ToolChoiceValue, Usage,
 };
 use crate::reasoning_parser::ParserFactory;
 use crate::routers::RouterTrait;
@@ -31,7 +31,8 @@ use crate::tokenizer::stop::{SequenceDecoderOutput, StopSequenceDecoderBuilder};
 use crate::tokenizer::traits::Tokenizer;
 use crate::tokenizer::HuggingFaceTokenizer;
 use crate::tool_parser::ParserRegistry;
-use serde_json::Value;
+use serde_json::{json, Map, Value};
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio_stream::StreamExt;
 use uuid::Uuid;
@@ -508,8 +509,6 @@ impl GrpcRouter {
         tool_choice: &Option<ToolChoice>,
         _model: &str,
     ) -> Option<(String, String)> {
-        use crate::protocols::spec::ToolChoiceValue;
-
         let choice = tool_choice.as_ref()?;
 
         match choice {
@@ -554,9 +553,6 @@ impl GrpcRouter {
     /// Build JSON schema for required tool calls (array with minItems: 1)
     /// Includes $defs consolidation from all tools (matching Python's behavior)
     fn build_required_array_schema(&self, tools: &[Tool]) -> Option<String> {
-        use serde_json::{json, Map, Value};
-        use std::collections::HashMap;
-
         // Build anyOf schemas for each tool
         let mut any_of_schemas = Vec::new();
         for tool in tools {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Add full support for tool_choice options in the gRPC router's OpenAI-compatible interface to enable fine-grained control over tool calling behavior:

- `tool_choice: "required"` - Force model to call one or more tools
- `tool_choice: {"type": "function", "name": "X"}` - Force model to call a specific tool
- `tool_choice: {"type": "allowed_tools", "mode": "auto|required", "tools": [...]}` - Restrict model to subset of tools (useful for prompt caching)

This implements the same behavior as the Python serving implementation via JSON Schema constraints.


## Modifications

### Protocol Changes `(src/protocols/spec.rs)`:

- Added `AllowedTools` variant to `ToolChoice` enum with mode ("auto"|"required") and tools fields
- Added `ToolReference` struct for specifying allowed tools by name

### Router Implementation `(src/routers/grpc/router.rs)`:

- Added tool filtering logic to pre-filter available tools based on tool_choice (only clones body when needed)
- Implemented `generate_tool_constraints()` to create JSON Schema constraints:
  - Specific function: Returns parameters schema directly (simpler than Python - no array wrapper)
  - Required mode: Returns array schema with minItems: 1 and anyOf for all tools
  - AllowedTools with mode: "required": Same as required mode but with filtered tools
- Added `build_required_array_schema()` with `$defs` consolidation (merges JSON Schema definitions from all tools with conflict detection)
- Implemented post-processing for constrained outputs:
  - Specific function: Wraps parameters into ToolCall with known function name
  - Required/AllowedTools: Parses array of {name, parameters} objects into ToolCall format
- Added `detect_format()` check before invoking model-specific parsers for non-constrained cases


## Complete Behavior Matrix

  | tool_choice                                   | Tools in Prompt | JSON Schema        | Parser         |
  |-----------------------------------------------|-----------------|--------------------|----------------|
  | "auto"                                        | All             | None               | Model-specific |
  | "required"                                    | All             | Array (minItems:1) | JSON direct    |
  | {"type": "function", "name": "X"}             | Only X          | Parameters only    | JSON direct    |
  | {"type": "allowed_tools", "mode": "auto"}     | Filtered        | None               | Model-specific |
  | {"type": "allowed_tools", "mode": "required"} | Filtered        | Array (minItems:1) | JSON direct    |


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
