### PR TITLE
fix: dummy health check server not accessible on non-zero rank nodes

### DIFF
--- a/python/sglang/compile_deep_gemm.py
+++ b/python/sglang/compile_deep_gemm.py
@@ -104,15 +104,21 @@ def launch_server_process_and_send_one_request(
             if response.status_code == 200:
                 # Rank-0 node send a request to sync with other node and then return.
                 if server_args.node_rank == 0:
+                    payload = {
+                        "input_ids": [0, 1, 2, 3],
+                        "sampling_params": {
+                            "max_new_tokens": 8,
+                            "temperature": 0,
+                        },
+                    }
+                    # In PD mode, include fake bootstrap fields so workers don't assert
+                    if server_args.disaggregation_mode != "null":
+                        payload["bootstrap_host"] = FAKE_BOOTSTRAP_HOST
+                        payload["bootstrap_room"] = 0
+
                     response = requests.post(
                         f"{base_url}/generate",
-                        json={
-                            "input_ids": [0, 1, 2, 3],
-                            "sampling_params": {
-                                "max_new_tokens": 8,
-                                "temperature": 0,
-                            },
-                        },
+                        json=payload,
                         timeout=600,
                     )
                     if response.status_code != 200:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2362,15 +2362,17 @@ def launch_dummy_health_check_server(host, port, enable_metrics):
     # Run server in a background daemon thread with its own event loop
     # This prevents blocking the main thread while still serving health checks
     def run_server():
-        asyncio.run(server.serve())
+        try:
+            asyncio.run(server.serve())
+        except Exception as e:
+            logger.error(f"Dummy health check server failed to start: {e}")
+            raise
+        finally:
+            logger.info(f"Dummy health check server stopped at {host}:{port}")
 
-    thread = threading.Thread(
-        target=run_server, daemon=True, name="health-check-server"
-    )
+    thread = threading.Thread(target=run_server, daemon=True, name="health-check-server")
     thread.start()
-    logger.info(
-        f"Dummy health check server started in background thread at {host}:{port}"
-    )
+    logger.info(f"Dummy health check server started in background thread at {host}:{port}")
 
 
 def create_checksum(directory: str):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2370,9 +2370,13 @@ def launch_dummy_health_check_server(host, port, enable_metrics):
         finally:
             logger.info(f"Dummy health check server stopped at {host}:{port}")
 
-    thread = threading.Thread(target=run_server, daemon=True, name="health-check-server")
+    thread = threading.Thread(
+        target=run_server, daemon=True, name="health-check-server"
+    )
     thread.start()
-    logger.info(f"Dummy health check server started in background thread at {host}:{port}")
+    logger.info(
+        f"Dummy health check server started in background thread at {host}:{port}"
+    )
 
 
 def create_checksum(directory: str):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2363,10 +2363,14 @@ def launch_dummy_health_check_server(host, port, enable_metrics):
     # This prevents blocking the main thread while still serving health checks
     def run_server():
         asyncio.run(server.serve())
-    
-    thread = threading.Thread(target=run_server, daemon=True, name="health-check-server")
+
+    thread = threading.Thread(
+        target=run_server, daemon=True, name="health-check-server"
+    )
     thread.start()
-    logger.info(f"Dummy health check server started in background thread at {host}:{port}")
+    logger.info(
+        f"Dummy health check server started in background thread at {host}:{port}"
+    )
 
 
 def create_checksum(directory: str):


### PR DESCRIPTION
### Problem

When running multi-node inference with `--nnodes > 1` and `--node-rank >= 1`, the dummy health check server logs that it's started but is not actually accessible:

```bash
# Launch command
sgl.Engine with the following args
  --model-path /model/ \
  --host 0.0.0.0 \
  --nnodes 2 \
  --node-rank 1 \
  --enable-metrics \
  --dist-init-addr 10.30.1.187:29500 \
  --tp 8

# Log output
2025-10-28T21:32:44.763434Z  INFO common.launch_dummy_health_check_server: Dummy health check server scheduled on existing loop at 0.0.0.0:30000

# But curl fails
curl http://localhost:30000/health
# Connection refused or timeout
```

Inference works correctly across nodes, but the health check and metrics endpoints are unreachable on non-zero rank nodes.

### Root Cause

The issue occurs in `launch_dummy_health_check_server()` when called from an async context (e.g., custom distributed runtime wrappers or when an event loop policy is set):

1. `asyncio.get_running_loop()` succeeds and finds the parent event loop
2. `loop.create_task(server.serve())` schedules the server as a task
3. The function returns immediately 
4. The main thread then blocks on `proc.join()` waiting for scheduler processes
5. **The scheduled task never executes** because the loop that owns it is now blocked

```python
# Old buggy code
try:
    loop = asyncio.get_running_loop()
    loop.create_task(server.serve())  # ← Scheduled but never runs
except RuntimeError:
    server.run()
```

### Solution

Run the health check server in a dedicated daemon thread with its own event loop:

```python
def run_server():
    asyncio.run(server.serve())

thread = threading.Thread(target=run_server, daemon=True, name="health-check-server")
thread.start()
```

**Benefits:**
- Works in both async and sync contexts
- Doesn't block the main thread
- Daemon thread ensures automatic cleanup on process exit
- Creates isolated event loop independent of parent context

### Testing

**Multi-node setup:**
```bash
# Node 0
python3 -m sglang.launch_server --model-path /model/ --nnodes 2 --node-rank 0 --enable-metrics --tp 8

# Node 1  
python3 -m sglang.launch_server --model-path /model/ --nnodes 2 --node-rank 1 --enable-metrics --tp 8

# Verify health checks work on both nodes
curl http://node0:30000/health  # ✓ Works
curl http://node1:30000/health  # ✓ Now works (previously failed)
curl http://node1:30000/metrics # ✓ Metrics accessible
```

**Custom async runtime:**
```python
async def init():
    engine = sgl.Engine(...)  # Called from async context
    # Health check server now accessible even when Engine() is called in async context
```

### Files Changed
- `python/sglang/srt/utils/common.py`: Fixed `launch_dummy_health_check_server()` to use background thread