### PR TITLE
[router][grpc] Simplify model_id determination

### DIFF
--- a/sgl-router/src/core/worker_manager.rs
+++ b/sgl-router/src/core/worker_manager.rs
@@ -22,7 +22,6 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{watch, Mutex};
@@ -1228,8 +1227,7 @@ impl WorkerManager {
             Ok(server_info) => {
                 if let Some(model_id) = server_info.model_id {
                     if !model_id.is_empty() {
-                        let normalized = Self::normalize_model_identifier(&model_id);
-                        discovery.labels.insert("model_id".to_string(), normalized);
+                        discovery.labels.insert("model_id".to_string(), model_id);
                     }
                 }
                 if let Some(model_path) = server_info.model_path {
@@ -1309,9 +1307,9 @@ impl WorkerManager {
                         "served_model_name".to_string(),
                         model_info.served_model_name.clone(),
                     );
-                    let normalized =
-                        Self::normalize_model_identifier(&model_info.served_model_name);
-                    discovery.labels.insert("model_id".to_string(), normalized);
+                    discovery
+                        .labels
+                        .insert("model_id".to_string(), model_info.served_model_name);
                 }
                 if !model_info.weight_version.is_empty() {
                     discovery.labels.insert(
@@ -1368,15 +1366,6 @@ impl WorkerManager {
         discovery
     }
 
-    fn normalize_model_identifier(value: &str) -> String {
-        let trimmed = value.trim();
-        if trimmed.contains('/') || trimmed.contains('\\') {
-            Self::derive_model_id_from_path(trimmed)
-        } else {
-            trimmed.to_string()
-        }
-    }
-
     fn finalize_model_id(labels: &mut HashMap<String, String>) {
         let has_model_id = labels
             .get("model_id")
@@ -1388,36 +1377,15 @@ impl WorkerManager {
 
         if let Some(served_name) = labels.get("served_model_name").cloned() {
             if !served_name.trim().is_empty() {
-                let normalized = Self::normalize_model_identifier(&served_name);
-                labels.insert("model_id".to_string(), normalized);
+                labels.insert("model_id".to_string(), served_name);
                 return;
             }
         }
 
         if let Some(model_path) = labels.get("model_path").cloned() {
             if !model_path.trim().is_empty() {
-                let derived = Self::derive_model_id_from_path(&model_path);
-                if !derived.is_empty() {
-                    labels.insert("model_id".to_string(), derived);
-                }
+                labels.insert("model_id".to_string(), model_path);
             }
-        }
-    }
-
-    fn derive_model_id_from_path(path: &str) -> String {
-        let trimmed = path.trim_end_matches(['/', '\\']);
-        if trimmed.is_empty() {
-            return path.to_string();
-        }
-
-        let candidate = Path::new(trimmed)
-            .file_name()
-            .and_then(|p| p.to_str())
-            .map(|s| s.to_string());
-
-        match candidate {
-            Some(name) if !name.is_empty() => name,
-            _ => trimmed.to_string(),
         }
     }
 
@@ -1873,20 +1841,6 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_model_id_from_path() {
-        let path = "/raid/models/meta-llama/Llama-3.1-8B-Instruct";
-        let derived = WorkerManager::derive_model_id_from_path(path);
-        assert_eq!(derived, "Llama-3.1-8B-Instruct");
-    }
-
-    #[test]
-    fn test_derive_model_id_trailing_slash() {
-        let path = "/models/foo/bar/";
-        let derived = WorkerManager::derive_model_id_from_path(path);
-        assert_eq!(derived, "bar");
-    }
-
-    #[test]
     fn test_finalize_model_id_prefers_existing() {
         let mut labels = HashMap::new();
         labels.insert("model_id".to_string(), "manual-id".to_string());
@@ -1908,12 +1862,6 @@ mod tests {
         let mut labels = HashMap::new();
         labels.insert("model_path".to_string(), "/models/alpha".to_string());
         WorkerManager::finalize_model_id(&mut labels);
-        assert_eq!(labels.get("model_id").unwrap(), "alpha");
-    }
-
-    #[test]
-    fn test_normalize_model_identifier_from_path() {
-        let normalized = WorkerManager::normalize_model_identifier("/raid/models/foo/bar-model");
-        assert_eq!(normalized, "bar-model");
+        assert_eq!(labels.get("model_id").unwrap(), "/models/alpha");
     }
 }

--- a/sgl-router/src/core/worker_manager.rs
+++ b/sgl-router/src/core/worker_manager.rs
@@ -1375,16 +1375,16 @@ impl WorkerManager {
             return;
         }
 
-        if let Some(served_name) = labels.get("served_model_name").cloned() {
+        if let Some(served_name) = labels.get("served_model_name") {
             if !served_name.trim().is_empty() {
-                labels.insert("model_id".to_string(), served_name);
+                labels.insert("model_id".to_string(), served_name.clone());
                 return;
             }
         }
 
-        if let Some(model_path) = labels.get("model_path").cloned() {
+        if let Some(model_path) = labels.get("model_path") {
             if !model_path.trim().is_empty() {
-                labels.insert("model_id".to_string(), model_path);
+                labels.insert("model_id".to_string(), model_path.clone());
             }
         }
     }


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR simplifies the router's model_id handling by removing all path normalization logic. 

**Justification**

When a worker is launched, engine will have a `served_model_name` defined. It is not worker's responsibility to normalize the id. It should be the same as the engine's. 

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. Remove `derive_model_id_from_path()` - unnecessary
2. Remove `normalize_model_identifier()` - unnecessary
3. Keep `finalize_model_id()` simple - just use the fallback hierarchy without any path manipulation:
  - If model_id exists → use it
  - Else if served_model_name exists → use it as-is
  - Else if model_path exists → use it as-is
  - Else → "unknown"

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<img width="584" height="33" alt="Screenshot 2025-10-15 at 2 30 32 PM" src="https://github.com/user-attachments/assets/091728be-0ad6-4771-8377-a9fa01b9cbaa" />

<img width="2962" height="390" alt="Screenshot 2025-10-15 at 2 33 58 PM" src="https://github.com/user-attachments/assets/bf2cd761-d393-4570-9ac8-0ef2671dff48" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
