### PR TITLE
[router] Fix tool_choice normalization in ChatCompletionRequest and fix ut

### DIFF
--- a/sgl-router/src/protocols/chat.rs
+++ b/sgl-router/src/protocols/chat.rs
@@ -531,13 +531,14 @@ impl Normalizable for ChatCompletionRequest {
 
         // Apply tool_choice defaults
         if self.tool_choice.is_none() {
-            let has_tools = self.tools.as_ref().is_some_and(|t| !t.is_empty());
-
-            self.tool_choice = if has_tools {
-                Some(ToolChoice::Value(ToolChoiceValue::Auto))
-            } else {
-                Some(ToolChoice::Value(ToolChoiceValue::None))
-            };
+            if let Some(tools) = &self.tools {
+                self.tool_choice = if !tools.is_empty() {
+                    Some(ToolChoice::Value(ToolChoiceValue::Auto))
+                } else {
+                    Some(ToolChoice::Value(ToolChoiceValue::None))
+                };
+            }
+            // If tools is None, leave tool_choice as None (don't set it)
         }
     }
 }

--- a/sgl-router/tests/spec/rerank.rs
+++ b/sgl-router/tests/spec/rerank.rs
@@ -231,45 +231,6 @@ fn test_rerank_response_serialization() {
 }
 
 #[test]
-fn test_rerank_response_sort_by_score() {
-    let results = vec![
-        RerankResult {
-            score: 0.6,
-            document: Some("doc2".to_string()),
-            index: 1,
-            meta_info: None,
-        },
-        RerankResult {
-            score: 0.8,
-            document: Some("doc1".to_string()),
-            index: 0,
-            meta_info: None,
-        },
-        RerankResult {
-            score: 0.4,
-            document: Some("doc3".to_string()),
-            index: 2,
-            meta_info: None,
-        },
-    ];
-
-    let mut response = RerankResponse::new(
-        results,
-        "test-model".to_string(),
-        Some(StringOrArray::String("req-123".to_string())),
-    );
-
-    response.sort_by_score();
-
-    assert_eq!(response.results[0].score, 0.8);
-    assert_eq!(response.results[0].index, 0);
-    assert_eq!(response.results[1].score, 0.6);
-    assert_eq!(response.results[1].index, 1);
-    assert_eq!(response.results[2].score, 0.4);
-    assert_eq!(response.results[2].index, 2);
-}
-
-#[test]
 fn test_rerank_response_apply_top_k() {
     let results = vec![
         RerankResult {
@@ -588,9 +549,6 @@ fn test_full_rerank_workflow() {
 
     // Create response
     let mut response = RerankResponse::new(results, request.model.clone(), request.rid.clone());
-
-    // Sort by score
-    response.sort_by_score();
 
     // Apply top_k
     response.apply_top_k(request.effective_top_k());


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Currently, openai proxy's /v1/chat/completions is broken. This is because the `normalize` function in `ChatCompletionRequest` sets `tool_choice` to `"none"` regardless of `tools` is `None` or empty `[]`.

`tool_choice` should only be set to `"none"` when `tools` is `[]` 

## Modifications

<!-- Detail the changes made in this pull request. -->
- Fix tool_choice validation in chat.rs
- Remove `sort_by_score` in tests/spec/rerank.rs as it has been removed. 

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
<img width="1005" height="675" alt="Screenshot 2025-10-16 at 11 20 45 AM" src="https://github.com/user-attachments/assets/f8ff3fbe-de70-4211-974e-446ce052a138" />


Payload before:
<img width="1290" height="103" alt="Screenshot 2025-10-16 at 1 32 16 PM" src="https://github.com/user-attachments/assets/6369bf26-c056-44b1-b45a-6025ed7f7275" />

After:
<img width="1714" height="213" alt="Screenshot 2025-10-16 at 1 32 30 PM" src="https://github.com/user-attachments/assets/ddc19295-65ea-4719-b778-a64beca830f4" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
