### PR TITLE
bug fix  for Ascend npu

### DIFF
--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -119,7 +119,7 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
             assert len(torch.unique(out_indices)) == len(out_indices)
 
         self.free_pages = self.free_pages[num_new_pages_item:]
-        return out_indices
+        return out_indices.int()
 
     def alloc_decode(
         self,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1026,16 +1026,19 @@ class AscendTokenToKVPool(MHATokenToKVPool):
             cache_k = cache_k.view(self.store_dtype)
             cache_v = cache_v.view(self.store_dtype)
 
-        torch_npu._npu_reshape_and_cache(
-            key=cache_k,
-            value=cache_v,
-            key_cache=self.k_buffer[layer_id].view(
-                -1, self.page_size, self.head_num, self.head_dim
+        torch_npu.npu_scatter_nd_update_(
+            self.k_buffer[layer_id - self.start_layer].view(
+                -1, 1, self.head_num, self.head_dim
             ),
-            value_cache=self.v_buffer[layer_id].view(
-                -1, self.page_size, self.head_num, self.head_dim
+            loc.view(-1, 1),
+            cache_k.view(-1, 1, self.head_num, self.head_dim),
+        )
+        torch_npu.npu_scatter_nd_update_(
+            self.v_buffer[layer_id - self.start_layer].view(
+                -1, 1, self.head_num, self.head_dim
             ),
-            slot_indices=loc,
+            loc.view(-1, 1),
+            cache_v.view(-1, 1, self.head_num, self.head_dim),
         )
 
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1026,19 +1026,16 @@ class AscendTokenToKVPool(MHATokenToKVPool):
             cache_k = cache_k.view(self.store_dtype)
             cache_v = cache_v.view(self.store_dtype)
 
-        torch_npu.npu_scatter_nd_update_(
-            self.k_buffer[layer_id - self.start_layer].view(
-                -1, 1, self.head_num, self.head_dim
+        torch_npu._npu_reshape_and_cache(
+            key=cache_k,
+            value=cache_v,
+            key_cache=self.k_buffer[layer_id].view(
+                -1, self.page_size, self.head_num, self.head_dim
             ),
-            loc.view(-1, 1),
-            cache_k.view(-1, 1, self.head_num, self.head_dim),
-        )
-        torch_npu.npu_scatter_nd_update_(
-            self.v_buffer[layer_id - self.start_layer].view(
-                -1, 1, self.head_num, self.head_dim
+            value_cache=self.v_buffer[layer_id].view(
+                -1, self.page_size, self.head_num, self.head_dim
             ),
-            loc.view(-1, 1),
-            cache_v.view(-1, 1, self.head_num, self.head_dim),
+            slot_indices=loc,
         )
 
 

--- a/python/sglang/srt/model_executor/npu_graph_runner.py
+++ b/python/sglang/srt/model_executor/npu_graph_runner.py
@@ -75,7 +75,7 @@ class NPUGraphRunner(CudaGraphRunner):
             self.positions[: self.raw_num_token].copy_(forward_batch.positions)
 
         # Replay
-        if self.model_runner.model_config.index_head_dim is None:
+        if getattr(self.model_runner.model_config, "index_head_dim", None) is None:
             seq_lens = forward_batch.seq_lens.cpu().tolist() + [0] * (
                 self.bs - self.raw_bs
             )

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -237,8 +237,10 @@ class BaseMultimodalProcessor(ABC):
             if not _is_npu:
                 kwargs["device"] = "cuda"
             elif processor.__class__.__name__ not in {
+                "Qwen2VLProcessor",
                 "Qwen2_5_VLProcessor",
                 "Qwen3VLProcessor",
+                "Glm4vProcessor",
             }:
                 # Note: for qwen-vl, processor has some reshape issue because of dims restriction on Ascend.
                 kwargs["device"] = "npu"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Bug fix for Ascend npu

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
1. use torch_npu.npu_scatter_nd_update_ instead of deprecated torch_npu._npu_reshape_and_cache. #11374 
2. run image_processor on CPU, because transformers has some limitations on Ascend.
3. fix npu graph index_head_dim AttributeError due to DS-V3.2 changes.https://github.com/sgl-project/sglang/pull/11061
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Server launch script
```{shell}
export HCCL_OP_EXPANSION_MODE="AIV"
#export CPU_AFFINITY_CONF=1,npu0:192-223,npu1:192-223,npu2:128-159,npu3:128-15
export STREAMS_PER_DEVICE=32

python -m sglang.launch_server \
    --model-path /model/Qwen3-VL-30B-A3B-Instruct/ \
    --tp-size 2  --device npu \
    --attention-backend ascend \
    --mm-attention-backend ascend_attn \
    --trust-remote-code
```
Accuracy test command
```{shell}
python3 -m sglang.test.few_shot_gsm8k --num-questions 200
```
Accuracy test result
>Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl  
/tmp/test.jsonl: 732kB [00:07, 101kB/s]  
100%|███████████████████████████████████████████████████████████████████| 200/200 [00:44<00:00,  4.51it/s]  
Accuracy: 0.945  
Invalid: 0.000  
Latency: 44.533 s  
Output throughput: 646.760 token/s

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
```
python -m sglang.bench_serving --backend sglang --num-prompt 10 --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json
```

>
>#Input tokens: 1997  
#Output tokens: 2798  
Starting warmup with 1 sequences...  
Warmup completed with 1 sequences. Starting main benchmark run...  
100%|███████████████████████████████████████████████| 10/10 [00:22<00:00,  2.20s/it]  
>  
>============ Serving Benchmark Result ============  
Backend:                                 sglang  
Traffic request rate:                    inf  
Max request concurrency:                 not set  
Successful requests:                     10  
Benchmark duration (s):                  22.04  
Total input tokens:                      1997  
Total input text tokens:                 1997  
Total input vision tokens:               0  
Total generated tokens:                  2798  
Total generated tokens (retokenized):    2783  
Request throughput (req/s):              0.45  
Input token throughput (tok/s):          90.60  
Output token throughput (tok/s):         126.94  
Total token throughput (tok/s):          217.54  
Concurrency:                             5.93  
----------------End-to-End Latency----------------  
Mean E2E Latency (ms):                   13079.63  
Median E2E Latency (ms):                 14950.25  
---------------Time to First Token----------------  
Mean TTFT (ms):                          404.65  
Median TTFT (ms):                        403.89  
P99 TTFT (ms):                           450.20  
---------------Inter-Token Latency----------------  
Mean ITL (ms):                           45.50  
Median ITL (ms):                         46.50  
P95 ITL (ms):                            50.18  
P99 ITL (ms):                            52.89  
Max ITL (ms):                            130.14  
==================================================

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
