### PR TITLE
[Bugfix][AMD] Fix memory access fault and update document

### DIFF
--- a/docs/platforms/amd_gpu.md
+++ b/docs/platforms/amd_gpu.md
@@ -54,7 +54,7 @@ python setup_rocm.py install
 
 # Install sglang python package
 cd ../python
-rm -r pyproject.toml && mv pyproject_other.toml pyproject.toml
+rm -f pyproject.toml && mv pyproject_other.toml pyproject.toml
 cd ..
 pip install -e "python[all_hip]"
 ```

--- a/docs/platforms/amd_gpu.md
+++ b/docs/platforms/amd_gpu.md
@@ -53,6 +53,8 @@ cd sgl-kernel
 python setup_rocm.py install
 
 # Install sglang python package
+cd ../python
+rm -rf pyproject.toml && mv pyproject_other.toml pyproject.toml
 cd ..
 pip install -e "python[all_hip]"
 ```

--- a/docs/platforms/amd_gpu.md
+++ b/docs/platforms/amd_gpu.md
@@ -54,7 +54,7 @@ python setup_rocm.py install
 
 # Install sglang python package
 cd ../python
-rm -rf pyproject.toml && mv pyproject_other.toml pyproject.toml
+rm -r pyproject.toml && mv pyproject_other.toml pyproject.toml
 cd ..
 pip install -e "python[all_hip]"
 ```

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -824,13 +824,12 @@ class FusedMoE(torch.nn.Module):
                 if _use_aiter:
                     # NOTE: Aiter's fused_moe does not support '-1' value which is broadly used to represent the invalid expert id.
                     # If '-1' is given to gpu kernel, it may cause memory access fault.
-                    if TopKOutputChecker.format_is_standard(topk_output):
-                        new_topk_ids = torch.where(
-                            topk_output.topk_ids == -1,
-                            self.num_local_experts,
-                            topk_output.topk_ids,
-                        )
-                        topk_output = topk_output._replace(topk_ids=new_topk_ids)
+                    new_topk_ids = torch.where(
+                        topk_output.topk_ids == -1,
+                        self.num_local_experts,
+                        topk_output.topk_ids,
+                    )
+                    topk_output = topk_output._replace(topk_ids=new_topk_ids)
 
             elif TopKOutputChecker.format_is_triton_kernel(topk_output):
                 raise NotImplementedError()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -820,19 +820,20 @@ class FusedMoE(torch.nn.Module):
                 topk_output = topk_output._replace(
                     topk_ids=self.expert_map_gpu[topk_output.topk_ids]
                 )
+
+                if _use_aiter:
+                    # NOTE: Aiter's fused_moe does not support '-1' value which is broadly used to represent the invalid expert id.
+                    # If '-1' is given to gpu kernel, it may cause memory access fault.
+                    if TopKOutputChecker.format_is_standard(topk_output):
+                        new_topk_ids = torch.where(
+                            topk_output.topk_ids == -1,
+                            self.num_local_experts,
+                            topk_output.topk_ids,
+                        )
+                        topk_output = topk_output._replace(topk_ids=new_topk_ids)
+
             elif TopKOutputChecker.format_is_triton_kernel(topk_output):
                 raise NotImplementedError()
-
-        if _use_aiter:
-            # NOTE: Aiter's fused_moe does not support '-1' value which is broadly used to represent the invalid expert id.
-            # If '-1' is given to gpu kernel, it may cause memory access fault.
-            if TopKOutputChecker.format_is_standard(topk_output):
-                new_topk_ids = torch.where(
-                    topk_output.topk_ids == -1,
-                    self.num_local_experts,
-                    topk_output.topk_ids,
-                )
-                topk_output = topk_output._replace(topk_ids=new_topk_ids)
 
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -56,7 +56,7 @@ if is_flashinfer_available():
 _is_hip = is_hip()
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
-
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 # Try to import FP4 TRTLLM function if flashinfer is available
 trtllm_fp4_block_scale_moe = None
@@ -822,6 +822,14 @@ class FusedMoE(torch.nn.Module):
                 )
             elif TopKOutputChecker.format_is_triton_kernel(topk_output):
                 raise NotImplementedError()
+
+        if _use_aiter:
+            # NOTE: Aiter's fused_moe does not support '-1' value which is broadly used to represent the invalid expert id.
+            # If '-1' is given to gpu kernel, it may cause memory access fault.
+            if TopKOutputChecker.format_is_standard(topk_output):
+                temp_topk_ids = topk_output.topk_ids
+                temp_topk_ids[temp_topk_ids == -1] = self.num_local_experts
+                topk_output = topk_output._replace(topk_ids=temp_topk_ids)
 
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output


### PR DESCRIPTION
Co-authored-by: HakJu Kim <hakju.kim@moreh.io>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
This PR is for bugfix and doc update. 
* Fixing memory access fault issue reported at #10195 .
* Following current `docs/platforms/amd_gpu.md` document causes installing unintended dependencies such as `nvidia-cuda-runtime-cu12-12.8.90` package due to out-dated guide. (Related PR: #10465)

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
There are two modifications.
1. Filter and change the value of topk_ids in `forward()` function of `FusedMoE` class, `-1` to self.local_num_experts`.
2. Update the install guide for AMD devices to represent current file structure.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Modification of topk_ids could make correctness issue so we tried accuracy test.
```
# python3 ./few_shot_gsm8k.py --num-questions 200
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 9.31MB/s]
100%|████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:39<00:00,  5.11it/s]
Accuracy: 0.970
Invalid: 0.000
Latency: 53.490 s
Output throughput: 342.343 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
This PR is not about speed-up or profiling features.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
