### PR TITLE
Enable mixed type LayerNorm kernel for NSA indexer

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -9,6 +9,7 @@ from einops import rearrange
 from torch import nn
 
 from sglang.srt.custom_op import CustomOp
+from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.utils import add_prefix, align, is_cuda, is_hip, is_npu
 
 if is_cuda():
@@ -83,24 +84,6 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     return hadamard_transform(x, scale=hidden_size**-0.5)
 
 
-class V32LayerNorm(nn.Module):
-    """
-    Layer Normalization.
-    """
-
-    def __init__(self, dim: int, eps: float = 1e-6):
-        super().__init__()
-        self.dim = dim
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
-        self.bias = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
-
-    def forward(self, x: torch.Tensor):
-        return F.layer_norm(
-            x.float(), (self.dim,), self.weight, self.bias, self.eps
-        ).type_as(x)
-
-
 class Indexer(CustomOp):
     def __init__(
         self,
@@ -164,7 +147,7 @@ class Indexer(CustomOp):
                 bias=False,
                 prefix=add_prefix("weights_proj", prefix),
             )
-        self.k_norm = V32LayerNorm(self.head_dim)
+        self.k_norm = LayerNorm(self.head_dim)
         self.rotary_emb = get_rope_wrapper(
             rope_head_dim,
             rotary_dim=rope_head_dim,

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -4,9 +4,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
-import torch.nn.functional as F
 from einops import rearrange
-from torch import nn
 
 from sglang.srt.custom_op import CustomOp
 from sglang.srt.layers.layernorm import LayerNorm
@@ -147,7 +145,7 @@ class Indexer(CustomOp):
                 bias=False,
                 prefix=add_prefix("weights_proj", prefix),
             )
-        self.k_norm = LayerNorm(self.head_dim)
+        self.k_norm = LayerNorm(self.head_dim, dtype=torch.float32)
         self.rotary_emb = get_rope_wrapper(
             rope_head_dim,
             rotary_dim=rope_head_dim,

--- a/python/sglang/test/test_layernorm.py
+++ b/python/sglang/test/test_layernorm.py
@@ -110,9 +110,10 @@ class TestGemmaRMSNorm(CustomTestCase):
 
 
 class TestLayerNorm(CustomTestCase):
-    DTYPES = [torch.bfloat16] # Only bfloat16 input and fp32 gamma/beta is supported for now
+    DTYPES = [torch.half, torch.bfloat16, torch.float32]
+    PARAM_DTYPES = [torch.half, torch.bfloat16, torch.float32]
     NUM_TOKENS = [7, 83, 1024]
-    HIDDEN_SIZES = [768, 769, 770, 771, 1024, 2048, 4096, 5120, 5124, 5125, 5126, 8192, 8199]
+    HIDDEN_SIZES = [768, 769, 770, 771, 5120, 5124, 5125, 5126, 8192, 8199]
     USE_AFFINE = [False, True]
     USE_BIAS = [False, True]
     SEEDS = [0]
@@ -123,10 +124,10 @@ class TestLayerNorm(CustomTestCase):
             raise unittest.SkipTest("CUDA is not available")
         torch.set_default_device("cuda")
 
-    def _run_layer_norm_test(self, num_tokens, hidden_size, use_affine, use_bias, dtype, seed):
+    def _run_layer_norm_test(self, num_tokens, hidden_size, use_affine, use_bias, dtype, seed, param_dtype):
         torch.manual_seed(seed)
 
-        layer = LayerNorm(hidden_size, elementwise_affine=use_affine, bias=use_bias)
+        layer = LayerNorm(hidden_size, elementwise_affine=use_affine, bias=use_bias, dtype=param_dtype)
         if use_affine:
             layer.weight.data.normal_(mean=1.0, std=0.1)
             if use_bias:
@@ -152,14 +153,16 @@ class TestLayerNorm(CustomTestCase):
             self.USE_BIAS,
             self.DTYPES,
             self.SEEDS,
+            self.PARAM_DTYPES,
         ):
             with self.subTest(
                 num_tokens=params[0],
                 hidden_size=params[1],
                 use_affine=params[2],
                 use_bias=params[3],
-                dtype=params[3],
-                seed=params[4],
+                dtype=params[4],
+                seed=params[5],
+                param_dtype=params[6],
             ):
                 self._run_layer_norm_test(*params)
 


### PR DESCRIPTION
## Motivation

Currently we cast input to layernorm to fp32 and use native Torch layernorm, then cast back. Instead we pull in a more efficient TRT-LLM kernel (via flashinfer) that supports mixed precision inputs.

## Modifications

Add flashinfer layernorm kernel and apply in NSA indexer.

## Accuracy Tests

```
python -m sglang.launch_server --model-path model_fp4/ --tp 4 --dp 4 --enable-dp-attention --reasoning-parser deepseek-v3

python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa --num-examples 198 --max-tokens 120000 --repeat 8 --thinking-mode deepseek-v3
```

sample results
```
# with old layernorm
Repeat: 8, mean: 0.783
Scores: ['0.788', '0.793', '0.808', '0.783', '0.742', '0.788', '0.783', '0.778']
====================/198 [22:35<00:52,  4.04s/it]
Writing report to /tmp/gpqa_model_fp4_.html
{'chars': np.float64(1464.3333333333333), 'chars:std': np.float64(356.735535690296), 'score:std': np.float64(0.41573970964154905), 'score': np.float64(0.7777777777777778)}
Writing results to /tmp/gpqa_model_fp4_.json
Total latency: 1422.309 s
Score: 0.778

# with new layernorm 
Repeat: 8, mean: 0.785
Scores: ['0.758', '0.763', '0.788', '0.753', '0.823', '0.808', '0.793', '0.793']
====================198 [22:02<2:29:43, 51.63s/it]
Writing report to /tmp/gpqa_model_fp4_.html
{'chars': np.float64(1474.1515151515152), 'chars:std': np.float64(341.7505399975447), 'score:std': np.float64(0.40520665017240837), 'score': np.float64(0.7929292929292929)}
Writing results to /tmp/gpqa_model_fp4_.json
Total latency: 1290.363 s
Score: 0.793
```

nsys trace shows the new kernel being used:

<img width="1510" height="250" alt="image" src="https://github.com/user-attachments/assets/73cdde24-dc57-4d1a-8569-de37b418ee3f" />

## Benchmarking and Profiling

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
