### PR TITLE
[router][grpc] Fix sampling_params.stop_strs is None

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -501,6 +501,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
         # Convert sampling params
         sampling_params = self._convert_sampling_params(grpc_req.sampling_params)
+        sampling_params.normalize(tokenizer=None)
 
         # Extract disaggregated params if present
         bootstrap_host = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The grpc router failed with

```
[2025-10-07 10:25:01] Scheduler hit an exception: Traceback (most recent call last):
  File "/home/ubuntu/simolin/sglang/python/sglang/srt/managers/scheduler_output_processor_mixin.py", line 248, in process_batch_result_decode
    req.check_finished()
  File "/home/ubuntu/simolin/sglang/python/sglang/srt/managers/schedule_batch.py", line 800, in check_finished
    if len(self.sampling_params.stop_strs) > 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

This is because `stop_strs` by default is `None`, it is transformed in `SamplingParams.normalize`

https://github.com/sgl-project/sglang/blob/f4affd4df53c3eecbb19c2a80cce0b627285582e/python/sglang/srt/sampling/sampling_params.py#L156-L172

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
- Add `sampling_params.normalize(tokenizer=None)` in grpc_server.py

## Accuracy Tests

<img width="1468" height="1314" alt="Screenshot 2025-10-07 at 10 49 37 AM" src="https://github.com/user-attachments/assets/77cd3e82-8051-444b-a82c-33b3cca1c34d" />

<img width="714" height="282" alt="Screenshot 2025-10-07 at 10 52 24 AM" src="https://github.com/user-attachments/assets/bffa679b-95be-4e80-8677-30542ad893bd" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
