### PR TITLE
[UT] Destroy process group after broadcast to resolve port occupation issues in multi-server tests

### DIFF
--- a/test/srt/rl/test_update_weights_from_distributed.py
+++ b/test/srt/rl/test_update_weights_from_distributed.py
@@ -188,6 +188,9 @@ def init_process_hf(
     print(f"[hf] {rank=} {broadcast_time=:.3f}s")
     param_queue.put(("broadcast_time", broadcast_time))
 
+    # Destroy process group and release related resource
+    torch.distributed.destroy_process_group(group)
+
     # Delete the huggingface models to free up memory.
     del hf_instruct_model
     del hf_base_model


### PR DESCRIPTION
Added cleanup step to destroy the process group after broadcasting.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Added a cleanup step to destroy the process group after broadcasting. This modification was made to resolve port occupation issues encountered when running multiple server tests with configurations like (tp=1, dp=1, server) and (tp=2, dp=2, server), ensuring proper resource management and preventing conflicts.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).

@zhaochenyang20 