### PR TITLE
[Bug fix][PP] fix deadlock with tie_word_embeddings

### DIFF
--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -462,7 +462,7 @@ class Qwen2ForCausalLM(nn.Module):
                 self.pp_group.send(
                     self.model.embed_tokens.weight, dst=self.pp_group.last_rank
                 )
-            else:
+            elif self.pp_group.is_last_rank:
                 emb_token_weight = self.pp_group.recv(
                     size=(config.vocab_size, config.hidden_size),
                     dtype=next(self.model.parameters()).dtype,

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -361,7 +361,7 @@ class Qwen3ForCausalLM(nn.Module):
                 self.pp_group.send(
                     self.model.embed_tokens.weight, dst=self.pp_group.last_rank
                 )
-            else:
+            elif self.pp_group.is_last_rank:
                 emb_token_weight = self.pp_group.recv(
                     size=(config.vocab_size, config.hidden_size),
                     dtype=next(self.model.parameters()).dtype,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Now when run Qwen model with tie_word_embeddings set  and the pp size > 2, the instance hangs like below:

[2025-10-30 08:58:23 PP3] Init torch distributed ends. mem usage=0.16 GB                                                                                                                       
[2025-10-30 08:58:23 PP0] Init torch distributed ends. mem usage=0.16 GB                                                                                                                       
[2025-10-30 08:58:23 PP2] Init torch distributed ends. mem usage=0.16 GB                                                                                                                       
[2025-10-30 08:58:23 PP1] Init torch distributed ends. mem usage=0.16 GB                                                                                                                       
[2025-10-30 08:58:23 PP2] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected                                                                                    
[2025-10-30 08:58:23 PP1] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected                                                                                    
[2025-10-30 08:58:23 PP0] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected                                                                                    
[2025-10-30 08:58:23 PP3] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected                                                                                    
[2025-10-30 08:58:24 PP1] Load weight begin. avail mem=21.92 GB                                                                                                                                
[2025-10-30 08:58:24 PP3] Load weight begin. avail mem=21.92 GB                                                                                                                                
[2025-10-30 08:58:24 PP0] Load weight begin. avail mem=21.92 GB                                                                                                                                
[2025-10-30 08:58:24 PP2] Load weight begin. avail mem=21.92 GB                                                                                                                                
[2025-10-30 08:58:25 PP3] Using model weights format ['*.safetensors']                                                                                                                         
[2025-10-30 08:58:25 PP0] Using model weights format ['*.safetensors']                                                                                                                         
[2025-10-30 08:58:26 PP3] No model.safetensors.index.json found in remote.                                                                                                                     
[2025-10-30 08:58:26 PP3] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=21.36 GB, mem usage=0.56 GB.                                                                 
[2025-10-30 08:58:26 PP3] Using KV cache dtype: torch.bfloat16                                                                                                                                 
[2025-10-30 08:58:27 PP0] No model.safetensors.index.json found in remote.                                                                                                                     
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]                                                                                                                   
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 10.46it/s]                                                                                                           
                                                                                                                                                                                               
[2025-10-30 08:58:27 PP0] Load weight end. type=Qwen3ForCausalLM, dtype=torch.bfloat16, avail mem=21.36 GB, mem usage=0.56 GB.                                                                 
[2025-10-30 08:58:27 PP0] Using KV cache dtype: torch.bfloat16

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

only send embeding to last pp rank

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
