### PR TITLE
[router] centralize mcp tool args handling

### DIFF
--- a/sgl-router/src/mcp/error.rs
+++ b/sgl-router/src/mcp/error.rs
@@ -31,6 +31,9 @@ pub enum McpError {
     #[error("Prompt not found: {0}")]
     PromptNotFound(String),
 
+    #[error("Invalid arguments: {0}")]
+    InvalidArguments(String),
+
     #[error(transparent)]
     Sdk(#[from] Box<rmcp::RmcpError>),
 

--- a/sgl-router/src/mcp/mod.rs
+++ b/sgl-router/src/mcp/mod.rs
@@ -14,6 +14,7 @@ pub mod inventory;
 pub mod manager;
 pub mod oauth;
 pub mod proxy;
+pub mod tool_args;
 
 // Re-export the main types for convenience
 pub use config::{
@@ -25,3 +26,4 @@ pub use error::{McpError, McpResult};
 pub use inventory::ToolInventory;
 pub use manager::{McpManager, McpManagerStats};
 pub use proxy::{create_http_client, resolve_proxy_config};
+pub use tool_args::ToolArgs;

--- a/sgl-router/src/mcp/tool_args.rs
+++ b/sgl-router/src/mcp/tool_args.rs
@@ -1,0 +1,93 @@
+//! Tool arguments handling and type coercion
+//!
+//! This module provides utilities for handling MCP tool arguments,
+//! supporting both JSON strings and parsed Maps with automatic type coercion.
+
+use serde_json::Map;
+
+/// Tool arguments input - supports both JSON strings and parsed Maps
+pub enum ToolArgs {
+    /// JSON string that needs parsing
+    JsonString(String),
+    /// Already parsed map
+    Map(Option<Map<String, serde_json::Value>>),
+}
+
+impl ToolArgs {
+    /// Convert to Map with type coercion based on tool schema
+    pub(crate) fn into_map(
+        self,
+        tool_schema: Option<&serde_json::Value>,
+    ) -> Result<Option<Map<String, serde_json::Value>>, String> {
+        match self {
+            ToolArgs::JsonString(s) => {
+                if s.is_empty() || s == "{}" {
+                    return Ok(None);
+                }
+                let mut value: serde_json::Value =
+                    serde_json::from_str(&s).map_err(|e| format!("parse tool args: {}", e))?;
+                Self::coerce_types(&mut value, tool_schema)?;
+                Ok(value.as_object().cloned())
+            }
+            ToolArgs::Map(map) => {
+                if let Some(m) = map {
+                    let mut value = serde_json::Value::Object(m);
+                    Self::coerce_types(&mut value, tool_schema)?;
+                    Ok(value.as_object().cloned())
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    /// Coerce string numbers to actual numbers based on schema
+    /// LLMs often output numbers as strings, so we need to convert them
+    fn coerce_types(
+        value: &mut serde_json::Value,
+        tool_schema: Option<&serde_json::Value>,
+    ) -> Result<(), String> {
+        if let Some(params) = tool_schema {
+            let properties = params.get("properties").and_then(|p| p.as_object());
+            let args_obj = value.as_object_mut();
+
+            if let (Some(props), Some(args)) = (properties, args_obj) {
+                for (key, val) in args.iter_mut() {
+                    let should_be_number = props
+                        .get(key)
+                        .and_then(|s| s.get("type"))
+                        .and_then(|t| t.as_str())
+                        .is_some_and(|t| matches!(t, "number" | "integer"));
+
+                    if should_be_number {
+                        if let Some(s) = val.as_str() {
+                            if let Ok(num) = s.parse::<f64>() {
+                                *val = serde_json::json!(num);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// Implement From traits for convenient conversion
+impl From<String> for ToolArgs {
+    fn from(s: String) -> Self {
+        ToolArgs::JsonString(s)
+    }
+}
+
+impl From<&str> for ToolArgs {
+    fn from(s: &str) -> Self {
+        ToolArgs::JsonString(s.to_string())
+    }
+}
+
+impl From<Option<Map<String, serde_json::Value>>> for ToolArgs {
+    fn from(map: Option<Map<String, serde_json::Value>>) -> Self {
+        ToolArgs::Map(map)
+    }
+}

--- a/sgl-router/src/routers/openai/mcp.rs
+++ b/sgl-router/src/routers/openai/mcp.rs
@@ -14,7 +14,7 @@ use axum::http::HeaderMap;
 use bytes::Bytes;
 use serde_json::{json, to_value, Value};
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::utils::{event_types, generate_id};
 use crate::{
@@ -191,31 +191,6 @@ pub async fn ensure_request_mcp_client(
 // Tool Execution
 // ============================================================================
 
-/// Execute an MCP tool call
-pub(super) async fn execute_mcp_call(
-    mcp_mgr: &Arc<mcp::McpManager>,
-    tool_name: &str,
-    args_json_str: &str,
-) -> Result<(String, String), String> {
-    let args_value: Value =
-        serde_json::from_str(args_json_str).map_err(|e| format!("parse tool args: {}", e))?;
-    let args_obj = args_value.as_object().cloned();
-
-    let server_name = mcp_mgr
-        .get_tool(tool_name)
-        .map(|t| t.server)
-        .ok_or_else(|| format!("tool not found: {}", tool_name))?;
-
-    let result = mcp_mgr
-        .call_tool(tool_name, args_obj)
-        .await
-        .map_err(|e| format!("tool call failed: {}", e))?;
-
-    let output_str = serde_json::to_string(&result)
-        .map_err(|e| format!("Failed to serialize tool result: {}", e))?;
-    Ok((server_name, output_str))
-}
-
 /// Execute detected tool calls and send completion events to client
 /// Returns false if client disconnected during execution
 pub(super) async fn execute_streaming_tool_calls(
@@ -249,12 +224,26 @@ pub(super) async fn execute_streaming_tool_calls(
             &call.arguments_buffer
         };
 
-        let call_result = execute_mcp_call(active_mcp, &call.name, args_str).await;
+        // Call tool directly - manager handles parsing and type coercion
+        debug!("Calling MCP tool '{}' with args: {}", call.name, args_str);
+        let call_result = active_mcp.call_tool(&call.name, args_str).await;
         let (output_str, success, error_msg) = match call_result {
-            Ok((_, output)) => (output, true, None),
+            Ok(result) => match serde_json::to_string(&result) {
+                Ok(output) => (output, true, None),
+                Err(e) => {
+                    let err = format!("Failed to serialize tool result: {}", e);
+                    warn!("{}", err);
+                    (json!({ "error": &err }).to_string(), false, Some(err))
+                }
+            },
             Err(err) => {
-                warn!("Tool execution failed during streaming: {}", err);
-                (json!({ "error": &err }).to_string(), false, Some(err))
+                let err_str = format!("tool call failed: {}", err);
+                warn!("Tool execution failed during streaming: {}", err_str);
+                (
+                    json!({ "error": &err_str }).to_string(),
+                    false,
+                    Some(err_str),
+                )
             }
         };
 
@@ -674,15 +663,27 @@ pub(super) async fn execute_tool_loop(
                 );
             }
 
-            // Execute tool
-            let call_result = execute_mcp_call(active_mcp, &tool_name, &args_json_str).await;
+            // Execute tool - manager handles parsing and type coercion
+            debug!(
+                "Calling MCP tool '{}' with args: {}",
+                tool_name, args_json_str
+            );
+            let call_result = active_mcp
+                .call_tool(&tool_name, args_json_str.as_str())
+                .await;
 
             let output_str = match call_result {
-                Ok((_, output)) => output,
+                Ok(result) => match serde_json::to_string(&result) {
+                    Ok(output) => output,
+                    Err(e) => {
+                        warn!("Failed to serialize tool result: {}", e);
+                        json!({ "error": format!("Serialization error: {}", e) }).to_string()
+                    }
+                },
                 Err(err) => {
                     warn!("Tool execution failed: {}", err);
                     // Return error as output, let model decide how to proceed
-                    json!({ "error": err }).to_string()
+                    json!({ "error": format!("tool call failed: {}", err) }).to_string()
                 }
             };
 


### PR DESCRIPTION
This commit refactors MCP tool argument handling by consolidating duplicated logic into a centralized ToolArgs module. The change eliminates code duplication across multiple routers (gRPC and OpenAI).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
