### PR TITLE
Feature/Add GET endpoint to query loaded LoRA adapters

### DIFF
--- a/docs/advanced_features/lora.ipynb
+++ b/docs/advanced_features/lora.ipynb
@@ -208,7 +208,21 @@
    "source": [
     "Instead of specifying all adapters during server startup via `--lora-paths`. You can also load & unload LoRA adapters dynamically via the `/load_lora_adapter` and `/unload_lora_adapter` API.\n",
     "\n",
-    "When using dynamic LoRA loading, it's recommended to explicitly specify both `--max-lora-rank` and `--lora-target-modules` at startup. For backward compatibility, SGLang will infer these values from `--lora-paths` if they are not explicitly provided. However, in that case, you would have to ensure that all dynamically loaded adapters share the same shape (rank and target modules) as those in the initial `--lora-paths` or are strictly \"smaller\"."
+    "When using dynamic LoRA loading, it's recommended to explicitly specify both `--max-lora-rank` and `--lora-target-modules` at startup. For backward compatibility, SGLang will infer these values from `--lora-paths` if they are not explicitly provided. However, in that case, you would have to ensure that all dynamically loaded adapters share the same shape (rank and target modules) as those in the initial `--lora-paths` or are strictly \"smaller\".\n",
+    "\n",
+    "### Querying Loaded Adapters\n",
+    "\n",
+    "To query which LoRA adapters are currently loaded, use the OpenAI-compatible `/v1/models` endpoint. This endpoint returns both the base model and all loaded LoRA adapters:\n",
+    "\n",
+    "```bash\n",
+    "curl http://127.0.0.1:30000/v1/models\n",
+    "```\n",
+    "\n",
+    "The response includes:\n",
+    "- **Base model**: Listed with its full configuration\n",
+    "- **LoRA adapters**: Each adapter is listed with `id` (adapter name), `root` (adapter path), and `parent` (base model name)\n",
+    "\n",
+    "This endpoint is useful for state reconciliation in production environments, especially after engine restarts."
    ]
   },
   {

--- a/docs/advanced_features/lora.ipynb
+++ b/docs/advanced_features/lora.ipynb
@@ -208,21 +208,7 @@
    "source": [
     "Instead of specifying all adapters during server startup via `--lora-paths`. You can also load & unload LoRA adapters dynamically via the `/load_lora_adapter` and `/unload_lora_adapter` API.\n",
     "\n",
-    "When using dynamic LoRA loading, it's recommended to explicitly specify both `--max-lora-rank` and `--lora-target-modules` at startup. For backward compatibility, SGLang will infer these values from `--lora-paths` if they are not explicitly provided. However, in that case, you would have to ensure that all dynamically loaded adapters share the same shape (rank and target modules) as those in the initial `--lora-paths` or are strictly \"smaller\".\n",
-    "\n",
-    "### Querying Loaded Adapters\n",
-    "\n",
-    "To query which LoRA adapters are currently loaded, use the OpenAI-compatible `/v1/models` endpoint. This endpoint returns both the base model and all loaded LoRA adapters:\n",
-    "\n",
-    "```bash\n",
-    "curl http://127.0.0.1:30000/v1/models\n",
-    "```\n",
-    "\n",
-    "The response includes:\n",
-    "- **Base model**: Listed with its full configuration\n",
-    "- **LoRA adapters**: Each adapter is listed with `id` (adapter name), `root` (adapter path), and `parent` (base model name)\n",
-    "\n",
-    "This endpoint is useful for state reconciliation in production environments, especially after engine restarts."
+    "When using dynamic LoRA loading, it's recommended to explicitly specify both `--max-lora-rank` and `--lora-target-modules` at startup. For backward compatibility, SGLang will infer these values from `--lora-paths` if they are not explicitly provided. However, in that case, you would have to ensure that all dynamically loaded adapters share the same shape (rank and target modules) as those in the initial `--lora-paths` or are strictly \"smaller\"."
    ]
   },
   {

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1182,7 +1182,7 @@ async def available_models():
     # Add loaded LoRA adapters
     if _global_state.tokenizer_manager.server_args.enable_lora:
         lora_registry = _global_state.tokenizer_manager.lora_registry
-        for lora_name, lora_ref in lora_registry._registry.items():
+        for _, lora_ref in lora_registry.get_all_adapters().items():
             model_cards.append(
                 ModelCard(
                     id=lora_ref.lora_name,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1168,6 +1168,8 @@ async def available_models():
     """Show available models. OpenAI-compatible endpoint."""
     served_model_names = [_global_state.tokenizer_manager.served_model_name]
     model_cards = []
+    
+    # Add base model
     for served_model_name in served_model_names:
         model_cards.append(
             ModelCard(
@@ -1176,6 +1178,20 @@ async def available_models():
                 max_model_len=_global_state.tokenizer_manager.model_config.context_len,
             )
         )
+    
+    # Add loaded LoRA adapters
+    if _global_state.tokenizer_manager.server_args.enable_lora:
+        lora_registry = _global_state.tokenizer_manager.lora_registry
+        for lora_name, lora_ref in lora_registry._registry.items():
+            model_cards.append(
+                ModelCard(
+                    id=lora_ref.lora_name,
+                    root=lora_ref.lora_path,
+                    parent=served_model_names[0],
+                    max_model_len=None,
+                )
+            )
+    
     return ModelList(data=model_cards)
 
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1168,7 +1168,7 @@ async def available_models():
     """Show available models. OpenAI-compatible endpoint."""
     served_model_names = [_global_state.tokenizer_manager.served_model_name]
     model_cards = []
-    
+
     # Add base model
     for served_model_name in served_model_names:
         model_cards.append(
@@ -1178,7 +1178,7 @@ async def available_models():
                 max_model_len=_global_state.tokenizer_manager.model_config.context_len,
             )
         )
-    
+
     # Add loaded LoRA adapters
     if _global_state.tokenizer_manager.server_args.enable_lora:
         lora_registry = _global_state.tokenizer_manager.lora_registry
@@ -1191,7 +1191,7 @@ async def available_models():
                     max_model_len=None,
                 )
             )
-    
+
     return ModelList(data=model_cards)
 
 

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -54,6 +54,7 @@ class ModelCard(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     owned_by: str = "sglang"
     root: Optional[str] = None
+    parent: Optional[str] = None
     max_model_len: Optional[int] = None
 
 

--- a/python/sglang/srt/lora/lora_registry.py
+++ b/python/sglang/srt/lora/lora_registry.py
@@ -205,3 +205,12 @@ class LoRARegistry:
         Returns the total number of LoRA adapters currently registered.
         """
         return len(self._registry)
+
+    def get_all_adapters(self) -> Dict[str, LoRARef]:
+        """
+        Returns a dictionary of all registered LoRA adapters.
+
+        Returns:
+            Dict[str, LoRARef]: A dictionary mapping LoRA names to LoRARef objects.
+        """
+        return dict(self._registry)

--- a/test/srt/lora/test_lora_update.py
+++ b/test/srt/lora/test_lora_update.py
@@ -1349,7 +1349,7 @@ class TestLoRADynamicUpdate(CustomTestCase):
         ) as session:
             # Test with no adapters loaded
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
-            self.assertTrue(response.ok, f"Failed to query /v1/models: {response.text}")
+            self.assertTrue(response.ok, response.text)
             models_data = response.json()
             self.assertEqual(models_data["object"], "list")
             self.assertEqual(len(models_data["data"]), 1)  # Only base model
@@ -1362,7 +1362,7 @@ class TestLoRADynamicUpdate(CustomTestCase):
             
             # Test with one adapter loaded
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
-            self.assertTrue(response.ok)
+            self.assertTrue(response.ok, response.text)
             models_data = response.json()
             self.assertEqual(len(models_data["data"]), 2)  # Base model + 1 adapter
             
@@ -1378,7 +1378,7 @@ class TestLoRADynamicUpdate(CustomTestCase):
             
             # Test with two adapters loaded
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
-            self.assertTrue(response.ok)
+            self.assertTrue(response.ok, response.text)
             models_data = response.json()
             self.assertEqual(len(models_data["data"]), 3)  # Base model + 2 adapters
             
@@ -1393,7 +1393,7 @@ class TestLoRADynamicUpdate(CustomTestCase):
             
             # Test after unloading
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
-            self.assertTrue(response.ok)
+            self.assertTrue(response.ok, response.text)
             models_data = response.json()
             self.assertEqual(len(models_data["data"]), 2)  # Base model + 1 adapter
             adapter_models = [m for m in models_data["data"] if m.get("parent")]

--- a/test/srt/lora/test_lora_update.py
+++ b/test/srt/lora/test_lora_update.py
@@ -1328,6 +1328,78 @@ class TestLoRADynamicUpdate(CustomTestCase):
             mode=LoRAUpdateTestSessionMode.SERVER, test_cases=test_cases
         )
 
+    def test_v1_models_endpoint_with_lora(self):
+        """
+        Test that /v1/models endpoint returns base model and loaded LoRA adapters.
+        """
+        adapters = [
+            "philschmid/code-llama-3-1-8b-text-to-sql-lora",
+            "Nutanix/Meta-Llama-3.1-8B-Instruct_lora_4_alpha_16",
+        ]
+        
+        with LoRAUpdateTestSession(
+            testcase=self,
+            mode=LoRAUpdateTestSessionMode.SERVER,
+            model_path="meta-llama/Llama-3.1-8B-Instruct",
+            lora_paths=[],
+            max_loras_per_batch=2,
+            max_lora_rank=256,
+            lora_target_modules=["all"],
+            enable_lora=True,
+        ) as session:
+            # Test with no adapters loaded
+            response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
+            self.assertTrue(response.ok, f"Failed to query /v1/models: {response.text}")
+            models_data = response.json()
+            self.assertEqual(models_data["object"], "list")
+            self.assertEqual(len(models_data["data"]), 1)  # Only base model
+            base_model = models_data["data"][0]
+            self.assertIn("meta-llama", base_model["id"].lower())
+            self.assertIsNone(base_model.get("parent"))
+            
+            # Load first adapter
+            session.load_lora_adapter(lora_name="adapter1", lora_path=adapters[0])
+            
+            # Test with one adapter loaded
+            response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
+            self.assertTrue(response.ok)
+            models_data = response.json()
+            self.assertEqual(len(models_data["data"]), 2)  # Base model + 1 adapter
+            
+            # Verify adapter information
+            adapter_models = [m for m in models_data["data"] if m.get("parent")]
+            self.assertEqual(len(adapter_models), 1)
+            self.assertEqual(adapter_models[0]["id"], "adapter1")
+            self.assertEqual(adapter_models[0]["root"], adapters[0])
+            self.assertIsNotNone(adapter_models[0]["parent"])
+            
+            # Load second adapter
+            session.load_lora_adapter(lora_name="adapter2", lora_path=adapters[1])
+            
+            # Test with two adapters loaded
+            response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
+            self.assertTrue(response.ok)
+            models_data = response.json()
+            self.assertEqual(len(models_data["data"]), 3)  # Base model + 2 adapters
+            
+            # Verify both adapters are listed
+            adapter_models = [m for m in models_data["data"] if m.get("parent")]
+            self.assertEqual(len(adapter_models), 2)
+            adapter_names = {m["id"] for m in adapter_models}
+            self.assertEqual(adapter_names, {"adapter1", "adapter2"})
+            
+            # Unload one adapter
+            session.unload_lora_adapter(lora_name="adapter1")
+            
+            # Test after unloading
+            response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
+            self.assertTrue(response.ok)
+            models_data = response.json()
+            self.assertEqual(len(models_data["data"]), 2)  # Base model + 1 adapter
+            adapter_models = [m for m in models_data["data"] if m.get("parent")]
+            self.assertEqual(len(adapter_models), 1)
+            self.assertEqual(adapter_models[0]["id"], "adapter2")
+
 
 if __name__ == "__main__":
     try:

--- a/test/srt/lora/test_lora_update.py
+++ b/test/srt/lora/test_lora_update.py
@@ -1336,7 +1336,7 @@ class TestLoRADynamicUpdate(CustomTestCase):
             "philschmid/code-llama-3-1-8b-text-to-sql-lora",
             "Nutanix/Meta-Llama-3.1-8B-Instruct_lora_4_alpha_16",
         ]
-        
+
         with LoRAUpdateTestSession(
             testcase=self,
             mode=LoRAUpdateTestSessionMode.SERVER,
@@ -1356,41 +1356,41 @@ class TestLoRADynamicUpdate(CustomTestCase):
             base_model = models_data["data"][0]
             self.assertIn("meta-llama", base_model["id"].lower())
             self.assertIsNone(base_model.get("parent"))
-            
+
             # Load first adapter
             session.load_lora_adapter(lora_name="adapter1", lora_path=adapters[0])
-            
+
             # Test with one adapter loaded
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
             self.assertTrue(response.ok, response.text)
             models_data = response.json()
             self.assertEqual(len(models_data["data"]), 2)  # Base model + 1 adapter
-            
+
             # Verify adapter information
             adapter_models = [m for m in models_data["data"] if m.get("parent")]
             self.assertEqual(len(adapter_models), 1)
             self.assertEqual(adapter_models[0]["id"], "adapter1")
             self.assertEqual(adapter_models[0]["root"], adapters[0])
             self.assertIsNotNone(adapter_models[0]["parent"])
-            
+
             # Load second adapter
             session.load_lora_adapter(lora_name="adapter2", lora_path=adapters[1])
-            
+
             # Test with two adapters loaded
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
             self.assertTrue(response.ok, response.text)
             models_data = response.json()
             self.assertEqual(len(models_data["data"]), 3)  # Base model + 2 adapters
-            
+
             # Verify both adapters are listed
             adapter_models = [m for m in models_data["data"] if m.get("parent")]
             self.assertEqual(len(adapter_models), 2)
             adapter_names = {m["id"] for m in adapter_models}
             self.assertEqual(adapter_names, {"adapter1", "adapter2"})
-            
+
             # Unload one adapter
             session.unload_lora_adapter(lora_name="adapter1")
-            
+
             # Test after unloading
             response = requests.get(DEFAULT_URL_FOR_TEST + "/v1/models")
             self.assertTrue(response.ok, response.text)


### PR DESCRIPTION
## Motivation
From: https://github.com/sgl-project/sglang/issues/12221
Expose loaded LoRA adapters via the `/v1/models` endpoint to enable state reconciliation after server restarts. This addresses a production issue where proxy services lose track of loaded adapters when the SGLang engine crashes and restarts.

## Modifications

- **Enhanced `/v1/models` endpoint**: Now returns both the base model and all currently loaded LoRA adapters
- **Added `parent` field** to `ModelCard`: Links LoRA adapters to their base model
- **User-friendly adapter IDs**: Use `lora_name` as the adapter `id` instead of internal hash
- **Documentation**: Added "Querying Loaded Adapters" section to `lora.ipynb`
- **Unit test**: Added `test_v1_models_endpoint_with_lora` to verify functionality

**Example response:**
```json
{
  "object": "list",
  "data": [
    {
      "id": "meta-llama/Llama-3.1-8B-Instruct",
      "parent": null,
      "max_model_len": 8192
    },
    {
      "id": "sql_expert",
      "root": "path/to/sql_adapter",
      "parent": "meta-llama/Llama-3.1-8B-Instruct",
      "max_model_len": null
    }
  ]
}
```

## Accuracy Tests

N/A - This change only affects API response structure, not model outputs.

## Benchmarking and Profiling

N/A - No impact on inference speed. The endpoint simply returns metadata from the existing `LoRARegistry`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed). *(N/A - No impact on accuracy