### PR TITLE
Enable Llama 4 + TRTLLM MHA

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -230,13 +230,10 @@ def get_quant_config(
                 else:
                     return quant_cls.from_config(config)
         elif model_config.quantization == "modelopt_fp8":
-            if config["producer"]["name"] == "modelopt_fp8":
-                return quant_cls.from_config(config)
-            else:
-                raise ValueError(
-                    f"Unsupported quantization config"
-                    f" found for {model_config.quantization} in {f}."
-                )
+            # Accept both legacy and current ModelOpt hf_quant_config.json formats.
+            # Some checkpoints set producer.name to "modelopt" even for FP8.
+            # Delegate parsing/validation to the quantization config class.
+            return quant_cls.from_config(config)
         elif model_config.quantization == "w8a8_int8":
             config["packed_modules_mapping"] = packed_modules_mapping
 

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -230,10 +230,13 @@ def get_quant_config(
                 else:
                     return quant_cls.from_config(config)
         elif model_config.quantization == "modelopt_fp8":
-            # Accept both legacy and current ModelOpt hf_quant_config.json formats.
-            # Some checkpoints set producer.name to "modelopt" even for FP8.
-            # Delegate parsing/validation to the quantization config class.
-            return quant_cls.from_config(config)
+            if config["producer"]["name"] == "modelopt_fp8":
+                return quant_cls.from_config(config)
+            else:
+                raise ValueError(
+                    f"Unsupported quantization config"
+                    f" found for {model_config.quantization} in {f}."
+                )
         elif model_config.quantization == "w8a8_int8":
             config["packed_modules_mapping"] = packed_modules_mapping
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -965,6 +965,7 @@ class ServerArgs:
                 "fa3",
                 "aiter",
                 "triton",
+                "trtllm_mha",
             }, "fa3, aiter, or triton is required for Llama4 model"
         elif model_arch in [
             "Gemma2ForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -968,6 +968,11 @@ class ServerArgs:
                 "triton",
                 "trtllm_mha",
             }, "fa3, aiter, triton, or trtllm_mha is required for Llama4 model"
+            if is_sm100_supported() and self.attention_backend is None:
+                self.attention_backend = "trtllm_mha"
+                logger.warning(
+                    "Use trtllm_mha as attention backend on sm100 for Llama4 model"
+                )
         elif model_arch in [
             "Gemma2ForCausalLM",
             "Gemma3ForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -966,7 +966,7 @@ class ServerArgs:
                 "aiter",
                 "triton",
                 "trtllm_mha",
-            }, "fa3, aiter, or triton is required for Llama4 model"
+            }, "fa3, aiter, trtllm_mha, or triton is required for Llama4 model"
         elif model_arch in [
             "Gemma2ForCausalLM",
             "Gemma3ForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -966,7 +966,7 @@ class ServerArgs:
                 "aiter",
                 "triton",
                 "trtllm_mha",
-            }, "fa3, aiter, trtllm_mha, or triton is required for Llama4 model"
+            }, "fa3, aiter, triton, or trtllm_mha is required for Llama4 model"
         elif model_arch in [
             "Gemma2ForCausalLM",
             "Gemma3ForCausalLM",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

I don't know why it was blocked originally from being used (TBD maybe it was either not in yet, or was untested). A lot better than triton (currently)

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Unblock it.

```
python -m sglang.launch_server \
                                                                                                                                                         --model-path /root/.cache/huggingface/hub/models--nvidia--Llama-4-Maverick-17B-128E-Instruct-FP8/snapshots/e91306aa6edc0a8b551b1815027163646638d252 \
                                                                                                                             --tp 8 \                                              
                                                                                                 --attention-backend trtllm_mha \                                                  
                                                                     --trust-remote-code          
```

`python3 -m sglang.bench_serving --backend sglang --num-prompts 64 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1 --max-concurrency=8 --flush-cache`
Before:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  53.09     
Total input tokens:                      65536     
Total input text tokens:                 65536     
Total input vision tokens:               0         
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65673     
Request throughput (req/s):              1.21      
Input token throughput (tok/s):          1234.33   
Output token throughput (tok/s):         1234.33   
Total token throughput (tok/s):          2468.67   
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6632.70   
Median E2E Latency (ms):                 6634.04   
---------------Time to First Token----------------
Mean TTFT (ms):                          144.41    
Median TTFT (ms):                        143.07    
P99 TTFT (ms):                           162.07    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           6.34      
Median ITL (ms):                         6.34      
P95 ITL (ms):                            6.74      
P99 ITL (ms):                            7.00      
Max ITL (ms):                            16.29     
==================================================
```

After:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  48.20     
Total input tokens:                      65536     
Total input text tokens:                 65536     
Total input vision tokens:               0         
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65785     
Request throughput (req/s):              1.33      
Input token throughput (tok/s):          1359.59   
Output token throughput (tok/s):         1359.59   
Total token throughput (tok/s):          2719.18   
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6022.57   
Median E2E Latency (ms):                 6015.51   
---------------Time to First Token----------------
Mean TTFT (ms):                          139.21    
Median TTFT (ms):                        137.55    
P99 TTFT (ms):                           155.55    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           5.75      
Median ITL (ms):                         5.74      
P95 ITL (ms):                            5.80      
P99 ITL (ms):                            5.91      
Max ITL (ms):                            61.09     
==================================================
```


| Metric | Before (--attention-backend triton) | After (--attention-backend trtllm_mha) | Δ | % Change |
|:--|--:|--:|--:|--:|
| Request Throughput (req/s) | 1.21 | 1.33 | +0.12 | +9.9% |
| Input Token Throughput (tok/s) | 1234.33 | 1359.59 | +125.26 | +10.2% |
| Total Token Throughput (tok/s) | 2468.67 | 2719.18 | +250.51 | +10.2% |
| Mean E2E Latency (ms) | 6632.70 | 6022.57 | −610.13 | −9.2% |
| Mean ITL (ms) | 6.34 | 5.75 | −0.59 | −9.3% |


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Acc is good
After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 50
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:19<00:00, 16.56it/s]
Accuracy: 0.933
Invalid: 0.000
Latency: 79.984 s
Output throughput: 1709.423 token/s
```

