### PR TITLE
Option to enable auxiliary hidden capture mode.

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -203,8 +203,7 @@ class ModelConfig:
     ):
         # convert server arg in a string to layer index lists in integers
         if server_args.capture_states_of_layers:
-            capture_states_of_layers = server_args.capture_states_of_layers.split(",")
-            capture_states_of_layers = map(lambda i: int(i), capture_states_of_layers)
+            capture_states_of_layers = [int(i) for i in server_args.capture_states_of_layers.split(",")]
         else:
             capture_states_of_layers = None
 

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -203,7 +203,7 @@ class ModelConfig:
     ):
         # convert server arg in a string to layer index lists in integers
         if server_args.capture_states_of_layers:
-            capture_states_of_layers = server_args.capture_states_of_layers.split(',')
+            capture_states_of_layers = server_args.capture_states_of_layers.split(",")
             capture_states_of_layers = map(lambda i: int(i), capture_states_of_layers)
         else:
             capture_states_of_layers = None

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -89,6 +89,7 @@ class ModelConfig:
         is_draft_model: bool = False,
         hybrid_kvcache_ratio: Optional[float] = None,
         model_impl: Union[str, ModelImpl] = ModelImpl.AUTO,
+        capture_states_of_layers: Optional[list] = None,
     ) -> None:
         # Parse args
         self.model_path = model_path
@@ -96,6 +97,7 @@ class ModelConfig:
         self.quantization = quantization
         self.is_draft_model = is_draft_model
         self.model_impl = model_impl
+        self.capture_states_of_layers = capture_states_of_layers
 
         # Get hf config
         self._maybe_pull_model_tokenizer_from_remote()
@@ -199,6 +201,13 @@ class ModelConfig:
         model_revision: str = None,
         **kwargs,
     ):
+        # convert server arg in a string to layer index lists in integers
+        if server_args.capture_states_of_layers:
+            capture_states_of_layers = server_args.capture_states_of_layers.split(',')
+            capture_states_of_layers = map(lambda i: int(i), capture_states_of_layers)
+        else:
+            capture_states_of_layers = None
+
         return ModelConfig(
             model_path=model_path or server_args.model_path,
             trust_remote_code=server_args.trust_remote_code,
@@ -211,6 +220,7 @@ class ModelConfig:
             quantization=server_args.quantization,
             hybrid_kvcache_ratio=server_args.hybrid_kvcache_ratio,
             model_impl=server_args.model_impl,
+            capture_states_of_layers=capture_states_of_layers,
             **kwargs,
         )
 

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -253,7 +253,7 @@ class LogitsProcessor(nn.Module):
         hidden_states,
         lm_head: VocabParallelEmbedding,
         logits_metadata: Union[LogitsMetadata, ForwardBatch],
-        aux_hidden_states: Optional[torch.Tensor] = None,
+        aux_hidden_states: Optional[List[torch.Tensor]] = None,
     ) -> LogitsProcessorOutput:
 
         # Similar to HuggingFace's convention, it is not always the case to expect

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -447,7 +447,9 @@ class ModelRunner:
             self.init_attention_backend()
 
         # auxiliary hidden capture mode.
-        is_eagle3_target_model_runner = (self.spec_algorithm.is_eagle3() and not self.is_draft_worker)
+        is_eagle3_target_model_runner = (
+            self.spec_algorithm.is_eagle3() and not self.is_draft_worker
+        )
         if self.model_config.capture_states_of_layers or is_eagle3_target_model_runner:
 
             if is_eagle3_target_model_runner:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -167,6 +167,7 @@ class ServerArgs:
     enable_multimodal: Optional[bool] = None
     revision: Optional[str] = None
     model_impl: str = "auto"
+    capture_states_of_layers: Optional[str] = None
 
     # HTTP server
     host: str = "127.0.0.1"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -167,7 +167,6 @@ class ServerArgs:
     enable_multimodal: Optional[bool] = None
     revision: Optional[str] = None
     model_impl: str = "auto"
-    capture_states_of_layers: Optional[str] = None
 
     # HTTP server
     host: str = "127.0.0.1"
@@ -416,6 +415,7 @@ class ServerArgs:
     disable_fast_image_processor: bool = False
     keep_mm_feature_on_device: bool = False
     enable_return_hidden_states: bool = False
+    capture_states_of_layers: Optional[str] = None
     scheduler_recv_interval: int = 1
     numa_node: Optional[List[int]] = None
     enable_deterministic_inference: bool = False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Related to https://github.com/sgl-project/sglang/pull/6716 (there are follow-up requests to get the entire hidden states)

In [this line](https://github.com/sgl-project/sglang/blob/c8d385ce68839b2232c8da5058d48a4032601433/python/sglang/srt/model_executor/model_runner.py#L474), we want some server arg to enable auxiliary hidden capture mode.

This is important for many distillation online training tasks (including [EAGLE3 online training](https://github.com/sgl-project/SpecForge/blob/6bde887cc78d3e5e173d1265215efbf44f81248f/scripts/prepare_hidden_states.py#L58)) where the training data size is prohibitive to be saved on disks (easily [5T Disk space](https://docs.sglang.ai/SpecForge/basic_usage/data_preparation.html) for every new model).  Exposing auxiliary hidden capture mode to the Scheduler level can help different acceleration strategies in online training data generation (e.g., buffering, load-balancing, train/load-stage overlapping, etc.).

## Modifications

Expose auxiliary hidden capture mode from model_runner to server args.

(The existing `--enable-return-hidden-states` option only returns the last layer; we need an option to get internal layer states.)     

## Accuracy Tests
To test:
```py
import torch
from transformers import AutoTokenizer, AutoModelForCausalLM
from transformers.models.qwen3 import Qwen3Model
import sglang

if __name__ == "__main__":
    prompt = "Thomas is very healthy, but he has to go to the hospital every day. What could be the reasons?"

    ### HuggingFace ###
    tokenizer = AutoTokenizer.from_pretrained('Qwen/Qwen3-4B-Instruct-2507') # 36 layers in total
    model = AutoModelForCausalLM.from_pretrained('Qwen/Qwen3-4B-Instruct-2507', torch_dtype=torch.bfloat16)
    inputs = tokenizer(prompt, return_tensors="pt") # or from llm.tokenizer_manager.tokenizer
    hgf_hiddens = model(**inputs, output_hidden_states=True).hidden_states[1:] # excluding emb outputs
    hgf_hiddens = torch.cat(hgf_hiddens, dim=-1) # [1, 22, 92160==36*2560]

    ### SGL ###
    capture_states_of_layers = ','.join([str(i) for i in range(0, model.config.num_hidden_layers - 1)]) # the last layer is returned as hidden_states and will be concatenated in logits_processor.
    llm = sglang.Engine(
        model_path='Qwen/Qwen3-4B-Instruct-2507',
        dtype='bfloat16',
        mem_fraction_static=0.7,
        capture_states_of_layers=capture_states_of_layers,
        enable_return_hidden_states=True,
    )

    sampling_params = {"temperature": 0, "max_new_tokens": 0}
    res = llm.generate(prompt, sampling_params, return_hidden_states=True)
    sgl_hiddens = torch.Tensor(res['meta_info']['hidden_states'])

    ### Test ###
    assert hgf_hiddens.shape == sgl_hiddens.shape
    assert (hgf_hiddens - sgl_hiddens).abs().mean().item() < 0.3
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
