### PR TITLE
[hotfix] missing `w13_weight_fp8` and `w2_weight_fp8` in UE8M0 requantization

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -131,23 +131,6 @@ class DeepEPMoE(FusedMoE):
             )
             # the last one is invalid rank_id
             self.expert_mask[:-1] = 1
-        elif not _is_npu:
-            self.w13_weight_fp8 = (
-                self.w13_weight,
-                (
-                    self.w13_weight_scale_inv
-                    if self.use_block_quant or self.use_w4afp8
-                    else self.w13_weight_scale
-                ),
-            )
-            self.w2_weight_fp8 = (
-                self.w2_weight,
-                (
-                    self.w2_weight_scale_inv
-                    if self.use_block_quant or self.use_w4afp8
-                    else self.w2_weight_scale
-                ),
-            )
 
     def forward(
         self,

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -227,15 +227,14 @@ class DeepGemmRunnerCore(MoeRunnerCore):
 
         hidden_states_device = running_state["hidden_states_device"]
 
-        if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
-            b, s_mn, s_k = hidden_states_scale.shape
-            assert (
-                s_mn % 4 == 0 and s_k % 4 == 0
-            ), f"scales must be aligned to 4, but got ({b}, {s_mn}, {s_k})"
-
         # GroupGemm-0
         if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
-            hidden_states_scale = _cast_to_e8m0_with_rounding_up(hidden_states_scale)
+            if hidden_states_scale.dtype != torch.int:
+                b, s_mn, s_k = hidden_states_scale.shape
+                assert (
+                    s_mn % 4 == 0 and s_k % 4 == 0
+                ), f"scales must be aligned to 4, but got ({b}, {s_mn}, {s_k})"
+                hidden_states_scale = _cast_to_e8m0_with_rounding_up(hidden_states_scale)
         else:
             hidden_states_scale = deep_gemm_wrapper.get_mn_major_tma_aligned_tensor(
                 hidden_states_scale

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -234,7 +234,9 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 assert (
                     s_mn % 4 == 0 and s_k % 4 == 0
                 ), f"scales must be aligned to 4, but got ({b}, {s_mn}, {s_k})"
-                hidden_states_scale = _cast_to_e8m0_with_rounding_up(hidden_states_scale)
+                hidden_states_scale = _cast_to_e8m0_with_rounding_up(
+                    hidden_states_scale
+                )
         else:
             hidden_states_scale = deep_gemm_wrapper.get_mn_major_tma_aligned_tensor(
                 hidden_states_scale

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -757,6 +757,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 ), "Fp8MoEMethod on CPU requires that CPU has AMX support"
                 _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
 
+            # TODO: required by ue8m0 requantization, should be removed after ue8m0 requantization is refactored
+            layer.w13_weight_fp8 = (layer.w13_weight, layer.w13_weight_scale_inv)
+            layer.w2_weight_fp8 = (layer.w2_weight, layer.w2_weight_scale_inv)
+
             return
 
         # If checkpoint is fp16 or bfloat16, quantize in place.
@@ -787,6 +791,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
+
+            layer.w13_weight_fp8 = (layer.w13_weight, layer.w13_weight_scale)
+            layer.w2_weight_fp8 = (layer.w2_weight, layer.w2_weight_scale)
+
             return
 
         # If checkpoint is fp8, we need to handle that the
@@ -870,6 +878,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
+
+            layer.w13_weight_fp8 = (layer.w13_weight, layer.w13_weight_scale)
+            layer.w2_weight_fp8 = (layer.w2_weight, layer.w2_weight_scale)
+
             return
 
     def process_weights_hip_int4(self, layer: Module):

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -757,10 +757,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 ), "Fp8MoEMethod on CPU requires that CPU has AMX support"
                 _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
 
-            # TODO: required by ue8m0 requantization, should be removed after ue8m0 requantization is refactored
-            layer.w13_weight_fp8 = (layer.w13_weight, layer.w13_weight_scale_inv)
-            layer.w2_weight_fp8 = (layer.w2_weight, layer.w2_weight_scale_inv)
-
             return
 
         # If checkpoint is fp16 or bfloat16, quantize in place.
@@ -791,9 +787,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
-
-            layer.w13_weight_fp8 = (layer.w13_weight, layer.w13_weight_scale)
-            layer.w2_weight_fp8 = (layer.w2_weight, layer.w2_weight_scale)
 
             return
 
@@ -878,9 +871,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
-
-            layer.w13_weight_fp8 = (layer.w13_weight, layer.w13_weight_scale)
-            layer.w2_weight_fp8 = (layer.w2_weight, layer.w2_weight_scale)
 
             return
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -787,7 +787,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
-
             return
 
         # If checkpoint is fp8, we need to handle that the
@@ -871,7 +870,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
             if _is_hip:
                 self.process_weights_hip_scale_padding(layer)
-
             return
 
     def process_weights_hip_int4(self, layer: Module):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3287,26 +3287,10 @@ class DeepseekV2ForCausalLM(nn.Module):
                         )
 
                 experts = layer.mlp.experts
-                w13_weight_fp8 = (
-                    experts.w13_weight,
-                    (
-                        experts.w13_weight_scale_inv
-                        if hasattr(experts, "w13_weight_scale_inv")
-                        else experts.w13_weight_scale
-                    ),
-                )
-                w2_weight_fp8 = (
-                    experts.w2_weight,
-                    (
-                        experts.w2_weight_scale_inv
-                        if hasattr(experts, "w2_weight_scale_inv")
-                        else experts.w2_weight_scale
-                    ),
-                )
                 if isinstance(experts, DeepEPMoE):
                     for w in [
-                        w13_weight_fp8,
-                        w2_weight_fp8,
+                        (experts.w13_weight, experts.w13_weight_scale_inv),
+                        (experts.w2_weight, experts.w2_weight_scale_inv),
                     ]:
                         requant_weight_ue8m0_inplace(w[0], w[1], weight_block_size)
             else:
@@ -3354,10 +3338,26 @@ class DeepseekV2ForCausalLM(nn.Module):
                 )
 
         experts = layer.mlp.experts
+        w13_weight_fp8 = (
+            experts.w13_weight,
+            (
+                experts.w13_weight_scale_inv
+                if hasattr(experts, "w13_weight_scale_inv")
+                else experts.w13_weight_scale
+            ),
+        )
+        w2_weight_fp8 = (
+            experts.w2_weight,
+            (
+                experts.w2_weight_scale_inv
+                if hasattr(experts, "w2_weight_scale_inv")
+                else experts.w2_weight_scale
+            ),
+        )
         if isinstance(experts, DeepEPMoE):
             for w in [
-                (experts.w13_weight, experts.w13_weight_scale_inv),
-                (experts.w2_weight, experts.w2_weight_scale_inv),
+                w13_weight_fp8,
+                w2_weight_fp8,
             ]:
                 transform_scale_ue8m0_inplace(w[1], mn=w[0].shape[-2])
 

--- a/python/sglang/srt/models/longcat_flash.py
+++ b/python/sglang/srt/models/longcat_flash.py
@@ -821,8 +821,8 @@ class LongcatFlashForCausalLM(nn.Module):
             experts = layer.mlp.experts
             if isinstance(experts, DeepEPMoE):
                 for w in [
-                    experts.w13_weight_fp8,
-                    experts.w2_weight_fp8,
+                    (experts.w13_weight, experts.w13_weight_scale_inv),
+                    (experts.w2_weight, experts.w2_weight_scale_inv),
                 ]:
                     requant_weight_ue8m0_inplace(w[0], w[1], weight_block_size)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

- Missing `w13_weight_fp8` and `w2_weight_fp8` in UE8M0 requantization
- In correct assertion and scales roundup for deepep + deep_gemm on blackwell

Fix an error reported by @ishandhanani.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
