### PR TITLE
Remove unused pack `.item()` in paged allocator.

### DIFF
--- a/python/sglang/srt/utils.py
+++ b/python/sglang/srt/utils.py
@@ -3265,13 +3265,8 @@ def get_num_new_pages(
     num_pages_after = (seq_lens + page_size - 1) // page_size
     num_pages_before = (prefix_lens + page_size - 1) // page_size
     num_new_pages = num_pages_after - num_pages_before
-    extend_lens = seq_lens - prefix_lens
     sum_num_new_pages = torch.sum(num_new_pages).to(torch.int64)
-    if decode:
-        return sum_num_new_pages.item()
-    merged_value = (sum_num_new_pages) << 32 | torch.sum(extend_lens).to(torch.int64)
-
-    return merged_value.item() >> 32
+    return sum_num_new_pages.item()
 
 
 class CachedKernel:


### PR DESCRIPTION
This PR removes the merged value in paged allocator

https://github.com/sgl-project/sglang/blob/c76040e31b90a9a7515b56a7165fe9e17fb3afd0/python/sglang/srt/mem_cache/paged_allocator.py#L221-L222

which seems the `sum_extend_lens` is never used after `.item()` from the triton kernel.