### PR TITLE
To implement attention-sink

### DIFF
--- a/test_attention_sink.sh
+++ b/test_attention_sink.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# To set up the sglang server:
+# python -m sglang.launch_server --model Qwen/Qwen3-8B --attention-backend fa3 --disable-cuda-graph
+
+curl http://localhost:30000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
+    "messages": [
+        {"role": "user", "content": "There are $n$ values of $x$ in the interval $0<x<2\\pi$ where $f(x)=\\sin(7\\pi\\cdot\\sin(5x))=0$. For $t$ of these $n$ values of $x$, the graph of $y=f(x)$ is tangent to the $x$-axis. Find $n+t$. Put your answer in \\boxed{}. For multiple-choice questions, only put the choice letter in the box."}
+    ],
+    "max_tokens": 16384
+}'


### PR DESCRIPTION
## Motivation

To implement [attention sink](https://arxiv.org/pdf/2309.17453) with customized window sizes (first-window-size=1024 and last-window-size=7168) for efficient reasoning. When implemented with huggingface transformers, it saves memories and compute without hurting the downstream tasks' performance (such as pass@1 on AIME25 for math reasoning) for various LLMs such as Qwen3. I would like to implement this in sglang as well but failed as discussed below. I could not figure out why and it would be great if someone can help check it out. Any suggestions and advice are welcome. 

## Modifications

Following the [blog](https://hebiao064.github.io/fa3-attn-backend-basic) of FA3 implementation in sglang, I change the logic of `init_forward_metadata` so that the maximum seqlens become 8192 and the page-tables become the concatenation of the first-window and last-window.

## Accuracy Tests

The model behaves differently from expected (as implemented in huggingface transformers). It will not generate reasonable sentences after 8K tokens and instead repeat single words like ` \n\nSo \n\nSo \n\nSo \n\nSo \n\nSo \n\nSo \n\nSo \n\nSo \n\nSo \n\nSo`. 

I attached a script `test_attention_sink.sh` for testing. To launch servers, I run
```
python -m sglang.launch_server --model Qwen/Qwen3-8B --attention-backend fa3 --disable-cuda-graph
```
To submit a request, I run
```
curl http://localhost:30000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "messages": [
        {"role": "user", "content": "There are $n$ values of $x$ in the interval $0<x<2\\pi$ where $f(x)=\\sin(7\\pi\\cdot\\sin(5x))=0$. For $t$ of these $n$ values of $x$, the graph of $y=f(x)$ is tangent to the $x$-axis. Find $n+t$. Put your answer in \\boxed{}. For multiple-choice questions, only put the choice letter in the box."}
    ],
    "max_tokens": 16384
}'
```

