### PR TITLE
Fix Flashinfer Backend for SM120 Usage

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -26,8 +26,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import (
     get_int_env_var,
-    is_blackwell_supported,
     is_flashinfer_available,
+    is_sm100_supported,
     next_power_of_2,
 )
 
@@ -229,7 +229,7 @@ class FlashInferAttnBackend(AttentionBackend):
             ]
 
         fmha_backend = "auto"
-        if is_blackwell_supported():
+        if is_sm100_supported():
             # Disable CUTLASS backend when piecewise cuda graph is enabled
             # due to TMA descriptor initialization issues on B200
             if model_runner.server_args.enable_piecewise_cuda_graph:

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -25,8 +25,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import (
-    is_blackwell_supported,
     is_flashinfer_available,
+    is_sm100_supported,
     next_power_of_2,
 )
 
@@ -242,9 +242,11 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         else:
             self.q_indptr_decode = q_indptr_decode_buf
 
-        self.fmha_backend = "auto"
-        if is_blackwell_supported():
+        if is_sm100_supported():
             self.fmha_backend = "cutlass"
+        else:
+            self.fmha_backend = "auto"
+
         self.prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
             self.workspace_buffer, "NHD", backend=self.fmha_backend
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
As trtllm backend don't support sm120, we need to use flashinfer backend instead. Current prefill in flashinfer backend for sm120 have to use paged attention as the cutlass backend will fail otherwise. But paged attention only support weight absorb path for MLA. For prefill it's better to not absorb the weights for perf.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Use fa2 backend in flashinfer MLA for sm120 as cutlass backend don't support sm120. With this we can use ragged attention.

I tested using PP as it's faster on RTX Pro 6000D
```
SGLANG_PP_LAYER_PARTITION=8,8,8,8,8,7,7,7 SGLANG_USE_CUTLASS_BACKEND_FOR_FP4_GEMM=1 python3 -m sglang.launch_server --model-path nvidia/DeepSeek-R1-0528-FP4-v2 --trust-remote-code --host 0.0.0.0 --port 30000 --pp-size 8 --tp 1 --ep 1 --attention-backend flashinfer --moe-runner-backend flashinfer_cutlass --max-running-requests 32 --cuda-graph-max-bs 32 --context-length 4011 --max-prefill-tokens 16000 --chunked-prefill-size -1 --quantization modelopt_fp4 --kv-cache-dtype fp8_e4m3 --mem-fraction-static 0.7 --disable-radix-cache --schedule-conservativeness 0.0 --allow-auto-truncate 
```

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9553|±  |0.0057|
|     |       |strict-match    |     5|exact_match|↑  |0.9522|±  |0.0059|

## Benchmarking and Profiling
I use this command on RTX Pro 6000D x 8 to test prefill perf(TTFT)
```
python3 -m sglang.bench_serving --backend sglang --model nvidia/DeepSeek-R1-0528-FP4-v2 --host 127.0.0.1 --port 30000 --dataset-name random --max-concurrency 32 --num-prompts 160 --random-input-len 3999 --random-output-len 1 --random-range-ratio 1
```
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Before the modification, we have to enable `--flashinfer-mla-disable-ragged` to the server otherwise it will fail for `Failed to launch the CUTLASS kernel. Last CUDA error is: no error` 
And the perf is 
```
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     160       
Benchmark duration (s):                  68.12     
Total input tokens:                      639840    
Total input text tokens:                 639840    
Total input vision tokens:               0         
Total generated tokens:                  160       
Total generated tokens (retokenized):    159       
Request throughput (req/s):              2.35      
Input token throughput (tok/s):          9392.55   
Output token throughput (tok/s):         2.35      
Total token throughput (tok/s):          9394.90   
Concurrency:                             29.91     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   12736.30  
Median E2E Latency (ms):                 12112.68  
---------------Time to First Token----------------
Mean TTFT (ms):                          12666.90  
Median TTFT (ms):                        12112.67  
P99 TTFT (ms):                           21516.09  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
```

After the modification:
```
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     160       
Benchmark duration (s):                  37.01     
Total input tokens:                      639840    
Total input text tokens:                 639840    
Total input vision tokens:               0         
Total generated tokens:                  160       
Total generated tokens (retokenized):    159       
Request throughput (req/s):              4.32      
Input token throughput (tok/s):          17289.02  
Output token throughput (tok/s):         4.32      
Total token throughput (tok/s):          17293.34  
Concurrency:                             30.00     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6938.33   
Median E2E Latency (ms):                 6751.35   
---------------Time to First Token----------------
Mean TTFT (ms):                          6902.94   
Median TTFT (ms):                        6751.35   
P99 TTFT (ms):                           11325.32  
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
