### PR TITLE
[Bug fix] Internvl dynamic_preprocess unexpectedly generating many tiles.

### DIFF
--- a/python/sglang/srt/multimodal/processors/internvl.py
+++ b/python/sglang/srt/multimodal/processors/internvl.py
@@ -145,18 +145,19 @@ class InternVLImageProcessor(BaseMultimodalProcessor):
         # Find closest ratio
         best_ratio_diff = float("inf")
         best_ratio = (1, 1)
+        area = H * W
 
         for x, y in target_ratios:
             target_ar = x / y
             diff = abs(aspect_ratio - target_ar)
             blocks = x * y
-            best_blocks = best_ratio[0] * best_ratio[1]
 
             if diff < best_ratio_diff:
                 best_ratio_diff = diff
                 best_ratio = (x, y)
-            elif diff == best_ratio_diff and blocks > best_blocks:
-                best_ratio = (x, y)
+            elif diff == best_ratio_diff:
+                if area > 0.5 * image_size * image_size * x * y:
+                    best_ratio = (x, y)
 
         target_w, target_h = image_size * best_ratio[0], image_size * best_ratio[1]
         blocks = best_ratio[0] * best_ratio[1]


### PR DESCRIPTION

## Motivation

When using internvl3, I noticed an anomaly in the number of image tokens. The default tile size is 448*448. If I input a 448*448 image, theoretically, I'd only get one tile, resulting in 256 tokens.

However, in practice, a 448*448 image was processed into 10 tiles, resulting in over 2,000 tokens.

This is because the target_ratios selection in dynamic_preprocess only considers aspect ratio, not the difference between 1:1 and 3:3.

Here, I've adapted the original internvl implementation to fix this bug.

## Modifications

python/sglang/srt/multimodal/processors/internvl.py
Function dynamic_preprocess

Modify the target_ratios matching part to the logic implemented by internvl in huggingface to adapt it to the current code.

## Accuracy Tests


## Benchmarking and Profiling

Each input has only one 448*448 image, concurrency 32. Tested on H200

Before change: 10.18 request per second.
After change: 23.35 request per second.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
