### PR TITLE
[overlap-spec] remove draft_extend_v2 & don't capture draft extend on spec v2

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -256,6 +256,10 @@ class LogitsProcessor(nn.Module):
             get_global_server_args().debug_tensor_dump_output_folder
         )
 
+        self.enable_overlap_schedule = (
+            not get_global_server_args().disable_overlap_schedule
+        )
+
     def compute_logprobs_for_multi_item_scoring(
         self,
         input_ids,
@@ -380,7 +384,10 @@ class LogitsProcessor(nn.Module):
         if (
             logits_metadata.forward_mode.is_decode_or_idle()
             or logits_metadata.forward_mode.is_target_verify()
-            or logits_metadata.forward_mode.is_draft_extend_v2()
+            or (
+                logits_metadata.forward_mode.is_draft_extend()
+                and self.enable_overlap_schedule
+            )
         ):
             pruned_states = hidden_states
             if aux_hidden_states is not None:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -76,8 +76,6 @@ class ForwardMode(IntEnum):
     # Used in speculative decoding: extend a batch in the draft model.
     DRAFT_EXTEND = auto()
 
-    DRAFT_EXTEND_V2 = auto()
-
     # Split Prefill for PD multiplexing
     SPLIT_PREFILL = auto()
 
@@ -109,10 +107,6 @@ class ForwardMode(IntEnum):
 
     def is_draft_extend(self):
         return self == ForwardMode.DRAFT_EXTEND
-
-    def is_draft_extend_v2(self):
-        # For fixed shape logits output in v2 eagle worker
-        return self == ForwardMode.DRAFT_EXTEND_V2
 
     def is_extend_or_draft_extend_or_mixed(self):
         return (

--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -181,7 +181,7 @@ class EagleDraftInputV2Mixin:
         batch.extend_prefix_lens = seq_lens_cpu_.tolist()
         batch.extend_num_tokens = extend_num_tokens
         batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        batch.forward_mode = ForwardMode.DRAFT_EXTEND_V2
+        batch.forward_mode = ForwardMode.DRAFT_EXTEND
         forward_batch = ForwardBatch.init_new(batch, draft_model_runner)
         draft_model_runner.attn_backend.init_forward_metadata(forward_batch)
         return forward_batch

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -17,9 +17,6 @@ from sglang.srt.speculative.draft_utils import DraftBackendFactory
 from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
     EAGLEDraftCudaGraphRunner,
 )
-from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
-    EAGLEDraftExtendCudaGraphRunner,
-)
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.eagle_info_v2 import (
     assign_extend_cache_locs,
@@ -222,19 +219,10 @@ class EagleDraftWorker(BaseDraftWorker):
                 f"Capture draft cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
             )
 
-        # Capture extend
+        # TODO: add draft extend cuda graph support
         if self.draft_extend_attn_backend:
-            tic = time.perf_counter()
-            before_mem = get_available_gpu_memory(self.device, self.gpu_id)
-            logger.info(
-                f"Capture draft extend cuda graph begin. This can take up to several minutes. avail mem={before_mem:.2f} GB"
-            )
-            self.cuda_graph_runner_for_draft_extend = EAGLEDraftExtendCudaGraphRunner(
-                self
-            )
-            after_mem = get_available_gpu_memory(self.device, self.gpu_id)
-            logger.info(
-                f"Capture draft extend cuda graph end. Time elapsed: {time.perf_counter() - tic:.2f} s. mem usage={(before_mem - after_mem):.2f} GB. avail mem={after_mem:.2f} GB."
+            logger.warning(
+                "Draft extend cuda graph is not supported yet. Running draft extend without cuda graph."
             )
 
     def draft(self, model_worker_batch: ModelWorkerBatch):


### PR DESCRIPTION
When modifying the internal attention backend, the introduction of draft_extend_v2 has made things slightly messy.

The Triton attention backend and logits here enable spec overlap, and the behavior of draft_extend changing seems to be a rare occurrence.
More often, the original draft extend logic is reused.

Perhaps using the original draft_extend + enabling the overlap scheduler for runtime decisions would be clearer?