### PR TITLE
fix(ci): Fix CI Monitor limit parameter and add CI Analysis to summary

### DIFF
--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -44,7 +44,7 @@ jobs:
           PYTHONIOENCODING: utf-8
         run: |
           cd scripts/ci_monitor
-          python ci_analyzer.py --token $GITHUB_TOKEN --limit ${{ github.event.inputs.limit || '1000' }} --output ci_analysis_$(date +%Y%m%d_%H%M%S).json
+          python ci_analyzer.py --token $GITHUB_TOKEN --limit ${{ inputs.limit || '1000' }} --output ci_analysis_$(date +%Y%m%d_%H%M%S).json
 
       - name: Run Performance Analysis
         env:
@@ -53,7 +53,7 @@ jobs:
           PYTHONIOENCODING: utf-8
         run: |
           cd scripts/ci_monitor
-          python ci_analyzer_perf.py --token $GITHUB_TOKEN --limit ${{ github.event.inputs.limit || '1000' }} --output-dir performance_tables_$(date +%Y%m%d_%H%M%S) --upload-to-github
+          python ci_analyzer_perf.py --token $GITHUB_TOKEN --limit ${{ inputs.limit || '1000' }} --output-dir performance_tables_$(date +%Y%m%d_%H%M%S) --upload-to-github
 
       - name: Upload Analysis Results
         uses: actions/upload-artifact@v4

--- a/scripts/ci_monitor/ci_analyzer_perf.py
+++ b/scripts/ci_monitor/ci_analyzer_perf.py
@@ -1304,8 +1304,8 @@ class SGLangPerfAnalyzer:
                     summary_lines.append("---")
                     summary_lines.append("")
 
-            # Write summary to GitHub Actions
-            with open(github_step_summary, "w", encoding="utf-8") as f:
+            # Write summary to GitHub Actions (append mode to preserve CI Analysis report)
+            with open(github_step_summary, "a", encoding="utf-8") as f:
                 f.write("\n".join(summary_lines))
 
             print("✅ GitHub Actions summary generated successfully")


### PR DESCRIPTION
## Summary
This PR fixes the CI Monitor workflow and improves its summary report.

## Changes

### 1. Fix `limit` parameter issue
- Changed `${{ github.event.inputs.limit || '1000' }}` to `${{ inputs.limit || '1000' }}` in workflow
- **Problem**: After manual runs, scheduled runs weren't using the default limit (1000), causing incomplete data collection (only a few days instead of 30 days)
- **Solution**: Use the shorter `inputs.limit` syntax which handles both scheduled and manual triggers correctly

<img width="728" height="415" alt="图片" src="https://github.com/user-attachments/assets/f74a8845-349a-4403-821e-b5db12ce5cd2" />


### 2. Add CI Analysis Report to GitHub Actions Summary
- Added `generate_github_summary()` method to `ci_analyzer.py`
- CI Analysis Report now displays before Performance Analysis Report in summary
- **Summary includes**:
  - Overall statistics (success rate, failed/successful runs)
  - Category failure statistics
  - Top 20 most frequently failed jobs with recent failure links
  - Failure pattern analysis

## Impact
- CI Monitor will now consistently analyze 30 days of data
- Both CI Analysis and Performance Analysis reports are visible in GitHub Actions summary