### PR TITLE
[Router]: Small Typo in a comment within tree.rs

### DIFF
--- a/sgl-router/src/tree.rs
+++ b/sgl-router/src/tree.rs
@@ -93,7 +93,7 @@ impl Tree {
     Thread-safe multi tenant radix tree
 
     1. Storing data for multiple tenants (the overlap of multiple radix tree)
-    2. Node-level lock to enable concurrent acesss on nodes
+    2. Node-level lock to enable concurrent access on nodes
     3. Leaf LRU eviction based on tenant access time
     */
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Spotted a small typo in a comment within `tree.rs`.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in internal comments (“acesss” → “access”) related to node locking, improving clarity and readability.
  * Clarified wording to ensure consistent terminology across the codebase.
  * No changes to functionality, APIs, configuration, or performance; behavior remains the same.
  * Safe to upgrade with no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->