### PR TITLE
[router] when given both local tokenizer and chat template, log all

### DIFF
--- a/sgl-router/src/tokenizer/factory.rs
+++ b/sgl-router/src/tokenizer/factory.rs
@@ -49,9 +49,9 @@ pub fn create_tokenizer_with_chat_template(
     if path.is_dir() {
         let tokenizer_json = path.join("tokenizer.json");
         if tokenizer_json.exists() {
-            let chat_template_path = chat_template_path
-                .map(|s| s.to_string())
-                .or_else(|| discover_chat_template_in_dir(path));
+            // Resolve chat template: provided path takes precedence over auto-discovery
+            let final_chat_template =
+                resolve_and_log_chat_template(chat_template_path, path, file_path);
             let tokenizer_path_str = tokenizer_json.to_str().ok_or_else(|| {
                 Error::msg(format!(
                     "Tokenizer path is not valid UTF-8: {:?}",
@@ -60,7 +60,7 @@ pub fn create_tokenizer_with_chat_template(
             })?;
             return create_tokenizer_with_chat_template(
                 tokenizer_path_str,
-                chat_template_path.as_deref(),
+                final_chat_template.as_deref(),
             );
         }
 


### PR DESCRIPTION
## Motivation
previously, when given local path of tokenizer and chat template
```
python3 -m sglang_router.launch_server \
    --host 0.0.0.0 \
    --port 8080 \
    --model /raid/models/meta-llama/Llama-3.1-8B-Instruct \
    --tp-size 1 \
    --dp-size 1 \
    --grpc-mode \
    --log-level debug \
    --router-prometheus-port 10001 \
    --router-tool-call-parser llama \
    --router-health-success-threshold 2 \
    --router-health-check-timeout-secs 6000 \
    --router-health-check-interval-secs 60 \
    --router-model-path /raid/models/meta-llama/Llama-3.1-8B-Instruct \
    --router-policy round_robin \
    --router-log-level debug \
    --router-chat-template /home/ubuntu/simolin/sglang/examples/chat_template/tool_chat_template_llama4_pythonic.jinja
INFO 10-14 02:11:06 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:11:07 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:11:07 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:11:07 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:11:07 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:11:07 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:11:07 __init__.py:190] Automatically detected platform cuda.
`torch_dtype` is deprecated! Use `dtype` instead!
[Router (Python)] 2025-10-14 02:11:07 - INFO - Launching DP server process 0 on port 31000 - launch_server.py:184
INFO:router:Launching DP server process 0 on port 31000
2025-10-14 09:11:07  INFO sglang_router_rs::server: src/server.rs:908: Starting router on 0.0.0.0:8080 | mode: Regular { worker_urls: ["grpc://0.0.0.0:31000"] } | policy: RoundRobin | max_payload: 512MB
2025-10-14 09:11:07  INFO sglang_router_rs::core::job_queue: src/core/job_queue.rs:126: Initializing worker job queue: capacity=1000, workers=2
2025-10-14 09:11:07  INFO sglang_router_rs::server: src/server.rs:943: Initializing workers for routing mode: Regular { worker_urls: ["grpc://0.0.0.0:31000"] }
2025-10-14 09:11:07  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:182: Starting worker initialization
2025-10-14 09:11:07  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:433: Creating 1 gRPC regular workers
2025-10-14 09:11:07  INFO sglang_router_rs::core::worker_manager: src/core/worker_manager.rs:933: Registered worker grpc://0.0.0.0:31000 with ID WorkerId("c4b27774-23c0-4b60-90f0-bd768cc395a2")
2025-10-14 09:11:07  INFO sglang_router_rs::core::job_queue: src/core/job_queue.rs:214: Worker job queue worker 1 started
2025-10-14 09:11:07 DEBUG sglang_router_rs::policies::registry: src/policies/registry.rs:61: Worker added for model unknown, count: 1
2025-10-14 09:11:07 DEBUG sglang_router_rs::policies::registry: src/policies/registry.rs:165: Using default policy for model unknown
2025-10-14 09:11:07  INFO sglang_router_rs::core::job_queue: src/core/job_queue.rs:214: Worker job queue worker 0 started
2025-10-14 09:11:07  INFO sglang_router_rs::policies::registry: src/policies/registry.rs:84: Assigning policy round_robin to new model unknown
```

with this fix
```
python3 -m sglang_router.launch_server \
    --host 0.0.0.0 \
    --port 8080 \
    --model /raid/models/meta-llama/Llama-3.1-8B-Instruct \
    --tp-size 1 \
    --dp-size 1 \
    --grpc-mode \
    --log-level debug \
    --router-prometheus-port 10001 \
    --router-tool-call-parser llama \
    --router-health-success-threshold 2 \
    --router-health-check-timeout-secs 6000 \
    --router-health-check-interval-secs 60 \
    --router-model-path /raid/models/meta-llama/Llama-3.1-8B-Instruct \
    --router-policy round_robin \
    --router-log-level debug \
    --router-chat-template /home/ubuntu/simolin/sglang/examples/chat_template/tool_chat_template_llama4_pythonic.jinja
INFO 10-14 02:21:00 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:21:01 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:21:01 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:21:01 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:21:01 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:21:01 __init__.py:190] Automatically detected platform cuda.
INFO 10-14 02:21:01 __init__.py:190] Automatically detected platform cuda.
`torch_dtype` is deprecated! Use `dtype` instead!
[Router (Python)] 2025-10-14 02:21:01 - INFO - Launching DP server process 0 on port 31402 - launch_server.py:184
INFO:router:Launching DP server process 0 on port 31402
2025-10-14 09:21:01  INFO sglang_router_rs::server: src/server.rs:908: Starting router on 0.0.0.0:8080 | mode: Regular { worker_urls: ["grpc://0.0.0.0:31402"] } | policy: RoundRobin | max_payload: 512MB
2025-10-14 09:21:01  INFO sglang_router_rs::tokenizer::factory: src/tokenizer/factory.rs:208: Using provided chat template: /home/ubuntu/simolin/sglang/examples/chat_template/tool_chat_template_llama4_pythonic.jinja
```


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
