### PR TITLE
Fix crash after flush cache 

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2306,6 +2306,8 @@ class Scheduler(
         no_request = (
             len(self.waiting_queue) == 0
             and self.running_batch.is_empty()
+            and (self.last_batch is None or self.last_batch.is_empty())
+            and (self.cur_batch is None or self.cur_batch.is_empty())
             and (not self.enable_overlap or len(self.result_queue) == 0)
             and (self.pp_size == 1 or all(x.is_empty() for x in self.running_mbs))
         )

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -533,6 +533,10 @@ class RadixCache(BasePrefixCache):
                 self.protected_size_ -= len(node.key)
                 delta += len(node.key)
             node.lock_ref -= 1
+            if node.parent is None:
+                assert (
+                    node is self.root_node
+                ), f"This request holds the node from another tree"
             node = node.parent
         return delta
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When calling `/flush_cache`, we should ensure the engine is completely idle with no requests living. The current checking is not complete for PD and overlap scheduler. 

### Typical Error
When the checking misses a request, that request might hold the tree node as `last_node` from the existing radix tree. After flush cache, the tree is rebuilt with a new root node. As a result, when trying to release that stale request, backtracing its `last_node` will reach the old tree's root, which cannot meet the ending condition by comparing with the current root node. Leading to the following error.

```
(SGLangEngine pid=36863) [2025-10-25 03:33:09] Scheduler hit an exception: Traceback (most recent call last):
(SGLangEngine pid=36863)   File "/host_home/primary_synced/sglang/python/sglang/srt/managers/scheduler.py", line 2769, in run_scheduler_process
(SGLangEngine pid=36863)     scheduler.event_loop_overlap()
(SGLangEngine pid=36863)   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(SGLangEngine pid=36863)     return func(*args, **kwargs)
(SGLangEngine pid=36863)            ^^^^^^^^^^^^^^^^^^^^^
(SGLangEngine pid=36863)   File "/host_home/primary_synced/sglang/python/sglang/srt/managers/scheduler.py", line 1015, in event_loop_overlap
(SGLangEngine pid=36863)     self.process_batch_result(tmp_batch, tmp_result)
(SGLangEngine pid=36863)   File "/host_home/primary_synced/sglang/python/sglang/srt/managers/scheduler.py", line 2019, in process_batch_result
(SGLangEngine pid=36863)     self.process_batch_result_prefill(batch, result)
(SGLangEngine pid=36863)   File "/host_home/primary_synced/sglang/python/sglang/srt/managers/scheduler_output_processor_mixin.py", line 108, in process_batch_result_prefill
(SGLangEngine pid=36863)     self.tree_cache.cache_finished_req(req)
(SGLangEngine pid=36863)   File "/host_home/primary_synced/sglang/python/sglang/srt/mem_cache/radix_cache.py", line 396, in cache_finished_req
(SGLangEngine pid=36863)     self.dec_lock_ref(req.last_node)
(SGLangEngine pid=36863)   File "/host_home/primary_synced/sglang/python/sglang/srt/mem_cache/radix_cache.py", line 531, in dec_lock_ref
(SGLangEngine pid=36863)     if node.lock_ref == 1:
(SGLangEngine pid=36863)        ^^^^^^^^^^^^^
(SGLangEngine pid=36863) AttributeError: 'NoneType' object has no attribute 'lock_ref'
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Enhance the request finding in flush cache
- Add assertion in `radix_cache.py` to capture this error

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
