### PR TITLE
Allow larger max num dispatch tokens per rank for DeepEP

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -294,7 +294,8 @@ class _DeepEPDispatcherImplBase:
         # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=2048
         # and the logic requires num-tokens-sent-from-one-rank-to-another-rank less than it
         # related: https://github.com/deepseek-ai/DeepEP/pull/440
-        assert self.num_max_dispatch_tokens_per_rank <= 2048
+        DEEPEP_FINISHED_SUM_TAG = 2048
+        assert self.num_max_dispatch_tokens_per_rank <= DEEPEP_FINISHED_SUM_TAG
 
         self.handle = None
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -291,9 +291,10 @@ class _DeepEPDispatcherImplBase:
         self.num_max_dispatch_tokens_per_rank = get_int_env_var(
             "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 128
         )
-        # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=1024
+        # DeepEP internode_ll dispatch uses FINISHED_SUM_TAG=2048
         # and the logic requires num-tokens-sent-from-one-rank-to-another-rank less than it
-        assert self.num_max_dispatch_tokens_per_rank <= 1024
+        # related: https://github.com/deepseek-ai/DeepEP/pull/440
+        assert self.num_max_dispatch_tokens_per_rank <= 2048
 
         self.handle = None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

can only merge after https://github.com/deepseek-ai/DeepEP/pull/440 is merged

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34827559414](https://github.com/sgl-project/sglang/actions/runs/34827559414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34827559129](https://github.com/sgl-project/sglang/actions/runs/34827559129)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34827559614](https://github.com/sgl-project/sglang/actions/runs/34827559614)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->