### PR TITLE
[router] fix p and d worker filtering and bootstrap port handling

### DIFF
--- a/sgl-router/src/core/worker.rs
+++ b/sgl-router/src/core/worker.rs
@@ -247,6 +247,20 @@ pub enum ConnectionMode {
     },
 }
 
+impl ConnectionMode {
+    /// Check if this connection mode matches another, with special handling for gRPC
+    /// This allows matching any gRPC connection regardless of port when comparing
+    /// Grpc { port: None } as a wildcard
+    pub fn matches(&self, filter: &ConnectionMode) -> bool {
+        match (self, filter) {
+            (ConnectionMode::Http, ConnectionMode::Http) => true,
+            (ConnectionMode::Grpc { .. }, ConnectionMode::Grpc { port: None }) => true,
+            (ConnectionMode::Grpc { port: p1 }, ConnectionMode::Grpc { port: p2 }) => p1 == p2,
+            _ => false,
+        }
+    }
+}
+
 impl fmt::Display for ConnectionMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/sgl-router/src/core/worker_registry.rs
+++ b/sgl-router/src/core/worker_registry.rs
@@ -308,9 +308,9 @@ impl WorkerRegistry {
                     }
                 }
 
-                // Check connection_mode if specified
+                // Check connection_mode if specified (using matches for flexible gRPC matching)
                 if let Some(ref conn) = connection_mode {
-                    if w.connection_mode() != *conn {
+                    if !w.connection_mode().matches(conn) {
                         return false;
                     }
                 }

--- a/sgl-router/src/routers/grpc/pipeline.rs
+++ b/sgl-router/src/routers/grpc/pipeline.rs
@@ -345,24 +345,24 @@ impl WorkerSelectionStage {
             false,
         );
 
-        let available_prefill: Vec<_> = all_workers
-            .iter()
-            .filter(|w| {
-                matches!(w.metadata().worker_type, WorkerType::Prefill { .. }) && w.is_available()
-            })
-            .cloned()
-            .collect();
+        let (available_prefill, available_decode): (Vec<_>, Vec<_>) =
+            all_workers
+                .into_iter()
+                .fold((Vec::new(), Vec::new()), |mut acc, w| {
+                    if w.is_available() {
+                        match w.metadata().worker_type {
+                            WorkerType::Prefill { .. } => acc.0.push(w),
+                            WorkerType::Decode => acc.1.push(w),
+                            _ => {}
+                        }
+                    }
+                    acc
+                });
 
         if available_prefill.is_empty() {
             warn!("No available prefill workers");
             return None;
         }
-
-        let available_decode: Vec<_> = all_workers
-            .iter()
-            .filter(|w| matches!(w.metadata().worker_type, WorkerType::Decode) && w.is_available())
-            .cloned()
-            .collect();
 
         if available_decode.is_empty() {
             warn!("No available decode workers");


### PR DESCRIPTION
## Motivation
add flexible ConnectionMode matching to handle gRPC workers with explicit bootstrap ports

## Modifications

  1. `src/core/worker.rs`
  - Added matches() method enabling Grpc { port: None } to act as wildcard
2. `src/core/worker_registry.rs`
  - Updated filter logic to use `matches()` instead of direct equality

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
