### PR TITLE
followup fix for llama 4 trtllm flashinfer backend

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -673,7 +673,7 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
                     routed_scaling_factor if routed_scaling_factor is not None else 1.0
                 ),
                 use_routing_scales_on_input=use_routing_scales_on_input,
-                tile_tokens_dim=8,
+                tile_tokens_dim=8,  # TODO(brayden): use the FI tile calculation
                 routing_method_type=routing_method_type,
             )
 

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -673,7 +673,7 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
                     routed_scaling_factor if routed_scaling_factor is not None else 1.0
                 ),
                 use_routing_scales_on_input=use_routing_scales_on_input,
-                tile_tokens_dim=None,
+                tile_tokens_dim=8,
                 routing_method_type=routing_method_type,
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

After rebasing https://github.com/sgl-project/sglang/pull/11563 onto https://github.com/sgl-project/sglang/pull/11928, I thought that this interface would also internally calculate tile_tokens_dim. However it does not. So quickly fix it by setting default 8 for now (TODO, add it to Flashinfer to do the calculation internally as well).

Otherwise we get this sort of error:
```
TypeError: Mismatched type on argument #18 when calling: `trtllm_fp8_per_tensor_scale_moe(0: DLTensor*, 1: Optional<DLTensor*>, 2: DLTensor*, 3: DLTensor*, 4: DLTensor*, 5: DLTensor*, 6: DLTensor*, 7: DLTensor*, 8: DLTensor*, 9: int, 10: int, 11: int, 12: int, 13: int, 14: int, 15: int, 16: float, 17: bool, 18: int, 19: int, 20: bool) -> void`. Expected `int` but got `None`
```

<!-- Describe the purpose and goals of this pull request. -->

Hotfix it.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
