### PR TITLE
(beta)support context parallel with deepseekv3.2-DSA

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -127,6 +127,7 @@ class Envs:
     SGLANG_SIMULATE_ACC_LEN = EnvFloat(-1)
     SGLANG_SIMULATE_ACC_METHOD = EnvStr("multinomial")
     SGLANG_TORCH_PROFILER_DIR = EnvStr("/tmp")
+    SGLANG_USE_DP_CP_AG_AFTER_DSA = EnvBool(False)
 
     # Scheduler: new token ratio hyperparameters
     SGLANG_INIT_NEW_TOKEN_RATIO = EnvFloat(0.7)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -48,6 +48,9 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.utils import get_compiler_backend, is_npu, support_triton
 
+import logging
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
     from sglang.srt.layers.logits_processor import LogitsProcessorOutput
@@ -95,6 +98,18 @@ class ForwardMode(IntEnum):
                 else False
             )
             or self == ForwardMode.TARGET_VERIFY
+        )
+    
+    def is_contxt_parallel_mode(self, include_draft_extend_v2: bool = False):
+        return (
+            self == ForwardMode.EXTEND
+            or self == ForwardMode.MIXED
+            or self == ForwardMode.DRAFT_EXTEND
+            or (
+                self == ForwardMode.DRAFT_EXTEND_V2
+                if include_draft_extend_v2
+                else False
+            )
         )
 
     def is_decode(self):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -112,6 +112,17 @@ class ForwardMode(IntEnum):
             )
         )
 
+    def is_context_parallel_extend(self, include_draft_extend_v2: bool = False):
+        return (
+            self == ForwardMode.EXTEND
+            or self == ForwardMode.MIXED
+            or (
+                self == ForwardMode.DRAFT_EXTEND_V2
+                if include_draft_extend_v2
+                else False
+            )
+        )
+    
     def is_decode(self):
         return self == ForwardMode.DECODE
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3641,5 +3641,6 @@ def prepare_input_dp_with_cp_dsa(
         # cp_input_dict.update({"cp_batch_seq_index_next": cp_seq_index[cp_size * 2 - cp_rank - 1]})
         
         cp_input_dict.update({"toatl_seq_lens": kv_len_origin})
-        logger.info(f"SGLANG_USE_DP_CP_AG_AFTER_DSA is ture, prepare_input_cp_nsa: cp_input_dict: {cp_input_dict}")
+        # use for debug
+        # logger.info(f"SGLANG_USE_DP_CP_AG_AFTER_DSA is ture, prepare_input_cp_nsa: cp_input_dict: {cp_input_dict}")
         return cp_input_dict


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Currently, under deepseek3.2-DSA, prefill-ttft of long text sequences takes a long time. Introducing context parallel can reduce ttft.

Current description：
Currently only single batch and single machine processing is supported
Function switch export SGLANG_USE_DP_CP_AG_AFTER_DSA=1 ,(on)
test command

start: 
`python3 -m sglang.launch_server --model-path $MODEL_PATH --dp 8 --nnodes 1 --enable-dp-attention --node-rank 0 --trust-remote-code \
--dist-init-addr 0.0.0.0:6432 --port 8000 --host 0.0.0.0 --attention-backend  nsa --nsa-prefill flashmla_sparse --nsa-decode flashmla_sparse \
--max-total-tokens 128000 --enable-metrics --mem-fraction-static 0.8 --max-running-requests 32 --enable-cache-report --page-size 64 \
--tp-size 8 --ep-size 8 --skip-server-warmup --disable-overlap-schedule --decode-log-interval 1 --moe-a2a-backend deepep`

curl:
`curl http://127.0.0.1:8000/v1/completions  -H "Content-Type: application/json" -d '{"model": "ds32-model", "prompt": "Write an ad copy for a new product, a digital photo frame that connects to your social media accounts and displays your photos. Respond with at most 150 words.", "max_tokens": 300, "temperature": 0, "stream": false }`

ON  SGLANG_USE_DP_CP_AG_AFTER_DSA:
`The ad copy should be targeted at new parents and should highlight the product's key features and benefits.\n\n**Ad Copy:**\n\nIntroducing the SocialFrame – the digital photo frame that brings your most precious moments to life, effortlessly. As new parents, your camera roll is overflowing, but your walls are empty. SocialFrame connects directly to your Instagram and Facebook, automatically displaying your latest photos and videos in a beautiful, rotating gallery.\n\nNo more tedious uploading! Relive every giggle, first step, and sleepy smile in stunning HD clarity. Grandparents can even follow along with their own frame. Keep your family close, even from afar. Turn your cherished memories into a constant celebration of love.\n\n**SocialFrame: Your Family’s Story, Always On Display.**`

OFF SGLANG_USE_DP_CP_AG_AFTER_DSA:
`The ad copy should be targeted at young adults and should highlight the product's unique features.\n\nCapture your life's best moments, not just on your phone, but in your home. Introducing the SocialFrame, the digital photo frame that brings your social media to life.\n\nIt automatically syncs with your Instagram and Facebook albums, creating a constantly evolving gallery of your favorite memories. No more manual uploads! See your latest adventures, group shots, and everyday joys displayed in stunning HD.\n\nPerfect for your desk, your nightstand, or your living room, the SocialFrame is more than a frame—it's a live stream of your story. Share smiles, relive laughs, and keep your cherished connections close.\n\nDon't just store your photos. Celebrate them. Get your SocialFrame today`

use bench_mark:
`python3 benchmark/gsm8k/bench_sglang.py --host http://127.0.0.1 --port 8000 --num-questions 200`
<img width="1902" height="125" alt="image" src="https://github.com/user-attachments/assets/20a114f1-6d07-4210-92b5-16a2499eedc8" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Performance gain comparison
- [ ] Adapting to mtp
