### PR TITLE
fix: bench_serving ITL calculation when using spec-decoding

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1626,6 +1626,7 @@ def calculate_metrics(
     dur_s: float,
     tokenizer: PreTrainedTokenizerBase,
     backend: str,
+    accept_length: Optional[float] = None,
 ) -> Tuple[BenchmarkMetrics, List[int]]:
     output_lens: List[int] = []
     retokenized_output_lens: List[int] = []
@@ -1650,7 +1651,14 @@ def calculate_metrics(
             total_input_vision += input_requests[i].vision_prompt_len
             if output_len > 1:
                 tpots.append((outputs[i].latency - outputs[i].ttft) / (output_len - 1))
-            itls += outputs[i].itl
+            if (
+                accept_length
+                and accept_length > 0
+                and backend in ("sglang-oai", "sglang-oai-chat")
+            ):
+                itls += [v / accept_length for v in outputs[i].itl]
+            else:
+                itls += outputs[i].itl
             ttfts.append(outputs[i].ttft)
 
             e2e_latencies.append(outputs[i].latency)
@@ -1929,6 +1937,7 @@ async def benchmark(
         dur_s=benchmark_duration,
         tokenizer=tokenizer,
         backend=backend,
+        accept_length=accept_length,
     )
 
     print("\n{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR addresses an inconsistency in the bench_serving results, specifically regarding the Inter-Token Latency (ITL) metric when speculative decoding is enabled for SGLang's OpenAI-compatible backend. Previously, ITL was calculated per speculative decoding verify step (chunk) rather than per token, leading to an inflated ITL value that did not align with the reported output token throughput.

Before this PR a bench result could like:
```
Output token throughput (tok/s):         292.29
Median ITL (ms):                         8.72
```
Where the real ITL should around 1000/292.29≈3.42 .

After this PR we could get:
```
Output token throughput (tok/s):         293.48
Median ITL (ms):                         3.20
```
Which is more reasonable.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

For `sglang-oai` and `sglang-oai-chat` backends, if accept_length is provided (indicating speculative decoding is active), the collected ITL values are divided by this `accept_length`. This converts the chunk-level latencies to estimated per-token latencies.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
