### PR TITLE
fix(deepep): resolve benchmark failure on 4×IB-card setup by aligning tuning config with DeepEP commit bdd119f8

### DIFF
--- a/benchmark/kernels/deepep/tuning_deepep.py
+++ b/benchmark/kernels/deepep/tuning_deepep.py
@@ -381,8 +381,8 @@ def test_main(
 
     # Tune combine performance
     best_time, best_results = 1e10, None
-    for nvl_chunk_size in range(1, 5, 1):
-        for rdma_chunk_size in range(8, 33, 4):
+    for nvl_chunk_size in range(1, 8, 1):
+        for rdma_chunk_size in range(12 if num_nodes == 2 else 8, 33, 4):
             config_kwargs = {
                 "num_sms": num_sms,
                 "num_max_nvl_chunked_send_tokens": nvl_chunk_size,


### PR DESCRIPTION
## Motivation

When running benchmark/kernels/deepep/tuning_deepep.py on a system equipped with 4 InfiniBand (IB) cards, the tuning script could fail due to unstable or invalid parameter combinations for nvl_chunk_size and rdma_chunk_size.
This issue mirrors the behavior reported in [DeepEP Issue #321](https://github.com/deepseek-ai/DeepEP/issues/321), which resulted in errors such as:

```
assertion num_max_rdma_chunked_send_tokens >= num_warps_per_forwarder fails.
```

The DeepEP team resolved this problem in commit [bdd119f8b249953cab366f4d737ad39d4246fd7e](https://github.com/deepseek-ai/DeepEP/commit/bdd119f8b249953cab366f4d737ad39d4246fd7e) by adjusting the tuning configuration to avoid problematic parameter ranges.
This PR brings the same fix into SGLang to ensure benchmark stability in multi-IB environments.

## Modifications

- File modified: benchmark/kernels/deepep/tuning_deepep.py
- Changes introduced:
- Expanded the tuning search range of nvl_chunk_size from range(1, 5) → range(1, 8) to explore more stable NVLink chunk configurations.
- Adjusted the starting value of rdma_chunk_size when num_nodes == 2, changing
range(8, 33, 4) → range(12 if num_nodes == 2 else 8, 33, 4)
to align with the DeepEP fix ([bdd119f8](https://github.com/deepseek-ai/DeepEP/commit/bdd119f8b249953cab366f4d737ad39d4246fd7e)).
- These refinements prevent unstable parameter combinations that previously caused assertion failures during tuning in multi-IB environments.

## Accuracy Tests

This change only modifies tuning parameter ranges and does not affect core kernel logic or model output accuracy.
No changes to mathematical computations or operator semantics.

## Benchmarking and Profiling

Preliminary testing shows:
- No regression in throughput or latency.
- Improved stability in 2-node configurations where previous parameter sets occasionally failed or produced inconsistent results.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
