### PR TITLE
[eagle overlap spec] wip impl top k > 1 in overlap eagle worker(v2)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1271,9 +1271,18 @@ class ServerArgs:
                 and self.page_size > 1
                 and self.attention_backend != "flashinfer"
             ):
-                raise ValueError(
-                    "speculative_eagle_topk > 1 with page_size > 1 is unstable and produces incorrect results for paged attention backends. This combination is only supported for the 'flashinfer' backend."
-                )
+                if (
+                    self.speculative_algorithm == "EAGLE"
+                    and self.enable_beta_spec
+                    and self.attention_backend == "triton"
+                ):
+                    logger.warning(
+                        "WARNING: Running EAGLE beta spec overlap with topk > 1 and page_size > 1 on triton backend. This combination is experimental and NOT officially supported. May produce incorrect results or crash."
+                    )
+                else:
+                    raise ValueError(
+                        "speculative_eagle_topk > 1 with page_size > 1 is unstable and produces incorrect results for paged attention backends. This combination is only supported for the 'flashinfer' backend."
+                    )
 
         if self.speculative_algorithm == "NGRAM":
             if not self.device.startswith("cuda"):

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -610,6 +610,8 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
     req_pool_indices_for_draft_extend: torch.Tensor = None
 
     # Inputs for V2 overlap worker
+    _pending_out_cache_loc: Optional[torch.Tensor] = None
+    _pending_extend_lens: Optional[torch.Tensor] = None
     future_indices: Optional[FutureIndices] = None
     allocate_lens: Optional[torch.Tensor] = None
     new_seq_lens: Optional[torch.Tensor] = None


### PR DESCRIPTION
## Summary
Try to impl top_k > 1 in eagle overlap spec (v2 ->> replace v1 (non overlap))


## Accuracy Tests
`SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 python -m sglang.launch_server --dtype float16 --model-path unsloth/Meta-llama-3.1-8b-instruct --attention-backend triton --decode-log-interval 1 --disable-cuda-graph --speculative-algorithm EAGLE --speculative-draft-model-path lmsys/sglang-EAGLE-LLAMA3-instruct-8B --mem-fraction-static 0.8 --speculative-num-steps 3 --speculative-eagle-topk 2 --speculative-num-draft-tokens 4 ---page-size 1 --disable-radix-cache --disable-cuda-graph --enable-beta-spec `

Right now it still produce gibberish. 
- If topk = 1 it's fine. Set page size 1 only. 
- Not explicitly supporting flashinfer

# Baseline result

| Implementation | Condition                 | Status    |
|----------------|--------------------------|-----------|
| Triton         | Page size > 1             | ✔         |
| Triton         | Page size = 1             | ✔         |
| Triton         | Topk = 1                  | ✔         |
| Triton         | Topk > 1                  | ✗         |
| Triton         | Both > 1                  | ✗         |
| Flashinfer     | Top K = 1                 | ✔         |
| Flashinfer     | Top K > 1                 | ✗         |
| Flashinfer     | Different page sizes      | untested  |

# Current Status
Still gibberish, focus on triton
