### PR TITLE
make sure logit bias is applied during eagle spec decoding verification

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -235,7 +235,10 @@ class EagleVerifyInput(SpecInput):
             )
 
         # Apply penalty
-        if sampling_info.penalizer_orchestrator.is_required:
+        if (
+            sampling_info.penalizer_orchestrator.is_required
+            or sampling_info.logit_bias is not None
+        ):
             # This is a relaxed version of penalties for speculative decoding.
             linear_penalty = torch.zeros(
                 (bs, logits_output.next_token_logits.shape[1]),


### PR DESCRIPTION
## Motivation

When EAGLE speculative decoding is turned on, the logit_bias parameter is ignored, as reported in [issue 10617](https://github.com/sgl-project/sglang/issues/10617)

## Modifications

This PR adds a missing check for whether logit biases have been sent in the EAGLE verify function.

## Accuracy Tests

I don't think this fix requires accuracy tests.

## Benchmarking and Profiling

I don't think this fix requires benchmarking. 

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
