### PR TITLE
Draft: [DSv32] Add triton fusion for _get_logits_head_gate

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/fused_logits_head_gate.py
+++ b/python/sglang/srt/layers/attention/nsa/fused_logits_head_gate.py
@@ -1,0 +1,136 @@
+"""
+Triton fused kernel for logits head gate computation in NSA indexer.
+
+This kernel fuses the following operations:
+    weights = weights * n_heads**-0.5
+    weights = weights.unsqueeze(-1) * q_scale * softmax_scale
+
+into a single optimized kernel.
+
+The computation is performed in float32 for numerical stability and outputs
+float32 regardless of input dtype (bf16/fp16/fp32).
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fused_logits_head_gate_kernel(
+    weights_ptr,  # Input: (M, N) where M is batch/seq_len, N is n_heads
+    q_scale_ptr,  # Input: (M, N, 1) quantization scale
+    output_ptr,  # Output: (M, N, 1)
+    n_heads_inv_sqrt: tl.constexpr,  # 1 / sqrt(n_heads)
+    softmax_scale: tl.constexpr,  # head_dim**-0.5
+    M,  # Batch size / sequence length
+    N,  # Number of heads
+    weights_stride_m,
+    weights_stride_n,
+    q_scale_stride_m,
+    q_scale_stride_n,
+    output_stride_m,
+    output_stride_n,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    """
+    Fused kernel for computing logits head gate.
+
+    Performs: output[m, n, 0] = weights[m, n] * n_heads**-0.5 * q_scale[m, n, 0] * softmax_scale
+    """
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    weights_ptrs = (
+        weights_ptr
+        + offs_m[:, None] * weights_stride_m
+        + offs_n[None, :] * weights_stride_n
+    )
+    q_scale_ptrs = (
+        q_scale_ptr
+        + offs_m[:, None] * q_scale_stride_m
+        + offs_n[None, :] * q_scale_stride_n
+    )
+    output_ptrs = (
+        output_ptr
+        + offs_m[:, None] * output_stride_m
+        + offs_n[None, :] * output_stride_n
+    )
+
+    weights = tl.load(weights_ptrs, mask=mask, other=0.0).to(tl.float32)
+    q_scale = tl.load(q_scale_ptrs, mask=mask, other=0.0).to(tl.float32)
+
+    result = weights * n_heads_inv_sqrt * q_scale * softmax_scale
+    tl.store(output_ptrs, result, mask=mask)
+
+
+def fused_logits_head_gate(
+    weights: torch.Tensor,  # (M, N)
+    q_scale: torch.Tensor,  # (M, N, 1)
+    n_heads: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """
+    Fused implementation of logits head gate computation.
+
+    Computes: output = weights * n_heads**-0.5 * q_scale * softmax_scale
+
+    The computation is performed in float32 for numerical stability,
+    regardless of input dtype.
+
+    Args:
+        weights: Input weights tensor of shape (M, N) where M is batch/seq_len
+                 and N is number of heads. Can be any dtype (bf16, fp16, fp32).
+        q_scale: Quantization scale tensor of shape (M, N, 1). Can be any dtype.
+        n_heads: Number of attention heads
+        softmax_scale: Softmax scale factor (typically head_dim**-0.5)
+
+    Returns:
+        Output tensor of shape (M, N, 1) in float32 dtype
+    """
+    assert weights.ndim == 2, f"weights must be 2D, got {weights.ndim}D"
+    assert q_scale.ndim == 3, f"q_scale must be 3D, got {q_scale.ndim}D"
+    assert q_scale.shape[2] == 1, f"q_scale last dim must be 1, got {q_scale.shape[2]}"
+    assert weights.shape[0] == q_scale.shape[0], "Batch dimension mismatch"
+    assert weights.shape[1] == q_scale.shape[1], "Number of heads mismatch"
+    assert weights.is_contiguous(), "weights must be contiguous"
+
+    M, N = weights.shape
+
+    output = torch.empty((M, N, 1), dtype=torch.float32, device=weights.device)
+
+    n_heads_inv_sqrt = n_heads**-0.5
+
+    BLOCK_SIZE_M = min(32, triton.next_power_of_2(M))
+    BLOCK_SIZE_N = min(64, triton.next_power_of_2(N))
+
+    # Launch kernel
+    grid = (
+        triton.cdiv(M, BLOCK_SIZE_M),
+        triton.cdiv(N, BLOCK_SIZE_N),
+    )
+
+    fused_logits_head_gate_kernel[grid](
+        weights,
+        q_scale,
+        output,
+        n_heads_inv_sqrt,
+        softmax_scale,
+        M,
+        N,
+        weights.stride(0),
+        weights.stride(1),
+        q_scale.stride(0),
+        q_scale.stride(1),
+        output.stride(0),
+        output.stride(1),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+    )
+
+    return output

--- a/test/srt/test_triton_fused_logits_head_gate.py
+++ b/test/srt/test_triton_fused_logits_head_gate.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+from sglang.srt.layers.attention.nsa.fused_logits_head_gate import (
+    fused_logits_head_gate,
+)
+
+
+def test_fused_logits_head_gate():
+    n_heads = 64
+    head_dim = 128
+    softmax_scale = head_dim**-0.5
+
+    weights = torch.randn(128, 64, dtype=torch.bfloat16, device="cuda")
+    q_scale = torch.randn(128, 64, 1, dtype=torch.float32, device="cuda")
+
+    # Reference
+    weights_ref = weights.clone()
+    weights_ref = weights_ref * n_heads**-0.5
+    weights_ref = weights_ref.unsqueeze(-1) * q_scale * softmax_scale
+
+    # Fused kernel
+    weights_fused = fused_logits_head_gate(weights, q_scale, n_heads, softmax_scale)
+
+    torch.testing.assert_close(weights_ref, weights_fused, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    test_fused_logits_head_gate()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Optimize DSv3.2 decode

## Modifications

Added a triton kernel to fuse 2 unary mul + 1 binary mul in `_get_logits_head_gate`.

## Accuracy Tests

Added unit test.

End-to-end:
```
Accuracy: 0.957
Invalid: 0.000
Latency: 82.141 s
Output throughput: 1558.434 token/s
```

## Profiling

Original: 6.683us
Fused: 1.479us

<img width="2280" height="851" alt="Screenshot 2025-10-09 at 2 29 57 PM" src="https://github.com/user-attachments/assets/7a2b14ec-2721-45d7-8fff-2040dcbbe43c" />

<img width="2262" height="695" alt="Screenshot 2025-10-09 at 2 31 50 PM" src="https://github.com/user-attachments/assets/0245aa1d-5e0d-4693-831b-450ccadfb948" />

## End to end Benchmarking
For some reason it appears to be worse in the end-to-end benchmarks.

Before
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  110.47    
Total input tokens:                      236166    
Total generated tokens:                  234891    
Request throughput (req/s):              2.32      
Output token throughput (tok/s):         2126.19   
Total Token throughput (tok/s):          4263.93   
---------------Time to First Token----------------
Mean TTFT (ms):                          47615.35  
Median TTFT (ms):                        47699.76  
P99 TTFT (ms):                           76635.09  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          64.91     
Median TPOT (ms):                        64.60     
P99 TPOT (ms):                           106.38    
---------------Inter-token Latency----------------
Mean ITL (ms):                           64.76     
Median ITL (ms):                         33.03     
P99 ITL (ms):                            38.39     
==================================================
```
After
```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  121.11    
Total input tokens:                      236166    
Total generated tokens:                  234891    
Request throughput (req/s):              2.11      
Output token throughput (tok/s):         1939.46   
Total Token throughput (tok/s):          3889.45   
---------------Time to First Token----------------
Mean TTFT (ms):                          48331.25  
Median TTFT (ms):                        47919.13  
P99 TTFT (ms):                           81273.82  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          75.92     
Median TPOT (ms):                        76.09     
P99 TPOT (ms):                           118.81    
---------------Inter-token Latency----------------
Mean ITL (ms):                           75.71     
Median ITL (ms):                         39.82     
P99 ITL (ms):                            45.60     
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
