### PR TITLE
[GDN] Mamba radix cache ratio support

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -190,6 +190,7 @@ class MambaPool:
             )
             logger.info(
                 f"Mamba Cache is allocated. "
+                f"max_mamba_cache_size: {size}, "
                 f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
                 f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
                 f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
@@ -199,6 +200,7 @@ class MambaPool:
             self.mamba_cache = self.State(conv=conv_state, temporal=temporal_state)
             logger.info(
                 f"Mamba Cache is allocated. "
+                f"max_mamba_cache_size: {size}, "
                 f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
                 f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
             )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -358,29 +358,15 @@ class ModelRunner:
             if architectures and not any("Llama4" in arch for arch in architectures):
                 self.is_hybrid = self.model_config.is_hybrid = True
 
-        if config := self.mambaish_config:
-            if self.server_args.max_mamba_cache_size is None:
-                if self.server_args.max_running_requests is not None:
-                    self.server_args.max_mamba_cache_size = (
-                        self.server_args.max_running_requests
-                        * MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO
-                    )
+        # sets the max_mamba_cache_size based on the max_running_requests for hybrid gdn
+        # and disable radix cache
+        # For hybrid gdn with radix cache, it is set in the init_memory_pool function
+        if self.mambaish_config is not None and server_args.disable_radix_cache:
+            if server_args.max_mamba_cache_size is None:
+                if server_args.max_running_requests is not None:
+                    server_args.max_mamba_cache_size = server_args.max_running_requests
                 else:
-                    self.server_args.max_mamba_cache_size = 512
-                    self.server_args.max_running_requests = (
-                        self.server_args.max_mamba_cache_size
-                        // MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO
-                    )
-
-        if self.hybrid_gdn_config is not None:
-            self.server_args.max_mamba_cache_size = (
-                self.server_args.max_mamba_cache_size
-                // (
-                    self.server_args.dp_size
-                    if self.server_args.enable_dp_attention
-                    else 1
-                )
-            )
+                    server_args.max_mamba_cache_size = 512
 
         # For MTP models like DeepSeek-V3 or GLM-4.5, the MTP layer(s) are used separately as draft
         # models for speculative decoding. In those cases, `num_nextn_predict_layers` is used to
@@ -1297,14 +1283,40 @@ class ModelRunner:
         rest_memory = available_gpu_memory - total_gpu_memory * (
             1 - self.mem_fraction_static
         )
-        if config := self.mambaish_config:
-            rest_memory -= (
-                self.server_args.max_mamba_cache_size
-                * config.mamba2_cache_params.mamba_cache_per_req
-                / (1 << 30)
-            )
+        if self.mambaish_config is not None:
+            rest_memory = self.handle_max_mamba_cache(rest_memory)
         max_num_token = int(rest_memory * (1 << 30) // cell_size)
         return max_num_token
+
+    def handle_max_mamba_cache(self, total_rest_memory):
+        config = self.mambaish_config
+        server_args = self.server_args
+        assert config is not None
+        if server_args.max_mamba_cache_size is None:
+            assert not server_args.disable_radix_cache
+            # allocate the memory based on the ratio between mamba state memory vs. full kv cache memory
+            # solve the equations:
+            # 1. mamba_state_memory + full_kv_cache_memory == total_rest_memory
+            # 2. mamba_state_memory / full_kv_cache_memory == server_args.mamba_full_memory_ratio
+            mamba_state_memory_raw = total_rest_memory * server_args.mamba_full_memory_ratio / (1 + server_args.mamba_full_memory_ratio)
+            # calculate the max_mamba_cache_size based on the given total mamba memory
+            server_args.max_mamba_cache_size = int((mamba_state_memory_raw * (1 << 30)) // config.mamba2_cache_params.mamba_cache_per_req)
+        
+        if self.hybrid_gdn_config is not None:
+            server_args.max_mamba_cache_size = (
+                server_args.max_mamba_cache_size
+                // (
+                    server_args.dp_size
+                    if server_args.enable_dp_attention
+                    else 1
+                )
+            )
+        mamba_state_memory = (
+            server_args.max_mamba_cache_size
+            * config.mamba2_cache_params.mamba_cache_per_req
+            / (1 << 30)
+        )
+        return total_rest_memory - mamba_state_memory
 
     @property
     def hybrid_gdn_config(self):
@@ -1457,6 +1469,10 @@ class ModelRunner:
                 ),
                 4096,
             )
+
+        if self.mambaish_config is not None:
+            ratio = MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO if not self.server_args.disable_radix_cache else 1
+            max_num_reqs = min(max_num_reqs, self.server_args.max_mamba_cache_size // ratio)
 
         if self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone():
             if self.is_draft_worker:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1298,18 +1298,20 @@ class ModelRunner:
             # solve the equations:
             # 1. mamba_state_memory + full_kv_cache_memory == total_rest_memory
             # 2. mamba_state_memory / full_kv_cache_memory == server_args.mamba_full_memory_ratio
-            mamba_state_memory_raw = total_rest_memory * server_args.mamba_full_memory_ratio / (1 + server_args.mamba_full_memory_ratio)
+            mamba_state_memory_raw = (
+                total_rest_memory
+                * server_args.mamba_full_memory_ratio
+                / (1 + server_args.mamba_full_memory_ratio)
+            )
             # calculate the max_mamba_cache_size based on the given total mamba memory
-            server_args.max_mamba_cache_size = int((mamba_state_memory_raw * (1 << 30)) // config.mamba2_cache_params.mamba_cache_per_req)
-        
+            server_args.max_mamba_cache_size = int(
+                (mamba_state_memory_raw * (1 << 30))
+                // config.mamba2_cache_params.mamba_cache_per_req
+            )
+
         if self.hybrid_gdn_config is not None:
-            server_args.max_mamba_cache_size = (
-                server_args.max_mamba_cache_size
-                // (
-                    server_args.dp_size
-                    if server_args.enable_dp_attention
-                    else 1
-                )
+            server_args.max_mamba_cache_size = server_args.max_mamba_cache_size // (
+                server_args.dp_size if server_args.enable_dp_attention else 1
             )
         mamba_state_memory = (
             server_args.max_mamba_cache_size
@@ -1471,8 +1473,14 @@ class ModelRunner:
             )
 
         if self.mambaish_config is not None:
-            ratio = MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO if not self.server_args.disable_radix_cache else 1
-            max_num_reqs = min(max_num_reqs, self.server_args.max_mamba_cache_size // ratio)
+            ratio = (
+                MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO
+                if not self.server_args.disable_radix_cache
+                else 1
+            )
+            max_num_reqs = min(
+                max_num_reqs, self.server_args.max_mamba_cache_size // ratio
+            )
 
         if self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone():
             if self.is_draft_worker:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -353,6 +353,7 @@ class ServerArgs:
     # Mamba cache
     max_mamba_cache_size: Optional[int] = None
     mamba_ssm_dtype: str = "float32"
+    mamba_full_memory_ratio: float = 0.2
 
     # Hierarchical cache
     enable_hierarchical_cache: bool = False
@@ -2333,6 +2334,12 @@ class ServerArgs:
             default=ServerArgs.mamba_ssm_dtype,
             choices=["float32", "bfloat16"],
             help="The data type of the SSM states in mamba cache.",
+        )
+        parser.add_argument(
+            "--mamba-full-memory-ratio",
+            type=float,
+            default=ServerArgs.mamba_full_memory_ratio,
+            help="The ratio of mamba state memory to full kv cache memory.",
         )
 
         # Hierarchical cache


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Depends on https://github.com/sgl-project/sglang/pull/11214

When mamba radix cache is enabled, allocate mamba pool size relative to full kv token pool size instead of max running requests.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
python3 -m sglang.launch_server --model Qwen/Qwen3-Next-80B-A3B-Instruct --tp 4  --chunked-prefill-size 64 --max-running-requests 16

root@memx-azj-30-sr1:~/oss/sglang# python3 benchmark/gsm8k/bench_sglang.py --num-question 1000
/root/xai/.venv/lib/python3.13/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [03:49<00:00,  4.36it/s]
Accuracy: 0.942
Invalid: 0.000
Latency: 230.713 s
Output throughput: 726.426 token/s
```