### PR TITLE
[fix] Handle escaped characters in GLM tool call parser to prevent double serialization

### DIFF
--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -55,9 +55,12 @@ class Glm4MoeDetector(BaseFormatDetector):
         self.bot_token = "<tool_call>"
         self.eot_token = "</tool_call>"
         self.func_call_regex = r"<tool_call>.*?</tool_call>"
-        self.func_detail_regex = r"<tool_call>(.*?)(?:\\n|\n)(.*)</tool_call>"
-        self.func_arg_regex = (
-            r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>"
+        self.func_detail_regex = re.compile(
+            r"<tool_call>(.*?)(?:\\n|\n)(.*)</tool_call>", re.DOTALL
+        )
+        self.func_arg_regex = re.compile(
+            r"<arg_key>(.*?)</arg_key>(?:\\n|\s)*<arg_value>(.*?)</arg_value>",
+            re.DOTALL,
         )
 
     def has_tool_call(self, text: str) -> bool:
@@ -81,14 +84,10 @@ class Glm4MoeDetector(BaseFormatDetector):
         try:
             for match_result in match_result_list:
                 # Get function name
-                func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
+                func_detail = self.func_detail_regex.search(match_result)
                 func_name = func_detail.group(1)
                 func_args = func_detail.group(2)
-                pairs = re.findall(
-                    self.func_arg_regex,
-                    func_args,
-                    re.DOTALL,
-                )
+                pairs = self.func_arg_regex.findall(func_args)
                 arguments = {}
                 for arg_key, arg_value in pairs:
                     arg_key = arg_key.strip()

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -32,7 +32,7 @@ def parse_arguments(json_value):
 
     # Try unescaping quotes only (handles escaped JSON from raw strings)
     try:
-        unescaped = json_value.replace(r"\"", '"')
+        unescaped = json_value.replace('\\"', '"')
         parsed_value = json.loads(unescaped)
         return parsed_value, True
     except:

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -24,14 +24,20 @@ def get_argument_type(func_name: str, arg_key: str, defined_tools: list):
 
 def parse_arguments(json_value):
     try:
-        try:
-            # unescape before parsing
-            parsed_value = json.loads(json_value.encode('utf-8').decode('unicode_escape'))
-        except:
-            parsed_value = ast.literal_eval(json_value)
+        parsed_value = json.loads(json_value)
         return parsed_value, True
     except:
-        return json_value, False
+        try:
+            # If parsing fails, try unescaping JSON characters
+            unescaped = json_value.encode("utf-8").decode("unicode_escape")
+            parsed_value = json.loads(unescaped)
+            return parsed_value, True
+        except:
+            try:
+                parsed_value = ast.literal_eval(json_value)
+                return parsed_value, True
+            except:
+                return json_value, False
 
 
 class Glm4MoeDetector(BaseFormatDetector):

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -23,29 +23,15 @@ def get_argument_type(func_name: str, arg_key: str, defined_tools: list):
 
 
 def parse_arguments(json_value):
-    # Try parsing as-is first (handles normal JSON)
     try:
-        parsed_value = json.loads(json_value)
+        try:
+            # unescape before parsing
+            parsed_value = json.loads(json_value.encode('utf-8').decode('unicode_escape'))
+        except:
+            parsed_value = ast.literal_eval(json_value)
         return parsed_value, True
     except:
-        pass
-
-    # Try unescaping quotes only (handles escaped JSON from raw strings)
-    try:
-        unescaped = json_value.replace('\\"', '"')
-        parsed_value = json.loads(unescaped)
-        return parsed_value, True
-    except:
-        pass
-
-    # Try ast.literal_eval as final fallback
-    try:
-        parsed_value = ast.literal_eval(json_value)
-        return parsed_value, True
-    except:
-        pass
-
-    return json_value, False
+        return json_value, False
 
 
 class Glm4MoeDetector(BaseFormatDetector):

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -27,12 +27,15 @@ def parse_arguments(json_value):
         parsed_value = json.loads(json_value)
         return parsed_value, True
     except:
+        # If that fails, try wrapping it to unescape JSON characters
         try:
-            # If parsing fails, try unescaping JSON characters
-            unescaped = json_value.encode("utf-8").decode("unicode_escape")
-            parsed_value = json.loads(unescaped)
+            # Wrap the value as a JSON string field
+            wrapped = json.loads('{"tmp": "' + json_value + '"}')
+            # parse the unescaped value
+            parsed_value = json.loads(wrapped["tmp"])
             return parsed_value, True
         except:
+            # Final fallback to ast.literal_eval
             try:
                 parsed_value = ast.literal_eval(json_value)
                 return parsed_value, True

--- a/test/srt/test_function_call_parser.py
+++ b/test/srt/test_function_call_parser.py
@@ -2294,6 +2294,7 @@ class TestGlm4MoeDetector(unittest.TestCase):
         )
         check_single_todos(result, expected_output)
 
+
 class TestJsonArrayParser(unittest.TestCase):
     def setUp(self):
         # Create sample tools for testing

--- a/test/srt/test_function_call_parser.py
+++ b/test/srt/test_function_call_parser.py
@@ -2221,7 +2221,7 @@ class TestGlm4MoeDetector(unittest.TestCase):
             self.assertIsInstance(
                 params["todos"],
                 list,
-                f"todos should be a list, not a string, {type(params["todos"])}",
+                f"todos should be a list, not a string",
             )
             self.assertEqual(len(params["todos"]), 4)
             self.assertEqual(params["todos"][0]["id"], "1")


### PR DESCRIPTION
## Motivation

This PR fixes a bug where the tool call parser fails when the model's output contains literal escaped characters, such as `\n`, `\"`.

**The Problem:**
When GLM-4 outputs tool calls, the XML may contain '\n' literal characters and the JSON content within `<arg_value>` tags may contain escaped characters like `\"`, causing regex matching and json parsing both failed. For example:

```
<tool_call>todo_write\n<arg_key>todos</arg_key>\n<arg_value>[{\"id\": \"1\", \"task\": \"检查后端代码中的硬编码问题\", \"status\": \"in_progress\"}, {\"id\": \"2\", \"task\": \"检查前端代码中的硬编码问题\", \"status\": \"pending\"}, {\"id\": \"3\", \"task\": \"检查违反单一职责的代码\", \"status\": \"pending\"}, {\"id\": \"4\", \"task\": \"创建整改建议报告\", \"status\": \"pending\"}]</arg_value>
</tool_call>
```

The current regex fails to match the literal \n. Besides, even if the regex extracts the content within <arg_value>, it is not valid JSON. Attempting json.loads() on this string fails with JSONDecodeError.

When parsing failed, the argument value was treated as a plain string. This led to incorrect behavior in `BaseFormatDetector` to incorrectly perform another layer of JSON serialization on the arguments. The result is a double-escaped string (e.g., `\\"` instead of `\"`), breaking the tool call functionality.

**Example of problematic tool output:**
```json
[
  {
    "function": {
      "name": "todo_write",
      "arguments": "{\"todos\": \"[{\\\"id\\\": \\\"1\\\", \\\"task\\\": \\\"检查后端代码的硬编码问题\\\", \\\"status\\\": \\\"in_progress\\\"}, {\\\"id\\\": \\\"2\\\", \\\"task\\\": \\\"检查前端代码的硬编码问题\\\", \\\"status\\\": \\\"pending\\\"}, {\\\"id\\\": \\\"3\\\", \\\"task\\\": \\\"检查违反单一职责原则的代码\\\", \\\"status\\\": \\\"pending\\\"}, {\\\"id\\\": \\\"4\\\", \\\"4\\\", \\\"task\\\": \\\"制定整改方案\\\", \\\"status\\\": \\\"pending\\\"}, {\\\"id\\\": \\\"5\\\", \\\"5\\\", \\\"task\\\": \\\"实施整改\\\", \\\"status\\\": \\\"pending\\\"}]\"}"
    },
    "index": 0,
    "id": "call_eb99d2a2c7fd44328776fb9c",
    "type": "function"
  }
]
```

more test cases can be found at `test_array_argument_with_escaped_json()`

## Modifications

1.  **Robust Regex for Newlines:** Updated regular expression used to extract the function name and arguments (`func_name`, `func_args`). It now correctly recognizes both actual newlines (`\n`) and their literal form (`\\n`). This ensures the initial parsing succeeds even with escaped newlines.

2.  **Robust JSON Deserialization:** Updated `parse_arguments()` in `glm4_moe_detector.py` to handle escaped JSON strings using a two-step JSON parsing approach:
    1. First attempt: Try parsing directly with json.loads() (handles normal case where no extra escaping is present)
    2. Second attempt (if first fails): Use two-step deserialization:
        - Wrap the input string as a JSON string value: '{"tmp": "' + json_value + '"}'
        - Parse this wrapper with json.loads() - this causes the JSON parser to unescape only JSON-specific escape sequences (\", \\,
  \n, \t, etc.)
        - Extract the unescaped value from wrapped["tmp"]
        - Parse the unescaped value again with json.loads()
   3. Final fallback: Use ast.literal_eval() for Python literals

Why twp-step deserialization:
  - Safer: Compared to `decode('unicode_escape')`, only unescapes JSON-standard escape sequences, not Python-specific ones (like \x, \0).

3. Compiled the regexes during initialization to improve performance at runtime.

These changes ensure that tool calls with escaped characters are parsed correctly on the first attempt, avoiding the double-serialization bug.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
