### PR TITLE
[router] Remove SharedXxxStorage type aliases to make Arc explicit

### DIFF
--- a/sgl-router/src/app_context.rs
+++ b/sgl-router/src/app_context.rs
@@ -10,8 +10,7 @@ use crate::{
     config::RouterConfig,
     core::{workflow::WorkflowEngine, ConnectionMode, JobQueue, LoadMonitor, WorkerRegistry},
     data_connector::{
-        create_storage, SharedConversationItemStorage, SharedConversationStorage,
-        SharedResponseStorage,
+        create_storage, ConversationItemStorage, ConversationStorage, ResponseStorage,
     },
     mcp::McpManager,
     middleware::TokenBucket,
@@ -49,9 +48,9 @@ pub struct AppContext {
     pub worker_registry: Arc<WorkerRegistry>,
     pub policy_registry: Arc<PolicyRegistry>,
     pub router_manager: Option<Arc<RouterManager>>,
-    pub response_storage: SharedResponseStorage,
-    pub conversation_storage: SharedConversationStorage,
-    pub conversation_item_storage: SharedConversationItemStorage,
+    pub response_storage: Arc<dyn ResponseStorage>,
+    pub conversation_storage: Arc<dyn ConversationStorage>,
+    pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
     pub load_monitor: Option<Arc<LoadMonitor>>,
     pub configured_reasoning_parser: Option<String>,
     pub configured_tool_parser: Option<String>,
@@ -70,9 +69,9 @@ pub struct AppContextBuilder {
     worker_registry: Option<Arc<WorkerRegistry>>,
     policy_registry: Option<Arc<PolicyRegistry>>,
     router_manager: Option<Arc<RouterManager>>,
-    response_storage: Option<SharedResponseStorage>,
-    conversation_storage: Option<SharedConversationStorage>,
-    conversation_item_storage: Option<SharedConversationItemStorage>,
+    response_storage: Option<Arc<dyn ResponseStorage>>,
+    conversation_storage: Option<Arc<dyn ConversationStorage>>,
+    conversation_item_storage: Option<Arc<dyn ConversationItemStorage>>,
     load_monitor: Option<Arc<LoadMonitor>>,
     worker_job_queue: Option<Arc<OnceLock<Arc<JobQueue>>>>,
     workflow_engine: Option<Arc<OnceLock<Arc<WorkflowEngine>>>>,
@@ -167,19 +166,22 @@ impl AppContextBuilder {
         self
     }
 
-    pub fn response_storage(mut self, response_storage: SharedResponseStorage) -> Self {
+    pub fn response_storage(mut self, response_storage: Arc<dyn ResponseStorage>) -> Self {
         self.response_storage = Some(response_storage);
         self
     }
 
-    pub fn conversation_storage(mut self, conversation_storage: SharedConversationStorage) -> Self {
+    pub fn conversation_storage(
+        mut self,
+        conversation_storage: Arc<dyn ConversationStorage>,
+    ) -> Self {
         self.conversation_storage = Some(conversation_storage);
         self
     }
 
     pub fn conversation_item_storage(
         mut self,
-        conversation_item_storage: SharedConversationItemStorage,
+        conversation_item_storage: Arc<dyn ConversationItemStorage>,
     ) -> Self {
         self.conversation_item_storage = Some(conversation_item_storage);
         self

--- a/sgl-router/src/data_connector/core.rs
+++ b/sgl-router/src/data_connector/core.rs
@@ -11,7 +11,6 @@
 use std::{
     collections::HashMap,
     fmt::{Display, Formatter},
-    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -141,9 +140,6 @@ pub trait ConversationStorage: Send + Sync + 'static {
     async fn delete_conversation(&self, id: &ConversationId) -> ConversationResult<bool>;
 }
 
-/// Shared pointer alias for conversation storage
-pub type SharedConversationStorage = Arc<dyn ConversationStorage>;
-
 // ============================================================================
 // PART 2: ConversationItem Storage
 // ============================================================================
@@ -258,8 +254,6 @@ pub trait ConversationItemStorage: Send + Sync + 'static {
         item_id: &ConversationItemId,
     ) -> ConversationItemResult<()>;
 }
-
-pub type SharedConversationItemStorage = Arc<dyn ConversationItemStorage>;
 
 /// Helper to build id prefix based on item_type
 pub fn make_item_id(item_type: &str) -> ConversationItemId {
@@ -481,9 +475,6 @@ pub trait ResponseStorage: Send + Sync {
     /// Delete all responses for a user
     async fn delete_user_responses(&self, user: &str) -> ResponseResult<usize>;
 }
-
-/// Type alias for shared storage
-pub type SharedResponseStorage = Arc<dyn ResponseStorage>;
 
 impl Default for StoredResponse {
     fn default() -> Self {

--- a/sgl-router/src/data_connector/mod.rs
+++ b/sgl-router/src/data_connector/mod.rs
@@ -13,12 +13,10 @@ mod memory;
 mod noop;
 mod oracle;
 
-// Re-export all core types
-pub use core::*;
-
-// Re-export factory function
+pub use core::{
+    Conversation, ConversationId, ConversationItem, ConversationItemId, ConversationItemStorage,
+    ConversationStorage, ListParams, NewConversation, NewConversationItem, ResponseId,
+    ResponseStorage, SortOrder, StoredResponse,
+};
 pub use factory::create_storage;
-// Re-export all storage implementations
-pub use memory::*;
-pub use noop::*;
-pub use oracle::*;
+pub use memory::{MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage};

--- a/sgl-router/src/data_connector/mod.rs
+++ b/sgl-router/src/data_connector/mod.rs
@@ -18,5 +18,6 @@ pub use core::{
     ConversationStorage, ListParams, NewConversation, NewConversationItem, ResponseId,
     ResponseStorage, SortOrder, StoredResponse,
 };
+
 pub use factory::create_storage;
 pub use memory::{MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage};

--- a/sgl-router/src/routers/grpc/responses/context.rs
+++ b/sgl-router/src/routers/grpc/responses/context.rs
@@ -10,9 +10,7 @@ use tokio::sync::RwLock;
 use super::types::BackgroundTaskInfo;
 use crate::{
     core::WorkerRegistry,
-    data_connector::{
-        SharedConversationItemStorage, SharedConversationStorage, SharedResponseStorage,
-    },
+    data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage},
     mcp::McpManager,
     routers::grpc::{context::SharedComponents, pipeline::RequestPipeline},
 };
@@ -32,13 +30,13 @@ pub struct ResponsesContext {
     pub worker_registry: Arc<WorkerRegistry>,
 
     /// Response storage backend
-    pub response_storage: SharedResponseStorage,
+    pub response_storage: Arc<dyn ResponseStorage>,
 
     /// Conversation storage backend
-    pub conversation_storage: SharedConversationStorage,
+    pub conversation_storage: Arc<dyn ConversationStorage>,
 
     /// Conversation item storage backend
-    pub conversation_item_storage: SharedConversationItemStorage,
+    pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
 
     /// MCP manager for tool support
     pub mcp_manager: Arc<McpManager>,
@@ -53,9 +51,9 @@ impl ResponsesContext {
         pipeline: Arc<RequestPipeline>,
         components: Arc<SharedComponents>,
         worker_registry: Arc<WorkerRegistry>,
-        response_storage: SharedResponseStorage,
-        conversation_storage: SharedConversationStorage,
-        conversation_item_storage: SharedConversationItemStorage,
+        response_storage: Arc<dyn ResponseStorage>,
+        conversation_storage: Arc<dyn ConversationStorage>,
+        conversation_item_storage: Arc<dyn ConversationItemStorage>,
         mcp_manager: Arc<McpManager>,
     ) -> Self {
         Self {

--- a/sgl-router/src/routers/grpc/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/responses/handlers.rs
@@ -57,8 +57,7 @@ use super::{
 };
 use crate::{
     data_connector::{
-        ConversationId, ResponseId, SharedConversationItemStorage, SharedConversationStorage,
-        SharedResponseStorage,
+        ConversationId, ConversationItemStorage, ConversationStorage, ResponseId, ResponseStorage,
     },
     protocols::{
         chat::ChatCompletionStreamResponse,
@@ -529,9 +528,9 @@ async fn process_and_transform_sse_stream(
     body: Body,
     original_request: ResponsesRequest,
     _chat_request: Arc<crate::protocols::chat::ChatCompletionRequest>,
-    response_storage: SharedResponseStorage,
-    conversation_storage: SharedConversationStorage,
-    conversation_item_storage: SharedConversationItemStorage,
+    response_storage: Arc<dyn ResponseStorage>,
+    conversation_storage: Arc<dyn ConversationStorage>,
+    conversation_item_storage: Arc<dyn ConversationItemStorage>,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) -> Result<(), String> {
     // Create accumulator for final response

--- a/sgl-router/src/routers/openai/conversations.rs
+++ b/sgl-router/src/routers/openai/conversations.rs
@@ -16,7 +16,7 @@ use crate::{
     data_connector::{
         Conversation, ConversationId, ConversationItemId, ConversationItemStorage,
         ConversationStorage, ListParams, NewConversation, NewConversationItem, ResponseId,
-        ResponseStorage, SharedConversationItemStorage, SharedConversationStorage, SortOrder,
+        ResponseStorage, SortOrder,
     },
     protocols::responses::{ResponseInput, ResponsesRequest},
 };
@@ -30,7 +30,7 @@ pub(crate) const MAX_METADATA_PROPERTIES: usize = 16;
 
 /// Create a new conversation
 pub(super) async fn create_conversation(
-    conversation_storage: &SharedConversationStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
     body: Value,
 ) -> Response {
     // TODO: The validation should be done in the right place
@@ -83,7 +83,7 @@ pub(super) async fn create_conversation(
 
 /// Get a conversation by ID
 pub(super) async fn get_conversation(
-    conversation_storage: &SharedConversationStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
     conv_id: &str,
 ) -> Response {
     let conversation_id = ConversationId::from(conv_id);
@@ -112,7 +112,7 @@ pub(super) async fn get_conversation(
 
 /// Update a conversation's metadata
 pub(super) async fn update_conversation(
-    conversation_storage: &SharedConversationStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
     conv_id: &str,
     body: Value,
 ) -> Response {
@@ -224,7 +224,7 @@ pub(super) async fn update_conversation(
 
 /// Delete a conversation
 pub(super) async fn delete_conversation(
-    conversation_storage: &SharedConversationStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
     conv_id: &str,
 ) -> Response {
     let conversation_id = ConversationId::from(conv_id);
@@ -280,8 +280,8 @@ pub(super) async fn delete_conversation(
 
 /// List items in a conversation with pagination
 pub(super) async fn list_conversation_items(
-    conversation_storage: &SharedConversationStorage,
-    item_storage: &SharedConversationItemStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
+    item_storage: &Arc<dyn ConversationItemStorage>,
     conv_id: &str,
     query_params: HashMap<String, String>,
 ) -> Response {
@@ -412,8 +412,8 @@ const IMPLEMENTED_ITEM_TYPES: &[&str] = &[
 
 /// Create items in a conversation (bulk operation)
 pub(super) async fn create_conversation_items(
-    conversation_storage: &SharedConversationStorage,
-    item_storage: &SharedConversationItemStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
+    item_storage: &Arc<dyn ConversationItemStorage>,
     conv_id: &str,
     body: Value,
 ) -> Response {
@@ -681,8 +681,8 @@ pub(super) async fn create_conversation_items(
 /// Get a single conversation item
 /// Note: `include` query parameter is accepted but not yet implemented
 pub(super) async fn get_conversation_item(
-    conversation_storage: &SharedConversationStorage,
-    item_storage: &SharedConversationItemStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
+    item_storage: &Arc<dyn ConversationItemStorage>,
     conv_id: &str,
     item_id: &str,
     _include: Option<Vec<String>>, // Reserved for future use
@@ -761,8 +761,8 @@ pub(super) async fn get_conversation_item(
 
 /// Delete a conversation item
 pub(super) async fn delete_conversation_item(
-    conversation_storage: &SharedConversationStorage,
-    item_storage: &SharedConversationItemStorage,
+    conversation_storage: &Arc<dyn ConversationStorage>,
+    item_storage: &Arc<dyn ConversationItemStorage>,
     conv_id: &str,
     item_id: &str,
 ) -> Response {

--- a/sgl-router/src/routers/openai/router.rs
+++ b/sgl-router/src/routers/openai/router.rs
@@ -38,8 +38,8 @@ use super::{
 use crate::{
     core::{CircuitBreaker, CircuitBreakerConfig as CoreCircuitBreakerConfig},
     data_connector::{
-        ConversationId, ListParams, ResponseId, SharedConversationItemStorage,
-        SharedConversationStorage, SharedResponseStorage, SortOrder,
+        ConversationId, ConversationItemStorage, ConversationStorage, ListParams, ResponseId,
+        ResponseStorage, SortOrder,
     },
     mcp::McpManager,
     protocols::{
@@ -81,11 +81,11 @@ pub struct OpenAIRouter {
     /// Health status
     healthy: AtomicBool,
     /// Response storage for managing conversation history
-    response_storage: SharedResponseStorage,
+    response_storage: Arc<dyn ResponseStorage>,
     /// Conversation storage backend
-    conversation_storage: SharedConversationStorage,
+    conversation_storage: Arc<dyn ConversationStorage>,
     /// Conversation item storage backend
-    conversation_item_storage: SharedConversationItemStorage,
+    conversation_item_storage: Arc<dyn ConversationItemStorage>,
     /// MCP manager (handles both static and dynamic servers)
     mcp_manager: Arc<McpManager>,
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The type aliases `SharedResponseStorage`, `SharedConversationStorage`, and `SharedConversationItemStorage` were hiding the Arc wrapper in their definitions:

`pub type SharedResponseStorage = Arc<dyn ResponseStorage>;`

This created two problems:
1. Easy to double-wrap Arc - Developers unfamiliar with the codebase could accidentally write Arc::new(shared_storage), creating Arc<Arc<T>>
2. Reduced clarity - The Arc ownership semantics were hidden, making it unclear that these are reference-counted shared pointers

`data_connector/mod.rs` uses `submodule::*` wildcard imports to re-export everything. This is not recommended in Rust.

## Modifications

<!-- Detail the changes made in this pull request. -->
1. Removed type aliases from data_connector/core.rs:
   - Deleted SharedResponseStorage
   - Deleted SharedConversationStorage
   - Deleted SharedConversationItemStorage
2. Updated 61 usages across 8 files to use explicit Arc<dyn Trait>
3. Replace `use sub_module::*` wildcard imports with explicit imports

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
