### PR TITLE
[fix]missing prefix_lens_cpu init when p/d disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -523,10 +523,18 @@ class DecodePreallocQueue:
                     dtype=torch.int64,
                     device=self.token_to_kv_pool_allocator.device,
                 ),
+                prefix_lens_cpu=torch.tensor(
+                    [0],
+                    dtype=torch.int64,
+                ),
                 seq_lens=torch.tensor(
                     [num_tokens],
                     dtype=torch.int64,
                     device=self.token_to_kv_pool_allocator.device,
+                ),
+                seq_lens_cpu=torch.tensor(
+                    [num_tokens],
+                    dtype=torch.int64,
                 ),
                 last_loc=torch.tensor(
                     [-1],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
fix #10720 when p/d disaggregation

```
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 928, in process_decode_queue
    req_conns = self.disagg_decode_prealloc_queue.pop_preallocated()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 408, in pop_preallocated
    self._pre_alloc(decode_req.req)
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 520, in _pre_alloc
    kv_loc = self.token_to_kv_pool_allocator.alloc_extend(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PagedTokenToKVPoolAllocator.alloc_extend() missing 2 required positional arguments: 'prefix_lens_cpu' and 'seq_lens_cpu'

[2025-10-03 14:38:55 DP2 TP2 EP2] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 2882, in run_scheduler_process
    scheduler.event_loop_normal_disagg_decode()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 704, in event_loop_normal_disagg_decode
    self.process_decode_queue()
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 928, in process_decode_queue
    req_conns = self.disagg_decode_prealloc_queue.pop_preallocated()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 408, in pop_preallocated
    self._pre_alloc(decode_req.req)
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 520, in _pre_alloc
    kv_loc = self.token_to_kv_pool_allocator.alloc_extend(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PagedTokenToKVPoolAllocator.alloc_extend() missing 2 required positional arguments: 'prefix_lens_cpu' and 'seq_lens_cpu'

[2025-10-03 14:38:55 DP1 TP1 EP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/scheduler.py", line 2882, in run_scheduler_process
    scheduler.event_loop_normal_disagg_decode()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 704, in event_loop_normal_disagg_decode
    self.process_decode_queue()
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 928, in process_decode_queue
    req_conns = self.disagg_decode_prealloc_queue.pop_preallocated()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 408, in pop_preallocated
    self._pre_alloc(decode_req.req)
  File "/usr/local/lib/python3.12/dist-packages/sglang/srt/disaggregation/decode.py", line 520, in _pre_alloc
    kv_loc = self.token_to_kv_pool_allocator.alloc_extend(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PagedTokenToKVPoolAllocator.alloc_extend() missing 2 required positional arguments: 'prefix_lens_cpu' and 'seq_lens_cpu'
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
