### PR TITLE
Revise POINTSV15Chat model

### DIFF
--- a/python/sglang/srt/multimodal/processors/points_v15_chat.py
+++ b/python/sglang/srt/multimodal/processors/points_v15_chat.py
@@ -7,12 +7,12 @@ from PIL import Image
 
 from sglang.srt.models.points_v15_chat import POINTSV15ChatModel
 from sglang.srt.multimodal.processors.qwen_vl import (
-    Qwen2_5VLImageProcessor,
+    QwenVLImageProcessor,
     resize_image_async,
 )
 
 
-class POINTSV15ChatProcessor(Qwen2_5VLImageProcessor):
+class POINTSV15ChatProcessor(QwenVLImageProcessor):
     models = [POINTSV15ChatModel]
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix the following error:
```
[2025-10-23 21:06:52] Ignore import error when loading sglang.srt.multimodal.processors.points_v15_chat: cannot import name 'Qwen2_5VLImageProcessor' from 'sglang.srt.multimodal.processors.qwen_vl' (/usr/local/lib/python3.10/dist-packages/sglang/srt/multimodal/processors/qwen_vl.py)
```
#10911 changed Qwen2_5VLImageProcessor to QwenVLImageProcessor
Revise POINTSV15Chat model accordingly to avoid error printing.

With fix no error printing anymore:
```
0, 768, 896, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8)
[2025-10-23 21:14:01] Using default HuggingFace chat template with detected content format: openai
[2025-10-23 21:14:05] INFO utils.py:148: Note: detected 248 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2025-10-23 21:14:05] INFO utils.py:151: Note: NumExpr detected 248 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2025-10-23 21:14:05] INFO utils.py:164: NumExpr defaulting to 16 threads.
INFO 10-23 21:14:06 [__init__.py:216] Automatically detected platform cuda.
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
