### PR TITLE
Allow use of TRTLLM_MHA backend for hybrid attention on Blackwell

### DIFF
--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -178,7 +178,8 @@ def attn_backend_wrapper(runner, full_attn_backend):
         if is_blackwell():
             assert (
                 runner.server_args.attention_backend == "triton"
-            ), "triton backend is the only supported backend on Blackwell GPUs for hybrid GDN models, use --attention-backend triton to specify the backend."
+                or runner.server_args.attention_backend == "trtllm_mha"
+            ), "triton or trtllm_mha backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend triton or --attention-backend trtllm_mha to specify the backend."
         if is_npu():
             assert (
                 runner.server_args.attention_backend == "ascend"

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1615,7 +1615,7 @@ class ModelRunner:
                 )
             elif self.is_hybrid_gdn:
                 self.token_to_kv_pool = HybridLinearKVPool(
-                    page_size=self.page_size if _is_npu else 1,
+                    page_size=self.page_size,
                     size=self.max_total_num_tokens,
                     dtype=self.kv_cache_dtype,
                     head_num=self.model_config.get_num_kv_heads(


### PR DESCRIPTION
Allows use of "trtllm_mha" attention backend for hybrid attention e.g. Qwen3 Next.

## Motivation

TRTLLM_MHA kernels exist in SGLang but could not be used in hybrid attention.

## Modifications

Modifies assertion to reflect that the new kernels can be used, and fixes a bug where page size was erroneously set to 1 instead of the value passed to the attention operator.

## Accuracy Tests

See comparison to Triton backend, below. Model is Qwen3-Next.

Triton

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9606|±  |0.0054|
|     |       |strict-match    |     8|exact_match|↑  |0.8461|±  |0.0099|


TRTLLM_MHA

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     8|exact_match|↑  |0.9621|±  |0.0053|
|     |       |strict-match    |     8|exact_match|↑  |0.8438|±  |0.0100|

## Benchmarking and Profiling

Tested Qwen3-Next on 4x B200. TP = EP = 4, ISL = OSL = 1024. Random dataset.

### Triton

| Concurrency | Mean TPOT (ms) | Output Token Throughput (tok / s) | Output Token / user / s | Output Token / GPU / s |
| ----------- | -------------- | --------------------------------- | ----------------------- | ---------------------- |
| 1           | 5.79           | 170.34                            | 172.7115717             | 42.585                 |
| 4           | 6.78           | 576.35                            | 147.4926254             | 144.0875               |
| 16          | 8.16           | 1891.02                           | 122.5490196             | 472.755                |
| 64          | 11.38          | 5243.1                            | 87.87346221             | 1310.775               |
| 256         | 20.74          | 11217.77                          | 48.21600771             | 2804.4425              |
| 1024        | 47.32          | 18919.49                          | 21.13271344             | 4729.8725              |

### TRTLLM MHA

| Concurrency | Mean TPOT (ms) | Output Token Throughput (tok / s) | Output Token / user / s | Output Token / GPU / s |
| ----------- | -------------- | --------------------------------- | ----------------------- | ---------------------- |
| 1           | 5.57           | 176.49                            | 179.533214              | 44.1225                |
| 4           | 6.46           | 603.87                            | 154.798762              | 150.9675               |
| 16          | 7.82           | 1925.89                           | 127.877238              | 481.4725               |
| 64          | 11.28          | 4817.91                           | 88.6524823              | 1204.4775              |
| 256         | 19.83          | 11550.72                          | 50.4286435              | 2887.68                |
| 1024        | 44.29          | 20113.63                          | 22.5784601              | 5028.4075              |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
