### PR TITLE
set default attention backend for deterministic inference

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1411,9 +1411,18 @@ class ServerArgs:
             )
 
             # Check attention backend
-            if self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
+            if self.attention_backend is None:
+                # User didn't specify attention backend, fallback to fa3
+                self.attention_backend = "fa3"
+                logger.warning(
+                    f"Attention backend not specified. Falling back to 'fa3' for deterministic inference. "
+                    f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
+                )
+            elif self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
+                # User explicitly specified an incompatible attention backend
                 raise ValueError(
-                    f"Currently only {DETERMINISTIC_ATTENTION_BACKEND_CHOICES} attention backends are supported for deterministic inference."
+                    f"Currently only {DETERMINISTIC_ATTENTION_BACKEND_CHOICES} attention backends are supported for deterministic inference, "
+                    f"but you explicitly specified '{self.attention_backend}'."
                 )
 
             # Currently, only FA3 supports radix cache. Support for other backends is in progress

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -44,6 +44,7 @@ from sglang.srt.utils import (
     is_remote_url,
     is_sm90_supported,
     is_sm100_supported,
+    is_sm120_supported,
     is_triton_kernels_available,
     is_valid_ipv6_address,
     json_list_type,
@@ -1413,18 +1414,16 @@ class ServerArgs:
             # Check attention backend
             if self.attention_backend is None:
                 # User didn't specify attention backend, fallback based on GPU architecture
-                if is_sm100_supported():
+                if is_sm100_supported() or is_sm120_supported():
+                    # Blackwell and newer architectures
                     self.attention_backend = "flashinfer"
-                    logger.warning(
-                        f"Attention backend not specified. Falling back to 'flashinfer' for deterministic inference on Blackwell (SM100). "
-                        f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
-                    )
                 else:
+                    # Hopper (SM90) and older architectures
                     self.attention_backend = "fa3"
-                    logger.warning(
-                        f"Attention backend not specified. Falling back to 'fa3' for deterministic inference. "
-                        f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
-                    )
+                logger.warning(
+                    f"Attention backend not specified. Falling back to '{self.attention_backend}' for deterministic inference. "
+                    f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
+                )
             elif self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
                 # User explicitly specified an incompatible attention backend
                 raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1412,12 +1412,19 @@ class ServerArgs:
 
             # Check attention backend
             if self.attention_backend is None:
-                # User didn't specify attention backend, fallback to flashinfer
-                self.attention_backend = "flashinfer"
-                logger.warning(
-                    f"Attention backend not specified. Falling back to 'flashinfer' for deterministic inference. "
-                    f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
-                )
+                # User didn't specify attention backend, fallback based on GPU architecture
+                if is_sm100_supported():
+                    self.attention_backend = "flashinfer"
+                    logger.warning(
+                        f"Attention backend not specified. Falling back to 'flashinfer' for deterministic inference on Blackwell (SM100). "
+                        f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
+                    )
+                else:
+                    self.attention_backend = "fa3"
+                    logger.warning(
+                        f"Attention backend not specified. Falling back to 'fa3' for deterministic inference. "
+                        f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
+                    )
             elif self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:
                 # User explicitly specified an incompatible attention backend
                 raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1412,10 +1412,10 @@ class ServerArgs:
 
             # Check attention backend
             if self.attention_backend is None:
-                # User didn't specify attention backend, fallback to fa3
-                self.attention_backend = "fa3"
+                # User didn't specify attention backend, fallback to flashinfer
+                self.attention_backend = "flashinfer"
                 logger.warning(
-                    f"Attention backend not specified. Falling back to 'fa3' for deterministic inference. "
+                    f"Attention backend not specified. Falling back to 'flashinfer' for deterministic inference. "
                     f"You can explicitly set --attention-backend to one of {DETERMINISTIC_ATTENTION_BACKEND_CHOICES}."
                 )
             elif self.attention_backend not in DETERMINISTIC_ATTENTION_BACKEND_CHOICES:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -173,6 +173,7 @@ def is_blackwell():
         return False
     return torch.cuda.get_device_capability()[0] == 10
 
+
 @lru_cache(maxsize=1)
 def is_sm120_supported(device=None) -> bool:
     if not is_cuda_alike():
@@ -180,6 +181,7 @@ def is_sm120_supported(device=None) -> bool:
     return (torch.cuda.get_device_capability(device)[0] == 12) and (
         torch.version.cuda >= "12.8"
     )
+
 
 @lru_cache(maxsize=1)
 def is_sm100_supported(device=None) -> bool:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -173,6 +173,13 @@ def is_blackwell():
         return False
     return torch.cuda.get_device_capability()[0] == 10
 
+@lru_cache(maxsize=1)
+def is_sm120_supported(device=None) -> bool:
+    if not is_cuda_alike():
+        return False
+    return (torch.cuda.get_device_capability(device)[0] == 12) and (
+        torch.version.cuda >= "12.8"
+    )
 
 @lru_cache(maxsize=1)
 def is_sm100_supported(device=None) -> bool:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Set default deterministic compatible attention backend when deterministic enabled and no attention backend being set.

Tested on a single H100
Before:

```
python3 -m sglang.launch_server --model-path /shared/public/elr-models/Qwen/Qwen3-8B/2069b3fae1114555f3c020c81410e51fa0f656f2 --enable-deterministic-inference
/home/jobuser/zminglei/sglang/venv/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
`torch_dtype` is deprecated! Use `dtype` instead!
WARNING:sglang.srt.server_args:Sampling backend is set to pytorch for deterministic inference.
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/jobuser/zminglei/sglang/python/sglang/launch_server.py", line 11, in <module>
    server_args = prepare_server_args(sys.argv[1:])
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/server_args.py", line 3489, in prepare_server_args
    return ServerArgs.from_cli_args(raw_args)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/server_args.py", line 3138, in from_cli_args
    return cls(**{attr: getattr(args, attr) for attr in attrs})
  File "<string>", line 258, in __init__
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/server_args.py", line 580, in __post_init__
    self._handle_deterministic_inference()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/server_args.py", line 1415, in _handle_deterministic_inference
    raise ValueError(
ValueError: Currently only ['flashinfer', 'fa3', 'triton'] attention backends are supported for deterministic inference.
```

After:
```
python3 -m sglang.launch_server --model-path /shared/public/elr-models/Qwen/Qwen3-8B/2069b3fae1114555f3c020c81410e51fa0f656f2 --enable-deterministic-inference

WARNING:sglang.srt.server_args:Attention backend not specified. Falling back to 'fa3' for deterministic inference. You can explicitly set --attention-backend to one of ['flashinfer', 'fa3', 'triton'].
[2025-10-17 21:28:32] INFO:     Started server process [14033]
[2025-10-17 21:28:32] INFO:     Waiting for application startup.
[2025-10-17 21:28:32] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2025-10-17 21:28:32] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}
[2025-10-17 21:28:32] INFO:     Application startup complete.
[2025-10-17 21:28:32] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2025-10-17 21:28:33] INFO:     127.0.0.1:54594 - "GET /get_model_info HTTP/1.1" 200 OK
[2025-10-17 21:28:33] Prefill batch. #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
[2025-10-17 21:28:35] INFO:     127.0.0.1:54600 - "POST /generate HTTP/1.1" 200 OK
[2025-10-17 21:28:35] The server is fired up and ready to roll!
```
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python benchmark/gsm8k/bench_sglang.py --data-path /shared/public/data/gsm8k/test.jsonl
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:24<00:00,  8.13it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 24.666 s
Output throughput: 964.265 token/s
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
