### PR TITLE
[Bug Fix] Fix Error When Returning Abort Request Without Logp Value

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1515,12 +1515,13 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             return
 
         if len(recv_obj.input_token_logprobs_val) > 0:
-            state.input_token_logprobs_val.extend(
-                recv_obj.input_token_logprobs_val[recv_obj_index]
-            )
-            state.input_token_logprobs_idx.extend(
-                recv_obj.input_token_logprobs_idx[recv_obj_index]
-            )
+            if recv_obj.input_token_logprobs_val[recv_obj_index]:
+                state.input_token_logprobs_val.extend(
+                    recv_obj.input_token_logprobs_val[recv_obj_index]
+                )
+                state.input_token_logprobs_idx.extend(
+                    recv_obj.input_token_logprobs_idx[recv_obj_index]
+                )
         state.output_token_logprobs_val.extend(
             recv_obj.output_token_logprobs_val[recv_obj_index]
         )
@@ -1732,14 +1733,24 @@ class TokenizerManager(TokenizerCommunicatorMixin):
         state.finished = True
         if recv_obj.finished_reason:
             out = {
+                "text": "",
+                "output_ids": [],
                 "meta_info": {
                     "id": recv_obj.rid,
                     "finish_reason": recv_obj.finished_reason,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "model_version": self.server_args.weight_version,
+                    "cached_tokens": 0,
+                    "e2e_latency": 0,
+                    "output_token_logprobs": [[]],
+                    "input_token_logprobs": [[]],
                 },
             }
         else:
             out = {
                 "text": "",
+                "output_ids": [],
                 "meta_info": {
                     "id": origin_rid,
                     "finish_reason": {
@@ -1748,6 +1759,11 @@ class TokenizerManager(TokenizerCommunicatorMixin):
                     },
                     "prompt_tokens": 0,
                     "completion_tokens": 0,
+                    "model_version": self.server_args.weight_version,
+                    "cached_tokens": 0,
+                    "e2e_latency": 0,
+                    "output_token_logprobs": [[]],
+                    "input_token_logprobs": [[]],
                 },
             }
         state.out_list.append(out)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This pull request addresses the issue of errors occurring when an abort request is returned without a logp value.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Added a logp key to the abort request output.
2. Implemented a check for the presence of the logp key before returning the output.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
No additional checks are required as this fix does not affect the model outputs.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
No impact on inference speed, so benchmarking and profiling are not needed.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
