### PR TITLE
[ROCm] AITER Custom All-reduce

### DIFF
--- a/benchmark/kernels/all_reduce/benchmark_aiter.py
+++ b/benchmark/kernels/all_reduce/benchmark_aiter.py
@@ -1,0 +1,328 @@
+"""
+Benchmark SGLang vs Aiter custom all-reduce across message sizes.
+Usage:
+    torchrun --nproc_per_node=2 benchmark_custom_allreduce.py
+    torchrun --nproc_per_node=4 benchmark_custom_allreduce.py
+    torchrun --nproc_per_node=8 benchmark_custom_allreduce.py
+"""
+
+import argparse
+import os
+import sys
+import time
+from typing import List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark SGLang vs Aiter custom all-reduce across message sizes."
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="gloo",
+        help="Process group backend for the custom-AR control path (must NOT be nccl).",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=5,
+        help="Warmup iterations per size per implementation.",
+    )
+    parser.add_argument(
+        "--iters-small",
+        type=int,
+        default=50,
+        help="Benchmark iterations for sizes <= 1MB.",
+    )
+    parser.add_argument(
+        "--iters-large",
+        type=int,
+        default=20,
+        help="Benchmark iterations for sizes > 1MB.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print per-iteration timings on rank 0 for debugging.",
+    )
+    return parser.parse_args()
+
+
+def get_env_rank_world() -> Tuple[int, int, int]:
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", str(rank)))
+    return rank, world_size, local_rank
+
+
+def init_dist(backend: str):
+    rank, world_size, _ = get_env_rank_world()
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend=backend,
+            init_method="env://",
+            rank=rank,
+            world_size=world_size,
+        )
+
+
+def get_device(local_rank: int) -> torch.device:
+    torch.cuda.set_device(local_rank)
+    return torch.device(f"cuda:{local_rank}")
+
+
+def human_size(num_bytes: int) -> str:
+    units = [("B", 1), ("K", 1024), ("M", 1024 * 1024), ("G", 1024 * 1024 * 1024)]
+    for suf, base in reversed(units):
+        if num_bytes % base == 0 and num_bytes >= base:
+            val = num_bytes // base
+            return f"{val}{suf}"
+    return f"{num_bytes}B"
+
+
+def get_message_sizes() -> List[int]:
+    return [
+        32 * 1024,
+        64 * 1024,
+        128 * 1024,
+        256 * 1024,
+        512 * 1024,
+        1 * 1024 * 1024,
+        2 * 1024 * 1024,
+        4 * 1024 * 1024,
+        8 * 1024 * 1024,
+        16 * 1024 * 1024,
+        32 * 1024 * 1024,
+        64 * 1024 * 1024,
+    ]
+
+
+@torch.inference_mode()
+def run_once(comm, inp: torch.Tensor) -> Optional[torch.Tensor]:
+    if hasattr(comm, "all_reduce_unreg"):
+        return comm.all_reduce_unreg(inp)
+    if hasattr(comm, "custom_all_reduce"):
+        return comm.custom_all_reduce(inp)
+    raise RuntimeError("No known all-reduce method found on the communicator.")
+
+
+@torch.inference_mode()
+def bench_impl(
+    name: str,
+    comm,
+    sizes: List[int],
+    device: torch.device,
+    warmup: int,
+    iters_small: int,
+    iters_large: int,
+    verbose: bool,
+    pg: Optional[dist.ProcessGroup] = None,
+) -> List[Tuple[int, Optional[float]]]:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    results: List[Tuple[int, Optional[float]]] = []
+
+    for size_bytes in sizes:
+        elems = size_bytes // 2  # float16: 2 bytes per element
+        inp = torch.empty(elems, dtype=torch.float16, device=device)
+        inp.uniform_(0, 1)
+
+        disabled = False
+        dist.barrier(group=pg)
+        for _ in range(warmup):
+            torch.cuda.synchronize()
+            out = run_once(comm, inp)
+            torch.cuda.synchronize()
+            if out is None:
+                disabled = True
+                break
+        dist.barrier(group=pg)
+
+        if disabled:
+            if rank == 0:
+                print(
+                    f"[{name}] {human_size(size_bytes)}: custom AR disabled (skipped)"
+                )
+            results.append((size_bytes, None))
+            continue
+
+        num_iters = iters_small if size_bytes <= (1 * 1024 * 1024) else iters_large
+
+        times_ms: List[float] = []
+        for it in range(num_iters):
+            dist.barrier(group=pg)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            out = run_once(comm, inp)
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            dist.barrier(group=pg)
+
+            if out is None:
+                disabled = True
+                break
+
+            dt_ms = (t1 - t0) * 1000.0
+            times_ms.append(dt_ms)
+
+            if verbose and rank == 0:
+                print(
+                    f"[{name}] size={human_size(size_bytes)} iter={it} time={dt_ms:.3f} ms"
+                )
+
+        if disabled or not times_ms:
+            if rank == 0:
+                print(
+                    f"[{name}] {human_size(size_bytes)}: custom AR disabled (no timings)"
+                )
+            results.append((size_bytes, None))
+            continue
+
+        avg_ms_local = sum(times_ms) / len(times_ms)
+        avg_tensor = torch.tensor([avg_ms_local], dtype=torch.float64, device=device)
+        gather_list = [torch.zeros_like(avg_tensor) for _ in range(world_size)]
+        dist.all_gather(gather_list, avg_tensor, group=pg)
+        if rank == 0:
+            avg_ms = float(torch.stack(gather_list).mean().item())
+            print(
+                f"[{name}] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)"
+            )
+            results.append((size_bytes, avg_ms))
+        else:
+            results.append((size_bytes, None))
+
+    return results
+
+
+def main():
+    args = parse_args()
+    rank, world_size, local_rank = get_env_rank_world()
+
+    if world_size not in (2, 4, 6, 8):
+        print(
+            f"[rank {rank}] WARNING: world_size={world_size} not in supported set (2,4,6,8). "
+            "Custom AR may disable itself.",
+            file=sys.stderr,
+        )
+
+    init_dist(args.backend)
+    device = get_device(local_rank)
+
+    # Import after dist init; some libs query torch dist state on import
+    sgl_comm = None
+    aiter_comm = None
+    HAVE_SGLANG = False
+    HAVE_AITER = False
+
+    try:
+        from sglang.srt.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce as SGLCustomAllreduce,
+        )
+
+        HAVE_SGLANG = True
+    except Exception as e:
+        if rank == 0:
+            print(f"SGLang CustomAllreduce import failed: {e}", file=sys.stderr)
+
+    try:
+        from aiter.dist.custom_all_reduce import CustomAllreduce as AiterCustomAllreduce
+
+        HAVE_AITER = True
+    except Exception as e:
+        if rank == 0:
+            print(f"Aiter CustomAllreduce import failed: {e}", file=sys.stderr)
+
+    if rank == 0:
+        print(f"Initialized PG backend={args.backend} world_size={world_size}")
+        print(f"Device: {device.type}:{device.index}")
+        print(f"SGLang available: {HAVE_SGLANG}, Aiter available: {HAVE_AITER}")
+
+    pg = dist.group.WORLD
+    sizes = get_message_sizes()
+    max_size = max(sizes) if sizes else (64 * 1024 * 1024)
+
+    if HAVE_SGLANG:
+        try:
+            sgl_comm = SGLCustomAllreduce(group=pg, device=device, max_size=max_size)
+        except Exception as e:
+            if rank == 0:
+                print(
+                    f"Failed to construct SGLang CustomAllreduce: {e}", file=sys.stderr
+                )
+            sgl_comm = None
+
+    if HAVE_AITER:
+        try:
+            aiter_comm = AiterCustomAllreduce(
+                group=pg, device=device, max_size=max_size
+            )
+        except Exception as e:
+            if rank == 0:
+                print(
+                    f"Failed to construct Aiter CustomAllreduce: {e}", file=sys.stderr
+                )
+            aiter_comm = None
+
+    sgl_results: List[Tuple[int, Optional[float]]] = []
+    aiter_results: List[Tuple[int, Optional[float]]] = []
+
+    if sgl_comm is not None:
+        sgl_results = bench_impl(
+            name="SGLang",
+            comm=sgl_comm,
+            sizes=sizes,
+            device=device,
+            warmup=args.warmup,
+            iters_small=args.iters_small,
+            iters_large=args.iters_large,
+            verbose=args.verbose,
+            pg=pg,
+        )
+
+    if aiter_comm is not None:
+        aiter_results = bench_impl(
+            name="Aiter",
+            comm=aiter_comm,
+            sizes=sizes,
+            device=device,
+            warmup=args.warmup,
+            iters_small=args.iters_small,
+            iters_large=args.iters_large,
+            verbose=args.verbose,
+            pg=pg,
+        )
+
+    for comm in (sgl_comm, aiter_comm):
+        if comm is not None and hasattr(comm, "close"):
+            try:
+                comm.close()
+            except Exception:
+                pass
+
+    if dist.get_rank() == 0:
+        print("\nResults (avg ms across ranks; None = disabled/unavailable):")
+        header = f"{'Size':>8}  {'SGLang(ms)':>12}  {'Aiter(ms)':>11}"
+        print(header)
+        print("-" * len(header))
+
+        sgl_map = {s: v for s, v in sgl_results if v is not None}
+        aiter_map = {s: v for s, v in aiter_results if v is not None}
+
+        for s in sizes:
+            sgl_ms = sgl_map.get(s, None)
+            aiter_ms = aiter_map.get(s, None)
+            print(
+                f"{human_size(s):>8}  {('%.3f' % sgl_ms) if sgl_ms is not None else 'None':>12}  "
+                f"{('%.3f' % aiter_ms) if aiter_ms is not None else 'None':>11}"
+            )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -424,8 +424,18 @@ class CustomAllreduce:
 def dispatch_custom_allreduce():
     """Return the CustomAllreduce class to use (aiter on ROCm if enabled)."""
     if is_hip():
-        from aiter.dist.custom_all_reduce import CustomAllreduce as AiterCustomAllreduce
+        try:
+            from aiter.dist.custom_all_reduce import (
+                CustomAllreduce as AiterCustomAllreduce,
+            )
 
-        logger.info("Using AiterCustomAllreduce for ROCm.")
-        return AiterCustomAllreduce
+            logger.info("Using AiterCustomAllreduce for ROCm.")
+            return AiterCustomAllreduce
+        except ImportError as e:
+            logger.warning(
+                "Aiter custom all-reduce not available (optional dependency missing); "
+                "falling back to sglang CustomAllreduce. Details: %s",
+                e,
+            )
+            return CustomAllreduce
     return CustomAllreduce

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -18,7 +18,7 @@ from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import 
     is_weak_contiguous,
 )
 from sglang.srt.distributed.parallel_state import in_the_same_node_as
-from sglang.srt.utils import get_bool_env_var, is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hip
 
 logger = logging.getLogger(__name__)
 
@@ -423,11 +423,9 @@ class CustomAllreduce:
 
 def dispatch_custom_allreduce():
     """Return the CustomAllreduce class to use (aiter on ROCm if enabled)."""
-    if is_hip() and get_bool_env_var("SGLANG_USE_AITER_CUSTOM_ALL_REDUCE", "false"):
+    if is_hip():
         from aiter.dist.custom_all_reduce import CustomAllreduce as AiterCustomAllreduce
 
-        logger.info(
-            "Using aiter.dist.custom_all_reduce.CustomAllreduce for ROCm platform"
-        )
+        logger.info("Using AiterCustomAllreduce for ROCm.")
         return AiterCustomAllreduce
     return CustomAllreduce

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -18,7 +18,7 @@ from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import 
     is_weak_contiguous,
 )
 from sglang.srt.distributed.parallel_state import in_the_same_node_as
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import get_bool_env_var, is_cuda, is_hip
 
 logger = logging.getLogger(__name__)
 
@@ -419,3 +419,15 @@ class CustomAllreduce:
 
     def __del__(self):
         self.close()
+
+
+def dispatch_custom_allreduce():
+    """Return the CustomAllreduce class to use (aiter on ROCm if enabled)."""
+    if is_hip() and get_bool_env_var("SGLANG_USE_AITER_CUSTOM_ALL_REDUCE", "false"):
+        from aiter.dist.custom_all_reduce import CustomAllreduce as AiterCustomAllreduce
+
+        logger.info(
+            "Using aiter.dist.custom_all_reduce.CustomAllreduce for ROCm platform"
+        )
+        return AiterCustomAllreduce
+    return CustomAllreduce

--- a/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from enum import Enum
+from functools import cache
 from typing import Union
 
 import torch
@@ -31,6 +32,7 @@ except Exception:
     quick_ar = False
 
 
+@cache
 def qr_rocm_arch_available():
     if not _is_hip:
         return False

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -298,7 +298,7 @@ class GroupCoordinator:
 
         # Lazy import to avoid documentation build error
         from sglang.srt.distributed.device_communicators.custom_all_reduce import (
-            CustomAllreduce,
+            dispatch_custom_allreduce,
         )
         from sglang.srt.distributed.device_communicators.pymscclpp import (
             PyMscclppCommunicator,
@@ -330,7 +330,7 @@ class GroupCoordinator:
                 device=self.device,
             )
 
-        self.ca_comm: Optional[CustomAllreduce] = None
+        self.ca_comm: Optional[Any] = None
         self.qr_comm: Optional[QuickAllReduce] = None
         if use_custom_allreduce and self.world_size > 1:
             # Initialize a custom fast all-reduce implementation.
@@ -341,7 +341,8 @@ class GroupCoordinator:
             else:
                 ca_max_size = 8 * 1024 * 1024
             try:
-                self.ca_comm = CustomAllreduce(
+                CAClass = dispatch_custom_allreduce()
+                self.ca_comm = CAClass(
                     group=self.cpu_group,
                     device=self.device,
                     max_size=ca_max_size,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Inspired by https://github.com/vllm-project/vllm/pull/23336, thanks to vLLM community.

For ROCm, faster than SGL custom all-reduce. Tested on MI355X

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

> Note: separately, we could also use PyTorch symm memory, so I wonder if we can get an additional speedup. However I think it can be a separate PR

## Accuracy Tests

Not a destructive AR, so no accy degradation is expected.

Before:

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
/opt/venv/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 90.7MB/s]                                                                                                                                                                                                          
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:23<00:00, 56.84it/s]
Accuracy: 0.961
Invalid: 0.000
Latency: 23.640 s
Output throughput: 5788.585 token/s
```

After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
/opt/venv/lib/python3.10/site-packages/transformers/utils/hub.py:111: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:22<00:00, 59.62it/s]
Accuracy: 0.960
Invalid: 0.000
Latency: 22.243 s
Output throughput: 6106.724 token/s
```


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

```
python3 -m sglang.bench_serving --backend sglang --num-prompts 64 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1 --max-concurrency=8 --flush-cache
...
python3 -m sglang.bench_serving --backend sglang --num-prompts 1024 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1 --max-concurrency=128 --flush-cache
```

Before:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  160.71    
Total input tokens:                      65536     
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65314     
Request throughput (req/s):              0.40      
Input token throughput (tok/s):          407.80    
Output token throughput (tok/s):         407.80    
Total token throughput (tok/s):          815.60    
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   20084.16  
Median E2E Latency (ms):                 20118.20  
---------------Time to First Token----------------
Mean TTFT (ms):                          315.13    
Median TTFT (ms):                        356.87    
P99 TTFT (ms):                           389.59    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           19.32     
Median ITL (ms):                         19.29     
P95 ITL (ms):                            19.45     
P99 ITL (ms):                            19.59     
Max ITL (ms):                            240.34    
==================================================
```

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 128       
Successful requests:                     1024      
Benchmark duration (s):                  302.02    
Total input tokens:                      1048576   
Total generated tokens:                  1048576   
Total generated tokens (retokenized):    1043454   
Request throughput (req/s):              3.39      
Input token throughput (tok/s):          3471.91   
Output token throughput (tok/s):         3471.91   
Total token throughput (tok/s):          6943.82   
Concurrency:                             127.91    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   37725.70  
Median E2E Latency (ms):                 37655.39  
---------------Time to First Token----------------
Mean TTFT (ms):                          2515.93   
Median TTFT (ms):                        2476.32   
P99 TTFT (ms):                           4345.29   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           34.42     
Median ITL (ms):                         32.76     
P95 ITL (ms):                            34.40     
P99 ITL (ms):                            36.47     
Max ITL (ms):                            3963.00   
==================================================
```

After:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  159.77    
Total input tokens:                      65536     
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65311     
Request throughput (req/s):              0.40      
Input token throughput (tok/s):          410.19    
Output token throughput (tok/s):         410.19    
Total token throughput (tok/s):          820.38    
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   19966.52  
Median E2E Latency (ms):                 20020.21  
---------------Time to First Token----------------
Mean TTFT (ms):                          308.65    
Median TTFT (ms):                        355.87    
P99 TTFT (ms):                           392.90    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           19.22     
Median ITL (ms):                         19.19     
P95 ITL (ms):                            19.34     
P99 ITL (ms):                            19.49     
Max ITL (ms):                            263.54    
==================================================
```

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 128       
Successful requests:                     1024      
Benchmark duration (s):                  290.74    
Total input tokens:                      1048576   
Total generated tokens:                  1048576   
Total generated tokens (retokenized):    1043514   
Request throughput (req/s):              3.52      
Input token throughput (tok/s):          3606.57   
Output token throughput (tok/s):         3606.57   
Total token throughput (tok/s):          7213.15   
Concurrency:                             127.87    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   36307.02  
Median E2E Latency (ms):                 36277.94  
---------------Time to First Token----------------
Mean TTFT (ms):                          2528.81   
Median TTFT (ms):                        2435.84   
P99 TTFT (ms):                           4232.62   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           33.02     
Median ITL (ms):                         31.43     
P95 ITL (ms):                            32.59     
P99 ITL (ms):                            34.79     
Max ITL (ms):                            4032.58   
==================================================
```

Approximately 4% throughput improvement at bs=4, 128


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Test

The main AR test.

> Actually there seems to be a bug in the TP = 6 custom AR, but I personally have never seen this TP setup, so I wonder if it's ok to simply skip the test in this case.
> Also note, I have not compared it against QR, but QR is not enabled by default/not an AITER operator, but this one is.

Generally, you can reproduce it with

```
export SGLANG_USE_AITER_CUSTOM_ALL_REDUCE=1
cd /sgl-workspace/sglang/test/srt
python -m unittest -q test_custom_allreduce.TestCustomAllReduce.test_eager_allreduce
python -m unittest -q test_custom_allreduce.TestCustomAllReduce.test_graph_allreduce
```

```
export SGLANG_USE_AITER_CUSTOM_ALL_REDUCE=1
cd /sgl-workspace/sglang/test/srt
python -m unittest -q test_custom_allreduce.TestCustomAllReduce.test_eager_allreduce
python -m unittest -q test_custom_allreduce.TestCustomAllReduce.test_graph_allreduce
```
```
(graph_allreduce pid=1417249)   warnings.warn( [repeated 7x across cluster]
/usr/lib/python3.10/subprocess.py:1072: ResourceWarning: subprocess 1416672 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
----------------------------------------------------------------------
Ran 1 test in 70.248s

OK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional ROCm-specific all‑reduce backend: when running on ROCm, an alternative all‑reduce implementation is selected automatically; default behavior unchanged.

* **Refactor**
  * Initialization now uses a runtime dispatcher to pick the appropriate all‑reduce implementation, streamlining selection while preserving existing public APIs and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->