### PR TITLE
[Bug fix] [PP] fix wrong dtype for quantified model

### DIFF
--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -320,11 +320,11 @@ class CudaGraphRunner:
                 self.pp_proxy_tensors = {
                     "hidden_states": torch.zeros(
                         (self.max_bs, self.model_runner.model_config.hidden_size),
-                        dtype=torch.bfloat16,
+                        dtype=self.model_runner.model_config.dtype,
                     ),
                     "residual": torch.zeros(
                         (self.max_bs, self.model_runner.model_config.hidden_size),
-                        dtype=torch.bfloat16,
+                        dtype=self.model_runner.model_config.dtype,
                     ),
                 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

when running with command  python3 -m sglang.launch_server --model /opt/models/Qwen3-8b-AWQ --pp-size 2

error occurs:

File "/root/pp-devel/ppdev/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 378, in __init__                                                                              
    self.capture()                                                                                                                                                                             
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 497, in capture                                                                               
    ) = self.capture_one_batch_size(bs, forward)                                                                                                                                               
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                               
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 676, in capture_one_batch_size                                                                
    run_once()                                                                                                                                                                                 
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py", line 663, in run_once                                                                              
    logits_output_or_pp_proxy_tensors = forward(                                                                                                                                               
                                        ^^^^^^^^                                                                                                                                               
  File "/root/pp-devel/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context                                                                                 
    return func(*args, **kwargs)                                                                                                                                                               
           ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                               
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/models/qwen3.py", line 391, in forward                                                                                                   
    hidden_states = self.model(                                                                                                                                                                
                    ^^^^^^^^^^^                                                                                                                                                                
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl                                                                              
    return self._call_impl(*args, **kwargs)                                                                                                                                                    
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                    
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl                                                                                      
    return forward_call(*args, **kwargs)                                                                                                                                                       
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                       
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/models/qwen2.py", line 363, in forward                                                                                                   
    hidden_states, residual = layer(         
    File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/models/qwen3.py", line 266, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/models/qwen3.py", line 173, in forward
    qkv, _ = self.qkv_proj(hidden_states)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/layers/linear.py", line 427, in forward
    output_parallel = self.quant_method.apply(self, input_, bias)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/layers/quantization/awq.py", line 584, in apply
    return apply_awq_marlin_linear(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/ppdev/sglang/python/sglang/srt/layers/quantization/marlin_utils.py", line 537, in apply_awq_marlin_linear
    output = gptq_marlin_gemm(
             ^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/sgl_kernel/gemm.py", line 529, in gptq_marlin_gemm
    return torch.ops.sgl_kernel.gptq_marlin_gemm(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/pp-devel/lib/python3.12/site-packages/torch/_ops.py", line 1243, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: expected scalar type BFloat16 but found Half

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

pass the model dtype to pp_proxy_tensors

<!-- Detail the changes made in this pull request. -->


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
