### PR TITLE
Limit the multimodal media access to whitelist domain, blacklist domain, and prevent redirect as a configurable toggle option

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -177,6 +177,8 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--chat-template` | The buliltin chat template name or the path of the chat template file. This is only used for OpenAI-compatible API server. | None |
 | `--completion-template` | The buliltin completion template name or the path of the completion template file. This is only used for OpenAI-compatible API server. only for code completion currently. | None |
 | `--file-storage-path` | The path of the file storage in backend. | sglang_storage |
+| `--media-whitelisted-domains` | Restrict remote multimodal downloads to these domains (case-insensitive, subdomains allowed). | None |
+| `--media-blacklisted-domains` | Block remote multimodal downloads that resolve to these domains (case-insensitive, subdomains allowed). | None |
 | `--enable-cache-report` | Return number of cached tokens in usage.prompt_tokens_details for each openai request. | False |
 | `--reasoning-parser` | Specify the parser for reasoning models, supported parsers are: {list(ReasoningParser.DetectorMap.keys())}. | None |
 | `--tool-call-parser` | Specify the parser for handling tool-call interactions. Options include: 'qwen25', 'mistral', 'llama3', 'deepseekv3', 'pythonic', 'kimi_k2', 'qwen3_coder', 'glm45', and 'step3'. | None |

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -13,6 +13,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_PORT` | Port for the server | auto-detected |
 | `SGLANG_LOGGING_CONFIG_PATH` | Custom logging configuration path | Not set |
 | `SGLANG_DISABLE_REQUEST_LOGGING` | Disable request logging | `false` |
+| `SGLANG_MM_ALLOW_REDIRECTS` | Allow HTTP redirects when downloading multimodal assets | `true` |
 | `SGLANG_HEALTH_CHECK_TIMEOUT` | Timeout for health check in seconds | `20` |
 
 ## Performance Tuning

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -14,6 +14,8 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_LOGGING_CONFIG_PATH` | Custom logging configuration path | Not set |
 | `SGLANG_DISABLE_REQUEST_LOGGING` | Disable request logging | `false` |
 | `SGLANG_MM_ALLOW_REDIRECTS` | Allow HTTP redirects when downloading multimodal assets | `true` |
+| `SGLANG_MEDIA_WHITELISTED_DOMAINS` | JSON list of domains allowed for remote multimodal downloads; blocks all others | Not set |
+| `SGLANG_MEDIA_BLACKLISTED_DOMAINS` | JSON list of domains blocked for remote multimodal downloads | Not set |
 | `SGLANG_HEALTH_CHECK_TIMEOUT` | Timeout for health check in seconds | `20` |
 
 ## Performance Tuning

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -111,7 +111,6 @@ class Envs:
     # Model & File Download
     SGLANG_USE_MODELSCOPE = EnvBool(False)
 
-
     # Test & Debug
     SGLANG_IS_IN_CI = EnvBool(False)
     SGLANG_AMD_CI = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -111,6 +111,9 @@ class Envs:
     # Model & File Download
     SGLANG_USE_MODELSCOPE = EnvBool(False)
 
+    # MM URLs
+    SGLANG_MM_ALLOW_REDIRECTS = EnvBool(True)
+
     # Test & Debug
     SGLANG_IS_IN_CI = EnvBool(False)
     SGLANG_AMD_CI = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -111,8 +111,6 @@ class Envs:
     # Model & File Download
     SGLANG_USE_MODELSCOPE = EnvBool(False)
 
-    # MM URLs
-    SGLANG_MM_ALLOW_REDIRECTS = EnvBool(True)
 
     # Test & Debug
     SGLANG_IS_IN_CI = EnvBool(False)
@@ -209,6 +207,11 @@ class Envs:
     SGLANG_FLASHINFER_DECODE_SPLIT_TILE_SIZE = EnvInt(2048)
     SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE = EnvInt(4096)
     SGLANG_TRITON_DECODE_SPLIT_TILE_SIZE = EnvInt(256)
+
+    # Media
+    SGLANG_MEDIA_WHITELISTED_DOMAINS = EnvStr(None)
+    SGLANG_MEDIA_BLACKLISTED_DOMAINS = EnvStr(None)
+    SGLANG_MM_ALLOW_REDIRECTS = EnvBool(True)
 
     # fmt: on
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1170,15 +1170,15 @@ class ServerArgs:
 
     def _set_media_domain_env_vars(self):
         if self.media_whitelisted_domains:
-            envs.SGLANG_MEDIA_WHITELISTED_DOMAINS.get() = json.dumps(
-                self.media_whitelisted_domains
+            envs.SGLANG_MEDIA_WHITELISTED_DOMAINS.set(
+                json.dumps(self.media_whitelisted_domains)
             )
         else:
             envs.SGLANG_MEDIA_WHITELISTED_DOMAINS.clear()
 
         if self.media_blacklisted_domains:
-            envs.SGLANG_MEDIA_BLACKLISTED_DOMAINS.get() = json.dumps(
-                self.media_blacklisted_domains
+            envs.SGLANG_MEDIA_BLACKLISTED_DOMAINS.set(
+                json.dumps(self.media_blacklisted_domains)
             )
         else:
             envs.SGLANG_MEDIA_BLACKLISTED_DOMAINS.clear()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -23,6 +23,7 @@ import tempfile
 from typing import List, Literal, Optional, Union
 
 from sglang.srt.connector import ConnectorType
+from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.parser.reasoning_parser import ReasoningParser
@@ -1167,6 +1168,21 @@ class ServerArgs:
                 "Please choose one tokenizer batching approach."
             )
 
+    def _set_media_domain_env_vars(self):
+        if self.media_whitelisted_domains:
+            envs.SGLANG_MEDIA_WHITELISTED_DOMAINS.get() = json.dumps(
+                self.media_whitelisted_domains
+            )
+        else:
+            envs.SGLANG_MEDIA_WHITELISTED_DOMAINS.clear()
+
+        if self.media_blacklisted_domains:
+            envs.SGLANG_MEDIA_BLACKLISTED_DOMAINS.get() = json.dumps(
+                self.media_blacklisted_domains
+            )
+        else:
+            envs.SGLANG_MEDIA_BLACKLISTED_DOMAINS.clear()
+
     def _handle_environment_variables(self):
         os.environ["SGLANG_ENABLE_TORCH_COMPILE"] = (
             "1" if self.enable_torch_compile else "0"
@@ -1258,6 +1274,8 @@ class ServerArgs:
                     "The following domains are present in both --media-whitelisted-domains "
                     f"and --media-blacklisted-domains: {', '.join(sorted(overlap))}"
                 )
+
+        self._set_media_domain_env_vars()
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -71,6 +71,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import numpy as np
+import orjson
 import psutil
 import pybase64
 import requests
@@ -104,10 +105,10 @@ def _parse_media_domains(raw_value: Optional[str]) -> List[str]:
 
     parsed: List[str] = []
     try:
-        loaded = json.loads(raw_value)
+        loaded = orjson.loads(raw_value)
         if isinstance(loaded, list):
             parsed = [item for item in loaded if isinstance(item, str)]
-    except json.JSONDecodeError:
+    except orjson.JSONDecodeError:
         parsed = raw_value.split(",")
 
     if not parsed:


### PR DESCRIPTION
# Whitelist test 
launch
```
python -m sglang.launch_server --model-path unsloth/Qwen2.5-VL-3B-Instruct --host 0.0.0.0 --port 30000 --media-whitelisted-domains github.com
```

test:
```bash
curl http://localhost:30000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "unsloth/Qwen2.5-VL-3B-Instruct",
  "messages": [
    {"role": "user", "content": [
      {"type": "text", "text": "What is in this image?"},
      {"type": "image_url", "image_url": {"url": "https://raw.githubusercontent.com/sgl-project/sglang/main/assets/logo.png"}}
    ]}
  ],
  "max_tokens": 100
}'
```


fail:
```bash
curl http://localhost:30000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "unsloth/Qwen2.5-VL-3B-Instruct",
  "messages": [
    {"role": "user", "content": [
      {"type": "text", "text": "What is in this image?"},
      {"type": "image_url", "image_url": {"url": "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"}}
    ]}
  ],
  "max_tokens": 100
}'
```


# Blacklist
```bash
python -m sglang.launch_server --model-path unsloth/Qwen2.5-VL-3B-Instruct --host 0.0.0.0 --port 30000 --media-blacklisted-domains google.com
```

below fail
```bash
curl http://localhost:30000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "unsloth/Qwen2.5-VL-3B-Instruct",
  "messages": [
    {"role": "user", "content": [
      {"type": "text", "text": "What is in this image?"},
      {"type": "image_url", "image_url": {"url": "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"}}
    ]}
  ],
  "max_tokens": 100
}'
```

disable redirect
```bash
SGLANG_MM_ALLOW_REDIRECTS=0 python -m sglang.launch_server --model-path unsloth/Qwen2.5-VL-3B-Instruct --host 0.0.0.0 --port 30000
```

Post a request with a URL that redirects (should fail):
This request uses a URL from httpbin.org that is configured to redirect. Since redirects are disabled, the server should return an error.

```bash
curl http://localhost:30000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "unsloth/Qwen2.5-VL-3B-Instruct",
  "messages": [
    {"role": "user", "content": [
      {"type": "text", "text": "What is in this image?"},
      {"type": "image_url", "image_url": {"url": "http://httpbin.org/redirect-to?url=https://raw.githubusercontent.com/sgl-project/sglang/main/assets/logo.png"}}
    ]}
  ],
  "max_tokens": 100
}'
```


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
