### PR TITLE
add served model name in bench serving

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2374,7 +2374,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--served-model-name",
         type=str,
-        help="Name of the model served name in serving service. If not set, the default model served name will the same with args.model",
+        help="The name of the model as served by the serving service. If not set, this defaults to the value of --model.",
     )
     parser.add_argument(
         "--tokenizer",

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2272,7 +2272,7 @@ def run_benchmark(args_: argparse.Namespace):
 
     # Read dataset
     backend = args.backend
-    model_id = args.model
+    model_id = args.served_model_name if args.served_model_name is not None else args.model
     tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
     tokenizer = get_tokenizer(tokenizer_id)
     input_requests = get_dataset(args, tokenizer, model_id)
@@ -2370,6 +2370,11 @@ if __name__ == "__main__":
         "--model",
         type=str,
         help="Name or path of the model. If not set, the default model will request /v1/models for conf.",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        type=str,
+        help="Name of the model served name in serving service. If not set, the default model served name will the same with args.model",
     )
     parser.add_argument(
         "--tokenizer",

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2272,7 +2272,7 @@ def run_benchmark(args_: argparse.Namespace):
 
     # Read dataset
     backend = args.backend
-    model_id = args.served_model_name if args.served_model_name is not None else args.model
+    model_id = args.served_model_name or args.model
     tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
     tokenizer = get_tokenizer(tokenizer_id)
     input_requests = get_dataset(args, tokenizer, model_id)


### PR DESCRIPTION

## Motivation

in my llm serving service，the model name is different with served model name, when use bench serving script, i found the script can't adjust this situation.

so i add an args with served-model-name in bench serving script.

## Modifications


## Accuracy Tests


## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
