### PR TITLE
[router][grpc] Fix request_id extraction when n > 1

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_request_manager.py
+++ b/python/sglang/srt/entrypoints/grpc_request_manager.py
@@ -263,8 +263,8 @@ class GrpcRequestManager:
                         response = await task
 
                         # Add index for client-side ordering
-                        if isinstance(response, dict) and "meta_info" in response:
-                            response_rid = response["meta_info"].get("id", "")
+                        if isinstance(response, dict):
+                            response_rid = response.get("request_id", "")
                             if response_rid in rid_to_index:
                                 response["index"] = rid_to_index[response_rid]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When `n>1`, `grpc_request_manager.py` relies on `rid_to_index` to map the rid to its index.

However, the current rid extraction is wrong. As in `_handle_batch_output`, rid is stored in `output_data["request_id"]`

https://github.com/sgl-project/sglang/blob/4ed67c27e39523225e1b01524be7eaa53d3a7773/python/sglang/srt/entrypoints/grpc_request_manager.py#L564-L566

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

- Fix rid extraction

## Accuracy Tests

Before

`request.n = 2`

No index = 1

<img width="849" height="469" alt="Screenshot 2025-10-07 at 4 19 57 PM" src="https://github.com/user-attachments/assets/0c4138a4-fcb5-40b3-a653-c1519b1d903b" />


After

There is index = 1
<img width="837" height="611" alt="Screenshot 2025-10-07 at 4 24 06 PM" src="https://github.com/user-attachments/assets/a24bd8dd-187c-4903-9b58-541a34e3d9c8" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
