### PR TITLE
[router][grpc] Remove timeout for connections and remove `max_tokens` deprecation warning log

### DIFF
--- a/sgl-router/src/grpc_client/sglang_scheduler.rs
+++ b/sgl-router/src/grpc_client/sglang_scheduler.rs
@@ -132,7 +132,6 @@ impl SglangSchedulerClient {
         };
 
         let channel = Channel::from_shared(http_endpoint)?
-            .timeout(Duration::from_secs(3600)) // 1 hr timeout for connection
             .http2_keep_alive_interval(Duration::from_secs(30))
             .keep_alive_timeout(Duration::from_secs(10))
             .keep_alive_while_idle(true)

--- a/sgl-router/src/protocols/chat.rs
+++ b/sgl-router/src/protocols/chat.rs
@@ -496,7 +496,6 @@ impl Normalizable for ChatCompletionRequest {
         // Migrate deprecated max_tokens → max_completion_tokens
         #[allow(deprecated)]
         if self.max_completion_tokens.is_none() && self.max_tokens.is_some() {
-            tracing::warn!("max_tokens is deprecated, use max_completion_tokens instead");
             self.max_completion_tokens = self.max_tokens;
             self.max_tokens = None; // Clear deprecated field
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Setting timeout for a connection to 1h still prevents some extremely long requests from success. 

Too many evaluation and benchmark tools still uses `max_tokens` field.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Remove timeout for connections (default is no timeout)
- Remove `max_tokens` deprecation warning log

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
