### PR TITLE
support more model in piecewise cuda graph

### DIFF
--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -142,8 +142,11 @@ def unified_attention_with_output(
     ret = forward_batch.attn_backend.forward(
         query, key, value, attention_layer, forward_batch, save_kv_cache
     )
-    assert output.shape == ret.shape
-    output.copy_(ret)
+    assert (
+        output.numel() == ret.numel()
+    ), f"Output tensor element mismatch: {output.numel()} != {ret.numel()}"
+
+    output.view(ret.shape).copy_(ret)
     return
 
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -327,7 +327,19 @@ class ModelRunner:
             and self.can_run_piecewise_cuda_graph()
         ):
             self.attention_layers = []
-            for layer in self.model.model.layers:
+
+            try:
+                layers = self.model.model.layers
+            except:
+                try:
+                    layers = self.model.language_model.model.layers
+                except:
+                    try:
+                        layers = self.model.language_model.layers
+                    except:
+                        self.piecewise_cuda_graph_runner = None
+                        return
+            for layer in layers:
                 if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "attn"):
                     self.attention_layers.append(layer.self_attn.attn)
             if len(self.attention_layers) < self.model_config.num_hidden_layers:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -327,19 +327,7 @@ class ModelRunner:
             and self.can_run_piecewise_cuda_graph()
         ):
             self.attention_layers = []
-
-            try:
-                layers = self.model.model.layers
-            except:
-                try:
-                    layers = self.model.language_model.model.layers
-                except:
-                    try:
-                        layers = self.model.language_model.layers
-                    except:
-                        self.piecewise_cuda_graph_runner = None
-                        return
-            for layer in layers:
+            for layer in self.model.model.layers:
                 if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "attn"):
                     self.attention_layers.append(layer.self_attn.attn)
             if len(self.attention_layers) < self.model_config.num_hidden_layers:

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -254,12 +254,13 @@ class PiecewiseCudaGraphRunner:
     def can_run(self, forward_batch: ForwardBatch):
         num_tokens = len(forward_batch.input_ids)
         # TODO(yuwei): support return input_ids' logprob
-        for start_len, seq_len in zip(
-            forward_batch.extend_logprob_start_lens_cpu,
-            forward_batch.extend_seq_lens_cpu,
-        ):
-            if start_len is not None and start_len < seq_len:
-                return True
+        if forward_batch.return_logprob:
+            for start_len, seq_len in zip(
+                forward_batch.extend_logprob_start_lens_cpu,
+                forward_batch.extend_seq_lens_cpu,
+            ):
+                if start_len is not None and start_len < seq_len:
+                    return False
         if num_tokens <= self.max_num_tokens:
             return True
         return False

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -253,9 +253,13 @@ class PiecewiseCudaGraphRunner:
 
     def can_run(self, forward_batch: ForwardBatch):
         num_tokens = len(forward_batch.input_ids)
-        # TODO(yuwei): support return logprob
-        if forward_batch.return_logprob:
-            return False
+        # TODO(yuwei): support return input_ids' logprob
+        for start_len, seq_len in zip(
+            forward_batch.extend_logprob_start_lens_cpu,
+            forward_batch.extend_seq_lens_cpu,
+        ):
+            if start_len is not None and start_len < seq_len:
+                return True
         if num_tokens <= self.max_num_tokens:
             return True
         return False
@@ -426,7 +430,7 @@ class PiecewiseCudaGraphRunner:
             out_cache_loc=out_cache_loc,
             seq_lens_sum=forward_batch.seq_lens_sum,
             encoder_lens=forward_batch.encoder_lens,
-            return_logprob=forward_batch.return_logprob,
+            return_logprob=False,
             extend_seq_lens=forward_batch.extend_seq_lens,
             extend_prefix_lens=forward_batch.extend_prefix_lens,
             extend_start_loc=forward_batch.extend_start_loc,

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -179,7 +179,20 @@ class PiecewiseCudaGraphRunner:
         # Set graph pool id globally to be able to use symmetric memory
         set_graph_pool_id(get_global_graph_memory_pool())
 
-        with patch_model(self.model_runner.model.model) as patched_model:
+        try:
+            model = self.model_runner.model.model
+        except:
+            try:
+                model = self.model_runner.model.language_model.model
+            except:
+                try:
+                    model = self.model_runner.model.language_model
+                except:
+                    raise Exception(
+                        "Cannot get the underlying model for PiecewiseCudaGraphRunner."
+                    )
+
+        with patch_model(model) as patched_model:
             install_torch_compiled(
                 patched_model,
                 fullgraph=True,

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -179,20 +179,7 @@ class PiecewiseCudaGraphRunner:
         # Set graph pool id globally to be able to use symmetric memory
         set_graph_pool_id(get_global_graph_memory_pool())
 
-        try:
-            model = self.model_runner.model.model
-        except:
-            try:
-                model = self.model_runner.model.language_model.model
-            except:
-                try:
-                    model = self.model_runner.model.language_model
-                except:
-                    raise Exception(
-                        "Cannot get the underlying model for PiecewiseCudaGraphRunner."
-                    )
-
-        with patch_model(model) as patched_model:
+        with patch_model(self.model_runner.model.model) as patched_model:
             install_torch_compiled(
                 patched_model,
                 fullgraph=True,

--- a/test/srt/test_piecewise_cuda_graph.py
+++ b/test/srt/test_piecewise_cuda_graph.py
@@ -44,6 +44,18 @@ class TestPiecewiseCudaGraphCorrectness(CustomTestCase):
         metrics = run_eval(args)
         self.assertGreaterEqual(metrics["score"], 0.235)
 
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.65)
+
 
 class TestPiecewiseCudaGraphBenchmark(CustomTestCase):
 

--- a/test/srt/test_piecewise_cuda_graph.py
+++ b/test/srt/test_piecewise_cuda_graph.py
@@ -44,6 +44,57 @@ class TestPiecewiseCudaGraphCorrectness(CustomTestCase):
         metrics = run_eval(args)
         self.assertGreaterEqual(metrics["score"], 0.235)
 
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.65)
+
+
+class TestPiecewiseCudaGraphGemmaModelCorrectness(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "unsloth/gemma-3-1b-it"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=["--enable-piecewise-cuda-graph", "--attention-backend", "fa3"],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gpqa(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gpqa",
+            num_examples=64,
+            num_threads=16,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.12)
+
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.3)
+
 
 class TestPiecewiseCudaGraphBenchmark(CustomTestCase):
 

--- a/test/srt/test_piecewise_cuda_graph.py
+++ b/test/srt/test_piecewise_cuda_graph.py
@@ -44,57 +44,6 @@ class TestPiecewiseCudaGraphCorrectness(CustomTestCase):
         metrics = run_eval(args)
         self.assertGreaterEqual(metrics["score"], 0.235)
 
-    def test_mmlu(self):
-        args = SimpleNamespace(
-            base_url=self.base_url,
-            model=self.model,
-            eval_name="mmlu",
-            num_examples=64,
-            num_threads=32,
-        )
-        metrics = run_eval(args)
-        self.assertGreaterEqual(metrics["score"], 0.65)
-
-
-class TestPiecewiseCudaGraphGemmaModelCorrectness(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = "unsloth/gemma-3-1b-it"
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--enable-piecewise-cuda-graph", "--attention-backend", "fa3"],
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-    def test_gpqa(self):
-        args = SimpleNamespace(
-            base_url=self.base_url,
-            model=self.model,
-            eval_name="gpqa",
-            num_examples=64,
-            num_threads=16,
-        )
-
-        metrics = run_eval(args)
-        self.assertGreaterEqual(metrics["score"], 0.12)
-
-    def test_mmlu(self):
-        args = SimpleNamespace(
-            base_url=self.base_url,
-            model=self.model,
-            eval_name="mmlu",
-            num_examples=64,
-            num_threads=32,
-        )
-        metrics = run_eval(args)
-        self.assertGreaterEqual(metrics["score"], 0.3)
-
 
 class TestPiecewiseCudaGraphBenchmark(CustomTestCase):
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR refines the execution conditions in the CUDA graph runner and relaxes strict output shape checks to improve compatibility with models that have different tensor layouts.

Specifically, some models (e.g., Gemma-3-1B-IT) produce tensors with the same total number of elements but different shapes due to layout or internal reshape differences. The previous strict assert output.shape == ret.shape would incorrectly fail in such cases.
In addition, CUDA graph execution should be allowed when logprobs are returned for the last token only, but not when input logprobs are required.

## Modifications

1 `piecewise_cuda_graph_runner.py`

Updated can_run() logic:
Previously, CUDA graph capture was skipped when forward_batch.return_logprobs was True.
Now, it only skips when input-id logprobs are requested.

```python
for start_len, seq_len in zip(
    forward_batch.extend_logprob_start_lens_cpu,
    forward_batch.extend_seq_lens_cpu
):
    if start_len is not None and start_len < seq_len:
        return True
```

2 `radix_attention.py`
Replaced strict shape check:
```python
assert output.shape == ret.shape
```
with a relaxed element-count check:
```python
assert output.numel() == ret.numel()
```


## Accuracy Tests

Verified correctness on multiple models including:

Qwen3-0.6B

Gemma-3-1B-IT

Outputs are numerically identical to the baseline (within FP16 tolerance).

Logprob return path remains functionally unchanged.

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
