### PR TITLE
dockerfile: drop duplicates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
  && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
  && apt-get update && apt-get install -y --no-install-recommends \
     tzdata \
-    software-properties-common netcat-openbsd kmod unzip openssh-server \
+    netcat-openbsd kmod unzip openssh-server \
     curl wget lsof zsh ccache tmux htop git-lfs tree \
     build-essential cmake \
     libopenmpi-dev libnuma1 libnuma-dev \
@@ -164,11 +164,6 @@ RUN python3 -m pip install --no-cache-dir \
     datamodel_code_generator \
     mooncake-transfer-engine==0.3.6.post1 \
     pre-commit \
-    pytest \
-    black \
-    isort \
-    icdiff \
-    uv \
     wheel \
     scikit-build-core \
     nixl \
@@ -179,25 +174,15 @@ RUN apt-get update && apt-get install -y \
     gdb \
     ninja-build \
     vim \
-    tmux \
-    htop \
-    wget \
-    curl \
     locales \
-    lsof \
     git \
-    git-lfs \
-    zsh \
-    tree \
     silversearcher-ag \
     cloc \
-    unzip \
     pkg-config \
     libssl-dev \
     bear \
-    ccache \
     less \
-    && apt install -y rdma-core infiniband-diags openssh-server perftest ibverbs-providers libibumad3 libibverbs1 libnl-3-200 libnl-route-3-200 librdmacm1 \
+    && apt install -y rdma-core \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -220,7 +205,6 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages \
     black \
     isort \
     icdiff \
-    scikit-build-core \
     uv \
     pre-commit \
     pandas \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Removes only duplicate packages in the dockerfile for better readability.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined container image by removing non‑essential development and diagnostic tooling.
  - Reduced image size for faster pulls, quicker deployments, and lower resource usage.
  - Leaner runtime environment with fewer preinstalled utilities, improving security by reducing surface area.
  - Note: Developer conveniences previously available in the image may no longer be present; use dedicated dev environments or install as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->