### PR TITLE
fix: llama 4 + trtllm gen + fp8 kv cache incompatibility

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -971,9 +971,10 @@ class ServerArgs:
                 logger.warning(
                     "Use trtllm_mha as attention backend on sm100 for Llama4 model"
                 )
-                self.kv_cache_dtype = "bfloat16"
+            if is_sm100_supported() and self.attention_backend == "trtllm_mha":
                 # TODO(brayden): remove this once TRTLLM MHA kernel for FP8 w/ tileSizeKv=128 is available.
                 # This is a Llama 4 specific issue only.
+                self.kv_cache_dtype = "bfloat16"
                 logger.warning(
                     "Setting kv_cache_dtype to bfloat16 for Llama4 with trtllm_mha backend, due to a missing FlashInfer TRTLLM MHA kernel for FP8 KV Cache"
                 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -971,6 +971,12 @@ class ServerArgs:
                 logger.warning(
                     "Use trtllm_mha as attention backend on sm100 for Llama4 model"
                 )
+                self.kv_cache_dtype = "bfloat16"
+                # TODO(brayden): remove this once TRTLLM MHA kernel for FP8 w/ tileSizeKv=128 is available.
+                # This is a Llama 4 specific issue only.
+                logger.warning(
+                    "Setting kv_cache_dtype to bfloat16 for Llama4 with trtllm_mha backend, due to a missing FlashInfer TRTLLM MHA kernel for FP8 KV Cache"
+                )
             if is_sm100_supported() and self.moe_runner_backend == "auto":
                 if self.quantization in {"fp8", "modelopt_fp8"}:
                     self.moe_runner_backend = "flashinfer_trtllm"


### PR DESCRIPTION
I spent way too long trying to debug this issue yesterday bc it used to work fine in the integration PR...

```
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/flashinfer/prefill.py", line 3482, in trtllm_batch_context_with_kv_cache
    run_func(
  File "python/tvm_ffi/cython/function.pxi", line 678, in core.Function.__call__
RuntimeError: Error in function 'trtllm_paged_attention_launcher' at /usr/local/lib/python3.12/dist-packages/flashinfer/data/csrc/trtllm_fmha_kernel_launcher.cu:171: Missing TRTLLM-GEN kernel (context): qkvLayout=2, maskType=1, kernelType=0, tileScheduler=1, multiCtasKvMode=0, headDimPerCtaV=128, headDimQk=128, headDimV=128, tileSizeKv=128, numTokensPerPage=64, maxNumHeadsQPerKvInCta=1, reuseSmemKForV=0, uses2CtaMma=0
```

It seems Flashinfer is missing tileSizeKv=128 for this kernel. Also it's Llama 4 specifically due to the head dim. I suppose other models might be affected for trtllm mha however currently the default is Flashinfer so we don't face these issues.

It works fine with bf16 kv cache.