### PR TITLE
Speed up by reducing _forward_extend_unified's gpu->cpu sync bubble by ~2x faster

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -867,7 +867,7 @@ class TritonAttnBackend(AttentionBackend):
         extend_start_loc_cpu = forward_batch.extend_start_loc[:bs].cpu()
         extend_seq_lens_cpu = forward_batch.extend_seq_lens[:bs].cpu()
 
-        # Compute prefix lengths on GPU (vectorized)
+        # Compute prefix lengths on CPU (vectorized)
         prefix_lens = (prefix_kv_indptr_cpu[1:] - prefix_kv_indptr_cpu[:-1]).to(
             torch.int32
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

As titled.

## Accuracy Tests
```
import sys
from sglang.srt.entrypoints.http_server import launch_server
from sglang.srt.server_args import prepare_server_args
if __name__ == "__main__":
    # Simulate CLI arguments (excluding the script name)
    args = [
        "--trust-remote-code",
        "--model-path",
        "Qwen/Qwen3-8B",
        "--attention-backend",
        "triton",
        "--tp",
        "4",
        "--enable-deterministic-inference",
        # "--disable-radix-cache",
        # "--disable-cuda-graph",
        # "--skip-server-warmup"
    ]
    server_args = prepare_server_args(args)
    launch_server(server_args)
```


After - Qwen3-8B:
```
Accuracy: 0.945
Invalid: 0.000
Latency: 15.683 s
Output throughput: 1513.949 token/s

Prompt 0 with prefix length 1: total samples: 302, Unique samples: 1
Prompt 1 with prefix length 511: total samples: 304, Unique samples: 1
Prompt 2 with prefix length 2048: total samples: 320, Unique samples: 1
Prompt 3 with prefix length 4097: total samples: 349, Unique samples: 1
```

After - Qwen3-30B-A3B: 
```
Accuracy: 0.920
Invalid: 0.000
Latency: 18.446 s
Output throughput: 1222.439 token/s


Prompt 0 with prefix length 1: total samples: 300, Unique samples: 1
Prompt 1 with prefix length 511: total samples: 326, Unique samples: 1
Prompt 2 with prefix length 2048: total samples: 316, Unique samples: 1
Prompt 3 with prefix length 4097: total samples: 333, Unique samples: 1
```

## Benchmarking and Profiling

For TP4 Qwen3-8B: 
```
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 32 --random-input-len 256 --random-output-len 256  --random-range-ratio 1 --profile
```

`sglang/srt/layers/attention/triton_backend.py(833): _forward_extend_unified` reduced from 3370us in avg -> 1634us in avg (~2x faster)

<img width="2358" height="364" alt="image" src="https://github.com/user-attachments/assets/84557112-3a87-4ae1-b15b-dbef1151e4e0" />


<img width="2343" height="327" alt="image" src="https://github.com/user-attachments/assets/67fda839-00ef-4307-b770-6c3ad574977d" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
