### PR TITLE
[Bug fix] trace: fix import error in mini_lb if sgl-router image does not install sglang

### DIFF
--- a/sgl-router/py_src/sglang_router/launch_router.py
+++ b/sgl-router/py_src/sglang_router/launch_router.py
@@ -38,20 +38,6 @@ def launch_router(args: argparse.Namespace) -> Optional[Router]:
             router_args = args
 
         if router_args.mini_lb:
-            if router_args.enable_trace:
-                try:
-                    from sglang.srt.tracing.trace import (
-                        process_tracing_init,
-                        trace_set_thread_info,
-                    )
-
-                    process_tracing_init(router_args.otlp_traces_endpoint, "sglang")
-                    trace_set_thread_info("Mini lb")
-                except ImportError:
-                    logger.warning(
-                        "Tracing is not supported in this environment. Please install sglang."
-                    )
-
             mini_lb = MiniLoadBalancer(router_args)
             mini_lb.start()
         else:

--- a/sgl-router/py_src/sglang_router/launch_router.py
+++ b/sgl-router/py_src/sglang_router/launch_router.py
@@ -39,13 +39,18 @@ def launch_router(args: argparse.Namespace) -> Optional[Router]:
 
         if router_args.mini_lb:
             if router_args.enable_trace:
-                from sglang.srt.tracing.trace import (
-                    process_tracing_init,
-                    trace_set_thread_info,
-                )
+                try:
+                    from sglang.srt.tracing.trace import (
+                        process_tracing_init,
+                        trace_set_thread_info,
+                    )
 
-                process_tracing_init(router_args.otlp_traces_endpoint, "sglang")
-                trace_set_thread_info("Mini lb")
+                    process_tracing_init(router_args.otlp_traces_endpoint, "sglang")
+                    trace_set_thread_info("Mini lb")
+                except ImportError:
+                    logger.warning(
+                        "Tracing is not supported in this environment. Please install sglang."
+                    )
 
             mini_lb = MiniLoadBalancer(router_args)
             mini_lb.start()

--- a/sgl-router/py_src/sglang_router/mini_lb.py
+++ b/sgl-router/py_src/sglang_router/mini_lb.py
@@ -18,13 +18,18 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 from sglang_router.router_args import RouterArgs
 
-from sglang.srt.tracing.trace import (
-    trace_get_remote_propagate_context,
-    trace_req_finish,
-    trace_req_start,
-    trace_slice_end,
-    trace_slice_start,
-)
+try:
+    from sglang.srt.tracing.trace import (
+        trace_get_remote_propagate_context,
+        trace_req_finish,
+        trace_req_start,
+        trace_slice_end,
+        trace_slice_start,
+    )
+
+    trace_package_imported = True
+except ImportError:
+    trace_package_imported = False
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +59,7 @@ class MiniLoadBalancer:
         self.prefill_urls = [url[0] for url in router_args.prefill_urls]
         self.prefill_bootstrap_ports = [url[1] for url in router_args.prefill_urls]
         self.decode_urls = router_args.decode_urls
-        self.enable_trace = router_args.enable_trace
+        self.enable_trace = trace_package_imported and router_args.enable_trace
 
     def _validate_router_args(self, router_args: RouterArgs):
         logger.warning(
@@ -441,8 +446,9 @@ async def handle_completion_request(request_data: dict):
 
 def _generate_bootstrap_room():
     bootstrap_room = random.randint(0, 2**63 - 1)
-    trace_req_start(bootstrap_room, bootstrap_room, role="router")
-    trace_slice_start("mini_lb_launch", bootstrap_room)
+    if lb.enable_trace:
+        trace_req_start(bootstrap_room, bootstrap_room, role="router")
+        trace_slice_start("mini_lb_launch", bootstrap_room)
     return bootstrap_room
 
 


### PR DESCRIPTION

## Motivation

The tracing package is implemented in sglang, so if mini_lb wants to enable tracing, it needs to import sglang.srt.tracing.trace. However, if the sgl-router image does not include sglang, this will cause an import error in mini_lb.

Thanks for reporting this bug @jinmingyi1998 

## Modifications

In mini_lb, check whether the tracing package is imported successfully; if not, disable tracing forcefully.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
