### PR TITLE
Fix LoRA support for multimodal models (VLMs) by implementing a consistent pattern for skipping vision components

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -420,15 +420,9 @@ class LoRAManager:
 
     def should_skip_lora_for_vision_model(self, module_name):
         # Skip vision/audio components for all multimodal models TODO: maybe need to support other multimodal models
-        vision_prefixes = [
-            "vision_model",
-            "vision_tower",
-            "multi_modal_projector",
-        ]
-        return any(
-            module_name.startswith(prefix) or f".{prefix}." in module_name
-            for prefix in vision_prefixes
-        )
+        vision_prefixes = {"vision_model", "vision_tower", "multi_modal_projector"}
+        module_parts = module_name.split(".")
+        return any(part in vision_prefixes for part in module_parts)
 
     def init_lora_modules(self):
         # Look-up table that essentially maps (layer_index, module_name) to the corresponding LoRA module.

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -419,8 +419,19 @@ class LoRAManager:
         return lora_module
 
     def should_skip_lora_for_vision_model(self, module_name):
-        # TODO: support different vision models
-        return module_name.find("vision_model.model") != -1
+        # Skip vision/audio components for all multimodal models
+        vision_prefixes = [
+            "vision_model",
+            "vision_tower",
+            "embed_vision",
+            "audio_tower",
+            "embed_audio",
+            "multi_modal_projector",
+        ]
+        return any(
+            module_name.startswith(prefix) or f".{prefix}." in module_name
+            for prefix in vision_prefixes
+        )
 
     def init_lora_modules(self):
         # Look-up table that essentially maps (layer_index, module_name) to the corresponding LoRA module.

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -419,13 +419,10 @@ class LoRAManager:
         return lora_module
 
     def should_skip_lora_for_vision_model(self, module_name):
-        # Skip vision/audio components for all multimodal models
+        # Skip vision/audio components for all multimodal models TODO: maybe need to support other multimodal models
         vision_prefixes = [
             "vision_model",
             "vision_tower",
-            "embed_vision",
-            "audio_tower",
-            "embed_audio",
             "multi_modal_projector",
         ]
         return any(

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -418,12 +418,6 @@ class LoRAManager:
         replace_submodule(self.base_model, module_name, lora_module)
         return lora_module
 
-    def should_skip_lora_for_vision_model(self, module_name):
-        # Skip vision/audio components for all multimodal models TODO: maybe need to support other multimodal models
-        vision_prefixes = {"vision_model", "vision_tower", "multi_modal_projector"}
-        module_parts = module_name.split(".")
-        return any(part in vision_prefixes for part in module_parts)
-
     def init_lora_modules(self):
         # Look-up table that essentially maps (layer_index, module_name) to the corresponding LoRA module.
         self.lora_modules: List[Dict[str, BaseLayerWithLoRA]] = [
@@ -439,10 +433,6 @@ class LoRAManager:
             if getattr(
                 self.base_model, "should_apply_lora", None
             ) and not self.base_model.should_apply_lora(module_name):
-                continue
-
-            # Skip vision model
-            if self.should_skip_lora_for_vision_model(module_name):
                 continue
 
             # The module should be converted if it is included in target_names

--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -16,6 +16,7 @@
 # https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/gemma3_mm.py
 
 import logging
+import re
 from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Set, Tuple, TypedDict
 
@@ -154,6 +155,10 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
     embedding_modules = {}
     embedding_padding_modules = []
     supports_lora = True
+    # Pattern to match language model layers only (skip vision_tower and multi_modal_projector)
+    lora_pattern = re.compile(
+        r"^language_model\.model\.layers\.(\d+)\.(?:self_attn|mlp)\.(?:qkv_proj|o_proj|down_proj|gate_up_proj)"
+    )
 
     def __init__(
         self,
@@ -386,6 +391,10 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
         )
 
         return hs
+
+    def should_apply_lora(self, module_name: str) -> bool:
+        """Skip vision tower and multi_modal_projector for LoRA."""
+        return bool(self.lora_pattern.match(module_name))
 
     def tie_weights(self):
         return self.language_model.tie_weights()

--- a/python/sglang/srt/models/gemma3_mm.py
+++ b/python/sglang/srt/models/gemma3_mm.py
@@ -165,6 +165,13 @@ class Gemma3ForConditionalGeneration(PreTrainedModel):
         self.config = config
         self.quant_config = quant_config
 
+        # For LoRA compatibility: expose text_config attributes at top level
+        # This allows LoRA code to work without special multimodal handling
+        if not hasattr(config, "num_hidden_layers"):
+            config.num_hidden_layers = config.text_config.num_hidden_layers
+        if not hasattr(config, "hidden_size"):
+            config.hidden_size = config.text_config.hidden_size
+
         self.vision_tower = SiglipVisionModel(
             config=config.vision_config,
             quant_config=quant_config,

--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -2,6 +2,7 @@ import json as json_lib
 import logging
 import math
 import os
+import re
 from collections.abc import Iterable
 from typing import List, Optional, Set, Tuple
 
@@ -422,6 +423,11 @@ class Llama4ForConditionalGeneration(nn.Module):
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
 
+    # Pattern to match language model layers only (skip vision_model and multi_modal_projector)
+    lora_pattern = re.compile(
+        r"^language_model\.model\.layers\.(\d+)\.(?:self_attn|mlp)\.(?:qkv_proj|o_proj|down_proj|gate_up_proj)"
+    )
+
     def __init__(
         self,
         config: Llama4Config,
@@ -543,6 +549,10 @@ class Llama4ForConditionalGeneration(nn.Module):
         projected_vision_flat = self.multi_modal_projector(vision_flat)
 
         return projected_vision_flat
+
+    def should_apply_lora(self, module_name: str) -> bool:
+        """Skip vision model and multi_modal_projector for LoRA."""
+        return bool(self.lora_pattern.match(module_name))
 
     def forward(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
1. LoRA initialization code expects `config.num_hidden_layers` and `config.hidden_size` at the top level of model config
2. For `Gemma3ForConditionalGeneration`, these attributes are nested under `config.text_config` (not at top level)
3. This caused: `AssertionError: LoRA buffer shape torch.Size([4096, 32]) does not match weight shape torch.Size([1728, 32])`
4. Vision/projector modules were being incorrectly included in LoRA initialization


## Modifications

1. **`gemma3_mm.py`** - Add LoRA support with config attribute exposure
2. **`mllama4.py`** - Add LoRA support (follows same pattern)
3. **`lora_manager.py`** - Remove generic vision skipping logic


## Accuracy Tests
N/A 
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
N/A 
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
