### PR TITLE
[Detokenizer Manager] Cleanup state when reqs are finished

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -235,6 +235,8 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                     new_text = ""
                 else:
                     new_text = find_printable_text(new_text)
+            else:
+                del self.decode_status[recv_obj.rids[i]]
 
             output_str = self.trim_matched_stop(
                 s.decoded_text + new_text,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When a request containing an `rid` field is sent to the SGLang engine multiple times, the resulting `output_strs` includes a few trailing tokens (usually up to 5), which are meaningless.

The root cause is that after a request is completed, the `DetokenizerManager` still retains the state associated with that `rid`. This can be seen more clearly in the figure below:

<img width="1782" height="370" alt="image" src="https://github.com/user-attachments/assets/bb9644a2-ff61-4bbe-86ba-8771ffb33b68" />


As shown in the second run, the previous state still exists. This causes the initial `surr_ids` of the new run to be treated as normal text, even though they actually come from the `input_ids`.

## Modifications

Clean up the retained state in `DetokenizerManager` once the corresponding request has finished.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
