### PR TITLE
Logging `cache_hit_rate` only for prefill and `speculative_decoding` metrics only for decode

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -928,7 +928,7 @@ class SchedulerMetricsCollector:
                 **dp_cooperation_info.to_labels(),
             ).inc(t)
 
-    def log_stats(self, stats: SchedulerStats) -> None:
+    def log_stats(self, stats: SchedulerStats, is_decode_stats: bool = False) -> None:
         self._log_gauge_queue_count(self.num_running_reqs, stats.num_running_reqs)
         self._log_gauge(self.num_used_tokens, stats.num_used_tokens)
         self._log_gauge(self.token_usage, stats.token_usage)
@@ -945,13 +945,16 @@ class SchedulerMetricsCollector:
         self._log_gauge(
             self.num_running_reqs_offline_batch, stats.num_running_reqs_offline_batch
         )
-        self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+
+        if not is_decode_stats:
+            self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
 
         self._log_gauge(self.max_total_num_tokens, stats.max_total_num_tokens)
 
         # Speculative decoding
-        self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
-        self._log_gauge(self.spec_accept_rate, stats.spec_accept_rate)
+        if is_decode_stats:
+            self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
+            self._log_gauge(self.spec_accept_rate, stats.spec_accept_rate)
 
         # PD disaggregation
         self._log_gauge_queue_count(

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -556,7 +556,7 @@ class SchedulerMetricsMixin:
             self.calculate_utilization()
             self.update_lora_metrics()
             self._log_hicache_stats()
-            self.metrics_collector.log_stats(self.stats)
+            self.metrics_collector.log_stats(self.stats, is_decode_stats=True)
             self._emit_kv_metrics()
         self._publish_kv_events()
 


### PR DESCRIPTION
Described as above in the title. Closes https://github.com/sgl-project/sglang/issues/12459.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
