### PR TITLE
[ROCm] Fix Mamba2 crash

### DIFF
--- a/python/sglang/srt/layers/attention/mamba/mamba.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba.py
@@ -436,7 +436,6 @@ class MambaMixer2(torch.nn.Module):
             dim=0,
         )
 
-        # Choose Triton on HIP (ROCm) or if explicitly requested.
         use_triton = use_triton_causal_conv or is_hip()
 
         # Process prefill requests

--- a/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
@@ -128,6 +128,7 @@ def _selective_scan_update_kernel(
     C_ptr += pid_b * stride_C_batch + (pid_h // nheads_ngroups_ratio) * stride_C_group
     if HAS_Z:
         z_ptr += pid_b * stride_z_batch + pid_h * stride_z_head
+    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
     state_ptrs = state_ptr + (
@@ -148,7 +149,6 @@ def _selective_scan_update_kernel(
         D_ptrs = D_ptr + offs_m * stride_D_dim
     if HAS_Z:
         z_ptrs = z_ptr + offs_m * stride_z_dim
-    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
     out_ptrs = out_ptr + offs_m * stride_out_dim
     mask = (offs_m[:, None] < dim) & (offs_n[None, :] < dstate)
     if HAS_STATE_BATCH_INDICES:

--- a/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/mamba_ssm.py
@@ -109,12 +109,21 @@ def _selective_scan_update_kernel(
     pid_b = tl.program_id(axis=1)
     pid_h = tl.program_id(axis=2)
 
+    # Precompute output pointers for potential early exit on padding slots
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
+    out_ptrs = out_ptr + offs_m * stride_out_dim
+
     # If HAS_STATE_BATCH_INDICES is true, then the ssm state's batch coordinate
     # is taken from the state_batch_indices_ptr Otherwise, the state coordinate
     # is the same as the batch id.
     if HAS_STATE_BATCH_INDICES:
         state_batch_indices_ptr += pid_b
         state_batch_idx = tl.load(state_batch_indices_ptr).to(tl.int64)
+        # Skip padding tokens by writing zeros to output and returning early
+        if state_batch_idx == pad_slot_id:
+            tl.store(out_ptrs, 0.0, mask=offs_m < dim)
+            return
         state_ptr += state_batch_idx * stride_state_batch + pid_h * stride_state_head
     else:
         state_ptr += pid_b * stride_state_batch + pid_h * stride_state_head
@@ -128,9 +137,7 @@ def _selective_scan_update_kernel(
     C_ptr += pid_b * stride_C_batch + (pid_h // nheads_ngroups_ratio) * stride_C_group
     if HAS_Z:
         z_ptr += pid_b * stride_z_batch + pid_h * stride_z_head
-    out_ptr += pid_b * stride_out_batch + pid_h * stride_out_head
-
-    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    # offs_m is already computed above
     offs_n = tl.arange(0, BLOCK_SIZE_DSTATE)
     state_ptrs = state_ptr + (
         offs_m[:, None] * stride_state_dim + offs_n[None, :] * stride_state_dstate
@@ -150,7 +157,7 @@ def _selective_scan_update_kernel(
         D_ptrs = D_ptr + offs_m * stride_D_dim
     if HAS_Z:
         z_ptrs = z_ptr + offs_m * stride_z_dim
-    out_ptrs = out_ptr + offs_m * stride_out_dim
+    # out_ptrs is already computed above
     mask = (offs_m[:, None] < dim) & (offs_n[None, :] < dstate)
     if HAS_STATE_BATCH_INDICES:
         mask &= state_batch_idx != pad_slot_id

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -232,9 +232,7 @@ def _chunk_state_fwd_kernel(
             scale = tl.exp(dA_cs_last - dA_cs_k) * dt_k
         else:
             scale = tl.where(
-                (seq_idx_last >= 0) & (seq_idx_k == seq_idx_last),
-                tl.exp(dA_cs_last - dA_cs_k) * dt_k,
-                0.0,
+                seq_idx_k == seq_idx_last, tl.exp(dA_cs_last - dA_cs_k) * dt_k, 0.0
             )
         b *= scale[:, None]
         b = b.to(x_ptr.dtype.element_ty)

--- a/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
+++ b/python/sglang/srt/layers/attention/mamba/ops/ssd_chunk_state.py
@@ -232,7 +232,9 @@ def _chunk_state_fwd_kernel(
             scale = tl.exp(dA_cs_last - dA_cs_k) * dt_k
         else:
             scale = tl.where(
-                seq_idx_k == seq_idx_last, tl.exp(dA_cs_last - dA_cs_k) * dt_k, 0.0
+                (seq_idx_last >= 0) & (seq_idx_k == seq_idx_last),
+                tl.exp(dA_cs_last - dA_cs_k) * dt_k,
+                0.0,
             )
         b *= scale[:, None]
         b = b.to(x_ptr.dtype.element_ty)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

1. Fix crash on rocm after mamba pr, it seems like bad merge: https://github.com/sgl-project/sglang/pull/10909

```
mamba/mamba.py", line 520, in forward
    hidden_states_B_C_d = ccu(
                          ^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/mamba/causal_conv1d.py", line 117, in causal_conv1d_update
    causal_conv1d_update_kernel(
  File "/usr/local/lib/python3.12/dist-packages/sgl_kernel-0.3.15-py3.12-linux-x86_64.egg/sgl_kernel/mamba.py", line 41, in causal_conv1d_update
    torch.ops.sgl_kernel.causal_conv1d_update(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1231, in __getattr__
    raise AttributeError(
AttributeError: '_OpNamespace' 'sgl_kernel' object has no attribute 'causal_conv1d_update'

[2025-10-10 02:37:07] Received sigquit from a child process. It usually means the child failed.
Killed
```

```
python3 -m sglang.launch_server --model tiiuae/Falcon-H1-0.5B-Instruct
```

Can launch.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 55.8MB/s]                                                                                                                                           
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:36<00:00, 36.15it/s]
Accuracy: 0.697
Invalid: 0.000
Latency: 36.886 s
Output throughput: 5148.924 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
