### PR TITLE
[router] change worker api to async instead of sync

### DIFF
--- a/sgl-router/src/core/job_queue.rs
+++ b/sgl-router/src/core/job_queue.rs
@@ -1,0 +1,360 @@
+//! Async job queue for control plane operations
+//!
+//! Provides non-blocking worker management by queuing operations and processing
+//! them asynchronously in background worker tasks.
+
+use crate::core::WorkerManager;
+use crate::protocols::worker_spec::{JobStatus, WorkerConfigRequest};
+use crate::server::AppContext;
+use dashmap::DashMap;
+use metrics::{counter, gauge, histogram};
+use std::sync::{Arc, Weak};
+use std::time::{Duration, SystemTime};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+
+/// Job types for control plane operations
+#[derive(Debug, Clone)]
+pub enum Job {
+    AddWorker { config: Box<WorkerConfigRequest> },
+    RemoveWorker { url: String },
+}
+
+impl Job {
+    /// Get job type as string for logging
+    pub fn job_type(&self) -> &str {
+        match self {
+            Job::AddWorker { .. } => "AddWorker",
+            Job::RemoveWorker { .. } => "RemoveWorker",
+        }
+    }
+
+    /// Get worker URL for logging
+    pub fn worker_url(&self) -> &str {
+        match self {
+            Job::AddWorker { config } => &config.url,
+            Job::RemoveWorker { url } => url,
+        }
+    }
+}
+
+impl JobStatus {
+    fn pending(job_type: &str, worker_url: &str) -> Self {
+        Self {
+            job_type: job_type.to_string(),
+            worker_url: worker_url.to_string(),
+            status: "pending".to_string(),
+            message: None,
+            timestamp: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+
+    fn processing(job_type: &str, worker_url: &str) -> Self {
+        Self {
+            job_type: job_type.to_string(),
+            worker_url: worker_url.to_string(),
+            status: "processing".to_string(),
+            message: None,
+            timestamp: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+
+    fn failed(job_type: &str, worker_url: &str, error: String) -> Self {
+        Self {
+            job_type: job_type.to_string(),
+            worker_url: worker_url.to_string(),
+            status: "failed".to_string(),
+            message: Some(error),
+            timestamp: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        }
+    }
+}
+
+/// Job queue configuration
+#[derive(Clone, Debug)]
+pub struct JobQueueConfig {
+    /// Maximum pending jobs in queue
+    pub queue_capacity: usize,
+    /// Number of worker tasks processing jobs
+    pub worker_count: usize,
+}
+
+impl Default for JobQueueConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: 1000,
+            worker_count: 2,
+        }
+    }
+}
+
+/// Job queue manager for worker validation and removal operations
+pub struct JobQueue {
+    /// Channel for submitting jobs
+    tx: mpsc::Sender<Job>,
+    /// Weak reference to AppContext to avoid circular dependencies
+    context: Weak<AppContext>,
+    /// Job status tracking by worker URL
+    status_map: Arc<DashMap<String, JobStatus>>,
+}
+
+impl std::fmt::Debug for JobQueue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobQueue")
+            .field("status_count", &self.status_map.len())
+            .finish()
+    }
+}
+
+impl JobQueue {
+    /// Create a new job queue with background workers (spawns tasks)
+    ///
+    /// Takes a Weak reference to AppContext to avoid circular strong references.
+    /// Spawns background worker tasks that will process jobs asynchronously.
+    pub fn new(config: JobQueueConfig, context: Weak<AppContext>) -> Arc<Self> {
+        let (tx, rx) = mpsc::channel(config.queue_capacity);
+
+        info!(
+            "Initializing worker job queue: capacity={}, workers={}",
+            config.queue_capacity, config.worker_count
+        );
+
+        let rx = Arc::new(tokio::sync::Mutex::new(rx));
+        let status_map = Arc::new(DashMap::new());
+
+        let queue = Arc::new(Self {
+            tx,
+            context: context.clone(),
+            status_map: status_map.clone(),
+        });
+
+        for i in 0..config.worker_count {
+            let rx = Arc::clone(&rx);
+            let context = context.clone();
+            let status_map = status_map.clone();
+
+            tokio::spawn(async move {
+                Self::worker_loop(i, rx, context, status_map).await;
+            });
+        }
+
+        // Spawn cleanup task for old job statuses (TTL 5 minutes)
+        let cleanup_status_map = status_map.clone();
+        tokio::spawn(async move {
+            Self::cleanup_old_statuses(cleanup_status_map).await;
+        });
+
+        queue
+    }
+
+    /// Submit a job
+    pub async fn submit(&self, job: Job) -> Result<(), String> {
+        // Check if context is still alive before accepting jobs
+        if self.context.upgrade().is_none() {
+            counter!("sgl_router_job_shutdown_rejected_total").increment(1);
+            return Err("Job queue shutting down: AppContext dropped".to_string());
+        }
+
+        // Extract values before moving job
+        let job_type = job.job_type().to_string();
+        let worker_url = job.worker_url().to_string();
+
+        // Record pending status
+        self.status_map.insert(
+            worker_url.clone(),
+            JobStatus::pending(&job_type, &worker_url),
+        );
+
+        match self.tx.send(job).await {
+            Ok(_) => {
+                let queue_depth = self.tx.max_capacity() - self.tx.capacity();
+                gauge!("sgl_router_job_queue_depth").set(queue_depth as f64);
+
+                info!(
+                    "Job submitted: type={}, worker={}, queue_depth={}",
+                    job_type, worker_url, queue_depth
+                );
+                Ok(())
+            }
+            Err(_) => {
+                counter!("sgl_router_job_queue_full_total").increment(1);
+                // Remove status on failure
+                self.status_map.remove(&worker_url);
+                Err("Worker job queue full".to_string())
+            }
+        }
+    }
+
+    /// Get job status by worker URL
+    pub fn get_status(&self, worker_url: &str) -> Option<JobStatus> {
+        self.status_map.get(worker_url).map(|entry| entry.clone())
+    }
+
+    /// Remove job status (called when worker is deleted)
+    pub fn remove_status(&self, worker_url: &str) {
+        self.status_map.remove(worker_url);
+    }
+
+    /// Worker loop that processes jobs
+    async fn worker_loop(
+        worker_id: usize,
+        rx: Arc<tokio::sync::Mutex<mpsc::Receiver<Job>>>,
+        context: Weak<AppContext>,
+        status_map: Arc<DashMap<String, JobStatus>>,
+    ) {
+        info!("Worker job queue worker {} started", worker_id);
+
+        loop {
+            // Lock the receiver and try to receive a job
+            let job = {
+                let mut rx_guard = rx.lock().await;
+                rx_guard.recv().await
+            };
+
+            match job {
+                Some(job) => {
+                    let job_type = job.job_type().to_string();
+                    let worker_url = job.worker_url().to_string();
+                    let start = std::time::Instant::now();
+
+                    // Update status to processing
+                    status_map.insert(
+                        worker_url.clone(),
+                        JobStatus::processing(&job_type, &worker_url),
+                    );
+
+                    info!(
+                        "Worker {} processing job: type={}, worker={}",
+                        worker_id, job_type, worker_url
+                    );
+
+                    // Upgrade weak reference to process job
+                    match context.upgrade() {
+                        Some(ctx) => {
+                            // Execute job
+                            let result = Self::execute_job(&job, &ctx).await;
+                            let duration = start.elapsed();
+
+                            // Record metrics
+                            histogram!("sgl_router_job_duration_seconds", "job_type" => job_type.clone())
+                                .record(duration.as_secs_f64());
+
+                            match result {
+                                Ok(message) => {
+                                    counter!("sgl_router_job_success_total", "job_type" => job_type.clone())
+                                        .increment(1);
+                                    // Remove status on success - worker in registry is sufficient
+                                    status_map.remove(&worker_url);
+                                    info!(
+                                        "Worker {} completed job: type={}, worker={}, duration={:.3}s, result={}",
+                                        worker_id, job_type, worker_url, duration.as_secs_f64(), message
+                                    );
+                                }
+                                Err(error) => {
+                                    counter!("sgl_router_job_failure_total", "job_type" => job_type.clone())
+                                        .increment(1);
+                                    // Keep failed status for API to report error details
+                                    status_map.insert(
+                                        worker_url.clone(),
+                                        JobStatus::failed(&job_type, &worker_url, error.clone()),
+                                    );
+                                    warn!(
+                                        "Worker {} failed job: type={}, worker={}, duration={:.3}s, error={}",
+                                        worker_id, job_type, worker_url, duration.as_secs_f64(), error
+                                    );
+                                }
+                            }
+                        }
+                        None => {
+                            let error_msg = "AppContext dropped".to_string();
+                            status_map.insert(
+                                worker_url.clone(),
+                                JobStatus::failed(&job_type, &worker_url, error_msg),
+                            );
+                            error!(
+                                "Worker {}: AppContext dropped, cannot process job: type={}, worker={}",
+                                worker_id, job_type, worker_url
+                            );
+                            break;
+                        }
+                    }
+                }
+                None => {
+                    warn!(
+                        "Worker job queue worker {} channel closed, stopping",
+                        worker_id
+                    );
+                    break;
+                }
+            }
+        }
+
+        warn!("Worker job queue worker {} stopped", worker_id);
+    }
+
+    /// Execute a specific job
+    async fn execute_job(job: &Job, context: &Arc<AppContext>) -> Result<String, String> {
+        match job {
+            Job::AddWorker { config } => {
+                // Register worker with is_healthy=false
+                let worker =
+                    WorkerManager::add_worker_from_config(config.as_ref(), context).await?;
+
+                // Validate and activate
+                WorkerManager::validate_and_activate_worker(&worker, context).await
+            }
+            Job::RemoveWorker { url } => {
+                let result = WorkerManager::remove_worker(url, context);
+                // Clean up job status when removing worker
+                if let Some(queue) = context.worker_job_queue.get() {
+                    queue.remove_status(url);
+                }
+                result
+            }
+        }
+    }
+
+    /// Cleanup old job statuses (TTL 5 minutes)
+    async fn cleanup_old_statuses(status_map: Arc<DashMap<String, JobStatus>>) {
+        const CLEANUP_INTERVAL: Duration = Duration::from_secs(60); // Run every minute
+        const STATUS_TTL: u64 = 300; // 5 minutes in seconds
+
+        loop {
+            tokio::time::sleep(CLEANUP_INTERVAL).await;
+
+            let now = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+
+            // Remove statuses older than TTL
+            status_map.retain(|_key, value| now - value.timestamp < STATUS_TTL);
+
+            debug!(
+                "Cleaned up old job statuses, remaining: {}",
+                status_map.len()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_job_queue_config_default() {
+        let config = JobQueueConfig::default();
+        assert_eq!(config.queue_capacity, 1000);
+        assert_eq!(config.worker_count, 2);
+    }
+}

--- a/sgl-router/src/core/mod.rs
+++ b/sgl-router/src/core/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod circuit_breaker;
 pub mod error;
+pub mod job_queue;
 pub mod retry;
 pub mod token_bucket;
 pub mod worker;
@@ -19,10 +20,11 @@ pub use circuit_breaker::{
     CircuitBreaker, CircuitBreakerConfig, CircuitBreakerStats, CircuitState,
 };
 pub use error::{WorkerError, WorkerResult};
+pub use job_queue::{Job, JobQueue, JobQueueConfig};
 pub use retry::{is_retryable_status, BackoffCalculator, RetryError, RetryExecutor};
 pub use worker::{
-    start_health_checker, BasicWorker, ConnectionMode, DPAwareWorker, HealthChecker, HealthConfig,
-    Worker, WorkerFactory, WorkerLoadGuard, WorkerType,
+    start_health_checker, worker_to_info, BasicWorker, ConnectionMode, DPAwareWorker,
+    HealthChecker, HealthConfig, Worker, WorkerFactory, WorkerLoadGuard, WorkerType,
 };
 pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
 pub use worker_manager::{DpInfo, LoadMonitor, ServerInfo, WorkerManager};

--- a/sgl-router/src/metrics.rs
+++ b/sgl-router/src/metrics.rs
@@ -71,6 +71,31 @@ pub fn init_metrics() {
         "Total requests processed by each worker"
     );
 
+    describe_gauge!(
+        "sgl_router_job_queue_depth",
+        "Current number of pending jobs in the queue"
+    );
+    describe_histogram!(
+        "sgl_router_job_duration_seconds",
+        "Job processing duration in seconds by job type"
+    );
+    describe_counter!(
+        "sgl_router_job_success_total",
+        "Total successful job completions by job type"
+    );
+    describe_counter!(
+        "sgl_router_job_failure_total",
+        "Total failed job completions by job type"
+    );
+    describe_counter!(
+        "sgl_router_job_queue_full_total",
+        "Total number of jobs rejected due to queue full"
+    );
+    describe_counter!(
+        "sgl_router_job_shutdown_rejected_total",
+        "Total number of jobs rejected due to shutdown"
+    );
+
     describe_counter!(
         "sgl_router_policy_decisions_total",
         "Total routing policy decisions by policy and worker"

--- a/sgl-router/src/protocols/worker_spec.rs
+++ b/sgl-router/src/protocols/worker_spec.rs
@@ -100,9 +100,27 @@ pub struct WorkerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template: Option<String>,
 
+    /// Bootstrap port for prefill workers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bootstrap_port: Option<u16>,
+
     /// Additional metadata
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, String>,
+
+    /// Job status for async operations (if available)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_status: Option<JobStatus>,
+}
+
+/// Job status for async control plane operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobStatus {
+    pub job_type: String,
+    pub worker_url: String,
+    pub status: String,
+    pub message: Option<String>,
+    pub timestamp: u64,
 }
 
 /// Worker list response

--- a/sgl-router/src/service_discovery.rs
+++ b/sgl-router/src/service_discovery.rs
@@ -383,18 +383,32 @@ async fn handle_pod_event(
                 api_key: None,
             };
 
-            let result = WorkerManager::add_worker_from_config(&config, &app_context).await;
+            // Submit job for async worker addition
+            use crate::core::Job;
+            let job = Job::AddWorker {
+                config: Box::new(config.clone()),
+            };
 
-            match result {
-                Ok(_) => {
-                    debug!("Worker added: {}", worker_url);
-                }
-                Err(e) => {
-                    error!("Failed to add worker {} to router: {}", worker_url, e);
-                    if let Ok(mut tracker) = tracked_pods.lock() {
-                        tracker.remove(pod_info);
+            if let Some(job_queue) = app_context.worker_job_queue.get() {
+                match job_queue.submit(job).await {
+                    Ok(_) => {
+                        debug!("Worker addition job submitted for: {}", worker_url);
+                    }
+                    Err(e) => {
+                        error!(
+                            "Failed to submit worker addition job for {}: {}",
+                            worker_url, e
+                        );
+                        if let Ok(mut tracker) = tracked_pods.lock() {
+                            tracker.remove(pod_info);
+                        }
                     }
                 }
+            } else {
+                debug!(
+                    "JobQueue not initialized, skipping async worker addition for: {}",
+                    worker_url
+                );
             }
         }
     }
@@ -529,6 +543,8 @@ mod tests {
             ..Default::default()
         };
 
+        // Note: Using uninitialized queue for tests to avoid spawning background workers
+        // Jobs submitted during tests will queue but not be processed
         Arc::new(AppContext {
             client: reqwest::Client::new(),
             router_config: router_config.clone(),
@@ -549,6 +565,7 @@ mod tests {
             load_monitor: None,
             configured_reasoning_parser: None,
             configured_tool_parser: None,
+            worker_job_queue: Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -907,8 +924,6 @@ mod tests {
         };
         let port = 8080u16;
 
-        // This test validates the structure but won't actually add workers since
-        // the test worker URL won't be reachable
         handle_pod_event(
             &pod_info,
             Arc::clone(&tracked_pods),
@@ -918,8 +933,12 @@ mod tests {
         )
         .await;
 
-        // Pod should not be tracked since add_worker_from_config will fail for non-running server
-        assert!(!tracked_pods.lock().unwrap().contains(&pod_info));
+        // With fully async control plane, pod is tracked and job is queued
+        // Worker registration and validation happen in background job
+        assert!(tracked_pods.lock().unwrap().contains(&pod_info));
+
+        // Note: In tests with uninitialized queue, background jobs don't process
+        // Worker won't appear in registry until background job runs (in production)
     }
 
     #[tokio::test]
@@ -945,8 +964,12 @@ mod tests {
         )
         .await;
 
-        // Pod should not be tracked since add_worker_from_config will fail for non-running server
-        assert!(!tracked_pods.lock().unwrap().contains(&pod_info));
+        // With fully async control plane, pod is tracked and job is queued
+        // Worker registration and validation happen in background job
+        assert!(tracked_pods.lock().unwrap().contains(&pod_info));
+
+        // Note: In tests with uninitialized queue, background jobs don't process
+        // Worker won't appear in registry until background job runs (in production)
     }
 
     #[tokio::test]
@@ -1033,7 +1056,13 @@ mod tests {
         )
         .await;
 
-        assert!(!tracked_pods.lock().unwrap().contains(&pod_info));
+        // With fully async control plane, pod is tracked and job is queued
+        // In regular mode (pd_mode=false), worker_type defaults to Regular
+        // Worker registration and validation happen in background job
+        assert!(tracked_pods.lock().unwrap().contains(&pod_info));
+
+        // Note: In tests with uninitialized queue, background jobs don't process
+        // Worker won't appear in registry until background job runs (in production)
     }
 
     #[tokio::test]
@@ -1059,8 +1088,12 @@ mod tests {
         )
         .await;
 
-        // Pod should not be tracked since add_worker_from_config will fail for non-running server
-        assert!(!tracked_pods.lock().unwrap().contains(&pod_info));
+        // With fully async control plane, pod is tracked and job is queued
+        // Worker registration and validation happen in background job
+        assert!(tracked_pods.lock().unwrap().contains(&pod_info));
+
+        // Note: In tests with uninitialized queue, background jobs don't process
+        // Worker won't appear in registry until background job runs (in production)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Refactors the worker management system from a hybrid synchronous/async model to a fully asynchronous control plane architecture. This change improves API responsiveness, provides better visibility into background operations, and aligns with standard async CP patterns.

## Problem

The previous design had a backwards async pattern:
1. Synchronously registered workers in registry
2. Asynchronously validated them in background
3. POST endpoint blocked on registration (could be slow)
4. No visibility into pending/processing operations
5. Two-phase initialization was complex and fragile

## Solution

Implemented proper async control plane pattern:
1. Submit job → return 202 immediately with resource ID
2. Background worker processes BOTH registration AND validation
3. Clients can poll GET endpoint to track progress
4. Clean, simple initialization using `OnceLock`

## Changes

### 1. Async Control Plane Architecture

**Job Queue** (`src/core/job_queue.rs`):
- Changed `Job::ValidateWorker` → `Job::AddWorker` with full config
- Background workers now handle complete workflow (register + validate)
- Only track failures in status map (success = worker in registry)
- Cleanup on delete operations
- TTL cleanup task for old statuses (5 min)
- Added 6 new metrics: `job_queue_depth`, `job_duration_seconds`, `job_success_total`, `job_failure_total`, `job_queue_full_total`, `job_shutdown_rejected_total`
- Structured logging with job type, worker URL, duration

**Worker Manager** (`src/core/worker_manager.rs`):
- Removed direct worker addition from API endpoints
- All operations go through job queue

### 2. API Improvements

**POST /workers** - Create Worker:
```json
// Response: 202 Accepted
{
  "status": "accepted",
  "worker_id": "http://worker-url",
  "message": "Worker addition queued for background processing"
}
```

**GET /workers/{url}** - Get Worker Status:
- **Worker in registry**: Returns full `WorkerInfo` with optional `job_status` if operation ongoing
- **Worker not in registry**: Returns partial `WorkerInfo` with current job status:
  - `pending`: Job queued, waiting to be processed
  - `processing`: Background worker currently adding/validating
  - `failed`: Job failed with error details
- **Worker not found**: Returns 404 `WORKER_NOT_FOUND`

Example responses:

```json
// Worker being processed
{
  "id": "http://worker-url",
  "url": "http://worker-url",
  "model_id": "unknown",
  "is_healthy": false,
  "job_status": {
    "job_type": "AddWorker",
    "worker_url": "http://worker-url",
    "status": "processing",
    "message": null,
    "timestamp": 1234567890
  }
}

// Worker ready (in registry)
{
  "id": "http://worker-url",
  "url": "http://worker-url",
  "model_id": "meta-llama/Llama-3.1-8B",
  "priority": 50,
  "cost": 1.0,
  "worker_type": "regular",
  "is_healthy": true,
  "load": 0,
  "connection_mode": "Http",
  "job_status": null
}

// Worker failed
{
  "id": "http://worker-url",
  "url": "http://worker-url",
  "model_id": "unknown",
  "is_healthy": false,
  "job_status": {
    "job_type": "AddWorker",
    "worker_url": "http://worker-url",
    "status": "failed",
    "message": "Connection refused: server not reachable",
    "timestamp": 1234567890
  }
}
```

**DELETE /workers/{url}** - Delete Worker:
```json
// Response: 202 Accepted
{
  "status": "accepted",
  "worker_id": "http://worker-url",
  "message": "Worker removal queued for background processing"
}
```


## Metrics

Added comprehensive observability:

```rust
// Queue depth gauge
gauge!("sgl_router_job_queue_depth").set(depth);

// Job duration histogram by type
histogram!("sgl_router_job_duration_seconds", "job_type" => type).record(secs);

// Success/failure counters by type
counter!("sgl_router_job_success_total", "job_type" => type).increment(1);
counter!("sgl_router_job_failure_total", "job_type" => type).increment(1);

// Queue errors
counter!("sgl_router_job_queue_full_total").increment(1);
counter!("sgl_router_job_shutdown_rejected_total").increment(1);
```

## Logging

Structured logs with context:

```
INFO  Initializing worker job queue: capacity=1000, workers=2
INFO  Worker 0 processing job: type=AddWorker, worker=http://w1
INFO  Worker 0 completed job: type=AddWorker, worker=http://w1, duration=2.345s, result=Worker registered and validated
WARN  Worker 0 failed job: type=AddWorker, worker=http://w2, duration=0.123s, error=Connection refused
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
