### PR TITLE
[oai serving chat] Add argument `--sampling-defaults` and fix `ChatCompletionRequest` defaults

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -672,7 +672,6 @@ class ModelConfig:
         Returns:
             A dictionary containing the non-default sampling parameters.
         """
-        # Only use model's generation config if sampling_defaults is set to "model"
         if self.sampling_defaults != "model":
             return {}
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -17,7 +17,7 @@ import logging
 import math
 import os
 from enum import Enum, IntEnum, auto
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import torch
 from transformers import PretrainedConfig
@@ -658,6 +658,35 @@ class ModelConfig:
                 )
                 eos_ids = eos_ids | generation_eos_ids
         return eos_ids
+
+    def get_default_sampling_params(self) -> dict[str, Any]:
+        """
+        Get default sampling parameters from the model's generation config.
+
+        This method returns non-default sampling parameters from the model's
+        generation_config.json.
+
+        Returns:
+            A dictionary containing the non-default sampling parameters.
+        """
+        if self.hf_generation_config is None:
+            return {}
+
+        config = self.hf_generation_config.to_dict()
+
+        available_params = [
+            "repetition_penalty",
+            "temperature",
+            "top_k",
+            "top_p",
+            "min_p",
+        ]
+
+        default_sampling_params = {
+            p: config.get(p) for p in available_params if config.get(p) is not None
+        }
+
+        return default_sampling_params
 
     def _maybe_pull_model_tokenizer_from_remote(self) -> None:
         """

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -90,6 +90,7 @@ class ModelConfig:
         is_draft_model: bool = False,
         hybrid_kvcache_ratio: Optional[float] = None,
         model_impl: Union[str, ModelImpl] = ModelImpl.AUTO,
+        sampling_defaults: str = "default",
     ) -> None:
         # Parse args
         self.model_path = model_path
@@ -98,6 +99,7 @@ class ModelConfig:
         self.modelopt_quant = modelopt_quant
         self.is_draft_model = is_draft_model
         self.model_impl = model_impl
+        self.sampling_defaults = sampling_defaults
 
         # Get hf config
         self._maybe_pull_model_tokenizer_from_remote()
@@ -214,6 +216,7 @@ class ModelConfig:
             modelopt_quant=server_args.modelopt_quant,
             hybrid_kvcache_ratio=server_args.hybrid_kvcache_ratio,
             model_impl=server_args.model_impl,
+            sampling_defaults=server_args.sampling_defaults,
             **kwargs,
         )
 
@@ -664,11 +667,15 @@ class ModelConfig:
         Get default sampling parameters from the model's generation config.
 
         This method returns non-default sampling parameters from the model's
-        generation_config.json.
+        generation_config.json when sampling_defaults is set to "model".
 
         Returns:
             A dictionary containing the non-default sampling parameters.
         """
+        # Only use model's generation config if sampling_defaults is set to "model"
+        if self.sampling_defaults != "model":
+            return {}
+
         if self.hf_generation_config is None:
             return {}
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -90,7 +90,7 @@ class ModelConfig:
         is_draft_model: bool = False,
         hybrid_kvcache_ratio: Optional[float] = None,
         model_impl: Union[str, ModelImpl] = ModelImpl.AUTO,
-        sampling_defaults: str = "default",
+        sampling_defaults: str = "openai",
     ) -> None:
         # Parse args
         self.model_path = model_path

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -191,39 +191,6 @@ async def init_multi_tokenizer() -> ServerArgs:
     return server_args
 
 
-def _override_protocol_defaults_from_model() -> None:
-    """Override ChatCompletionRequest defaults with model generation_config at server startup."""
-
-    model_config = _global_state.tokenizer_manager.model_config
-    default_sampling_params = model_config.get_default_sampling_params()
-
-    if not default_sampling_params:
-        return
-
-    overrides_applied = {}
-    for param_name, param_default in default_sampling_params.items():
-        if param_default is None:
-            continue
-        field_info = ChatCompletionRequest.model_fields.get(param_name)
-        if field_info is None:
-            continue
-        original_default = field_info.default
-        if original_default == param_default:
-            continue
-        field_info.default = param_default
-        overrides_applied[param_name] = {
-            "previous": original_default,
-            "new": param_default,
-        }
-
-    if overrides_applied:
-        # Rebuild the model to apply the new defaults
-        ChatCompletionRequest.model_rebuild(force=True)
-        logger.info(
-            f"Overrode ChatCompletionRequest defaults with model defaults: {overrides_applied}"
-        )
-
-
 @asynccontextmanager
 async def lifespan(fast_api_app: FastAPI):
     if not getattr(fast_api_app, "is_single_tokenizer_mode", False):
@@ -245,9 +212,6 @@ async def lifespan(fast_api_app: FastAPI):
                 None,  # launch_callback not needed in worker
             ),
         )
-
-    # Override protocol defaults with model-specific defaults before creating handlers
-    _override_protocol_defaults_from_model()
 
     # Initialize OpenAI serving handlers
     fast_api_app.state.openai_serving_completion = OpenAIServingCompletion(

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -425,15 +425,6 @@ class ToolChoice(BaseModel):
 
 
 class ChatCompletionRequest(BaseModel):
-    # OpenAI/SGLang default sampling parameters
-    _DEFAULT_SAMPLING_PARAMS = {
-        "temperature": 1.0,
-        "top_p": 1.0,
-        "top_k": -1,
-        "min_p": 0.0,
-        "repetition_penalty": 1.0,
-    }
-
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
     messages: List[ChatCompletionMessageParam]
@@ -474,6 +465,15 @@ class ChatCompletionRequest(BaseModel):
         "result in faster responses and fewer tokens used on reasoning in a response. "
         "Currently only supported for OpenAI models in the harmony path, i.e GPT-OSS models.",
     )
+
+    # OpenAI/SGLang default sampling parameters
+    _DEFAULT_SAMPLING_PARAMS = {
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "top_k": -1,
+        "min_p": 0.0,
+        "repetition_penalty": 1.0,
+    }
 
     @model_validator(mode="before")
     @classmethod

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -13,7 +13,6 @@
 # ==============================================================================
 """Pydantic models for OpenAI API protocol"""
 
-import logging
 import time
 import uuid
 from dataclasses import dataclass
@@ -37,10 +36,6 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Literal
-
-from sglang.utils import convert_json_schema_to_str
-
-logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL_NAME = "default"
 
@@ -425,15 +420,6 @@ class ToolChoice(BaseModel):
 
 
 class ChatCompletionRequest(BaseModel):
-    # OpenAI/SGLang default sampling parameters
-    _DEFAULT_SAMPLING_PARAMS = {
-        "temperature": 1.0,
-        "top_p": 1.0,
-        "top_k": -1,
-        "min_p": 0.0,
-        "repetition_penalty": 1.0,
-    }
-
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
     messages: List[ChatCompletionMessageParam]
@@ -459,8 +445,8 @@ class ChatCompletionRequest(BaseModel):
     stop: Optional[Union[str, List[str]]] = None
     stream: bool = False
     stream_options: Optional[StreamOptions] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
+    temperature: float = 1.0
+    top_p: float = 1.0
     user: Optional[str] = None
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])
     tool_choice: Union[ToolChoice, Literal["auto", "required", "none"]] = Field(
@@ -546,12 +532,12 @@ class ChatCompletionRequest(BaseModel):
         return values
 
     # Extra parameters for SRT backend only and will be ignored by OpenAI models.
-    top_k: Optional[int] = None
-    min_p: Optional[float] = None
+    top_k: int = -1
+    min_p: float = 0.0
     min_tokens: int = 0
     regex: Optional[str] = None
     ebnf: Optional[str] = None
-    repetition_penalty: Optional[float] = None
+    repetition_penalty: float = 1.0
     stop_token_ids: Optional[List[int]] = None
     no_stop_trim: bool = False
     ignore_eos: bool = False
@@ -576,82 +562,6 @@ class ChatCompletionRequest(BaseModel):
     bootstrap_host: Optional[Union[List[str], str]] = None
     bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
     bootstrap_room: Optional[Union[List[int], int]] = None
-
-    def to_sampling_params(
-        self,
-        stop: List[str],
-        model_generation_config: Dict[str, Any],
-        tool_call_constraint: Optional[Any] = None,
-    ) -> Dict[str, Any]:
-        """
-        Convert request to sampling parameters.
-        Priority: user value > model generation_config > OpenAI defaults
-        """
-
-        def get_param(param_name: str):
-            value = getattr(self, param_name)
-            if value is None:
-                return model_generation_config.get(
-                    param_name, self._DEFAULT_SAMPLING_PARAMS[param_name]
-                )
-            return value
-
-        sampling_params = {
-            "temperature": get_param("temperature"),
-            "max_new_tokens": self.max_tokens or self.max_completion_tokens,
-            "min_new_tokens": self.min_tokens,
-            "stop": stop,
-            "stop_token_ids": self.stop_token_ids,
-            "top_p": get_param("top_p"),
-            "top_k": get_param("top_k"),
-            "min_p": get_param("min_p"),
-            "presence_penalty": self.presence_penalty,
-            "frequency_penalty": self.frequency_penalty,
-            "repetition_penalty": get_param("repetition_penalty"),
-            "regex": self.regex,
-            "ebnf": self.ebnf,
-            "n": self.n,
-            "no_stop_trim": self.no_stop_trim,
-            "ignore_eos": self.ignore_eos,
-            "skip_special_tokens": self.skip_special_tokens,
-            "logit_bias": self.logit_bias,
-        }
-
-        if self.response_format and self.response_format.type == "json_schema":
-            sampling_params["json_schema"] = convert_json_schema_to_str(
-                self.response_format.json_schema.schema_
-            )
-        elif self.response_format and self.response_format.type == "json_object":
-            sampling_params["json_schema"] = '{"type": "object"}'
-        elif self.response_format and self.response_format.type == "structural_tag":
-            sampling_params["structural_tag"] = convert_json_schema_to_str(
-                self.response_format.model_dump(by_alias=True)
-            )
-
-        # Check if there are already existing output constraints
-        has_existing_constraints = (
-            sampling_params.get("regex")
-            or sampling_params.get("ebnf")
-            or sampling_params.get("structural_tag")
-            or sampling_params.get("json_schema")
-        )
-
-        if tool_call_constraint and has_existing_constraints:
-            logger.warning("Constrained decoding is not compatible with tool calls.")
-        elif tool_call_constraint:
-            constraint_type, constraint_value = tool_call_constraint
-            if constraint_type == "structural_tag":
-                sampling_params[constraint_type] = convert_json_schema_to_str(
-                    constraint_value.model_dump(by_alias=True)
-                )
-            elif constraint_type == "json_schema":
-                sampling_params[constraint_type] = convert_json_schema_to_str(
-                    constraint_value
-                )
-            else:
-                sampling_params[constraint_type] = constraint_value
-
-        return sampling_params
 
 
 class ChatMessage(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -445,7 +445,7 @@ class ChatCompletionRequest(BaseModel):
     stop: Optional[Union[str, List[str]]] = None
     stream: bool = False
     stream_options: Optional[StreamOptions] = None
-    temperature: float = 0.7
+    temperature: float = 1.0
     top_p: float = 1.0
     user: Optional[str] = None
     tools: Optional[List[Tool]] = Field(default=None, examples=[None])

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -466,6 +466,38 @@ class ChatCompletionRequest(BaseModel):
         "Currently only supported for OpenAI models in the harmony path, i.e GPT-OSS models.",
     )
 
+    # Extra parameters for SRT backend only and will be ignored by OpenAI models.
+    top_k: Optional[int] = None
+    min_p: Optional[float] = None
+    min_tokens: int = 0
+    regex: Optional[str] = None
+    ebnf: Optional[str] = None
+    repetition_penalty: Optional[float] = None
+    stop_token_ids: Optional[List[int]] = None
+    no_stop_trim: bool = False
+    ignore_eos: bool = False
+    continue_final_message: bool = False
+    skip_special_tokens: bool = True
+    lora_path: Optional[Union[List[Optional[str]], Optional[str]]] = None
+    session_params: Optional[Dict] = None
+    separate_reasoning: bool = True
+    stream_reasoning: bool = True
+    chat_template_kwargs: Optional[Dict] = None
+
+    # For request id
+    rid: Optional[Union[List[str], str]] = None
+    # Extra key for classifying the request (e.g. cache_salt)
+    extra_key: Optional[Union[List[str], str]] = None
+    # Cache salt for request caching
+    cache_salt: Optional[Union[List[str], str]] = None
+    # Priority for the request
+    priority: Optional[int] = None
+
+    # For PD disaggregation
+    bootstrap_host: Optional[Union[List[str], str]] = None
+    bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
+    bootstrap_room: Optional[Union[List[int], int]] = None
+
     # OpenAI/SGLang default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {
         "temperature": 1.0,
@@ -544,38 +576,6 @@ class ChatCompletionRequest(BaseModel):
             }
 
         return values
-
-    # Extra parameters for SRT backend only and will be ignored by OpenAI models.
-    top_k: Optional[int] = None
-    min_p: Optional[float] = None
-    min_tokens: int = 0
-    regex: Optional[str] = None
-    ebnf: Optional[str] = None
-    repetition_penalty: Optional[float] = None
-    stop_token_ids: Optional[List[int]] = None
-    no_stop_trim: bool = False
-    ignore_eos: bool = False
-    continue_final_message: bool = False
-    skip_special_tokens: bool = True
-    lora_path: Optional[Union[List[Optional[str]], Optional[str]]] = None
-    session_params: Optional[Dict] = None
-    separate_reasoning: bool = True
-    stream_reasoning: bool = True
-    chat_template_kwargs: Optional[Dict] = None
-
-    # For request id
-    rid: Optional[Union[List[str], str]] = None
-    # Extra key for classifying the request (e.g. cache_salt)
-    extra_key: Optional[Union[List[str], str]] = None
-    # Cache salt for request caching
-    cache_salt: Optional[Union[List[str], str]] = None
-    # Priority for the request
-    priority: Optional[int] = None
-
-    # For PD disaggregation
-    bootstrap_host: Optional[Union[List[str], str]] = None
-    bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
-    bootstrap_room: Optional[Union[List[int], int]] = None
 
     def to_sampling_params(
         self,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -74,6 +74,31 @@ class OpenAIServingChat(OpenAIServingBase):
             logger.info(
                 f"Using default chat sampling params from model generation config: {self.default_sampling_params}",
             )
+            self._override_chat_protocol_defaults()
+
+    def _override_chat_protocol_defaults(self) -> None:
+        """Override protocol-level defaults with model-specific sampling defaults."""
+        overrides_applied = {}
+        for param_name, param_default in self.default_sampling_params.items():
+            if param_default is None:
+                continue
+            field_info = ChatCompletionRequest.model_fields.get(param_name)
+            if field_info is None or field_info.is_required():
+                continue
+            current_default = field_info.default
+            if current_default == param_default:
+                continue
+            field_info.default = param_default
+            overrides_applied[param_name] = current_default
+        if overrides_applied:
+            ChatCompletionRequest.model_rebuild(force=True)
+            logger.debug(
+                "Overrode chat protocol defaults with model defaults: %s",
+                {
+                    name: {"previous": previous, "current": ChatCompletionRequest.model_fields[name].default}
+                    for name, previous in overrides_applied.items()
+                },
+            )
 
     def _request_id_prefix(self) -> str:
         return "chatcmpl-"
@@ -426,36 +451,18 @@ class OpenAIServingChat(OpenAIServingBase):
         tool_call_constraint: Optional[Any],
     ) -> Dict[str, Any]:
         """Build sampling parameters for the request"""
-
-        # Get defaults directly from the ChatCompletionRequest
-        request_defaults = {
-            p: ChatCompletionRequest.model_fields[p].default
-            for p in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty")
-        }
-
-        # Helper to get parameter value with generation config fallback
-        def get_param(request_value, param_name):
-            if param_name in request_defaults:
-                if request_value != request_defaults[param_name]:
-                    return request_value
-                if param_name in self.default_sampling_params:
-                    return self.default_sampling_params[param_name]
-            return request_value
-
         sampling_params = {
-            "temperature": get_param(request.temperature, "temperature"),
+            "temperature": request.temperature,
             "max_new_tokens": request.max_tokens or request.max_completion_tokens,
             "min_new_tokens": request.min_tokens,
             "stop": stop,
             "stop_token_ids": request.stop_token_ids,
-            "top_p": get_param(request.top_p, "top_p"),
-            "top_k": get_param(request.top_k, "top_k"),
-            "min_p": get_param(request.min_p, "min_p"),
+            "top_p": request.top_p,
+            "top_k": request.top_k,
+            "min_p": request.min_p,
             "presence_penalty": request.presence_penalty,
             "frequency_penalty": request.frequency_penalty,
-            "repetition_penalty": get_param(
-                request.repetition_penalty, "repetition_penalty"
-            ),
+            "repetition_penalty": request.repetition_penalty,
             "regex": request.regex,
             "ebnf": request.ebnf,
             "n": request.n,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -427,14 +427,10 @@ class OpenAIServingChat(OpenAIServingBase):
     ) -> Dict[str, Any]:
         """Build sampling parameters for the request"""
 
-        # Map of request parameters to their Pydantic defaults
-        # If request value == default, we'll use generation config instead
+        # Get defaults directly from the ChatCompletionRequest
         request_defaults = {
-            "temperature": 1.0,
-            "top_p": 1.0,
-            "top_k": -1,
-            "min_p": 0.0,
-            "repetition_penalty": 1.0,
+            p: ChatCompletionRequest.model_fields[p].default
+            for p in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty")
         }
 
         # Helper to get parameter value with generation config fallback

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -457,7 +457,9 @@ class OpenAIServingChat(OpenAIServingBase):
             "min_p": get_param(request.min_p, "min_p"),
             "presence_penalty": request.presence_penalty,
             "frequency_penalty": request.frequency_penalty,
-            "repetition_penalty": get_param(request.repetition_penalty, "repetition_penalty"),
+            "repetition_penalty": get_param(
+                request.repetition_penalty, "repetition_penalty"
+            ),
             "regex": request.regex,
             "ebnf": request.ebnf,
             "n": request.n,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -66,6 +66,40 @@ class OpenAIServingChat(OpenAIServingBase):
         self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
 
+        # Get default sampling parameters from model's generation config
+        self.default_sampling_params = (
+            self.tokenizer_manager.model_config.get_default_sampling_params()
+        )
+        if self.default_sampling_params:
+            logger.info(
+                f"Using default chat sampling params from model generation config: {self.default_sampling_params}",
+            )
+            self._override_chat_protocol_defaults()
+
+    def _override_chat_protocol_defaults(self) -> None:
+        """Override protocol-level defaults with model-specific sampling defaults."""
+        overrides_applied = {}
+        for param_name, param_default in self.default_sampling_params.items():
+            if param_default is None:
+                continue
+            field_info = ChatCompletionRequest.model_fields.get(param_name)
+            if field_info is None or field_info.is_required():
+                continue
+            current_default = field_info.default
+            if current_default == param_default:
+                continue
+            field_info.default = param_default
+            overrides_applied[param_name] = current_default
+        if overrides_applied:
+            ChatCompletionRequest.model_rebuild(force=True)
+            logger.debug(
+                "Overrode chat protocol defaults with model defaults: %s",
+                {
+                    name: {"previous": previous, "current": ChatCompletionRequest.model_fields[name].default}
+                    for name, previous in overrides_applied.items()
+                },
+            )
+
     def _request_id_prefix(self) -> str:
         return "chatcmpl-"
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -44,7 +44,6 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
 from sglang.srt.parser.reasoning_parser import ReasoningParser
-from sglang.utils import convert_json_schema_to_str
 
 if TYPE_CHECKING:
     from sglang.srt.managers.template_manager import TemplateManager
@@ -146,10 +145,10 @@ class OpenAIServingChat(OpenAIServingBase):
         processed_messages = self._process_messages(request, is_multimodal)
 
         # Build sampling parameters
-        sampling_params = self._build_sampling_params(
-            request,
-            processed_messages.stop,
-            processed_messages.tool_call_constraint,
+        sampling_params = request.to_sampling_params(
+            stop=processed_messages.stop,
+            model_generation_config=self.default_sampling_params,
+            tool_call_constraint=processed_messages.tool_call_constraint,
         )
 
         # Handle single vs multiple requests
@@ -418,89 +417,6 @@ class OpenAIServingChat(OpenAIServingBase):
             modalities=modalities,
             stop=stop,
         )
-
-    def _build_sampling_params(
-        self,
-        request: ChatCompletionRequest,
-        stop: List[str],
-        tool_call_constraint: Optional[Any],
-    ) -> Dict[str, Any]:
-        """Build sampling parameters for the request"""
-
-        # Get defaults directly from the ChatCompletionRequest
-        request_defaults = {
-            p: ChatCompletionRequest.model_fields[p].default
-            for p in ("temperature", "top_p", "top_k", "min_p", "repetition_penalty")
-        }
-
-        # Helper to get parameter value with generation config fallback
-        def get_param(request_value, param_name):
-            if param_name in request_defaults:
-                if request_value != request_defaults[param_name]:
-                    return request_value
-                if param_name in self.default_sampling_params:
-                    return self.default_sampling_params[param_name]
-            return request_value
-
-        sampling_params = {
-            "temperature": get_param(request.temperature, "temperature"),
-            "max_new_tokens": request.max_tokens or request.max_completion_tokens,
-            "min_new_tokens": request.min_tokens,
-            "stop": stop,
-            "stop_token_ids": request.stop_token_ids,
-            "top_p": get_param(request.top_p, "top_p"),
-            "top_k": get_param(request.top_k, "top_k"),
-            "min_p": get_param(request.min_p, "min_p"),
-            "presence_penalty": request.presence_penalty,
-            "frequency_penalty": request.frequency_penalty,
-            "repetition_penalty": get_param(
-                request.repetition_penalty, "repetition_penalty"
-            ),
-            "regex": request.regex,
-            "ebnf": request.ebnf,
-            "n": request.n,
-            "no_stop_trim": request.no_stop_trim,
-            "ignore_eos": request.ignore_eos,
-            "skip_special_tokens": request.skip_special_tokens,
-            "logit_bias": request.logit_bias,
-        }
-
-        if request.response_format and request.response_format.type == "json_schema":
-            sampling_params["json_schema"] = convert_json_schema_to_str(
-                request.response_format.json_schema.schema_
-            )
-        elif request.response_format and request.response_format.type == "json_object":
-            sampling_params["json_schema"] = '{"type": "object"}'
-        elif (
-            request.response_format and request.response_format.type == "structural_tag"
-        ):
-            sampling_params["structural_tag"] = convert_json_schema_to_str(
-                request.response_format.model_dump(by_alias=True)
-            )
-
-        # Check if there are already existing output constraints
-        has_existing_constraints = (
-            sampling_params.get("regex")
-            or sampling_params.get("ebnf")
-            or sampling_params.get("structural_tag")
-            or sampling_params.get("json_schema")
-        )
-
-        if tool_call_constraint and has_existing_constraints:
-            logger.warning("Constrained decoding is not compatible with tool calls.")
-        elif tool_call_constraint:
-            constraint_type, constraint_value = tool_call_constraint
-            if constraint_type == "structural_tag":
-                sampling_params[constraint_type] = convert_json_schema_to_str(
-                    constraint_value.model_dump(by_alias=True)
-                )
-            elif constraint_type == "json_schema":
-                sampling_params[constraint_type] = convert_json_schema_to_str(
-                    constraint_value
-                )
-            else:
-                sampling_params[constraint_type] = constraint_value
-        return sampling_params
 
     async def _handle_streaming_request(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1874,7 +1874,8 @@ class ServerArgs:
             default=ServerArgs.sampling_defaults,
             help="Where to get default sampling parameters. "
             "'openai' uses SGLang/OpenAI defaults (temperature=1.0, top_p=1.0, etc.). "
-            "'model' uses the model's generation_config.json if available.",
+            "'model' uses the model's generation_config.json to get the recommended "
+            "sampling parameters if available. Default is 'model'.",
         )
         parser.add_argument(
             "--tool-server",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -252,7 +252,7 @@ class ServerArgs:
     reasoning_parser: Optional[str] = None
     tool_call_parser: Optional[str] = None
     tool_server: Optional[str] = None
-    sampling_defaults: str = "default"
+    sampling_defaults: str = "model"
 
     # Data parallelism
     dp_size: int = 1
@@ -1870,10 +1870,10 @@ class ServerArgs:
         parser.add_argument(
             "--sampling-defaults",
             type=str,
-            choices=["default", "model"],
+            choices=["openai", "model"],
             default=ServerArgs.sampling_defaults,
             help="Where to get default sampling parameters. "
-            "'default' uses SGLang/OpenAI defaults (temperature=1.0, top_p=1.0, etc.). "
+            "'openai' uses SGLang/OpenAI defaults (temperature=1.0, top_p=1.0, etc.). "
             "'model' uses the model's generation_config.json if available.",
         )
         parser.add_argument(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -252,6 +252,7 @@ class ServerArgs:
     reasoning_parser: Optional[str] = None
     tool_call_parser: Optional[str] = None
     tool_server: Optional[str] = None
+    sampling_defaults: str = "default"
 
     # Data parallelism
     dp_size: int = 1
@@ -1865,6 +1866,15 @@ class ServerArgs:
             choices=tool_call_parser_choices,
             default=ServerArgs.tool_call_parser,
             help=f"Specify the parser for handling tool-call interactions. Options include: {tool_call_parser_choices}.",
+        )
+        parser.add_argument(
+            "--sampling-defaults",
+            type=str,
+            choices=["default", "model"],
+            default=ServerArgs.sampling_defaults,
+            help="Where to get default sampling parameters. "
+            "'default' uses SGLang/OpenAI defaults (temperature=1.0, top_p=1.0, etc.). "
+            "'model' uses the model's generation_config.json if available.",
         )
         parser.add_argument(
             "--tool-server",

--- a/test/srt/openai_server/basic/test_protocol.py
+++ b/test/srt/openai_server/basic/test_protocol.py
@@ -150,9 +150,25 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertEqual(len(request.messages), 1)
         self.assertEqual(request.messages[0].role, "user")
         self.assertEqual(request.messages[0].content, "Hello")
-        self.assertEqual(request.temperature, 0.7)  # default
+        self.assertEqual(request.temperature, None)  # default
         self.assertFalse(request.stream)  # default
         self.assertEqual(request.tool_choice, "none")  # default when no tools
+
+    def test_sampling_param_build(self):
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.8,
+            max_tokens=150,
+            min_tokens=5,
+            top_p=0.9,
+            stop=["</s>"],
+        )
+        params = req.to_sampling_params(["</s>"], {}, None)
+        self.assertEqual(params["temperature"], 0.8)
+        self.assertEqual(params["max_new_tokens"], 150)
+        self.assertEqual(params["min_new_tokens"], 5)
+        self.assertEqual(params["stop"], ["</s>"])
 
     def test_chat_completion_tool_choice_validation(self):
         """Test tool choice validation logic"""

--- a/test/srt/openai_server/basic/test_serving_chat.py
+++ b/test/srt/openai_server/basic/test_serving_chat.py
@@ -177,28 +177,6 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertNotIn("CUSTOM_STOP", result2.stop)
             self.assertEqual(conv_ins.stop_str, initial_stop_str)
 
-    # ------------- sampling-params -------------
-    def test_sampling_param_build(self):
-        req = ChatCompletionRequest(
-            model="x",
-            messages=[{"role": "user", "content": "Hi"}],
-            temperature=0.8,
-            max_tokens=150,
-            min_tokens=5,
-            top_p=0.9,
-            stop=["</s>"],
-        )
-        with patch.object(
-            self.chat,
-            "_process_messages",
-            return_value=("Prompt", [1], None, None, [], ["</s>"], None),
-        ):
-            params = self.chat._build_sampling_params(req, ["</s>"], None)
-            self.assertEqual(params["temperature"], 0.8)
-            self.assertEqual(params["max_new_tokens"], 150)
-            self.assertEqual(params["min_new_tokens"], 5)
-            self.assertEqual(params["stop"], ["</s>"])
-
     async def test_unstreamed_tool_args_completion(self):
         """Test that remaining tool call arguments are sent when generation finishes."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently, SGLang's `ChatCompletionRequest` uses `tempature=0.7` as a default. That is inconsistent with OpenAI API's default value, which is 1.0.

1.0 may be too high for generations and many models have a recommended sampling parameter setting in their `generation_config.json`.

This PR adds support for using a model's recommended default sampling parameters by passing `--sampling-defaults model`.

## Modifications

- Fixed `temperature` default value in `ChatCompletionRequest`
  - Set all sampling parameters field to `None`
  - Created `_DEFAULT_SAMPLING_PARAMS` in `ChatCompletionRequest`, similar to `ResponsesRequest`
- Added `--sampling-defaults` CLI parameter
  - Values: `"default"` (SGLang/OpenAI defaults) or `"model"` (use model's generation_config.json)
  - Updated value `default` to `openai` in fab44da
  - Default: `"model"`
- Added `get_default_sampling_params` in `ModelConfig` to get the sampling params based on `server_args.sampling_defaults`
- Move `_build_sampling_params()` to `ChatCompletionRequest.to_sampling_params()` to implement proper priority: **User explicit values > Model generation config > SGLang/OpenAI defaults**

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

### Default sampling parameters

```
python3 -m sglang.launch_server \
--model /models/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
--port=8080 --tp-size=8 --context-length=20000 \
--attention-backend=fa3 --enable-multimodal \
--tool-call-parser=pythonic \
--log-requests --log-requests-level=1 \
--sampling-defaults=openai
```

#### Request

```
response_non_stream = client.chat.completions.create(
    model=model_name,
    messages=messages,
    stream=False,  # Non-streaming
    max_tokens=2000,
)
```

#### Log

<img width="1443" height="564" alt="Screenshot 2025-10-07 at 9 32 18 AM" src="https://github.com/user-attachments/assets/53da7486-9d06-469c-9577-63c6b1be2f39" />

### Model sampling parameters

```
python3 -m sglang.launch_server \
--model /models/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
--port=8080 --tp-size=8 --context-length=20000 \
--attention-backend=fa3 --enable-multimodal \
--tool-call-parser=pythonic \
--log-requests --log-requests-level=1 \
--sampling-defaults=model
```

#### Request 1

Same as above

#### Log

The `Using default chat sampling` log appears twice because `OpenAIServingResponse` inherits from `OpenAIServingChat`

<img width="1450" height="573" alt="Screenshot 2025-10-07 at 9 17 51 AM" src="https://github.com/user-attachments/assets/0e1de480-c786-4163-9d54-ebd1a39f2eca" />

#### Request 2: pass `top_k=-1` in request 

<img width="1707" height="579" alt="Screenshot 2025-10-07 at 12 44 22 PM" src="https://github.com/user-attachments/assets/1b43dc2b-7ee9-49d8-9955-20fb37d5a264" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
