### PR TITLE
Avoid using flashinfer_allreduce_fusion when dp attention is enabled.

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -336,6 +336,7 @@ class LayerCommunicator:
         static_conditions_met = (
             (not self.is_last_layer)
             and (self._context.tp_size > 1)
+            and not is_dp_attention_enabled()
             and get_global_server_args().enable_flashinfer_allreduce_fusion
             and _is_flashinfer_available
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

There are a few functional bugs related to `--enable-flashinfer-allreduce-fusion` 
https://github.com/sgl-project/sglang/issues/9061
https://github.com/sgl-project/sglang/issues/8689

From the profile, it seems DP attention would have communication pattern like `add + rmsnorm + allreduce` instead of `allreduce + add + rmsnorm` that's supported by Flashinfer's `trtllm_allreduce_fusion`. 


Below is a DP attention profile screenshot with command
```
 SGLANG_ENABLE_JIT_DEEPGEMM=false SGLANG_ENABLE_FLASHINFER_GEMM=true python3 python/sglang/bench_one_batch.py  --model-path "deepseek-ai/DeepSeek-R1-0528" --trust-remote-code --page-size 64 --tp-size 8 --max-running-requests 64 --cuda-graph-max-bs 64 --enable-dp-attention --dp-size 8  --profile --load-format dummy --mem-fraction-static 0.90 --dist-timeout 1800 --profile-filename-prefix dp_pattern
```
<img width="1894" height="502" alt="Screenshot 2025-10-14 at 2 32 28 PM" src="https://github.com/user-attachments/assets/17d5c0d1-5485-4f67-9be4-7eda4839eecb" />

Below is what Flashinfer supports:
https://github.com/sgl-project/sglang/blob/27d710457c0f0b482c7764703aefd99554cc1770/python/sglang/srt/layers/flashinfer_comm_fusion.py#L137-L151



## Modifications

Disable the fusion when dp attention is enabled.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
