### PR TITLE
[WIP] [Router] Enable gRPC routers in IGW mode with automatic service discovery

### DIFF
--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -209,20 +209,44 @@ impl RouterManager {
     }
 
     pub fn get_router_for_model(&self, model_id: &str) -> Option<Arc<dyn RouterTrait>> {
+        // Use core::ConnectionMode locally to distinguish from config::ConnectionMode
+        use crate::core::ConnectionMode as ConnectionMode;
+
         let workers = self.worker_registry.get_by_model(model_id);
 
-        if !workers.is_empty() {
-            let has_pd_workers = workers.iter().any(|w| {
+        // Separate workers by connection mode
+        let http_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Http))
+            .collect();
+
+        let grpc_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Grpc { .. }))
+            .collect();
+
+        // Prefer gRPC if available; otherwise fall back to HTTP
+        let (selected_workers, connection_mode) = if !grpc_workers.is_empty() {
+            (grpc_workers, ConnectionMode::Grpc { port: None })
+        } else {
+            (http_workers, ConnectionMode::Http)
+        };
+
+        if !selected_workers.is_empty() {
+            // Check if selected workers are PD type
+            let has_pd_workers = selected_workers.iter().any(|w| {
                 matches!(
                     w.worker_type(),
                     WorkerType::Prefill { .. } | WorkerType::Decode
                 )
             });
 
-            let router_id = if has_pd_workers {
-                RouterId::new("http-pd".to_string())
-            } else {
-                RouterId::new("http-regular".to_string())
+            // Construct router ID based on connection mode and worker type
+            let router_id = match (connection_mode, has_pd_workers) {
+                (ConnectionMode::Http, true) => RouterId::new("http-pd".to_string()),
+                (ConnectionMode::Http, false) => RouterId::new("http-regular".to_string()),
+                (ConnectionMode::Grpc { .. }, true) => RouterId::new("grpc-pd".to_string()),
+                (ConnectionMode::Grpc { .. }, false) => RouterId::new("grpc-regular".to_string()),
             };
 
             if let Some(router) = self.routers.get(&router_id) {

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -107,7 +107,36 @@ impl RouterManager {
                 }
             }
 
-            // TODO: Add gRPC routers once we have dynamic tokenizer loading
+            match RouterFactory::create_grpc_router(app_context).await {
+                Ok(grpc_regular) => {
+                    info!("Created gRPC Regular router");
+                    manager.register_router(
+                        RouterId::new("grpc-regular".to_string()),
+                        Arc::from(grpc_regular),
+                    );
+                }
+                Err(e) => {
+                    warn!("Failed to create gRPC Regular router: {e}");
+                }
+            }
+
+            match RouterFactory::create_grpc_pd_router(
+                None,
+                None,
+                &config.router_config.policy,
+                app_context,
+            )
+            .await
+            {
+                Ok(grpc_pd) => {
+                    info!("Created gRPC PD router");
+                    manager
+                        .register_router(RouterId::new("grpc-pd".to_string()), Arc::from(grpc_pd));
+                }
+                Err(e) => {
+                    warn!("Failed to create gRPC PD router: {e}");
+                }
+            }
 
             info!(
                 "RouterManager initialized with {} routers for multi-router mode",

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -797,7 +797,7 @@ pub fn build_app(
         .with_state(app_state)
 }
 
-pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn startup(mut config: ServerConfig) -> Result<(), Box<dyn std::error::Error>> {
     static LOGGING_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
     let _log_guard = if !LOGGING_INITIALIZED.swap(true, Ordering::SeqCst) {
@@ -825,6 +825,20 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
 
     if let Some(prometheus_config) = &config.prometheus_config {
         metrics::start_prometheus(prometheus_config.clone());
+    }
+
+    // Auto-enable IGW mode when service discovery is enabled
+    // This ensures all router types (HTTP/gRPC, Regular/PD) are available to handle
+    // dynamically discovered workers whose protocols and modes are not known in advance
+    if let Some(ref sd_config) = config.service_discovery_config {
+        if sd_config.enabled && !config.router_config.enable_igw {
+            info!(
+                "Automatically enabling IGW mode because service discovery is enabled. \
+                IGW mode spins up all router types (HTTP/gRPC, Regular/PD) to handle any workers \
+                that may be dynamically discovered, since their protocols and modes are not known in advance."
+            );
+            config.router_config.enable_igw = true;
+        }
     }
 
     info!(

--- a/sgl-router/src/service_discovery.rs
+++ b/sgl-router/src/service_discovery.rs
@@ -161,8 +161,8 @@ impl PodInfo {
     }
 
     pub fn worker_url(&self, port: u16) -> String {
-        // Default to http:// prefix; workflow will detect actual protocol (HTTP vs gRPC)
-        format!("http://{}:{}", self.ip, port)
+        // Default to ip:port with no prefix; workflow will detect actual protocol (HTTP vs gRPC)
+        format!("{}:{}", self.ip, port)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR enables gRPC router support in IGW mode and adds automatic IGW mode enablement when service discovery is active. The changes ensure that routers can handle both HTTP and gRPC connections, preferring gRPC when available.

### Key Changes

1. **gRPC Router Creation**: Created and registered both gRPC Regular and gRPC PD (Prefill-Decode) routers alongside existing HTTP routers in IGW mode
   - Added gRPC Regular router registration in `router_manager.rs:110-120`
   - Added gRPC PD router registration in `router_manager.rs:122-137`

2. **Smart Router Selection**: Enhanced `get_router_for_model()` to intelligently select routers based on worker connection mode
   - Separates workers by connection mode (HTTP vs gRPC)
   - Prefers gRPC routers when gRPC workers are available, falls back to HTTP
   - Constructs appropriate router IDs based on connection mode and worker type (Regular vs PD)

3. **Auto-enable IGW Mode**: Automatically enables IGW mode when service discovery is enabled
   - Ensures all router types are available to handle dynamically discovered workers
   - Prevents configuration errors where service discovery finds workers but routers aren't available

4. **Worker URL Format**: Updated worker URL generation to use bare `ip:port` format instead of `http://` prefix
   - Allows protocol detection workflow to determine actual protocol (HTTP vs gRPC)
   - Avoids hardcoding HTTP assumption

### Files Modified

- `sgl-router/src/routers/router_manager.rs`: +67 lines (gRPC router creation and smart selection logic)
- `sgl-router/src/server.rs`: +16 lines (auto-enable IGW mode)
- `sgl-router/src/service_discovery.rs`: +4 lines (worker URL format)

### Testing

- [ ] Test with HTTP-only workers
- [ ] Test with gRPC-only workers
- [ ] Test with mixed HTTP and gRPC workers
- [ ] Test service discovery with IGW auto-enablement
- [ ] Test router selection logic

**Note**: This is a work in progress. Additional testing and validation needed before merge.