### PR TITLE
Remove deprecated --enable-beta-spec argument and fix b200 test

### DIFF
--- a/test/srt/test_deepseek_v3_fp4_4gpu.py
+++ b/test/srt/test_deepseek_v3_fp4_4gpu.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from types import SimpleNamespace
 
@@ -83,6 +84,7 @@ class TestDeepseekV3FP4(CustomTestCase):
 class TestDeepseekV3FP4MTP(CustomTestCase):
     @classmethod
     def setUpClass(cls):
+        os.environ["SGLANG_ENABLE_SPEC_V2"] = "1"
         cls.model = FULL_DEEPSEEK_V3_FP4_MODEL_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
         other_args = [
@@ -115,6 +117,8 @@ class TestDeepseekV3FP4MTP(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
+        if "SGLANG_ENABLE_SPEC_V2" in os.environ:
+            del os.environ["SGLANG_ENABLE_SPEC_V2"]
 
     def test_a_gsm8k(
         self,

--- a/test/srt/test_deepseek_v3_fp4_4gpu.py
+++ b/test/srt/test_deepseek_v3_fp4_4gpu.py
@@ -104,7 +104,6 @@ class TestDeepseekV3FP4MTP(CustomTestCase):
             "4",
             "--kv-cache-dtype",
             "fp8_e4m3",
-            "--enable-beta-spec",
         ]
         cls.process = popen_launch_server(
             cls.model,


### PR DESCRIPTION
The --enable-beta-spec CLI argument was removed in commit 8491c794a and replaced with the SGLANG_ENABLE_SPEC_V2 environment variable. This commit removes the argument from the test to fix the failing B200 CI test.

Fixes https://github.com/sgl-project/sglang/actions/runs/18820548930/job/53695908507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
