### PR TITLE
[router][grpc] Consolidate error messages build in error.rs

### DIFF
--- a/sgl-router/src/routers/grpc/error.rs
+++ b/sgl-router/src/routers/grpc/error.rs
@@ -1,0 +1,143 @@
+//! Centralized error response handling for all routers
+//!
+//! This module provides consistent error responses across OpenAI and gRPC routers,
+//! ensuring all errors follow OpenAI's API error format.
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use tracing::{error, warn};
+
+/// Create a 500 Internal Server Error response
+///
+/// Use this for unexpected server-side errors, database failures, etc.
+///
+/// # Example
+/// ```ignore
+/// return Err(internal_error("Database connection failed"));
+/// ```
+pub fn internal_error(message: impl Into<String>) -> Response {
+    let msg = message.into();
+    error!("{}", msg);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({
+            "error": {
+                "message": msg,
+                "type": "internal_error",
+                "code": 500
+            }
+        })),
+    )
+        .into_response()
+}
+
+/// Create a 400 Bad Request response
+///
+/// Use this for invalid request parameters, malformed JSON, validation errors, etc.
+///
+/// # Example
+/// ```ignore
+/// return Err(bad_request("Invalid conversation ID format"));
+/// ```
+pub fn bad_request(message: impl Into<String>) -> Response {
+    let msg = message.into();
+    error!("{}", msg);
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": {
+                "message": msg,
+                "type": "invalid_request_error",
+                "code": 400
+            }
+        })),
+    )
+        .into_response()
+}
+
+/// Create a 404 Not Found response
+///
+/// Use this for resources that don't exist (conversations, responses, etc.)
+///
+/// # Example
+/// ```ignore
+/// return Err(not_found(format!("Conversation '{}' not found", id)));
+/// ```
+pub fn not_found(message: impl Into<String>) -> Response {
+    let msg = message.into();
+    warn!("{}", msg);
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "error": {
+                "message": msg,
+                "type": "invalid_request_error",
+                "code": 404
+            }
+        })),
+    )
+        .into_response()
+}
+
+/// Create a 503 Service Unavailable response
+///
+/// Use this for temporary service issues like no workers available, rate limiting, etc.
+///
+/// # Example
+/// ```ignore
+/// return Err(service_unavailable("No workers available for this model"));
+/// ```
+pub fn service_unavailable(message: impl Into<String>) -> Response {
+    let msg = message.into();
+    warn!("{}", msg);
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "error": {
+                "message": msg,
+                "type": "service_unavailable",
+                "code": 503
+            }
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internal_error_string() {
+        let response = internal_error("Test error");
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_internal_error_format() {
+        let response = internal_error(format!("Error: {}", 42));
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_bad_request() {
+        let response = bad_request("Invalid input");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_not_found() {
+        let response = not_found("Resource not found");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_service_unavailable() {
+        let response = service_unavailable("No workers");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/sgl-router/src/routers/grpc/harmony/stages/preparation.rs
+++ b/sgl-router/src/routers/grpc/harmony/stages/preparation.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     routers::grpc::{
         context::{PreparationOutput, RequestContext, RequestType},
+        error,
         stages::PipelineStage,
         utils,
     },
@@ -56,7 +57,7 @@ impl PipelineStage for HarmonyPreparationStage {
             let request_arc = ctx.responses_request_arc();
             self.prepare_responses(ctx, &request_arc).await?;
         } else {
-            return Err(utils::bad_request_error(
+            return Err(error::bad_request(
                 "Only Chat and Responses requests supported in Harmony pipeline".to_string(),
             ));
         }
@@ -78,7 +79,7 @@ impl HarmonyPreparationStage {
     ) -> Result<Option<Response>, Response> {
         // Validate - reject logprobs
         if request.logprobs {
-            return Err(utils::bad_request_error(
+            return Err(error::bad_request(
                 "logprobs are not supported for Harmony models".to_string(),
             ));
         }
@@ -97,7 +98,7 @@ impl HarmonyPreparationStage {
         let build_output = self
             .builder
             .build_from_chat(&body_ref)
-            .map_err(|e| utils::bad_request_error(format!("Harmony build failed: {}", e)))?;
+            .map_err(|e| error::bad_request(format!("Harmony build failed: {}", e)))?;
 
         // Step 4: Store results
         ctx.state.preparation = Some(PreparationOutput {
@@ -132,7 +133,7 @@ impl HarmonyPreparationStage {
         let build_output = self
             .builder
             .build_from_responses(request)
-            .map_err(|e| utils::bad_request_error(format!("Harmony build failed: {}", e)))?;
+            .map_err(|e| error::bad_request(format!("Harmony build failed: {}", e)))?;
 
         // Store results in preparation output
         ctx.state.preparation = Some(PreparationOutput {
@@ -202,7 +203,7 @@ impl HarmonyPreparationStage {
 
         // Validate specific function exists
         if specific_function.is_some() && tools_to_use.is_empty() {
-            return Err(Box::new(utils::bad_request_error(format!(
+            return Err(Box::new(error::bad_request(format!(
                 "Tool '{}' not found in tools list",
                 specific_function.unwrap()
             ))));
@@ -236,7 +237,7 @@ impl HarmonyPreparationStage {
         });
 
         serde_json::to_string(&structural_tag).map_err(|e| {
-            Box::new(utils::internal_error_message(format!(
+            Box::new(error::internal_error(format!(
                 "Failed to serialize structural tag: {}",
                 e
             )))

--- a/sgl-router/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/sgl-router/src/routers/grpc/harmony/stages/response_processing.rs
@@ -8,8 +8,8 @@ use axum::response::Response;
 use super::super::{HarmonyResponseProcessor, HarmonyStreamingProcessor};
 use crate::routers::grpc::{
     context::{FinalResponse, RequestContext, RequestType},
+    error,
     stages::PipelineStage,
-    utils,
 };
 
 /// Harmony Response Processing stage: Parse and format Harmony responses
@@ -51,14 +51,14 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                     .response
                     .execution_result
                     .take()
-                    .ok_or_else(|| utils::internal_error_static("No execution result"))?;
+                    .ok_or_else(|| error::internal_error("No execution result"))?;
 
                 let dispatch = ctx
                     .state
                     .dispatch
                     .as_ref()
                     .cloned()
-                    .ok_or_else(|| utils::internal_error_static("Dispatch metadata not set"))?;
+                    .ok_or_else(|| error::internal_error("Dispatch metadata not set"))?;
 
                 // For streaming, delegate to streaming processor and return SSE response
                 if is_streaming {
@@ -97,14 +97,14 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                     .response
                     .execution_result
                     .take()
-                    .ok_or_else(|| utils::internal_error_static("No execution result"))?;
+                    .ok_or_else(|| error::internal_error("No execution result"))?;
 
                 let dispatch = ctx
                     .state
                     .dispatch
                     .as_ref()
                     .cloned()
-                    .ok_or_else(|| utils::internal_error_static("Dispatch metadata not set"))?;
+                    .ok_or_else(|| error::internal_error("Dispatch metadata not set"))?;
 
                 let responses_request = ctx.responses_request_arc();
                 let iteration_result = self
@@ -115,7 +115,7 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                 ctx.state.response.responses_iteration_result = Some(iteration_result);
                 Ok(None)
             }
-            RequestType::Generate(_) => Err(utils::internal_error_static(
+            RequestType::Generate(_) => Err(error::internal_error(
                 "Generate requests not supported in Harmony pipeline",
             )),
         }

--- a/sgl-router/src/routers/grpc/mod.rs
+++ b/sgl-router/src/routers/grpc/mod.rs
@@ -3,6 +3,7 @@
 use crate::{grpc_client::proto, protocols::common::StringOrArray};
 
 pub mod context;
+pub mod error;
 pub mod harmony;
 pub mod pd_router;
 pub mod pipeline;

--- a/sgl-router/src/routers/grpc/pipeline.rs
+++ b/sgl-router/src/routers/grpc/pipeline.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error};
 
 // Import all stage types from the stages module
 use super::stages::*;
-use super::{context::*, harmony, processing, responses::BackgroundTaskInfo, streaming, utils};
+use super::{context::*, harmony, error, processing, responses::BackgroundTaskInfo, streaming, utils};
 use crate::{
     core::WorkerRegistry,
     policies::PolicyRegistry,
@@ -228,9 +228,9 @@ impl RequestPipeline {
         match ctx.state.response.final_response {
             Some(FinalResponse::Chat(response)) => axum::Json(response).into_response(),
             Some(FinalResponse::Generate(_)) => {
-                utils::internal_error_static("Internal error: wrong response type")
+                error::internal_error("Internal error: wrong response type")
             }
-            None => utils::internal_error_static("No response produced"),
+            None => error::internal_error("No response produced"),
         }
     }
 
@@ -272,9 +272,9 @@ impl RequestPipeline {
         match ctx.state.response.final_response {
             Some(FinalResponse::Generate(response)) => axum::Json(response).into_response(),
             Some(FinalResponse::Chat(_)) => {
-                utils::internal_error_static("Internal error: wrong response type")
+                error::internal_error("Internal error: wrong response type")
             }
-            None => utils::internal_error_static("No response produced"),
+            None => error::internal_error("No response produced"),
         }
     }
 
@@ -303,7 +303,7 @@ impl RequestPipeline {
             match stage.execute(&mut ctx).await {
                 Ok(Some(_response)) => {
                     // Streaming not supported for responses sync mode
-                    return Err(utils::bad_request_error(
+                    return Err(error::bad_request(
                         "Streaming is not supported in this context".to_string(),
                     ));
                 }
@@ -360,10 +360,10 @@ impl RequestPipeline {
         // Extract final response
         match ctx.state.response.final_response {
             Some(FinalResponse::Chat(response)) => Ok(response),
-            Some(FinalResponse::Generate(_)) => Err(utils::internal_error_static(
-                "Internal error: wrong response type",
-            )),
-            None => Err(utils::internal_error_static("No response produced")),
+            Some(FinalResponse::Generate(_)) => {
+                Err(error::internal_error("Internal error: wrong response type"))
+            }
+            None => Err(error::internal_error("No response produced")),
         }
     }
 

--- a/sgl-router/src/routers/grpc/pipeline.rs
+++ b/sgl-router/src/routers/grpc/pipeline.rs
@@ -11,7 +11,7 @@ use tracing::{debug, error};
 
 // Import all stage types from the stages module
 use super::stages::*;
-use super::{context::*, harmony, error, processing, responses::BackgroundTaskInfo, streaming, utils};
+use super::{context::*, error, harmony, processing, responses::BackgroundTaskInfo, streaming};
 use crate::{
     core::WorkerRegistry,
     policies::PolicyRegistry,
@@ -384,7 +384,7 @@ impl RequestPipeline {
         _model_id: Option<String>,
         _components: Arc<SharedComponents>,
     ) -> Response {
-        utils::internal_error_static("Responses API execution not yet implemented")
+        error::internal_error("Responses API execution not yet implemented")
     }
 
     /// Execute Harmony Responses API request through all pipeline stages
@@ -451,7 +451,7 @@ impl RequestPipeline {
             .responses_iteration_result
             .take()
             .ok_or_else(|| {
-                utils::internal_error_static("No ResponsesIterationResult produced by pipeline")
+                error::internal_error("No ResponsesIterationResult produced by pipeline")
             })
     }
 
@@ -501,6 +501,6 @@ impl RequestPipeline {
             .response
             .execution_result
             .take()
-            .ok_or_else(|| utils::internal_error_static("No ExecutionResult produced by pipeline"))
+            .ok_or_else(|| error::internal_error("No ExecutionResult produced by pipeline"))
     }
 }

--- a/sgl-router/src/routers/grpc/processing.rs
+++ b/sgl-router/src/routers/grpc/processing.rs
@@ -11,7 +11,7 @@ use tracing::error;
 
 use super::{
     context::{DispatchMetadata, ExecutionResult},
-    utils,
+    error, utils,
 };
 use crate::{
     grpc_client::proto,
@@ -104,7 +104,7 @@ impl ResponseProcessor {
         };
 
         if all_responses.is_empty() {
-            return Err(utils::internal_error_static("No responses from server"));
+            return Err(error::internal_error("No responses from server"));
         }
 
         Ok(all_responses)
@@ -332,7 +332,7 @@ impl ResponseProcessor {
             {
                 Ok(choice) => choices.push(choice),
                 Err(e) => {
-                    return Err(utils::internal_error_message(format!(
+                    return Err(error::internal_error(format!(
                         "Failed to process choice {}: {}",
                         index, e
                     )));
@@ -447,7 +447,7 @@ impl ResponseProcessor {
             let outputs = match stop_decoder.process_tokens(&complete.output_ids) {
                 Ok(outputs) => outputs,
                 Err(e) => {
-                    return Err(utils::internal_error_message(format!(
+                    return Err(error::internal_error(format!(
                         "Failed to process tokens: {}",
                         e
                     )))

--- a/sgl-router/src/routers/grpc/responses/tool_loop.rs
+++ b/sgl-router/src/routers/grpc/responses/tool_loop.rs
@@ -19,6 +19,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use super::{
+    super::error,
     conversions,
     streaming::{OutputItemType, ResponseStreamEventEmitter},
 };
@@ -247,12 +248,8 @@ pub(super) async fn execute_tool_loop(
 
     loop {
         // Convert to chat request
-        let mut chat_request = conversions::responses_to_chat(&current_request).map_err(|e| {
-            crate::routers::grpc::utils::bad_request_error(format!(
-                "Failed to convert request: {}",
-                e
-            ))
-        })?;
+        let mut chat_request = conversions::responses_to_chat(&current_request)
+            .map_err(|e| error::bad_request(format!("Failed to convert request: {}", e)))?;
 
         // Add MCP tools to chat request so LLM knows about them
         chat_request.tools = Some(chat_tools.clone());
@@ -301,10 +298,7 @@ pub(super) async fn execute_tool_loop(
                     response_id.clone(),
                 )
                 .map_err(|e| {
-                    crate::routers::grpc::utils::internal_error_message(format!(
-                        "Failed to convert to responses format: {}",
-                        e
-                    ))
+                    error::internal_error(format!("Failed to convert to responses format: {}", e))
                 })?;
 
                 // Mark as completed but with incomplete details
@@ -423,10 +417,7 @@ pub(super) async fn execute_tool_loop(
                 response_id.clone(),
             )
             .map_err(|e| {
-                crate::routers::grpc::utils::internal_error_message(format!(
-                    "Failed to convert to responses format: {}",
-                    e
-                ))
+                error::internal_error(format!("Failed to convert to responses format: {}", e))
             })?;
 
             // Inject MCP metadata into output

--- a/sgl-router/src/routers/grpc/stages/client_acquisition.rs
+++ b/sgl-router/src/routers/grpc/stages/client_acquisition.rs
@@ -6,7 +6,7 @@ use axum::response::Response;
 use super::PipelineStage;
 use crate::routers::grpc::{
     context::{ClientSelection, RequestContext, WorkerSelection},
-    utils,
+    error, utils,
 };
 
 /// Client acquisition stage: Get gRPC clients from selected workers
@@ -19,7 +19,7 @@ impl PipelineStage for ClientAcquisitionStage {
             .state
             .workers
             .as_ref()
-            .ok_or_else(|| utils::internal_error_static("Worker selection not completed"))?;
+            .ok_or_else(|| error::internal_error("Worker selection not completed"))?;
 
         let clients = match workers {
             WorkerSelection::Single { worker } => {

--- a/sgl-router/src/routers/grpc/stages/dispatch_metadata.rs
+++ b/sgl-router/src/routers/grpc/stages/dispatch_metadata.rs
@@ -8,7 +8,7 @@ use axum::response::Response;
 use super::PipelineStage;
 use crate::routers::grpc::{
     context::{DispatchMetadata, RequestContext, RequestType, WorkerSelection},
-    utils,
+    error,
 };
 
 /// Dispatch metadata stage: Prepare metadata for dispatch
@@ -21,7 +21,7 @@ impl PipelineStage for DispatchMetadataStage {
             .state
             .proto_request
             .as_ref()
-            .ok_or_else(|| utils::internal_error_static("Proto request not built"))?;
+            .ok_or_else(|| error::internal_error("Proto request not built"))?;
 
         let request_id = proto_request.request_id.clone();
         let model = match &ctx.input.request_type {

--- a/sgl-router/src/routers/grpc/stages/response_processing.rs
+++ b/sgl-router/src/routers/grpc/stages/response_processing.rs
@@ -11,7 +11,7 @@ use axum::response::Response;
 use super::PipelineStage;
 use crate::routers::grpc::{
     context::{FinalResponse, RequestContext, RequestType},
-    processing, streaming, utils,
+    error, processing, streaming,
 };
 
 /// Response processing stage: Handles both streaming and non-streaming responses
@@ -42,7 +42,7 @@ impl PipelineStage for ResponseProcessingStage {
         match &ctx.input.request_type {
             RequestType::Chat(_) => self.process_chat_response(ctx).await,
             RequestType::Generate(_) => self.process_generate_response(ctx).await,
-            RequestType::Responses(_) => Err(utils::bad_request_error(
+            RequestType::Responses(_) => Err(error::bad_request(
                 "Responses API processing must be handled by responses handler".to_string(),
             )),
         }
@@ -66,14 +66,14 @@ impl ResponseProcessingStage {
             .response
             .execution_result
             .take()
-            .ok_or_else(|| utils::internal_error_static("No execution result"))?;
+            .ok_or_else(|| error::internal_error("No execution result"))?;
 
         // Get dispatch metadata (needed by both streaming and non-streaming)
         let dispatch = ctx
             .state
             .dispatch
             .as_ref()
-            .ok_or_else(|| utils::internal_error_static("Dispatch metadata not set"))?
+            .ok_or_else(|| error::internal_error("Dispatch metadata not set"))?
             .clone();
 
         if is_streaming {
@@ -100,7 +100,7 @@ impl ResponseProcessingStage {
             .response
             .stop_decoder
             .as_mut()
-            .ok_or_else(|| utils::internal_error_static("Stop decoder not initialized"))?;
+            .ok_or_else(|| error::internal_error("Stop decoder not initialized"))?;
 
         let response = self
             .processor
@@ -132,14 +132,14 @@ impl ResponseProcessingStage {
             .response
             .execution_result
             .take()
-            .ok_or_else(|| utils::internal_error_static("No execution result"))?;
+            .ok_or_else(|| error::internal_error("No execution result"))?;
 
         // Get dispatch metadata (needed by both streaming and non-streaming)
         let dispatch = ctx
             .state
             .dispatch
             .as_ref()
-            .ok_or_else(|| utils::internal_error_static("Dispatch metadata not set"))?
+            .ok_or_else(|| error::internal_error("Dispatch metadata not set"))?
             .clone();
 
         if is_streaming {
@@ -162,7 +162,7 @@ impl ResponseProcessingStage {
             .response
             .stop_decoder
             .as_mut()
-            .ok_or_else(|| utils::internal_error_static("Stop decoder not initialized"))?;
+            .ok_or_else(|| error::internal_error("Stop decoder not initialized"))?;
 
         let result_array = self
             .processor

--- a/sgl-router/src/routers/grpc/stages/worker_selection.rs
+++ b/sgl-router/src/routers/grpc/stages/worker_selection.rs
@@ -12,7 +12,7 @@ use crate::{
     policies::PolicyRegistry,
     routers::grpc::{
         context::{RequestContext, WorkerSelection},
-        utils,
+        error,
     },
 };
 
@@ -51,7 +51,7 @@ impl PipelineStage for WorkerSelectionStage {
             .state
             .preparation
             .as_ref()
-            .ok_or_else(|| utils::internal_error_static("Preparation stage not completed"))?;
+            .ok_or_else(|| error::internal_error("Preparation stage not completed"))?;
 
         // For Harmony, use selection_text produced during Harmony encoding
         // Otherwise, use original_text from regular preparation
@@ -66,7 +66,7 @@ impl PipelineStage for WorkerSelectionStage {
                 match self.select_single_worker(ctx.input.model_id.as_deref(), text) {
                     Some(w) => WorkerSelection::Single { worker: w },
                     None => {
-                        return Err(utils::service_unavailable_error(format!(
+                        return Err(error::service_unavailable(format!(
                             "No available workers for model: {:?}",
                             ctx.input.model_id
                         )));
@@ -77,7 +77,7 @@ impl PipelineStage for WorkerSelectionStage {
                 match self.select_pd_pair(ctx.input.model_id.as_deref(), text) {
                     Some((prefill, decode)) => WorkerSelection::Dual { prefill, decode },
                     None => {
-                        return Err(utils::service_unavailable_error(format!(
+                        return Err(error::service_unavailable(format!(
                             "No available PD worker pairs for model: {:?}",
                             ctx.input.model_id
                         )));


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

There are too many functions in `utils.rs`. Functions related to error message handling should be put in `error.rs`.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Create `error.rs` and move all error message functions from `utils.rs` to `error.rs`
- Merge `internal_error_static` and `internal_error_message` into `internal_error(message: impl Into<String>)`. It handles both types.
- Update all references 
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
