### PR TITLE
[router][grpc] Cleanup debug logs in grpc_server and grpc_router

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_request_manager.py
+++ b/python/sglang/srt/entrypoints/grpc_request_manager.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import time
 import uuid
-from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+from typing import AsyncGenerator, Dict, List, Optional, Union
 
 import grpc
 import zmq

--- a/python/sglang/srt/entrypoints/grpc_request_manager.py
+++ b/python/sglang/srt/entrypoints/grpc_request_manager.py
@@ -397,9 +397,7 @@ class GrpcRequestManager:
         # Wait for result in background
         async def wait_for_result():
             try:
-                # Wait for completion
                 await state.event.wait()
-                # Get result from queue
                 result = await state.out_queue.get()
                 future.set_result(result)
             except Exception as e:

--- a/python/sglang/srt/entrypoints/grpc_request_manager.py
+++ b/python/sglang/srt/entrypoints/grpc_request_manager.py
@@ -13,7 +13,7 @@ import sys
 import threading
 import time
 import uuid
-from typing import AsyncGenerator, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 import grpc
 import zmq
@@ -777,6 +777,14 @@ class GrpcRequestManager:
         self.context.term()
 
         logger.info("GrpcRequestManager shutdown complete")
+
+    def get_server_info(self) -> Dict[str, Any]:
+        """Get server information for health checks."""
+        return {
+            "active_requests": len(self.rid_to_state),
+            "paused": self.is_pause,
+            "last_receive_time": self.last_receive_tstamp,
+        }
 
     def auto_create_handle_loop(self):
         """Automatically create and start the handle_loop task, matching TokenizerManager pattern."""

--- a/python/sglang/srt/entrypoints/grpc_request_manager.py
+++ b/python/sglang/srt/entrypoints/grpc_request_manager.py
@@ -437,19 +437,6 @@ class GrpcRequestManager:
 
         return True
 
-    async def pause_generation(self):
-        """Pause generation processing."""
-        async with self.is_pause_cond:
-            self.is_pause = True
-            logger.info("Generation paused")
-
-    async def resume_generation(self):
-        """Resume generation processing."""
-        async with self.is_pause_cond:
-            self.is_pause = False
-            self.is_pause_cond.notify_all()
-            logger.info("Generation resumed")
-
     async def handle_loop(self):
         """
         Main event loop - processes outputs from scheduler.
@@ -792,14 +779,6 @@ class GrpcRequestManager:
         self.context.term()
 
         logger.info("GrpcRequestManager shutdown complete")
-
-    def get_server_info(self) -> Dict[str, Any]:
-        """Get server information for health checks."""
-        return {
-            "active_requests": len(self.rid_to_state),
-            "paused": self.is_pause,
-            "last_receive_time": self.last_receive_tstamp,
-        }
 
     def auto_create_handle_loop(self):
         """Automatically create and start the handle_loop task, matching TokenizerManager pattern."""

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -189,7 +189,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         # Start the request manager's event loop using auto_create_handle_loop
         self.request_manager.auto_create_handle_loop()
 
-        logger.info("Standalone gRPC scheduler service initialized")
+        logger.info("gRPC scheduler servicer initialized")
 
     async def Generate(
         self,
@@ -840,7 +840,6 @@ async def serve_grpc(
         port_args=port_args,
         bootstrap_server=bootstrap_server,
     )
-    logger.info("Request manager created successfully")
 
     # Create gRPC server
     server = grpc.aio.server(
@@ -859,7 +858,6 @@ async def serve_grpc(
         scheduler_info=scheduler_info,
     )
     sglang_scheduler_pb2_grpc.add_SglangSchedulerServicer_to_server(servicer, server)
-    logger.info("gRPC servicer registered")
 
     # Enable reflection
     SERVICE_NAMES = (

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -197,7 +197,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         context: grpc.aio.ServicerContext,
     ) -> AsyncIterator[sglang_scheduler_pb2.GenerateResponse]:
         """Handle generation requests with streaming responses."""
-        logger.info(f"Generation request: {request.request_id}")
+        logger.debug(f"Receive generation request: {request.request_id}")
 
         try:
             # Convert gRPC request to internal format
@@ -249,7 +249,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                         yield self._create_chunk_response(request.request_id, output)
 
         except Exception as e:
-            logger.error(f"Generate failed: {e}\n{get_exception_traceback()}")
+            logger.error(
+                f"Generate failed for request {request.request_id}: {e}\n"
+                f"{get_exception_traceback()}"
+            )
             yield sglang_scheduler_pb2.GenerateResponse(
                 request_id=request.request_id,
                 error=sglang_scheduler_pb2.GenerateError(
@@ -262,10 +265,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
     async def Embed(
         self,
         request: sglang_scheduler_pb2.EmbedRequest,
-        context: grpc.aio.ServicerContext,
+        _context: grpc.aio.ServicerContext,
     ) -> sglang_scheduler_pb2.EmbedResponse:
         """Handle embedding requests."""
-        logger.info(f"Embedding request: {request.request_id}")
+        logger.debug(f"Receive embedding request: {request.request_id}")
 
         try:
             # Convert request
@@ -292,7 +295,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             )
 
         except Exception as e:
-            logger.error(f"Embed failed: {e}\n{get_exception_traceback()}")
+            logger.error(
+                f"Embed failed for request {request.request_id}: {e}\n"
+                f"{get_exception_traceback()}"
+            )
             return sglang_scheduler_pb2.EmbedResponse(
                 request_id=request.request_id,
                 error=sglang_scheduler_pb2.EmbedError(
@@ -344,7 +350,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 health_request.bootstrap_host = FAKE_BOOTSTRAP_HOST
                 health_request.bootstrap_room = 0
 
-            logger.info(f"Sending health check request to request manager...")
+            logger.debug(f"Receive health check request: {rid}")
 
             # Submit and wait for response
             output_generator = self.request_manager.generate_request(
@@ -375,7 +381,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 )
 
         except Exception as e:
-            logger.error(f"Health check failed: {e}")
+            logger.error(f"Health check failed: {e}\n{get_exception_traceback()}")
             return sglang_scheduler_pb2.HealthCheckResponse(
                 healthy=False, message=f"Health check error: {str(e)}"
             )
@@ -383,10 +389,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
     async def Abort(
         self,
         request: sglang_scheduler_pb2.AbortRequest,
-        context: grpc.aio.ServicerContext,
+        _context: grpc.aio.ServicerContext,
     ) -> sglang_scheduler_pb2.AbortResponse:
         """Abort an ongoing request."""
-        logger.info(f"Aborting request: {request.request_id}")
+        logger.debug(f"Receive abort request: {request.request_id}")
 
         try:
             success = await self.request_manager.abort_request(request.request_id)
@@ -396,7 +402,10 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 message=f"Request {request.request_id} {'aborted' if success else 'not found'}",
             )
         except Exception as e:
-            logger.error(f"Abort failed: {e}")
+            logger.error(
+                f"Abort failed for request {request.request_id}: {e}\n"
+                f"{get_exception_traceback()}"
+            )
             return sglang_scheduler_pb2.AbortResponse(
                 success=False,
                 message=str(e),
@@ -404,11 +413,11 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
     async def GetModelInfo(
         self,
-        request: sglang_scheduler_pb2.GetModelInfoRequest,
-        context: grpc.aio.ServicerContext,
+        _request: sglang_scheduler_pb2.GetModelInfoRequest,
+        _context: grpc.aio.ServicerContext,
     ) -> sglang_scheduler_pb2.GetModelInfoResponse:
         """Get model information."""
-        logger.info("Model info request received")
+        logger.debug("Receive model info request")
 
         is_generation = self.scheduler_info.get("is_generation")
         if is_generation is None:
@@ -435,11 +444,11 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
     async def GetServerInfo(
         self,
-        request: sglang_scheduler_pb2.GetServerInfoRequest,
-        context: grpc.aio.ServicerContext,
+        _request: sglang_scheduler_pb2.GetServerInfoRequest,
+        _context: grpc.aio.ServicerContext,
     ) -> sglang_scheduler_pb2.GetServerInfoResponse:
         """Get server information."""
-        logger.info("Server info request received")
+        logger.debug("Receive server info request")
 
         server_args_dict = dataclasses.asdict(self.server_args)
         server_args_struct = Struct()
@@ -831,6 +840,7 @@ async def serve_grpc(
         port_args=port_args,
         bootstrap_server=bootstrap_server,
     )
+    logger.info("Request manager created successfully")
 
     # Create gRPC server
     server = grpc.aio.server(
@@ -849,6 +859,7 @@ async def serve_grpc(
         scheduler_info=scheduler_info,
     )
     sglang_scheduler_pb2_grpc.add_SglangSchedulerServicer_to_server(servicer, server)
+    logger.info("gRPC servicer registered")
 
     # Enable reflection
     SERVICE_NAMES = (
@@ -861,9 +872,8 @@ async def serve_grpc(
     listen_addr = f"{server_args.host}:{server_args.port}"
     server.add_insecure_port(listen_addr)
 
-    logger.info(f"Starting standalone gRPC server on {listen_addr}")
-
     await server.start()
+    logger.info(f"gRPC server listening on {listen_addr}")
 
     # Handle shutdown signals
     loop = asyncio.get_running_loop()

--- a/sgl-router/src/reasoning_parser/parsers/base.rs
+++ b/sgl-router/src/reasoning_parser/parsers/base.rs
@@ -2,7 +2,6 @@
 // for detecting and extracting reasoning blocks from text.
 
 use crate::reasoning_parser::traits::{ParseError, ParserConfig, ParserResult, ReasoningParser};
-use tracing as log;
 
 /// Base reasoning parser implementation.
 ///

--- a/sgl-router/src/reasoning_parser/parsers/base.rs
+++ b/sgl-router/src/reasoning_parser/parsers/base.rs
@@ -46,18 +46,14 @@ impl BaseReasoningParser {
 
 impl ReasoningParser for BaseReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
-        log::debug!("detect_and_parse_reasoning called with text: {:?}", text);
-
         // Check input size against buffer limit
         if text.len() > self.config.max_buffer_size {
             return Err(ParseError::BufferOverflow(text.len()));
         }
 
         let in_reasoning = self.in_reasoning || text.contains(&self.config.think_start_token);
-        log::debug!("in_reasoning: {}", in_reasoning);
 
         if !in_reasoning {
-            log::debug!("No reasoning detected, returning normal text.");
             return Ok(ParserResult::normal(text.to_string()));
         }
 
@@ -66,15 +62,8 @@ impl ReasoningParser for BaseReasoningParser {
             .replace(&self.config.think_start_token, "")
             .trim()
             .to_string();
-        log::debug!(
-            "Processed text after removing think_start_token: {:?}",
-            processed_text
-        );
 
         if !processed_text.contains(&self.config.think_end_token) {
-            log::debug!(
-                "Reasoning truncated, think_end_token not found. Returning reasoning text."
-            );
             // Assume reasoning was truncated before end token
             return Ok(ParserResult::reasoning(processed_text));
         }
@@ -88,9 +77,6 @@ impl ReasoningParser for BaseReasoningParser {
             .get(1)
             .map(|s| s.trim().to_string())
             .unwrap_or_default();
-
-        log::debug!("Extracted reasoning_text: {:?}", reasoning_text);
-        log::debug!("Extracted normal_text: {:?}", normal_text);
 
         Ok(ParserResult::new(normal_text, reasoning_text))
     }
@@ -107,19 +93,6 @@ impl ReasoningParser for BaseReasoningParser {
         // Incrementally parse the streaming text
         self.buffer.push_str(text);
         let mut current_text = self.buffer.clone();
-
-        log::debug!(
-            "parse_reasoning_streaming_incremental called with text: {:?}",
-            text
-        );
-        log::debug!("current buffer: {:?}", self.buffer);
-        log::debug!("current_text: {:?}", current_text);
-        log::debug!(
-            "in_reasoning: {}, stripped_think_start: {}, stream_reasoning: {}",
-            self.in_reasoning,
-            self.stripped_think_start,
-            self.config.stream_reasoning
-        );
 
         // If the current text is a prefix of a token, keep buffering
         if self.is_partial_token(&current_text) {

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -21,7 +21,7 @@ use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tonic::codec::Streaming;
-use tracing::{debug, error, warn};
+use tracing::{error, warn};
 use uuid::Uuid;
 
 /// Get gRPC client from worker, returning appropriate error response on failure

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -602,10 +602,6 @@ pub async fn collect_stream_responses(
             Ok(gen_response) => {
                 match gen_response.response {
                     Some(Complete(complete)) => {
-                        debug!(
-                        "{} completed: prompt_tokens={}, completion_tokens={}, finish_reason={}",
-                        worker_name, complete.prompt_tokens, complete.completion_tokens, complete.finish_reason
-                    );
                         all_responses.push(complete);
                     }
                     Some(Error(err)) => {
@@ -615,11 +611,11 @@ pub async fn collect_stream_responses(
                             worker_name, err.message
                         )));
                     }
-                    Some(Chunk(chunk)) => {
-                        debug!("{} chunk: {} tokens", worker_name, chunk.token_ids.len());
+                    Some(Chunk(_chunk)) => {
+                        // Streaming chunk - no action needed
                     }
                     None => {
-                        debug!("{}: empty response", worker_name);
+                        // Empty response - no action needed
                     }
                 }
             }
@@ -633,7 +629,6 @@ pub async fn collect_stream_responses(
         }
     }
 
-    debug!("{} stream closed", worker_name);
     Ok(all_responses)
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Both gRPC server and router has a lot of debug logs or info logs that are spam. 

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Remove unused function in grpc_request_manager.py
- Cleanup logs and comments in grpc_server.py
- Clean up debug logs in sgl-router
  - Remove all debug logs from reasoning_parser/parsers/base.rs
    - Context: Fires multiple times per token in streaming
  - Remove pipeline stage debug logs from grpc/pipeline.r
    - Context: Fires on every request (multiple times)
  - Remove streaming chunk debug logs from grpc/utils.rs
    - Context: Fires on every streaming chunk
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
