### PR TITLE
[Entrypoint][Model-Gateway] Add GetTokenizer endpoint for gRPC server and load Tokenizer to registry from temp zip for model gateway

### DIFF
--- a/python/sglang/srt/grpc/sglang_scheduler.proto
+++ b/python/sglang/srt/grpc/sglang_scheduler.proto
@@ -29,6 +29,9 @@ service SglangScheduler {
   // Get comprehensive load metrics
   rpc GetLoads(GetLoadsRequest) returns (GetLoadsResponse);
 
+  // Get tokenizer artifacts for remote construction
+  rpc GetTokenizer(GetTokenizerRequest) returns (stream GetTokenizerChunk);
+
 }
 
 // =====================
@@ -563,4 +566,39 @@ message AggregateMetrics {
   double avg_token_usage = 4;
   double avg_throughput = 5;
   double avg_utilization = 6;
+}
+
+
+// =====================
+// Tokenizer
+// =====================
+
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  oneof chunk {
+    TokenizerMetadata metadata = 1;
+    TokenizerFileChunk file_chunk = 2;
+  }
+}
+
+message TokenizerMetadata {
+  string model_identifier = 1;
+  string fingerprint = 2;
+  repeated TokenizerFileDescriptor files = 3;
+  string bundle_format = 4;
+}
+
+message TokenizerFileDescriptor {
+  string file_name = 1;
+  string mime_type = 2;
+  bool optional = 3;
+}
+
+message TokenizerFileChunk {
+  string file_name = 1;
+  bytes data = 2;
+  uint32 chunk_index = 3;
+  bool is_last_chunk = 4;
+  string compression = 5;
 }

--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -109,6 +109,8 @@ base64 = "0.22"
 openai-harmony = { git = "https://github.com/openai/harmony", tag = "v0.0.4" }
 openmetrics-parser = "0.4.4"
 arc-swap = "1.7.1"
+zip = "7.0.0"
+tempfile = "3.8"
 
 # gRPC and Protobuf dependencies
 tonic = { version = "0.14.2", features = ["gzip", "transport"] }
@@ -145,7 +147,6 @@ criterion = { version = "0.5", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 portpicker = "0.1"
-tempfile = "3.8"
 lazy_static = "1.4"
 wasm-encoder = "0.242"
 npyz = { version = "0.8", features = ["npz"] }  # For reading numpy .npz files in golden tests

--- a/sgl-model-gateway/src/proto/sglang_scheduler.proto
+++ b/sgl-model-gateway/src/proto/sglang_scheduler.proto
@@ -29,6 +29,9 @@ service SglangScheduler {
   // Get comprehensive load metrics
   rpc GetLoads(GetLoadsRequest) returns (GetLoadsResponse);
 
+  // Get tokenizer artifacts for remote construction
+  rpc GetTokenizer(GetTokenizerRequest) returns (stream GetTokenizerChunk);
+
 }
 
 // =====================
@@ -563,4 +566,39 @@ message AggregateMetrics {
   double avg_token_usage = 4;
   double avg_throughput = 5;
   double avg_utilization = 6;
+}
+
+
+// =====================
+// Tokenizer
+// =====================
+
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  oneof chunk {
+    TokenizerMetadata metadata = 1;
+    TokenizerFileChunk file_chunk = 2;
+  }
+}
+
+message TokenizerMetadata {
+  string model_identifier = 1;
+  string fingerprint = 2;
+  repeated TokenizerFileDescriptor files = 3;
+  string bundle_format = 4;
+}
+
+message TokenizerFileDescriptor {
+  string file_name = 1;
+  string mime_type = 2;
+  bool optional = 3;
+}
+
+message TokenizerFileChunk {
+  string file_name = 1;
+  bytes data = 2;
+  uint32 chunk_index = 3;
+  bool is_last_chunk = 4;
+  string compression = 5;
 }

--- a/test/srt/entrypoints/grpc_server/test_get_tokenizer.py
+++ b/test/srt/entrypoints/grpc_server/test_get_tokenizer.py
@@ -1,0 +1,114 @@
+import os
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import MagicMock
+
+import grpc
+from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
+
+from sglang.srt.entrypoints.grpc_server import SGLangSchedulerServicer
+from sglang.srt.grpc import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
+from sglang.srt.server_args import ServerArgs
+
+
+class TestGetTokenizer(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        # valid tiny model from HF
+        cls.model_id = "HuggingFaceM4/tiny-random-LlamaForCausalLM"
+        cls.model_path = snapshot_download(cls.model_id)
+
+    async def asyncSetUp(self):
+        self.server = grpc.aio.server()
+        self.mock_manager = MagicMock()
+
+        # Minimal server args
+        self.server_args = ServerArgs(
+            model_path=self.model_path,
+            host="127.0.0.1",
+            port=0,  # Unused for internal logic but good for completeness
+            tokenizer_path=self.model_path,
+        )
+
+        self.servicer = SGLangSchedulerServicer(
+            request_manager=self.mock_manager,
+            server_args=self.server_args,
+            model_info={},  # pass in Minimal info if needed, or empty dict
+            scheduler_info={},
+        )
+
+        sglang_scheduler_pb2_grpc.add_SglangSchedulerServicer_to_server(
+            self.servicer, self.server
+        )
+
+        # Bind to a random port
+        port = self.server.add_insecure_port("127.0.0.1:0")
+        await self.server.start()
+        self.address = f"127.0.0.1:{port}"
+
+    async def asyncTearDown(self):
+        await self.server.stop(0)
+
+    async def test_get_tokenizer(self):
+        print(f"Connecting to test server at {self.address}")
+        async with grpc.aio.insecure_channel(self.address) as channel:
+            stub = sglang_scheduler_pb2_grpc.SglangSchedulerStub(channel)
+
+            request = sglang_scheduler_pb2.GetTokenizerRequest()
+
+            # Stream response
+            file_chunks = []
+            metadata_received = False
+
+            async for response in stub.GetTokenizer(request):
+                if response.HasField("metadata"):
+                    print(f"Received metadata: {response.metadata.model_identifier}")
+                    metadata_received = True
+                elif response.HasField("file_chunk"):
+                    file_chunks.append(response.file_chunk.data)
+
+            self.assertTrue(metadata_received, "Should have received metadata")
+            self.assertTrue(len(file_chunks) > 0, "Should have received file chunks")
+
+            # Reassemble zip
+            zip_content = b"".join(file_chunks)
+            print(f"Total zip size: {len(zip_content)} bytes")
+
+            # verify zip content
+            with tempfile.TemporaryDirectory() as temp_dir:
+                zip_path = os.path.join(temp_dir, "tokenizer.zip")
+                with open(zip_path, "wb") as f:
+                    f.write(zip_content)
+
+                with zipfile.ZipFile(zip_path, "r") as zip_ref:
+                    zip_ref.extractall(temp_dir)
+
+                # Check that essential files exist
+                self.assertTrue(
+                    os.path.exists(os.path.join(temp_dir, "tokenizer.json"))
+                )
+                self.assertTrue(
+                    os.path.exists(os.path.join(temp_dir, "tokenizer_config.json"))
+                )
+
+                # Try loading with AutoTokenizer
+                print("Loading tokenizer with transformers...")
+                tokenizer = AutoTokenizer.from_pretrained(temp_dir)
+
+                test_text = "Hello, world!"
+                tokens = tokenizer.encode(test_text)
+                decoded = tokenizer.decode(tokens)
+
+                print(f"Original: {test_text}")
+                print(f"Tokens: {tokens}")
+                print(f"Decoded: {decoded}")
+
+                # Basic sanity check (decoded text might not match exactly for random models but shouldn't error)
+                self.assertIsInstance(tokens, list)
+                self.assertGreater(len(tokens), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/entrypoints/grpc_server/test_tokenizer_stream.py
+++ b/test/srt/entrypoints/grpc_server/test_tokenizer_stream.py
@@ -1,0 +1,91 @@
+import hashlib
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+try:
+    import sglang.srt.entrypoints.grpc_server as grpc_server
+except Exception as exc:  # pragma: no cover - optional dependency guard
+    pytest.skip(
+        f"gRPC server dependencies not available ({exc})",
+        allow_module_level=True,
+    )
+
+SGLangSchedulerServicer = grpc_server.SGLangSchedulerServicer
+sglang_scheduler_pb2 = grpc_server.sglang_scheduler_pb2
+from sglang.srt.server_args import ServerArgs
+
+
+class DummyRequestManager:
+    def auto_create_handle_loop(self) -> None:
+        pass
+
+    def get_server_info(self) -> dict:
+        return {
+            "active_requests": 0,
+            "paused": False,
+            "last_receive_time": 0.0,
+        }
+
+
+class DummyContext:
+    def __init__(self) -> None:
+        self.code = None
+        self.details = None
+
+    def set_code(self, code) -> None:  # pragma: no cover - simple setter
+        self.code = code
+
+    def set_details(self, details: str) -> None:  # pragma: no cover - simple setter
+        self.details = details
+
+
+@pytest.mark.asyncio
+async def test_get_tokenizer_stream(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer.json").write_text(
+        '{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],'
+        '"model":{"type":"WordLevel","vocab":{"[UNK]":0,"hello":1},"unk_token":"[UNK]"},'
+        '"pre_tokenizer":{"type":"Whitespace"}}',
+        encoding="utf-8",
+    )
+    (tmp_path / "tokenizer_config.json").write_text(
+        '{"chat_template": "{% for m in messages %}{{ m.role }}: {{ m.content }}\n{% endfor %}"}',
+        encoding="utf-8",
+    )
+
+    request_manager = DummyRequestManager()
+    server_args = ServerArgs(model_path=str(tmp_path), tokenizer_path=str(tmp_path))
+    servicer = SGLangSchedulerServicer(
+        request_manager=request_manager,
+        server_args=server_args,
+        model_info={},
+        scheduler_info={},
+    )
+
+    metadata, _, bundle_bytes = servicer._prepare_tokenizer_bundle()
+    expected_fingerprint = hashlib.sha256(bundle_bytes).hexdigest()
+
+    received = []
+    async for chunk in servicer.GetTokenizer(
+        sglang_scheduler_pb2.GetTokenizerRequest(),
+        DummyContext(),
+    ):
+        received.append(chunk)
+
+    assert len(received) >= 2
+    assert received[0].WhichOneof("chunk") == "metadata"
+    assert received[0].metadata.fingerprint == expected_fingerprint
+
+    archive_bytes = b"".join(
+        chunk.file_chunk.data
+        for chunk in received
+        if chunk.WhichOneof("chunk") == "file_chunk"
+    )
+    assert hashlib.sha256(archive_bytes).hexdigest() == expected_fingerprint
+
+    with zipfile.ZipFile(io.BytesIO(archive_bytes), "r") as archive:
+        names = set(archive.namelist())
+    assert "tokenizer.json" in names
+    assert "tokenizer_config.json" in names

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -60,6 +60,8 @@ suites = {
         TestFile("test_gguf.py", 96),
     ],
     "__not_in_ci__": [
+        TestFile("entrypoints/grpc_server/test_get_tokenizer.py"),
+        TestFile("entrypoints/grpc_server/test_tokenizer_stream.py"),
         TestFile("test_release_memory_occupation.py", 200),  # Temporarily disabled
         TestFile("models/test_dummy_grok_models.py"),
         TestFile("test_bench_one_batch.py"),


### PR DESCRIPTION
## Summary

This PR adds a new GetTokenizer endpoint to the gRPC server, enabling clients to retrieve tokenizer information. Also adds a new GetTokenizer gRPC method to the SGLang scheduler service, enabling the model gateway to dynamically fetch tokenizer files from the backend via streaming then load into the tokenizer registry. This eliminates the need for static tokenizer configuration or local access to tokenizer files in the model gateway and ensures the router always uses the same tokenizer as the backend.

## Motivation

Currently, the SGLang model gateway requires to access the tokenizer files locally. This creates several challenges:

Configuration complexity: Users must manually ensure the model gateway has the same tokenizer files access matching the backend model
Deployment overhead: Tokenizer files must be distributed separately from the backend
Dynamic model support: The model gateway cannot adapt to backend model changes without reconfiguration
By enabling dynamic tokenizer streaming, the router can automatically obtain the correct tokenizer from the backend, simplifying deployment and ensuring consistency.

GetTokenizer endpoint will be used by sglang model gateway when inference gateway mode (multi model) is turned on. Router has no knowledge of what tokenizer should be used during start up and it will get tokenizer at runtime when workers are added into the registry. 

## Changes

On SGLang Server: 
- Added GetTokenizer RPC definition to sglang_scheduler.proto
- Implemented GetTokenizer endpoint in grpc_server.py with streaming support
- Generated updated protocol buffer bindings (pb2.py, pb2.pyi, pb2_grpc.py)
- Added comprehensive test coverage in test_tokenizer_stream.py

On SGLang Router: 
- Added new protobuf messages for tokenizer streaming
- Added get_tokenizer() method to SglangSchedulerClient
- Added logic to load tokenizer from streamed zip bundle into registry in worker registration

## Output
```
sglang git:(grpc-server-get-tokenizer) ✗ python3 ./test/srt/entrypoints/grpc_server/test_get_tokenizer.py
Sending GetTokenizer request...
Received metadata: meta.llama-3-8b
Received file chunk: tokenizer_bundle.zip, size: 2097152
Received file chunk: tokenizer_bundle.zip, size: 237091
Total zip size: 2334243 bytes
Extracting to /tmp/tmpm4e0l07n
Listing extracted files:
 - tokenizer_config.json
 - tokenizer.json
 - tokenizer.zip
Loading tokenizer with transformers...
Tokenizer loaded successfully!
Test text: Hello, world! This is a test.
Encoded: [128000, 9906, 11, 1917, 0, 1115, 374, 264, 1296, 13]
Decoded: <|begin_of_text|>Hello, world! This is a test.
```

```
2026-01-08 22:06:31  INFO smg::core::steps::worker::shared::activate: src/core/steps/worker/shared/activate.rs:27: Activated 1 worker(s) (marked as healthy)
2026-01-08 22:06:31  INFO smg::workflow::event: src/workflow/event.rs:131: Step succeeded instance_id=06e7a708-2146-470d-bf17-7bf768b84200 step_id=activate_workers duration_ms=0
2026-01-08 22:06:31 DEBUG smg::core::steps::worker::local::register_tokenizer: src/core/steps/worker/local/register_tokenizer.rs:41: Registering tokenizer for model gpt-oss-20b from /models/openai/gpt-oss-20b
2026-01-08 22:06:31 DEBUG smg::policies::registry: src/policies/registry.rs:61: Worker added for model gpt-oss-20b, count: 1
2026-01-08 22:06:31 DEBUG smg::workflow::engine: src/workflow/engine.rs:353: Step completed step_id=activate_workers result=Success
2026-01-08 22:06:31 DEBUG smg::tokenizer::registry: src/tokenizer/registry.rs:103: Tokenizer cache miss for name: gpt-oss-20b
2026-01-08 22:06:31 DEBUG smg::policies::registry: src/policies/registry.rs:156: Using default policy for model gpt-oss-20b
2026-01-08 22:06:31  INFO smg::policies::registry: src/policies/registry.rs:77: Assigning policy cache_aware to new model gpt-oss-20b
2026-01-08 22:06:31  INFO smg::tokenizer::registry: src/tokenizer/registry.rs:121: Loading tokenizer 'gpt-oss-20b' from source: /models/openai/gpt-oss-20b
2026-01-08 22:06:31 DEBUG smg::policies::registry: src/policies/registry.rs:272: Initializing cache-aware policy with 1 workers for model gpt-oss-20b
2026-01-08 22:06:31  INFO smg::core::steps::worker::local::register_tokenizer: src/core/steps/worker/local/register_tokenizer.rs:87: Fetching tokenizer from worker: grpc://127.0.0.1:18080
2026-01-08 22:06:31  INFO smg::core::worker: src/core/worker.rs:761: Lazily initializing gRPC client (sglang) for worker: grpc://127.0.0.1:18080
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:138: Connecting to SGLang scheduler at grpc://127.0.0.1:18080
2026-01-08 22:06:31 DEBUG smg::core::steps::worker::shared::update_policies: src/core/steps/worker/shared/update_policies.rs:133: Updated policies for 1 workers across 1 models
2026-01-08 22:06:31  INFO smg::workflow::event: src/workflow/event.rs:131: Step succeeded instance_id=06e7a708-2146-470d-bf17-7bf768b84200 step_id=update_policies duration_ms=0
2026-01-08 22:06:31 DEBUG smg::workflow::engine: src/workflow/engine.rs:353: Step completed step_id=update_policies result=Success
2026-01-08 22:06:31  INFO smg::core::worker: src/core/worker.rs:768: Successfully connected gRPC client (sglang) for worker: grpc://127.0.0.1:18080
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:303: Requesting tokenizer from backend
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:317: Received tokenizer metadata: model=gpt-oss-20b, fingerprint=04b544516abc8dde49f9755b38e7b740c9041aa13f5f5613ecd0fb6d8443af0b, files=3, format=zip
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:339: Starting to receive file chunks
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:352: Received file chunk 0: 2097152 bytes, is_last=false
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:352: Received file chunk 1: 2097152 bytes, is_last=false
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:352: Received file chunk 2: 386192 bytes, is_last=true
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:365: Last chunk received, total data size: 4580496 bytes
2026-01-08 22:06:31 DEBUG smg::grpc_client::sglang_scheduler: src/grpc_client/sglang_scheduler.rs:400: Tokenizer bundle download complete
2026-01-08 22:06:31  INFO smg::core::steps::worker::local::register_tokenizer: src/core/steps/worker/local/register_tokenizer.rs:113: Tokenizer extracted to temporary path: /tmp/.tmph5xhMK
2026-01-08 22:06:31 DEBUG smg::tokenizer::factory: src/tokenizer/factory.rs:221: Auto-discovered chat template in '/tmp/.tmph5xhMK': /tmp/.tmph5xhMK/chat_template.jinja
2026-01-08 22:06:33  INFO smg::tokenizer::registry: src/tokenizer/registry.rs:141: Successfully registered tokenizer 'gpt-oss-20b' with id: accb4650-06e3-493e-b5a8-e2934b0f1ea9
2026-01-08 22:06:33 DEBUG smg::core::steps::worker::local::register_tokenizer: src/core/steps/worker/local/register_tokenizer.rs:129: Successfully registered tokenizer for model gpt-oss-20b from /models/openai/gpt-oss-20b
2026-01-08 22:06:33  INFO smg::workflow::event: src/workflow/event.rs:131: Step succeeded instance_id=06e7a708-2146-470d-bf17-7bf768b84200 step_id=register_tokenizer duration_ms=2289
2026-01-08 22:06:33 DEBUG smg::workflow::engine: src/workflow/engine.rs:353: Step completed step_id=register_tokenizer result=Success
2026-01-08 22:06:33  INFO smg::workflow::event: src/workflow/event.rs:170: Workflow completed instance_id=06e7a708-2146-470d-bf17-7bf768b84200 duration_ms=3296
2026-01-08 22:06:33 DEBUG smg::core::job_queue: src/core/job_queue.rs:872: Completed job: type=AddWorker, worker=grpc://127.0.0.1:18080, result=Worker grpc://127.0.0.1:18080 registered and activated successfully via workflow
```