### PR TITLE
[router][grpc] Fix error message format in grpc chat handler

### DIFF
--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -469,7 +469,10 @@ impl GrpcPDRouter {
         let prefill_stream = match prefill_result {
             Ok(s) => s,
             Err(e) => {
-                return utils::internal_error_message(format!("Prefill worker failed to start: {}", e));
+                return utils::internal_error_message(format!(
+                    "Prefill worker failed to start: {}",
+                    e
+                ));
             }
         };
 
@@ -477,7 +480,10 @@ impl GrpcPDRouter {
         let decode_stream = match decode_result {
             Ok(s) => s,
             Err(e) => {
-                return utils::internal_error_message(format!("Decode worker failed to start: {}", e));
+                return utils::internal_error_message(format!(
+                    "Decode worker failed to start: {}",
+                    e
+                ));
             }
         };
 
@@ -565,7 +571,10 @@ impl GrpcPDRouter {
         let prefill_stream = match prefill_result {
             Ok(s) => s,
             Err(e) => {
-                return utils::internal_error_message(format!("Prefill worker failed to start: {}", e));
+                return utils::internal_error_message(format!(
+                    "Prefill worker failed to start: {}",
+                    e
+                ));
             }
         };
 
@@ -573,7 +582,10 @@ impl GrpcPDRouter {
         let decode_stream = match decode_result {
             Ok(s) => s,
             Err(e) => {
-                return utils::internal_error_message(format!("Decode worker failed to start: {}", e));
+                return utils::internal_error_message(format!(
+                    "Decode worker failed to start: {}",
+                    e
+                ));
             }
         };
 

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -194,8 +194,7 @@ impl GrpcPDRouter {
         let (original_text, token_ids) = match self.resolve_generate_input(body) {
             Ok(res) => res,
             Err(msg) => {
-                error!("Invalid generate request: {}", msg);
-                return (StatusCode::BAD_REQUEST, msg).into_response();
+                return utils::bad_request_error(msg);
             }
         };
 
@@ -208,8 +207,7 @@ impl GrpcPDRouter {
         {
             Ok(pair) => pair,
             Err(e) => {
-                warn!("Failed to select PD worker pair: {}", e);
-                return (StatusCode::SERVICE_UNAVAILABLE, e).into_response();
+                return utils::service_unavailable_error(e);
             }
         };
 
@@ -244,15 +242,13 @@ impl GrpcPDRouter {
         ) {
             Ok(req) => req,
             Err(e) => {
-                error!("Failed to build generate request: {}", e);
-                return (StatusCode::BAD_REQUEST, e).into_response();
+                return utils::bad_request_error(e);
             }
         };
 
         // Step 5: Inject bootstrap metadata
         if let Err(e) = Self::inject_bootstrap_metadata(&mut request, &*prefill_worker) {
-            error!("Failed to inject bootstrap metadata: {}", e);
-            return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response();
+            return utils::internal_error_message(e);
         }
 
         // Step 6: Get weight version for response metadata
@@ -334,8 +330,7 @@ impl GrpcPDRouter {
         let processed_messages = match utils::process_chat_messages(&body_ref, &*self.tokenizer) {
             Ok(msgs) => msgs,
             Err(e) => {
-                error!("Failed to process chat messages: {}", e);
-                return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+                return utils::bad_request_error(e.to_string());
             }
         };
 
@@ -343,12 +338,7 @@ impl GrpcPDRouter {
         let encoding = match self.tokenizer.encode(&processed_messages.text) {
             Ok(encoding) => encoding,
             Err(e) => {
-                error!("Tokenization failed: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Tokenization failed: {}", e),
-                )
-                    .into_response();
+                return utils::internal_error_message(format!("Tokenization failed: {}", e));
             }
         };
 
@@ -368,8 +358,7 @@ impl GrpcPDRouter {
         {
             Ok(pair) => pair,
             Err(e) => {
-                warn!("Failed to select PD worker pair: {}", e);
-                return (StatusCode::SERVICE_UNAVAILABLE, e).into_response();
+                return utils::service_unavailable_error(e);
             }
         };
 
@@ -402,19 +391,13 @@ impl GrpcPDRouter {
         ) {
             Ok(request) => request,
             Err(e) => {
-                error!("Failed to build gRPC request: {}", e);
-                return (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid request parameters: {}", e),
-                )
-                    .into_response();
+                return utils::bad_request_error(format!("Invalid request parameters: {}", e));
             }
         };
 
         // Step 8: Inject bootstrap metadata into the request
         if let Err(e) = Self::inject_bootstrap_metadata(&mut request, &*prefill_worker) {
-            error!("Failed to inject bootstrap metadata: {}", e);
-            return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response();
+            return utils::internal_error_message(e);
         }
 
         // Step 9: Handle streaming vs non-streaming
@@ -486,12 +469,7 @@ impl GrpcPDRouter {
         let prefill_stream = match prefill_result {
             Ok(s) => s,
             Err(e) => {
-                error!("Failed to start prefill generation: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Prefill worker failed to start: {}", e),
-                )
-                    .into_response();
+                return utils::internal_error_message(format!("Prefill worker failed to start: {}", e));
             }
         };
 
@@ -499,12 +477,7 @@ impl GrpcPDRouter {
         let decode_stream = match decode_result {
             Ok(s) => s,
             Err(e) => {
-                error!("Failed to start decode generation: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Decode worker failed to start: {}", e),
-                )
-                    .into_response();
+                return utils::internal_error_message(format!("Decode worker failed to start: {}", e));
             }
         };
 
@@ -592,12 +565,7 @@ impl GrpcPDRouter {
         let prefill_stream = match prefill_result {
             Ok(s) => s,
             Err(e) => {
-                error!("Failed to start prefill generation: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Prefill worker failed to start: {}", e),
-                )
-                    .into_response();
+                return utils::internal_error_message(format!("Prefill worker failed to start: {}", e));
             }
         };
 
@@ -605,12 +573,7 @@ impl GrpcPDRouter {
         let decode_stream = match decode_result {
             Ok(s) => s,
             Err(e) => {
-                error!("Failed to start decode generation: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Decode worker failed to start: {}", e),
-                )
-                    .into_response();
+                return utils::internal_error_message(format!("Decode worker failed to start: {}", e));
             }
         };
 

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -407,12 +407,32 @@ impl GrpcRouter {
 
     fn internal_error_static(msg: &'static str) -> Response {
         error!("{}", msg);
-        (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": {
+                    "message": msg,
+                    "type": "internal_error",
+                    "code": 500
+                }
+            })),
+        )
+            .into_response()
     }
 
     fn internal_error_message(message: String) -> Response {
         error!("{}", message);
-        (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": {
+                    "message": message,
+                    "type": "internal_error",
+                    "code": 500
+                }
+            })),
+        )
+            .into_response()
     }
 
     /// Count the number of tool calls in the request message history
@@ -740,12 +760,7 @@ impl GrpcRouter {
         let mut grpc_stream = match client.generate(request).await {
             Ok(stream) => stream,
             Err(e) => {
-                error!("Failed to start generation: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Generation failed: {}", e),
-                )
-                    .into_response();
+                return Self::internal_error_message(format!("Generation failed: {}", e));
             }
         };
 

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -139,7 +139,10 @@ impl GrpcRouter {
         {
             Some(w) => w,
             None => {
-                return utils::service_unavailable_error(format!("No available workers for model: {:?}", model_id));
+                return utils::service_unavailable_error(format!(
+                    "No available workers for model: {:?}",
+                    model_id
+                ));
             }
         };
 
@@ -198,7 +201,10 @@ impl GrpcRouter {
         let worker = match self.select_worker_for_request(model_id, original_text.as_deref()) {
             Some(w) => w,
             None => {
-                return utils::service_unavailable_error(format!("No available workers for model: {:?}", model_id));
+                return utils::service_unavailable_error(format!(
+                    "No available workers for model: {:?}",
+                    model_id
+                ));
             }
         };
 
@@ -1268,7 +1274,10 @@ impl GrpcRouter {
             let outputs = match stop_decoder.process_tokens(&complete.output_ids) {
                 Ok(outputs) => outputs,
                 Err(e) => {
-                    return utils::internal_error_message(format!("Failed to process tokens: {}", e))
+                    return utils::internal_error_message(format!(
+                        "Failed to process tokens: {}",
+                        e
+                    ))
                 }
             };
 

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -113,8 +113,7 @@ impl GrpcRouter {
         let processed_messages = match utils::process_chat_messages(&body_ref, &*self.tokenizer) {
             Ok(msgs) => msgs,
             Err(e) => {
-                error!("Failed to process chat messages: {}", e);
-                return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+                return utils::bad_request_error(e.to_string());
             }
         };
 
@@ -122,12 +121,7 @@ impl GrpcRouter {
         let encoding = match self.tokenizer.encode(&processed_messages.text) {
             Ok(encoding) => encoding,
             Err(e) => {
-                error!("Tokenization failed: {}", e);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Tokenization failed: {}", e),
-                )
-                    .into_response();
+                return utils::internal_error_message(format!("Tokenization failed: {}", e));
             }
         };
 
@@ -145,8 +139,7 @@ impl GrpcRouter {
         {
             Some(w) => w,
             None => {
-                warn!("No available workers for model: {:?}", model_id);
-                return (StatusCode::SERVICE_UNAVAILABLE, "No available workers").into_response();
+                return utils::service_unavailable_error(format!("No available workers for model: {:?}", model_id));
             }
         };
 
@@ -170,12 +163,7 @@ impl GrpcRouter {
         ) {
             Ok(request) => request,
             Err(e) => {
-                error!("Failed to build gRPC request: {}", e);
-                return (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid request parameters: {}", e),
-                )
-                    .into_response();
+                return utils::bad_request_error(format!("Invalid request parameters: {}", e));
             }
         };
 
@@ -200,8 +188,7 @@ impl GrpcRouter {
         let (original_text, token_ids) = match self.resolve_generate_input(body) {
             Ok(res) => res,
             Err(msg) => {
-                error!("Invalid generate request: {}", msg);
-                return (StatusCode::BAD_REQUEST, msg).into_response();
+                return utils::bad_request_error(msg);
             }
         };
 
@@ -211,8 +198,7 @@ impl GrpcRouter {
         let worker = match self.select_worker_for_request(model_id, original_text.as_deref()) {
             Some(w) => w,
             None => {
-                warn!("No available workers for model: {:?}", model_id);
-                return (StatusCode::SERVICE_UNAVAILABLE, "No available workers").into_response();
+                return utils::service_unavailable_error(format!("No available workers for model: {:?}", model_id));
             }
         };
 
@@ -238,8 +224,7 @@ impl GrpcRouter {
         ) {
             Ok(req) => req,
             Err(e) => {
-                error!("Failed to build generate request: {}", e);
-                return (StatusCode::BAD_REQUEST, e).into_response();
+                return utils::bad_request_error(e);
             }
         };
 
@@ -403,36 +388,6 @@ impl GrpcRouter {
             .encode(text)
             .map_err(|e| format!("Tokenization failed: {}", e))?;
         Ok((text.to_string(), encoding.token_ids().to_vec()))
-    }
-
-    fn internal_error_static(msg: &'static str) -> Response {
-        error!("{}", msg);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": {
-                    "message": msg,
-                    "type": "internal_error",
-                    "code": 500
-                }
-            })),
-        )
-            .into_response()
-    }
-
-    fn internal_error_message(message: String) -> Response {
-        error!("{}", message);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({
-                "error": {
-                    "message": message,
-                    "type": "internal_error",
-                    "code": 500
-                }
-            })),
-        )
-            .into_response()
     }
 
     /// Count the number of tool calls in the request message history
@@ -760,7 +715,7 @@ impl GrpcRouter {
         let mut grpc_stream = match client.generate(request).await {
             Ok(stream) => stream,
             Err(e) => {
-                return Self::internal_error_message(format!("Generation failed: {}", e));
+                return utils::internal_error_message(format!("Generation failed: {}", e));
             }
         };
 
@@ -1198,7 +1153,7 @@ impl GrpcRouter {
         let stream = match client.generate(request).await {
             Ok(s) => s,
             Err(e) => {
-                return Self::internal_error_message(format!("Failed to start generation: {}", e))
+                return utils::internal_error_message(format!("Failed to start generation: {}", e))
             }
         };
 
@@ -1208,7 +1163,7 @@ impl GrpcRouter {
         };
 
         if all_responses.is_empty() {
-            return Self::internal_error_static("No responses from server");
+            return utils::internal_error_static("No responses from server");
         }
 
         // Process each response into a ChatChoice
@@ -1227,7 +1182,7 @@ impl GrpcRouter {
             {
                 Ok(choice) => choices.push(choice),
                 Err(e) => {
-                    return Self::internal_error_message(format!(
+                    return utils::internal_error_message(format!(
                         "Failed to process choice {}: {}",
                         index, e
                     ));
@@ -1280,7 +1235,7 @@ impl GrpcRouter {
         let stream = match client.generate(request).await {
             Ok(stream) => stream,
             Err(e) => {
-                return Self::internal_error_message(format!("Failed to start generation: {}", e))
+                return utils::internal_error_message(format!("Failed to start generation: {}", e))
             }
         };
 
@@ -1291,7 +1246,7 @@ impl GrpcRouter {
         };
 
         if responses.is_empty() {
-            return Self::internal_error_static("No completion received from scheduler");
+            return utils::internal_error_static("No completion received from scheduler");
         }
 
         // Create stop decoder from sampling params
@@ -1313,7 +1268,7 @@ impl GrpcRouter {
             let outputs = match stop_decoder.process_tokens(&complete.output_ids) {
                 Ok(outputs) => outputs,
                 Err(e) => {
-                    return Self::internal_error_message(format!("Failed to process tokens: {}", e))
+                    return utils::internal_error_message(format!("Failed to process tokens: {}", e))
                 }
             };
 
@@ -1392,7 +1347,7 @@ impl GrpcRouter {
         let stream = match client.generate(request).await {
             Ok(stream) => stream,
             Err(e) => {
-                return Self::internal_error_message(format!("Failed to start generation: {}", e))
+                return utils::internal_error_message(format!("Failed to start generation: {}", e))
             }
         };
 

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -14,13 +14,14 @@ pub use crate::tokenizer::StopSequenceDecoder;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
+    Json,
 };
 use futures::StreamExt;
 use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::codec::Streaming;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 /// Get gRPC client from worker, returning appropriate error response on failure
@@ -30,22 +31,8 @@ pub async fn get_grpc_client_from_worker(
     let client_arc = worker
         .get_grpc_client()
         .await
-        .map_err(|e| {
-            error!("Failed to get gRPC client from worker: {}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get gRPC client: {}", e),
-            )
-                .into_response()
-        })?
-        .ok_or_else(|| {
-            error!("Selected worker is not a gRPC worker");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Selected worker is not configured for gRPC",
-            )
-                .into_response()
-        })?;
+        .map_err(|e| internal_error_message(format!("Failed to get gRPC client: {}", e)))?
+        .ok_or_else(|| internal_error_static("Selected worker is not configured for gRPC"))?;
 
     let client = client_arc.lock().await.clone();
     Ok(client)
@@ -422,12 +409,62 @@ pub fn process_chat_messages(
 /// Error response helpers (shared between regular and PD routers)
 pub fn internal_error_static(msg: &'static str) -> Response {
     error!("{}", msg);
-    (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": {
+                "message": msg,
+                "type": "internal_error",
+                "code": 500
+            }
+        })),
+    )
+        .into_response()
 }
 
 pub fn internal_error_message(message: String) -> Response {
     error!("{}", message);
-    (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": {
+                "message": message,
+                "type": "internal_error",
+                "code": 500
+            }
+        })),
+    )
+        .into_response()
+}
+
+pub fn bad_request_error(message: String) -> Response {
+    error!("{}", message);
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "message": message,
+                "type": "invalid_request_error",
+                "code": 400
+            }
+        })),
+    )
+        .into_response()
+}
+
+pub fn service_unavailable_error(message: String) -> Response {
+    warn!("{}", message);
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "error": {
+                "message": message,
+                "type": "service_unavailable",
+                "code": 503
+            }
+        })),
+    )
+        .into_response()
 }
 
 /// Create a StopSequenceDecoder from stop parameters


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR makes sure the error response from grpc router chat completions endpoint matches the OpenAI standard.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
- Added error helper functions to src/routers/grpc/utils.rs:
  - internal_error_static() - for internal errors with static messages
  - internal_error_message() - for internal errors with dynamic messages
  - bad_request_error() - for 400 bad request errors
  - service_unavailable_error() - for 503 service unavailable errors
- Updated error responses in both routers (router.rs and pd_router.rs):
  - All error responses in route_chat_impl now use JSON format
  - All error responses in route_generate_impl now use JSON format
  - All error responses in streaming handlers now use JSON format
  - Updated get_grpc_client_from_worker in utils to use JSON format
- All errors now follow this JSON structure:
```
{
 "error": {
   "message": "error message here",
   "type": "error_type",
   "code": http_status_code
 }
}
```

## Accuracy Tests

<img width="817" height="200" alt="Screenshot 2025-10-07 at 1 39 05 PM" src="https://github.com/user-attachments/assets/c57d6b99-6c6f-4f82-93a7-d856d749a87b" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
