### PR TITLE
[router] Add BRANCH_TYPE=local support to Dockerfile.router for local builds

### DIFF
--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -68,6 +68,7 @@ WORKDIR /opt/sglang/sgl-router
 
 # build the rust dependencies
 RUN cargo clean \
+    && rm -rf dist/ \
     && cargo build --release \
     && uv build \
     && rm -rf /root/.cache

--- a/docker/Dockerfile.router
+++ b/docker/Dockerfile.router
@@ -29,10 +29,14 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # install python
 RUN uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
 
+FROM scratch AS local_src
+COPY . /src
+
 ######################### BUILD IMAGE #########################
 FROM base AS build-image
 
 ARG SGLANG_REPO_REF=main
+ARG BRANCH_TYPE=remote
 
 # set the environment variables
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -47,17 +51,24 @@ RUN apt update -y \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rustc --version && cargo --version && protoc --version
 
-# pull the github repository
-RUN cd /opt \
-    && git clone --depth=1 https://github.com/sgl-project/sglang.git \
-    && cd /opt/sglang \
-    && git checkout ${SGLANG_REPO_REF}
+# pull the github repository or use local source
+COPY --from=local_src /src /tmp/local_src
+RUN if [ "$BRANCH_TYPE" = "local" ]; then \
+        cp -r /tmp/local_src /opt/sglang; \
+    else \
+        cd /opt \
+        && git clone --depth=1 https://github.com/sgl-project/sglang.git \
+        && cd /opt/sglang \
+        && git checkout ${SGLANG_REPO_REF}; \
+    fi \
+    && rm -rf /tmp/local_src
 
 # working directory
 WORKDIR /opt/sglang/sgl-router
 
 # build the rust dependencies
-RUN cargo build --release \
+RUN cargo clean \
+    && cargo build --release \
     && uv build \
     && rm -rf /root/.cache
 


### PR DESCRIPTION
## Summary

This PR adds support for building the router Docker image from local source code, matching the functionality available in the main `Dockerfile`. It also includes build cleanup improvements.

### Changes

1. **Add `BRANCH_TYPE` build argument support to `docker/Dockerfile.router`**
   - Added `local_src` stage to capture local build context
   - Added `ARG BRANCH_TYPE=remote` with default value for backward compatibility
   - Modified git clone logic to conditionally use local source or remote clone
   - Pattern matches the implementation in `docker/Dockerfile`

2. **Clean previous builds**
   - Added `cargo clean` and `rm -rf dist/` before building to ensure clean builds

### Usage

**Build from remote (default behavior):**
```bash
docker build -f docker/Dockerfile.router -t sgl-router:latest .
```

**Build from local source:**
```bash
docker build -f docker/Dockerfile.router --build-arg BRANCH_TYPE=local -t sgl-router:latest .
```

### Benefits

- Enables faster iteration during development (no need to push to GitHub)
- Consistent with main Dockerfile behavior
- Maintains full backward compatibility (defaults to remote builds)
- Clean builds prevent potential issues from previous artifacts

## Test Plan

- [ ] Verify default behavior (remote clone) still works
- [ ] Test local build with `--build-arg BRANCH_TYPE=local`
- [ ] Verify router functionality in both build modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)