### PR TITLE
[CI] fix possible port conflicts.

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -151,7 +151,7 @@ def _use_cached_default_models(model_repo: str):
 
 if is_in_ci():
     DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
-        10000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 1000
+        10000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 2000
     )
 else:
     DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (


### PR DESCRIPTION
The stride for different tests on different GPUs is `1000`:

```python
DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
    10000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 1000
)
```

But it may cause conflicts when other tests are using:

```
DEFAULT_URL_FOR_TEST = f"http://127.0.0.1:{DEFAULT_PORT_FOR_SRT_TEST_RUNNER + 1000}"
```