### PR TITLE
fix: release workflow should work on both archs

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -114,6 +114,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         cuda-version: ["13.0"]
+        arch: [x86_64, aarch64]
         include:
           - arch: x86_64
             runner: x64-kernel-build-node

--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         cuda-version: ["12.9"]
+        arch: [x86_64, aarch64]
         include:
           - arch: x86_64
             runner: x64-kernel-build-node


### PR DESCRIPTION
Added support for building and releasing on the aarch64 architecture in the GitHub Actions workflow for kernel releases.
- Added `arch: [x86_64, aarch64]` to the build matrix in `.github/workflows/release-whl-kernel.yml`.
