### PR TITLE
a tiny fix for support deepseek bf16 weights

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2998,7 +2998,7 @@ class DeepseekV2ForCausalLM(nn.Module):
             disable_reason = "Only Deepseek V3/R1 on NV-platform with capability >= 80 can use shared experts fusion optimization."
         elif get_moe_expert_parallel_world_size() > 1:
             disable_reason = "Deepseek V3/R1 can not use shared experts fusion optimization under expert parallelism."
-        elif self.quant_config.get_name() == "w4afp8":
+        elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "Deepseek V3/R1 W4AFP8 model uses different quant method for routed experts and shared experts."
 
         if disable_reason is not None:


### PR DESCRIPTION
when i dequant the FP8 deepseek weights to BF16 and start the inference, it raises error：
<img width="3372" height="416" alt="image" src="https://github.com/user-attachments/assets/0edc5bce-7684-4e39-ac4a-8a3a0348361d" />

by fix the 【elif self.quant_config.get_name() == "w4afp8":】to 【elif self.quant_config and self.quant_config.get_name() == "w4afp8":】，it can run successful.