### PR TITLE
Analysis for priority scheduler performance and efficiency 

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -887,6 +887,7 @@ def get_benchmark_args(
         prompt_suffix="",
         device=device,
         pd_separated=pd_separated,
+        priorities=None,
     )
 
 

--- a/test/srt/test_priority_scheduling_perf.py
+++ b/test/srt/test_priority_scheduling_perf.py
@@ -1,0 +1,346 @@
+import copy
+import json
+import random
+import unittest
+
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    get_benchmark_args,
+    run_bench_serving_multi,
+)
+
+class TestPrioritySchedulingPerf(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_priority_scheduling_perf(self):
+        # run_traffic_based_benchmark(MAX_CONCURRENCY_MODE)
+        run_traffic_based_benchmark(FIXED_QPS_MODE)
+        run_traffic_based_benchmark_with_preemption(MAX_CONCURRENCY_MODE)
+
+def run_traffic_based_benchmark_with_preemption(mode: int):
+    # 1. Build test configs
+    bench_args = []
+    bench_args_with_priority = []
+    max_concurrency_or_fixed_qps = [2**i for i in range(7)]
+    # We want to use the same distribution of priorities and ordering across different tests.
+    prioritiy_distribution_base = [1] * 5 + [2] * 5 + [3] * 5
+    random.shuffle(prioritiy_distribution_base)
+
+    # Preemption debug - start
+    prioritiy_distribution_base = [1] * 5 + [2] * 5 + [3] * 5
+    # Preemption debug - end
+
+
+    for c_or_qps in max_concurrency_or_fixed_qps:
+        num_prompts = 15 * c_or_qps
+        request_rate = 2 * c_or_qps
+        if mode == FIXED_QPS_MODE:
+            # Send the load for 60 seconds 
+            num_prompts = 60 * c_or_qps
+            request_rate = c_or_qps            
+        priorities = prioritiy_distribution_base * c_or_qps
+        bench_arg = get_benchmark_args(
+            base_url="http://localhost:30000",
+            dataset_name="random",
+            tokenizer="openai/gpt-oss-120b",
+            num_prompts=num_prompts,
+            sharegpt_output_len=None,
+            random_input_len=1024,
+            random_output_len=512,
+            request_rate=request_rate,
+        )
+        bench_arg.model = "openai/gpt-oss-120b"
+        bench_arg.backend = "sglang-oai-chat"
+        bench_arg.max_concurrency = c_or_qps
+
+        bench_args.append(bench_arg)
+
+        bench_arg_with_priority = copy.deepcopy(bench_arg)
+        bench_arg_with_priority.priorities = priorities
+        bench_args_with_priority.append(bench_arg_with_priority)
+    
+    # Preemption debug - start
+    bench_args_with_priority = bench_args_with_priority[3:]
+    # Preemption debug - end
+    
+    # Test setting dictionary that combines test setting name, corresponding server config, benchmark arguments and metadata.
+    tests = {
+        "priority-scheduling-with-preemption": {
+            "other_server_args": [
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--max-running-requests",
+                "8",
+                "--enable-priority-scheduling",
+                "--priority-scheduling-preemption-threshold",
+                "1"
+            ],
+            "bench_args": bench_args_with_priority,
+            "use_priority": True,
+        },
+        "default": {
+            "other_server_args": [
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--max-running-requests",
+                "8",
+            ],
+            "bench_args": bench_args,
+            "use_priority": False,
+        },
+        "priority-scheduling": {
+            "other_server_args": [
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--max-running-requests",
+                "8",
+                "--enable-priority-scheduling",
+                "--priority_scheduling_preemption_threshold",
+                "1"
+            ],
+            "bench_args": bench_args_with_priority,
+            "use_priority": True,
+        },
+    }
+
+    # 2. Run Tests
+    benchmark_metric_collection = dict()
+    for server_setting_name, cfg in tests.items():
+        benchmark_metric_collection[server_setting_name] = dict()
+        results = run_bench_serving_multi(
+            model="openai/gpt-oss-120b",
+            base_url="http://localhost:30000",
+            other_server_args=cfg["other_server_args"],
+            benchmark_args=cfg["bench_args"],
+        )
+        if cfg["use_priority"]:
+            for c_or_qps, result in zip(max_concurrency_or_fixed_qps, results):
+                _, metric = result
+                benchmark_metric_collection[server_setting_name][str(c_or_qps)] = metric
+        else:
+            for c_or_qps, result in zip(max_concurrency_or_fixed_qps, results):
+                _, metric = result
+                # this is to have uniform metric data format
+                benchmark_metric_collection[server_setting_name][str(c_or_qps)] = dict()
+                benchmark_metric_collection[server_setting_name][str(c_or_qps)]["all"] = metric
+
+    # 3. Print results
+    for c_or_qps in max_concurrency_or_fixed_qps:
+        if mode == MAX_CONCURRENCY_MODE:
+            print(f"\nConcurrency: {c_or_qps}")
+        elif mode == FIXED_QPS_MODE:
+            print(f"\nQPS: {c_or_qps}")
+        header = (
+            f"{'Setting':<{40}} "
+            f"{'Priority':<{10}} "
+            f"{'Median TTFT (ms)':<{20}} "
+            f"{'Median TPOT (ms)':<{20}} "
+            f"{'Median E2E Latency (ms)':<{20}} "
+            f"{'Completed':>{10}}"
+        )
+        dashed_line = "-" * len(header)
+        print(header)
+        print(dashed_line)
+
+        for i, setting_name in enumerate(tests.keys()):
+            metric = benchmark_metric_collection[setting_name][str(c_or_qps)]["all"]
+
+            # Print the main row for the setting
+            print(
+                f"{setting_name:<{40}} "
+                f"{'Overall':<{10}} "
+                f"{metric['median_ttft_ms']:<{20}.2f} "
+                f"{metric['median_tpot_ms']:<{20}.2f} "
+                f"{metric['median_e2e_latency_ms']:<{20}.2f} "
+                f"{metric['completed']:>{10}}"
+            )
+
+            # Print per-priority metrics if they exist
+            if setting_name != "default":
+                for p in sorted(set(prioritiy_distribution_base)):
+                    metric = benchmark_metric_collection[setting_name][str(c_or_qps)][p]
+                    print(
+                        f"{'':<{40}} "
+                        f"{p:<{10}} "
+                        f"{metric['median_ttft_ms']:<{20}.2f} "
+                        f"{metric['median_tpot_ms']:<{20}.2f} "
+                        f"{metric['median_e2e_latency_ms']:<{20}.2f} "
+                        f"{metric['completed']:>{10}}"
+                    )
+
+            if i < len(tests) - 1:
+                print(dashed_line)
+
+    # save the data.
+    with open("preemption_fixed_concurrency_bench_result_" + str(mode) + ".json" , "w") as f:
+        json.dump(benchmark_metric_collection, f, indent=4)
+
+
+def run_traffic_based_benchmark(mode: int):
+    # 1. Build test configs
+    bench_args = []
+    bench_args_with_priority = []
+    max_concurrency_or_fixed_qps = [2**i for i in range(7)]
+    # We want to use the same distribution of priorities and ordering across different tests.
+    prioritiy_distribution_base = [1] * 5 + [2] * 5 + [3] * 5
+    random.shuffle(prioritiy_distribution_base)
+    for c_or_qps in max_concurrency_or_fixed_qps:
+        num_prompts = 15 * c_or_qps
+        request_rate = 2 * c_or_qps
+        if mode == FIXED_QPS_MODE:
+            # Send the load for 60 seconds 
+            num_prompts = 60 * c_or_qps
+            request_rate = c_or_qps            
+        priorities = prioritiy_distribution_base * c_or_qps
+        bench_arg = get_benchmark_args(
+            base_url="http://localhost:30000",
+            dataset_name="random",
+            tokenizer="openai/gpt-oss-120b",
+            num_prompts=num_prompts,
+            sharegpt_output_len=None,
+            random_input_len=1024,
+            random_output_len=512,
+            request_rate=request_rate,
+        )
+        bench_arg.model = "openai/gpt-oss-120b"
+        bench_arg.backend = "sglang-oai-chat"
+        bench_arg.max_concurrency = c_or_qps
+
+        bench_args.append(bench_arg)
+
+        bench_arg_with_priority = copy.deepcopy(bench_arg)
+        bench_arg_with_priority.priorities = priorities
+        bench_args_with_priority.append(bench_arg_with_priority)
+    # Test setting dictionary that combines test setting name, corresponding server config, benchmark arguments and metadata.
+    tests = {
+        "default": {
+            "other_server_args": [
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--max-running-requests",
+                "8",
+            ],
+            "bench_args": bench_args,
+            "use_priority": False,
+        },
+        "priority-scheduling": {
+            "other_server_args": [
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--max-running-requests",
+                "8",
+                "--enable-priority-scheduling",
+            ],
+            "bench_args": bench_args_with_priority,
+            "use_priority": True,
+        },
+        "priority-scheduling-low-value-first": {
+            "other_server_args": [
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--max-running-requests",
+                "8",
+                "--enable-priority-scheduling",
+                "--schedule-low-priority-values-first",
+            ],
+            "bench_args": bench_args_with_priority,
+            "use_priority": True,
+        },
+    }
+
+    # 2. Run Tests
+    benchmark_metric_collection = dict()
+    for server_setting_name, cfg in tests.items():
+        benchmark_metric_collection[server_setting_name] = dict()
+        results = run_bench_serving_multi(
+            model="openai/gpt-oss-120b",
+            base_url="http://localhost:30000",
+            other_server_args=cfg["other_server_args"],
+            benchmark_args=cfg["bench_args"],
+        )
+        if cfg["use_priority"]:
+            for c_or_qps, result in zip(max_concurrency_or_fixed_qps, results):
+                _, metric = result
+                benchmark_metric_collection[server_setting_name][str(c_or_qps)] = metric
+        else:
+            for c_or_qps, result in zip(max_concurrency_or_fixed_qps, results):
+                _, metric = result
+                # this is to have uniform metric data format
+                benchmark_metric_collection[server_setting_name][str(c_or_qps)] = dict()
+                benchmark_metric_collection[server_setting_name][str(c_or_qps)]["all"] = metric
+
+    # 3. Print results
+    for c_or_qps in max_concurrency_or_fixed_qps:
+        if mode == MAX_CONCURRENCY_MODE:
+            print(f"\nConcurrency: {c_or_qps}")
+        elif mode == FIXED_QPS_MODE:
+            print(f"\nQPS: {c_or_qps}")
+        header = (
+            f"{'Setting':<{40}} "
+            f"{'Priority':<{10}} "
+            f"{'Median TTFT (ms)':<{20}} "
+            f"{'Median TPOT (ms)':<{20}} "
+            f"{'Median E2E Latency (ms)':<{20}} "
+            f"{'Completed':>{10}}"
+        )
+        dashed_line = "-" * len(header)
+        print(header)
+        print(dashed_line)
+
+        for i, setting_name in enumerate(tests.keys()):
+            metric = benchmark_metric_collection[setting_name][str(c_or_qps)]["all"]
+
+            # Print the main row for the setting
+            print(
+                f"{setting_name:<{40}} "
+                f"{'Overall':<{10}} "
+                f"{metric['median_ttft_ms']:<{20}.2f} "
+                f"{metric['median_tpot_ms']:<{20}.2f} "
+                f"{metric['median_e2e_latency_ms']:<{20}.2f} "
+                f"{metric['completed']:>{10}}"
+            )
+
+            # Print per-priority metrics if they exist
+            if setting_name != "default":
+                for p in sorted(set(prioritiy_distribution_base)):
+                    metric = benchmark_metric_collection[setting_name][str(c_or_qps)][p]
+                    print(
+                        f"{'':<{40}} "
+                        f"{p:<{10}} "
+                        f"{metric['median_ttft_ms']:<{20}.2f} "
+                        f"{metric['median_tpot_ms']:<{20}.2f} "
+                        f"{metric['median_e2e_latency_ms']:<{20}.2f} "
+                        f"{metric['completed']:>{10}}"
+                    )
+
+            if i < len(tests) - 1:
+                print(dashed_line)
+
+    # save the data.
+    with open("fixed_concurrency_bench_result_" + str(mode) + ".json" , "w") as f:
+        json.dump(benchmark_metric_collection, f, indent=4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
We want to run and analyze benchmarks for priority scheduler based on different traffic scenarios. Specifically, we will  confirm that a) the scheduling overhead is minimal and b) priority scheduler prioritizes traffics in intended manner for both default (higher values first) and low priority values first mode.

## Modifications
* Tooling and refactoring for serving benchmark. 
* Adding additional CI tests for priority scheduler

## Benchmarking and Profiling
In this issue, we will focus on scheduling efficiency and traffic management related tests; we plan to have a separate profiling study on preemption cost. 

### Fixed Concurrency Test
#### Notes
* We are using a 8xH100 machine and gpt-oss-120b in test runs.
* We ran three test settings of servers while fixing the max batch size to 8 (`--max-running-requests=8`). The three settings are FCFS scheduling, FCFS + priority scheduling, and FCFS + priority + low value first scheduling.
* In this test, we ran each of the test setting through fixed max_concurrency in [1, 2, 4, 8, 16, 32, 64] and collected metrics. For a given concurrency, number of prompts sent to each server config are same and requests' priority orderings are also  preserved. 
* The data presents median latency metrics for the test setting and concurrency combinations. For priority scheduling enabled settings, we show both aggregated ("Overall") and per-priority metrics. 
* In the fixed concurrency test, we will focus on analyzing TTFT. The queue size is limited as the concurrency was intentionally fixed, and the overhead from sorting a small queue is negligible.   


#### Analysis
* Below graphs show that the priority scheduler effectively prioritizes higher priority request's ttft when there are surplus of requests beyond the max batch size (that is specified with `--max-running-requests` or decided by runtime heuristic).  
* Users can use `--max-queued-requests` to drive down TTFT for lower priority requests
* Below data confirms that expected, functional behaviors that the priority scheduler is no-op when traffic_size < max_batch_size. In other words, there is no unexpected latency regression from the implementation. 

concurrency=8, so the requests are put on waiting queue then into a  batch, within the same scheduling cycle. 
<img width="855" height="547" alt="outputc=8" src="https://github.com/user-attachments/assets/87c79729-928b-4339-b470-31b12b05befc" />

concurrency=16, so there will be constantly ~8 requests in the waiting queue 
<img width="843" height="547" alt="outputc=16" src="https://github.com/user-attachments/assets/4407fb42-4276-4606-a2e9-9053d40f31ad" />


* Below data confirms that TPOT is maintained across priorities with or without priority scheduling when preemption is not used. This is expected as priority scheduling itself doesn't impact decoding speed.
```
Concurrency: 4
Setting                                  Priority   Median TTFT (ms)     Median TPOT (ms)     Median E2E Latency (ms)  Completed
--------------------------------------------------------------------------------------------------------------------------------
default                                  Overall    78.17                4.47                 895.75                       60
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling                      Overall    78.62                4.42                 915.56                       60
                                         1          78.75                4.34                 1168.67                      20
                                         2          78.82                4.50                 915.56                       20
                                         3          78.62                4.39                 822.07                       20
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling-low-value-first      Overall    78.20                4.39                 916.06                       60
                                         1          77.70                4.40                 1169.07                      20
                                         2          78.82                4.50                 916.06                       20
                                         3          78.67                4.23                 833.51                       20

Concurrency: 8
Setting                                  Priority   Median TTFT (ms)     Median TPOT (ms)     Median E2E Latency (ms)  Completed
--------------------------------------------------------------------------------------------------------------------------------
default                                  Overall    78.84                5.99                 1263.46                     120
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling                      Overall    79.62                5.94                 1270.33                     120
                                         1          79.67                5.90                 1690.02                      40
                                         2          79.44                5.85                 1355.37                      40
                                         3          79.62                6.15                 1153.81                      40
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling-low-value-first      Overall    78.59                5.98                 1263.43                     120
                                         1          79.02                5.95                 1680.14                      40
                                         2          78.28                5.92                 1334.70                      40
                                         3          78.60                6.04                 1154.54                      40

Concurrency: 16
Setting                                  Priority   Median TTFT (ms)     Median TPOT (ms)     Median E2E Latency (ms)  Completed
--------------------------------------------------------------------------------------------------------------------------------
default                                  Overall    1593.37              5.98                 2952.98                     240
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling                      Overall    326.09               5.92                 2444.15                     240
                                         1          4063.87              6.00                 5476.56                      80
                                         2          225.66               5.90                 1553.38                      80
                                         3          223.43               5.95                 1679.02                      80
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling-low-value-first      Overall    327.37               5.94                 2304.04                     240
                                         1          212.04               5.95                 1599.78                      80
                                         2          256.78               5.81                 1625.94                      80
                                         3          4187.68              5.95                 5534.59                      80

Concurrency: 32
Setting                                  Priority   Median TTFT (ms)     Median TPOT (ms)     Median E2E Latency (ms)  Completed
--------------------------------------------------------------------------------------------------------------------------------
default                                  Overall    5016.90              5.87                 6558.77                     480
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling                      Overall    378.80               5.88                 2677.56                     480
                                         1          14568.66             5.79                 16021.75                    160
                                         2          263.87               5.93                 1851.46                     160
                                         3          217.98               5.84                 1869.41                     160
--------------------------------------------------------------------------------------------------------------------------------
priority-scheduling-low-value-first      Overall    376.40               5.86                 2617.48                     480
                                         1          208.64               5.76                 1711.32                     160
                                         2          276.13               5.90                 1801.60                     160
                                         3          13928.32             5.90                 15700.93                    160

```
TODOs:
*  Profiling to understand compute cost of preemption
* Add the usage of throttling to drive down ttft - add metric collection for errored responses  in benchmark script
* (Optional) Add fixed QPS test run and result


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
