### PR TITLE
Fix index out of bounds in _modify_tuple for LoRA tensors

### DIFF
--- a/python/sglang/srt/utils/patch_torch.py
+++ b/python/sglang/srt/utils/patch_torch.py
@@ -77,6 +77,12 @@ def _device_from_maybe_uuid(device_maybe_uuid: Union[int, str]) -> int:
 
 
 def _modify_tuple(t, index: int, modifier: Callable):
+    # Handle cases where tuple is shorter than expected (e.g., LoRA tensors)
+    if index >= len(t):
+        return t
+    # If index is the last element, don't include the tail slice
+    if index == len(t) - 1:
+        return *t[:index], modifier(t[index])
     return *t[:index], modifier(t[index]), *t[index + 1 :]
 
 


### PR DESCRIPTION
## Problem
The `_modify_tuple` function in `python/sglang/srt/utils/patch_torch.py` crashes with IndexError when working with LoRA tensors that have fewer elements than expected. This occurs during multiturn VERL experiments that use both SGLang and vLLM with LoRA adaptation in the RL loop.

## Solution
Enhanced `_modify_tuple` to handle edge cases:
1. **Index beyond tuple length**: Returns original tuple unchanged
2. **Index at last element**: Handles correctly without creating empty tail slice
3. **Normal cases**: Preserves original behavior

## Testing
- [x] Verified fix handles out-of-bounds access
- [x] Confirmed last-element edge case works correctly
- [x] Ensured backward compatibility for existing use cases

## Context
This issue manifests when using LoRA adapters with SGLang in reinforcement learning scenarios where tensor shapes may vary from expected configurations.