### PR TITLE
Fix DeepSeek-v3.2 default config (ValueError: not enough values to unpack (expected 4, got 3))

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -804,7 +804,7 @@ class ServerArgs:
 
         hf_config = self.get_hf_config()
         model_arch = hf_config.architectures[0]
-        if model_arch in ["DeepseekV3ForCausalLM"]:
+        if model_arch in ["DeepseekV3ForCausalLM"] and not is_deepseek_nsa(hf_config):
             if is_cuda() and is_sm100_supported():
                 if (
                     self.attention_backend is None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Changes to DeepSeek-R1-FP4 default config in #11512 are accidently being applied to DeepSeek-V3.2-Exp. On blackwell, this causes the attention backend for 3.2 to be set to `trtllm_mla` instead of `nsa` which leads to this error at runtime:
```
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 1299, in forward
    return self.forward_core(s)
           ^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 1385, in forward_core
    return self.forward_absorb_core(*inner_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 1640, in forward_absorb_core
    attn_output = self.attn_mqa(
                  ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/radix_attention.py", line 121, in forward
    return forward_batch.attn_backend.forward(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/attention/base_attn_backend.py", line 91, in forward
    return self.forward_decode(
           ^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/attention/trtllm_mla_backend.py", line 497, in forward_decode
    forward_batch.token_to_kv_pool.set_mla_kv_buffer(
  File "/trevor/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 1256, in set_mla_kv_buffer
    cache_k = quantize_k_cache(cache_k.unsqueeze(1)).squeeze(1)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/attention/nsa/quant_k_cache.py", line 11, in quantize_k_cache
    return _quantize_k_cache_fast_wrapped(cache_k)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/attention/nsa/quant_k_cache.py", line 76, in _quantize_k_cache_fast_wrapped
    num_blocks, block_size, _, dim_nope_and_rope = input_k_cache.shape
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 4, got 3)
```

## Modifications

Make sure DeepSeek R1 default config doesn't apply to NSA model.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
