### PR TITLE
[router][grpc] Remove `continue_final_message` in `ChatTemplateParams` and add `minijinja-contrib`

### DIFF
--- a/sgl-router/Cargo.toml
+++ b/sgl-router/Cargo.toml
@@ -64,6 +64,7 @@ anyhow = "1.0"
 tokenizers = { version = "0.22.0" }
 tiktoken-rs = { version = "0.7.0" }
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins"] }
+minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 hf-hub = { version = "0.4.3", features = ["tokio"] }
 rmcp = { version = "0.6.3", features = ["client", "server",

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -382,7 +382,6 @@ pub fn process_chat_messages(
 
         let params = ChatTemplateParams {
             add_generation_prompt: true,
-            continue_final_message: request.continue_final_message,
             tools: tools_json.as_deref(),
             template_kwargs: final_template_kwargs,
             ..Default::default()

--- a/sgl-router/src/tokenizer/chat_template.rs
+++ b/sgl-router/src/tokenizer/chat_template.rs
@@ -350,7 +350,6 @@ fn detect_format_with_ast(template: &str) -> Option<ChatTemplateContentFormat> {
 #[derive(Default)]
 pub struct ChatTemplateParams<'a> {
     pub add_generation_prompt: bool,
-    pub continue_final_message: bool,
     pub tools: Option<&'a [serde_json::Value]>,
     pub documents: Option<&'a [serde_json::Value]>,
     pub template_kwargs: Option<&'a HashMap<String, serde_json::Value>>,
@@ -377,10 +376,6 @@ impl ChatTemplateProcessor {
         messages: &[serde_json::Value],
         params: ChatTemplateParams,
     ) -> Result<String> {
-        // Validate incompatible options
-        if params.continue_final_message && params.add_generation_prompt {
-            return Err(anyhow!("continue_final_message and add_generation_prompt are not compatible. Use continue_final_message when you want the model to continue the final message, and add_generation_prompt when you want to add a header that will prompt it to start a new assistant message instead."));
-        }
         let mut env = Environment::new();
 
         // Register the template

--- a/sgl-router/src/tokenizer/chat_template.rs
+++ b/sgl-router/src/tokenizer/chat_template.rs
@@ -3,12 +3,16 @@
 //! This module provides functionality to apply chat templates to messages,
 //! similar to HuggingFace transformers' apply_chat_template method.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fs};
 
 use anyhow::{anyhow, Result};
 use minijinja::{
     context,
-    machinery::ast::{Expr, Stmt},
+    machinery::{
+        ast::{Expr, Stmt},
+        parse, WhitespaceConfig,
+    },
+    syntax::SyntaxConfig,
     Environment, Value,
 };
 use serde_json;
@@ -323,11 +327,6 @@ impl<'a> Detector<'a> {
 /// AST-based detection using minijinja's unstable machinery
 /// Single-pass detector with scope tracking
 fn detect_format_with_ast(template: &str) -> Option<ChatTemplateContentFormat> {
-    use minijinja::{
-        machinery::{parse, WhitespaceConfig},
-        syntax::SyntaxConfig,
-    };
-
     let ast = match parse(
         template,
         "template",
@@ -382,6 +381,9 @@ impl ChatTemplateProcessor {
         env.add_template("chat", &self.template)
             .map_err(|e| anyhow!("Failed to add template: {}", e))?;
 
+        // Enable Python method compatibility (e.g., str.startswith, str.endswith)
+        env.set_unknown_method_callback(minijinja_contrib::pycompat::unknown_method_callback);
+
         // Get the template
         let tmpl = env
             .get_template("chat")
@@ -418,8 +420,6 @@ impl ChatTemplateProcessor {
 
 /// Load chat template from tokenizer config JSON
 pub fn load_chat_template_from_config(config_path: &str) -> Result<Option<String>> {
-    use std::fs;
-
     let content = fs::read_to_string(config_path)?;
     let config: serde_json::Value = serde_json::from_str(&content)?;
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix grpc /v1/chat/completions when user passes `continue_final_message: True`
Fix unknown method in chat template rendering when using `Qwen/Qwen3-30B-A3B`

## Modifications

<!-- Detail the changes made in this pull request. -->
- `apply_chat_template` doesn't need `continue_final_message`. It is only used for chat messages processing.
- `startswith` is a python string method, minijinja supports that in `minijinja-contrib::pycompat`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

<img width="1008" height="354" alt="Screenshot 2025-10-20 at 5 47 21 PM" src="https://github.com/user-attachments/assets/43e0120d-3428-418f-8a2a-1ddaffad0213" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
