### PR TITLE
[Deepseek V3.2] Enable flashmla_auto with MTP

### DIFF
--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1225,8 +1225,7 @@ class NativeSparseAttnBackend(AttentionBackend):
                     # TODO(hlu1): enable MTP
                     is_blackwell()
                     and forward_batch is not None
-                    and forward_batch.forward_mode.is_extend()
-                    and forward_batch.spec_algorithm.is_none()
+                    and forward_batch.forward_mode == ForwardMode.EXTEND
                 ):
                     total_kv_tokens = forward_batch.seq_lens_sum
                     total_q_tokens = forward_batch.extend_num_tokens

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -1222,7 +1222,6 @@ class NativeSparseAttnBackend(AttentionBackend):
         if self.enable_auto_select_prefill_impl:
             if self.nsa_kv_cache_store_fp8:
                 if (
-                    # TODO(hlu1): enable MTP
                     is_blackwell()
                     and forward_batch is not None
                     and forward_batch.forward_mode == ForwardMode.EXTEND


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Follow up to https://github.com/sgl-project/sglang/pull/11655


## Modifications

With fp8 kvcache on B200, flashmla_sparse can be used in the extend (not draft_extend) phases in both normal and speculative (eagle/MTP) settings. 

## Accuracy Tests

With fp4 checkpoint on 4xB200:
```
 python -m sglang.launch_server --model $MODEL --tp 4 --dp 4 --enable-dp-attention --reasoning-parser deepseek-v3 --kv-cache-dtype fp8_e4m3 --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --cuda-graph-max-bs 48 --max-running-requests 48
```

gsm8k with mtp:
```
Accuracy: 0.953
Invalid: 0.000
Latency: 176.234 s
Output throughput: 741.819 token/s
```
gpqa with thinking with mtp:
```
Repeat: 4, mean: 0.801
Scores: ['0.758', '0.828', '0.788', '0.828']
```

## Benchmarking and Profiling
With fp4 checkpoint on 4xB200 (700W):

```
 python3 -m sglang.bench_one_batch_server --model-path $MODEL --tp 4 --dp 4 --enable-dp-attention --batch 8 --input-len 8192 --output-len 1024 --disable-radix-cache --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --cuda-graph-max-bs 48 --max-running-requests 48
```

With mtp on

before
```
batch size: 8
input_len: 8192
output_len: 1024
latency: 37.61 s
ttft: 13.53 s
last generation throughput: 0.00 tok/s
input throughput: 4844.35 tok/s
output throughput: 340.18 tok/s
```
after
```
batch size: 8
input_len: 8192
output_len: 1024
latency: 35.98 s
ttft: 10.41 s
last generation throughput: 0.00 tok/s
input throughput: 6296.66 tok/s
output throughput: 320.37 tok/s
```
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
