### PR TITLE
[hot fix] Remove `from python.sglang.xxx`

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import torch
 from torch.nn.parameter import Parameter
 
-from python.sglang.srt.utils.common import is_sm120_supported
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import get_dp_global_num_tokens, get_local_dp_buffer
 from sglang.srt.layers.moe import (
@@ -42,6 +41,7 @@ from sglang.srt.layers.quantization.utils import (
 )
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.utils import get_bool_env_var, is_cuda, next_power_of_2
+from sglang.srt.utils.common import is_sm120_supported
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE


### PR DESCRIPTION
This replaces the wrong relative importing `from python.sglang.xxx` with `from sglang.xxx`.

If anyone encounters this issue with VSCode auto Python import, please add this to your configuration:

```json
    "python.analysis.extraPaths": [
        "./python"
    ],
```

@Qiaolin-Yu 