### PR TITLE
[AMD] Serialize cross-ProcessGroup collectives for dp_attention

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -154,6 +154,18 @@ def get_cuda_version():
     return (0, 0)
 
 
+def get_rocm_version():
+    """Return (major, minor) from torch.version.hip, tolerant of suffixes like '7.0.51831-abc'."""
+    s = getattr(torch.version, "hip", None)  # None on non-ROCm builds
+    if s:
+        nums = re.findall(r"\d+", s)  # e.g. ['7','0','51831']
+        if len(nums) >= 2:
+            return int(nums[0]), int(nums[1])
+        if len(nums) == 1:
+            return int(nums[0]), 0
+    return (0, 0)
+
+
 def _check(cc_major):
     if not is_cuda():
         return False

--- a/test/srt/models/test_vlm_models.py
+++ b/test/srt/models/test_vlm_models.py
@@ -27,8 +27,9 @@ MODELS = [
     SimpleNamespace(model="openbmb/MiniCPM-V-2_6", mmmu_accuracy=0.4),
 ]
 
-#Set default mem_fraction_static to 0.8
+# Set default mem_fraction_static to 0.8
 DEFAULT_MEM_FRACTION_STATIC = 0.8
+
 
 class TestVLMModels(CustomTestCase):
     parsed_args = None  # Class variable to store args
@@ -41,7 +42,9 @@ class TestVLMModels(CustomTestCase):
         cls.time_out = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
 
         if cls.parsed_args is None:
-            cls.parsed_args = SimpleNamespace(mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC)
+            cls.parsed_args = SimpleNamespace(
+                mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC
+            )
 
         # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
         os.environ["OPENAI_API_KEY"] = cls.api_key


### PR DESCRIPTION
Co-author: @kkHuang-amd 

## Motivation

We previously landed a workaround in https://github.com/sgl-project/sglang/pull/10434 that switched _dp_gather_via_all_gather to _dp_gather_via_all_reduce to avoid an RCCL/HIP failure when DP was enabled on dsv3. 

The root cause is stricter stream-capture checks in ROCm 7.0: chaining reduce_scatter_tensor on the attention TP process group immediately followed by all_gather_into_tensor on the TP process group inside a captured region can lead to `hipErrorCapturedEvent (“operation not permitted on an event last recorded in a capturing stream”)`. ROCm 7 updated event/callback behavior during capture (e.g., `hipEventQuery`, `hipStreamAddCallback`) to match CUDA, so any out-of-order polling or cross-stream/event use triggers an error (https://rocm.docs.amd.com/projects/HIP/en/docs-develop/hip-7-changes.html#stream-capture-updates). 

NCCL/RCCL collectives are capturable, but they require stable streams and explicit ordering; PyTorch also documents that when using multiple process groups, outstanding async ops on one PG must be synchronized before issuing collectives on another. 

This PR restores the all-gather path and makes it graph-safe by launching reduce_scatter_tensor(..., async_op=True) on the attention process group (from `get_attention_tp_group`), then calling work.wait() before invoking all_gather_into_tensor on the TP process group (from `get_tp_group`) (both on the same capturing stream). With TORCH_NCCL_BLOCKING_WAIT=1, the wait avoids host-side polling of captured events. This preserves the original RS→AG algorithm while complying with ROCm 7’s capture rules.

## Modifications


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

```
# Server command
python3 -m sglang.launch_server --model-path /data/deepseek-ai/DeepSeek-R1-0528 --tp 8 --trust-remote-code --chunked-prefill-size 131072 --dp-size 8 --enable-dp-attention --mem-fraction-static 0.85

# Client command
python3 benchmark/gsm8k/bench_sglang.py --parallel 1400 --num-questions 1400
---
Accuracy: 0.941
Invalid: 0.000
```
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

CC: @HaiShaw 
