### PR TITLE
Fix enable_v2 in int8 quant

### DIFF
--- a/python/sglang/srt/layers/quantization/int8_kernel.py
+++ b/python/sglang/srt/layers/quantization/int8_kernel.py
@@ -15,10 +15,12 @@ if _is_cuda:
     # Temporary
     try:
         from sgl_kernel import sgl_per_token_group_quant_8bit
+
+        enable_sgl_per_token_group_quant_8bit = True
     except ImportError:
-        from sgl_kernel import (
-            sgl_per_token_group_quant_int8 as sgl_per_token_group_quant_8bit,
-        )
+        from sgl_kernel import sgl_per_token_group_quant_int8
+
+        enable_sgl_per_token_group_quant_8bit = False
 
 logger = logging.getLogger(__name__)
 
@@ -211,9 +213,14 @@ def sglang_per_token_group_quant_int8(
         dtype=torch.float32,
     )
 
-    sgl_per_token_group_quant_8bit(
-        x, x_q, x_s, group_size, eps, int8_min, int8_max, enable_v2=enable_v2
-    )
+    # Temporary
+    if enable_sgl_per_token_group_quant_8bit:
+        sgl_per_token_group_quant_8bit(
+            x, x_q, x_s, group_size, eps, int8_min, int8_max, enable_v2=enable_v2
+        )
+    else:
+        assert not enable_v2
+        sgl_per_token_group_quant_int8(x, x_q, x_s, group_size, eps, int8_min, int8_max)
 
     return x_q, x_s
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

the ci passed b/c that pr triggers the new sgl-kernel, while main branch use old sgl-kernel

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically uses 8-bit accelerated quantization when available, improving performance with no configuration required.
  - Seamlessly falls back to standard int8 quantization to ensure compatibility across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->