### PR TITLE
[router][grpc] Fix inconsistent behavior of conversation_id not found

### DIFF
--- a/sgl-router/src/protocols/responses.rs
+++ b/sgl-router/src/protocols/responses.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use validator::Validate;
 
 // Import shared types from common module
 use super::common::{
@@ -439,7 +440,7 @@ fn default_top_p() -> Option<f32> {
 // Request/Response Types
 // ============================================================================
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Validate)]
 pub struct ResponsesRequest {
     /// Run the request in the background
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -474,6 +475,7 @@ pub struct ResponsesRequest {
 
     /// Optional conversation id to persist input/output as items
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(custom(function = "validate_conversation_id"))]
     pub conversation: Option<String>,
 
     /// Whether to enable parallel tool calls
@@ -681,6 +683,27 @@ impl GenerationRequest for ResponsesRequest {
                 .join(" "),
         }
     }
+}
+
+/// Validate conversation ID format
+///
+/// OpenAI enforces that conversation IDs must only contain letters, numbers,
+/// underscores, or dashes.
+pub fn validate_conversation_id(conv_id: &str) -> Result<(), validator::ValidationError> {
+    // Check if the conversation ID contains only valid characters
+    let is_valid = conv_id
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
+
+    if !is_valid {
+        let mut error = validator::ValidationError::new("invalid_conversation_id");
+        error.message = Some(std::borrow::Cow::Owned(format!(
+            "Invalid 'conversation': '{}'. Expected an ID that contains letters, numbers, underscores, or dashes, but this value contained additional characters.",
+            conv_id
+        )));
+        return Err(error);
+    }
+    Ok(())
 }
 
 /// Normalize a SimpleInputMessage to a proper Message item

--- a/sgl-router/src/protocols/responses.rs
+++ b/sgl-router/src/protocols/responses.rs
@@ -690,6 +690,15 @@ impl GenerationRequest for ResponsesRequest {
 /// OpenAI enforces that conversation IDs must only contain letters, numbers,
 /// underscores, or dashes.
 pub fn validate_conversation_id(conv_id: &str) -> Result<(), validator::ValidationError> {
+    if !conv_id.starts_with("conv_") {
+        let mut error = validator::ValidationError::new("invalid_conversation_id");
+        error.message = Some(std::borrow::Cow::Owned(format!(
+            "Invalid 'conversation': '{}'. Expected an ID that begins with 'conv_'.",
+            conv_id
+        )));
+        return Err(error);
+    }
+
     // Check if the conversation ID contains only valid characters
     let is_valid = conv_id
         .chars()

--- a/sgl-router/src/protocols/responses.rs
+++ b/sgl-router/src/protocols/responses.rs
@@ -686,9 +686,6 @@ impl GenerationRequest for ResponsesRequest {
 }
 
 /// Validate conversation ID format
-///
-/// OpenAI enforces that conversation IDs must only contain letters, numbers,
-/// underscores, or dashes.
 pub fn validate_conversation_id(conv_id: &str) -> Result<(), validator::ValidationError> {
     if !conv_id.starts_with("conv_") {
         let mut error = validator::ValidationError::new("invalid_conversation_id");

--- a/sgl-router/src/routers/grpc/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/responses/handlers.rs
@@ -48,6 +48,7 @@ use tokio::sync::{mpsc, RwLock};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, warn};
 use uuid::Uuid;
+use validator::Validate;
 
 use super::{
     conversions,
@@ -109,7 +110,32 @@ pub async fn route_responses(
         }
     }
 
-    // 1. Validate mutually exclusive parameters
+    // 1. Validate request (includes conversation ID format)
+    if let Err(validation_errors) = request.validate() {
+        // Extract the first error message for conversation field
+        let error_message = validation_errors
+            .field_errors()
+            .get("conversation")
+            .and_then(|errors| errors.first())
+            .and_then(|error| error.message.as_ref())
+            .map(|msg| msg.to_string())
+            .unwrap_or_else(|| "Invalid request parameters".to_string());
+
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({
+                "error": {
+                    "message": error_message,
+                    "type": "invalid_request_error",
+                    "param": "conversation",
+                    "code": "invalid_value"
+                }
+            })),
+        )
+            .into_response();
+    }
+
+    // 2. Validate mutually exclusive parameters
     if request.previous_response_id.is_some() && request.conversation.is_some() {
         return (
             StatusCode::BAD_REQUEST,
@@ -125,7 +151,7 @@ pub async fn route_responses(
             .into_response();
     }
 
-    // 2. Check for incompatible parameter combinations
+    // 3. Check for incompatible parameter combinations
     let is_streaming = request.stream.unwrap_or(false);
     let is_background = request.background.unwrap_or(false);
 
@@ -144,7 +170,7 @@ pub async fn route_responses(
             .into_response();
     }
 
-    // 3. Route based on execution mode
+    // 4. Route based on execution mode
     if is_streaming {
         route_responses_streaming(ctx, request, headers, model_id).await
     } else if is_background {
@@ -928,33 +954,22 @@ async fn load_conversation_history(
     if let Some(ref conv_id_str) = request.conversation {
         let conv_id = ConversationId::from(conv_id_str.as_str());
 
-        // Auto-create conversation if it doesn't exist (OpenAI behavior)
-        if let Ok(None) = ctx.conversation_storage.get_conversation(&conv_id).await {
-            debug!(
-                "Creating new conversation with user-provided ID: {}",
-                conv_id_str
-            );
-
-            // Convert HashMap to JsonMap for metadata
-            let metadata = request.metadata.as_ref().map(|m| {
-                m.iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect::<serde_json::Map<String, serde_json::Value>>()
-            });
-
-            let new_conv = crate::data_connector::NewConversation {
-                id: Some(conv_id.clone()), // Use user-provided conversation ID
-                metadata,
-            };
-            ctx.conversation_storage
-                .create_conversation(new_conv)
-                .await
-                .map_err(|e| {
-                    crate::routers::grpc::utils::internal_error_message(format!(
-                        "Failed to create conversation: {}",
-                        e
-                    ))
-                })?;
+        // Check if conversation exists - return error if not found
+        match ctx.conversation_storage.get_conversation(&conv_id).await {
+            Ok(Some(_)) => {
+                // Conversation exists, continue to load history
+            }
+            Ok(None) => {
+                return Err(crate::routers::grpc::utils::bad_request_error(format!(
+                    "Conversation '{}' not found. Please create the conversation first using the conversations API.",
+                    conv_id_str
+                )));
+            }
+            Err(e) => {
+                return Err(crate::routers::grpc::utils::internal_error_message(
+                    format!("Failed to check conversation: {}", e),
+                ));
+            }
         }
 
         // Load conversation history

--- a/sgl-router/tests/spec/mod.rs
+++ b/sgl-router/tests/spec/mod.rs
@@ -6,3 +6,4 @@ mod chat_completion;
 mod chat_message;
 mod embedding;
 mod rerank;
+mod responses;

--- a/sgl-router/tests/spec/responses.rs
+++ b/sgl-router/tests/spec/responses.rs
@@ -1,0 +1,158 @@
+use sglang_router_rs::protocols::responses::{ResponseInput, ResponsesRequest};
+use validator::Validate;
+
+/// Test that valid conversation IDs pass validation
+#[test]
+fn test_validate_conversation_id_valid() {
+    let valid_ids = vec![
+        "conv_123",
+        "conversation-456",
+        "my_conversation_123",
+        "conv-test-123_abc",
+        "ABC123",
+        "test_123_conv",
+        "conv123",
+        "CONV_ABC_123",
+    ];
+
+    for id in valid_ids {
+        let request = ResponsesRequest {
+            conversation: Some(id.to_string()),
+            input: ResponseInput::Text("test".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            request.validate().is_ok(),
+            "Expected '{}' to be valid, but got error: {:?}",
+            id,
+            request.validate().err()
+        );
+    }
+}
+
+/// Test that invalid conversation IDs fail validation
+#[test]
+fn test_validate_conversation_id_invalid() {
+    let invalid_ids = vec![
+        "conv.test",     // contains dot
+        "conv test",     // contains space
+        "conv@test",     // contains @
+        "conv/test",     // contains /
+        "conv\\test",    // contains backslash
+        "conv:test",     // contains colon
+        "conv;test",     // contains semicolon
+        "conv,test",     // contains comma
+        "conv+test",     // contains plus
+        "conv=test",     // contains equals
+        "conv[test]",    // contains brackets
+        "conv{test}",    // contains braces
+        "conv(test)",    // contains parentheses
+        "conv!test",     // contains exclamation
+        "conv?test",     // contains question mark
+        "conv#test",     // contains hash
+        "conv$test",     // contains dollar sign
+        "conv%test",     // contains percent
+        "conv&test",     // contains ampersand
+        "conv*test",     // contains asterisk
+        "conv test-123", // contains space
+    ];
+
+    for id in invalid_ids {
+        let request = ResponsesRequest {
+            conversation: Some(id.to_string()),
+            input: ResponseInput::Text("test".to_string()),
+            ..Default::default()
+        };
+        let result = request.validate();
+        assert!(
+            result.is_err(),
+            "Expected '{}' to be invalid, but validation passed",
+            id
+        );
+
+        // Verify error is for conversation field
+        if let Err(errors) = result {
+            let field_errors = errors.field_errors();
+            let conversation_errors = field_errors.get("conversation");
+            assert!(
+                conversation_errors.is_some(),
+                "Expected error for 'conversation' field, but got errors for: {:?}",
+                field_errors.keys()
+            );
+
+            let error_msg = conversation_errors
+                .and_then(|errs| errs.first())
+                .and_then(|err| err.message.as_ref())
+                .map(|msg| msg.to_string());
+
+            assert!(
+                error_msg.is_some(),
+                "Expected error message for conversation field"
+            );
+            let msg = error_msg.unwrap();
+            assert!(
+                msg.contains("Invalid 'conversation'"),
+                "Error message should mention 'conversation', got: {}",
+                msg
+            );
+            assert!(
+                msg.contains(id),
+                "Error message should include the invalid ID '{}', got: {}",
+                id,
+                msg
+            );
+        }
+    }
+}
+
+/// Test that None conversation ID is valid
+#[test]
+fn test_validate_conversation_id_none() {
+    let request = ResponsesRequest {
+        conversation: None,
+        input: ResponseInput::Text("test".to_string()),
+        ..Default::default()
+    };
+    assert!(
+        request.validate().is_ok(),
+        "Request with no conversation ID should be valid"
+    );
+}
+
+/// Test the exact error format matches OpenAI's error message
+#[test]
+fn test_validate_conversation_id_error_message_format() {
+    let invalid_id = "conv.test-conv-streaming";
+    let request = ResponsesRequest {
+        conversation: Some(invalid_id.to_string()),
+        input: ResponseInput::Text("test".to_string()),
+        ..Default::default()
+    };
+
+    let result = request.validate();
+    assert!(result.is_err());
+
+    if let Err(errors) = result {
+        let error_msg = errors
+            .field_errors()
+            .get("conversation")
+            .and_then(|errs| errs.first())
+            .and_then(|err| err.message.as_ref())
+            .map(|msg| msg.to_string())
+            .unwrap();
+
+        // Verify the error message matches OpenAI's format
+        assert!(
+            error_msg.starts_with("Invalid 'conversation':"),
+            "Error should start with \"Invalid 'conversation':\""
+        );
+        assert!(
+            error_msg.contains("letters, numbers, underscores, or dashes"),
+            "Error should mention valid characters"
+        );
+        assert!(
+            error_msg.contains(invalid_id),
+            "Error should include the invalid conversation ID"
+        );
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The current responses/handler.rs tries to create a conversation when the request contains a conversation id that is not found. The correct behavior is to throw a not found error.

<img width="1493" height="272" alt="Screenshot 2025-10-28 at 7 12 32 PM" src="https://github.com/user-attachments/assets/bf326803-5ead-4661-9410-d5e3d66e90e6" />

OpenAI also checks for the conversation id format first.

<img width="1495" height="589" alt="Screenshot 2025-10-28 at 7 13 05 PM" src="https://github.com/user-attachments/assets/8512c56b-ba30-484d-8706-1479d36209b1" />

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Add `Validate` derive to protocols/responses.rs
- Add `validate_conversation_id` to validate conversation id.
- Add tests
- Replace conversation logic to a BadRequestError when a conversation id is invalid

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
