### PR TITLE
fix rmsnorm -> layernorm in qwen3 omni

### DIFF
--- a/python/sglang/srt/models/qwen3_omni_moe.py
+++ b/python/sglang/srt/models/qwen3_omni_moe.py
@@ -31,7 +31,6 @@ from sglang.srt.configs.qwen3_omni import (
 )
 from sglang.srt.configs.qwen3_vl import Qwen3VLMoeConfig
 from sglang.srt.layers.attention.vision import VisionAttention
-from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -318,7 +317,7 @@ class Qwen3OmniMoeVisionPatchMerger(nn.Module):
         super().__init__()
         self.hidden_size = context_dim * (spatial_merge_size**2)
         self.use_postshuffle_norm = use_postshuffle_norm
-        self.ln_q = RMSNorm(
+        self.ln_q = nn.LayerNorm(
             self.hidden_size if use_postshuffle_norm else context_dim, eps=1e-6
         )
         self.mlp = nn.ModuleList(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
If you look at the transformer's modeling code, then you will notice that it's actually supposed to be layer norm instead of RMS norm. 

You can transform RMS norm to be the same as layer norm with a subtraction, but we don't have that offset available in SGL. 


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

| Subject | RMSNorm | LayerNorm | Δ Absolute | Δ Relative |
|---------|---------|-----------|------------|------------|
| Accounting | 40.0% | 43.3% | +3.3% | +8.3% |
| Agriculture | 60.0% | 56.7% | -3.3% | -5.5% |
| Architecture_and_Engineering | 20.0% | 23.3% | +3.3% | +16.5% |
| Art | 60.0% | 73.3% | +13.3% | +22.2% |
| Art_Theory | 83.3% | 83.3% | 0.0% | 0.0% |
| Basic_Medical_Science | 63.3% | 63.3% | 0.0% | 0.0% |
| Biology | 46.7% | 50.0% | +3.3% | +7.1% |
| Chemistry | 43.3% | 46.7% | +3.4% | +7.9% |
| Clinical_Medicine | 63.3% | 63.3% | 0.0% | 0.0% |
| Computer_Science | 56.7% | 63.3% | +6.6% | +11.6% |
| Design | 83.3% | 83.3% | 0.0% | 0.0% |
| Diagnostics_and_Laboratory_Medicine | 30.0% | 40.0% | +10.0% | +33.3% |
| Economics | 66.7% | 70.0% | +3.3% | +5.0% |
| Electronics | 33.3% | 50.0% | +16.7% | +50.2% |
| Energy_and_Power | 43.3% | 43.3% | 0.0% | 0.0% |
| Finance | 20.0% | 23.3% | +3.3% | +16.5% |
| Geography | 60.0% | 60.0% | 0.0% | 0.0% |
| History | 66.7% | 73.3% | +6.6% | +9.9% |
| Literature | 90.0% | 90.0% | 0.0% | 0.0% |
| Manage | 50.0% | 53.3% | +3.3% | +6.6% |
| Marketing | 46.7% | 50.0% | +3.3% | +7.1% |
| Materials | 36.7% | 43.3% | +6.6% | +18.0% |
| Math | 30.0% | 40.0% | +10.0% | +33.3% |
| Mechanical_Engineering | 33.3% | 46.7% | +13.4% | +40.2% |
| Music | 30.0% | 36.7% | +6.7% | +22.3% |
| Pharmacy | 63.3% | 70.0% | +6.7% | +10.6% |
| Physics | 53.3% | 60.0% | +6.7% | +12.6% |
| Psychology | 60.0% | 66.7% | +6.7% | +11.2% |
| Public_Health | 56.7% | 66.7% | +10.0% | +17.6% |
| Sociology | 70.0% | 70.0% | 0.0% | 0.0% |

```
cd /root/sglang
source .venv/bin/activate
nohup python -m sglang.launch_server \
  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --port 30000 \
  --mem-fraction-static 0.8 \
  --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
  > bench_runs/server_rmsnorm.log 2>&1 &
```

Then
```
cd /root/sglang
source .venv/bin/activate
python benchmark/mmmu/bench_sglang.py \
  --port 30000 \
  --concurrency 16 \
  2>&1 | tee bench_runs/benchmark_layernorm_output.log
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
