### PR TITLE
fix: Llama 4 BF16 load on Blackwell

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -972,10 +972,11 @@ class ServerArgs:
                     "Use trtllm_mha as attention backend on sm100 for Llama4 model"
                 )
             if is_sm100_supported() and self.moe_runner_backend == "auto":
-                self.moe_runner_backend = "flashinfer_trtllm"
-                logger.info(
-                    "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
-                )
+                if self.quantization in {"fp8", "modelopt_fp8"}:
+                    self.moe_runner_backend = "flashinfer_trtllm"
+                    logger.info(
+                        "Use flashinfer_trtllm as MoE runner backend on SM100 for Llama4"
+                    )
         elif model_arch in [
             "Gemma2ForCausalLM",
             "Gemma3ForCausalLM",


### PR DESCRIPTION
Small oversight in https://github.com/sgl-project/sglang/pull/11928. This fp8 moe kernel currently only support fp8 quantization input, therefore, it will choose this wrongly for bf16 or fp4 still.

Fix it