### PR TITLE
Fix flaky hicache test with mooncake backend

### DIFF
--- a/test/srt/hicache/test_hicache_storage_mooncake_backend.py
+++ b/test/srt/hicache/test_hicache_storage_mooncake_backend.py
@@ -201,9 +201,9 @@ class HiCacheStorageMooncakeBackendBaseMixin(HiCacheStorageBaseMixin):
         # Set the environment variables for Mooncake using dynamic ports
         env_vars = {
             "MOONCAKE_MASTER": f"127.0.0.1:{cls.mooncake_master_port}",
-            "MOONCAKE_PROTOCOL": "rdma",
+            "MOONCAKE_PROTOCOL": "tcp",
             "MC_MS_AUTO_DISC": "0",
-            "MOONCAKE_DEVICE": get_rdma_devices_args(),
+            "MOONCAKE_DEVICE": "",
             "MOONCAKE_TE_META_DATA_SERVER": f"http://127.0.0.1:{cls.mooncake_metadata_port}/metadata",
             "MOONCAKE_GLOBAL_SEGMENT_SIZE": "4294967296",  # 4 GiB
         }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Hicache+mooncake backend is not stable when using the RDMA protocol with an inaccessible IB device setup: https://github.com/sgl-project/sglang/actions/runs/18701060380/job/53329743180?pr=11821

Using TCP can improve the CI success rate while preserving the verification of hicache correctness.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
