### PR TITLE
[router] Add global proxy configuration for MCP clients

### DIFF
--- a/docs/advanced_features/router.md
+++ b/docs/advanced_features/router.md
@@ -310,6 +310,7 @@ python -m sglang_router.launch_router \
 - Tool-call parsers cover JSON, Pythonic, XML, and custom schemas with streaming/non-streaming execution loops.
 - Reasoning parsers ship for DeepSeek-R1, Qwen3, Step-3, GLM4, Llama families, Kimi K2, GPT-OSS, Mistral, and more (`src/reasoning_parser`).
 - Tokenizer factory accepts HuggingFace IDs, local directories, and explicit `tokenizer.json` files with chat template overrides (`src/tokenizer`).
+- Configure a global MCP proxy with `--mcp-http-proxy`, `--mcp-https-proxy`, and `--mcp-no-proxy` (or the `MCP_HTTP_PROXY`, `MCP_HTTPS_PROXY`, `MCP_NO_PROXY` environment variables). The settings apply to every MCP client transport, including SSE and Streamable HTTP.
 
 Use CLI flags to select parsers:
 ```bash
@@ -367,6 +368,14 @@ Use CLI flags to select parsers:
 | `--balance-rel-threshold`  | float | 1.5      | Relative load ratio.        |
 | `--eviction-interval-secs` | int   | 120      | Cache eviction cadence.     |
 | `--max-tree-size`          | int   | 67108864 | Max nodes in cache tree.    |
+
+### MCP Proxy Settings
+
+| Parameter           | Type | Default | Description                                             |
+|---------------------|------|---------|----------------------------------------------------------|
+| `--mcp-http-proxy`  | str  | None    | Global HTTP proxy applied to every MCP transport.       |
+| `--mcp-https-proxy` | str  | None    | Global HTTPS proxy applied to every MCP transport.      |
+| `--mcp-no-proxy`    | str  | None    | Comma-separated host list that bypasses the MCP proxy.  |
 
 ### Fault Tolerance
 

--- a/sgl-router/src/config/builder.rs
+++ b/sgl-router/src/config/builder.rs
@@ -1,7 +1,7 @@
 use super::{
     CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
-    HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig, RouterConfig,
-    RoutingMode, TokenizerCacheConfig,
+    HistoryBackend, McpProxyConfig, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig,
+    RouterConfig, RoutingMode, TokenizerCacheConfig,
 };
 use crate::core::ConnectionMode;
 
@@ -413,6 +413,14 @@ impl RouterConfigBuilder {
         self
     }
 
+    // ==================== MCP Proxy Configuration ====================
+
+    /// Set MCP proxy configuration
+    pub fn mcp_proxy(mut self, proxy: McpProxyConfig) -> Self {
+        self.config.mcp_proxy = Some(proxy);
+        self
+    }
+
     // ==================== Parsers Configuration ====================
 
     /// Set reasoning parser
@@ -563,6 +571,12 @@ impl RouterConfigBuilder {
             self.config.history_backend = HistoryBackend::Oracle;
             self.config.oracle = Some(cfg);
         }
+        self
+    }
+
+    /// Set MCP proxy configuration if Some
+    pub fn maybe_mcp_proxy(mut self, proxy: Option<McpProxyConfig>) -> Self {
+        self.config.mcp_proxy = proxy;
         self
     }
 

--- a/sgl-router/src/main.rs
+++ b/sgl-router/src/main.rs
@@ -4,8 +4,8 @@ use clap::{ArgAction, Parser, ValueEnum};
 use sglang_router_rs::{
     config::{
         CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
-        HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig, RouterConfig,
-        RoutingMode, TokenizerCacheConfig,
+        HistoryBackend, McpProxyConfig, MetricsConfig, OracleConfig, PolicyConfig, RetryConfig,
+        RouterConfig, RoutingMode, TokenizerCacheConfig,
     },
     core::ConnectionMode,
     metrics::PrometheusConfig,
@@ -310,6 +310,15 @@ struct CliArgs {
     #[arg(long, env = "ATP_POOL_TIMEOUT_SECS")]
     oracle_pool_timeout_secs: Option<u64>,
 
+    #[arg(long, env = "MCP_HTTP_PROXY")]
+    mcp_http_proxy: Option<String>,
+
+    #[arg(long, env = "MCP_HTTPS_PROXY")]
+    mcp_https_proxy: Option<String>,
+
+    #[arg(long, env = "MCP_NO_PROXY")]
+    mcp_no_proxy: Option<String>,
+
     #[arg(long)]
     reasoning_parser: Option<String>,
 
@@ -538,6 +547,12 @@ impl CliArgs {
             None
         };
 
+        let mcp_proxy = McpProxyConfig::new(
+            self.mcp_http_proxy.clone(),
+            self.mcp_https_proxy.clone(),
+            self.mcp_no_proxy.clone(),
+        );
+
         let builder = RouterConfig::builder()
             .mode(mode)
             .policy(policy)
@@ -592,6 +607,7 @@ impl CliArgs {
             .maybe_tokenizer_path(self.tokenizer_path.as_ref())
             .maybe_chat_template(self.chat_template.as_ref())
             .maybe_oracle(oracle)
+            .maybe_mcp_proxy(mcp_proxy)
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
             .dp_aware(self.dp_aware)

--- a/sgl-router/src/mcp/config.rs
+++ b/sgl-router/src/mcp/config.rs
@@ -2,9 +2,14 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::types::McpProxyConfig;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpConfig {
     pub servers: Vec<McpServerConfig>,
+    /// Global proxy configuration for all MCP servers
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<McpProxyConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/sgl-router/src/mcp/http_client.rs
+++ b/sgl-router/src/mcp/http_client.rs
@@ -1,0 +1,253 @@
+//! Global HTTP client management for MCP connections
+//!
+//! This module provides a globally shared HTTP client for all MCP connections,
+//! initialized once during server startup with optional proxy configuration.
+
+use std::sync::OnceLock;
+
+use reqwest::header::HeaderMap;
+
+use crate::config::types::McpProxyConfig;
+
+/// Globally shared HTTP client for all MCP connections
+static SHARED_MCP_HTTP_CLIENT: OnceLock<std::sync::Arc<reqwest::Client>> = OnceLock::new();
+
+/// Stored proxy configuration for building derived clients
+static STORED_PROXY_CONFIG: OnceLock<Option<McpProxyConfig>> = OnceLock::new();
+
+/// Initialize the global MCP HTTP client with optional proxy configuration.
+///
+/// This should be called once during server startup. If called multiple times,
+/// subsequent calls will be ignored with a warning.
+///
+/// # Arguments
+/// * `proxy_config` - Optional proxy configuration from RouterConfig
+///
+/// # Returns
+/// * `Ok(true)` - Successfully initialized
+/// * `Ok(false)` - Already initialized (ignored with warning)
+/// * `Err(String)` - Failed to build HTTP client
+pub fn init(proxy_config: Option<McpProxyConfig>) -> Result<bool, String> {
+    // Check if already initialized
+    if SHARED_MCP_HTTP_CLIENT.get().is_some() {
+        tracing::warn!(
+            "MCP HTTP client already initialized, ignoring new proxy config"
+        );
+        return Ok(false);
+    }
+
+    let mut builder = reqwest::Client::builder();
+
+    // Store proxy config for later use in build_with_headers
+    let proxy_cfg_ref = if let Some(ref cfg) = proxy_config {
+        builder = apply_proxy_config(builder, cfg)?;
+
+        let no_proxy_entry_count = cfg
+            .no_proxy
+            .as_ref()
+            .map(|raw| raw.split(',').filter(|s| !s.trim().is_empty()).count())
+            .unwrap_or(0);
+
+        tracing::info!(
+            http_proxy = cfg.http_proxy.as_deref(),
+            https_proxy = cfg.https_proxy.as_deref(),
+            no_proxy_entries = no_proxy_entry_count,
+            "Initialized global MCP HTTP client with proxy configuration"
+        );
+        Some(cfg)
+    } else {
+        tracing::info!("Initialized global MCP HTTP client without proxy");
+        None
+    };
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("Failed to build MCP HTTP client: {}", e))?;
+
+    // Store the proxy config
+    let _ = STORED_PROXY_CONFIG.set(proxy_cfg_ref.cloned());
+
+    // Store the client
+    SHARED_MCP_HTTP_CLIENT
+        .set(std::sync::Arc::new(client))
+        .map_err(|_| "MCP HTTP client already initialized".to_string())?;
+
+    Ok(true)
+}
+
+/// Get the global shared MCP HTTP client.
+///
+/// If not yet initialized via `init()`, this will lazily initialize with default
+/// configuration (no proxy). In production, `init()` should be called during
+/// server startup to configure proxy settings.
+pub fn client() -> std::sync::Arc<reqwest::Client> {
+    SHARED_MCP_HTTP_CLIENT
+        .get_or_init(|| {
+            // Lazy initialization with default config (no proxy)
+            let client = reqwest::Client::builder()
+                .build()
+                .expect("Failed to build default MCP HTTP client");
+
+            tracing::debug!("Lazily initialized MCP HTTP client with default configuration (no proxy)");
+
+            // Store empty proxy config
+            let _ = STORED_PROXY_CONFIG.set(None);
+
+            std::sync::Arc::new(client)
+        })
+        .clone()
+}
+
+/// Get the global shared MCP HTTP client if initialized.
+///
+/// Returns `None` if not yet initialized. Unlike `client()`, this will NOT
+/// perform lazy initialization.
+pub fn try_client() -> Option<std::sync::Arc<reqwest::Client>> {
+    SHARED_MCP_HTTP_CLIENT.get().cloned()
+}
+
+/// Build a new HTTP client with custom headers, inheriting global proxy configuration.
+///
+/// This is used for SSE connections that require authentication headers.
+/// The returned client will have the same proxy configuration as the global client,
+/// but with additional default headers.
+///
+/// # Arguments
+/// * `headers` - Default headers to include in all requests
+///
+/// # Returns
+/// A new `reqwest::Client` with the specified headers and global proxy config
+pub fn build_with_headers(headers: HeaderMap) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder().default_headers(headers);
+
+    // Apply the same proxy config as the global client
+    if let Some(Some(proxy_cfg)) = STORED_PROXY_CONFIG.get() {
+        builder = apply_proxy_config(builder, proxy_cfg)?;
+    }
+
+    builder
+        .build()
+        .map_err(|e| format!("Failed to build MCP client with headers: {}", e))
+}
+
+/// Apply proxy configuration to a reqwest::ClientBuilder
+fn apply_proxy_config(
+    builder: reqwest::ClientBuilder,
+    proxy_config: &McpProxyConfig,
+) -> Result<reqwest::ClientBuilder, String> {
+    let mut builder = builder;
+
+    // Parse no_proxy configuration
+    let no_proxy = proxy_config.no_proxy.as_ref().and_then(|raw| {
+        let result = reqwest::NoProxy::from_string(raw);
+        if result.is_none() {
+            tracing::warn!("Invalid MCP no_proxy value '{}'. Ignoring no_proxy.", raw);
+        }
+        result
+    });
+
+    // Apply HTTP proxy
+    if let Some(http_proxy) = &proxy_config.http_proxy {
+        let proxy = build_proxy(http_proxy, "http", no_proxy.as_ref())?;
+        builder = builder.proxy(proxy);
+    }
+
+    // Apply HTTPS proxy
+    if let Some(https_proxy) = &proxy_config.https_proxy {
+        let proxy = build_proxy(https_proxy, "https", no_proxy.as_ref())?;
+        builder = builder.proxy(proxy);
+    }
+
+    Ok(builder)
+}
+
+/// Helper function to build a proxy with optional no_proxy configuration
+fn build_proxy(
+    proxy_url: &str,
+    proxy_type: &str,
+    no_proxy: Option<&reqwest::NoProxy>,
+) -> Result<reqwest::Proxy, String> {
+    let proxy = match proxy_type {
+        "http" => reqwest::Proxy::http(proxy_url),
+        "https" => reqwest::Proxy::https(proxy_url),
+        _ => unreachable!("Invalid proxy type"),
+    }
+    .map_err(|e| {
+        format!(
+            "invalid {}_proxy '{}': {}",
+            proxy_type, proxy_url, e
+        )
+    })?;
+
+    let proxy = if let Some(no_proxy_cfg) = no_proxy {
+        proxy.no_proxy(Some(no_proxy_cfg.clone()))
+    } else {
+        proxy
+    };
+
+    Ok(proxy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_without_proxy() {
+        // Note: This test may fail if run after other tests that initialize the client
+        // In a real scenario, we'd need a way to reset the static for testing
+        let result = init(None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_proxy_config_accepts_http_proxy() {
+        let cfg = McpProxyConfig {
+            http_proxy: Some("http://127.0.0.1:18080".into()),
+            https_proxy: None,
+            no_proxy: None,
+        };
+        let builder = reqwest::Client::builder();
+        let result = apply_proxy_config(builder, &cfg);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_proxy_config_accepts_https_proxy() {
+        let cfg = McpProxyConfig {
+            http_proxy: None,
+            https_proxy: Some("https://127.0.0.1:18443".into()),
+            no_proxy: None,
+        };
+        let builder = reqwest::Client::builder();
+        let result = apply_proxy_config(builder, &cfg);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_proxy_config_supports_no_proxy_list() {
+        let cfg = McpProxyConfig {
+            http_proxy: Some("http://127.0.0.1:18080".into()),
+            https_proxy: Some("https://127.0.0.1:18443".into()),
+            no_proxy: Some("localhost,example.com".into()),
+        };
+        let builder = reqwest::Client::builder();
+        let result = apply_proxy_config(builder, &cfg);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_proxy_config_rejects_invalid_http_proxy() {
+        let cfg = McpProxyConfig {
+            http_proxy: Some("http://[::1".into()),
+            https_proxy: None,
+            no_proxy: None,
+        };
+        let builder = reqwest::Client::builder();
+        let result = apply_proxy_config(builder, &cfg);
+        assert!(result.is_err());
+        if let Err(msg) = result {
+            assert!(msg.contains("invalid http_proxy"));
+        }
+    }
+}

--- a/sgl-router/src/mcp/mod.rs
+++ b/sgl-router/src/mcp/mod.rs
@@ -10,6 +10,7 @@
 pub mod client_manager;
 pub mod config;
 pub mod error;
+pub mod http_client;
 pub mod oauth;
 
 // Re-export the main types for convenience

--- a/sgl-router/src/routers/openai/mcp.rs
+++ b/sgl-router/src/routers/openai/mcp.rs
@@ -161,6 +161,7 @@ pub async fn mcp_manager_from_request_tools(
     };
     let cfg = crate::mcp::McpConfig {
         servers: vec![crate::mcp::McpServerConfig { name, transport }],
+        proxy: None, // Proxy is configured globally via http_client module
     };
     match McpClientManager::new(cfg).await {
         Ok(mgr) => Some(Arc::new(mgr)),

--- a/sgl-router/src/routers/openai/router.rs
+++ b/sgl-router/src/routers/openai/router.rs
@@ -142,13 +142,15 @@ impl OpenAIRouter {
         let mcp_manager = match std::env::var("SGLANG_MCP_CONFIG").ok() {
             Some(path) if !path.trim().is_empty() => {
                 match crate::mcp::McpConfig::from_file(&path).await {
-                    Ok(cfg) => match crate::mcp::McpClientManager::new(cfg).await {
-                        Ok(mgr) => Some(Arc::new(mgr)),
-                        Err(err) => {
-                            warn!("Failed to initialize MCP manager: {}", err);
-                            None
+                    Ok(cfg) => {
+                        match crate::mcp::McpClientManager::new(cfg).await {
+                            Ok(mgr) => Some(Arc::new(mgr)),
+                            Err(err) => {
+                                warn!("Failed to initialize MCP manager: {}", err);
+                                None
+                            }
                         }
-                    },
+                    }
                     Err(err) => {
                         warn!("Failed to load MCP config from '{}': {}", path, err);
                         None

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -855,6 +855,11 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         .build()
         .expect("Failed to create HTTP client");
 
+    // Initialize global MCP HTTP client
+    if let Err(e) = crate::mcp::http_client::init(config.router_config.mcp_proxy.clone()) {
+        warn!("Failed to initialize MCP HTTP client: {}", e);
+    }
+
     // Initialize rate limiter
     let rate_limiter = match config.router_config.max_concurrent_requests {
         n if n <= 0 => None,

--- a/sgl-router/tests/common/mod.rs
+++ b/sgl-router/tests/common/mod.rs
@@ -6,6 +6,7 @@ pub mod mock_openai_server;
 pub mod mock_worker;
 pub mod streaming_helpers;
 pub mod test_app;
+pub mod test_proxy;
 
 use std::{
     fs,

--- a/sgl-router/tests/common/test_proxy.rs
+++ b/sgl-router/tests/common/test_proxy.rs
@@ -1,0 +1,225 @@
+// Simple HTTP proxy for testing proxy configuration
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use tokio::sync::oneshot;
+
+pub struct TestProxy {
+    addr: SocketAddr,
+    hits: Arc<AtomicUsize>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl TestProxy {
+    pub async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind proxy");
+        let addr = listener.local_addr().expect("Failed to get proxy addr");
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+        let hits_clone = hits.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    result = listener.accept() => {
+                        let Ok((stream, _)) = result else { break };
+                        let hits = hits_clone.clone();
+                        tokio::spawn(async move {
+                            let _ = Self::handle_connection(stream, hits).await;
+                        });
+                    }
+                }
+            }
+        });
+
+        Self {
+            addr,
+            hits,
+            shutdown_tx: Some(shutdown_tx),
+            handle: Some(handle),
+        }
+    }
+
+    async fn handle_connection(
+        stream: tokio::net::TcpStream,
+        hits: Arc<AtomicUsize>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+
+        hits.fetch_add(1, Ordering::SeqCst);
+
+        let mut reader = BufReader::new(stream);
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).await?;
+
+        let parts: Vec<&str> = request_line.split_whitespace().collect();
+        if parts.len() < 2 {
+            return Ok(());
+        }
+
+        let method = parts[0];
+        let target = parts[1];
+
+        if method == "CONNECT" {
+            Self::handle_connect(reader, target).await
+        } else {
+            Self::handle_http(reader, method, target).await
+        }
+    }
+
+    async fn handle_connect(
+        mut reader: tokio::io::BufReader<tokio::net::TcpStream>,
+        target: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+
+        let (host, port) = target
+            .split_once(':')
+            .map(|(h, p)| (h, p.parse().unwrap_or(443)))
+            .unwrap_or((target, 443));
+
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).await?;
+            if line == "\r\n" || line == "\n" {
+                break;
+            }
+        }
+
+        let mut client = reader.into_inner();
+        let mut server = tokio::net::TcpStream::connect((host, port)).await?;
+        client
+            .write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")
+            .await?;
+
+        let (mut cr, mut cw) = client.split();
+        let (mut sr, mut sw) = server.split();
+        tokio::try_join!(
+            tokio::io::copy(&mut cr, &mut sw),
+            tokio::io::copy(&mut sr, &mut cw)
+        )?;
+        Ok(())
+    }
+
+    async fn handle_http(
+        mut reader: tokio::io::BufReader<tokio::net::TcpStream>,
+        method: &str,
+        target: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
+
+        let mut headers = Vec::new();
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).await?;
+            if line == "\r\n" || line == "\n" {
+                break;
+            }
+            headers.push(line);
+        }
+
+        let (host, port, path) = if target.starts_with("http://") {
+            let url = target.strip_prefix("http://").unwrap();
+            let (authority, path) = url.split_once('/').unwrap_or((url, "/"));
+            let (h, p) = authority
+                .split_once(':')
+                .map(|(h, p)| (h.to_string(), p.parse().unwrap_or(80)))
+                .unwrap_or((authority.to_string(), 80));
+            (h, p, path.to_string())
+        } else {
+            let host_header = headers
+                .iter()
+                .find(|h| h.to_lowercase().starts_with("host:"))
+                .ok_or("Missing Host header")?;
+            let host_value = host_header.split_once(':').unwrap().1.trim();
+            let (h, p) = host_value
+                .split_once(':')
+                .map(|(h, p)| (h.to_string(), p.parse().unwrap_or(80)))
+                .unwrap_or((host_value.to_string(), 80));
+            (h, p, target.to_string())
+        };
+
+        let mut server = tokio::net::TcpStream::connect((host.as_str(), port)).await?;
+
+        server
+            .write_all(format!("{} {} HTTP/1.1\r\n", method, path).as_bytes())
+            .await?;
+        for header in &headers {
+            server.write_all(header.as_bytes()).await?;
+        }
+        server.write_all(b"\r\n").await?;
+
+        if let Some(len) = headers
+            .iter()
+            .find(|h| h.to_lowercase().starts_with("content-length:"))
+            .and_then(|h| h.split_once(':'))
+            .and_then(|(_, v)| v.trim().parse::<usize>().ok())
+        {
+            let mut buf = vec![0u8; len];
+            reader.read_exact(&mut buf).await?;
+            server.write_all(&buf).await?;
+        }
+        server.flush().await?;
+
+        let mut client = reader.into_inner();
+        let (mut cr, mut cw) = client.split();
+        let (mut sr, mut sw) = server.split();
+
+        tokio::try_join!(
+            tokio::io::copy(&mut cr, &mut sw),
+            tokio::io::copy(&mut sr, &mut cw)
+        )?;
+
+        Ok(())
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    pub fn hit_count(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_for_hits(&self, expected: usize, timeout: Duration) -> bool {
+        let hits = self.hits.clone();
+        tokio::time::timeout(timeout, async move {
+            while hits.load(Ordering::SeqCst) < expected {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    pub async fn shutdown(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for TestProxy {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

This PR adds global proxy configuration support for MCP clients to enable deployments behind corporate proxies or in restricted network environments. This feature enables users to configure HTTP/HTTPS proxies for all MCP client connections, with support for no_proxy exclusions for internal services.

## Modifications

### Configuration (Python)
Added three new CLI arguments:
- `--mcp-http-proxy`: HTTP proxy URL for MCP client connections
- `--mcp-https-proxy`: HTTPS proxy URL for MCP client connections  
- `--mcp-no-proxy`: Comma-separated list of hostnames/domains to bypass proxy

Corresponding environment variables:
- `MCP_HTTP_PROXY`
- `MCP_HTTPS_PROXY`
- `MCP_NO_PROXY`

### Core Implementation (Rust)

**Configuration** (`config/types.rs`, `mcp/config.rs`, `lib.rs`, `main.rs`):
- Added `McpProxyConfig` struct in `mcp/config.rs` with `http_proxy`, `https_proxy`, and `no_proxy` fields
- Added `mcp_proxy` field to `RouterConfig` for proxy configuration
- Extended Python `Router.__init__()` to accept `mcp_http_proxy`, `mcp_https_proxy`, `mcp_no_proxy` parameters
- Proxy config is constructed when any proxy parameter is provided

**MCP Client Manager** (`mcp/client_manager.rs`):
- Added shared HTTP client using `static SHARED_MCP_HTTP_CLIENT: OnceLock<Arc<reqwest::Client>>` for connection reuse across all MCP instances
- Modified `McpClientManager::new()` to accept `proxy_config: Option<McpProxyConfig>` parameter
- Implemented `get_or_create_shared_client()` to lazily initialize and cache the HTTP client with proxy configuration
- Modified `connect_server()` and `connect_server_impl()` to accept and use pre-configured shared HTTP client
- Added `apply_proxy_config()` helper to configure `reqwest::ClientBuilder` with:
  - HTTP proxy via `reqwest::Proxy::http()`
  - HTTPS proxy via `reqwest::Proxy::https()`
  - No-proxy exclusions via `reqwest::NoProxy::from_string()`
- Proxy configuration is applied to both SSE and Streamable MCP transports

**Router Integration** (`routers/openai/router.rs`, `routers/grpc/router.rs`):
- Updated `McpClientManager::new()` calls to pass `router_config.mcp_proxy` from context
- Proxy configuration is applied when loading MCP config from `SGLANG_MCP_CONFIG` environment variable
- Added `mcp_proxy_config` parameter to MCP-related functions for per-request proxy override support

**Request-level Proxy Support** (`routers/grpc/responses/handlers.rs`, `routers/openai/mcp.rs`):
- Implemented `create_mcp_manager_from_request()` to support per-request MCP tool definitions
- Per-request MCP managers use the same global proxy configuration for consistency

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

## Local E2E test

1. Start a local proxy server

1. Set the local environments
   ```bash
   export MCP_HTTP_PROXY=http://127.0.0.1:8888                         
   export MCP_HTTPS_PROXY=http://127.0.0.1:8888
   ```

1. Send the request
   ```bash
   curl http://localhost:30000/v1/responses \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -d '{
       "model": "gpt-5-nano",
       "tools": [
         {
           "type": "mcp",
           "server_label": "deepwiki",
           "server_url": "https://mcp.deepwiki.com/mcp",
           "require_approval": "always",
           "allowed_tools": ["read_wiki_structure"]
         }
       ],
       "input": "What transport protocols does the 2025-03-26 version of the MCP spec (modelcontextprotocol/modelcontextprotocol) support?"
     }' | jq
   ```

1. Get a response  
   <img width="857" height="1057" alt="image" src="https://github.com/user-attachments/assets/e50957db-d7b8-4830-b9da-337ffd6b74ec" />

1. Proxy server logs  
   <img width="770" height="598" alt="image" src="https://github.com/user-attachments/assets/3f0c36b4-4f3d-40a2-a056-1ff45d7d0112" />
