### PR TITLE
[router][grpc] Add dependencies in Cargo.toml to support chat template rendering

### DIFF
--- a/sgl-router/Cargo.toml
+++ b/sgl-router/Cargo.toml
@@ -57,7 +57,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 anyhow = "1.0"
 tokenizers = { version = "0.22.0" }
 tiktoken-rs = { version = "0.7.0" }
-minijinja = { version = "2.0", features = ["unstable_machinery"] }
+minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 hf-hub = { version = "0.4.3", features = ["tokio"] }
 rmcp = { version = "0.6.3", features = ["client", "server",

--- a/sgl-router/src/tool_parser/parsers/json_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/json_parser.rs
@@ -175,10 +175,6 @@ impl JsonParser {
         Ok(tools)
     }
 
-    /// Check if text contains tool calls
-    fn has_tool_call(&self, text: &str) -> bool {
-        text.contains('[') || text.contains('{')
-    }
 }
 
 impl Default for JsonParser {
@@ -216,7 +212,7 @@ impl ToolParser for JsonParser {
         let current_text = &self.buffer.clone();
 
         // Check if current_text has tool_call
-        let has_tool_start = self.has_tool_call(current_text)
+        let has_tool_start = self.has_tool_markers(current_text)
             || (self.current_tool_id >= 0 && current_text.starts_with(self.tool_call_separator));
 
         if !has_tool_start {
@@ -263,7 +259,7 @@ impl ToolParser for JsonParser {
 
     fn has_tool_markers(&self, text: &str) -> bool {
         let trimmed = text.trim();
-        (trimmed.starts_with('[') || trimmed.starts_with('{')) && trimmed.contains(r#""name""#)
+        trimmed.starts_with('[') || trimmed.starts_with('{')
     }
 
     fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {

--- a/sgl-router/src/tool_parser/parsers/json_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/json_parser.rs
@@ -174,7 +174,6 @@ impl JsonParser {
 
         Ok(tools)
     }
-
 }
 
 impl Default for JsonParser {

--- a/sgl-router/src/tool_parser/parsers/llama_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/llama_parser.rs
@@ -121,7 +121,6 @@ impl LlamaParser {
 
         Ok(all_tools)
     }
-
 }
 
 impl Default for LlamaParser {

--- a/sgl-router/src/tool_parser/parsers/llama_parser.rs
+++ b/sgl-router/src/tool_parser/parsers/llama_parser.rs
@@ -122,10 +122,6 @@ impl LlamaParser {
         Ok(all_tools)
     }
 
-    /// Check if text has tool call
-    fn has_tool_call(&self, text: &str) -> bool {
-        text.contains("<|python_tag|>") || text.contains('{')
-    }
 }
 
 impl Default for LlamaParser {
@@ -184,7 +180,7 @@ impl ToolParser for LlamaParser {
         let current_text = &self.buffer.clone();
 
         // Check if current_text has tool_call
-        let has_tool_start = self.has_tool_call(current_text)
+        let has_tool_start = self.has_tool_markers(current_text)
             || (self.current_tool_id >= 0 && current_text.starts_with(self.tool_call_separator));
 
         if !has_tool_start {
@@ -230,8 +226,7 @@ impl ToolParser for LlamaParser {
 
     fn has_tool_markers(&self, text: &str) -> bool {
         // Llama format if contains python_tag or starts with JSON object
-        text.contains("<|python_tag|>")
-            || (text.trim_start().starts_with('{') && text.contains(r#""name""#))
+        text.contains("<|python_tag|>") || text.trim_start().starts_with('{')
     }
 
     fn get_unstreamed_tool_args(&self) -> Option<Vec<crate::tool_parser::types::ToolCallItem>> {

--- a/sgl-router/tests/tool_parser_llama.rs
+++ b/sgl-router/tests/tool_parser_llama.rs
@@ -119,7 +119,6 @@ async fn test_llama_format_detection() {
     assert!(parser.has_tool_markers(r#"<|python_tag|>{"name": "test"}"#));
     assert!(parser.has_tool_markers(r#"{"name": "test", "parameters": {}}"#));
     assert!(!parser.has_tool_markers("plain text"));
-    assert!(!parser.has_tool_markers(r#"{"key": "value"}"#)); // No name field
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The current grpc router would fail with tool call request.

Error:
```
2025-10-08 20:01:48 ERROR http_request{method=POST uri=/v1/chat/completions version=HTTP/1.1 request_id="chatcmpl-pWPzLmWXND9b39GTogjW5XIm"}: sglang_router_rs::routers::grpc::utils: src/routers/grpc/utils.rs:441: Failed to apply chat template: Failed to render template: unknown filter: filter tojson is unknown (in chat:60)
```

RCA:
The model being tested is Llama-3.1-8B-Instruct. Its chat template requires `tojson` filter to parse tool call. See https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct?chat_template=default#L38

This is available in `json` and `builtins` features in minijinja crate.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Add `json` and `builtins` for minijinja in `Cargo.toml`
- Remove duplicate `has_tool_call` in `json_parser.rs` and `llama_parser.rs`
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

non-stream, tool_choice = "auto"
<img width="1514" height="1318" alt="non-stream-auto" src="https://github.com/user-attachments/assets/6cc28cf4-9fbc-484b-946b-19f274d3a7a9" />

non-stream, tool_choice = "required"
<img width="1618" height="1329" alt="non-stream-required" src="https://github.com/user-attachments/assets/a863ec3b-cf8f-4ed9-aec5-d9a951ab3a7d" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
