### PR TITLE
[Router] Consolidate ConnectionMode enum to core module

### DIFF
--- a/sgl-router/src/config/types.rs
+++ b/sgl-router/src/config/types.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use super::ConfigResult;
+use crate::core::ConnectionMode;
 
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,16 +207,6 @@ impl std::fmt::Debug for OracleConfig {
             .field("pool_timeout_secs", &self.pool_timeout_secs)
             .finish()
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-#[serde(tag = "type")]
-pub enum ConnectionMode {
-    #[default]
-    #[serde(rename = "http")]
-    Http,
-    #[serde(rename = "grpc")]
-    Grpc,
 }
 
 /// Routing mode configuration

--- a/sgl-router/src/config/validation.rs
+++ b/sgl-router/src/config/validation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::ConnectionMode;
 
 /// Configuration validator
 pub struct ConfigValidator;
@@ -476,7 +477,7 @@ impl ConfigValidator {
         }
 
         // Validate gRPC connection mode requires tokenizer configuration
-        if config.connection_mode == ConnectionMode::Grpc
+        if matches!(config.connection_mode, ConnectionMode::Grpc { .. })
             && config.tokenizer_path.is_none()
             && config.model_path.is_none()
         {
@@ -832,7 +833,7 @@ mod tests {
         );
 
         // Set connection mode to gRPC without tokenizer config
-        config.connection_mode = ConnectionMode::Grpc;
+        config.connection_mode = ConnectionMode::Grpc { port: None };
         config.tokenizer_path = None;
         config.model_path = None;
 
@@ -852,7 +853,7 @@ mod tests {
             PolicyConfig::Random,
         );
 
-        config.connection_mode = ConnectionMode::Grpc;
+        config.connection_mode = ConnectionMode::Grpc { port: None };
         config.model_path = Some("meta-llama/Llama-3-8B".to_string());
 
         let result = ConfigValidator::validate(&config);
@@ -868,7 +869,7 @@ mod tests {
             PolicyConfig::Random,
         );
 
-        config.connection_mode = ConnectionMode::Grpc;
+        config.connection_mode = ConnectionMode::Grpc { port: None };
         config.tokenizer_path = Some("/path/to/tokenizer.json".to_string());
 
         let result = ConfigValidator::validate(&config);

--- a/sgl-router/src/core/worker.rs
+++ b/sgl-router/src/core/worker.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use serde_json;
 use tokio::{sync::RwLock, time};
 
@@ -240,13 +241,17 @@ pub trait Worker: Send + Sync + fmt::Debug {
 }
 
 /// Connection mode for worker communication
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum ConnectionMode {
     /// HTTP/REST connection
+    #[default]
     Http,
     /// gRPC connection
     Grpc {
         /// Optional port for gRPC endpoint (if different from URL)
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
         port: Option<u16>,
     },
 }

--- a/sgl-router/src/lib.rs
+++ b/sgl-router/src/lib.rs
@@ -194,7 +194,7 @@ struct Router {
     queue_size: usize,
     queue_timeout_secs: u64,
     rate_limit_tokens_per_second: Option<i32>,
-    connection_mode: config::ConnectionMode,
+    connection_mode: core::ConnectionMode,
     model_path: Option<String>,
     tokenizer_path: Option<String>,
     chat_template: Option<String>,
@@ -211,13 +211,13 @@ struct Router {
 
 impl Router {
     /// Determine connection mode from worker URLs
-    fn determine_connection_mode(worker_urls: &[String]) -> config::ConnectionMode {
+    fn determine_connection_mode(worker_urls: &[String]) -> core::ConnectionMode {
         for url in worker_urls {
             if url.starts_with("grpc://") || url.starts_with("grpcs://") {
-                return config::ConnectionMode::Grpc;
+                return core::ConnectionMode::Grpc { port: None };
             }
         }
-        config::ConnectionMode::Http
+        core::ConnectionMode::Http
     }
 
     pub fn to_router_config(&self) -> config::ConfigResult<config::RouterConfig> {

--- a/sgl-router/src/main.rs
+++ b/sgl-router/src/main.rs
@@ -3,10 +3,11 @@ use std::collections::HashMap;
 use clap::{ArgAction, Parser, ValueEnum};
 use sglang_router_rs::{
     config::{
-        CircuitBreakerConfig, ConfigError, ConfigResult, ConnectionMode, DiscoveryConfig,
-        HealthCheckConfig, HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig,
-        RouterConfig, RoutingMode, TokenizerCacheConfig,
+        CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
+        HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig, RouterConfig,
+        RoutingMode, TokenizerCacheConfig,
     },
+    core::ConnectionMode,
     metrics::PrometheusConfig,
     server::{self, ServerConfig},
     service_discovery::ServiceDiscoveryConfig,
@@ -325,7 +326,7 @@ impl CliArgs {
     fn determine_connection_mode(worker_urls: &[String]) -> ConnectionMode {
         for url in worker_urls {
             if url.starts_with("grpc://") || url.starts_with("grpcs://") {
-                return ConnectionMode::Grpc;
+                return ConnectionMode::Grpc { port: None };
             }
         }
         ConnectionMode::Http

--- a/sgl-router/src/routers/factory.rs
+++ b/sgl-router/src/routers/factory.rs
@@ -9,7 +9,8 @@ use super::{
     RouterTrait,
 };
 use crate::{
-    config::{ConnectionMode, PolicyConfig, RoutingMode},
+    config::{PolicyConfig, RoutingMode},
+    core::ConnectionMode,
     policies::PolicyFactory,
     server::AppContext,
 };
@@ -21,7 +22,7 @@ impl RouterFactory {
     /// Create a router instance from application context
     pub async fn create_router(ctx: &Arc<AppContext>) -> Result<Box<dyn RouterTrait>, String> {
         match ctx.router_config.connection_mode {
-            ConnectionMode::Grpc => match &ctx.router_config.mode {
+            ConnectionMode::Grpc { .. } => match &ctx.router_config.mode {
                 RoutingMode::Regular { .. } => Self::create_grpc_router(ctx).await,
                 RoutingMode::PrefillDecode {
                     prefill_policy,

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -18,8 +18,8 @@ use serde_json::Value;
 use tracing::{debug, info, warn};
 
 use crate::{
-    config::{ConnectionMode, RoutingMode},
-    core::{WorkerRegistry, WorkerType},
+    config::RoutingMode,
+    core::{ConnectionMode, WorkerRegistry, WorkerType},
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
@@ -148,13 +148,13 @@ impl RouterManager {
             (ConnectionMode::Http, RoutingMode::OpenAI { .. }) => {
                 RouterId::new("http-openai".to_string())
             }
-            (ConnectionMode::Grpc, RoutingMode::Regular { .. }) => {
+            (ConnectionMode::Grpc { .. }, RoutingMode::Regular { .. }) => {
                 RouterId::new("grpc-regular".to_string())
             }
-            (ConnectionMode::Grpc, RoutingMode::PrefillDecode { .. }) => {
+            (ConnectionMode::Grpc { .. }, RoutingMode::PrefillDecode { .. }) => {
                 RouterId::new("grpc-pd".to_string())
             }
-            (ConnectionMode::Grpc, RoutingMode::OpenAI { .. }) => {
+            (ConnectionMode::Grpc { .. }, RoutingMode::OpenAI { .. }) => {
                 RouterId::new("grpc-regular".to_string())
             }
         }

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -20,14 +20,15 @@ use tokio::{net::TcpListener, signal, spawn};
 use tracing::{error, info, warn, Level};
 
 use crate::{
-    config::{ConnectionMode, HistoryBackend, RouterConfig, RoutingMode},
+    config::{HistoryBackend, RouterConfig, RoutingMode},
     core::{
         worker_to_info,
         workflow::{
             create_worker_registration_workflow, create_worker_removal_workflow, LoggingSubscriber,
             WorkflowEngine,
         },
-        Job, JobQueue, JobQueueConfig, LoadMonitor, WorkerManager, WorkerRegistry, WorkerType,
+        ConnectionMode, Job, JobQueue, JobQueueConfig, LoadMonitor, WorkerManager, WorkerRegistry,
+        WorkerType,
     },
     data_connector::{
         MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
@@ -825,11 +826,10 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     };
 
     // Initialize tokenizer and parser factories for gRPC mode
-    let (tokenizer, reasoning_parser_factory, tool_parser_factory) = if config
-        .router_config
-        .connection_mode
-        == ConnectionMode::Grpc
-    {
+    let (tokenizer, reasoning_parser_factory, tool_parser_factory) = if matches!(
+        config.router_config.connection_mode,
+        ConnectionMode::Grpc { .. }
+    ) {
         let tokenizer_path = config
             .router_config
             .tokenizer_path

--- a/sgl-router/tests/api_endpoints_test.rs
+++ b/sgl-router/tests/api_endpoints_test.rs
@@ -11,10 +11,8 @@ use common::mock_worker::{HealthStatus, MockWorker, MockWorkerConfig, WorkerType
 use reqwest::Client;
 use serde_json::json;
 use sglang_router_rs::{
-    config::{
-        CircuitBreakerConfig, ConnectionMode, PolicyConfig, RetryConfig, RouterConfig, RoutingMode,
-    },
-    core::Job,
+    config::{CircuitBreakerConfig, PolicyConfig, RetryConfig, RouterConfig, RoutingMode},
+    core::{ConnectionMode, Job},
     routers::{RouterFactory, RouterTrait},
     server::AppContext,
 };

--- a/sgl-router/tests/responses_api_test.rs
+++ b/sgl-router/tests/responses_api_test.rs
@@ -16,9 +16,10 @@ use common::{
 };
 use sglang_router_rs::{
     config::{
-        CircuitBreakerConfig, ConnectionMode, HealthCheckConfig, PolicyConfig, RetryConfig,
-        RouterConfig, RoutingMode,
+        CircuitBreakerConfig, HealthCheckConfig, PolicyConfig, RetryConfig, RouterConfig,
+        RoutingMode,
     },
+    core::ConnectionMode,
     routers::RouterFactory,
 };
 

--- a/sgl-router/tests/test_pd_routing.rs
+++ b/sgl-router/tests/test_pd_routing.rs
@@ -2,11 +2,8 @@
 mod test_pd_routing {
     use serde_json::json;
     use sglang_router_rs::{
-        config::{
-            CircuitBreakerConfig, ConnectionMode, PolicyConfig, RetryConfig, RouterConfig,
-            RoutingMode,
-        },
-        core::{BasicWorkerBuilder, Worker, WorkerType},
+        config::{CircuitBreakerConfig, PolicyConfig, RetryConfig, RouterConfig, RoutingMode},
+        core::{BasicWorkerBuilder, ConnectionMode, Worker, WorkerType},
         routers::{http::pd_types::PDSelectionPolicy, RouterFactory},
     };
 


### PR DESCRIPTION
## Summary

Consolidates the `ConnectionMode` enum definition from the configuration layer (`config/types.rs`) to the core domain layer (`core/worker.rs`), eliminating code duplication and improving type safety.

## Motivation

Addresses #11901

Previously, `ConnectionMode` existed in two separate locations:
- `config/types.rs` - Simple enum for configuration serialization
- `core/worker.rs` - Enum with additional fields for worker communication

This duplication required conversion logic and created a maintenance burden. The consolidation establishes a single source of truth and improves the domain model.

## Changes

### Core Changes
- Moved `ConnectionMode` enum from `config/types.rs` to `core/worker.rs`
- Enhanced enum with `Serialize` and `Deserialize` traits for configuration interop
- Changed `Grpc` variant from unit to struct: `Grpc { port: Option<u16> }`
- Removed redundant `convert_connection_mode()` function from `worker_manager.rs`

### Updated Files
- `sgl-router/src/config/types.rs` - Removed ConnectionMode definition
- `sgl-router/src/core/worker.rs` - Added ConnectionMode with serde support
- `sgl-router/src/config/validation.rs` - Updated imports and pattern matching
- `sgl-router/src/core/worker_manager.rs` - Updated imports, removed conversion function
- `sgl-router/src/lib.rs` - Updated imports and return types
- `sgl-router/src/main.rs` - Updated imports
- `sgl-router/src/routers/factory.rs` - Updated imports and pattern matching
- `sgl-router/src/routers/router_manager.rs` - Updated imports and pattern matching
- `sgl-router/src/server.rs` - Updated imports and pattern matching
- Test files updated accordingly

### Pattern Matching Updates
All pattern matches updated to handle struct variant:
```rust
// Before
ConnectionMode::Grpc => { ... }

// After  
ConnectionMode::Grpc { .. } => { ... }
```

## Benefits

1. **Eliminates duplication** - Single source of truth for connection mode
2. **Improved type safety** - Port configuration embedded directly in enum variant
3. **Better domain model** - ConnectionMode semantically belongs with Worker entities
4. **Reduced complexity** - Removed error-prone conversion logic between config and core types
5. **Easier extensibility** - Adding new connection modes or parameters is simpler

## Backward Compatibility

- Fully backward compatible for configuration files
- Old format `{"type": "grpc"}` still deserializes correctly
- New format `{"type": "grpc", "port": 50051}` supported via optional port field
- No impact on Python CLI user interactions (connection mode auto-detected from URLs)
- All existing tests pass with updated pattern matching

## Testing

- Updated all affected unit tests
- Updated integration tests in `tests/` directory
- All pattern matching validated by Rust compiler
- Verified backward compatibility with configuration parsing

## Additional Notes

This change makes it easier to add an explicit `--connection-mode` CLI flag in the future if needed, as ConnectionMode now has proper serialization support throughout the codebase.

## Integration Test Screenshots
4 Llama 3.1 8B with HTTP router and service discovery
<img width="1920" height="1080" alt="Screenshot 2025-10-22 at 11 11 51 PM" src="https://github.com/user-attachments/assets/3956f343-69e6-478e-9ab7-d95b8f88ff9e" />

1P2D Llama 4 Mav with gRPC router
<img width="1920" height="1080" alt="Screenshot 2025-10-22 at 11 41 18 PM" src="https://github.com/user-attachments/assets/d2869014-4ee5-4ee4-a53d-09abf7aae784" />
