### PR TITLE
fix: do not wrap invalid grammar objects during constrained generation

### DIFF
--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -17,7 +17,11 @@ from typing import List, Optional, Tuple
 
 import torch
 
-from .base_grammar_backend import BaseGrammarBackend, BaseGrammarObject
+from .base_grammar_backend import (
+    INVALID_GRAMMAR_OBJ,
+    BaseGrammarBackend,
+    BaseGrammarObject,
+)
 
 
 class ReasonerGrammarObject(BaseGrammarObject):
@@ -81,10 +85,9 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
         self.grammar_backend = grammar_backend
         self.think_end_id = think_end_id
 
-    def _init_value_dispatch(
-        self, key: Tuple[str, str]
-    ) -> Optional[ReasonerGrammarObject]:
+    def _init_value_dispatch(self, key: Tuple[str, str]) -> Optional[BaseGrammarObject]:
         ret = self.grammar_backend._init_value_dispatch(key)
-        if ret is None:
-            return None
+        # avoid wrapping invalid grammar, so that the scheduler can detect it
+        if ret is None or ret is INVALID_GRAMMAR_OBJ:
+            return ret
         return ReasonerGrammarObject(ret, self.think_end_id)


### PR DESCRIPTION
Wrapping invalid grammar objects in the reasoner backend causes the scheduler's check for invalid grammars to not notice them.

This can lead to requests with invalid grammars (e.g. on regex validity issues) to be scheduled, eventually causing a crash when the invalid grammar is used for masking.

This relates to sgl-project/sglang#9187

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This pull request is motivated by a production incident in which a user managed to bring down several LLM instances (DeepSeek-3.2 and GLM-4.6) by supplying the following JSON schema in a request:

```
{"type": "object", "properties": {"reasoning": {"type": "string", "minLength": 16, "description": "A SINGLE multiline plain-text string. Use \'- \' for bullet points inside the string. Do NOT return arrays or objects here.", "pattern": "^(?!\\\\s*[\\\\[{]).+"}, "test_code_lines": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Full test code, split line-by-line. Each array element is one code line."}}, "required": ["reasoning", "test_code_lines"], "additionalProperties": false}
```

The regular expression here causes `/project/cpp/regex_converter.cc:75: Regex parsing error at position 4: Lookahead is not supported yet.`, produces an invalid grammar object, and later sglang attempts to call methods on this object.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Ensured that we don't wrap invalid grammar objects in the reasoner grammar wrapper. This way further checks for invalid grammar objects "further down the pipe" will work as intended.

## Accuracy Tests

We tried sending requests with this JSON schema after the patch, and no more crashes were observed.
