### PR TITLE
[Ascend] Deepseek v3 and v3.2 support Context Parallelism

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -42,6 +42,10 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce,
     prepare_abort,
 )
+from sglang.srt.distributed import (
+    get_context_model_parallel_world_size,
+    get_world_group,
+)
 from sglang.srt.managers.schedule_batch import (
     FINISH_LENGTH,
     Req,
@@ -105,6 +109,7 @@ class PrefillBootstrapQueue:
         self.bootstrap_port = bootstrap_port
         self.queue: List[Req] = []
         self.gloo_group = gloo_group
+        self.world_group = get_world_group()
         self.max_total_num_tokens = max_total_num_tokens
         self.scheduler = scheduler
         self.transfer_backend = transfer_backend
@@ -243,8 +248,15 @@ class PrefillBootstrapQueue:
             else:
                 return [], []
 
+        cp_size = get_context_model_parallel_world_size()
+        if cp_size > 1:
+            cpu_group = self.world_group.cpu_group
+        else:
+            cpu_group = self.gloo_group
+
         polls = poll_and_all_reduce(
-            [req.disagg_kv_sender for req in self.queue], self.gloo_group
+            [req.disagg_kv_sender for req in self.queue],
+            cpu_group,
         )
 
         for i, (req, poll) in enumerate(zip(self.queue, polls)):
@@ -517,7 +529,11 @@ class SchedulerDisaggregationPrefillMixin:
 
         polls = poll_and_all_reduce(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
-            self.attn_tp_cpu_group,
+            (
+                get_world_group().cpu_group
+                if self.server_args.cp_size > 1
+                else self.attn_tp_cpu_group
+            ),
         )
 
         undone_reqs: List[Req] = []

--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Union
 import torch
 import torch.distributed
 
-from .parallel_state import get_tp_group
+from .parallel_state import get_cp_group, get_tp_group
 
 
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
@@ -25,6 +25,13 @@ def tensor_model_parallel_gather(
 ) -> Optional[torch.Tensor]:
     """Gather the input tensor across model parallel group."""
     return get_tp_group().gather(input_, dst, dim)
+
+
+def context_model_parallel_all_gather(
+    input_: torch.Tensor, dim: int = -1
+) -> torch.Tensor:
+    """All-gather the input tensor across model parallel group."""
+    return get_cp_group().all_gather(input_, dim)
 
 
 def broadcast_tensor_dict(

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -834,6 +834,10 @@ def _launch_subprocesses(
                 moe_ep_rank = tp_rank // (server_args.tp_size // server_args.ep_size)
 
                 with maybe_reindex_device_id(gpu_id) as gpu_id:
+                    attn_tp_size = server_args.tp_size // server_args.cp_size
+                    attn_cp_rank = (
+                        tp_rank // attn_tp_size if server_args.cp_size > 1 else None
+                    )
                     proc = mp.Process(
                         target=run_scheduler_process,
                         args=(
@@ -844,6 +848,7 @@ def _launch_subprocesses(
                             moe_ep_rank,
                             pp_rank,
                             None,
+                            attn_cp_rank,
                             writer,
                         ),
                     )

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -8,15 +8,29 @@ from einops import rearrange
 
 from sglang.srt.custom_op import CustomOp
 from sglang.srt.layers.layernorm import LayerNorm
-from sglang.srt.utils import add_prefix, ceil_align, is_cuda, is_hip, is_npu
+from sglang.srt.utils import (
+    add_prefix,
+    ceil_align,
+    get_bool_env_var,
+    is_cuda,
+    is_hip,
+    is_npu,
+)
 
 if is_cuda():
     try:
         import deep_gemm
     except ImportError as e:
         deep_gemm = e
+elif is_npu():
+    import torch_npu
+    import custom_ops  # noqa: F401
 
-
+from sglang.srt.distributed import (
+    context_model_parallel_all_gather,
+    get_context_model_parallel_rank,
+    get_context_model_parallel_world_size,
+)
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.attention.nsa.utils import (
     NSA_DUAL_STREAM,
@@ -166,6 +180,10 @@ class Indexer(CustomOp):
         self.block_size = block_size
         self.scale_fmt = scale_fmt
         self.softmax_scale = self.head_dim**-0.5
+        self.cp_size = get_context_model_parallel_world_size()
+        self.cp_rank = get_context_model_parallel_rank()
+        self.attention_tp_rank = get_attention_tp_rank()
+        self.attention_tp_size = get_attention_tp_size()
 
     @torch.compile(dynamic=True)
     def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
@@ -944,15 +962,6 @@ class Indexer(CustomOp):
         forward_batch: ForwardBatch,
         layer_id: int,
     ) -> torch.Tensor:
-        import custom_ops  # noqa: F401
-        import torch_npu
-
-        from sglang.srt.layers.dp_attention import (
-            get_attention_tp_rank,
-            get_attention_tp_size,
-        )
-        from sglang.srt.utils import get_bool_env_var
-
         if forward_batch.attn_backend.forward_metadata.seq_lens_cpu_int is None:
             actual_seq_lengths_kv = forward_batch.attn_backend.forward_metadata.seq_lens
         else:
@@ -976,24 +985,25 @@ class Indexer(CustomOp):
         cos, sin = cos_sin.chunk(2, dim=-1)
         cos = cos.repeat(1, 2).view(-1, 1, 1, self.rope_head_dim)
         sin = sin.repeat(1, 2).view(-1, 1, 1, self.rope_head_dim)
-        if is_prefill and enable_index_cp:
-            slice_length = cos.shape[0] // attention_tp_size
-            cos = cos[
-                slice_length
-                * attention_tp_rank : slice_length
-                * (attention_tp_rank + 1)
-            ]
-            sin = sin[
-                slice_length
-                * attention_tp_rank : slice_length
-                * (attention_tp_rank + 1)
-            ]
-
-        slot_mapping = forward_batch.out_cache_loc
-        block_table = forward_batch.attn_backend.forward_metadata.block_tables
+        if is_prefill:
+            assert not (enable_index_cp and self.cp_size > 1)
+            if self.cp_size > 1:  # todo(zyj),  can split position at first
+                cos = cos.tensor_split(self.cp_size)[self.cp_rank]
+                sin = sin.tensor_split(self.cp_size)[self.cp_rank]
+            if enable_index_cp:
+                slice_length = cos.shape[0] // self.attention_tp_size
+                cos = cos[
+                    slice_length
+                    * self.attention_tp_rank : slice_length
+                    * (self.attention_tp_rank + 1)
+                ]
+                sin = sin[
+                    slice_length
+                    * self.attention_tp_rank : slice_length
+                    * (self.attention_tp_rank + 1)
+                ]
 
         bs = x.shape[0]
-
         q = self.wq_b(q_lora)[0]  # [bs, 1536] @ [1536, 64 * 128] = [bs, 64 * 128]
         q = q.view(bs, self.n_heads, self.head_dim)  # [bs, 64, 128]
         q_pe, q_nope = torch.split(
@@ -1022,40 +1032,50 @@ class Indexer(CustomOp):
         )  # [bs, 1, d]
         k = torch.cat([k_pe, k_nope.unsqueeze(1)], dim=-1)  # [bs, 1, 128]
 
-        if is_prefill and enable_index_cp:
-            k, local_k = (
-                torch.empty(
-                    (k.shape[0] * attention_tp_size, k.shape[1], k.shape[2]),
-                    dtype=k.dtype,
-                    device=k.device,
-                ),
-                k,
-            )
-            get_attention_tp_group().all_gather_into_tensor(k, local_k)
-
-        forward_batch.token_to_kv_pool.set_index_k_buffer(layer_id, slot_mapping, k)
-
-        indexer_input = {}
         if is_prefill:
-            actual_seq_lengths_kv = forward_batch.seq_lens.to(device=q.device)
-            actual_seq_lengths_q = forward_batch.seq_lens.cumsum(dim=0).to(
-                device=q.device
-            )
             if enable_index_cp:
-                actual_seq_lengths_q -= bs * attention_tp_rank
-                actual_seq_lengths_q = torch.max(
-                    actual_seq_lengths_q,
-                    torch.zeros_like(actual_seq_lengths_q).to(
-                        device=actual_seq_lengths_q.device
+                k, local_k = (
+                    torch.empty(
+                        (k.shape[0] * self.attention_tp_size, k.shape[1], k.shape[2]),
+                        dtype=k.dtype,
+                        device=k.device,
                     ),
+                    k,
                 )
-                actual_seq_lengths_q = torch.min(
-                    actual_seq_lengths_q,
-                    torch.full(actual_seq_lengths_q.shape, bs).to(
-                        device=actual_seq_lengths_q.device
-                    ),
-                )
+                get_attention_tp_group().all_gather_into_tensor(k, local_k)
+            if self.cp_size > 1:
+                k = context_model_parallel_all_gather(k, 0)
 
+        forward_batch.token_to_kv_pool.set_index_k_buffer(
+            layer_id, forward_batch.out_cache_loc, k
+        )
+
+        if is_prefill:
+            if enable_index_cp:
+                actual_seq_lengths_kv = forward_batch.seq_lens.clone()
+                actual_seq_lengths_q = forward_batch.seq_lens.cumsum(dim=0)
+                rank_offset = (
+                    self.attention_tp_rank + self.attention_tp_size * self.cp_rank
+                )
+                actual_seq_lengths_q -= bs * rank_offset
+                actual_seq_lengths_q.clip_(min=0, max=bs)
+                total_num = bs * (rank_offset + 1)
+                for i in range(len(actual_seq_lengths_kv)):
+                    if total_num <= actual_seq_lengths_kv[i]:
+                        actual_seq_lengths_kv[i] = total_num
+                        total_num = 0
+                    else:
+                        total_num -= actual_seq_lengths_kv[i]
+            elif self.cp_size > 1:
+                actual_seq_lengths_q = (
+                    forward_batch.attn_backend.forward_metadata.actual_seq_lengths_q
+                )
+                actual_seq_lengths_kv = (
+                    forward_batch.attn_backend.forward_metadata.actual_seq_lengths_kv
+                )
+            else:
+                actual_seq_lengths_kv = forward_batch.seq_lens
+                actual_seq_lengths_q = forward_batch.seq_lens.cumsum(dim=0)
         else:
             if forward_batch.attn_backend.forward_metadata.actual_seq_lengths_q is None:
                 if (
@@ -1088,6 +1108,7 @@ class Indexer(CustomOp):
 
         x = x.view(-1, self.hidden_size)
         weights = self.weights_proj(x.float())[0].to(torch.bfloat16)
+        block_table = forward_batch.attn_backend.forward_metadata.block_tables
         block_table = (
             block_table[: actual_seq_lengths_q.size()[0]] if is_prefill else block_table
         )
@@ -1109,7 +1130,7 @@ class Indexer(CustomOp):
             topk_indices, local_topk_indices = (
                 torch.empty(
                     (
-                        topk_indices.shape[0] * attention_tp_size,
+                        topk_indices.shape[0] * self.attention_tp_size,
                         topk_indices.shape[1],
                         topk_indices.shape[2],
                     ),

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -11,6 +11,10 @@ import triton
 import triton.language as tl
 
 from sglang.srt.custom_op import CustomOp
+from sglang.srt.distributed import (
+    get_context_model_parallel_rank,
+    get_context_model_parallel_world_size,
+)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     cpu_has_amx_support,
@@ -917,19 +921,25 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
         if self.rotary_dim < self.head_size:
             query_pass = query[..., self.rotary_dim :]
             key_pass = key[..., self.rotary_dim :]
-
+        if positions.numel() != num_tokens:
+            cp_size = get_context_model_parallel_world_size()
+            cp_rank = get_context_model_parallel_rank()
+            cos_split = cos.tensor_split(cp_size)[cp_rank]
+            sin_split = sin.tensor_split(cp_size)[cp_rank]
+        else:
+            cos_split, sin_split = cos, sin
         query_rot = torch_npu.npu_interleave_rope(
             query_rot.reshape(num_tokens, num_q_heads, 1, self.rotary_dim),
-            cos,
-            sin,
+            cos_split,
+            sin_split,
         )
         key_rot = torch_npu.npu_interleave_rope(
-            key_rot.reshape(num_tokens, num_k_heads, 1, self.rotary_dim),
+            key_rot.reshape(-1, num_k_heads, 1, self.rotary_dim),
             cos,
             sin,
         )
-        query_rot = query_rot.reshape(num_tokens, -1, self.rotary_dim)
-        key_rot = key_rot.reshape(num_tokens, -1, self.rotary_dim)
+        query_rot = query_rot.reshape(num_tokens, num_q_heads, self.rotary_dim)
+        key_rot = key_rot.reshape(-1, num_k_heads, self.rotary_dim)
 
         if self.rotary_dim < self.head_size:
             query = torch.cat((query_rot, query_pass), dim=-1)

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -438,6 +438,7 @@ class DataParallelController:
                             moe_ep_rank,
                             pp_rank,
                             dp_rank,
+                            None,
                             writer,
                         ),
                     )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -231,6 +231,7 @@ class Scheduler(
         moe_ep_rank: int,
         pp_rank: int,
         dp_rank: Optional[int],
+        cp_rank: Optional[int],
     ):
         # Parse args
         self.server_args = server_args
@@ -238,10 +239,12 @@ class Scheduler(
         self.moe_ep_rank = moe_ep_rank
         self.pp_rank = pp_rank
         self.dp_rank = dp_rank
+        self.cp_rank = cp_rank if cp_rank is not None else 0
         self.tp_size = server_args.tp_size
         self.moe_ep_size = server_args.ep_size
         self.pp_size = server_args.pp_size
         self.dp_size = server_args.dp_size
+        self.cp_size = server_args.cp_size
         self.schedule_policy = server_args.schedule_policy
         self.enable_priority_scheduling = server_args.enable_priority_scheduling
         self.abort_on_priority_when_disabled = (
@@ -282,7 +285,7 @@ class Scheduler(
                 server_args.enable_dp_attention,
                 self.tp_rank,
                 self.tp_size,
-                self.dp_size,
+                max(self.dp_size, self.cp_size),
             )
         )
 
@@ -320,6 +323,7 @@ class Scheduler(
             moe_ep_rank=moe_ep_rank,
             pp_rank=pp_rank,
             dp_rank=dp_rank,
+            cp_rank=cp_rank,
             nccl_port=port_args.nccl_port,
         )
 
@@ -332,6 +336,7 @@ class Scheduler(
             nccl_port=port_args.nccl_port,
             target_worker=self.tp_worker,
             dp_rank=dp_rank,
+            cp_rank=cp_rank,
         )
 
         if server_args.speculative_draft_load_format is not None:
@@ -612,7 +617,7 @@ class Scheduler(
 
                 self.socket.send_pyobj(output)
 
-        if self.pp_rank == 0 and self.attn_tp_rank == 0:
+        if self.pp_rank == 0 and self.attn_tp_rank == 0 and self.cp_rank == 0:
             self.recv_from_tokenizer = get_zmq_socket(
                 context, zmq.PULL, port_args.scheduler_input_ipc_name, False
             )
@@ -1067,7 +1072,7 @@ class Scheduler(
                 return []
 
         if self.pp_rank == 0:
-            if self.attn_tp_rank == 0:
+            if self.attn_tp_rank == 0 and self.cp_rank == 0:
                 recv_reqs = []
 
                 while True:
@@ -1105,7 +1110,14 @@ class Scheduler(
         if self.input_blocker is not None:
             recv_reqs = self.input_blocker.handle(recv_reqs)
 
-        if self.server_args.enable_dp_attention:
+        if self.cp_size != 1:
+            recv_reqs = broadcast_pyobj(
+                recv_reqs,
+                self.world_group.rank,
+                self.world_group.cpu_group,
+                src=self.world_group.ranks[0],
+            )
+        elif self.server_args.enable_dp_attention:
             if self.attn_tp_rank == 0:
                 work_reqs = [
                     req
@@ -2602,6 +2614,7 @@ def run_scheduler_process(
     moe_ep_rank: int,
     pp_rank: int,
     dp_rank: Optional[int],
+    cp_rank: Optional[int],
     pipe_writer,
 ):
     # Generate the logger prefix
@@ -2613,6 +2626,8 @@ def run_scheduler_process(
         prefix += f" DP{dp_rank}"
     if server_args.pp_size > 1:
         prefix += f" PP{pp_rank}"
+    if cp_rank is not None:
+        prefix += f" CP{cp_rank}"
     if server_args.tp_size > 1:
         prefix += f" TP{tp_rank}"
     if server_args.ep_size > 1:
@@ -2658,6 +2673,7 @@ def run_scheduler_process(
             moe_ep_rank,
             pp_rank,
             dp_rank,
+            cp_rank,
         )
         pipe_writer.send(
             {

--- a/python/sglang/srt/managers/scheduler_dp_attn_mixin.py
+++ b/python/sglang/srt/managers/scheduler_dp_attn_mixin.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable
 import torch
 
 from sglang.srt.batch_overlap.two_batch_overlap import TboDPAttentionPreparer
+from sglang.srt.distributed import get_context_model_parallel_world_size
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.utils.common import require_mlp_tp_gather
 
@@ -49,8 +50,9 @@ class MLPSyncBatchInfo:
 
     def all_gather(self, device, group: torch.distributed.ProcessGroup):
         local_info_tensor = self._get_local_tensor(device=device)
+        cp_size = get_context_model_parallel_world_size()
         global_info_tensor = torch.empty(
-            (self.dp_size, self.tp_size, 6),
+            (max(self.dp_size, cp_size), self.tp_size, 6),
             dtype=torch.int64,
             device=device,
         )

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -212,6 +212,7 @@ class TpModelWorker(BaseTpWorker):
         moe_ep_rank: int,
         pp_rank: int,
         dp_rank: Optional[int],
+        cp_rank: Optional[int],
         nccl_port: int,
         is_draft_worker: bool = False,
         req_to_token_pool: Optional[ReqToTokenPool] = None,
@@ -219,9 +220,11 @@ class TpModelWorker(BaseTpWorker):
     ):
         # Parse args
         self.tp_size = server_args.tp_size
+        self.pp_size = server_args.pp_size
         self.tp_rank = tp_rank
         self.moe_ep_rank = moe_ep_rank
         self.pp_rank = pp_rank
+        self.cp_rank = cp_rank if cp_rank is not None else 0
 
         # Init model and tokenizer
         self.model_config = ModelConfig.from_server_args(
@@ -252,6 +255,8 @@ class TpModelWorker(BaseTpWorker):
             moe_ep_size=server_args.ep_size,
             pp_rank=pp_rank,
             pp_size=server_args.pp_size,
+            cp_rank=cp_rank if cp_rank is not None else 0,
+            cp_size=server_args.cp_size,
             nccl_port=nccl_port,
             dp_rank=dp_rank,
             server_args=server_args,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -39,6 +39,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.distributed.parallel_state import (
+    get_context_model_parallel_world_size,
     get_moe_expert_parallel_world_size,
     get_tensor_model_parallel_world_size,
 )
@@ -727,13 +728,19 @@ class ForwardBatch:
         global_num_tokens = self.global_num_tokens_cpu
         sync_group_size = len(global_num_tokens)
         attn_tp_size = get_attention_tp_size()
-
+        tp_size = get_tensor_model_parallel_world_size()
+        cp_size = get_context_model_parallel_world_size()
         for i in range(sync_group_size):
             # make sure that the padded length is divisible by attn_tp_size because we may need reduce-scatter across attn_tp dim.
             # there is no reduce-scatter in LM logprob, so we do not need to adjust the padded length for logprob
-            global_num_tokens[i] = (
-                (global_num_tokens[i] - 1) // attn_tp_size + 1
-            ) * attn_tp_size
+            if cp_size > 1:
+                global_num_tokens[i] = (
+                    (global_num_tokens[i] - 1) // tp_size + 1
+                ) * tp_size
+            else:
+                global_num_tokens[i] = (
+                    (global_num_tokens[i] - 1) // attn_tp_size + 1
+                ) * attn_tp_size
 
         dp_padding_mode = DpPaddingMode.get_dp_padding_mode(
             self.is_extend_in_batch, global_num_tokens
@@ -758,7 +765,10 @@ class ForwardBatch:
 
         self.global_dp_buffer_len = buffer_len
         set_dp_buffer_len(
-            buffer_len, num_tokens, dp_padding_mode.is_max_len(), global_num_tokens
+            buffer_len // cp_size,
+            num_tokens // cp_size,
+            dp_padding_mode.is_max_len(),
+            global_num_tokens,
         )
         set_is_extend_in_batch(self.is_extend_in_batch)
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -278,6 +278,8 @@ class ModelRunner:
         moe_ep_size: int,
         pp_rank: int,
         pp_size: int,
+        cp_rank: int,
+        cp_size: int,
         nccl_port: int,
         server_args: ServerArgs,
         dp_rank: Optional[int] = None,
@@ -296,6 +298,8 @@ class ModelRunner:
         self.dp_size = server_args.dp_size
         self.pp_rank = pp_rank
         self.pp_size = pp_size
+        self.cp_rank = cp_rank
+        self.cp_size = cp_size
         self.model_config = model_config
         self.dist_port = nccl_port
         self.server_args = server_args
@@ -686,6 +690,7 @@ class ModelRunner:
             initialize_model_parallel(
                 tensor_model_parallel_size=self.tp_size,
                 pipeline_model_parallel_size=self.pp_size,
+                context_model_parallel_size=self.cp_size,
                 expert_model_parallel_size=self.moe_ep_size,
                 duplicate_tp_group=self.server_args.enable_pdmux,
                 torch_compile=self.server_args.enable_piecewise_cuda_graph,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -348,6 +348,9 @@ class ServerArgs:
     # FIXME: remove this after dp rank scheduling is fully supported with PD-Disaggregation
     prefill_round_robin_balance: bool = False
 
+    # Context parallelism
+    cp_size: int = 1
+
     # Multi-node distributed serving
     dist_init_addr: Optional[str] = None
     nnodes: int = 1
@@ -1497,6 +1500,10 @@ class ServerArgs:
             logger.warning(
                 f"DP attention is enabled. The chunked prefill size is adjusted to {self.chunked_prefill_size} to avoid MoE kernel issues. "
             )
+
+        if self.cp_size > 1 and self.disaggregation_mode != "decode":
+            self.enable_dp_attention = True
+            assert self.tp_size % self.cp_size == 0
 
         if self.enable_dp_lm_head:
             assert (
@@ -2743,6 +2750,15 @@ class ServerArgs:
             help="Prefill is round robin balanced. This is used to promise decode server can get the correct dp rank.",
         )
 
+        # Context parallelism
+        parser.add_argument(
+            "--context-parallel-size",
+            "--cp-size",
+            type=int,
+            default=ServerArgs.cp_size,
+            help="The context parallelism size.",
+        )
+
         # Multi-node distributed serving
         parser.add_argument(
             "--dist-init-addr",
@@ -3901,6 +3917,7 @@ class ServerArgs:
         args.tp_size = args.tensor_parallel_size
         args.pp_size = args.pipeline_parallel_size
         args.dp_size = args.data_parallel_size
+        args.cp_size = args.context_parallel_size
         args.ep_size = args.expert_parallel_size
 
         attrs = [attr.name for attr in dataclasses.fields(cls)]

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -82,6 +82,7 @@ class EAGLEWorker(TpModelWorker):
         tp_rank: int,
         dp_rank: Optional[int],
         moe_ep_rank: int,
+        cp_rank: int,
         nccl_port: int,
         target_worker: TpModelWorker,
     ):
@@ -140,6 +141,7 @@ class EAGLEWorker(TpModelWorker):
                 pp_rank=0,  # FIXME
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
+                cp_rank=cp_rank,
                 nccl_port=nccl_port,
                 is_draft_worker=True,
                 req_to_token_pool=self.req_to_token_pool,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -76,6 +76,7 @@ class EagleDraftWorker(BaseDraftWorker):
         tp_rank: int,
         dp_rank: int,
         moe_ep_rank: int,
+        cp_rank: int,
         nccl_port: int,
         target_worker: TpModelWorker,
     ):
@@ -121,6 +122,7 @@ class EagleDraftWorker(BaseDraftWorker):
                 pp_rank=0,  # FIXME
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
+                cp_rank=cp_rank,
                 nccl_port=nccl_port,
                 is_draft_worker=True,
                 req_to_token_pool=self.req_to_token_pool,
@@ -549,6 +551,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         tp_rank: int,
         dp_rank: Optional[int],
         moe_ep_rank: int,
+        cp_rank: int,
         nccl_port: int,
         target_worker: TpModelWorker,
     ):
@@ -575,7 +578,14 @@ class EAGLEWorkerV2(BaseSpecWorker):
         server_args.context_length = target_worker.model_runner.model_config.context_len
 
         self._draft_worker = EagleDraftWorker(
-            server_args, gpu_id, tp_rank, dp_rank, moe_ep_rank, nccl_port, target_worker
+            server_args,
+            gpu_id,
+            tp_rank,
+            dp_rank,
+            moe_ep_rank,
+            cp_rank,
+            nccl_port,
+            target_worker,
         )
 
         # Some dummy tensors

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2798,7 +2798,9 @@ def require_mlp_tp_gather(server_args: ServerArgs):
     Check if the input of MLP is obtained by all-gather rather than all-reduce. This only happens when each MLP TP group contains multiple attention DP groups.
     """
     if server_args.enable_dp_attention:
-        assert server_args.dp_size > 1, "dp_size must be greater than 1"
+        assert (
+            server_args.dp_size > 1 or server_args.cp_size > 1
+        ), "dp_size or cp_size must be greater than 1"
         if (
             server_args.moe_dense_tp_size is None
         ):  # TODO(ch-wan): some MoE models do not have dense layers


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->
Co-author: @zhuyijie88 @Todobe @ichaoren @ZhengdQin 

## Motivation
dsv3.2 LLM has been released for long context inference recently. In the case of long context, the model inference time of prefill stage is bounded by dense computing.  The computation load in the indexer module of Attention Layer scales with the square of context length `S`. To alleviate the problem, we introduce `Context Parallel` (CP) method, which splits context into multiple pieces, so that each rank gets a part of context and reduce the TTFT computation and activation memory footprint. The modification has no influence on the MOE layer, as it reuse the same strategy (EP) as dsv3. Attention weights are not partitioned in CP, so it risks OOM. In this case, a hybrid parallelism of CP and TP may be required.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- CP reuses the DP communication domain, and only one of CP or DP can be selected in prefill.
- add `--cp-size` paramater in server_args.py
- use the full kv buffer. Before saving the kv cache,  a all_gather operator is required to collect it from all cp ranks.
- In the case of PD disaggregation, recomputing the prefill ranks mapping to decode ranks to transfer the kv data.
- the input `actual_seq_qlen` of sparse_flash_attention needs to be update according to CP
- A all_gather operator is needed to refine the logit computation stage in  `LogitsProcessor`

The figure below shows our  Parallelism strategy across the network. 
<img width="506" height="377" alt="image" src="https://github.com/user-attachments/assets/79f07171-319c-454b-a0d2-5daa1e3fb0f6" />


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```[shell]
# PREFILL LAUNCH COMMEND
IPs=('x.x.x.x')  # ONE PREFILL NODES
export p0=x.x.x.x  # IP
export d0=x.x.x.x  # IP
nnodes=${#IPs[@]}
tp_size=`expr 16 \* ${nnodes}`
export ASCEND_MF_STORE_URL=tcp://${p0}:24667

python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
--tp $tp_size \
--cp-size 8 --mem-fraction-static 0.9 \
--max-total-tokens 10240 \
--trust-remote-code \
--attention-backend ascend \
--device npu \
--watchdog-timeout 9000 \
--host 0.0.0.0 --port 30002 \
--disable-radix-cache \
--max-running-requests 16 \
--disable-overlap-schedule \
--nnodes $nnodes --node-rank $VC_TASK_INDEX \
--disable-cuda-graph \
--skip-server-warmup \
--quantization w8a8_int8 \
--disaggregation-transfer-backend ascend \
--disaggregation-mode prefill \
--moe-a2a-backend deepep --deepep-mode auto \
--context-length 66000 --chunked-prefill-size 327680 --max-prefill-tokens 66000 \
--dist-init-addr ${p0}:10000 2>&1 | tee launch.log &
```
```[shell]
# DECODE LAUNCH COMMEND
IPs=('x.x.x.x')  # ONE DECODE NODES
export p0=x.x.x.x  # IP
export d0=x.x.x.x  # IP
nnodes=${#IPs[@]}
tp_size=`expr 16 \* ${nnodes}`
export ASCEND_MF_STORE_URL=tcp://${p0}:24667

python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
--tp $tp_size \
--mem-fraction-static 0.8 \
--max-total-tokens 10240 \
--trust-remote-code \
--attention-backend ascend \
--device npu \
--watchdog-timeout 9000 \
--host 0.0.0.0 --port 30002 \
--disable-radix-cache \
--max-running-requests 16 \
--disable-overlap-schedule \
--nnodes $nnodes --node-rank $VC_TASK_INDEX \
--disable-cuda-graph \
--disaggregation-transfer-backend ascend \
--disaggregation-mode decode \
--context-length 66000 --chunked-prefill-size 327680 --max-prefill-tokens 66000 \
--quantization w8a8_int8 | tee launch.log &
```

Launch the router:
```[shell]
# on the prefill node
export p0=x.x.x.x  # IP
export d0=x.x.x.x  # IP
python3 -m sglang_router.launch_router --decode http://${d0}:30002 --prefill http://${p0}:30002 --pd-disaggregation --policy cache_aware --mini-lb --host 0.0.0.0 --port 8000
```

We test 200 questions in the GMS8K dataset with 8CP-2TP configuration of  one prefill node and 16TP  configuration of  one decode node. The **accuracy is 0.97**, which indicates correctness.
```[shell]
cd python/sglang/test
python3 few_shot_gsm8k.py --data-path "test.jsonl.txt" --parallel 16 --num-questions 200 --num-shots 5 --port 8000 --temperature 0 | tee answer.log
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
Under the 32CP configuration of two prefill nodes and 16TP configuration of one decode nodes, the 64K context query cost **5s** compared to **30s** under the 32TP configuration of two prefill nodes.

More results  of other CP configurations are listed below:
<img width="596" height="182" alt="image" src="https://github.com/user-attachments/assets/187f10e8-48e9-47c3-bef8-12d9af561ff7" />
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
