### PR TITLE
[Router] Add GetTokenizer gRPC method to stream tokenizer files from backend to router

### DIFF
--- a/sgl-router/src/grpc_client/sglang_scheduler.rs
+++ b/sgl-router/src/grpc_client/sglang_scheduler.rs
@@ -116,6 +116,13 @@ impl futures::Stream for AbortOnDropStream {
     }
 }
 
+/// Tokenizer bundle downloaded from backend
+#[derive(Debug, Clone)]
+pub struct TokenizerBundle {
+    pub metadata: proto::TokenizerMetadata,
+    pub compressed_data: Vec<u8>,
+}
+
 /// gRPC client for SGLang scheduler
 #[derive(Clone)]
 pub struct SglangSchedulerClient {
@@ -237,6 +244,123 @@ impl SglangSchedulerClient {
         let response = client.get_server_info(request).await?;
         debug!("Server info response received");
         Ok(response.into_inner())
+    }
+
+    /// Get tokenizer bundle from the backend
+    ///
+    /// This method streams a tokenizer bundle from the backend, which consists of:
+    /// 1. A metadata chunk (first message) containing tokenizer information
+    /// 2. One or more file chunks containing compressed tokenizer data
+    ///
+    /// The method validates the streaming protocol:
+    /// - Metadata must arrive first
+    /// - File chunks must have sequential chunk indices
+    /// - The last chunk must be marked with is_last_chunk flag
+    pub async fn get_tokenizer(
+        &self,
+    ) -> Result<TokenizerBundle, Box<dyn std::error::Error + Send + Sync>> {
+        debug!("Requesting tokenizer from backend");
+        let request = Request::new(proto::GetTokenizerRequest {});
+
+        let mut client = self.client.clone();
+        let mut stream = client.get_tokenizer(request).await?.into_inner();
+
+        // First message must be metadata
+        let first_chunk = stream
+            .message()
+            .await?
+            .ok_or("Empty stream: expected metadata chunk")?;
+
+        let metadata = match first_chunk.chunk {
+            Some(proto::get_tokenizer_chunk::Chunk::Metadata(meta)) => {
+                debug!(
+                    "Received tokenizer metadata: model={}, fingerprint={}, files={}, format={}",
+                    meta.model_identifier,
+                    meta.fingerprint,
+                    meta.files.len(),
+                    meta.bundle_format
+                );
+                meta
+            }
+            Some(proto::get_tokenizer_chunk::Chunk::FileChunk(_)) => {
+                return Err("Protocol error: first chunk must be metadata, got file chunk".into());
+            }
+            None => {
+                return Err("Protocol error: first chunk is empty".into());
+            }
+        };
+
+        // Collect file chunks
+        let mut compressed_data = Vec::new();
+        let mut expected_chunk_index = 0u32;
+        let mut last_chunk_received = false;
+
+        debug!("Starting to receive file chunks");
+        while let Some(chunk) = stream.message().await? {
+            match chunk.chunk {
+                Some(proto::get_tokenizer_chunk::Chunk::FileChunk(file_chunk)) => {
+                    // Validate chunk ordering
+                    if file_chunk.chunk_index != expected_chunk_index {
+                        return Err(format!(
+                            "Protocol error: expected chunk index {}, got {}",
+                            expected_chunk_index, file_chunk.chunk_index
+                        )
+                        .into());
+                    }
+
+                    debug!(
+                        "Received file chunk {}: {} bytes, is_last={}",
+                        file_chunk.chunk_index,
+                        file_chunk.data.len(),
+                        file_chunk.is_last_chunk
+                    );
+
+                    // Append data
+                    compressed_data.extend_from_slice(&file_chunk.data);
+
+                    // Check if this is the last chunk
+                    if file_chunk.is_last_chunk {
+                        last_chunk_received = true;
+                        debug!(
+                            "Last chunk received, total data size: {} bytes",
+                            compressed_data.len()
+                        );
+                        break;
+                    }
+
+                    expected_chunk_index += 1;
+                }
+                Some(proto::get_tokenizer_chunk::Chunk::Metadata(_)) => {
+                    return Err(format!(
+                        "Protocol error: unexpected metadata chunk at position {}",
+                        expected_chunk_index
+                    )
+                    .into());
+                }
+                None => {
+                    return Err(format!(
+                        "Protocol error: empty chunk at position {}",
+                        expected_chunk_index
+                    )
+                    .into());
+                }
+            }
+        }
+
+        // Validate that we received the last chunk marker
+        if !last_chunk_received {
+            return Err(format!(
+                "Protocol error: stream ended without is_last_chunk flag (received {} chunks)",
+                expected_chunk_index
+            )
+            .into());
+        }
+
+        debug!("Tokenizer bundle download complete");
+        Ok(TokenizerBundle {
+            metadata,
+            compressed_data,
+        })
     }
 
     /// Build a single SGLang GenerateRequest from OpenAI ChatCompletionRequest

--- a/sgl-router/src/proto/sglang_scheduler.proto
+++ b/sgl-router/src/proto/sglang_scheduler.proto
@@ -26,6 +26,8 @@ service SglangScheduler {
   // Get server information
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
 
+  // Fetch tokenizer artifacts for remote construction
+  rpc GetTokenizer(GetTokenizerRequest) returns (stream GetTokenizerChunk);
 }
 
 // =====================
@@ -456,4 +458,35 @@ message GetServerInfoResponse {
   // Scheduler-side metrics (memory usage, throughput) require
   // bidirectional communicator infrastructure not available in gRPC.
   // Use HTTP /get_server_info if scheduler internal state is needed.
+}
+
+// Get Tokenizer
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  oneof chunk {
+    TokenizerMetadata metadata = 1;
+    TokenizerFileChunk file_chunk = 2;
+  }
+}
+
+message TokenizerMetadata {
+  string model_identifier = 1;
+  string fingerprint = 2;
+  repeated TokenizerFileDescriptor files = 3;
+  string bundle_format = 4;
+}
+
+message TokenizerFileDescriptor {
+  string file_name = 1;
+  string mime_type = 2;
+  bool optional = 3;
+}
+
+message TokenizerFileChunk {
+  string file_name = 1;
+  bytes data = 2;
+  uint32 chunk_index = 3;
+  bool is_last_chunk = 4;
+  string compression = 5;
 }


### PR DESCRIPTION
## Summary

This PR adds a new `GetTokenizer` gRPC method to the SGLang scheduler service, enabling the router to dynamically fetch tokenizer files from the backend via streaming. This eliminates the need for static tokenizer configuration in the router and ensures the router always uses the same tokenizer as the backend.

## Motivation

Currently, the SGLang router requires static tokenizer files to be configured locally. This creates several challenges:

1. **Configuration complexity**: Users must manually ensure the router has the correct tokenizer files matching the backend model
2. **Deployment overhead**: Tokenizer files must be distributed separately from the backend
3. **Dynamic model support**: The router cannot adapt to backend model changes without reconfiguration

By enabling dynamic tokenizer streaming, the router can automatically obtain the correct tokenizer from the backend, simplifying deployment and ensuring consistency.

Python server implementation of the `GetTokenizer` RPC in https://github.com/sgl-project/sglang/pull/12407

## Implementation Details

### Protocol Definition

Added new protobuf messages for tokenizer streaming:

- `GetTokenizerRequest`: Request message (empty for now)
- `GetTokenizerChunk`: Streamed response containing either metadata or file chunks
- `TokenizerMetadata`: Information about the tokenizer bundle (model identifier, fingerprint, file list, format)
- `TokenizerFileDescriptor`: Metadata for individual tokenizer files
- `TokenizerFileChunk`: Chunked file data with sequential indexing and compression support

The protocol follows a metadata-first streaming pattern:
1. First message contains metadata about the tokenizer bundle
2. Subsequent messages contain file chunks with sequential indices
3. Last chunk is marked with `is_last_chunk` flag

### Rust Client Implementation

Added `get_tokenizer()` method to `SglangSchedulerClient` that:

- Initiates a streaming RPC call to the backend
- Validates the streaming protocol (metadata first, sequential chunks, last chunk marker)
- Accumulates compressed data chunks
- Returns a `TokenizerBundle` containing metadata and compressed data

The implementation includes robust error handling for protocol violations:
- Validates metadata arrives first
- Ensures chunks have sequential indices
- Verifies the last chunk marker is received
- Provides detailed error messages for debugging

### Future Work

This PR lays the foundation for dynamic tokenizer streaming. Future enhancements will include:

- `TokenizerRegistry` for caching downloaded tokenizers
- Integration with the router's worker registration workflow
- Configuration options for remote vs. static tokenizer sources
- Automatic fallback mechanisms

## Testing

Manual testing was performed to verify:
- Proto definitions compile correctly
- Rust client compiles without errors
- Protocol validation logic works as expected

Integration testing will be added once the Python server PR is merged.