### PR TITLE
[router][grpc] Refine streaming processes

### DIFF
--- a/sgl-router/src/reasoning_parser/parsers/base.rs
+++ b/sgl-router/src/reasoning_parser/parsers/base.rs
@@ -187,6 +187,10 @@ impl ReasoningParser for BaseReasoningParser {
     fn model_type(&self) -> &str {
         &self.model_type
     }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.in_reasoning
+    }
 }
 
 #[cfg(test)]

--- a/sgl-router/src/reasoning_parser/parsers/deepseek_r1.rs
+++ b/sgl-router/src/reasoning_parser/parsers/deepseek_r1.rs
@@ -55,6 +55,10 @@ impl ReasoningParser for DeepSeekR1Parser {
     fn model_type(&self) -> &str {
         self.base.model_type()
     }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
 }
 
 #[cfg(test)]

--- a/sgl-router/src/reasoning_parser/parsers/glm45.rs
+++ b/sgl-router/src/reasoning_parser/parsers/glm45.rs
@@ -54,6 +54,10 @@ impl ReasoningParser for Glm45Parser {
     fn model_type(&self) -> &str {
         self.base.model_type()
     }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
 }
 
 #[cfg(test)]

--- a/sgl-router/src/reasoning_parser/parsers/kimi.rs
+++ b/sgl-router/src/reasoning_parser/parsers/kimi.rs
@@ -54,6 +54,10 @@ impl ReasoningParser for KimiParser {
     fn model_type(&self) -> &str {
         self.base.model_type()
     }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
 }
 
 #[cfg(test)]

--- a/sgl-router/src/reasoning_parser/parsers/qwen3.rs
+++ b/sgl-router/src/reasoning_parser/parsers/qwen3.rs
@@ -55,6 +55,10 @@ impl ReasoningParser for Qwen3Parser {
     fn model_type(&self) -> &str {
         self.base.model_type()
     }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
 }
 
 /// QwenThinking parser - variant that assumes reasoning from start.
@@ -105,6 +109,10 @@ impl ReasoningParser for QwenThinkingParser {
 
     fn model_type(&self) -> &str {
         self.base.model_type()
+    }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
     }
 }
 

--- a/sgl-router/src/reasoning_parser/parsers/step3.rs
+++ b/sgl-router/src/reasoning_parser/parsers/step3.rs
@@ -54,6 +54,10 @@ impl ReasoningParser for Step3Parser {
     fn model_type(&self) -> &str {
         self.base.model_type()
     }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
 }
 
 #[cfg(test)]

--- a/sgl-router/src/reasoning_parser/traits.rs
+++ b/sgl-router/src/reasoning_parser/traits.rs
@@ -69,6 +69,11 @@ pub trait ReasoningParser: Send + Sync {
 
     /// Get the model type this parser is designed for.
     fn model_type(&self) -> &str;
+
+    /// Check if the parser is currently in reasoning mode.
+    ///
+    /// Returns true if the parser is currently parsing reasoning content.
+    fn is_in_reasoning(&self) -> bool;
 }
 
 /// Error types for reasoning parsing operations.

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -922,27 +922,31 @@ impl GrpcPDRouter {
                     stream_buffer.push_str(&delta);
 
                     // Reasoning content handling
-                    if separate_reasoning {
-                        let (normal_text, reasoning_chunk) = router.process_reasoning_stream(
-                            &delta,
-                            index,
-                            &mut reasoning_parsers,
-                            &request_id,
-                            &model,
-                            created,
-                        );
+                    let in_reasoning = if separate_reasoning {
+                        let (normal_text, reasoning_chunk, in_reasoning) = router
+                            .process_reasoning_stream(
+                                &delta,
+                                index,
+                                &mut reasoning_parsers,
+                                &request_id,
+                                &model,
+                                created,
+                            );
                         if let Some(chunk) = reasoning_chunk {
                             tx.send(Ok(bytes::Bytes::from(Self::format_sse_chunk(&chunk))))
                                 .map_err(|_| "Failed to send reasoning chunk".to_string())?;
                         }
                         delta = normal_text;
-                    }
+                        in_reasoning
+                    } else {
+                        false
+                    };
 
                     // Tool call handling
                     let tool_choice_enabled =
                         !matches!(tool_choice, Some(ToolChoice::Value(ToolChoiceValue::None)));
 
-                    if tool_choice_enabled && tools.is_some() {
+                    if !in_reasoning && tool_choice_enabled && tools.is_some() {
                         let (should_skip, tool_chunks) = router
                             .process_tool_calls_stream(
                                 &delta,
@@ -1173,16 +1177,18 @@ impl GrpcPDRouter {
         request_id: &str,
         model: &str,
         created: u64,
-    ) -> (String, Option<ChatCompletionStreamResponse>) {
+    ) -> (String, Option<ChatCompletionStreamResponse>, bool) {
         // Get or create parser for this index
         reasoning_parsers
             .entry(index)
             .or_insert_with(|| self.reasoning_parser_factory.get_pooled(model));
 
         if let Some(pooled_parser) = reasoning_parsers.get(&index) {
-            let parse_result = {
+            let (parse_result, in_reasoning) = {
                 let mut parser = pooled_parser.lock().unwrap();
-                parser.parse_reasoning_streaming_incremental(delta)
+                let result = parser.parse_reasoning_streaming_incremental(delta);
+                let in_reasoning = parser.is_in_reasoning();
+                (result, in_reasoning)
             };
 
             match parse_result {
@@ -1214,7 +1220,7 @@ impl GrpcPDRouter {
                     } else {
                         None
                     };
-                    return (normal_text, chunk);
+                    return (normal_text, chunk, in_reasoning);
                 }
                 Err(e) => {
                     warn!("Reasoning parsing error: {}", e);
@@ -1222,7 +1228,7 @@ impl GrpcPDRouter {
             }
         }
 
-        (delta.to_string(), None)
+        (delta.to_string(), None, false)
     }
 
     /// Helper: Process tool calls in streaming mode


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In streaming, if the model is still in reasoning stage, we can skip tool call parsing.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Add `is_in_reasoning` for reasoning parsers.
- Extract `is_in_reasoning` after calling `reasoing_parser. parse_reasoning_streaming_incremental`
- Add check for `in_reasoning` besides tool_choice and tools for tool call parsing.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
