### PR TITLE
Fix cache_tokens caculate issue when retracted

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -539,6 +539,8 @@ class Req:
 
         # For retraction
         self.is_retracted = False
+        # indicate the req ever been retracted
+        self.has_retracted = False
 
         # Incremental streamining
         self.send_token_offset: int = 0
@@ -876,6 +878,7 @@ class Req:
         self.swa_uuid_for_lock = None
         self.extend_input_len = 0
         self.is_retracted = True
+        self.has_retracted = True
         self.input_token_logprobs = None
         self.temp_input_top_logprobs_val = None
         self.temp_input_top_logprobs_idx = None
@@ -1233,8 +1236,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
             multimodal_inputs.append(req.multimodal_inputs)
 
-            req.cached_tokens += pre_len - req.already_computed
-            req.already_computed = seq_len
+            # Only caculate cached_tokens once, once retracted, the 'has_retracted'
+            # flag will always True
+            if req.has_retracted is False:
+                req.cached_tokens += pre_len - req.already_computed
+                req.already_computed = seq_len
             req.is_retracted = False
 
             # Compute the relative logprob_start_len in an extend batch


### PR DESCRIPTION
When retracted happens, cache_tokens may greater than prompt tokens, just like:

\'meta_info\': {\'id\': \'21b1cabf17607522173946331ee5e9_d71b9220\',
\'finish_reason\': {\'type\': \'stop\', \'matched\': 156892},
\'prompt_tokens\': 59946, \'weight_version\': \'default\',
\'completion_tokens\': 7437, \'cached_tokens\': 122884,
\'e2e_latency\': 791.9391989707947,
\'ttft_latency\': 13.77153491973877,
\'queue_latency\': 0.0010406021028757095}}'

This patch fix this issue, Do not caculate the cached_tokens when retracted prefill.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
