### PR TITLE
[Fix] Fix Bug in ascend allocator

### DIFF
--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -55,6 +55,8 @@ def alloc_extend_kernel_ascend(
 
         num3 = seq_lens[i] - seq_lens[i] // page_size * page_size
         if num3:
+            if end_pos[i] - num3 < 0:
+                num3 = extend_lens[i] - extend_lens[i] // page_size * page_size
             out_indices[end_pos[i] - num3 : end_pos[i]] = (
                 free_pages[end_new_pages[i] - 1] * page_size + pos_in_page[:num3]
             ).view(-1)

--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -161,4 +161,3 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices.int()
-    

--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -161,3 +161,4 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices.int()
+    


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When running using LEval dataset on ascend 910B, I noticed the bug in `srt/mem_cache/allocator_ascend.py`.  When `seq_lens[i] < page_size`, the original code computes

    end_pos[i] - num3

which can become negative, causing an invalid slice on `out_indices`
and a RuntimeError:

    The expanded size of the tensor (0) must match ...
    Target sizes: [0].  Tensor sizes: [X]

## Modifications

<!-- Detail the changes made in this pull request. -->

Add a guard in the `num3 > 0` branch:
```python
if end_pos[i] - num3 < 0:
        num3 = extend_lens[i] - extend_lens[i] // page_size * page_size
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
