### PR TITLE
[CI] disable glm4.1v and fix the flashinfer installation

### DIFF
--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -34,7 +34,7 @@ else
     export UV_SYSTEM_PYTHON=true
 
     PIP_CMD="uv pip"
-    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match"
+    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match --prerelease=allow"
 
     # Clean up existing installations
     $PIP_CMD uninstall flashinfer_python sgl-kernel sglang vllm || true

--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -40,11 +40,14 @@ else
     $PIP_CMD uninstall flashinfer_python sgl-kernel sglang vllm || true
 fi
 
+# Install the main package without deps
+$PIP_CMD install -e "python[dev]" --no-deps $PIP_INSTALL_SUFFIX --force-reinstall
+
 # Install flashinfer-python 0.4.0 dependency that requires prerelease (This should be removed when flashinfer fixes this issue)
-$PIP_CMD install flashinfer-python --prerelease=allow $PIP_INSTALL_SUFFIX --force-reinstall
+$PIP_CMD install flashinfer-python==0.4.0 --prerelease=allow $PIP_INSTALL_SUFFIX
 
 # Install the main package
-$PIP_CMD install -e "python[dev]" --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX --force-reinstall
+$PIP_CMD install -e "python[dev]" --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX --upgrade
 
 # Install router for pd-disagg test
 SGLANG_ROUTER_BUILD_NO_RUST=1 $PIP_CMD install -e "sgl-router" $PIP_INSTALL_SUFFIX

--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -34,7 +34,7 @@ else
     export UV_SYSTEM_PYTHON=true
 
     PIP_CMD="uv pip"
-    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match --prerelease=allow"
+    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match"
 
     # Clean up existing installations
     $PIP_CMD uninstall flashinfer_python sgl-kernel sglang vllm || true

--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -41,7 +41,7 @@ else
 fi
 
 # Install flashinfer-python 0.4.0 dependency that requires prerelease (This should be removed when flashinfer fixes this issue)
-$PIP_CMD install apache-tvm-ffi==0.1.0b15 --prerelease=allow $PIP_INSTALL_SUFFIX
+$PIP_CMD install flashinfer-python --prerelease=allow $PIP_INSTALL_SUFFIX --force-reinstall
 
 # Install the main package
 $PIP_CMD install -e "python[dev]" --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX --force-reinstall

--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -62,7 +62,10 @@ fi
 $PIP_CMD list
 
 # Install additional dependencies
-$PIP_CMD install apache-tvm-ffi==0.1.0b15 mooncake-transfer-engine==0.3.6.post1 nvidia-cuda-nvrtc-cu12 py-spy scipy huggingface_hub[hf_xet] $PIP_INSTALL_SUFFIX
+$PIP_CMD install mooncake-transfer-engine==0.3.6.post1 nvidia-cuda-nvrtc-cu12 py-spy scipy huggingface_hub[hf_xet] $PIP_INSTALL_SUFFIX
+
+# Install flashinfer-python 0.4.0 dependency that requires prerelease (This should be removed when flashinfer fixes this issue)
+$PIP_CMD install apache-tvm-ffi==0.1.0b15 --prerelease=allow $PIP_INSTALL_SUFFIX
 
 if [ "$IS_BLACKWELL" != "1" ]; then
     # For lmms_evals evaluating MMMU

--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -40,6 +40,9 @@ else
     $PIP_CMD uninstall flashinfer_python sgl-kernel sglang vllm || true
 fi
 
+# Install flashinfer-python 0.4.0 dependency that requires prerelease (This should be removed when flashinfer fixes this issue)
+$PIP_CMD install apache-tvm-ffi==0.1.0b15 --prerelease=allow $PIP_INSTALL_SUFFIX
+
 # Install the main package
 $PIP_CMD install -e "python[dev]" --extra-index-url https://download.pytorch.org/whl/${CU_VERSION} $PIP_INSTALL_SUFFIX --force-reinstall
 
@@ -63,9 +66,6 @@ $PIP_CMD list
 
 # Install additional dependencies
 $PIP_CMD install mooncake-transfer-engine==0.3.6.post1 nvidia-cuda-nvrtc-cu12 py-spy scipy huggingface_hub[hf_xet] $PIP_INSTALL_SUFFIX
-
-# Install flashinfer-python 0.4.0 dependency that requires prerelease (This should be removed when flashinfer fixes this issue)
-$PIP_CMD install apache-tvm-ffi==0.1.0b15 --prerelease=allow $PIP_INSTALL_SUFFIX
 
 if [ "$IS_BLACKWELL" != "1" ]; then
     # For lmms_evals evaluating MMMU

--- a/scripts/ci/ci_install_dependency.sh
+++ b/scripts/ci/ci_install_dependency.sh
@@ -34,7 +34,7 @@ else
     export UV_SYSTEM_PYTHON=true
 
     PIP_CMD="uv pip"
-    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match --prerelease=allow"
+    PIP_INSTALL_SUFFIX="--index-strategy unsafe-best-match"
 
     # Clean up existing installations
     $PIP_CMD uninstall flashinfer_python sgl-kernel sglang vllm || true
@@ -62,7 +62,7 @@ fi
 $PIP_CMD list
 
 # Install additional dependencies
-$PIP_CMD install mooncake-transfer-engine==0.3.6.post1 nvidia-cuda-nvrtc-cu12 py-spy scipy huggingface_hub[hf_xet] $PIP_INSTALL_SUFFIX
+$PIP_CMD install apache-tvm-ffi==0.1.0b15 mooncake-transfer-engine==0.3.6.post1 nvidia-cuda-nvrtc-cu12 py-spy scipy huggingface_hub[hf_xet] $PIP_INSTALL_SUFFIX
 
 if [ "$IS_BLACKWELL" != "1" ]; then
     # For lmms_evals evaluating MMMU

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -133,7 +133,7 @@ suites = {
         TestFile("test_triton_sliding_window.py", 250),
         TestFile("test_utils_update_weights.py", 48),
         TestFile("test_vision_chunked_prefill.py", 175),
-        TestFile("test_vision_openai_server_a.py", 608),
+        TestFile("test_vision_openai_server_a.py", 918),
         TestFile("test_vlm_input_format.py", 300),
     ],
     "per-commit-2-gpu": [

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -136,11 +136,11 @@ class TestKimiVLServer(ImageOpenAITestMixin):
         pass
 
 
-# class TestGLM41VServer(ImageOpenAITestMixin, VideoOpenAITestMixin):
-#     model = "zai-org/GLM-4.1V-9B-Thinking"
-#     extra_args = [
-#         "--reasoning-parser=glm45",
-#     ]
+class TestGLM41VServer(ImageOpenAITestMixin, VideoOpenAITestMixin):
+    model = "zai-org/GLM-4.1V-9B-Thinking"
+    extra_args = [
+        "--reasoning-parser=glm45",
+    ]
 
 
 class TestQwen2AudioServer(AudioOpenAITestMixin):

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -136,7 +136,9 @@ class TestKimiVLServer(ImageOpenAITestMixin):
         pass
 
 
-@unittest.skip("Temporarily disabling this test to fix CI. It should be re-enabled when #11800 is done.")
+@unittest.skip(
+    "Temporarily disabling this test to fix CI. It should be re-enabled when #11800 is done."
+)
 class TestGLM41VServer(ImageOpenAITestMixin, VideoOpenAITestMixin):
     model = "zai-org/GLM-4.1V-9B-Thinking"
     extra_args = [

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -136,6 +136,7 @@ class TestKimiVLServer(ImageOpenAITestMixin):
         pass
 
 
+@unittest.skip("Temporarily disabling this test to fix CI. It should be re-enabled when #11800 is done.")
 class TestGLM41VServer(ImageOpenAITestMixin, VideoOpenAITestMixin):
     model = "zai-org/GLM-4.1V-9B-Thinking"
     extra_args = [

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -136,11 +136,11 @@ class TestKimiVLServer(ImageOpenAITestMixin):
         pass
 
 
-class TestGLM41VServer(ImageOpenAITestMixin, VideoOpenAITestMixin):
-    model = "zai-org/GLM-4.1V-9B-Thinking"
-    extra_args = [
-        "--reasoning-parser=glm45",
-    ]
+# class TestGLM41VServer(ImageOpenAITestMixin, VideoOpenAITestMixin):
+#     model = "zai-org/GLM-4.1V-9B-Thinking"
+#     extra_args = [
+#         "--reasoning-parser=glm45",
+#     ]
 
 
 class TestQwen2AudioServer(AudioOpenAITestMixin):

--- a/test/srt/test_vision_openai_server_common.py
+++ b/test/srt/test_vision_openai_server_common.py
@@ -191,6 +191,7 @@ class ImageOpenAITestMixin(TestOpenAIMLLMServerBase):
                 {"role": "user", "content": content},
             ],
             temperature=0,
+            max_tokens=128,
             **(self.get_vision_request_kwargs()),
         )
 

--- a/test/srt/test_vision_openai_server_common.py
+++ b/test/srt/test_vision_openai_server_common.py
@@ -191,7 +191,6 @@ class ImageOpenAITestMixin(TestOpenAIMLLMServerBase):
                 {"role": "user", "content": content},
             ],
             temperature=0,
-            max_tokens=128,
             **(self.get_vision_request_kwargs()),
         )
 


### PR DESCRIPTION
As flashinfer uses the beta version of `apache-tvm-ffi==0.1.0b15`, CI is broken without `--prerelease=allow`. The previous PR #11895 enabled pre-release for all packages, which is not expected. This PR uses a hacky way to only install `flashinfer` with `--prerelease=allow` and keep other packages the same.

cc @zihaoye 