### PR TITLE
[Ascend]Support dynamic w8a8

### DIFF
--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -243,6 +243,9 @@ class ReplicatedLinear(LinearBase):
                 else:
                     raise ValueError(f"{loaded_weight} are not all equal")
 
+            if param.dtype == torch.int8 or loaded_weight.dtype == torch.int8:
+                assert param.dtype == loaded_weight.dtype
+
         assert param.size() == loaded_weight.size()
         param.data.copy_(loaded_weight)
 

--- a/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
@@ -79,7 +79,7 @@ def check_equal_or_regex_match(layer_name: str, targets: Iterable[str]) -> bool:
     if target starts with 're:' to any target in list.
     """
     for target in targets:
-        if _is_equal_or_regex_match(layer_name, target):
+        if _is_equal_or_regex_match(layer_name, target, check_contains=True):
             return True
     return False
 

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -209,7 +209,7 @@ class W8A8Int8Config(QuantizationConfig):
             packed_modules_mapping if packed_modules_mapping is not None else {}
         )
 
-        if _is_npu:
+        if _is_npu:  # TODO: refactor out _is_npu here
             if self.is_dynamic:
                 return
             # Ascend w8a8_int8 quantization with bias, use wrappers to isolate the effects between models


### PR DESCRIPTION
## Motivation

Static quantization method & dynamic w8a8 quantization method are all support for Ascend NPU. In this pr, we support dynamic w8a8 weights. We test on gms8k dataset, and two kinds of weights get the same scores. One can use the weight converter script to convert the raw fp8 weights to the dynamic w8a8 weights (compressed tensor), see https://gitcode.com/cann/cann-recipes-infer/blob/master/models/deepseek-v3.2-exp/utils/weight_convert.sh.

## Modifications

-  We extended the conditional statement for `is_layer_skipped` to the NPU for the case that the weight name is found;

-  We added `should_ignore_layer` to the NPU branch. This logic was originally included in other hardware but was omitted before.

-  We extended the conditional statement for `is_dynamic` to determine if the weights are dynamic;

## Accuracy Tests

We test on the GMS8K dataset. The accuracy is **0.955** for static W8A8-weight and dynamic W8A8-weight.
<img width="1060" height="129" alt="image001" src="https://github.com/user-attachments/assets/cdc74e17-e330-4128-8c6a-6d8ff5989e7c" />



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
