### PR TITLE
[router][grpc] Further delegate non-stream processing to `processing.rs` 

### DIFF
--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -23,6 +23,9 @@ use std::sync::Arc;
 
 use tracing::debug;
 
+use super::context::SharedComponents;
+use super::pipeline::RequestPipeline;
+
 /// gRPC PD (Prefill-Decode) router implementation for SGLang
 #[derive(Clone)]
 #[allow(dead_code)] // Fields will be used once implementation is complete
@@ -37,8 +40,8 @@ pub struct GrpcPDRouter {
     retry_config: RetryConfig,
     configured_reasoning_parser: Option<String>,
     configured_tool_parser: Option<String>,
-    pipeline: super::pipeline::ChatCompletionPipeline,
-    shared_components: Arc<super::context::SharedComponents>,
+    pipeline: RequestPipeline,
+    shared_components: Arc<SharedComponents>,
 }
 
 impl GrpcPDRouter {
@@ -66,7 +69,7 @@ impl GrpcPDRouter {
             .clone();
 
         // Create shared components for pipeline
-        let shared_components = Arc::new(super::context::SharedComponents {
+        let shared_components = Arc::new(SharedComponents {
             tokenizer: tokenizer.clone(),
             tool_parser_factory: tool_parser_factory.clone(),
             reasoning_parser_factory: reasoning_parser_factory.clone(),
@@ -91,7 +94,7 @@ impl GrpcPDRouter {
         ));
 
         // Create PD pipeline
-        let pipeline = super::pipeline::ChatCompletionPipeline::new_pd(
+        let pipeline = RequestPipeline::new_pd(
             worker_registry.clone(),
             policy_registry.clone(),
             processor,

--- a/sgl-router/src/routers/grpc/pd_router.rs
+++ b/sgl-router/src/routers/grpc/pd_router.rs
@@ -75,30 +75,15 @@ impl GrpcPDRouter {
             reasoning_parser_factory: reasoning_parser_factory.clone(),
         });
 
-        // Create response processor
-        let processor = super::processing::ResponseProcessor::new(
-            tokenizer.clone(),
-            tool_parser_factory.clone(),
-            reasoning_parser_factory.clone(),
-            ctx.configured_tool_parser.clone(),
-            ctx.configured_reasoning_parser.clone(),
-        );
-
-        // Create streaming processor
-        let streaming_processor = Arc::new(super::streaming::StreamingProcessor::new(
-            tokenizer.clone(),
-            tool_parser_factory.clone(),
-            reasoning_parser_factory.clone(),
-            ctx.configured_tool_parser.clone(),
-            ctx.configured_reasoning_parser.clone(),
-        ));
-
         // Create PD pipeline
         let pipeline = RequestPipeline::new_pd(
             worker_registry.clone(),
             policy_registry.clone(),
-            processor,
-            streaming_processor,
+            tokenizer.clone(),
+            tool_parser_factory.clone(),
+            reasoning_parser_factory.clone(),
+            ctx.configured_tool_parser.clone(),
+            ctx.configured_reasoning_parser.clone(),
         );
 
         Ok(GrpcPDRouter {

--- a/sgl-router/src/routers/grpc/pipeline.rs
+++ b/sgl-router/src/routers/grpc/pipeline.rs
@@ -904,16 +904,16 @@ impl ResponseProcessingStage {
 // Pipeline Orchestrator
 // ============================================================================
 
-/// Complete chat completion pipeline
+/// Generic request pipeline for all request types
 ///
 /// Orchestrates all stages from request preparation to response delivery.
 /// Configured differently for regular vs PD mode.
 #[derive(Clone)]
-pub struct ChatCompletionPipeline {
+pub struct RequestPipeline {
     stages: Arc<Vec<Box<dyn PipelineStage>>>,
 }
 
-impl ChatCompletionPipeline {
+impl RequestPipeline {
     /// Create a regular (single-worker) pipeline
     pub fn new_regular(
         worker_registry: Arc<WorkerRegistry>,

--- a/sgl-router/src/routers/grpc/processing.rs
+++ b/sgl-router/src/routers/grpc/processing.rs
@@ -61,16 +61,27 @@ impl ResponseProcessor {
         request_logprobs: bool,
     ) -> Result<Vec<proto::GenerateComplete>, axum::response::Response> {
         let all_responses = match execution_result {
-            ExecutionResult::Single { stream } => {
-                utils::collect_stream_responses(stream, "Single").await?
+            ExecutionResult::Single { mut stream } => {
+                let responses = utils::collect_stream_responses(&mut stream, "Single").await?;
+                stream.mark_completed();
+                responses
             }
-            ExecutionResult::Dual { prefill, decode } => {
-                // Collect prefill for input_logprobs
-                let prefill_responses = utils::collect_stream_responses(prefill, "Prefill").await?;
+            ExecutionResult::Dual {
+                mut prefill,
+                decode,
+            } => {
+                // Collect prefill for input_logprobs (don't mark completed yet)
+                let prefill_responses =
+                    utils::collect_stream_responses(&mut prefill, "Prefill").await?;
 
-                // Collect decode for actual output
+                // Collect decode for actual output (don't mark completed yet)
+                let mut decode_stream = *decode;
                 let mut decode_responses =
-                    utils::collect_stream_responses(*decode, "Decode").await?;
+                    utils::collect_stream_responses(&mut decode_stream, "Decode").await?;
+
+                // Mark both streams as completed now that both succeeded
+                prefill.mark_completed();
+                decode_stream.mark_completed();
 
                 // Merge prefill input_logprobs if requested
                 if request_logprobs {

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -24,6 +24,9 @@ use crate::server::AppContext;
 use crate::tokenizer::traits::Tokenizer;
 use crate::tool_parser::ParserFactory as ToolParserFactory;
 
+use super::context::SharedComponents;
+use super::pipeline::RequestPipeline;
+
 /// gRPC router implementation for SGLang
 #[derive(Clone)]
 #[allow(dead_code)]
@@ -38,8 +41,8 @@ pub struct GrpcRouter {
     retry_config: RetryConfig,
     configured_reasoning_parser: Option<String>,
     configured_tool_parser: Option<String>,
-    pipeline: super::pipeline::ChatCompletionPipeline,
-    shared_components: Arc<super::context::SharedComponents>,
+    pipeline: RequestPipeline,
+    shared_components: Arc<SharedComponents>,
 }
 
 impl GrpcRouter {
@@ -66,7 +69,7 @@ impl GrpcRouter {
         let policy_registry = ctx.policy_registry.clone();
 
         // Create shared components for pipeline
-        let shared_components = Arc::new(super::context::SharedComponents {
+        let shared_components = Arc::new(SharedComponents {
             tokenizer: tokenizer.clone(),
             tool_parser_factory: tool_parser_factory.clone(),
             reasoning_parser_factory: reasoning_parser_factory.clone(),
@@ -91,7 +94,7 @@ impl GrpcRouter {
         ));
 
         // Create pipeline
-        let pipeline = super::pipeline::ChatCompletionPipeline::new_regular(
+        let pipeline = RequestPipeline::new_regular(
             worker_registry.clone(),
             policy_registry.clone(),
             processor,

--- a/sgl-router/src/routers/grpc/router.rs
+++ b/sgl-router/src/routers/grpc/router.rs
@@ -75,30 +75,15 @@ impl GrpcRouter {
             reasoning_parser_factory: reasoning_parser_factory.clone(),
         });
 
-        // Create response processor
-        let processor = super::processing::ResponseProcessor::new(
-            tokenizer.clone(),
-            tool_parser_factory.clone(),
-            reasoning_parser_factory.clone(),
-            ctx.configured_tool_parser.clone(),
-            ctx.configured_reasoning_parser.clone(),
-        );
-
-        // Create streaming processor
-        let streaming_processor = Arc::new(super::streaming::StreamingProcessor::new(
-            tokenizer.clone(),
-            tool_parser_factory.clone(),
-            reasoning_parser_factory.clone(),
-            ctx.configured_tool_parser.clone(),
-            ctx.configured_reasoning_parser.clone(),
-        ));
-
         // Create pipeline
         let pipeline = RequestPipeline::new_regular(
             worker_registry.clone(),
             policy_registry.clone(),
-            processor,
-            streaming_processor,
+            tokenizer.clone(),
+            tool_parser_factory.clone(),
+            reasoning_parser_factory.clone(),
+            ctx.configured_tool_parser.clone(),
+            ctx.configured_reasoning_parser.clone(),
         );
 
         Ok(GrpcRouter {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The gRPC router had significant code duplication between `router.rs`, `pd_router.rs`, and `pipeline.rs` for non-streaming response processing. This PR consolidates response processing logic into the processing.rs module to:

  - Eliminate ~400 lines of duplicate code across router implementations
  - Improve maintainability with a single source of truth for response processing
  - Better separation of concerns - pipeline orchestrates stages, processing transforms responses

## Modifications

- Created `process_non_streaming_chat_response()` in ResponseProcessor
- Created `process_non_streaming_generate_response()` in ResponseProcessor
- Added `collect_and_merge_responses()` helper method
- Renamed `ChatCompletionPipeline` → `RequestPipeline`
- Moved processor creation into pipeline constructors
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
