### PR TITLE
[Deterministic] Blockscale FP8 kernel

### DIFF
--- a/sgl-kernel/csrc/cutlass_extensions/gemm/fp8_blockwise_gemm_sm90_dispatch.cuh
+++ b/sgl-kernel/csrc/cutlass_extensions/gemm/fp8_blockwise_gemm_sm90_dispatch.cuh
@@ -2,8 +2,6 @@
 // https://github.com/vllm-project/vllm/blob/main/csrc/quantization/cutlass_w8a8/c3x/scaled_mm_blockwise_sm90_fp8_dispatch.cuh
 #pragma once
 
-#include <cstdlib>
-
 #include "cute/tensor.hpp"
 #include "cutlass/cutlass.h"
 #include "cutlass/epilogue/collective/collective_builder.hpp"
@@ -20,14 +18,6 @@
 #include "cutlass_extensions/gemm/dispatch_policy.hpp"
 
 using namespace cute;
-
-static inline bool sglang_determinism_enabled() {
-  const char* v = std::getenv("SGLANG_ENABLE_DETERMINISTIC_INFERENCE");
-  if (v == nullptr || v[0] == '\0') return false;
-  char c0 = v[0];
-  if (c0 == '0' || c0 == 'f' || c0 == 'F' || c0 == 'n' || c0 == 'N') return false;
-  return true;
-}
 
 template <
     typename SchedulerType,

--- a/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
+++ b/sgl-kernel/csrc/gemm/fp8_blockwise_gemm_kernel.cu
@@ -418,10 +418,20 @@ torch::Tensor fp8_blockwise_scaled_mm(
     torch::Tensor scales_b_contiguous = scales_b.contiguous();
     if (out_dtype == torch::kBFloat16) {
       cutlass_gemm_blockwise_sm90_fp8_dispatch<cutlass::bfloat16_t>(
-          out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b_contiguous);
+          out_padded,
+          mat_a_padded,
+          mat_b,
+          scales_a_padded,
+          scales_b_contiguous,
+          getBoolEnv("SGLANG_ENABLE_DETERMINISTIC_INFERENCE"));
     } else {
       cutlass_gemm_blockwise_sm90_fp8_dispatch<cutlass::half_t>(
-          out_padded, mat_a_padded, mat_b, scales_a_padded, scales_b_contiguous);
+          out_padded,
+          mat_a_padded,
+          mat_b,
+          scales_a_padded,
+          scales_b_contiguous,
+          getBoolEnv("SGLANG_ENABLE_DETERMINISTIC_INFERENCE"));
     }
     return out_padded.slice(0, 0, original_rows);
   }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Part of https://github.com/sgl-project/sglang/issues/11402
Enable deterministic inference on R1/V3. According to @Fridge003 If FP8 fused MoE is deterministic, then this should be one of the remaining kernel (maybe for Hopper only)

> After rebasing, I encountered https://github.com/sgl-project/sglang/issues/11529 on triton, but I don't know how to solve this. So I used flashinfer but still not deterministic

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Make 2 changes to blockwise FP8 for deterministic inference.

1. Avoid StreamK (which is another way to do Split-K) in CUTLASS
2. Avoid `ReductionMode::Nondeterministic`. To my understanding, it is also part of StreamK scheduler, because the reduction modes can occur in any order, and FP addition is non-deterministic.

I also disabled DeepGEMM through env vars.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Before cmd (100% not deterministic):

```
python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-R1   --tp 8   --trust-remote-code
```

Results:

```
python3 -m sglang.test.test_deterministic --test-mode single
python3 -m sglang.test.test_deterministic --test-mode mixed
python3 -m sglang.test.test_deterministic --test-mode prefix
...
Total samples: 50, Unique samples: 3

Prompt 1: total samples: 424, Unique samples: 6
Prompt 2: total samples: 629, Unique samples: 6
Long prompt: total samples: 222, Unique samples: 14

Prompt 0 with prefix length 1: total samples: 340, Unique samples: 58
Prompt 1 with prefix length 511: total samples: 312, Unique samples: 163
Prompt 2 with prefix length 2048: total samples: 305, Unique samples: 115
Prompt 3 with prefix length 4097: total samples: 318, Unique samples: 115
```

Try to enable deterministic before this PR (default blockwise fp8 is flashinfer)

```
python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-R1 --tp 8 --trust-remote-code --enable-deterministic-inference --disable-radix-cache --attention-backend flashinfer --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' --flashinfer-mla-disable-ragged
```

```
python3 -m sglang.test.test_deterministic --test-mode single
python3 -m sglang.test.test_deterministic --test-mode mixed
python3 -m sglang.test.test_deterministic --test-mode prefix
...
Total samples: 50, Unique samples: 6

Prompt 1: total samples: 559, Unique samples: 4
Prompt 2: total samples: 509, Unique samples: 7
Long prompt: total samples: 207, Unique samples: 3

Prompt 0 with prefix length 1: total samples: 310, Unique samples: 7
Prompt 1 with prefix length 511: total samples: 321, Unique samples: 23
Prompt 2 with prefix length 2048: total samples: 316, Unique samples: 9
Prompt 3 with prefix length 4097: total samples: 328, Unique samples: 20
```

After cmd:
> Note by default, it seems to use the flashinfer blockwise FP8, however I am unsure/did not look into whether how to make it deterministic.
```
SGL_CHUNKED_PREFIX_CACHE_THRESHOLD=0 SGLANG_SUPPORT_CUTLASS_BLOCK_FP8=1 python3 -m sglang.launch_server   --model-path deepseek-ai/DeepSeek-R1  --tp 8   --trust-remote-code --enable-deterministic-inference --disable-radix-cache --attention-backend triton --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' --attention-backend flashinfer --flashinfer-mla-disable-ragged
```

Results (TODO redo these):
```
...
Total samples: 50, Unique samples: 14
...
Prompt 1: total samples: 609, Unique samples: 5
Prompt 2: total samples: 485, Unique samples: 5
Long prompt: total samples: 181, Unique samples: 7
...
Prompt 0 with prefix length 1: total samples: 322, Unique samples: 5
Prompt 1 with prefix length 511: total samples: 322, Unique samples: 11
Prompt 2 with prefix length 2048: total samples: 334, Unique samples: 7
Prompt 3 with prefix length 4097: total samples: 297, Unique samples: 20
...
```

The script to test the determinism of the op itself.

```python3
# sgl-kernel/tests/test_fp8_blockwise_gemm_deterministic.py
import os
import torch

from sgl_kernel.gemm import fp8_blockwise_scaled_mm


def _m_major_view_2d(t: torch.Tensor) -> torch.Tensor:
    # M major
    base = t.t().contiguous()
    return base.t()


def _col_major_view_k_n(mat_k_n: torch.Tensor) -> torch.Tensor:
    # Col major
    # by materializing a transposed contiguous base and returning the transpose view.
    base = mat_k_n.t().contiguous()     # (n, k), row-major contiguous
    return base.t()                     # (k, n), column-major view (stride(0) == 1)


def _make_fp8_with_scales(m, k, n, device, dtype_out):
    torch.manual_seed(1234)
    assert k % 128 == 0 and n % 128 == 0

    fp8_dtype = torch.float8_e4m3fn
    fp8_max = torch.finfo(fp8_dtype).max

    # A: (m, k), per-128 block scales along K
    a_bf16 = torch.randn(m, k, device=device, dtype=torch.bfloat16)
    a_scales_blocks = (
        a_bf16.abs().view(m, k // 128, 128).amax(dim=2) / fp8_max
    ).clamp_min(1e-8).to(torch.float32).contiguous()
    a_scale_full = a_scales_blocks.repeat_interleave(128, dim=1)
    a_fp8 = torch.clamp(
        (a_bf16 / a_scale_full).to(torch.float32), min=-fp8_max, max=fp8_max
    ).to(fp8_dtype).contiguous()
    # M major
    a_scales = _m_major_view_2d(a_scales_blocks)
    assert a_scales.size() == (m, k // 128) and a_scales.stride(0) == 1

    # B: (k, n), per-128x128 block scales
    b_bf16 = torch.randn(k, n, device=device, dtype=torch.bfloat16)
    b_scales_blocks = (
        b_bf16.abs().view(k // 128, 128, n // 128, 128).amax(dim=(1, 3))
    ).clamp_min(1e-8).to(torch.float32).contiguous()
    b_scale_full = b_scales_blocks.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
    b_fp8_k_n = torch.clamp(
        (b_bf16 / b_scale_full).to(torch.float32), min=-fp8_max, max=fp8_max
    ).to(fp8_dtype)
    # Col major
    b_fp8 = _col_major_view_k_n(b_fp8_k_n)
    assert b_fp8.size() == (k, n) and b_fp8.stride(0) == 1

    b_scales = _m_major_view_2d(b_scales_blocks)
    assert b_scales.size() == (k // 128, n // 128) and b_scales.stride(0) == 1

    return a_fp8, a_scales, b_fp8, b_scales, dtype_out


def _run_once(m, k, n, device, dtype_out):
    a_fp8, a_scales, b_fp8, b_scales, out_dtype = _make_fp8_with_scales(
        m, k, n, device, dtype_out
    )
    # print(a_fp8.shape, b_fp8.shape, a_scales.shape, b_scales.shape)
    return fp8_blockwise_scaled_mm(a_fp8, b_fp8, a_scales, b_scales, out_dtype)


def test_fp8_blockwise_gemm_deterministic_sm90():
    if not torch.cuda.is_available():
        return
    dev = torch.device("cuda")
    os.environ["SGLANG_ENABLE_DETERMINISTIC_INFERENCE"] = "1"

    shapes = [(1024, 4096, 1024), (2048, 2048, 2048)]
    dtypes = [torch.bfloat16, torch.half]

    for (m, k, n) in shapes:
        for out_dtype in dtypes:
            y0 = _run_once(m, k, n, dev, out_dtype)
            for _ in range(5):
                y = _run_once(m, k, n, dev, out_dtype)
                assert torch.equal(y0, y), f"Non-deterministic result for shape {(m,k,n)} dtype {out_dtype}"
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
