### PR TITLE
added QWen3 EAGLE model

### DIFF
--- a/python/sglang/srt/models/qwen3_eagle.py
+++ b/python/sglang/srt/models/qwen3_eagle.py
@@ -108,8 +108,6 @@ class Qwen3ForCausalLMEagle(Qwen3ForCausalLM):
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         weights = [(add_prefix(k, "model"), v) for k, v in weights]
-        print([w[0] for w in weights])
-        print([k for k, v in self.named_parameters()])
         super().load_weights(weights)
 
 

--- a/python/sglang/srt/models/qwen3_eagle.py
+++ b/python/sglang/srt/models/qwen3_eagle.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2023-2025 SGLang Team
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from functools import partial
+from typing import Iterable, Optional, Tuple, Union
+
+import torch
+
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.qwen3 import Qwen3Config, Qwen3ForCausalLM
+from sglang.srt.utils import add_prefix
+
+
+class FusedResidualIdentity(torch.nn.Identity):
+    def forward(self, hidden_states, residual=None):
+        if residual is None:
+            return (hidden_states, None)
+        else:
+            return (hidden_states + residual, None)
+
+
+class Qwen3ForCausalLMEagle(Qwen3ForCausalLM):
+    def __init__(
+        self,
+        config: Qwen3Config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+
+        super().__init__(config, quant_config, prefix)
+
+        # EAGLE-2 overwrites draft model embedding and lm_head from target layers.
+        # See the calling of `set_embed_and_head` in EAGLE worker and SGL Qwen3ForCausalLM.
+        # Under tie_word_embeddings, this could be deleted twice by the SGLang, so we make a placeholder here.
+        if getattr(self.config, "tie_word_embeddings", True):
+            assert id(self.lm_head.weight) == id(self.model.embed_tokens.weight)
+            self.lm_head = torch.nn.Linear(1, 1)
+
+        # Skip the first layer's input_layernorm:
+        # https://github.com/SafeAILab/EAGLE/blob/35c78f6cdc19a73e05cf5c330b4c358dad970c6a/eagle/model/cnets.py#L427
+        if getattr(self.config, "skip_first_input_layernorm", True):
+            self.model.layers[0].input_layernorm = torch.nn.Identity()
+            self.model.layers[0].layer_communicator.input_layernorm = (
+                torch.nn.Identity()
+            )
+
+        # Eagle-2 does not normalize model output by default
+        if getattr(self.config, "skip_output_norm", True):
+            self.model.norm = FusedResidualIdentity()
+
+        # Add the fully connected layer:
+        # https://github.com/SafeAILab/EAGLE/blob/35c78f6cdc19a73e05cf5c330b4c358dad970c6a/eagle/model/cnets.py#L511
+        self.model.eagle_fc = torch.nn.Linear(
+            2 * self.config.hidden_size, self.config.hidden_size
+        )
+
+        # wrap Qwen3 forward to be pass through the eagle_fc layer:
+        self.model.forward = partial(
+            self.wrap_forward, self.model, origin_forward=self.model.forward
+        )
+
+    @staticmethod
+    def wrap_forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        **kwargs
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+
+        origin_forward = kwargs.pop("origin_forward", None)
+        assert origin_forward is not None
+
+        if self.pp_group.is_first_rank:
+            if input_embeds is None:
+                hidden_states = self.embed_tokens(input_ids)
+            else:
+                hidden_states = input_embeds
+
+            prev_states = forward_batch.spec_info.hidden_states
+            hidden_states = self.eagle_fc(
+                torch.cat((hidden_states, prev_states), dim=-1)
+            )
+        else:
+            assert "pp_proxy_tensors" in kwargs
+
+        return origin_forward(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=hidden_states,
+            **kwargs
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        weights = [(add_prefix(k, "model"), v) for k, v in weights]
+        print([w[0] for w in weights])
+        print([k for k, v in self.named_parameters()])
+        super().load_weights(weights)
+
+
+EntryClass = [Qwen3ForCausalLMEagle]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
SImilar PR: https://github.com/sgl-project/sglang/pull/2863

Although eagle-3 generally achieves higher speedups, eagle-2 requires far less training time. Adding eagle-2 to recent models could remain beneficial.

For example:
* When accelerating customized small models in resource-constrained environments.
  For eagle (v1/v2) to train a 7B model, a single RTX 3090 with 24GiB of CUDA memory is sufficient (ref: https://arxiv.org/pdf/2401.15077), and 8x less training data is used compared to eagle-3 official checkpoints.
* And in research, this can be used as a baseline option to compare speculative algorithms in batched serving scenarios.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
A single dense qwen3 version for now, but I am open to further adding eagle for qwen-moe if you want.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
On a RTX 5070 Ti (sm120a)
```sh
python -m sglang.launch_server \
  --model Qwen/Qwen3-4B-Instruct-2507 \
  --speculative-algo EAGLE  \
  --speculative-draft-model-path w32zhong/sglang-EAGLE-Qwen3-4B-Instruct-2507 \
  --speculative-num-steps 6 \
  --speculative-eagle-topk 10 \
  --speculative-num-draft-tokens 60 \
  --mem-fraction 0.7 \
  --disable-cuda-graph # for faster test
```

```sh
python bench_sglang_eagle.py --parallel 1 --num-questions 80
```
```
#questions: 80, Throughput: 87.15 token/s, Acceptance length: 3.08
```
I don't see an official eagle(v1/v2) draft model for Qwen3, but the accept length should be valid since this checkpoint was trained using a prototype framework that has been verified to align with the official EAGLE + LLaMA-2 accept length. (I’m ok to transfer [this test checkpoint](https://huggingface.co/w32zhong/sglang-EAGLE-Qwen3-4B-Instruct-2507) to lmsys if needed)

On a RTX 4070 TiS (sm89), here are some more comprehensive results with CUDA graph **on/off**:

| accept length | bs=1, tree=6,10,60 | bs=4, tree=6,10,60 |
|:-------------------------:|:----------------:|:----------------:|
| 3.07              | 98.79/90.74      | 236.35/225.97    |

| accept length | bs=1, tree=3,1,4 | bs=4, tree=3,1,4 | bs=8, tree=3,1,4 |
|:------------------:|:--------------:|:--------------:|:--------------:|
| 1.96               | 90.04/73.14    | 316.89/272.38  | 504.65/476.0   |

## Benchmarking and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
