### PR TITLE
[PD] Adjustable dispatch node count in fake mode for ideal expert distribution

### DIFF
--- a/python/sglang/srt/eplb/expert_location_dispatch.py
+++ b/python/sglang/srt/eplb/expert_location_dispatch.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import random
 from dataclasses import dataclass
 from typing import Literal, Optional
 
@@ -19,6 +20,8 @@ import torch
 
 from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
 from sglang.srt.server_args import get_global_server_args
+
+DUMMY_MAX_TOPK_SHAPE = (256, 8)  # (max batch size, topk)
 
 
 @dataclass
@@ -31,6 +34,7 @@ class ExpertLocationDispatchInfo:
     # (num_logical_experts,)
     partial_logical_to_all_physical_map_num_valid: torch.Tensor
     num_physical_experts: int
+    precomputed_balanced_tensor_map: dict
 
     @classmethod
     def init_new(cls, layer_id: int):
@@ -40,6 +44,24 @@ class ExpertLocationDispatchInfo:
 
         if ep_dispatch_algorithm is None:
             return None
+
+        precomputed_balanced_tensor_map = {}
+        if ep_dispatch_algorithm == "fake":
+            nnodes = get_global_server_args().nnodes
+            node_rank = get_global_server_args().node_rank
+            device = get_global_server_args().device
+            num_physical_experts = expert_location_metadata.num_physical_experts
+            dispatch_node = get_global_server_args().fake_node
+            dummy_topk_ids_shape = DUMMY_MAX_TOPK_SHAPE
+            balanced_tensor = generate_balanced_expert_selection(
+                dummy_topk_ids_shape,
+                node_rank=node_rank,
+                nnodes=nnodes,
+                total_experts=num_physical_experts,
+                dispatch_node=dispatch_node,
+                device=device,
+            )
+            precomputed_balanced_tensor_map[dummy_topk_ids_shape] = balanced_tensor
 
         return cls(
             ep_dispatch_algorithm=ep_dispatch_algorithm,
@@ -58,19 +80,8 @@ class ExpertLocationDispatchInfo:
                 layer_id, :
             ],
             num_physical_experts=expert_location_metadata.num_physical_experts,
+            precomputed_balanced_tensor_map=precomputed_balanced_tensor_map,
         )
-
-
-def transform_select_experts_inputs(
-    router_logits: torch.Tensor,
-    correction_bias: Optional[torch.Tensor],
-    info: Optional[ExpertLocationDispatchInfo],
-):
-    if (info is not None) and (info.ep_dispatch_algorithm == "fake"):
-        router_logits.uniform_(5, 10)
-        if correction_bias is not None:
-            correction_bias = torch.zeros_like(correction_bias)
-    return router_logits, correction_bias
 
 
 def topk_ids_logical_to_physical(
@@ -81,8 +92,10 @@ def topk_ids_logical_to_physical(
 
     if info.ep_dispatch_algorithm == "static":
         return _topk_ids_logical_to_physical_static(topk_ids, info)
-    if info.ep_dispatch_algorithm in ["dynamic", "fake"]:
+    if info.ep_dispatch_algorithm == "dynamic":
         return _topk_ids_logical_to_physical_dynamic(topk_ids, info)
+    if info.ep_dispatch_algorithm == "fake":
+        return _topk_ids_logical_to_physical_fake(topk_ids, info)
     raise NotImplementedError(f"Unknown algorithm {info.ep_dispatch_algorithm}")
 
 
@@ -107,3 +120,63 @@ def _topk_ids_logical_to_physical_dynamic(
 
     topk_ids = topk_ids.view(topk_ids_original_shape)
     return topk_ids
+
+
+def _topk_ids_logical_to_physical_fake(
+    topk_ids: torch.Tensor, info: Optional[ExpertLocationDispatchInfo]
+) -> torch.Tensor:
+
+    topk_ids_original_shape = topk_ids.shape
+    target_len = topk_ids_original_shape[0]
+    base_shape, base_tensor = next(iter(info.precomputed_balanced_tensor_map.items()))
+    base_len = base_shape[0]
+
+    repeat_n = target_len // base_len
+    remaining = target_len % base_len
+
+    balanced_tensor = (
+        torch.cat([base_tensor.repeat((repeat_n, 1)), base_tensor[:remaining]], dim=0)
+        if target_len > 0
+        else base_tensor[:0]
+    )
+
+    topk_ids = balanced_tensor.view(topk_ids_original_shape)
+
+    return topk_ids
+
+
+def generate_balanced_expert_selection(
+    topk_ids_shape,
+    node_rank=0,
+    nnodes=1,
+    total_experts=288,
+    dispatch_node=1,
+    device="cpu",
+):
+    num_elements = topk_ids_shape[0] * topk_ids_shape[1]
+    # Number of experts per node
+    assert total_experts % nnodes == 0
+    experts_per_node = total_experts // nnodes
+
+    # Number of tokens processed by each expert
+    tokens_per_expert = num_elements // experts_per_node // dispatch_node
+    remaining_tokens_per_expert = num_elements // experts_per_node % dispatch_node
+
+    repeat = []
+    remaining_list = []
+    # Select experts from multiple nodes
+    for i in range(dispatch_node):
+        start = (node_rank + i) * experts_per_node
+        end = (node_rank + i + 1) * experts_per_node
+        base = torch.arange(start, end, device=device) % total_experts
+        if remaining_tokens_per_expert != 0:
+            remaining_list.append(base)
+        repeat.append(base.repeat(tokens_per_expert))
+    selected_experts = torch.cat(repeat)
+
+    if remaining_tokens_per_expert != 0:
+        sampled = random.sample(remaining_list, remaining_tokens_per_expert)
+        random_remaining = torch.cat(sampled)
+        selected_experts = torch.cat([selected_experts, random_remaining])
+
+    return selected_experts.view(topk_ids_shape)

--- a/python/sglang/srt/eplb/expert_location_dispatch.py
+++ b/python/sglang/srt/eplb/expert_location_dispatch.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import os
 import random
 from dataclasses import dataclass
 from typing import Literal, Optional
@@ -21,7 +22,8 @@ import torch
 from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
 from sglang.srt.server_args import get_global_server_args
 
-DUMMY_MAX_TOPK_SHAPE = (256, 8)  # (max batch size, topk)
+max_batch_size = int(os.getenv("MAX_BATCH_SIZE", 256))
+DUMMY_MAX_TOPK_SHAPE = (max_batch_size, 8)  # (max batch size, topk)
 
 
 @dataclass
@@ -51,7 +53,7 @@ class ExpertLocationDispatchInfo:
             node_rank = get_global_server_args().node_rank
             device = get_global_server_args().device
             num_physical_experts = expert_location_metadata.num_physical_experts
-            dispatch_node = get_global_server_args().fake_node
+            dispatch_node = get_global_server_args().ep_dispatch_fake_num_node
             dummy_topk_ids_shape = DUMMY_MAX_TOPK_SHAPE
             balanced_tensor = generate_balanced_expert_selection(
                 dummy_topk_ids_shape,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -841,14 +841,6 @@ def select_experts(
         topk_config.apply_routed_scaling_factor_on_output
     )
 
-    router_logits, correction_bias = (
-        expert_location_dispatch.transform_select_experts_inputs(
-            router_logits=router_logits,
-            correction_bias=correction_bias,
-            info=expert_location_dispatch_info,
-        )
-    )
-
     # DeepSeek V2/V3/R1 series models use grouped_top_k
     if use_grouped_topk:
         assert topk_group is not None

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -36,7 +36,6 @@ from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
-from sglang.srt.eplb import expert_location_dispatch
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location_dispatch import (
     ExpertLocationDispatchInfo,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -419,6 +419,7 @@ class ServerArgs:
     moe_dense_tp_size: Optional[int] = None
     elastic_ep_backend: Literal[None, "mooncake"] = None
     mooncake_ib_device: Optional[str] = None
+    fake_node: int = 1
 
     # Mamba cache
     max_mamba_cache_size: Optional[int] = None
@@ -2861,6 +2862,12 @@ class ServerArgs:
             type=str,
             default=ServerArgs.ep_dispatch_algorithm,
             help="The algorithm to choose ranks for redundant experts in expert parallel.",
+        )
+        parser.add_argument(
+            "--fake-node",
+            type=int,
+            default=ServerArgs.fake_node,
+            help="Allocate this number of dispatch nodes in fake mode. Useful when --ep-dispatch-algorithm=fake is set.",
         )
         parser.add_argument(
             "--init-expert-location",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -419,7 +419,7 @@ class ServerArgs:
     moe_dense_tp_size: Optional[int] = None
     elastic_ep_backend: Literal[None, "mooncake"] = None
     mooncake_ib_device: Optional[str] = None
-    fake_node: int = 1
+    ep_dispatch_fake_num_node: int = 4
 
     # Mamba cache
     max_mamba_cache_size: Optional[int] = None
@@ -2864,9 +2864,9 @@ class ServerArgs:
             help="The algorithm to choose ranks for redundant experts in expert parallel.",
         )
         parser.add_argument(
-            "--fake-node",
+            "--ep-dispatch-fake-num-node",
             type=int,
-            default=ServerArgs.fake_node,
+            default=ServerArgs.ep_dispatch_fake_num_node,
             help="Allocate this number of dispatch nodes in fake mode. Useful when --ep-dispatch-algorithm=fake is set.",
         )
         parser.add_argument(


### PR DESCRIPTION
After multiple experiments and investigations, we found that the existing fake mode's expert distribution is relatively evenly distributed in terms of logical experts, but cannot achieve perfect expert distribution in terms of physical expert mapping. To simulate a perfect physical expert distribution, By modifying the following code logic. By default, all tokens are distributed  evenly  to  the current node. The number of nodes to which each batch of tokens is distributed can also be manually adjusted by using the --ep-dispatch-fake-num-node option to control the distribution. This ensures the optimal state and evaluates the maximum performance limit of expert distribution under PD separation. Experiments have shown that in the 4p9d isl-2000/osl-100 scenario, the maximum performance of a single node in the decoding phase can reach 26400 tok/s，expert balance close to 1, and the performance is stable.