### PR TITLE
[Fix] sampling defaults: avoid inheriting HF defaults when using “model” sampling

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -703,10 +703,20 @@ class ModelConfig:
         default_sampling_params: dict[str, Any] = {}
 
         base = GenerationConfig()
+
+        explicit_keys = getattr(self.hf_generation_config, "_explicit_keys", set())
+
         for param in available_params:
             value = getattr(self.hf_generation_config, param, None)
             if value is None:
                 continue
+
+            # respect explicit keys from the JSON
+            if param in explicit_keys:
+                default_sampling_params[param] = value
+                continue
+
+            # otherwise, only include if it differs from HF base defaults
             base_default = getattr(base, param, None)
             if base_default is None or value != base_default:
                 default_sampling_params[param] = value

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -20,7 +20,7 @@ from enum import Enum, IntEnum, auto
 from typing import Any, Dict, List, Optional, Set, Union
 
 import torch
-from transformers import PretrainedConfig
+from transformers import GenerationConfig, PretrainedConfig
 
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization import QUANTIZATION_METHODS
@@ -701,8 +701,6 @@ class ModelConfig:
             "min_p",
         ]
         default_sampling_params: dict[str, Any] = {}
-
-        from transformers import GenerationConfig
 
         base = GenerationConfig()
         for param in available_params:

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -702,13 +702,12 @@ class ModelConfig:
         ]
         default_sampling_params: dict[str, Any] = {}
 
+        from transformers import GenerationConfig
+        base = GenerationConfig()
         for param in available_params:
             value = getattr(self.hf_generation_config, param, None)
             if value is None:
                 continue
-            from transformers import GenerationConfig
-
-            base = GenerationConfig()
             base_default = getattr(base, param, None)
             if base_default is None or value != base_default:
                 default_sampling_params[param] = value

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -703,6 +703,7 @@ class ModelConfig:
         default_sampling_params: dict[str, Any] = {}
 
         from transformers import GenerationConfig
+
         base = GenerationConfig()
         for param in available_params:
             value = getattr(self.hf_generation_config, param, None)

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -251,11 +251,27 @@ def get_generation_config(
     **kwargs,
 ):
     try:
-        return GenerationConfig.from_pretrained(
+        cfg = GenerationConfig.from_pretrained(
             model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
         )
     except OSError as e:
         return None
+
+    explicit_keys = set()
+    json_path = os.path.join(model, "generation_config.json")
+    if os.path.exists(json_path):
+        try:
+            with open(json_path, "r") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    explicit_keys = set(data.keys())
+        except Exception as e:
+            logger.warning(
+                f"Failed to read generation_config.json for explicit keys: {e}"
+            )
+
+    cfg._explicit_keys = explicit_keys
+    return cfg
 
 
 # Qwen-1M related


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
fixes: https://github.com/sgl-project/sglang/issues/11574
When `--sampling-defaults=model` is enabled, it would inadvertently use HuggingFace’s default sampling parameters [(e.g. top_k = 50)](https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.GenerationConfig.top_k) when the model’s generation_config.json did not explicitly define them.

## Modifications

- Only includes sampling parameters from hf_generation_config if they differ from HuggingFace’s base defaults
- Omits parameters that are unset or equal to HF’s defaults
- Returns an empty dict if nothing is explicitly defined, so SGLang’s own fallback defaults are used

eg:
```bash
python3 -m sglang.launch_server --model-path meta-llama/Llama-3.2-1B --host 0.0.0.0 --sampling-defaults model
```

before:

```
[2025-10-14 12:27:18] INFO:     Started server process [10577]
[2025-10-14 12:27:18] INFO:     Waiting for application startup.
[2025-10-14 12:27:18] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 50, 'top_p': 0.9}
[2025-10-14 12:27:18] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 50, 'top_p': 0.9}
[2025-10-14 12:27:18] INFO:     Application startup complete.
[2025-10-14 12:27:18] INFO:     Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)
```

after:
```
[2025-10-14 12:25:11] INFO:     Started server process [9684]
[2025-10-14 12:25:11] INFO:     Waiting for application startup.
[2025-10-14 12:25:11] Using default chat sampling params from model generation config: {'temperature': 0.6, 'top_p': 0.9}
[2025-10-14 12:25:11] Using default chat sampling params from model generation config: {'temperature': 0.6, 'top_p': 0.9}
[2025-10-14 12:25:11] INFO:     Application startup complete.
[2025-10-14 12:25:11] INFO:     Uvicorn running on http://0.0.0.0:30000 (Press CTRL+C to quit)
```

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).