### PR TITLE
[router][grpc] Fix wram-up random token ids for small models

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -1001,7 +1001,15 @@ def _execute_grpc_server_warmup(
             warmup_request_kwargs = {
                 "request_id": f"WARMUP_{time.time()}",
                 "tokenized": sglang_scheduler_pb2.TokenizedInput(
-                    input_ids=[123, 456, 789, 234, 567, 890, 345],  # Random-looking but safe token IDs
+                    input_ids=[
+                        123,
+                        456,
+                        789,
+                        234,
+                        567,
+                        890,
+                        345,
+                    ],  # Random-looking but safe token IDs
                     original_text="warmup request",
                 ),
                 "sampling_params": sglang_scheduler_pb2.SamplingParams(

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -998,20 +998,11 @@ def _execute_grpc_server_warmup(
         max_new_tokens = 8 if is_generation else 1
 
         if is_generation:
-            # Create tokenized input for warmup
             warmup_request_kwargs = {
                 "request_id": f"WARMUP_{time.time()}",
                 "tokenized": sglang_scheduler_pb2.TokenizedInput(
-                    input_ids=[
-                        954,
-                        15541,
-                        2181,
-                        23496,
-                        1476,
-                        64710,
-                        280,
-                    ],  # Simple token sequence
-                    original_text="The capital city of France is",
+                    input_ids=[123, 456, 789, 234, 567, 890, 345],  # Random-looking but safe token IDs
+                    original_text="warmup request",
                 ),
                 "sampling_params": sglang_scheduler_pb2.SamplingParams(
                     temperature=0.0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
For small models, which have very short context length, having a token id with `64710` will cause the server to crash.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Fix random token ids in warm up thread to a smaller range.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
