### PR TITLE
[Fix] Add IPv6 support for worker URLs in sglang_router

### DIFF
--- a/sgl-router/src/routers/http/pd_types.rs
+++ b/sgl-router/src/routers/http/pd_types.rs
@@ -37,6 +37,16 @@ pub fn get_hostname(url: &str) -> String {
     let url = url
         .trim_start_matches("http://")
         .trim_start_matches("https://");
+
+    // Handle IPv6 addresses (e.g., [::1]:8000 or [fdbd:dccd:cdd2:2001::19d]:8000)
+    if let Some(start) = url.find('[') {
+        if let Some(end) = url.find(']') {
+            // Extract hostname between brackets
+            return url[start + 1..end].to_string();
+        }
+    }
+
+    // Handle IPv4 or hostname (e.g., localhost:8000 or 192.168.1.1:8000)
     url.split(':').next().unwrap_or("localhost").to_string()
 }
 

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -350,7 +350,9 @@ mod test_pd_routing {
             ("http://10.0.0.1:8080", "10.0.0.1"),
             ("https://api.example.com:443", "api.example.com"),
             ("http://prefill-server", "prefill-server"),
-            ("http://[::1]:8080", "["),  // IPv6 edge case
+            ("http://[::1]:8080", "::1"),  // IPv6 edge case (previously returned "[" - now fixed)
+            ("http://[fdbd:dccd:cdd2:2001::19d]:8000", "fdbd:dccd:cdd2:2001::19d"),  // IPv6 address
+            ("[2001:db8::1]:443", "2001:db8::1"),  // IPv6 without protocol
             ("prefill:8080", "prefill"), // No protocol
         ];
 

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -351,8 +351,6 @@ mod test_pd_routing {
             ("https://api.example.com:443", "api.example.com"),
             ("http://prefill-server", "prefill-server"),
             ("http://[::1]:8080", "::1"),  // IPv6 edge case (previously returned "[" - now fixed)
-            ("http://[fdbd:dccd:cdd2:2001::19d]:8000", "fdbd:dccd:cdd2:2001::19d"),  // IPv6 address
-            ("[2001:db8::1]:443", "2001:db8::1"),  // IPv6 without protocol
             ("prefill:8080", "prefill"), // No protocol
         ];
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fixes #11190. The `get_hostname()` function was using `split(':')` which incorrectly parsed IPv6 addresses containing multiple colons (e.g., `[fdbd:dccd:cdd2:2001::19d]:8000`), extracting only `"["` instead of the full hostname, causing the router to fail with invalid port errors.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
