### PR TITLE
fix: Prevent errors from being hidden during graph capture with custom all reduce

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -251,12 +251,14 @@ class CustomAllreduce:
         `register_graph_buffers` call at the end of the context.
         It records all the buffer addresses used in the CUDA graph.
         """
+        success = False
         try:
             self._IS_CAPTURING = True
             yield
+            success = True
         finally:
             self._IS_CAPTURING = False
-            if not self.disabled:
+            if success and not self.disabled:
                 self.register_graph_buffers()
 
     def _get_ipc_meta(self, inp: torch.Tensor):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Errors during graph capture when custom all reduce is enabled can cause a hang like this and the error message is not shown:

```
[2025-10-06 20:05:22 DP0 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=3.66 GB
[2025-10-06 20:05:22 DP0 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]
Capturing batches (bs=512 avail_mem=3.10 GB):   0%|                                                                                                                                                                                                                                                                                      | 0/52 [00:04<?, ?it/s]
[2025-10-06 20:05:27 DP0 TP0] Registering 0 cuda graph addresses
[2025-10-06 20:05:27 DP6 TP6] Registering 0 cuda graph addresses
[2025-10-06 20:05:27 DP3 TP3] Registering 0 cuda graph addresses
[2025-10-06 20:05:27 DP1 TP1] Registering 0 cuda graph addresses
[2025-10-06 20:05:27 DP4 TP4] Registering 0 cuda graph addresses
[2025-10-06 20:05:27 DP2 TP2] Registering 0 cuda graph addresses
[2025-10-06 20:05:27 DP5 TP5] Registering 0 cuda graph addresses
<hangs>
```


With this fix, you can now see the error which occured during graph capture:

```
[2025-10-06 19:57:35 DP0 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=3.66 GB
[2025-10-06 19:57:35 DP0 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]
Capturing batches (bs=512 avail_mem=3.10 GB):   0%|                                                                                                                                                                                                                                                                                      | 0/52 [00:04<?, ?it/s]
[2025-10-06 19:57:41 DP4 TP4] Scheduler hit an exception: Traceback (most recent call last):
  File "/trevor/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 366, in __init__
    self.capture()
  File "/trevor/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 485, in capture
    ) = self.capture_one_batch_size(bs, forward)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 661, in capture_one_batch_size
    run_once()
  File "/trevor/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 650, in run_once
    logits_output_or_pp_proxy_tensors = forward(
                                        ^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 2874, in forward
    return self.logits_processor(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/logits_processor.py", line 341, in forward
    logits = self._get_logits(pruned_states, lm_head, logits_metadata)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/logits_processor.py", line 525, in _get_logits
    logits = tensor_model_parallel_all_gather(logits)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/distributed/communication_op.py", line 20, in tensor_model_parallel_all_gather
    return get_tp_group().all_gather(input_, dim)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/distributed/parallel_state.py", line 745, in all_gather
    output_tensor = output_tensor.reshape(
                    ^^^^^^^^^^^^^^^^^^^^^^
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1010.00 MiB. GPU 4 has a total capacity of 178.35 GiB of which 609.75 MiB is free. Including non-PyTorch memory, this process has 177.74 GiB memory in use. Of the allocated memory 172.62 GiB is allocated by PyTorch, and 1.93 GiB is reserved by PyTorch but unallocated. If reserved but unall
ocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
                                                                                                                                                                                                                                       cumentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)                                                                                                                                   

```



## Modifications

If an error occurs during graph capture, the `finally` block will call `register_graph_buffers()` which performs a collective broadcast. These failing ranks will get stuck here waiting for all others to join the collective. The hang occurs if one or more ranks manages to not hit the error during `run_once` and it will get stuck at [this barrier ](https://github.com/sgl-project/sglang/blob/eb30b888db78944d5fdf2df86511aff1c66dba83/python/sglang/srt/model_executor/cuda_graph_runner.py#L660) at second warmup iteration.

Since python does not re-raise the exception until after `finally` completes, the error message was never being displayed.
The fix is to not call `register_graph_buffers()` when the error occurs, so the hang doesn't occur and the error message is shown. However, the rank which succeeded will still be stuck at the barrier until it times out.

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
