### PR TITLE
Fix the shared expert & routed expert overlap in Llama 4

### DIFF
--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -148,7 +148,7 @@ class Llama4MoE(nn.Module):
         return out_aD
 
     def _forward_core(self, hidden_states, forward_mode: ForwardMode):
-        if hidden_states.shape[0] < 4 and _is_cuda:
+        if _is_cuda:
             return self._forward_core_shared_routed_overlap(hidden_states)
         else:
             return self._forward_core_normal(hidden_states)


### PR DESCRIPTION
It seems that the original PR to overlap the shared expert and routed expert computation for Llama 4 specifically was correct, but incorrectly applied: https://github.com/sgl-project/sglang/pull/5121

Due to this issue:

The shape of `hidden_states` is ` ([num_tokens, hidden_size])` and is the number of local tokens per TP rank, so this suggestion was incorrect. Currently, it is only applied for the `num_tokens` < 4 per TP rank, which is incorrect.

The original motivation was to increase keep this overlap in the case that BS < 4, but I find at at BS = 8 and BS = 128, there is still a good performance gain as detailed below, so I have not kept a heuristic. In Deepseek, this heuristic is enabled for `0 < num_tokens ≤ 1024` per TP rank.

<img width="824" height="371" alt="Screenshot 2025-10-30 at 10 18 17 AM" src="https://github.com/user-attachments/assets/20555742-2127-4a49-95e6-aec698ae4025" />

```
root@ip-10-40-9-126:/sgl-workspace/sglang# python3 -m sglang.launch_server   --model-path=nvidia/Llama-4-Scout-17B-16E-Instruct-FP8   --tp=8   --trust-remote-code   --mem-fraction-static=0.7   --context-length=131072   --attention-backend=fa3   --enable-multimodal   --tool-call-parser=pythonic   --cuda-graph-max-bs=512  --kv-cache-dtype=fp8_e4m3   --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'
```

The speed of bs = 1 has went from:
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    3.615    |  512   |   1.000    |     141.64      |
+-------------+--------+------------+-----------------+
```

```
root@ip-10-40-9-126:/sgl-workspace/sglang# python3 -m sglang.test.send_one --stream
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    3.021    |  512   |   1.000    |     169.46      |
+-------------+--------+------------+-----------------+
```

So it is a 20% increase at BS = 1.

```
python3 -m sglang.bench_serving --backend sglang --num-prompts 64 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1 --max-concurrency=8 --flush-cache
```

Before:

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  71.45     
Total input tokens:                      65536     
Total input text tokens:                 65536     
Total input vision tokens:               0         
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65269     
Request throughput (req/s):              0.90      
Input token throughput (tok/s):          917.21    
Output token throughput (tok/s):         917.21    
Total token throughput (tok/s):          1834.41   
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   8928.68   
Median E2E Latency (ms):                 8914.09   
---------------Time to First Token----------------
Mean TTFT (ms):                          199.85    
Median TTFT (ms):                        190.82    
P99 TTFT (ms):                           270.28    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           8.53      
Median ITL (ms):                         8.53      
P95 ITL (ms):                            8.81      
P99 ITL (ms):                            9.04      
Max ITL (ms):                            79.24     
==================================================
```

After:

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  65.76     
Total input tokens:                      65536     
Total input text tokens:                 65536     
Total input vision tokens:               0         
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65276     
Request throughput (req/s):              0.97      
Input token throughput (tok/s):          996.66    
Output token throughput (tok/s):         996.66    
Total token throughput (tok/s):          1993.32   
Concurrency:                             8.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   8217.04   
Median E2E Latency (ms):                 8213.17   
---------------Time to First Token----------------
Mean TTFT (ms):                          196.99    
Median TTFT (ms):                        193.88    
P99 TTFT (ms):                           211.59    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           7.84      
Median ITL (ms):                         7.84      
P95 ITL (ms):                            8.10      
P99 ITL (ms):                            8.20      
Max ITL (ms):                            12.47     
==================================================
```

| Metric | Before | After | Δ | Gain |
|:--|:--:|:--:|:--:|:--:|
| Request Throughput (req/s) | 0.90 | 0.97 | +0.07 | +7.8% |
| Input Token Throughput (tok/s) | 921.09 | 996.66 | +75.57 | +8.2% |
| Output Token Throughput (tok/s) | 921.09 | 996.66 | +75.57 | +8.2% |
| Total Token Throughput (tok/s) | 1842.18 | 1993.32 | +151.14 | +8.2% |
| Mean E2E Latency (ms) | 8891.25 | 8217.04 | −674.21 | −7.6% |
| Median E2E Latency (ms) | 8887.62 | 8213.17 | −674.45 | −7.6% |
| Mean ITL (ms) | 8.50 | 7.84 | −0.66 | −7.8% |
| P99 ITL (ms) | 8.87 | 8.20 | −0.67 | −7.6% |

```
python3 -m sglang.bench_serving --backend sglang --num-prompts 1024 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1 --max-concurrency=128 --flush-cache
```

Before:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 128       
Successful requests:                     1024      
Benchmark duration (s):                  128.73    
Total input tokens:                      1048576   
Total input text tokens:                 1048576   
Total input vision tokens:               0         
Total generated tokens:                  1048576   
Total generated tokens (retokenized):    1036137   
Request throughput (req/s):              7.95      
Input token throughput (tok/s):          8145.57   
Output token throughput (tok/s):         8145.57   
Total token throughput (tok/s):          16291.14  
Concurrency:                             127.83    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16070.39  
Median E2E Latency (ms):                 16039.41  
---------------Time to First Token----------------
Mean TTFT (ms):                          1082.92   
Median TTFT (ms):                        1105.09   
P99 TTFT (ms):                           2050.51   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           14.65     
Median ITL (ms):                         13.85     
P95 ITL (ms):                            14.77     
P99 ITL (ms):                            15.46     
Max ITL (ms):                            1486.54   
==================================================
```

After:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 128       
Successful requests:                     1024      
Benchmark duration (s):                  121.95    
Total input tokens:                      1048576   
Total input text tokens:                 1048576   
Total input vision tokens:               0         
Total generated tokens:                  1048576   
Total generated tokens (retokenized):    1036644   
Request throughput (req/s):              8.40      
Input token throughput (tok/s):          8598.44   
Output token throughput (tok/s):         8598.44   
Total token throughput (tok/s):          17196.88  
Concurrency:                             127.83    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   15224.03  
Median E2E Latency (ms):                 15206.45  
---------------Time to First Token----------------
Mean TTFT (ms):                          1065.03   
Median TTFT (ms):                        1059.22   
P99 TTFT (ms):                           1757.02   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           13.84     
Median ITL (ms):                         13.12     
P95 ITL (ms):                            14.00     
P99 ITL (ms):                            14.78     
Max ITL (ms):                            1558.56   
==================================================
```

| Metric | Before | After | Δ | Gain |
|:--|:--:|:--:|:--:|:--:|
| Request Throughput (req/s) | 7.95 | 8.40 | +0.45 | +5.7% |
| Input Token Throughput (tok/s) | 8145.57 | 8598.44 | +452.87 | +5.6% |
| Output Token Throughput (tok/s) | 8145.57 | 8598.44 | +452.87 | +5.6% |
| Total Token Throughput (tok/s) | 16291.14 | 17196.88 | +905.74 | +5.6% |
| Mean E2E Latency (ms) | 16070.39 | 15224.03 | −846.36 | −5.3% |
| Median E2E Latency (ms) | 16039.41 | 15206.45 | −832.96 | −5.2% |
| Mean TTFT (ms) | 1082.92 | 1065.03 | −17.89 | −1.7% |
| Median TTFT (ms) | 1105.09 | 1059.22 | −45.87 | −4.2% |
| P99 TTFT (ms) | 2050.51 | 1757.02 | −293.49 | −14.3% |
| Mean ITL (ms) | 14.65 | 13.84 | −0.81 | −5.5% |
| P99 ITL (ms) | 15.46 | 14.78 | −0.68 | −4.4% |


```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:26<00:00, 49.08it/s]
Accuracy: 0.926
Invalid: 0.000
Latency: 27.027 s
Output throughput: 4982.632 token/s
```