### PR TITLE
Fix Illegal Instruction/IMA errors when using DP attention -- num_tokens_for_logprob calculation

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2075,13 +2075,12 @@ class Scheduler(
             num_tokens = local_batch.extend_num_tokens
             if local_batch.return_logprob:
                 num_tokens_for_logprob = sum(
-                    [
-                        # We should have at least 1 token for sample in every case.
-                        max(extend_len - logprob_start_len, 1)
-                        for logprob_start_len, extend_len in zip(
-                            local_batch.extend_logprob_start_lens, local_batch.extend_lens
-                        )
-                    ]
+                    # We should have at least 1 token for sample in every case.
+                    max(extend_len - logprob_start_len, 1)
+                    for logprob_start_len, extend_len in zip(
+                        local_batch.extend_logprob_start_lens,
+                        local_batch.extend_lens,
+                    )
                 )
             else:
                 # When return_logprob = False, only need last token per request

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2073,15 +2073,19 @@ class Scheduler(
             num_tokens_for_logprob = num_tokens
         else:
             num_tokens = local_batch.extend_num_tokens
-            num_tokens_for_logprob = sum(
-                [
-                    # We should have at least 1 token for sample in every case.
-                    max(extend_len - logprob_start_len, 1)
-                    for logprob_start_len, extend_len in zip(
-                        local_batch.extend_logprob_start_lens, local_batch.extend_lens
-                    )
-                ]
-            )
+            if local_batch.return_logprob:
+                num_tokens_for_logprob = sum(
+                    [
+                        # We should have at least 1 token for sample in every case.
+                        max(extend_len - logprob_start_len, 1)
+                        for logprob_start_len, extend_len in zip(
+                            local_batch.extend_logprob_start_lens, local_batch.extend_lens
+                        )
+                    ]
+                )
+            else:
+                # When return_logprob = False, only need last token per request
+                num_tokens_for_logprob = local_batch.batch_size()
 
         if local_batch is None or local_batch.forward_mode.is_decode_or_idle():
             can_cuda_graph = 1


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Finding the root fix for https://github.com/sgl-project/sglang/pull/12052

Issue: When running with --enable-dp-attention, the DP gather operation in logits stage uses incorrect metadata, causing Triton kernel to access out-of-bounds memory.

```
AssertionError: src OOB: sz=661, chunk_size=7168, required=4738048, src.numel=21504
```

Root cause: The scheduler calculates num_tokens_for_logprob incorrectly by always assuming all tokens need logits computation, but when return_logprob=False, LogitsProcessor only constructs pruned_states with the last token per request (batch_size tokens). This mismatch causes DP gather to expect 661 tokens but only receive 3 tokens, leading to out-of-bounds memory access.

## Modifications

Key debug log before crash:
```

================================================================================
ERROR at DP1 TP1
Exception: src OOB: sz=661, chunk_size=7168, required=4738048, src.numel=21504
================================================================================
hidden_states.shape: (1111, 7168)
local_hidden_states.shape: (3, 7168)
hidden_states.dtype: torch.bfloat16
local_hidden_states.dtype: torch.bfloat16
hidden_states.device: cuda:1
local_hidden_states.device: cuda:1

--- LogitsMetadata ---
global_dp_buffer_len: 1111
dp_local_start_pos: 67
dp_local_num_tokens: 661
global_num_tokens_gpu: [67, 899, 54, 63, 67, 80, 61, 58]
global_num_tokens_for_logprob_gpu: [67, 661, 54, 63, 67, 80, 61, 58]
global_num_tokens_for_logprob_cpu: [67, 661, 54, 63, 67, 80, 61, 58]

--- Batch Info ---
extend_seq_lens_cpu: [253, 291, 355]
extend_logprob_start_lens_cpu: [62, 58, 118]
extend_logprob_pruned_lens_cpu: False
extend_return_logprob: False

--- Calculated Values ---
local_hidden_states.shape[0]: 3
max(extend_len - start_len, 1) per req: [191, 233, 237]
sum of above: 661
================================================================================

```

File: `sglang/python/sglang/srt/managers/scheduler.py`

In `prepare_mlp_sync_batch_raw()`, distinguish two cases when calculating `num_tokens_for_logprob` for extend mode:
When `return_logprob=True`: Keep original logic - `sum of max(extend_len - logprob_start_len, 1)` across all requests (needs logits for input logprob computation)

When `return_logprob=False`: Use `batch_size()` - only need last token per request for sampling
This ensures the token count synchronized across DP ranks matches the actual pruned_states size in `LogitsProcessor`, preventing the memory access violation.

## Accuracy Tests

```
Repeat: 8, mean: 0.795
Scores: ['0.803', '0.808', '0.768', '0.828', '0.823', '0.773', '0.813', '0.742']
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
