### PR TITLE
[DSv32] Use torch.compile for _get_logits_head_gate

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -205,6 +205,7 @@ class Indexer(CustomOp):
 
         return ans
 
+    @torch.compile(dynamic=True)
     def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
         weights, _ = self.weights_proj(x)
         weights = weights * self.n_heads**-0.5


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

fuse 2 unary mul + 1 binary mul in _get_logits_head_gate.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python3 -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --dp 8 --enable-dp-attention
python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 4096 --repeat 10
Repeat: 10, mean: 0.767
Scores: ['0.773', '0.763', '0.773', '0.732', '0.747', '0.803', '0.753', '0.763', '0.783', '0.778']
====================
Writing report to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2-Exp.html
{'chars': np.float64(3255.313131313131), 'chars:std': np.float64(1966.1770584515282), 'score:std': np.float64(0.41573970964154905), 'score': np.float64(0.7777777777777778)}
Writing results to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2-Exp.json
Total latency: 241.572 s
Score: 0.778
```

## Benchmarking and Profiling

1.8% e2e total throughput
<img width="2260" height="732" alt="Screenshot 2025-10-10 at 4 31 40 PM" src="https://github.com/user-attachments/assets/c1b22558-d975-4099-9fb8-46f18e38e47d" />

With torch.compile
```
python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --dp 8 --enable-dp-attention
python3 /trevor/bench_serving/benchmark_serving.py --backend openai --host 0.0.0.0 --port 30000 --model deepseek-ai/DeepSeek-V3.2-Exp --num-prompts 256 --trust-remote-code --ignore-eos --max-concurrency 256 --random-input-len 1024 --random-output-len 1024 --random-range-ratio 0.8 --use-chat-template --dataset-name random
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  50.31     
Total input tokens:                      236041    
Total generated tokens:                  235141    
Request throughput (req/s):              5.09      
Output token throughput (tok/s):         4673.86   
Total Token throughput (tok/s):          9365.60   
---------------Time to First Token----------------
Mean TTFT (ms):                          5657.55   
Median TTFT (ms):                        6100.96   
P99 TTFT (ms):                           8742.13   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          44.53     
Median TPOT (ms):                        44.24     
P99 TPOT (ms):                           49.73     
---------------Inter-token Latency----------------
Mean ITL (ms):                           44.51     
Median ITL (ms):                         41.25     
P99 ITL (ms):                            47.54     
==================================================
```

Without
<img width="2244" height="772" alt="Screenshot 2025-10-09 at 2 29 57 PM" src="https://github.com/user-attachments/assets/4cb0df25-4f29-48af-8b96-8e0a2426c27c" />

```
============ Serving Benchmark Result ============
Successful requests:                     256       
Benchmark duration (s):                  51.19     
Total input tokens:                      236041    
Total generated tokens:                  235141    
Request throughput (req/s):              5.00      
Output token throughput (tok/s):         4593.42   
Total Token throughput (tok/s):          9204.41   
---------------Time to First Token----------------
Mean TTFT (ms):                          5673.64   
Median TTFT (ms):                        5751.11   
P99 TTFT (ms):                           9266.61   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          45.47     
Median TPOT (ms):                        45.36     
P99 TPOT (ms):                           50.81     
---------------Inter-token Latency----------------
Mean ITL (ms):                           45.44     
Median ITL (ms):                         41.65     
P99 ITL (ms):                            47.81     
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
