### PR TITLE
fix: the hardcode hf repo name comparison for deepseek-ocr

### DIFF
--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -198,7 +198,7 @@ def get_config(
             model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
         )
         if (
-            config.auto_map
+            getattr(config, 'auto_map', None) is not None
             and config.auto_map.get("AutoModel")
             == "modeling_deepseekocr.DeepseekOCRForCausalLM"
         ):

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -197,7 +197,11 @@ def get_config(
         config = AutoConfig.from_pretrained(
             model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
         )
-        if "deepseek-ai/DeepSeek-OCR" in model:
+        if (
+            config.auto_map
+            and config.auto_map.get("AutoModel")
+            == "modeling_deepseekocr.DeepseekOCRForCausalLM"
+        ):
             config.model_type = "deepseek-ocr"
             # Due to an unknown reason, Hugging Face’s AutoConfig mistakenly recognizes the configuration of deepseek-ocr as deepseekvl2.
             # This is a temporary workaround and will require further optimization.

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -203,8 +203,8 @@ def get_config(
             == "modeling_deepseekocr.DeepseekOCRForCausalLM"
         ):
             config.model_type = "deepseek-ocr"
-            # Due to an unknown reason, Hugging Face’s AutoConfig mistakenly recognizes the configuration of deepseek-ocr as deepseekvl2.
-            # This is a temporary workaround and will require further optimization.
+            # TODO: Remove this workaround when AutoConfig correctly identifies deepseek-ocr.
+            # Hugging Face's AutoConfig currently misidentifies it as deepseekvl2.
 
     except ValueError as e:
         if not "deepseek_v32" in str(e):

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -198,7 +198,7 @@ def get_config(
             model, trust_remote_code=trust_remote_code, revision=revision, **kwargs
         )
         if (
-            getattr(config, 'auto_map', None) is not None
+            getattr(config, "auto_map", None) is not None
             and config.auto_map.get("AutoModel")
             == "modeling_deepseekocr.DeepseekOCRForCausalLM"
         ):

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -13,13 +13,11 @@ import time
 import traceback
 import urllib.request
 import weakref
-from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from io import BytesIO
 from json import dumps
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
-import numpy as np
 import pybase64
 import requests
 from IPython.display import HTML, display

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -13,11 +13,13 @@ import time
 import traceback
 import urllib.request
 import weakref
+from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from io import BytesIO
 from json import dumps
 from typing import Any, Callable, List, Optional, Tuple, Type, Union
 
+import numpy as np
 import pybase64
 import requests
 from IPython.display import HTML, display


### PR DESCRIPTION
…nfiguration as deepseekvl2 with model in local directory

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

We should not hardcode the hf repo in the code since we may download the repo to local directory

## Modifications

Use the AutoModel instead of the hf repo to determine whether the model is deepseek-ocr

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
