### PR TITLE
Bump grace blackwell DeepEP version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,7 +98,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel html5li
 
 
 # Download NVSHMEM source files
-# We use Tom's DeepEP fork for GB200 for now; the 1fd57b0276311d035d16176bb0076426166e52f3 commit is the one for GB200 blog part 2
+# We use Tom's DeepEP fork for GB200 for now; the 1fd57b0276311d035d16176bb0076426166e52f3 commit is https://github.com/fzyzcjy/DeepEP/tree/gb200_blog_part_2
 RUN wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.3.9/source/nvshmem_src_cuda12-all-all-3.3.9.tar.gz && \
     if [ "$GRACE_BLACKWELL" = "1" ]; then \
       git clone https://github.com/fzyzcjy/DeepEP.git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,11 +98,11 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel html5li
 
 
 # Download NVSHMEM source files
-# We use Tom's DeepEP fork for GB200 for now
+# We use Tom's DeepEP fork for GB200 for now; the 1fd57b0276311d035d16176bb0076426166e52f3 commit is the one for GB200 blog part 2
 RUN wget https://developer.download.nvidia.com/compute/redist/nvshmem/3.3.9/source/nvshmem_src_cuda12-all-all-3.3.9.tar.gz && \
     if [ "$GRACE_BLACKWELL" = "1" ]; then \
       git clone https://github.com/fzyzcjy/DeepEP.git \
-      && cd DeepEP && git checkout 2555874d8713ea758671867a50ebc9883552686d && sed -i 's/#define NUM_CPU_TIMEOUT_SECS 100/#define NUM_CPU_TIMEOUT_SECS 1000/' csrc/kernels/configs.cuh && cd .. ; \
+      && cd DeepEP && git checkout 1fd57b0276311d035d16176bb0076426166e52f3 && sed -i 's/#define NUM_CPU_TIMEOUT_SECS 100/#define NUM_CPU_TIMEOUT_SECS 1000/' csrc/kernels/configs.cuh && cd .. ; \
     else \
       git clone https://github.com/deepseek-ai/DeepEP.git \
       && cd DeepEP && git checkout ${DEEPEP_COMMIT} && sed -i 's/#define NUM_CPU_TIMEOUT_SECS 100/#define NUM_CPU_TIMEOUT_SECS 1000/' csrc/kernels/configs.cuh && cd .. ; \


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Summary

This PR updates SGLang’s grace blackwell DeepEP version use the new `gb200_blog_part_2` branch from [fzyzcjy/DeepEP](https://github.com/fzyzcjy/DeepEP/tree/gb200_blog_part_2)

As of 10/22 - this branch serves as the canonical reference for FP4 and FP8 performance on Grace-Blackwell and is the same codebase used in DeepSeek’s Blog Post 2 benchmarks.

## Background and Context

Previously, two divergent DeepEP branches were floating around for Grace-Blackwell:

`2555874d` — the version pinned in our main Dockerfile

`1fd57b0` — the version used in Blog Post 2 (FP4 benchmarks)

A comparison (git rev-list --left-right --count 2555874d...1fd57b0) showed:

29 commits behind, 113 commits ahead

indicating substantial divergence. This made it difficult to build reproducible containers for external benchmark submissions. fzyzcjy confirmed that the Blog Part 2 commit contains all optimizations and hidden-dim support needed for FP4/FP8 workloads and can safely replace the Dockerfile version.