### PR TITLE
[Fix]: HiCache hasher failed when EAGLE mode enabled

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -19,7 +19,13 @@ def get_hash_str(token_ids: List[int], prior_hash: str = None) -> str:
         hasher.update(bytes.fromhex(prior_hash))
 
     for t in token_ids:
-        hasher.update(t.to_bytes(4, byteorder="little", signed=False))
+        if isinstance(t, tuple):
+            # EAGLE bigram mode: hash both elements to uniquely identify the bigram
+            for elem in t:
+                hasher.update(elem.to_bytes(4, byteorder="little", signed=False))
+        else:
+            # Regular mode: single integer token
+            hasher.update(t.to_bytes(4, byteorder="little", signed=False))
 
     return hasher.hexdigest()
 

--- a/python/sglang/srt/mem_cache/storage/hf3fs/mini_3fs_metadata_server.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/mini_3fs_metadata_server.py
@@ -3,8 +3,9 @@ import atexit
 import json
 import logging
 import threading
+from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, List, Optional, OrderedDict, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import orjson
 import requests
@@ -136,7 +137,7 @@ class GlobalMetadataState:
                     num_pages = data["num_pages"]
                     rank_meta = RankMetadata(num_pages)
                     rank_meta.free_pages = data["free_pages"]
-                    rank_meta.key_to_index = dict(data["key_to_index"])
+                    rank_meta.key_to_index = OrderedDict(data["key_to_index"])
                     self.ranks[rank_id] = rank_meta
                 logging.info(
                     f"Successfully loaded metadata for {len(self.ranks)} ranks."


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->


Fix #11919. This PR addresses two separate issues:

1. **EAGLE mode compatibility**: An `AttributeError` occurs when using EAGLE mode with hierarchical cache storage backend (HiCache). In EAGLE mode, token IDs are represented as bigram tuples `(int, int)` instead of single integers. The `get_hash_str` function in `hicache_storage.py` assumed token IDs are always integers and called `.to_bytes()` directly, causing it to fail on tuples.

2. **Incorrect OrderedDict import**: `mini_3fs_metadata_server.py` incorrectly imported `OrderedDict` from the `typing` module instead of `collections`. This caused it to fall back to a regular `dict` that lacks the `move_to_end` method, leading to runtime errors.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. **`hicache_storage.py`**: Modified `get_hash_str` function to handle both single integer tokens and tuple tokens (EAGLE bigram mode). When a tuple is detected, the function iterates through tuple elements and hashes each integer separately.

2. **`mini_3fs_metadata_server.py`**: Fixed the import statement from `from typing import OrderedDict` to `from collections import OrderedDict` to use the actual `OrderedDict` implementation rather than the type hint.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
