### PR TITLE
[router] allow router launch server to use grpc mode

### DIFF
--- a/sgl-router/py_src/sglang_router/launch_server.py
+++ b/sgl-router/py_src/sglang_router/launch_server.py
@@ -186,8 +186,10 @@ def main():
     )
 
     # Update router args with worker URLs
+    # Use grpc:// protocol if server is in gRPC mode, otherwise http://
+    protocol = "grpc" if server_args.grpc_mode else "http"
     router_args.worker_urls = [
-        f"http://{server_args.host}:{port}" for port in worker_ports
+        f"{protocol}://{server_args.host}:{port}" for port in worker_ports
     ]
 
     # Start the router

--- a/sgl-router/py_src/sglang_router/launch_server.py
+++ b/sgl-router/py_src/sglang_router/launch_server.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import copy
 import logging
 import multiprocessing as mp
@@ -13,7 +14,6 @@ import requests
 from setproctitle import setproctitle
 from sglang_router.launch_router import RouterArgs, launch_router
 
-from sglang.srt.entrypoints.http_server import launch_server
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import is_port_available
 
@@ -72,7 +72,15 @@ def run_server(server_args, dp_rank):
     # Set SGLANG_DP_RANK environment variable
     os.environ["SGLANG_DP_RANK"] = str(dp_rank)
 
-    launch_server(server_args)
+    # Launch server in appropriate mode (HTTP or gRPC)
+    if server_args.grpc_mode:
+        from sglang.srt.entrypoints.grpc_server import serve_grpc
+
+        asyncio.run(serve_grpc(server_args))
+    else:
+        from sglang.srt.entrypoints.http_server import launch_server
+
+        launch_server(server_args)
 
 
 def launch_server_process(


### PR DESCRIPTION
## Motivation
allow `sgl-router.launch_server` to support grpc mode

```
python3 -m sglang_router.launch_server \
    --host 0.0.0.0 \
    --port 8080 \
    --model /raid/models/meta-llama/Llama-3.1-8B-Instruct \
    --tp-size 1 \
    --grpc-mode \
    --log-level debug \
    --router-prometheus-port 10001 \
    --router-tool-call-parser llama \
    --router-health-success-threshold 2 \
    --router-health-check-timeout-secs 6000 \
    --router-health-check-interval-secs 60 \
    --router-model-path /raid/models/meta-llama/Llama-3.1-8B-Instruct
```
above cmd will launch both router and grpc server


```
python3 -m sglang_router.launch_server \
    --host 0.0.0.0 \
    --port 8080 \
    --model /raid/models/meta-llama/Llama-3.1-8B-Instruct \
    --tp-size 1 \
    --dp-size 5 \
    --grpc-mode \
    --log-level debug \
    --router-prometheus-port 10001 \
    --router-tool-call-parser llama \
    --router-health-success-threshold 2 \
    --router-health-check-timeout-secs 6000 \
    --router-health-check-interval-secs 60 \
    --router-model-path /raid/models/meta-llama/Llama-3.1-8B-Instruct
```
above cmd will launch router and 5 grpc servers

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
