### PR TITLE
[Feature] Trace: Support http/protobuf span exporter protocol

### DIFF
--- a/docs/references/production_request_trace.md
+++ b/docs/references/production_request_trace.md
@@ -33,6 +33,12 @@ This section explains how to configure the request tracing and export the trace 
 
     Replace `0.0.0.0:4317` with the actual endpoint of the opentelemetry collector. If you launched the openTelemetry collector with tracing_compose.yaml, the default receiving port is 4317.
 
+    To use the HTTP/protobuf span exporter, set the following environment variable and point to an HTTP endpoint, for example, `http://0.0.0.0:4318/v1/traces`.
+    ```bash
+    export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+    ```
+
+
 4. raise some requests
 5. Observe whether trace data is being exported
     * Access port 16686 of Jaeger using a web browser to visualize the request traces.

--- a/python/sglang/srt/tracing/trace.py
+++ b/python/sglang/srt/tracing/trace.py
@@ -37,6 +37,12 @@ tracing_enabled = False
 
 try:
     from opentelemetry import context, propagate, trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter as GRPCSpanExporter,
+    )
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter as HTTPSpanExporter,
+    )
     from opentelemetry.sdk.environment_variables import (
         OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
     )
@@ -238,17 +244,9 @@ def get_otlp_span_exporter(endpoint):
         )
 
     if protocol == "grpc":
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-            OTLPSpanExporter,
-        )
-
-        return OTLPSpanExporter(endpoint=endpoint, insecure=True)
+        return GRPCSpanExporter(endpoint=endpoint, insecure=True)
     elif protocol == "http/protobuf":
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-            OTLPSpanExporter,
-        )
-
-        return OTLPSpanExporter(endpoint=endpoint)
+        return HTTPSpanExporter(endpoint=endpoint)
 
 
 # Should be called by each tracked thread.

--- a/python/sglang/srt/tracing/trace.py
+++ b/python/sglang/srt/tracing/trace.py
@@ -37,7 +37,9 @@ tracing_enabled = False
 
 try:
     from opentelemetry import context, propagate, trace
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.environment_variables import (
+        OTEL_EXPORTER_OTLP_TRACES_PROTOCOL,
+    )
     from opentelemetry.sdk.resources import SERVICE_NAME, Resource
     from opentelemetry.sdk.trace import TracerProvider, id_generator
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -207,7 +209,7 @@ def process_tracing_init(otlp_endpoint, server_name):
         )
 
         processor = BatchSpanProcessor(
-            OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True),
+            span_exporter=get_otlp_span_exporter(otlp_endpoint),
             schedule_delay_millis=schedule_delay_millis,
             max_export_batch_size=max_export_batch_size,
         )
@@ -223,6 +225,30 @@ def process_tracing_init(otlp_endpoint, server_name):
         __get_cur_time_ns = lambda: int(time.time_ns())
 
     tracing_enabled = True
+
+
+def get_otlp_span_exporter(endpoint):
+    protocol = os.environ.get(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL, "grpc")
+    supported_protocols = {"grpc", "http/protobuf"}
+
+    if protocol not in supported_protocols:
+        raise ValueError(
+            f"Unsupported OTLP protocol '{protocol}' configured. "
+            f"Supported protocols are: {', '.join(sorted(supported_protocols))}"
+        )
+
+    if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        return OTLPSpanExporter(endpoint=endpoint, insecure=True)
+    elif protocol == "http/protobuf":
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        return OTLPSpanExporter(endpoint=endpoint)
 
 
 # Should be called by each tracked thread.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
SGLang already supports tracing with OpenTelemetry. We want to use this feature in production, but our collector requires an HTTP/protobuf-based span exporter. This PR adds support for an HTTP/protobuf span exporter to enable production use and integration with our collector.

## Modifications

<!-- Detail the changes made in this pull request. -->
This PR:

- Reads the OTEL_EXPORTER_OTLP_TRACES_PROTOCOL environment variable to determine which protocol to use (defaults to "grpc")
- Validates that the specified protocol is supported (only "grpc" and "http/protobuf" are supported)
- Creates and returns the corresponding OTLPSpanExporter instance:
    - For "grpc" protocol: Uses the gRPC exporter with insecure connection
    - For "http/protobuf" protocol: Uses the HTTP protobuf exporter

This allows the tracing system to be flexible and support different OTLP protocols based on environment configuration, making it easier to integrate with various tracing backends like Jaeger, Zipkin, or other OpenTelemetry collectors.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
