### PR TITLE
[router][grpc] Fix background tasks stored with wrong id

### DIFF
--- a/sgl-router/src/routers/grpc/responses/conversions.rs
+++ b/sgl-router/src/routers/grpc/responses/conversions.rs
@@ -187,7 +187,7 @@ fn extract_text_from_content(content: &[ResponseContentPart]) -> String {
 /// Convert a ChatCompletionResponse to ResponsesResponse
 ///
 /// # Conversion Logic
-/// - `id` → `id` (pass through)
+/// - `id` → `response_id_override` if provided, otherwise `chat_resp.id`
 /// - `model` → `model` (pass through)
 /// - `choices[0].message` → `output` array (convert to ResponseOutputItem::Message)
 /// - `choices[0].finish_reason` → determines `status` (stop/length → Completed)
@@ -195,6 +195,7 @@ fn extract_text_from_content(content: &[ResponseContentPart]) -> String {
 pub fn chat_to_responses(
     chat_resp: &ChatCompletionResponse,
     original_req: &ResponsesRequest,
+    response_id_override: Option<String>,
 ) -> Result<ResponsesResponse, String> {
     // Extract the first choice (responses API doesn't support n>1)
     let choice = chat_resp
@@ -275,7 +276,7 @@ pub fn chat_to_responses(
 
     // Generate response
     Ok(ResponsesResponse {
-        id: chat_resp.id.clone(),
+        id: response_id_override.unwrap_or_else(|| chat_resp.id.clone()),
         object: "response".to_string(),
         created_at: chat_resp.created as i64,
         status,

--- a/sgl-router/src/routers/grpc/responses/tool_loop.rs
+++ b/sgl-router/src/routers/grpc/responses/tool_loop.rs
@@ -365,9 +365,12 @@ pub(super) async fn execute_tool_loop(
                 );
 
                 // Convert chat response to responses format and mark as incomplete
-                let mut responses_response =
-                    conversions::chat_to_responses(&chat_response, original_request)
-                        .map_err(|e| format!("Failed to convert to responses format: {}", e))?;
+                let mut responses_response = conversions::chat_to_responses(
+                    &chat_response,
+                    original_request,
+                    response_id.clone(),
+                )
+                .map_err(|e| format!("Failed to convert to responses format: {}", e))?;
 
                 // Mark as completed but with incomplete details
                 responses_response.status = ResponseStatus::Completed;
@@ -461,9 +464,12 @@ pub(super) async fn execute_tool_loop(
             );
 
             // Convert final chat response to responses format
-            let mut responses_response =
-                conversions::chat_to_responses(&chat_response, original_request)
-                    .map_err(|e| format!("Failed to convert to responses format: {}", e))?;
+            let mut responses_response = conversions::chat_to_responses(
+                &chat_response,
+                original_request,
+                response_id.clone(),
+            )
+            .map_err(|e| format!("Failed to convert to responses format: {}", e))?;
 
             // Inject MCP metadata into output
             if state.total_calls > 0 {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Background tasks were completing successfully but storing responses with the wrong ID:
- Background response ID: `resp_b99907a8-77bd-4c94-8de5-3de9191a11a4`
- Stored response ID: `chatcmpl-1e093101-3e87-4913-a3de-0945e93402a5` (internal gRPC request ID)

This caused GET requests to return the original queued response instead of the completed one.

### Root Cause:
The `chat_to_responses()` function was using chat_resp.id (the internal gRPC request ID) instead of the background response_id parameter.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. Created chat_to_responsesd() that accepts an optional response_id_override
2. Updated all call sites to use the new function and pass the response_id when available

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

### Before

Get response always shows the `status` is `queued`
<img width="1619" height="345" alt="Screenshot 2025-10-21 at 6 29 01 PM" src="https://github.com/user-attachments/assets/28e7e849-3d5b-4f85-b771-b9f579400cfb" />

### After

Fixed. Able to get full response
<img width="1622" height="736" alt="Screenshot 2025-10-21 at 6 28 50 PM" src="https://github.com/user-attachments/assets/af75f6a3-c11c-4e2f-b35b-79e805f51396" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
