### PR TITLE
[router] cleanup worker health check to return early

### DIFF
--- a/sgl-router/src/core/worker_manager.rs
+++ b/sgl-router/src/core/worker_manager.rs
@@ -953,113 +953,105 @@ impl WorkerManager {
             return Ok(());
         }
 
+        // Mark all workers as unhealthy initially
         info!(
-            "Marking {} workers as unhealthy before initial health checks",
+            "Marking {} workers as unhealthy before health checks",
             workers.len()
         );
         for worker in &workers {
             worker.set_healthy(false);
         }
 
-        info!(
-            "Performing initial health checks for {} workers",
-            workers.len()
-        );
-        let health_check_futures: Vec<_> = workers
-            .iter()
-            .map(|worker| {
-                let w = worker.clone();
-                let url = worker.url().to_string();
-                async move {
-                    match w.check_health_async().await {
-                        Ok(_) => {
-                            w.set_healthy(true);
-                            debug!(
-                                "Worker {} passed initial health check and marked healthy",
-                                url
-                            );
-                            Ok(url)
-                        }
-                        Err(e) => {
-                            warn!("Worker {} failed initial health check: {}", url, e);
-                            Err(url)
-                        }
-                    }
-                }
-            })
-            .collect();
-
-        let health_results = future::join_all(health_check_futures).await;
-        let failed_checks: Vec<_> = health_results.into_iter().filter_map(|r| r.err()).collect();
-
-        if !failed_checks.is_empty() {
-            info!(
-                "Initial health check: {} workers failed: {:?}",
-                failed_checks.len(),
-                failed_checks
-            );
-        }
-
         loop {
+            // 1. Filter unhealthy workers
             let workers = registry.get_all();
-            let healthy_workers: Vec<_> = workers
-                .iter()
-                .filter(|w| w.is_healthy())
-                .map(|w| w.url().to_string())
-                .collect();
             let unhealthy_workers: Vec<_> = workers
                 .iter()
                 .filter(|w| !w.is_healthy())
-                .map(|w| w.url().to_string())
+                .cloned()
                 .collect();
 
+            // 2. If all workers are healthy, return immediately
             if unhealthy_workers.is_empty() {
+                let healthy_urls: Vec<_> = workers.iter().map(|w| w.url().to_string()).collect();
                 info!(
                     "All {} workers are healthy: {:?}",
                     workers.len(),
-                    healthy_workers
+                    healthy_urls
                 );
                 return Ok(());
             }
 
+            // Check timeout
             if start_time.elapsed() > timeout {
+                let healthy_workers: Vec<_> = workers
+                    .iter()
+                    .filter(|w| w.is_healthy())
+                    .map(|w| w.url().to_string())
+                    .collect();
+                let unhealthy_urls: Vec<_> = unhealthy_workers
+                    .iter()
+                    .map(|w| w.url().to_string())
+                    .collect();
+
                 error!(
                     "Workers failed to become healthy after {}s. Unhealthy: {:?}, Healthy: {:?}",
-                    timeout_secs, unhealthy_workers, healthy_workers
+                    timeout_secs, unhealthy_urls, healthy_workers
                 );
                 return Err(format!(
                     "Workers failed to become healthy after {}s. Unhealthy: {:?}",
-                    timeout_secs, unhealthy_workers
+                    timeout_secs, unhealthy_urls
                 ));
             }
+
+            let unhealthy_urls: Vec<_> = unhealthy_workers
+                .iter()
+                .map(|w| w.url().to_string())
+                .collect();
 
             info!(
                 "Waiting for {} workers to become healthy. Unhealthy: {:?}",
                 unhealthy_workers.len(),
-                unhealthy_workers
+                unhealthy_urls
             );
 
-            let unhealthy_workers_to_check = workers
+            // 3. Check health of all unhealthy workers in parallel
+            let health_check_futures: Vec<_> = unhealthy_workers
                 .iter()
-                .filter(|w| !w.is_healthy())
-                .cloned()
-                .collect::<Vec<_>>();
-
-            for worker in unhealthy_workers_to_check {
-                let url = worker.url().to_string();
-                match worker.check_health_async().await {
-                    Ok(_) => {
-                        if !worker.is_healthy() {
-                            worker.set_healthy(true);
-                            debug!("Worker {} now healthy after health check", url);
+                .map(|worker| {
+                    let w = worker.clone();
+                    let url = worker.url().to_string();
+                    async move {
+                        match w.check_health_async().await {
+                            Ok(_) => {
+                                w.set_healthy(true);
+                                debug!("Worker {} now healthy", url);
+                            }
+                            Err(e) => {
+                                debug!("Worker {} health check failed: {}", url, e);
+                            }
                         }
                     }
-                    Err(e) => {
-                        debug!("Worker {} health check failed: {}", url, e);
-                    }
-                }
+                })
+                .collect();
+
+            future::join_all(health_check_futures).await;
+
+            // 4. Check if all workers are now healthy after health checks
+            let still_unhealthy: Vec<_> = workers.iter().filter(|w| !w.is_healthy()).collect();
+
+            // 5. If all workers are now healthy, return immediately without sleeping
+            if still_unhealthy.is_empty() {
+                let healthy_urls: Vec<_> = workers.iter().map(|w| w.url().to_string()).collect();
+                info!(
+                    "All {} workers are healthy: {:?}",
+                    workers.len(),
+                    healthy_urls
+                );
+                return Ok(());
             }
 
+            // 6. Otherwise, sleep before next iteration
             tokio::time::sleep(check_interval).await;
         }
     }


### PR DESCRIPTION
## Motivation
original worker health check had a small bug where when workers return healthy, it sleeps anyway
this pr consolidate the health check into a single loop
1. fetch all unhealthy worker
2. send health check in parallel
3. fetch unhealthy workers -> return if empty
4. sleep otherwise

## Tests
```
2025-10-07 23:31:33 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:28: Connecting to SGLang scheduler at grpc://localhost:20001
2025-10-07 23:31:33 ERROR sglang_router_rs::core::worker: src/core/worker.rs:517: Failed to connect gRPC client for worker grpc://localhost:20000: transport error
2025-10-07 23:31:33 DEBUG sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1031: Worker grpc://localhost:20000 health check failed: Connection failed for worker grpc://localhost:20000: Failed to connect to gRPC server: transport error
2025-10-07 23:31:33 ERROR sglang_router_rs::core::worker: src/core/worker.rs:517: Failed to connect gRPC client for worker grpc://localhost:20001: transport error
2025-10-07 23:31:33 DEBUG sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1031: Worker grpc://localhost:20001 health check failed: Connection failed for worker grpc://localhost:20001: Failed to connect to gRPC server: transport error
2025-10-07 23:32:33  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1012: Waiting for 2 workers to become healthy. Unhealthy: ["grpc://localhost:20000", "grpc://localhost:20001"]
2025-10-07 23:32:33  INFO sglang_router_rs::core::worker: src/core/worker.rs:502: Lazily initializing gRPC client for worker: grpc://localhost:20000
2025-10-07 23:32:33 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:28: Connecting to SGLang scheduler at grpc://localhost:20000
2025-10-07 23:32:33  INFO sglang_router_rs::core::worker: src/core/worker.rs:502: Lazily initializing gRPC client for worker: grpc://localhost:20001
2025-10-07 23:32:33 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:28: Connecting to SGLang scheduler at grpc://localhost:20001
2025-10-07 23:32:33  INFO sglang_router_rs::core::worker: src/core/worker.rs:510: Successfully connected gRPC client for worker: grpc://localhost:20000
2025-10-07 23:32:33 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:70: Sending health check request
2025-10-07 23:32:33  INFO sglang_router_rs::core::worker: src/core/worker.rs:510: Successfully connected gRPC client for worker: grpc://localhost:20001
2025-10-07 23:32:33 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:70: Sending health check request
2025-10-07 23:32:33 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:79: Health check response received
2025-10-07 23:32:33 DEBUG sglang_router_rs::core::worker: src/core/worker.rs:560: gRPC health OK for grpc://localhost:20001: healthy=true
2025-10-07 23:32:33 DEBUG sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1028: Worker grpc://localhost:20001 now healthy
2025-10-07 23:32:34 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:79: Health check response received
2025-10-07 23:32:34 DEBUG sglang_router_rs::core::worker: src/core/worker.rs:560: gRPC health OK for grpc://localhost:20000: healthy=true
2025-10-07 23:32:34 DEBUG sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1028: Worker grpc://localhost:20000 now healthy
2025-10-07 23:32:34  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1046: All 2 workers are healthy: ["grpc://localhost:20000", "grpc://localhost:20001"]
2025-10-07 23:32:34  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:245: Worker initialization completed successfully
2025-10-07 23:32:34  INFO sglang_router_rs::server: src/server.rs:730: Workers initialized: 2 total, 2 healthy
2025-10-07 23:32:34  INFO sglang_router_rs::routers::router_manager: src/routers/router_manager.rs:107: Initializing RouterManager in single-router mode
2025-10-07 23:32:34  INFO sglang_router_rs::routers::router_manager: src/routers/router_manager.rs:115: Created single router with ID: grpc-pd
2025-10-07 23:32:34  INFO sglang_router_rs::routers::router_manager: src/routers/router_manager.rs:159: Set default router to grpc-pd
2025-10-07 23:32:34  INFO sglang_router_rs::server: src/server.rs:741: Started health checker for workers with 60s interval
2025-10-07 23:32:34  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1378: Starting load monitoring with interval: 30s
2025-10-07 23:32:34  INFO sglang_router_rs::server: src/server.rs:748: Started LoadMonitor for PowerOfTwo policies
2025-10-07 23:32:34  INFO sglang_router_rs::server: src/server.rs:759: Started request queue with size: 100, timeout: 60s
2025-10-07 23:32:34  INFO sglang_router_rs::middleware: src/middleware.rs:375: Starting concurrency queue processor
2025-10-07 23:32:34  INFO sglang_router_rs::server: src/server.rs:791: Router ready | workers: ["grpc://localhost:20000", "grpc://localhost:20001"]
2025-10-07 23:32:34  INFO sglang_router_rs::server: src/server.rs:819: Starting server on 0.0.0.0:8080
2025-10-07 23:32:34 DEBUG sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1427: No PowerOfTwo policies found, skipping load fetch
2025-10-07 23:32:34 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:70: Sending health check request
2025-10-07 23:32:34 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:79: Health check response received
2025-10-07 23:32:34 DEBUG sglang_router_rs::core::worker: src/core/worker.rs:560: gRPC health OK for grpc://localhost:20000: healthy=true
2025-10-07 23:32:34 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:70: Sending health check request
2025-10-07 23:32:34 DEBUG sglang_router_rs::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:79: Health check response received
2025-10-07 23:32:34 DEBUG sglang_router_rs::core::worker: src/core/worker.rs:560: gRPC health OK for grpc://localhost:20001: healthy=true
2025-10-07 23:33:04 DEBUG sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:1427: No PowerOfTwo policies found, skipping load fetch
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
