### PR TITLE
[DeepSeek-V3.2] Include indexer kv cache when estimating kv cache size

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -857,9 +857,6 @@ class ServerArgs:
                 self.page_size = 64
                 logger.warning("Setting page size to 64 for DeepSeek NSA.")
 
-                self.mem_fraction_static = 0.8
-                logger.warning("Setting mem fraction static to 0.8 for DeepSeek NSA.")
-
                 # For Hopper, we support both bf16 and fp8 kv cache; for Blackwell, we support fp8 only currently
                 import torch
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

For DS v3.2 to avoid OOM.

## Results

On 8xB200:
With this PR:
```
$ python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --dp 8 --enable-dp-attention
...                                                                                    
[2025-10-07 23:17:19 DP0 TP0] KV Cache is allocated. #tokens: 975424, KV size: 43.67 GB                                                                                         
[2025-10-07 23:17:19 DP0 TP0] Memory pool end. avail mem=37.71 GB  
```

With main (hardcoded mem-fraction-static=0.8) - KV size including index is actually 65.49 GB
```
[2025-10-07 22:29:11 DP0 TP0] KV Cache is allocated. #tokens: 1462784, KV size: 54.52 GB
[2025-10-07 22:29:11 DP0 TP0] Memory pool end. avail mem=15.38 GB
```

## Modifications

* Include indexer kv cache size in `profile_max_num_token`. I used the size calculation in `NSATokenToKVPool.__init__()` - can someone confirm if this is correct? It seems to be working.
* Include indexer kv cache size in allocation log

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
