### PR TITLE
[CPU] Use covt_e4m3_bf16 to optim BF16 to FP8 convert

### DIFF
--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -52,11 +52,10 @@ convert_from_float_ext<at::BFloat16>(const Vectorized<float>& a, const Vectorize
 // this doesn't handle NaN.
 inline __m512bh cvt_e4m3_bf16_intrinsic_no_nan(__m256i fp8_vec) {
   const __m512i x = _mm512_cvtepu8_epi16(fp8_vec);
-
-  __m512i combined = _mm512_add_epi16(x, mm780);
+  __m512i combined = _mm512_add_epi16(x, _mm512_set1_epi16(0x0780));
   combined = _mm512_slli_epi16(combined, 4);
-  combined = _mm512_and_si512(combined, mm87f0);
-  combined = _mm512_add_epi16(combined, mm3c00);
+  combined = _mm512_and_si512(combined, _mm512_set1_epi16(0x87f0));
+  combined = _mm512_add_epi16(combined, _mm512_set1_epi16(0x3c00));
 
   const __mmask32 is_nonzero = _mm512_cmpneq_epi16_mask(x, _mm512_setzero_si512());
   return (__m512bh)_mm512_maskz_mov_epi16(is_nonzero, combined);

--- a/sgl-kernel/csrc/cpu/vec.h
+++ b/sgl-kernel/csrc/cpu/vec.h
@@ -53,13 +53,10 @@ convert_from_float_ext<at::BFloat16>(const Vectorized<float>& a, const Vectorize
 inline __m512bh cvt_e4m3_bf16_intrinsic_no_nan(__m256i fp8_vec) {
   const __m512i x = _mm512_cvtepu8_epi16(fp8_vec);
 
-  const __m512i mant = _mm512_slli_epi16(_mm512_and_si512(x, _mm512_set1_epi16(0x07)), 4);
-  const __m512i raw_exp = _mm512_srli_epi16(_mm512_and_si512(x, _mm512_set1_epi16(0x78)), 3);
-  const __m512i exp = _mm512_slli_epi16(_mm512_add_epi16(raw_exp, _mm512_set1_epi16(120)), 7);
-  const __m512i nonsign = _mm512_or_si512(exp, mant);
-
-  const __m512i sign = _mm512_slli_epi16(_mm512_and_si512(x, _mm512_set1_epi16(0x80)), 8);
-  const __m512i combined = _mm512_or_si512(nonsign, sign);
+  __m512i combined = _mm512_add_epi16(x, mm780);
+  combined = _mm512_slli_epi16(combined, 4);
+  combined = _mm512_and_si512(combined, mm87f0);
+  combined = _mm512_add_epi16(combined, mm3c00);
 
   const __mmask32 is_nonzero = _mm512_cmpneq_epi16_mask(x, _mm512_setzero_si512());
   return (__m512bh)_mm512_maskz_mov_epi16(is_nonzero, combined);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The primary goal of this PR is to optimize the performance of the E4M3 (FP8) to BF16 type conversion.

## Modifications

The cvt_e4M3_bf16_intrinsic_no_nan function is a high-frequency hot path during inference or model loading. The current implementation (Algorithm 1) uses a "textbook" conversion method, which involves separately extracting the sign, exponent, and mantissa, processing them individually, and then merging them back together using OR operations.

While this method is clear, it is not the most efficient in terms of AVX-512 instructions. To improve the throughput of this critical path, we are replacing it with a more efficient "fused algorithm"

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
