### PR TITLE
[fix] Support torch_dtype attribute in model config dtype detection

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -821,7 +821,7 @@ def _get_and_verify_dtype(
 ) -> torch.dtype:
     # NOTE: getattr(config, "torch_dtype", torch.float32) is not correct
     # because config.torch_dtype can be None.
-    config_dtype = getattr(config, "dtype", None)
+    config_dtype = getattr(config, "torch_dtype", getattr(config, "dtype", None))
     if isinstance(config_dtype, str):
         config_dtype = _STR_DTYPE_TO_TORCH_DTYPE.get(config_dtype, None)
     if config_dtype is None:


### PR DESCRIPTION
Fix dtype detection in _get_and_verify_dtype by checking torch_dtype attribute first before falling back to dtype attribute. This ensures proper handling of model configs that use torch_dtype (e.g., DeepSeek R1/V3) while maintaining backward compatibility with configs that use dtype attribute.