### PR TITLE
Modify SWAChunkCache to support SWA.

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -736,6 +736,11 @@ class Scheduler(
                 req_to_token_pool=self.req_to_token_pool,
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 page_size=self.page_size,
+                **(
+                    {"sliding_window_size": self.sliding_window_size}
+                    if self.is_hybrid and ChunkCacheClass is SWAChunkCache
+                    else {}
+                ),
             )
         else:
             if os.environ.get("SGLANG_EXPERIMENTAL_CPP_RADIX_TREE") == "1":
@@ -1878,6 +1883,7 @@ class Scheduler(
             self.chunked_prefill_size,
             running_bs if self.is_mixed_chunk else 0,
             self.priority_scheduling_preemption_threshold,
+            use_hybrid_full_pool=self.server_args.hybrid_aggressive_schedule_use_full_pool,
         )
 
         if self.chunked_req is not None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -215,6 +215,7 @@ class ServerArgs:
     swa_full_tokens_ratio: float = 0.8
     disable_hybrid_swa_memory: bool = False
     radix_eviction_policy: str = "lru"
+    hybrid_aggressive_schedule_use_full_pool: bool = False
 
     # Runtime options
     device: Optional[str] = None
@@ -1611,6 +1612,12 @@ class ServerArgs:
             "--disable-hybrid-swa-memory",
             action="store_true",
             help="Disable the hybrid SWA memory.",
+        )
+        parser.add_argument(
+            "--hybrid-aggressive-schedule-use-full-pool",
+            action="store_true",
+            default=ServerArgs.hybrid_aggressive_schedule_use_full_pool,
+            help="For hybrid KV cache, estimate prefill budget using the full-layer pool instead of the minimum with the SWA pool.",
         )
 
         # Runtime options


### PR DESCRIPTION
## Motivation

Add support for SWAChunkCache to support sliding window attention. Currently SWAChunkCache evicts the whole chunk when it reaches the attention_chunk_size. But for SWA, we will need to keep the most recent sliding_window_size tokens.

Also add a server config to schedule aggressively using the full pool when the model architecture has lots of local attention layers and sliding_window_size is much smaller than decoding length.

The changes here are mainly to accommodate the type of traffic
- A model architecture heavily rely on SWA layers, which means the SWA tokens pool will be much smaller than full tokens pool
- Long decoding length which far exceeds sliding_window_size

Please note no changes have been applied to SWARadixCache. As SWARadixCache is designed with concept of maximizing cache hit rate, making changes with evicting KV tokens falls out of sliding window right away will hurt the cache hit rate. I haven't come up a good design for radix cache support on this type of traffic (long decoding length, short sliding window size) yet. Will leave that for now.

## Modifications
Modify the SWAChunkCache to support SWA by keeping the most recent sliding_window_size tokens instead of evicting the whole chunk. If no sliding_window_size is passed in, the behavior is exactly the same as before.

Add a server config so that we can aggressively schedule a high batch size when the hybrid model architecture heavily rely on local attention and the sliding window size is far smaller the decoding length. 

## Accuracy Tests

## Benchmarking and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
