### PR TITLE
[Fix] Remove assertion for padding for NVFP4 weight scales to fix GLM 4.5 NVFP4

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1510,10 +1510,13 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                     weight_scale.shape[-1] == expected_blocks[name]
                 ), f"Expected {name}_weight_scale.dim(2) == {expected_blocks[name]}, got {weight_scale.shape[-1]}"
             else:
-                # For other backends, ensure the per-input block dimension is aligned to 16.
-                assert (
-                    weight_scale.shape[assert_dim] % block_size == 0
-                ), f"Expected {name}_weight_scale.dim({assert_dim}) to be divisible by {block_size}"
+                if weight_scale.shape[assert_dim] % 4 != 0:
+                    logger.warning(
+                        "NVFP4 %s_weight_scale K' not multiple of 4: shape=%s, group_size=%s",
+                        name,
+                        tuple(weight_scale.shape),
+                        getattr(self.quant_config, "group_size", None),
+                    )
             assert (
                 weight_scale.dtype == torch.float8_e4m3fn
             ), f"{name} Weight Blockscale must be represented as FP8-E4M3"


### PR DESCRIPTION
Fix https://github.com/sgl-project/sglang/issues/12208
Fix https://github.com/sgl-project/sglang/issues/14388

I didn't run into the original error, but actually a padding error first:

```
               ^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/__init__.py", line 28, in get_model
    return loader.load_model(
           ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 1960, in load_model
    return super().load_model(
           ^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 595, in load_model
    self.load_weights_and_postprocess(
  File "/sgl-workspace/sglang/python/sglang/srt/model_loader/loader.py", line 614, in load_weights_and_postprocess
    quant_method.process_weights_after_loading(module)
  File "/sgl-workspace/sglang/python/sglang/srt/layers/quantization/modelopt_quant.py", line 1453, in process_weights_after_loading
    weight_scale.shape[2] % 16 == 0
AssertionError: Expected w2_weight_scale.dim(2) to be divisible by 16
```

Since we do swizzle padding, it is not necessary.

Latest accuracy test:

```
python3 -m sglang.launch_server --model-path iAzure/GLM-4.5-NVFP4 --trust-remote-code --tp 8 --quantization modelopt_fp4
```
  
```
python3 benchmark/gsm8k/bench_sglang.py --num-questions 1319 --parallel 1319
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:59<00:00, 22.13it/s]
Accuracy: 0.945
Invalid: 0.000
Latency: 59.981 s
Output throughput: 2362.182 token/s
```