### PR TITLE
[router] Add multi-turn tool calling loop support for MCP integration

### DIFF
--- a/sgl-router/src/protocols/spec.rs
+++ b/sgl-router/src/protocols/spec.rs
@@ -723,7 +723,10 @@ pub enum ResponseToolType {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResponseReasoningParam {
     #[serde(default = "default_reasoning_effort")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ReasoningSummary>,
 }
 
 fn default_reasoning_effort() -> Option<ReasoningEffort> {
@@ -736,6 +739,14 @@ pub enum ReasoningEffort {
     Low,
     Medium,
     High,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningSummary {
+    Auto,
+    Concise,
+    Detailed,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -1261,12 +1261,6 @@ impl OpenAIRouter {
             "role": "user",
             "content": args.original_body.input.clone()
         });
-        // temp system message since currently only support 1 turn of mcp function call
-        let system_item = serde_json::json!({
-            "type": "message",
-            "role": "system",
-            "content": "please resume with the following tool result, and answer user's question directly, don't trigger any more tool calls"
-        });
 
         let func_item = serde_json::json!({
             "type": "function_call",
@@ -1283,7 +1277,7 @@ impl OpenAIRouter {
 
         obj.insert(
             "input".to_string(),
-            Value::Array(vec![user_item, system_item, func_item, tool_item]),
+            Value::Array(vec![user_item, func_item, tool_item]),
         );
 
         // Ensure non-streaming and no store to upstream

--- a/sgl-router/src/routers/http/openai_router.rs
+++ b/sgl-router/src/routers/http/openai_router.rs
@@ -1168,7 +1168,7 @@ impl OpenAIRouter {
         server_label: &str,
     ) -> Vec<Value> {
         let mut mcp_call_items = Vec::new();
-        
+
         for item in conversation_history {
             if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
                 let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
@@ -1208,7 +1208,7 @@ impl OpenAIRouter {
                 mcp_call_items.push(mcp_call_item);
             }
         }
-        
+
         mcp_call_items
     }
 
@@ -1271,11 +1271,9 @@ impl OpenAIRouter {
                 output_array.insert(0, list_tools_item);
 
                 // Add mcp_call items for executed calls using helper
-                let executed_items = Self::build_executed_mcp_call_items(
-                    &state.conversation_history,
-                    server_label,
-                );
-                
+                let executed_items =
+                    Self::build_executed_mcp_call_items(&state.conversation_history, server_label);
+
                 let mut insert_pos = 1;
                 for item in executed_items {
                     output_array.insert(insert_pos, item);
@@ -1377,18 +1375,24 @@ impl OpenAIRouter {
                     Some(user_max) => user_max.min(config.max_iterations),
                     None => config.max_iterations,
                 };
-                
+
                 if state.total_calls > effective_limit {
                     if let Some(user_max) = max_tool_calls {
                         if state.total_calls > user_max {
                             warn!("Reached user-specified max_tool_calls limit: {}", user_max);
                         } else {
-                            warn!("Reached safety max_iterations limit: {}", config.max_iterations);
+                            warn!(
+                                "Reached safety max_iterations limit: {}",
+                                config.max_iterations
+                            );
                         }
                     } else {
-                        warn!("Reached safety max_iterations limit: {}", config.max_iterations);
+                        warn!(
+                            "Reached safety max_iterations limit: {}",
+                            config.max_iterations
+                        );
                     }
-                    
+
                     return Self::build_incomplete_response(
                         response_json,
                         state,

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -559,24 +559,36 @@ async fn test_multi_turn_loop_with_mcp() {
     let response = router.route_responses(None, &req, None).await;
 
     // Check status
-    assert_eq!(response.status(), axum::http::StatusCode::OK, "Request should succeed");
-    
+    assert_eq!(
+        response.status(),
+        axum::http::StatusCode::OK,
+        "Request should succeed"
+    );
+
     // Read the response body
     use axum::body::to_bytes;
     let response_body = response.into_body();
     let body_bytes = to_bytes(response_body, usize::MAX).await.unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
-    println!("Multi-turn response: {}", serde_json::to_string_pretty(&response_json).unwrap());
+    println!(
+        "Multi-turn response: {}",
+        serde_json::to_string_pretty(&response_json).unwrap()
+    );
 
     // Verify the response structure
     assert_eq!(response_json["object"], "response");
     assert_eq!(response_json["status"], "completed");
     // Note: mock worker generates its own ID, so we just verify it exists
-    assert!(response_json["id"].is_string(), "Response should have an id");
+    assert!(
+        response_json["id"].is_string(),
+        "Response should have an id"
+    );
 
     // Check that output contains final message
-    let output = response_json["output"].as_array().expect("output should be array");
+    let output = response_json["output"]
+        .as_array()
+        .expect("output should be array");
     assert!(!output.is_empty(), "output should not be empty");
 
     // Find the final message with text
@@ -602,7 +614,9 @@ async fn test_multi_turn_loop_with_mcp() {
     assert!(has_final_text, "Should have final text output");
 
     // Verify tools are masked back to MCP format
-    let tools = response_json["tools"].as_array().expect("tools should be array");
+    let tools = response_json["tools"]
+        .as_array()
+        .expect("tools should be array");
     assert_eq!(tools.len(), 1);
     assert_eq!(tools[0]["type"], "mcp");
     assert_eq!(tools[0]["server_label"], "mock");
@@ -718,27 +732,32 @@ async fn test_max_tool_calls_limit() {
 
     let response = router.route_responses(None, &req, None).await;
     assert_eq!(response.status(), axum::http::StatusCode::OK);
-    
+
     use axum::body::to_bytes;
     let response_body = response.into_body();
     let body_bytes = to_bytes(response_body, usize::MAX).await.unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
-    println!("Max calls response: {}", serde_json::to_string_pretty(&response_json).unwrap());
+    println!(
+        "Max calls response: {}",
+        serde_json::to_string_pretty(&response_json).unwrap()
+    );
 
     // With max_tool_calls=1, the mock returns a final answer after 1 call
     // So it completes normally without exceeding the limit
     assert_eq!(response_json["status"], "completed");
-    
+
     // Verify the basic response structure
     assert!(response_json["id"].is_string());
     assert_eq!(response_json["object"], "response");
-    
+
     // The response should have tools masked back to MCP format
-    let tools = response_json["tools"].as_array().expect("tools should be array");
+    let tools = response_json["tools"]
+        .as_array()
+        .expect("tools should be array");
     assert_eq!(tools.len(), 1);
     assert_eq!(tools[0]["type"], "mcp");
-    
+
     // Note: To test actual limit exceeding, we would need a mock that keeps
     // calling tools indefinitely, which would hit max_iterations (safety limit)
 

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -252,6 +252,7 @@ fn test_responses_request_creation() {
         previous_response_id: None,
         reasoning: Some(ResponseReasoningParam {
             effort: Some(ReasoningEffort::Medium),
+            summary: None,
         }),
         service_tier: ServiceTier::Auto,
         store: true,
@@ -380,6 +381,7 @@ fn test_usage_conversion() {
 fn test_reasoning_param_default() {
     let param = ResponseReasoningParam {
         effort: Some(ReasoningEffort::Medium),
+        summary: None,
     };
 
     let json = serde_json::to_string(&param).unwrap();
@@ -403,6 +405,7 @@ fn test_json_serialization() {
         previous_response_id: None,
         reasoning: Some(ResponseReasoningParam {
             effort: Some(ReasoningEffort::High),
+            summary: None,
         }),
         service_tier: ServiceTier::Priority,
         store: false,
@@ -436,4 +439,310 @@ fn test_json_serialization() {
     assert!(parsed.background);
     assert!(parsed.stream);
     assert_eq!(parsed.tools.len(), 1);
+}
+
+#[tokio::test]
+async fn test_multi_turn_loop_with_mcp() {
+    // This test verifies the multi-turn loop functionality:
+    // 1. Initial request with MCP tools
+    // 2. Mock worker returns function_call
+    // 3. Router executes MCP tool and resumes
+    // 4. Mock worker returns final answer
+    // 5. Verify the complete flow worked
+
+    // Start mock MCP server
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    // Write a temp MCP config file
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+    std::env::set_var("SGLANG_MCP_CONFIG", cfg_path.to_str().unwrap());
+
+    // Start mock OpenAI worker
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    // Build router config
+    let router_cfg = RouterConfig {
+        mode: RoutingMode::OpenAI {
+            worker_urls: vec![worker_url],
+        },
+        connection_mode: ConnectionMode::Http,
+        policy: PolicyConfig::Random,
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        max_payload_size: 8 * 1024 * 1024,
+        request_timeout_secs: 60,
+        worker_startup_timeout_secs: 5,
+        worker_startup_check_interval_secs: 1,
+        dp_aware: false,
+        api_key: None,
+        discovery: None,
+        metrics: None,
+        log_dir: None,
+        log_level: Some("info".to_string()),
+        request_id_headers: None,
+        max_concurrent_requests: 32,
+        queue_size: 0,
+        queue_timeout_secs: 5,
+        rate_limit_tokens_per_second: None,
+        cors_allowed_origins: vec![],
+        retry: RetryConfig::default(),
+        circuit_breaker: CircuitBreakerConfig::default(),
+        disable_retries: false,
+        disable_circuit_breaker: false,
+        health_check: HealthCheckConfig::default(),
+        enable_igw: false,
+        model_path: None,
+        tokenizer_path: None,
+        history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+        oracle: None,
+    };
+
+    let ctx = AppContext::new(router_cfg, reqwest::Client::new(), 64, None).expect("ctx");
+    let router = RouterFactory::create_router(&Arc::new(ctx))
+        .await
+        .expect("router");
+
+    // Build request with MCP tools
+    let req = ResponsesRequest {
+        background: false,
+        include: None,
+        input: ResponseInput::Text("search for SGLang".to_string()),
+        instructions: Some("Be helpful".to_string()),
+        max_output_tokens: Some(128),
+        max_tool_calls: None, // No limit - test unlimited
+        metadata: None,
+        model: Some("mock-model".to_string()),
+        parallel_tool_calls: true,
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: ServiceTier::Auto,
+        store: true,
+        stream: false,
+        temperature: Some(0.7),
+        tool_choice: ToolChoice::Value(ToolChoiceValue::Auto),
+        tools: vec![ResponseTool {
+            r#type: ResponseToolType::Mcp,
+            server_url: Some(mcp.url()),
+            server_label: Some("mock".to_string()),
+            server_description: Some("Mock MCP server for testing".to_string()),
+            require_approval: Some("never".to_string()),
+            ..Default::default()
+        }],
+        top_logprobs: 0,
+        top_p: Some(1.0),
+        truncation: Truncation::Disabled,
+        user: None,
+        request_id: "resp_multi_turn_test".to_string(),
+        priority: 0,
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+        stop: None,
+        top_k: 50,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+    };
+
+    // Execute the request (this should trigger the multi-turn loop)
+    let response = router.route_responses(None, &req, None).await;
+
+    // Check status
+    assert_eq!(response.status(), axum::http::StatusCode::OK, "Request should succeed");
+    
+    // Read the response body
+    use axum::body::to_bytes;
+    let response_body = response.into_body();
+    let body_bytes = to_bytes(response_body, usize::MAX).await.unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    println!("Multi-turn response: {}", serde_json::to_string_pretty(&response_json).unwrap());
+
+    // Verify the response structure
+    assert_eq!(response_json["object"], "response");
+    assert_eq!(response_json["status"], "completed");
+    // Note: mock worker generates its own ID, so we just verify it exists
+    assert!(response_json["id"].is_string(), "Response should have an id");
+
+    // Check that output contains final message
+    let output = response_json["output"].as_array().expect("output should be array");
+    assert!(!output.is_empty(), "output should not be empty");
+
+    // Find the final message with text
+    let has_final_text = output.iter().any(|item| {
+        item.get("type")
+            .and_then(|t| t.as_str())
+            .map(|t| t == "message")
+            .unwrap_or(false)
+            && item
+                .get("content")
+                .and_then(|c| c.as_array())
+                .map(|arr| {
+                    arr.iter().any(|part| {
+                        part.get("type")
+                            .and_then(|t| t.as_str())
+                            .map(|t| t == "output_text")
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+    });
+
+    assert!(has_final_text, "Should have final text output");
+
+    // Verify tools are masked back to MCP format
+    let tools = response_json["tools"].as_array().expect("tools should be array");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["type"], "mcp");
+    assert_eq!(tools[0]["server_label"], "mock");
+
+    // Clean up
+    std::env::remove_var("SGLANG_MCP_CONFIG");
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_max_tool_calls_limit() {
+    // This test verifies that max_tool_calls is respected
+    // Note: The mock worker returns a final answer after one tool call,
+    // so with max_tool_calls=1, it completes normally (doesn't exceed the limit)
+
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+    std::env::set_var("SGLANG_MCP_CONFIG", cfg_path.to_str().unwrap());
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig {
+        mode: RoutingMode::OpenAI {
+            worker_urls: vec![worker_url],
+        },
+        connection_mode: ConnectionMode::Http,
+        policy: PolicyConfig::Random,
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        max_payload_size: 8 * 1024 * 1024,
+        request_timeout_secs: 60,
+        worker_startup_timeout_secs: 5,
+        worker_startup_check_interval_secs: 1,
+        dp_aware: false,
+        api_key: None,
+        discovery: None,
+        metrics: None,
+        log_dir: None,
+        log_level: Some("info".to_string()),
+        request_id_headers: None,
+        max_concurrent_requests: 32,
+        queue_size: 0,
+        queue_timeout_secs: 5,
+        rate_limit_tokens_per_second: None,
+        cors_allowed_origins: vec![],
+        retry: RetryConfig::default(),
+        circuit_breaker: CircuitBreakerConfig::default(),
+        disable_retries: false,
+        disable_circuit_breaker: false,
+        health_check: HealthCheckConfig::default(),
+        enable_igw: false,
+        model_path: None,
+        tokenizer_path: None,
+        history_backend: sglang_router_rs::config::HistoryBackend::Memory,
+        oracle: None,
+    };
+
+    let ctx = AppContext::new(router_cfg, reqwest::Client::new(), 64, None).expect("ctx");
+    let router = RouterFactory::create_router(&Arc::new(ctx))
+        .await
+        .expect("router");
+
+    let req = ResponsesRequest {
+        background: false,
+        include: None,
+        input: ResponseInput::Text("test max calls".to_string()),
+        instructions: None,
+        max_output_tokens: Some(128),
+        max_tool_calls: Some(1), // Limit to 1 call
+        metadata: None,
+        model: Some("mock-model".to_string()),
+        parallel_tool_calls: true,
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: ServiceTier::Auto,
+        store: false,
+        stream: false,
+        temperature: Some(0.7),
+        tool_choice: ToolChoice::Value(ToolChoiceValue::Auto),
+        tools: vec![ResponseTool {
+            r#type: ResponseToolType::Mcp,
+            server_url: Some(mcp.url()),
+            server_label: Some("mock".to_string()),
+            ..Default::default()
+        }],
+        top_logprobs: 0,
+        top_p: Some(1.0),
+        truncation: Truncation::Disabled,
+        user: None,
+        request_id: "resp_max_calls_test".to_string(),
+        priority: 0,
+        frequency_penalty: 0.0,
+        presence_penalty: 0.0,
+        stop: None,
+        top_k: 50,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+    };
+
+    let response = router.route_responses(None, &req, None).await;
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    
+    use axum::body::to_bytes;
+    let response_body = response.into_body();
+    let body_bytes = to_bytes(response_body, usize::MAX).await.unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    println!("Max calls response: {}", serde_json::to_string_pretty(&response_json).unwrap());
+
+    // With max_tool_calls=1, the mock returns a final answer after 1 call
+    // So it completes normally without exceeding the limit
+    assert_eq!(response_json["status"], "completed");
+    
+    // Verify the basic response structure
+    assert!(response_json["id"].is_string());
+    assert_eq!(response_json["object"], "response");
+    
+    // The response should have tools masked back to MCP format
+    let tools = response_json["tools"].as_array().expect("tools should be array");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0]["type"], "mcp");
+    
+    // Note: To test actual limit exceeding, we would need a mock that keeps
+    // calling tools indefinitely, which would hit max_iterations (safety limit)
+
+    std::env::remove_var("SGLANG_MCP_CONFIG");
+    worker.stop().await;
+    mcp.stop().await;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
- Support multi-turn tool calling loop 
- Return incomplete message if it hits max_tool_calls limits
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
1. **`McpLoopConfig`** - Internal config struct with `max_iterations: 10` safety limit and per-tool timeout
2. **`ToolLoopState`** - State tracking for loop iterations, total calls, and conversation history
3. **`execute_tool_loop()`** - Main loop orchestrator that:
   - Makes upstream model calls with accumulated conversation history
   - Detects and executes function calls via MCP
   - Enforces `max_tool_calls` (user-specified) and `max_iterations` (safety) limits
   - Returns when model provides final answer or limit is hit
4. **`build_resume_payload()`** - Constructs payloads with complete conversation history (`function_call` + `function_call_output` pairs)
5. **`build_incomplete_response()`** - Formats responses when limits exceeded:
   - Sets `status: "completed"` with `incomplete_details`
   - Converts unexecuted `function_call` → `mcp_call` (marked as not executed)
   - Adds MCP metadata for transparency
<!-- Detail the changes made in this pull request. -->

## Tests
Success case:
log:
```
2025-10-01 17:42:21  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb"}: sglang_router_rs::routers::http::openai_router: src/routers/http/openai_router.rs:1326: Starting tool loop: max_tool_calls=Some(3), max_iterations=10
2025-10-01 17:42:39  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb"}: sglang_router_rs::routers::http::openai_router: src/routers/http/openai_router.rs:1363: Tool loop iteration 1: calling brave_web_search (call_id: call_OLTwznXR7VKc1bAX1kG5uqbI)
2025-10-01 17:42:45  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb"}: sglang_router_rs::routers::http::openai_router: src/routers/http/openai_router.rs:1363: Tool loop iteration 2: calling brave_web_search (call_id: call_NTP60bSD2rD9uOew2j41wDDa)
2025-10-01 17:42:57  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb"}: sglang_router_rs::routers::http::openai_router: src/routers/http/openai_router.rs:1418: Tool loop completed: 2 iterations, 2 total calls
2025-10-01 17:42:57  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb"}: sglang_router_rs::data_connector::response_memory_store: src/data_connector/response_memory_store.rs:77: memory_store_size=5
2025-10-01 17:42:57  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb"}: sglang_router_rs::routers::http::openai_router: src/routers/http/openai_router.rs:756: Stored response locally response_id=resp_0ebc878abc137aae0168dd681625408195b9ce53d76dd04981
2025-10-01 17:42:57  INFO http_request{method=POST uri=/v1/responses version=HTTP/1.1 request_id="req-IUyFh6ha3trrAbAfxQ9waFnb" status_code=200 latency="43.549636421s"}: sglang_router_rs::response: src/middleware.rs:259: finished processing request
```
response:
```
{
    "id": "resp_0ebc878abc137aae0168dd681625408195b9ce53d76dd04981",
    "object": "response",
    "created_at": 1759340566,
    "status": "completed",
    "background": false,
    "billing": {
        "payer": "developer"
    },
    "error": null,
    "incomplete_details": null,
    "instructions": null,
    "max_output_tokens": null,
    "max_tool_calls": 3,
    "model": "gpt-5-nano-2025-08-07",
    "output": [
        {
            "id": "mcpl_59b3925e8aa5d22e82cc0d3c06a8dfa01ceacb52ad8da27e1a9d3e58d3fa",
            "type": "mcp_list_tools",
            "server_label": "brave",
            "tools": [
                {
                    "name": "brave_web_search",
                    "description": "Performs a web search using the Brave Search API, ideal for general queries, news, articles, and online content. Use this for broad information gathering, recent events, or when you need diverse web sources. Supports pagination, content filtering, and freshness controls. Maximum 20 results per request, with offset for pagination. ",
                    "input_schema": {
                        "type": "object",
                        "properties": {
                            "query": {
                                "type": "string",
                                "description": "Search query (max 400 chars, 50 words)"
                            },
                            "count": {
                                "type": "number",
                                "description": "Number of results (1-20, default 10)",
                                "default": 10
                            },
                            "offset": {
                                "type": "number",
                                "description": "Pagination offset (max 9, default 0)",
                                "default": 0
                            }
                        },
                        "required": [
                            "query"
                        ]
                    },
                    "annotations": {
                        "read_only": false
                    }
                },
                {
                    "name": "brave_local_search",
                    "description": "Searches for local businesses and places using Brave's Local Search API. Best for queries related to physical locations, businesses, restaurants, services, etc. Returns detailed information including:\n- Business names and addresses\n- Ratings and review counts\n- Phone numbers and opening hours\nUse this when the query implies 'near me' or mentions specific locations. Automatically falls back to web search if no local results are found.",
                    "input_schema": {
                        "type": "object",
                        "properties": {
                            "query": {
                                "type": "string",
                                "description": "Local search query (e.g. 'pizza near Central Park')"
                            },
                            "count": {
                                "type": "number",
                                "description": "Number of results (1-20, default 5)",
                                "default": 5
                            }
                        },
                        "required": [
                            "query"
                        ]
                    },
                    "annotations": {
                        "read_only": false
                    }
                }
            ]
        },
        {
            "id": "mcp_9d4066526a4ad429880b6def061b52ba9ec138a8ab5d0f06e029df9c2c61",
            "type": "mcp_call",
            "status": "completed",
            "approval_request_id": null,
            "arguments": "{\"query\":\"ORCL historical data 2025-09-22 Yahoo Finance\", \"count\": 5, \"offset\": 0}",
            "error": null,
            "name": "brave_web_search",
            "output": "{\"content\":[{\"type\":\"text\",\"text\":\"Title: Oracle Corporation (ORCL) *****\"}],\"isError\":false}",
            "server_label": "brave"
        },
        {
            "id": "mcp_fab3064b13a0afee2da7e9dc47ec1925969c6efaa28ecf6fd72c7909cbc5",
            "type": "mcp_call",
            "status": "completed",
            "approval_request_id": null,
            "arguments": "{\"query\":\"ORCL history 2025-09-22 Yahoo Finance\", \"count\": 5, \"offset\": 0}",
            "error": null,
            "name": "brave_web_search",
            "output": "{\"content\":[{\"type\":\"text\",\"text\":\"Title: Oracle Corporation (ORCL) *****\"}],\"isError\":false}",
            "server_label": "brave"
        },
        {
            "id": "rs_0ebc878abc137aae0168dd6816caa0819598c90840389b4d5f",
            "type": "reasoning",
            "summary": []
        },
        {
            "id": "msg_0ebc878abc137aae0168dd6820b2908195b91558796105ef9a",
            "type": "message",
            "status": "completed",
            "content": [
                {
                    "type": "output_text",
                    "annotations": [],
                    "logprobs": [],
                    "text": "I pulled up Yahoo Finance pages related to ORCL historical data. Here are the relevant links:\n\n- Oracle Corporation (ORCL) historical data (NYSE): https://finance.yahoo.com/quote/ORCL/history/\n- Oracle Corporation (ORCL.SN) historical data (ADR in Switzerland): https://finance.yahoo.com/quote/ORCL.SN/history/\n- Oracle Corporation (ORCL.BA) historical data (ADR in Argentina): https://finance.yahoo.com/quote/ORCL.BA/history/\n- Related Yahoo Finance news item (about Oracle): https://finance.yahoo.com/news/oracle-orcl-initiated-sell-rothschild-052501702.html\n\nWould you like me to fetch the exact OHLC data for 2025-09-22 (Open, High, Low, Close, Volume) from the main ORCL history page and present it here? If you meant a different symbol (ORCL.SN or ORCL.BA), tell me which one to pull. I can also show you how to download the data as CSV if you prefer."
                }
            ],
            "role": "assistant"
        }
    ],
    "parallel_tool_calls": true,
    "previous_response_id": null,
    "prompt_cache_key": null,
    "reasoning": {
        "effort": "medium",
        "summary": null
    },
    "safety_identifier": null,
    "service_tier": "default",
    "store": false,
    "temperature": 1.0,
    "text": {
        "format": {
            "type": "text"
        },
        "verbosity": "medium"
    },
    "tool_choice": "auto",
    "tools": [
        {
            "type": "mcp",
            "server_label": "brave",
            "server_url": "http://localhost:8001/sse",
            "server_description": "A Tool to do web serch",
            "require_approval": "never"
        }
    ],
    "top_logprobs": 0,
    "top_p": 1.0,
    "truncation": "disabled",
    "usage": {
        "input_tokens": 1348,
        "input_tokens_details": {
            "cached_tokens": 0
        },
        "output_tokens": 1569,
        "output_tokens_details": {
            "reasoning_tokens": 1344
        },
        "total_tokens": 2917
    },
    "user": null,
    "metadata": {}
}
```

Hit the max_tool_calls limit case
```
{
    "id": "resp_04bd2ed45e7751bb0168dd628c998c81939de1dca8db3265e6",
    "object": "response",
    "created_at": 1759339148,
    "status": "completed",
    "background": false,
    "billing": {
        "payer": "developer"
    },
    "error": null,
    "incomplete_details": {
        "reason": "max_tool_calls"
    },
    "instructions": null,
    "max_output_tokens": null,
    "max_tool_calls": 3,
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
