### PR TITLE
bump sgl-kernel version to 3.14 for Dockerfile.b300

### DIFF
--- a/docker/Dockerfile.b300
+++ b/docker/Dockerfile.b300
@@ -35,6 +35,7 @@ RUN if [ "$BRANCH_TYPE" = "local" ]; then \
 # Remove after the next torch release
 RUN sed -i "/torch/d" sglang/sgl-kernel/pyproject.toml && \
     sed -i -e "/torchaudio/d" \
+        -e "s/sgl-kernel==0.3.10/sgl-kernel==0.3.14/" \
         -e "s/torch==2.8.0/torch==2.8.0a0+34c6371d24.nv25.8/" \
         -e "s/torchao==0.9.0/torchao==0.12.0+git/" \
         sglang/python/pyproject.toml


### PR DESCRIPTION
SGLang pyproject.toml uses sgl-kernel==0.3.10, which will invalidate the 3.14 sgl-kernel compilation.

SGLang's pyproject.toml expects sgl-kernel==0.3.10
The compiled sgl-kernel is version 3.14.
This version mismatch will cause import/compatibility errors