### PR TITLE
[Fix] moe fused gate kernel race condition

### DIFF
--- a/sgl-kernel/csrc/moe/moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/moe_fused_gate.cu
@@ -215,6 +215,8 @@ __device__ void moe_fused_gate_impl(
       indices_ptr[idx] = static_cast<int32_t>(expert);
     }
 
+    __syncwarp();
+
     // accumulate sum for all elements
     if (thread_group_idx == 0) {
       output_sum += output_ptr[idx];


### PR DESCRIPTION

## Motivation

There was a race condition in the kernel `sgl-kernel/csrc/moe/moe_fused_gate.cu ` . The race condition was not always triggered but the tests failed couple times. The outputs were incorrect due to that and output sum was becoming zero causing the tensors to have inf and NaN outputs. 

## Modifications

I added a __syncwarp() to fix the issue.

It was setting the output sum to 0 during sum accumulation, and the output_ptr values were coming to be 0 too. The winner thread was writing to the global memory, and the thread with idx == 0 was reading before the winner was able to write.

## Accuracy Tests

## Benchmarking and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
