### PR TITLE
[VLM] Optimize qwen_vl preprocess_video

### DIFF
--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -2,6 +2,7 @@ import asyncio
 import math
 import os
 import re
+import time
 from typing import List, Union
 
 import torch
@@ -175,6 +176,7 @@ async def preprocess_video(
     image_factor: int = IMAGE_FACTOR,
     # vr: VideoReader, image_factor: int = IMAGE_FACTOR
 ) -> torch.Tensor:
+    entry_time = time.perf_counter()
     ele = {}
     total_frames, video_fps = len(vr), vr.get_avg_fps()
     nframes = smart_nframes({}, total_frames=total_frames, video_fps=video_fps)
@@ -188,6 +190,9 @@ async def preprocess_video(
         min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR),
         int(min_pixels * 1.05),
     )
+
+    process1_time = time.perf_counter()
+
     max_pixels_supposed = ele.get("max_pixels", max_pixels)
     if max_pixels_supposed > max_pixels:
         logger.warning(
@@ -208,6 +213,8 @@ async def preprocess_video(
             min_pixels=min_pixels,
             max_pixels=max_pixels,
         )
+
+    process2_time = time.perf_counter()
     video = torchvision.transforms.functional.resize(
         video,
         [resized_height, resized_width],
@@ -221,6 +228,14 @@ async def preprocess_video(
         "frames_indices": idx,
         "video_backend": "torchvision",
     }
+    process3_time = time.perf_counter()
+    logger.info(
+        f"[preprocess_video Perf], "
+        f"get_batch_time: {(process1_time - entry_time) * 1000:.2f} ms, "
+        f"smart_resize_time: {(process2_time - process1_time) * 1000:.2f} ms, "
+        f"torchvision_resize_time: {(process3_time - process2_time) * 1000:.2f} ms, "
+        f"total_time: {(process3_time - entry_time) * 1000:.2f} ms"
+    )
     return video, video_metadata
 
 
@@ -273,6 +288,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         *args,
         **kwargs,
     ):
+        entry_time = time.perf_counter()
         base_output = self.load_mm_data(
             prompt=input_text,
             image_data=image_data,
@@ -280,6 +296,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             audio_data=request_obj.audio_data,
             multimodal_tokens=self.mm_tokens,
         )
+        load_time = time.perf_counter()
+        rid = getattr(request_obj, "rid", "anonymous_rid")
 
         # Qwen-specific: resize images if they are raw Image objects
         if base_output.images and isinstance(base_output.images[0], Image.Image):
@@ -292,6 +310,8 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
                 *[preprocess_video(video) for video in base_output.videos]
             )
             base_output.videos, video_metadata = map(list, zip(*video_results))
+
+        preprocess_time = time.perf_counter()
 
         # NOTE: for qwen3-vl, video_meta need to be passed in, since do_sample_frames is already done in preprocess_video
         if self.hf_config.model_type in ("qwen3_vl", "qwen3_vl_moe"):
@@ -317,6 +337,15 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
         second_per_grid_ts = getattr(ret, "second_per_grid_ts", None) or getattr(
             ret, "video_second_per_grid", None
+        )
+
+        process_time = time.perf_counter()
+        logger.info(
+            f"[QwenVLProcessor Perf] {rid=}, "
+            f"load_time: {(load_time - entry_time) * 1000:.2f} ms, "
+            f"preprocess_time: {(preprocess_time - load_time) * 1000:.2f} ms, "
+            f"process_time: {(process_time - preprocess_time) * 1000:.2f} ms, "
+            f"total_time: {(process_time - entry_time) * 1000:.2f} ms"
         )
 
         input_ids = input_ids.flatten()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The preprocess_video function can be divided into several stages. Through a combination of optimizations, each stage achieved varying degrees of performance improvement:

get_batch:             283.89 → 240.82 ms (speedup 15.17%)
torchvision resize: 111.87 → 9.02 ms (speedup 91.9%)
preprocess total:   405.72 → 249.86 ms (speedup 38.4%)
process_and_combine_mm_data: 156.81 → 37.96 ms (speedup 75.8%)

e2e speedup 14.2% (from 3.37s → 2.89s)

This PR is to optimize qwen_vl preprocess_video. The following is the specific optimization measures.

- Use of deduplicated sampling indices:
   Replaced torch.linspace(...).round() with np.linspace(..., dtype=np.int64) + np.unique
   This avoids repeated frame indices caused by rounding in linspace, reducing redundant decoding and memory copies.
   Result: get_batch latency reduced from an average of 283.89 ms → 240.82 ms (a 15.17% decrease).

- Use of torch.from_numpy(video_np) instead of torch.tensor(video)
   Saves one CPU memory copy operation.

- Offloaded torchvision resize to GPU and switched to the faster BILINEAR interpolation algorithm. [Update: Offload the torchvision resize to GPU will OOM in case of large video file >= 150MB, so the final decision is to keep CPU torchvision resize]

- Removed float() conversion after interpolation. Saves one unnecessary data type conversion.

- Kept the video tensor on GPU. After converting the tensor to GPU, it no longer needs to be transferred back to CPU.
   The video and video_metadata returned by preprocess_video are passed directly to process_and_combine_mm_data(), where the HF transformers multimodal processing logic (process_mm_data) runs directly on GPU.

As a result, process_and_collect_mm_items latency dropped from ~150 ms → ~39 ms.

Additional Note
In BaseMultimodalProcessor::process_mm_data(), if keep_mm_feature_on_device is not set, the function moves the resulting multimodal features back to CPU at the end. This introduces an additional D2H (device-to-host) copy.

The following is the time cost for the 2MB video inference in Qwen2.5-VL-72B tp8 e2e and divided operations.
```
python -m sglang.launch_server --model-path Qwen/Qwen2.5-VL-72B-Instruct --host 0.0.0.0 --port 30000 --trust-remote-code --tp-size 8 --enable-cache-report --log-level info --max-running-requests 64 --mem-fraction-static 0.65 --chunked-prefill-size 8192 --attention-backend fa3 --chat-template qwen2-vl --mm-attention-backend fa3 --enable-metrics --keep-mm-feature-on-device

MAIN

client side:
{"id":"8f6a739a326947c6baa0f232bad69782","object":"chat.completion","created":1761618312,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频中的招牌上写着“小鞋匠洗鞋”。招牌上还有一些其他文字和图案，但主要的招牌内容是“小鞋匠洗鞋”。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":20906,"total_tokens":20940,"completion_tokens":34,"prompt_tokens_details":{"cached_tokens":20905},"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m3.328s
user    0m0.001s
sys     0m0.003s
{"id":"2c24ae10bf854721aaff660144660827","object":"chat.completion","created":1761618315,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频中的招牌上写着“小鞋匠洗鞋”。招牌上还有一些其他文字和图案，但主要的招牌内容是“小鞋匠洗鞋”。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":20906,"total_tokens":20940,"completion_tokens":34,"prompt_tokens_details":{"cached_tokens":20905},"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m3.370s
user    0m0.001s
sys     0m0.002s

server side:
[2025-10-28 10:23:52] INFO:     127.0.0.1:41404 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-10-28 10:23:52] [preprocess_video Perf], get_batch_time: 293.83 ms, smart_resize_time: 0.03 ms, torchvision_resize_time: 111.87 ms, total_time: 405.72 ms
[2025-10-28 10:23:52] [process_and_combine_mm_data Perf], process_and_collect_mm_items_time: 156.81 ms, misc_time: 0.26 ms, total_time: 157.07 ms
[2025-10-28 10:23:52] [QwenVLProcessor Perf] rid='ff8a9b16cadf4b028e702e2a5611e287', load_time: 9.23 ms, preprocess_time: 409.25 ms, process_time: 157.25 ms, total_time: 575.74 ms
[2025-10-28 10:23:54 TP0] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 20905, token usage: 0.02, #running-req: 0, #queue-req: 0, 
[2025-10-28 10:23:55 TP0] Decode batch, #running-req: 1, #token: 20913, token usage: 0.02, cuda graph: True, gen throughput (token/s): 6.29, #queue-req: 0, 
[2025-10-28 10:23:55] INFO:     127.0.0.1:41414 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-10-28 10:23:56] [preprocess_video Perf], get_batch_time: 273.95 ms, smart_resize_time: 0.02 ms, torchvision_resize_time: 115.42 ms, total_time: 389.39 ms
[2025-10-28 10:23:56] [process_and_combine_mm_data Perf], process_and_collect_mm_items_time: 161.38 ms, misc_time: 0.26 ms, total_time: 161.65 ms
[2025-10-28 10:23:56] [QwenVLProcessor Perf] rid='fbe91272142d41e49b73c468ad1aafd4', load_time: 7.81 ms, preprocess_time: 393.02 ms, process_time: 161.83 ms, total_time: 562.66 ms
[2025-10-28 10:23:57 TP0] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 20905, token usage: 0.02, #running-req: 0, #queue-req: 0, 
[2025-10-28 10:23:58 TP0] Decode batch, #running-req: 1, #token: 20919, token usage: 0.02, cuda graph: True, gen throughput (token/s): 11.78, #queue-req: 0, 

PR:
client side：
{"id":"649a898bd0aa44a3ad2a75a60bae14d0","object":"chat.completion","created":1761617802,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频中的招牌上写着“小鞋匠洗鞋”。招牌上还有一些其他文字和图案，但主要的招牌内容是“小鞋匠洗鞋”。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":20906,"total_tokens":20940,"completion_tokens":34,"prompt_tokens_details":{"cached_tokens":20905},"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m2.977s
user    0m0.000s
sys     0m0.004s
{"id":"0442b82292964fd9a58594d73b80ebf3","object":"chat.completion","created":1761617804,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频中的招牌上写着“小鞋匠洗鞋”。招牌上还有一些其他文字和图案，但主要的招牌内容是“小鞋匠洗鞋”。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":20906,"total_tokens":20940,"completion_tokens":34,"prompt_tokens_details":{"cached_tokens":20905},"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m2.897s
user    0m0.000s
sys     0m0.004s

server side：
[2025-10-28 10:16:39] INFO:     127.0.0.1:46990 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-10-28 10:16:39] [preprocess_video Perf], get_batch_time: 258.23 ms, smart_resize_time: 0.02 ms, torchvision_resize_time: 9.02 ms, total_time: 267.27 ms
[2025-10-28 10:16:39] [process_and_combine_mm_data Perf], process_and_collect_mm_items_time: 37.63 ms, misc_time: 0.23 ms, total_time: 37.85 ms
[2025-10-28 10:16:39] [QwenVLProcessor Perf] rid='649a898bd0aa44a3ad2a75a60bae14d0', load_time: 7.48 ms, preprocess_time: 271.18 ms, process_time: 38.02 ms, total_time: 316.68 ms
[2025-10-28 10:16:40 TP0] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 20905, token usage: 0.02, #running-req: 0, #queue-req: 0, 
[2025-10-28 10:16:42 TP0] Decode batch, #running-req: 1, #token: 20939, token usage: 0.02, cuda graph: True, gen throughput (token/s): 13.12, #queue-req: 0, 
[2025-10-28 10:16:42] INFO:     127.0.0.1:64018 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-10-28 10:16:42] [preprocess_video Perf], get_batch_time: 242.76 ms, smart_resize_time: 0.02 ms, torchvision_resize_time: 9.43 ms, total_time: 252.21 ms
[2025-10-28 10:16:42] [process_and_combine_mm_data Perf], process_and_collect_mm_items_time: 39.70 ms, misc_time: 0.30 ms, total_time: 40.00 ms
[2025-10-28 10:16:42] [QwenVLProcessor Perf] rid='0442b82292964fd9a58594d73b80ebf3', load_time: 7.90 ms, preprocess_time: 255.71 ms, process_time: 40.18 ms, total_time: 303.79 ms
[2025-10-28 10:16:43 TP0] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 20905, token usage: 0.02, #running-req: 0, #queue-req: 0, 
[2025-10-28 10:16:44] INFO:     127.0.0.1:64028 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-10-28 10:16:45] [preprocess_video Perf], get_batch_time: 240.82 ms, smart_resize_time: 0.02 ms, torchvision_resize_time: 9.02 ms, total_time: 249.86 ms
[2025-10-28 10:16:45] [process_and_combine_mm_data Perf], process_and_collect_mm_items_time: 37.96 ms, misc_time: 0.30 ms, total_time: 38.26 ms
[2025-10-28 10:16:45] [QwenVLProcessor Perf] rid='a3fb8a45324244979984d53a87494928', load_time: 7.63 ms, preprocess_time: 253.68 ms, process_time: 38.44 ms, total_time: 299.75 ms
[2025-10-28 10:16:46 TP0] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 20905, token usage: 0.02, #running-req: 0, #queue-req: 0, 
[2025-10-28 10:16:47 TP0] Decode batch, #running-req: 1, #token: 20911, token usage: 0.02, cuda graph: True, gen throughput (token/s): 7.33, #queue-req: 0,  

```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
