### PR TITLE
[BugFix] fix generating endlessly bug when reasoner grammar & spec decoding are enabled

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -112,6 +112,9 @@ class BaseGrammarObject:
         """
         raise NotImplementedError()
 
+    def accept_token_length(self) -> int:
+        raise NotImplementedError()
+
 
 INVALID_GRAMMAR_OBJ = BaseGrammarObject()
 

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -25,11 +25,16 @@ from .base_grammar_backend import (
 
 
 class ReasonerGrammarObject(BaseGrammarObject):
-    def __init__(self, grammar: BaseGrammarObject, think_end_id):
+    def __init__(
+        self,
+        grammar: BaseGrammarObject,
+        think_end_id,
+        is_in_reasoning=True,
+    ):
         super().__init__()
         self.grammar = grammar
         self.think_end_id = think_end_id
-        self.is_in_reasoning = True
+        self.is_in_reasoning = is_in_reasoning
 
     def accept_token(self, token: int):
         if token == self.think_end_id:
@@ -38,12 +43,27 @@ class ReasonerGrammarObject(BaseGrammarObject):
         if not self.is_in_reasoning and token != self.think_end_id:
             self.grammar.accept_token(token)
 
+    def rollback(self, k: int):
+        if self.accept_token_length() > 0:
+            return self.grammar.rollback(k)
+        else:
+            # for spec decoding.
+            self.is_in_reasoning = True
+
+    def is_terminated(self):
+        return self.grammar.is_terminated()
+
     def allocate_vocab_mask(
         self, vocab_size: int, batch_size: int, device
     ) -> torch.Tensor:
         return self.grammar.allocate_vocab_mask(vocab_size, batch_size, device)
 
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
+        # in reasoning, do not mask, otherwise there will be no token to sample
+        if self.is_in_reasoning:
+            vocab_mask[idx].fill_(-1)
+            return
+
         if not self.is_in_reasoning:
             self.grammar.fill_vocab_mask(vocab_mask, idx)
 
@@ -55,7 +75,11 @@ class ReasonerGrammarObject(BaseGrammarObject):
         return self.grammar.apply_vocab_mask
 
     def copy(self) -> BaseGrammarObject:
-        return ReasonerGrammarObject(self.grammar.copy(), self.think_end_id)
+        return ReasonerGrammarObject(
+            self.grammar.copy(),
+            self.think_end_id,
+            self.is_in_reasoning,
+        )
 
     @property
     def finished(self):
@@ -77,6 +101,9 @@ class ReasonerGrammarObject(BaseGrammarObject):
         return self.grammar.jump_and_retokenize(
             old_output_ids, new_output_ids, next_state
         )
+
+    def accept_token_length(self) -> int:
+        return self.grammar.accept_token_length()
 
 
 class ReasonerGrammarBackend(BaseGrammarBackend):

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -158,6 +158,9 @@ class XGrammarGrammar(BaseGrammarObject):
         for i in range(k, len(new_output_ids)):
             assert self.matcher.accept_token(new_output_ids[i])
 
+    def accept_token_length(self) -> int:
+        return len(self.accepted_tokens)
+
     def __repr__(self):
         return f"XGrammarGrammar({self.key_string=}, {self.accepted_tokens=}, {self.current_token=})"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Related to #9187 and #11550.

When reasoner grammar and spec decoding are enabled at the same time.
The model will generate `<think>` first, and nothing would be generated till reach `max_tokens`.

I found that the problem comes from `allocate_token_bitmask.fill_(0)` and `reasoner grammar`.

```
def traverse_tree(
    retrieve_next_token: torch.Tensor,
    retrieve_next_sibling: torch.Tensor,
    draft_tokens: torch.Tensor,
    grammar: BaseGrammarObject,
    allocate_token_bitmask: torch.Tensor,
):
    """
    Traverse the tree constructed by the draft model to generate the logits mask.
    """
    assert (
        retrieve_next_token.shape == retrieve_next_sibling.shape == draft_tokens.shape
    )

    allocate_token_bitmask.fill_(0)

    def dfs(
        curr: int,
        retrieve_next_token: torch.Tensor,
        retrieve_next_sibling: torch.Tensor,
        parent_pos: int,
    ):
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
