### PR TITLE
[Quantization] Deepseek-R1 mixed static and dynamic mxfp4 quant in Quark

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -202,7 +202,6 @@ class QuarkConfig(QuantizationConfig):
             logger.debug("Quark model is not in MX-FP4 format: not group_size=32")
             return False
 
-
         # Activations need to use dynamic quantization.
         if input_quant.get("is_dynamic") is False:
             logger.debug("Quark model is not in MX-FP4 format: not activation dynamic")
@@ -264,7 +263,9 @@ class QuarkConfig(QuantizationConfig):
             )
             return global_quant_config
 
-    def _get_scheme_from_config(self, config: dict[str, Any], layer_name: str) -> "QuarkScheme":
+    def _get_scheme_from_config(
+        self, config: dict[str, Any], layer_name: str
+    ) -> "QuarkScheme":
         if config.get("output_tensors") or config.get("bias"):
             raise NotImplementedError(
                 "Currently, Quark models with output_tensors "

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -25,19 +25,50 @@ OCP_MX_BLOCK_SIZE = 32
 class QuarkW4A4MXFP4(QuarkScheme):
 
     def __init__(
-        self, weight_quant_spec: dict[str, Any], input_quant_spec: dict[str, Any]
+        self, weight_quant_spec: dict[str, Any], input_quant_spec: dict[str, Any], layer_name: Optional[str] = None
     ):
         self.out_dtype = torch.get_default_dtype()
         self.qscheme = "per_group"
         self.weight_quant_spec = weight_quant_spec
         self.input_quant_spec = input_quant_spec
+        self.layer_name = layer_name
 
     @classmethod
     def get_min_capability(cls) -> int:
         return 70
 
+    def mxfp4_quantize(self, w):
+        w_shape = w.shape
+        w_need_reshape = True if w.dim() != 2 else False
+
+        if w_need_reshape:
+            w_last_dim_size = w_shape[-1]
+            w = w.view(-1, w_last_dim_size)
+
+        w, mx_scales = dynamic_mxfp4_quant(w)
+
+        if w_need_reshape:
+            w_new_shape = w_shape[:-1] + (w.shape[-1],)
+            w = w.view(w_new_shape)
+
+        return w, mx_scales
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        return
+        if self.weight_quant_spec.get("is_dynamic") is True:
+            # NOTE: This step happens after `post_load_weights` for deepseek models.
+            # So it is safe for kv_b_proj quantization of w_kc and w_vc in `quark_post_load_weights`
+            # since kv_b_proj.weight at that point is still bfloat16.
+            w, mx_scales = self.mxfp4_quantize(layer.weight.data)
+            weight = PackedvLLMParameter(
+                data=w,
+                input_dim=1,
+                output_dim=0,
+                packed_dim=1,
+                packed_factor=2,
+                weight_loader=layer.weight.weight_loader,
+            )
+            layer.register_parameter("weight", weight)
+            layer.weight_scale.data = mx_scales
 
     def create_weights(
         self,
@@ -52,16 +83,25 @@ class QuarkW4A4MXFP4(QuarkScheme):
         layer.logical_widths = output_partition_sizes
 
         # WEIGHT
+        if self.weight_quant_spec.get("is_dynamic") is True:
+            # Create and load bfloat16 weight
+            # quantize to mxfp4 during `process_weights_after_loading`
+            pack_factor = 1
+            dtype = torch.bfloat16
+        else:
+            pack_factor = 2
+            dtype = torch.uint8
+
         weight = PackedvLLMParameter(
             data=torch.empty(
                 output_size_per_partition,
-                input_size_per_partition // 2,
-                dtype=torch.uint8,
+                input_size_per_partition // pack_factor,
+                dtype=dtype,
             ),
             input_dim=1,
             output_dim=0,
             packed_dim=1,
-            packed_factor=2,
+            packed_factor=pack_factor,
             weight_loader=weight_loader,
         )
         layer.register_parameter("weight", weight)

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -25,7 +25,10 @@ OCP_MX_BLOCK_SIZE = 32
 class QuarkW4A4MXFP4(QuarkScheme):
 
     def __init__(
-        self, weight_quant_spec: dict[str, Any], input_quant_spec: dict[str, Any], layer_name: Optional[str] = None
+        self,
+        weight_quant_spec: dict[str, Any],
+        input_quant_spec: dict[str, Any],
+        layer_name: Optional[str] = None,
     ):
         self.out_dtype = torch.get_default_dtype()
         self.qscheme = "per_group"

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -40,9 +40,10 @@ class QuarkW4A4MXFP4(QuarkScheme):
     def get_min_capability(cls) -> int:
         return 70
 
-    def mxfp4_quantize(self, w):
+    @staticmethod
+    def mxfp4_quantize(w):
         w_shape = w.shape
-        w_need_reshape = True if w.dim() != 2 else False
+        w_need_reshape = w.dim() != 2
 
         if w_need_reshape:
             w_last_dim_size = w_shape[-1]


### PR DESCRIPTION
Allows flexible adjustment of additional layers to be quantized at load time from existing pre-quantized Quark mxfp4 model.

Taking https://huggingface.co/amd/DeepSeek-R1-0528-MXFP4-ASQ as example, where all attention projection layers were excluded. Modifying the config.json as follows to enable additional `o_proj` layer quantization. Note that `online: true` is set as an additional field to mark that this layer is quantized online after loading.

```diff
76d75
<       "re:model.layers.*.self_attn.o_proj",
122c121,158
<     "layer_quant_config": {},
---
>     "layer_quant_config": {
>       "*.o_proj": {
>         "online": true,
>         "bias": null,
>         "input_tensors": {
>           "ch_axis": -1,
>           "dtype": "fp4",
>           "group_size": 32,
>           "is_dynamic": true,
>           "is_scale_quant": false,
>           "mx_element_dtype": null,
>           "observer_cls": "PerBlockMXObserver",
>           "qscheme": "per_group",
>           "round_method": "half_even",
>           "scale_calculation_mode": "even",
>           "scale_format": "e8m0",
>           "scale_type": "float",
>           "symmetric": null
>         },
>         "output_tensors": null,
>         "target_device": null,
>         "weight": {
>           "ch_axis": -1,
>           "dtype": "fp4",
>           "group_size": 32,
>           "is_dynamic": false,
>           "is_scale_quant": false,
>           "mx_element_dtype": null,
>           "observer_cls": "PerBlockMXObserver",
>           "qscheme": "per_group",
>           "round_method": "half_even",
>           "scale_calculation_mode": "even",
>           "scale_format": "e8m0",
>           "scale_type": "float",
>           "symmetric": null
>         }
>       }
>     },
152d187
< 
```

Accuracy comparison:
Static quantization only:
```
# gsm8k
Accuracy: 0.947
Invalid: 0.000
```

Static quantization + dynamic quantization of attention projections:
```
# gsm8k
Accuracy: 0.943
Invalid: 0.000
```



