### PR TITLE
[NVIDIA] Adding default args for DSR1 on Blackwell

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -775,6 +775,30 @@ class ServerArgs:
                 # use bf16 for mxfp4 triton kernels
                 self.dtype = "bfloat16"
 
+        elif model_arch == "DeepseekV3ForCausalLM":
+            # Enable optimizations for DeepSeek V3 on Blackwell
+            if is_sm100_supported():
+                # Set attention backend to trtllm_mla if not already set
+                if self.attention_backend is None:
+                    self.attention_backend = "trtllm_mla"
+                    logger.info(
+                        f"Set attention backend to trtllm_mla on sm100 for {model_arch}"
+                    )
+                
+                # Enable FlashInfer TRTLLM MoE
+                if not self.enable_flashinfer_trtllm_moe:
+                    self.enable_flashinfer_trtllm_moe = True
+                    logger.info(
+                        f"Enable FlashInfer TRTLLM MoE on sm100 for {model_arch}"
+                    )
+                
+                # Enable FlashInfer AllReduce Fusion
+                if not self.enable_dp_attention:
+                    self.enable_flashinfer_allreduce_fusion = True
+                    logger.info(
+                        f"Enable FlashInfer AllReduce Fusion on sm100 for {model_arch}"
+                    )
+
         elif "Llama4" in model_arch and self.device != "cpu":
             assert self.attention_backend in {
                 "fa3",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

Optimized performance on Blackwell is achieved with these defaults:
--enable-flashinfer-allreduce-fusion
--attention-backend=trtllm_mla
--enable-flashinfer-trtllm-moe
This change sets those as the default behaviors.

<!-- Describe the purpose and goals of this pull request. -->

Update server arguments to apply DSv3 default backends for attention, allreduce fusion, and MoE

<!-- Detail the changes made in this pull request. -->

N/A

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
