### PR TITLE
[feature] support prefill-cuda-graph based on cuda-graph-runner(including mla & prefix-cache)

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -375,6 +375,7 @@ class AiterAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             qo_indptr = None
@@ -511,6 +512,7 @@ class AiterAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             kv_indptr = self.kv_indptr

--- a/python/sglang/srt/layers/attention/ascend_backend.py
+++ b/python/sglang/srt/layers/attention/ascend_backend.py
@@ -120,6 +120,7 @@ class AscendAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         metadata = ForwardMetadata()
 
@@ -141,6 +142,7 @@ class AscendAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         metadata = self.graph_metadata[bs]
         max_len = seq_lens_cpu[:bs].max().item()

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -32,6 +32,7 @@ class AttentionBackend(ABC):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Init the metadata for a forward pass for capturing a cuda graph."""
         raise NotImplementedError()
@@ -46,6 +47,7 @@ class AttentionBackend(ABC):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Init the metadata for a forward pass for replaying a cuda graph."""
         raise NotImplementedError()

--- a/python/sglang/srt/layers/attention/cutlass_mla_backend.py
+++ b/python/sglang/srt/layers/attention/cutlass_mla_backend.py
@@ -152,6 +152,7 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             if spec_info is None:
@@ -192,6 +193,7 @@ class CutlassMLABackend(FlashInferMLAAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
 
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/dual_chunk_flashattention_backend.py
@@ -538,6 +538,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[None],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         metadata = DualChunkFlashAttentionMetadata()
 
@@ -588,6 +589,7 @@ class DualChunkFlashAttentionBackend(AttentionBackend):
         spec_info: Optional[None],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: torch.Tensor = None,
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize forward metadata for replaying CUDA graph."""
         assert forward_mode.is_decode()

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1454,6 +1454,7 @@ class FlashAttentionBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize forward metadata for capturing CUDA graph."""
         metadata = FlashAttentionMetadata()
@@ -1691,6 +1692,7 @@ class FlashAttentionBackend(AttentionBackend):
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: Optional[torch.Tensor] = None,
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize forward metadata for replaying CUDA graph."""
         seq_lens = seq_lens[:bs]

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -85,7 +85,7 @@ class FlashInferAttnBackend(AttentionBackend):
         kv_last_page_len_buf: Optional[torch.Tensor] = None,
     ):
         super().__init__()
-
+        self.first_init = True
         # Parse constants
         self.decode_use_tensor_cores = should_use_tensor_core(
             kv_cache_dtype=model_runner.kv_cache_dtype,
@@ -281,33 +281,36 @@ class FlashInferAttnBackend(AttentionBackend):
         max_num_tokens: int,
         kv_indices_buf: Optional[torch.Tensor] = None,
     ):
-        if kv_indices_buf is None:
-            cuda_graph_kv_indices = torch.zeros(
-                (max_num_tokens * self.max_context_len,),
-                dtype=torch.int32,
-                device="cuda",
-            )
-        else:
-            cuda_graph_kv_indices = kv_indices_buf
+        if self.first_init:
+            if kv_indices_buf is None:
+                cuda_graph_kv_indices = torch.zeros(
+                    (max_num_tokens * self.max_context_len,),
+                    dtype=torch.int32,
+                    device="cuda",
+                )
+            else:
+                cuda_graph_kv_indices = kv_indices_buf
 
-        self.cuda_graph_kv_indices = [cuda_graph_kv_indices] + [
-            cuda_graph_kv_indices.clone() for _ in range(self.num_wrappers - 1)
-        ]
+            self.cuda_graph_kv_indices = [cuda_graph_kv_indices] + [
+                cuda_graph_kv_indices.clone() for _ in range(self.num_wrappers - 1)
+            ]
 
-        # Ensure tensors are properly allocated
-        for i in range(self.num_wrappers):
-            # Force allocation by performing a small operation
-            if len(self.cuda_graph_kv_indices[i]) > 0:
-                self.cuda_graph_kv_indices[i][0] = 0
+            # Ensure tensors are properly allocated
+            for i in range(self.num_wrappers):
+                # Force allocation by performing a small operation
+                if len(self.cuda_graph_kv_indices[i]) > 0:
+                    self.cuda_graph_kv_indices[i][0] = 0
 
-        if not self.skip_prefill:
-            self.cuda_graph_custom_mask = torch.zeros(
-                (max_num_tokens * self.max_context_len),
-                dtype=torch.uint8,
-                device="cuda",
-            )
-            self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
-            self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
+            if not self.skip_prefill:
+                self.cuda_graph_custom_mask = torch.zeros(
+                    (max_num_tokens * self.max_context_len),
+                    dtype=torch.uint8,
+                    device="cuda",
+                )
+                self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
+                self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
+
+            self.first_init = False
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -318,6 +321,7 @@ class FlashInferAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             decode_wrappers = []
@@ -381,7 +385,7 @@ class FlashInferAttnBackend(AttentionBackend):
             )
             self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(prefill_wrappers, False, False)
-        elif forward_mode.is_draft_extend():
+        elif forward_mode.is_draft_extend() or forward_mode.is_extend():
             prefill_wrappers = []
             for i in range(self.num_wrappers):
                 prefill_wrappers.append(
@@ -403,13 +407,18 @@ class FlashInferAttnBackend(AttentionBackend):
                 seq_lens,
                 seq_lens.cpu(),  # may add a little overhead in capture stage
                 seq_lens_sum,
-                prefix_lens=None,
+                prefix_lens=extend_prefix_lens if forward_mode.is_extend() else None,
                 prefill_wrappers=prefill_wrappers,
                 use_ragged=False,
                 encoder_lens=encoder_lens,
                 spec_info=spec_info,
             )
-            self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
+            if forward_mode.is_extend():
+                if seq_lens_sum not in self.prefill_cuda_graph_metadata:
+                    self.prefill_cuda_graph_metadata[seq_lens_sum] = {}
+                self.prefill_cuda_graph_metadata[seq_lens_sum][bs] = prefill_wrappers
+            else:
+                self.prefill_cuda_graph_metadata[bs] = prefill_wrappers
             self.forward_metadata = PrefillMetadata(prefill_wrappers, False, False)
         else:
             raise ValueError(f"Invalid mode: {forward_mode=}")
@@ -424,6 +433,7 @@ class FlashInferAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             self.indices_updater_decode.update(
@@ -447,14 +457,21 @@ class FlashInferAttnBackend(AttentionBackend):
                 encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
                 spec_info=spec_info,
             )
-        elif forward_mode.is_draft_extend():
+        elif forward_mode.is_draft_extend() or forward_mode.is_extend():
+            if forward_mode.is_extend():
+                prefill_cuda_graph_metadata_tmp = self.prefill_cuda_graph_metadata[
+                    seq_lens_sum
+                ][bs]
+            else:
+                prefill_cuda_graph_metadata_tmp = self.prefill_cuda_graph_metadata[bs]
+            prefix_lens = extend_prefix_lens if forward_mode.is_extend() else None
             self.indices_updater_prefill.update(
                 req_pool_indices[:bs],
                 seq_lens[:bs],
                 seq_lens_cpu[:bs] if seq_lens_cpu is not None else None,
                 seq_lens_sum,
-                prefix_lens=None,
-                prefill_wrappers=self.prefill_cuda_graph_metadata[bs],
+                prefix_lens=prefix_lens,
+                prefill_wrappers=prefill_cuda_graph_metadata_tmp,
                 use_ragged=False,
                 encoder_lens=encoder_lens[:bs] if encoder_lens is not None else None,
                 spec_info=spec_info,
@@ -1004,11 +1021,15 @@ class FlashInferIndicesUpdaterPrefill:
             # Normal extend
             kv_indptr[1 : bs + 1] = torch.cumsum(paged_kernel_lens, dim=0)
             kv_indptr = kv_indptr[: bs + 1]
-            kv_indices = torch.empty(
-                paged_kernel_lens_sum + 256,
-                dtype=torch.int32,
-                device=req_pool_indices.device,
-            )
+            if wrapper_paged.is_cuda_graph_enabled:
+                # Directly write to the cuda graph input buffer
+                kv_indices = wrapper_paged._paged_kv_indices_buf
+            else:
+                kv_indices = torch.empty(
+                    paged_kernel_lens_sum + 256,
+                    dtype=torch.int32,
+                    device=req_pool_indices.device,
+                )
             create_flashinfer_kv_indices_triton[(bs,)](
                 self.req_to_token,
                 req_pool_indices,

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -362,6 +362,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             decode_wrapper = BatchMLAPagedAttentionWrapper(
@@ -443,6 +444,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             assert seq_lens_cpu is not None

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -188,6 +188,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             max_seqlen_pad = triton.cdiv(seq_lens.max().item(), PAGE_SIZE)
@@ -259,6 +260,7 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
 
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -44,6 +44,7 @@ class HybridAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             self.decode_backend.init_forward_metadata_capture_cuda_graph(
@@ -76,6 +77,7 @@ class HybridAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         if forward_mode.is_decode_or_idle():
             self.decode_backend.init_forward_metadata_replay_cuda_graph(

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -47,6 +47,7 @@ class TboAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: "ForwardMode",
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         self.primary.init_forward_metadata_capture_cuda_graph(
             bs=bs,
@@ -79,6 +80,7 @@ class TboAttnBackend(AttentionBackend):
         forward_mode: "ForwardMode",
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         self.primary.init_forward_metadata_replay_cuda_graph(
             bs=bs,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -433,6 +433,7 @@ class TritonAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         assert encoder_lens is None, "Not supported"
         window_kv_indptr = self.window_kv_indptr
@@ -590,6 +591,7 @@ class TritonAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         # NOTE: encoder_lens expected to be zeros or None
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -202,6 +202,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize metadata for CUDA graph capture."""
         metadata = TRTLLMMHAMetadata()
@@ -316,6 +317,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Replay CUDA graph with new inputs."""
         seq_lens = seq_lens[:bs]

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -202,6 +202,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Initialize metadata for CUDA graph capture."""
 
@@ -257,6 +258,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInfo],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         """Replay CUDA graph with new inputs."""
         # Delegate to parent for non-decode modes.

--- a/python/sglang/srt/layers/attention/wave_backend.py
+++ b/python/sglang/srt/layers/attention/wave_backend.py
@@ -394,6 +394,7 @@ class WaveAttnBackend(AttentionBackend):
         encoder_lens: Optional[torch.Tensor],
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         assert encoder_lens is None, "Not supported"
 
@@ -479,6 +480,7 @@ class WaveAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
         seq_lens_cpu: Optional[torch.Tensor],
+        extend_prefix_lens: Optional[torch.Tensor] = None,
     ):
         # NOTE: encoder_lens expected to be zeros or None
         if forward_mode.is_decode_or_idle():

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -272,6 +272,7 @@ class LogitsProcessor(nn.Module):
                     + logits_metadata.extend_seq_lens
                     - 1
                 )
+             #print(f"{logits_metadata.extend_seq_lens.tolist()=}, {last_index.tolist()=}, {hidden_states.shape=}")
             pruned_states = hidden_states[last_index]
             if aux_hidden_states is not None:
                 aux_pruned_states = [hidden[last_index] for hidden in aux_hidden_states]

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -787,8 +787,12 @@ class Scheduler(
             self.cur_batch = batch
 
             if batch:
+                #t0 = time.time()
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
+                #t1 = time.time()
+                #if self.attn_tp_rank == 0:
+                #    logger.info(f"run dt: {(t1-t0)*1000} ms")
             else:
                 # When the server is idle, do self-check and re-init some states
                 self.self_check_during_idle()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1691,7 +1691,6 @@ class ModelRunner:
     ) -> LogitsProcessorOutput:
         if not skip_attn_backend_init:
             self.attn_backend.init_forward_metadata(forward_batch)
-
         kwargs = {}
         if self.support_pp:
             kwargs["pp_proxy_tensors"] = pp_proxy_tensors
@@ -1699,12 +1698,14 @@ class ModelRunner:
             kwargs["input_embeds"] = forward_batch.input_embeds.bfloat16()
         if not self.is_generation:
             kwargs["get_embedding"] = True
-        return self.model.forward(
+
+        out = self.model.forward(
             forward_batch.input_ids,
             forward_batch.positions,
             forward_batch,
             **kwargs,
         )
+        return out
 
     def forward_idle(
         self, forward_batch: ForwardBatch, pp_proxy_tensors=None
@@ -1781,13 +1782,13 @@ class ModelRunner:
             else (
                 forward_batch.forward_mode.is_cuda_graph
                 or (
-                    forward_batch.forward_mode == ForwardMode.EXTEND
+                    forward_batch.forward_mode.is_extend()
                     and self.graph_runner.enable_prefill_cuda_graph
                 )
             )
         )
-        can_run_graph = bool(
-            mode_check()
+        can_run_cuda_graph = bool(
+            mode_check
             and self.graph_runner
             and self.graph_runner.can_run(forward_batch)
         )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1868,7 +1868,9 @@ class DeepseekV2AttentionMLA(nn.Module):
         )
 
     def forward_normal_chunked_kv_core(self, q, k, v, forward_batch):
-        has_extend_prefix = any(forward_batch.extend_prefix_lens_cpu)
+        has_extend_prefix = False
+        if forward_batch.extend_prefix_lens_cpu is not None:
+            has_extend_prefix = any(forward_batch.extend_prefix_lens_cpu)
         # Only initialize the info once
         if has_extend_prefix and forward_batch.num_prefix_chunks is None:
             forward_batch.prepare_chunked_prefix_cache_info(q.device)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -317,6 +317,9 @@ class ServerArgs:
     disable_radix_cache: bool = False
     cuda_graph_max_bs: Optional[int] = None
     cuda_graph_bs: Optional[List[int]] = None
+    enable_prefill_cuda_graph: bool = False
+    cuda_graph_prefill_max_seqlen: Optional[int] = None
+    cuda_graph_prefill_max_bs: Optional[int] = None
     disable_cuda_graph: bool = False
     disable_cuda_graph_padding: bool = False
     enable_profile_cuda_graph: bool = False
@@ -588,6 +591,13 @@ class ServerArgs:
                     f"TensorRT-LLM MHA only supports page_size of 16, 32 or 64, changing page_size from {self.page_size} to 64."
                 )
                 self.page_size = 64
+
+        if self.enable_prefill_cuda_graph:
+            logger.warning(
+                f"self.disable_radix_cache will be assigned as true and self.attention_backend will be assigned as flashinfer when you turn on --enable-prefill-cuda-graph"
+            )
+            self.disable_radix_cache = True
+            self.attention_backend = "flashinfer"
 
         if self.attention_backend == "dual_chunk_flash_attn":
             logger.warning(
@@ -1816,6 +1826,21 @@ class ServerArgs:
             type=int,
             nargs="+",
             help="Set the list of batch sizes for cuda graph.",
+        )
+        parser.add_argument(
+            "--enable-prefill-cuda-graph",
+            action="store_true",
+            help="Enable cuda graph for prefill.",
+        )
+        parser.add_argument(
+            "--cuda-graph-prefill-max-seqlen",
+            type=int,
+            help="Set the prefill seqlen range(32, cuda_graph_prefill_max_seqlen + 1, 32) for cuda graph.",
+        )
+        parser.add_argument(
+            "--cuda-graph-prefill-max-bs",
+            type=int,
+            help="Set the prefill bs range(1, cuda_graph_prefill_max_bs + 1, 1) for cuda graph.",
         )
         parser.add_argument(
             "--disable-cuda-graph",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -596,8 +596,8 @@ class ServerArgs:
             logger.warning(
                 f"self.disable_radix_cache will be assigned as true and self.attention_backend will be assigned as flashinfer when you turn on --enable-prefill-cuda-graph"
             )
-            self.disable_radix_cache = True
             self.attention_backend = "flashinfer"
+            self.flashinfer_mla_disable_ragged = True
 
         if self.attention_backend == "dual_chunk_flash_attn":
             logger.warning(

--- a/test/srt/test_enable_prefill_cuda_graph.py
+++ b/test/srt/test_enable_prefill_cuda_graph.py
@@ -1,0 +1,86 @@
+import time
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_amd_ci,
+    popen_launch_server,
+)
+
+
+class TestPreillCudaGraph(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--enable-prefill-cuda-graph",
+                "--cuda-graph-prefill-max-seqlen",
+                "256",
+                "--cuda-graph-prefill-max-bs",
+                "8",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmlu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.65)
+
+    def run_decode(self, max_new_tokens):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": max_new_tokens,
+                    "ignore_eos": True,
+                },
+            },
+        )
+        return response.json()
+
+    def test_throughput(self):
+        # Warmup
+        res = self.run_decode(16)
+
+        max_tokens = 256
+        tic = time.perf_counter()
+        res = self.run_decode(max_tokens)
+        tok = time.perf_counter()
+        print(f"{res=}")
+        throughput = max_tokens / (tok - tic)
+        print(f"Throughput: {throughput} tokens/s")
+
+        if is_in_amd_ci():
+            self.assertGreaterEqual(throughput, 30)
+        else:
+            self.assertGreaterEqual(throughput, 40)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

I find a bad case that when cache hit rate reaches 90%+, and new_tokens is only <10, ttft could be 80-100ms
then I find that prefill latency is similar when new_tokens  <100
so we try to accelerate it by cuda-graph.
this pr is based on the former pr (https://github.com/sgl-project/sglang/pull/9186/commits/2d13b541b5b208f5d4754880aea2ff3361c39228)
as piecewise-cudagraph has not supported mla)I push here for new commers who want to try prefill-cuda-graph

## Modifications

as the pr (https://github.com/sgl-project/sglang/pull/9186/commits/2d13b541b5b208f5d4754880aea2ff3361c39228) has said, we abstract a CudaGraphBuffer to store related data
and add some capture logics to support cache case.

## Accuracy Tests

under deepseek-v3, aime25 50-60%(not enough test)


## Benchmarking and Profiling
from
```
[2025-10-14 12:28:26 TP0] Prefill batch. #new-seq: 1, #new-token: 1, #cached-token: 1, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-10-14 12:28:26 TP0] forward cost-82.6406478881836 ms
```
to
```
[2025-10-16 07:25:56 TP0] Prefill batch. #new-seq: 1, #new-token: 1, #cached-token: 6, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-10-16 07:25:56 TP0]  forward cost- 23.097753524780273 ms
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
