### PR TITLE
perf: cache kernel launch of static w8a8 quant

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -26,6 +26,7 @@ import triton.language as tl
 from sglang.srt.layers.quantization import deep_gemm_wrapper
 from sglang.srt.utils import (
     align,
+    cached_triton_kernel,
     direct_register_custom_op,
     get_bool_env_var,
     get_device_core_count,
@@ -562,6 +563,7 @@ def sglang_per_token_quant_fp8(
     return x_q, x_s
 
 
+@cached_triton_kernel(lambda _, kwargs: (kwargs["BLOCK"], kwargs["REPEAT_SCALE"]))
 @triton.jit
 def _static_quant_fp8(
     # Pointers to inputs and output

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3323,6 +3323,7 @@ class CachedKernel:
             else:
                 # Use cached kernel
                 all_args = self._build_args(args, kwargs)
+                # Do not forward non-parameter kwargs (e.g., num_warps/num_stages) to compiled kernels
                 cached_kernel[grid](*all_args)
                 return cached_kernel
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

We can cache the result of triton kernel launch config for w8a8, as to avoid repeated launch overhead.
> Generally I think we can probably improve the performance further through adding sgl-kernel impl but it is TBD.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Before:
<img width="2978" height="1582" alt="image" src="https://github.com/user-attachments/assets/b38a96b9-4360-4198-9fd4-d2da2166b26a" />
After:
<img width="2458" height="1228" alt="image" src="https://github.com/user-attachments/assets/467c0c89-bec7-4993-abbc-cac223a9c76e" />

The actual time taken in the CUDA stream stays the same.
<img width="2330" height="244" alt="image" src="https://github.com/user-attachments/assets/2c12f023-2e71-40d3-a94b-84d482979f1d" />
<img width="2318" height="302" alt="image" src="https://github.com/user-attachments/assets/0234a21e-3725-42dc-924c-99c468e4a684" />

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Before:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:12<00:00, 104.27it/s]
Accuracy: 0.793
Invalid: 0.002
Latency: 12.702 s
Output throughput: 10511.778 token/s
```
After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:12<00:00, 103.70it/s]
Accuracy: 0.792
Invalid: 0.001
Latency: 12.754 s
Output throughput: 10522.233 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
```
python -m sglang.bench_serving --backend sglang --dataset-name random --random-input-len 3500 --random-output-len 1500 --request-rate 8 --num-prompts 64 --random-range-ratio 1
```
```
python3 -m sglang.launch_server --model-path amd/Llama-3.1-8B-Instruct-FP8-KV
# MI355X result
before:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  22.38     
Total input tokens:                      224000    
Total generated tokens:                  96000     
Total generated tokens (retokenized):    95988     
Request throughput (req/s):              2.86      
Input token throughput (tok/s):          10008.07  
Output token throughput (tok/s):         4289.17   
Total token throughput (tok/s):          14297.25  
Concurrency:                             48.03     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16796.05  
Median E2E Latency (ms):                 16961.21  
---------------Time to First Token----------------
Mean TTFT (ms):                          80.21     
Median TTFT (ms):                        74.02     
P99 TTFT (ms):                           140.78    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           11.15     
Median ITL (ms):                         11.44     
P95 ITL (ms):                            12.17     
P99 ITL (ms):                            40.12     
Max ITL (ms):                            260.93    
==================================================

after:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  22.39     
Total input tokens:                      224000    
Total generated tokens:                  96000     
Total generated tokens (retokenized):    95988     
Request throughput (req/s):              2.86      
Input token throughput (tok/s):          10004.84  
Output token throughput (tok/s):         4287.79   
Total token throughput (tok/s):          14292.63  
Concurrency:                             47.98     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16786.30  
Median E2E Latency (ms):                 16951.78  
---------------Time to First Token----------------
Mean TTFT (ms):                          78.33     
Median TTFT (ms):                        73.87     
P99 TTFT (ms):                           140.08    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           11.15     
Median ITL (ms):                         11.45     
P95 ITL (ms):                            12.20     
P99 ITL (ms):                            35.60     
Max ITL (ms):                            266.40    
==================================================
```
```
python3 -m sglang.launch_server  --model-path nvidia/Llama-3.1-8B-Instruct-FP8
# H200 result
before:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  26.15     
Total input tokens:                      224000    
Total generated tokens:                  96000     
Total generated tokens (retokenized):    95994     
Request throughput (req/s):              2.45      
Input token throughput (tok/s):          8566.48   
Output token throughput (tok/s):         3671.35   
Total token throughput (tok/s):          12237.83  
Concurrency:                             51.54     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   21057.42  
Median E2E Latency (ms):                 21355.01  
---------------Time to First Token----------------
Mean TTFT (ms):                          137.11    
Median TTFT (ms):                        125.78    
P99 TTFT (ms):                           276.95    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           13.96     
Median ITL (ms):                         13.40     
P95 ITL (ms):                            15.10     
P99 ITL (ms):                            57.91     
Max ITL (ms):                            571.13    
==================================================

after:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    8.0       
Max request concurrency:                 not set   
Successful requests:                     64        
Benchmark duration (s):                  26.09     
Total input tokens:                      224000    
Total generated tokens:                  96000     
Total generated tokens (retokenized):    95990     
Request throughput (req/s):              2.45      
Input token throughput (tok/s):          8584.18   
Output token throughput (tok/s):         3678.94   
Total token throughput (tok/s):          12263.12  
Concurrency:                             51.52     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   21005.54  
Median E2E Latency (ms):                 21304.98  
---------------Time to First Token----------------
Mean TTFT (ms):                          131.62    
Median TTFT (ms):                        118.47    
P99 TTFT (ms):                           268.24    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           13.93     
Median ITL (ms):                         13.33     
P95 ITL (ms):                            14.84     
P99 ITL (ms):                            59.32     
Max ITL (ms):                            563.21    
==================================================
```

Caching reduced the TTFT by ~2.5% on MI355X and ~4% on H200

## Checklist

- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
