### PR TITLE
fix self.enable_kv_cache_events

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -298,8 +298,8 @@ class Scheduler(
         self.enable_metrics_for_all_schedulers = (
             server_args.enable_metrics_for_all_schedulers
         )
-        self.enable_kv_cache_events = (
-            server_args.kv_events_config is not None and tp_rank == 0
+        self.enable_kv_cache_events = bool(
+            server_args.kv_events_config and tp_rank == 0
         )
         self.enable_trace = server_args.enable_trace
         self.stream_interval = server_args.stream_interval

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -298,7 +298,9 @@ class Scheduler(
         self.enable_metrics_for_all_schedulers = (
             server_args.enable_metrics_for_all_schedulers
         )
-        self.enable_kv_cache_events = server_args.kv_events_config and tp_rank == 0
+        self.enable_kv_cache_events = (
+            server_args.kv_events_config is not None and tp_rank == 0
+        )
         self.enable_trace = server_args.enable_trace
         self.stream_interval = server_args.stream_interval
         self.spec_algorithm = SpeculativeAlgorithm.from_string(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

`server_args.kv_events_config` defaults to None.
The original assignment:
`self.enable_kv_cache_events = server_args.kv_events_config and tp_rank == 0`
propagates None into `self.enable_kv_cache_events` when `kv_events_config` is None, because Python’s and returns the first falsy operand (None). This leads downstream to an assertion failure in `radix_cache_cpp.py:`
```python
assert (enable_kv_cache_events is False), "HiRadixCache does not support kv cache events yet"
```
Since `enable_kv_cache_events` was None (not False), the assertion triggers even though events were effectively “disabled”.

## Modifications
Make the intent explicit: only enable events when a config is provided and we’re on tp_rank == 0; otherwise set a strict boolean False.
```python
# Before
self.enable_kv_cache_events = server_args.kv_events_config and tp_rank == 0

# After
self.enable_kv_cache_events = (
    server_args.kv_events_config is not None and tp_rank == 0
)
```



## Accuracy Tests

No model logic changed; this is a control-flow/flag fix.
I print `self.enable_kv_cache_events ` before and after
before `self.enable_kv_cache_events`: None
after `self.enable_kv_cache_events`: False
## Benchmarking and Profiling

No runtime impact: single boolean expression change. No kernel or scheduling changes.

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
