### PR TITLE
[router] Fix type unmatch during validation

### DIFF
--- a/sgl-router/src/core/workflow/steps/mcp_registration.rs
+++ b/sgl-router/src/core/workflow/steps/mcp_registration.rs
@@ -204,7 +204,7 @@ impl StepExecutor for ValidateRegistrationStep {
             .ok_or_else(|| WorkflowError::ContextValueNotFound("mcp_server_config".to_string()))?;
 
         let client_registered = context
-            .get::<Arc<RunningService<RoleClient, ()>>>("mcp_client")
+            .get::<RunningService<RoleClient, ()>>("mcp_client")
             .is_some();
 
         if client_registered {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Got error when start the mcp server
```
error=Workflow failed at step validate_registration: Step failed: validate_registration - Required MCP server 'web_search_preview' failed to register
```

## Modifications
The return type of get method is `Option<Arc<RunningService<...>>>`, current `Arc<RunningService<...>>` approach couldn't match, there are two approaches to resolve:
- explicitly set T which is  `<RunningService<>>` . The return type is Option<Arc<T>> which is `Option<Arc<RunningService<...>>>`
- explicitly set the return type: `Option<Arc<RunningService<RoleClient, ()>>>`

This fix choose approach 1
<!-- Describe the purpose and goals of this pull request. -->
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
