### PR TITLE
support spec decoding in triton unified kernel

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -276,7 +276,9 @@ def _fwd_kernel(
             ) <= (start_n + offs_n[None, :] + SLIDING_WINDOW_SIZE)
             final_mask &= window_mask
 
-        SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
+        SKIP_TILE = False
+        if (USE_CUSTOM_MASK and not SKIP_PREFIX_CUSTOM_MASK) or SLIDING_WINDOW_SIZE > 0:
+            SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
 
         if not SKIP_TILE:
             offs_kv_loc = tl.load(

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -276,9 +276,7 @@ def _fwd_kernel(
             ) <= (start_n + offs_n[None, :] + SLIDING_WINDOW_SIZE)
             final_mask &= window_mask
 
-        SKIP_TILE = False
-        if (USE_CUSTOM_MASK and not SKIP_PREFIX_CUSTOM_MASK) or SLIDING_WINDOW_SIZE > 0:
-            SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
+        SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
 
         if not SKIP_TILE:
             offs_kv_loc = tl.load(

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -118,10 +118,12 @@ def build_unified_kv_indices(
 
     # Create unified_kv_indptr avoiding direct assignment (for CUDA graph compatibility)
     unified_lens = prefix_lens + extend_seq_lens[:bs]
-    unified_kv_indptr = torch.cat([
-        torch.zeros(1, dtype=torch.int32, device=device),
-        torch.cumsum(unified_lens, dim=0)
-    ])
+    unified_kv_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(unified_lens, dim=0),
+        ]
+    )
 
     max_unified_len = len(prefix_kv_indices) + len(extend_kv_indices)
 
@@ -713,7 +715,7 @@ def _fwd_kernel_unified(
     cur_window_start = 0
     if SLIDING_WINDOW_SIZE > 0:
         cur_window_start = tl.load(window_start_pos + cur_seq)
-    
+
     # Load custom mask start index if using custom mask (for speculative decoding)
     if USE_CUSTOM_MASK:
         cur_seq_mask_start_idx = tl.load(mask_indptr + cur_seq)
@@ -942,7 +944,7 @@ def extend_attention_fwd_unified(
         prefix_lens: Prefix length for each sequence [batch_size]
         max_len_extend: Maximum extend length
         custom_mask: Custom attention mask (for speculative decoding tree attention)
-        mask_indptr: Mask offsets [batch_size + 1] 
+        mask_indptr: Mask offsets [batch_size + 1]
         sm_scale: Softmax scale
         logit_cap: Logit capping value
         is_causal: Whether to apply causal mask

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -116,12 +116,12 @@ def build_unified_kv_indices(
 
     prefix_lens = prefix_kv_indptr[1 : bs + 1] - prefix_kv_indptr[:bs]
 
-    unified_kv_indptr = torch.empty(bs + 1, dtype=torch.int32, device=device)
-    unified_kv_indptr[0] = 0
-    unified_kv_indptr[1:] = prefix_lens + extend_seq_lens[:bs]
-
-    # Compute cumsum in-place
-    torch.cumsum(unified_kv_indptr[1:], dim=0, out=unified_kv_indptr[1:])
+    # Create unified_kv_indptr avoiding direct assignment (for CUDA graph compatibility)
+    unified_lens = prefix_lens + extend_seq_lens[:bs]
+    unified_kv_indptr = torch.cat([
+        torch.zeros(1, dtype=torch.int32, device=device),
+        torch.cumsum(unified_lens, dim=0)
+    ])
 
     max_unified_len = len(prefix_kv_indices) + len(extend_kv_indices)
 
@@ -664,6 +664,8 @@ def _fwd_kernel_unified(
     kv_indptr,
     kv_indices,
     prefix_lens,
+    mask_ptr,
+    mask_indptr,
     sink_ptr,
     window_start_pos,
     sm_scale,
@@ -687,6 +689,7 @@ def _fwd_kernel_unified(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
+    USE_CUSTOM_MASK: tl.constexpr,
     HAS_SINK: tl.constexpr,
 ):
     """
@@ -710,6 +713,10 @@ def _fwd_kernel_unified(
     cur_window_start = 0
     if SLIDING_WINDOW_SIZE > 0:
         cur_window_start = tl.load(window_start_pos + cur_seq)
+    
+    # Load custom mask start index if using custom mask (for speculative decoding)
+    if USE_CUSTOM_MASK:
+        cur_seq_mask_start_idx = tl.load(mask_indptr + cur_seq)
 
     offs_d = tl.arange(0, BLOCK_DMODEL)
     offs_dv = tl.arange(0, BLOCK_DV)
@@ -758,8 +765,23 @@ def _fwd_kernel_unified(
         # Compute mask
         final_mask = mask_m[:, None] & mask_n[None, :]
 
+        # Apply custom mask if provided (for speculative decoding tree attention)
+        if USE_CUSTOM_MASK:
+            # Custom mask shape: [num_draft_tokens, total_seq_len]
+            # We index by: q_position_in_extend * total_kv_len + kv_position_in_total
+            custom_mask = tl.load(
+                mask_ptr
+                + cur_seq_mask_start_idx
+                + (cur_block_m * BLOCK_M + offs_m[:, None]) * cur_seq_kv_len
+                + start_n
+                + offs_n[None, :],
+                mask=(mask_m[:, None] & mask_n[None, :]),
+                other=0,
+            )
+            final_mask &= custom_mask
+
         # Apply causal mask for extend part
-        if IS_CAUSAL:
+        if IS_CAUSAL and not USE_CUSTOM_MASK:
             # Determine if current KV block is in extend region
             # Only apply causal mask when both Q and K are in extend region
             q_idx = cur_block_m * BLOCK_M + offs_m[:, None]
@@ -794,7 +816,9 @@ def _fwd_kernel_unified(
             final_mask &= window_mask
 
         # Check if we can skip this tile
-        SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
+        SKIP_TILE = False
+        if USE_CUSTOM_MASK or SLIDING_WINDOW_SIZE > 0:
+            SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
 
         if not SKIP_TILE:
             # Load KV indices
@@ -894,6 +918,8 @@ def extend_attention_fwd_unified(
     kv_indices,
     prefix_lens,
     max_len_extend,
+    custom_mask=None,
+    mask_indptr=None,
     sm_scale=None,
     logit_cap=0.0,
     is_causal=True,
@@ -915,6 +941,8 @@ def extend_attention_fwd_unified(
         kv_indices: Unified KV indices (both prefix and extend)
         prefix_lens: Prefix length for each sequence [batch_size]
         max_len_extend: Maximum extend length
+        custom_mask: Custom attention mask (for speculative decoding tree attention)
+        mask_indptr: Mask offsets [batch_size + 1] 
         sm_scale: Softmax scale
         logit_cap: Logit capping value
         is_causal: Whether to apply causal mask
@@ -973,6 +1001,7 @@ def extend_attention_fwd_unified(
     batch_size, head_num = qo_indptr.shape[0] - 1, q.shape[1]
     kv_group_num = q.shape[1] // k_buffer.shape[1]
 
+    USE_CUSTOM_MASK = custom_mask is not None
     HAS_SINK = sinks is not None
 
     # For sliding window attention, window_start_pos tracks the absolute position
@@ -997,6 +1026,8 @@ def extend_attention_fwd_unified(
         kv_indptr,
         kv_indices,
         prefix_lens,
+        custom_mask,
+        mask_indptr,
         sinks,
         window_start_pos,
         sm_scale,
@@ -1020,6 +1051,7 @@ def extend_attention_fwd_unified(
         Lq=Lq,
         Lv=Lv,
         IS_CAUSAL=is_causal,
+        USE_CUSTOM_MASK=USE_CUSTOM_MASK,
         HAS_SINK=HAS_SINK,
         num_warps=num_warps,
         num_stages=num_stages,

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -767,10 +767,8 @@ def _fwd_kernel_unified(
         # Compute mask
         final_mask = mask_m[:, None] & mask_n[None, :]
 
-        # Apply custom mask if provided (for speculative decoding tree attention)
+        # Apply custom mask if provided
         if USE_CUSTOM_MASK:
-            # Custom mask shape: [num_draft_tokens, total_seq_len]
-            # We index by: q_position_in_extend * total_kv_len + kv_position_in_total
             custom_mask = tl.load(
                 mask_ptr
                 + cur_seq_mask_start_idx

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -10,7 +10,9 @@ from sglang.srt.layers.attention.triton_ops.decode_attention import (
     decode_attention_fwd_normal,
 )
 from sglang.srt.layers.attention.triton_ops.extend_attention import (
+    build_unified_kv_indices,
     extend_attention_fwd,
+    extend_attention_fwd_unified,
     redundant_attention,
 )
 from sglang.srt.layers.attention.triton_ops.prefill_attention import (
@@ -570,6 +572,206 @@ class TestTritonAttention(CustomTestCase):
         for S in seq_lens:
             for B, H_Q, H_KV, D, D_V in configs:
                 self._test_grouped_decode_attention_once(B, S, H_Q, H_KV, D, D_V)
+
+    def _test_extend_attention_unified_vs_regular_once(
+        self, B, N_CTX, H_Q, H_KV, D
+    ):
+        """Test that unified kernel produces same results as 2-stage kernel."""
+        dtype = torch.bfloat16
+
+        b_seq_len_prefix = torch.randint(
+            1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
+        )
+        b_seq_len_extend = torch.randint(
+            1, N_CTX // 2, (B,), dtype=torch.int32, device="cuda"
+        )
+        b_seq_len = b_seq_len_prefix + b_seq_len_extend
+
+        b_start_loc = torch.zeros((B,), dtype=torch.int32, device="cuda")
+        b_start_loc[1:] = torch.cumsum(b_seq_len[:-1], 0)
+        b_start_loc_extend = torch.zeros((B,), dtype=torch.int32, device="cuda")
+        b_start_loc_extend[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+
+        # Setup prefix KV indices
+        kv_indptr = torch.zeros((B + 1,), dtype=torch.int32, device="cuda")
+        kv_indptr[1 : B + 1] = torch.cumsum(b_seq_len_prefix[:B], dim=0)
+        kv_indices = torch.zeros(
+            (b_seq_len_prefix.sum().item(),), dtype=torch.int64, device="cuda"
+        )
+
+        for i in range(B):
+            kv_indices[kv_indptr[i] : kv_indptr[i + 1]] = torch.arange(
+                b_start_loc[i], b_start_loc[i] + b_seq_len_prefix[i]
+            )
+
+        total_token_num = torch.sum(b_seq_len).item()
+        extend_token_num = torch.sum(b_seq_len_extend).item()
+        k_buffer = torch.empty(
+            (total_token_num, H_KV, D), dtype=dtype, device="cuda"
+        ).normal_(mean=0.1, std=0.2)
+        v_buffer = torch.empty(
+            (total_token_num, H_KV, D), dtype=dtype, device="cuda"
+        ).normal_(mean=0.1, std=0.2)
+
+        k_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype, device="cuda")
+        v_extend = torch.empty((extend_token_num, H_KV, D), dtype=dtype, device="cuda")
+        q_extend = torch.empty((extend_token_num, H_Q, D), dtype=dtype, device="cuda")
+
+        for i in range(B):
+            extend_start_in_buffer = b_start_loc[i] + b_seq_len_prefix[i]
+            extend_end_in_buffer = b_start_loc[i] + b_seq_len[i]
+            extend_start = b_start_loc_extend[i]
+            extend_end = b_start_loc_extend[i] + b_seq_len_extend[i]
+            k_extend[extend_start:extend_end] = k_buffer[
+                extend_start_in_buffer:extend_end_in_buffer
+            ]
+            v_extend[extend_start:extend_end] = v_buffer[
+                extend_start_in_buffer:extend_end_in_buffer
+            ]
+            q_extend[extend_start:extend_end] = torch.empty(
+                (b_seq_len_extend[i], H_Q, D), dtype=dtype, device="cuda"
+            ).normal_(mean=0.1, std=0.2)
+
+        # Setup for extend attention
+        max_len_extend = torch.max(b_seq_len_extend, 0)[0].item()
+        qo_indptr = torch.zeros((B + 1,), dtype=torch.int32, device="cuda")
+        qo_indptr[1 : B + 1] = torch.cumsum(b_seq_len_extend[:B], dim=0)
+
+        # Run 2-stage kernel
+        o_regular = torch.empty((extend_token_num, H_Q, D), dtype=dtype, device="cuda")
+        extend_attention_fwd(
+            q_extend,
+            k_extend,
+            v_extend,
+            o_regular,
+            k_buffer,
+            v_buffer,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            custom_mask=None,
+            is_causal=True,
+            mask_indptr=None,
+            max_len_extend=max_len_extend,
+        )
+
+        # Build unified KV indices
+        extend_kv_indices = torch.arange(
+            total_token_num - extend_token_num,
+            total_token_num,
+            dtype=torch.int64,
+            device="cuda",
+        )
+        extend_start_loc = torch.zeros((B,), dtype=torch.int32, device="cuda")
+        extend_start_loc[1:] = torch.cumsum(b_seq_len_extend[:-1], 0)
+
+        unified_kv_indptr, unified_kv_indices, prefix_lens = build_unified_kv_indices(
+            kv_indptr,
+            kv_indices,
+            extend_start_loc,
+            b_seq_len_extend,
+            extend_kv_indices,
+            B,
+        )
+
+        # Run unified kernel
+        o_unified = torch.empty((extend_token_num, H_Q, D), dtype=dtype, device="cuda")
+        extend_attention_fwd_unified(
+            q_extend,
+            o_unified,
+            k_buffer,
+            v_buffer,
+            qo_indptr,
+            unified_kv_indptr,
+            unified_kv_indices,
+            prefix_lens,
+            max_len_extend=max_len_extend,
+            custom_mask=None,
+            mask_indptr=None,
+            sm_scale=None,
+            logit_cap=0.0,
+            is_causal=True,
+        )
+
+        # Compare results
+        self.assertTrue(
+            torch.allclose(o_regular, o_unified, rtol=0.15, atol=0.15),
+            f"Unified kernel output differs from 2-stage kernel. "
+            f"Max diff: {(o_regular - o_unified).abs().max()}",
+        )
+
+    def test_extend_attention_unified_vs_regular(self):
+        """Test unified kernel matches 2-stage kernel across different configs."""
+        configs = [
+            (4, 512, 32, 8, 128),  # Standard config
+            (2, 2048, 32, 8, 128),  # Long sequence (test 2048 specifically)
+            (8, 256, 64, 8, 80),  # Non-standard head dim
+        ]
+
+        for B, N_CTX, H_Q, H_KV, D in configs:
+            with self.subTest(B=B, N_CTX=N_CTX, H_Q=H_Q, H_KV=H_KV, D=D):
+                self._test_extend_attention_unified_vs_regular_once(
+                    B, N_CTX, H_Q, H_KV, D
+                )
+
+    def test_build_unified_kv_indices(self):
+        """Test build_unified_kv_indices correctness."""
+        B = 4
+        dtype = torch.int64
+        device = "cuda"
+
+        # Setup test data
+        prefix_lens = torch.tensor([10, 20, 15, 25], dtype=torch.int32, device=device)
+        extend_lens = torch.tensor([5, 3, 7, 4], dtype=torch.int32, device=device)
+
+        # Build prefix indices
+        prefix_kv_indptr = torch.zeros((B + 1,), dtype=torch.int32, device=device)
+        prefix_kv_indptr[1:] = torch.cumsum(prefix_lens, dim=0)
+        prefix_kv_indices = torch.arange(
+            prefix_lens.sum().item(), dtype=dtype, device=device
+        )
+
+        # Build extend indices
+        extend_start_loc = torch.zeros((B,), dtype=torch.int32, device=device)
+        extend_start_loc[1:] = torch.cumsum(extend_lens[:-1], dim=0)
+        extend_kv_indices = torch.arange(
+            prefix_lens.sum().item(),
+            prefix_lens.sum().item() + extend_lens.sum().item(),
+            dtype=dtype,
+            device=device,
+        )
+
+        # Build unified indices
+        unified_kv_indptr, unified_kv_indices, returned_prefix_lens = (
+            build_unified_kv_indices(
+                prefix_kv_indptr,
+                prefix_kv_indices,
+                extend_start_loc,
+                extend_lens,
+                extend_kv_indices,
+                B,
+            )
+        )
+
+        # Verify unified_kv_indptr
+        expected_lens = prefix_lens + extend_lens
+        expected_indptr = torch.zeros((B + 1,), dtype=torch.int32, device=device)
+        expected_indptr[1:] = torch.cumsum(expected_lens, dim=0)
+        self.assertTrue(torch.equal(unified_kv_indptr, expected_indptr))
+
+        # Verify prefix_lens
+        self.assertTrue(torch.equal(returned_prefix_lens, prefix_lens))
+
+        # Verify unified_kv_indices structure
+        for i in range(B):
+            start_idx = int(unified_kv_indptr[i])
+            end_idx = int(unified_kv_indptr[i + 1])
+            prefix_len = int(prefix_lens[i])
+            extend_len = int(extend_lens[i])
+
+            # Check that prefix and extend are concatenated correctly
+            unified_seq = unified_kv_indices[start_idx:end_idx]
+            self.assertEqual(len(unified_seq), prefix_len + extend_len)
 
 
 if __name__ == "__main__":

--- a/test/srt/test_triton_attention_kernels.py
+++ b/test/srt/test_triton_attention_kernels.py
@@ -573,9 +573,7 @@ class TestTritonAttention(CustomTestCase):
             for B, H_Q, H_KV, D, D_V in configs:
                 self._test_grouped_decode_attention_once(B, S, H_Q, H_KV, D, D_V)
 
-    def _test_extend_attention_unified_vs_regular_once(
-        self, B, N_CTX, H_Q, H_KV, D
-    ):
+    def _test_extend_attention_unified_vs_regular_once(self, B, N_CTX, H_Q, H_KV, D):
         """Test that unified kernel produces same results as 2-stage kernel."""
         dtype = torch.bfloat16
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

support speculative decoding in triton unified (deterministic inference) kernel.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
**Before**:
spec decoding can't launch successfully with --enable-deterministic-inference (unified triton kernel)

**After**:
```
python3 -m sglang.launch_server --model /shared/public/elr-models/meta-llama/Meta-Llama-3.1-8B-Instruct/07eb05b21d191a58c577b4a45982fe0c049d0693  --speculative-algorithm EAGLE3 --speculative-draft-model-path /shared/public/elr-models/jamesliu1/sglang-EAGLE3-Llama-3.1-Instruct-8B/e5ed08d66f528a95ce89f5d4fd136a28f6def714 --speculative-num-steps 3         --speculative-eagle-topk 1 --speculative-num-draft-tokens 4  --trust-remote-code --dtype float16 --enable-torch-compile --attention-backend triton --cuda-graph-max-bs 2 --enable-deterministic-inference

python benchmark/gsm8k/bench_sglang.py --data-path /shared/public/data/gsm8k/test.jsonl
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:18<00:00, 10.70it/s]
Accuracy: 0.770
Invalid: 0.000
Latency: 18.762 s
Output throughput: 909.155 token/s

python3 -m sglang.test.test_deterministic --test-mode prefix --n-trials 50
Prompt 0 with prefix length 1: total samples: 286, Unique samples: 1
Prompt 1 with prefix length 511: total samples: 333, Unique samples: 1
Prompt 2 with prefix length 2048: total samples: 311, Unique samples: 1
Prompt 3 with prefix length 4097: total samples: 345, Unique samples: 1
```
This score is aligned with the source-of-truth for this model (verified with no --enable-deterministic-inference)
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
