### PR TITLE
Reduce time it takes to import SGLang

### DIFF
--- a/python/sglang/srt/compilation/piecewise_context_manager.py
+++ b/python/sglang/srt/compilation/piecewise_context_manager.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 _in_piecewise_cuda_graph = False
 

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -43,5 +43,94 @@ __all__ = [
     "NemotronHConfig",
     "NemotronH_Nano_VL_V2_Config",
     "JetNemotronConfig",
-    "JetVLMConfig",
+    "JetVLMConfig"
 ]
+
+
+def __getattr__(name):
+    """Lazily import config classes on first access."""
+    if name == "ChatGLMConfig":
+        from sglang.srt.configs.chatglm import ChatGLMConfig
+
+        return ChatGLMConfig
+    elif name == "DbrxConfig":
+        from sglang.srt.configs.dbrx import DbrxConfig
+
+        return DbrxConfig
+    elif name == "DeepseekVL2Config":
+        from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
+
+        return DeepseekVL2Config
+    elif name == "DotsOCRConfig":
+        from sglang.srt.configs.dots_ocr import DotsOCRConfig
+
+        return DotsOCRConfig
+    elif name == "DotsVLMConfig":
+        from sglang.srt.configs.dots_vlm import DotsVLMConfig
+
+        return DotsVLMConfig
+    elif name == "ExaoneConfig":
+        from sglang.srt.configs.exaone import ExaoneConfig
+
+        return ExaoneConfig
+    elif name == "FalconH1Config":
+        from sglang.srt.configs.falcon_h1 import FalconH1Config
+
+        return FalconH1Config
+    elif name == "MultiModalityConfig":
+        from sglang.srt.configs.janus_pro import MultiModalityConfig
+
+        return MultiModalityConfig
+    elif name == "KimiLinearConfig":
+        from sglang.srt.configs.kimi_linear import KimiLinearConfig
+
+        return KimiLinearConfig
+    elif name == "KimiVLConfig":
+        from sglang.srt.configs.kimi_vl import KimiVLConfig
+
+        return KimiVLConfig
+    elif name == "MoonViTConfig":
+        from sglang.srt.configs.kimi_vl_moonvit import MoonViTConfig
+
+        return MoonViTConfig
+    elif name == "LongcatFlashConfig":
+        from sglang.srt.configs.longcat_flash import LongcatFlashConfig
+
+        return LongcatFlashConfig
+    elif name == "NemotronHConfig":
+        from sglang.srt.configs.nemotron_h import NemotronHConfig
+
+        return NemotronHConfig
+    elif name == "NemotronH_Nano_VL_V2_Config":
+        from sglang.srt.configs.nano_nemotron_vl import NemotronH_Nano_VL_V2_Config
+        
+        return NemotronH_Nano_VL_V2_Config
+    elif name == "JetNemotronConfig":
+        from sglang.srt.configs.jet_nemotron import JetNemotronConfig
+
+        return JetNemotronConfig
+    elif name == "JetVLMConfig":
+        from sglang.srt.configs.jet_vlm import JetVLMConfig
+
+        return JetVLMConfig
+    elif name == "Olmo3Config":
+        from sglang.srt.configs.olmo3 import Olmo3Config
+
+        return Olmo3Config
+    elif name == "Qwen3NextConfig":
+        from sglang.srt.configs.qwen3_next import Qwen3NextConfig
+
+        return Qwen3NextConfig
+    elif name == "Step3TextConfig":
+        from sglang.srt.configs.step3_vl import Step3TextConfig
+
+        return Step3TextConfig
+    elif name == "Step3VisionEncoderConfig":
+        from sglang.srt.configs.step3_vl import Step3VisionEncoderConfig
+
+        return Step3VisionEncoderConfig
+    elif name == "Step3VLConfig":
+        from sglang.srt.configs.step3_vl import Step3VLConfig
+
+        return Step3VLConfig
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -1,25 +1,29 @@
-from sglang.srt.configs.chatglm import ChatGLMConfig
-from sglang.srt.configs.dbrx import DbrxConfig
-from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
-from sglang.srt.configs.dots_ocr import DotsOCRConfig
-from sglang.srt.configs.dots_vlm import DotsVLMConfig
-from sglang.srt.configs.exaone import ExaoneConfig
-from sglang.srt.configs.falcon_h1 import FalconH1Config
-from sglang.srt.configs.janus_pro import MultiModalityConfig
-from sglang.srt.configs.jet_nemotron import JetNemotronConfig
-from sglang.srt.configs.jet_vlm import JetVLMConfig
-from sglang.srt.configs.kimi_linear import KimiLinearConfig
-from sglang.srt.configs.kimi_vl import KimiVLConfig
-from sglang.srt.configs.kimi_vl_moonvit import MoonViTConfig
-from sglang.srt.configs.longcat_flash import LongcatFlashConfig
-from sglang.srt.configs.nano_nemotron_vl import NemotronH_Nano_VL_V2_Config
-from sglang.srt.configs.nemotron_h import NemotronHConfig
-from sglang.srt.configs.olmo3 import Olmo3Config
-from sglang.srt.configs.qwen3_next import Qwen3NextConfig
-from sglang.srt.configs.step3_vl import (
-    Step3TextConfig,
-    Step3VisionEncoderConfig,
-    Step3VLConfig,
+from sglang.utils import LazyImport
+
+ChatGLMConfig = LazyImport("sglang.srt.configs.chatglm", "ChatGLMConfig")
+DbrxConfig = LazyImport("sglang.srt.configs.dbrx", "DbrxConfig")
+DeepseekVL2Config = LazyImport("sglang.srt.configs.deepseekvl2", "DeepseekVL2Config")
+DotsOCRConfig = LazyImport("sglang.srt.configs.dots_ocr", "DotsOCRConfig")
+DotsVLMConfig = LazyImport("sglang.srt.configs.dots_vlm", "DotsVLMConfig")
+ExaoneConfig = LazyImport("sglang.srt.configs.exaone", "ExaoneConfig")
+FalconH1Config = LazyImport("sglang.srt.configs.falcon_h1", "FalconH1Config")
+MultiModalityConfig = LazyImport("sglang.srt.configs.janus_pro", "MultiModalityConfig")
+JetNemotronConfig = LazyImport("sglang.srt.configs.jet_nemotron", "JetNemotronConfig")
+JetVLMConfig = LazyImport("sglang.srt.configs.jet_vlm", "JetVLMConfig")
+KimiLinearConfig = LazyImport("sglang.srt.configs.kimi_linear", "KimiLinearConfig")
+KimiVLConfig = LazyImport("sglang.srt.configs.kimi_vl", "KimiVLConfig")
+MoonViTConfig = LazyImport("sglang.srt.configs.kimi_vl_moonvit", "MoonViTConfig")
+LongcatFlashConfig = LazyImport(
+    "sglang.srt.configs.longcat_flash", "LongcatFlashConfig"
+)
+NemotronHConfig = LazyImport("sglang.srt.configs.nemotron_h", "NemotronHConfig")
+NemotronH_Nano_VL_V2_Config = LazyImport("sglang.srt.configs.nano_nemotron_vl", "NemotronH_Nano_VL_V2_Config")
+Olmo3Config = LazyImport("sglang.srt.configs.olmo3", "Olmo3Config")
+Qwen3NextConfig = LazyImport("sglang.srt.configs.qwen3_next", "Qwen3NextConfig")
+Step3VLConfig = LazyImport("sglang.srt.configs.step3_vl", "Step3VLConfig")
+Step3TextConfig = LazyImport("sglang.srt.configs.step3_vl", "Step3TextConfig")
+Step3VisionEncoderConfig = LazyImport(
+    "sglang.srt.configs.step3_vl", "Step3VisionEncoderConfig"
 )
 
 __all__ = [
@@ -45,92 +49,3 @@ __all__ = [
     "JetNemotronConfig",
     "JetVLMConfig"
 ]
-
-
-def __getattr__(name):
-    """Lazily import config classes on first access."""
-    if name == "ChatGLMConfig":
-        from sglang.srt.configs.chatglm import ChatGLMConfig
-
-        return ChatGLMConfig
-    elif name == "DbrxConfig":
-        from sglang.srt.configs.dbrx import DbrxConfig
-
-        return DbrxConfig
-    elif name == "DeepseekVL2Config":
-        from sglang.srt.configs.deepseekvl2 import DeepseekVL2Config
-
-        return DeepseekVL2Config
-    elif name == "DotsOCRConfig":
-        from sglang.srt.configs.dots_ocr import DotsOCRConfig
-
-        return DotsOCRConfig
-    elif name == "DotsVLMConfig":
-        from sglang.srt.configs.dots_vlm import DotsVLMConfig
-
-        return DotsVLMConfig
-    elif name == "ExaoneConfig":
-        from sglang.srt.configs.exaone import ExaoneConfig
-
-        return ExaoneConfig
-    elif name == "FalconH1Config":
-        from sglang.srt.configs.falcon_h1 import FalconH1Config
-
-        return FalconH1Config
-    elif name == "MultiModalityConfig":
-        from sglang.srt.configs.janus_pro import MultiModalityConfig
-
-        return MultiModalityConfig
-    elif name == "KimiLinearConfig":
-        from sglang.srt.configs.kimi_linear import KimiLinearConfig
-
-        return KimiLinearConfig
-    elif name == "KimiVLConfig":
-        from sglang.srt.configs.kimi_vl import KimiVLConfig
-
-        return KimiVLConfig
-    elif name == "MoonViTConfig":
-        from sglang.srt.configs.kimi_vl_moonvit import MoonViTConfig
-
-        return MoonViTConfig
-    elif name == "LongcatFlashConfig":
-        from sglang.srt.configs.longcat_flash import LongcatFlashConfig
-
-        return LongcatFlashConfig
-    elif name == "NemotronHConfig":
-        from sglang.srt.configs.nemotron_h import NemotronHConfig
-
-        return NemotronHConfig
-    elif name == "NemotronH_Nano_VL_V2_Config":
-        from sglang.srt.configs.nano_nemotron_vl import NemotronH_Nano_VL_V2_Config
-        
-        return NemotronH_Nano_VL_V2_Config
-    elif name == "JetNemotronConfig":
-        from sglang.srt.configs.jet_nemotron import JetNemotronConfig
-
-        return JetNemotronConfig
-    elif name == "JetVLMConfig":
-        from sglang.srt.configs.jet_vlm import JetVLMConfig
-
-        return JetVLMConfig
-    elif name == "Olmo3Config":
-        from sglang.srt.configs.olmo3 import Olmo3Config
-
-        return Olmo3Config
-    elif name == "Qwen3NextConfig":
-        from sglang.srt.configs.qwen3_next import Qwen3NextConfig
-
-        return Qwen3NextConfig
-    elif name == "Step3TextConfig":
-        from sglang.srt.configs.step3_vl import Step3TextConfig
-
-        return Step3TextConfig
-    elif name == "Step3VisionEncoderConfig":
-        from sglang.srt.configs.step3_vl import Step3VisionEncoderConfig
-
-        return Step3VisionEncoderConfig
-    elif name == "Step3VLConfig":
-        from sglang.srt.configs.step3_vl import Step3VLConfig
-
-        return Step3VLConfig
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -17,7 +17,9 @@ LongcatFlashConfig = LazyImport(
     "sglang.srt.configs.longcat_flash", "LongcatFlashConfig"
 )
 NemotronHConfig = LazyImport("sglang.srt.configs.nemotron_h", "NemotronHConfig")
-NemotronH_Nano_VL_V2_Config = LazyImport("sglang.srt.configs.nano_nemotron_vl", "NemotronH_Nano_VL_V2_Config")
+NemotronH_Nano_VL_V2_Config = LazyImport(
+    "sglang.srt.configs.nano_nemotron_vl", "NemotronH_Nano_VL_V2_Config"
+)
 Olmo3Config = LazyImport("sglang.srt.configs.olmo3", "Olmo3Config")
 Qwen3NextConfig = LazyImport("sglang.srt.configs.qwen3_next", "Qwen3NextConfig")
 Step3VLConfig = LazyImport("sglang.srt.configs.step3_vl", "Step3VLConfig")
@@ -47,5 +49,5 @@ __all__ = [
     "NemotronHConfig",
     "NemotronH_Nano_VL_V2_Config",
     "JetNemotronConfig",
-    "JetVLMConfig"
+    "JetVLMConfig",
 ]

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -22,7 +22,6 @@ from enum import Enum, IntEnum, auto
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Union
 
 import torch
-from transformers import PretrainedConfig
 
 from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -12,18 +12,19 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
 import json
 import logging
 import math
 import os
 from enum import Enum, IntEnum, auto
-from typing import Any, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Union
 
 import torch
 from transformers import PretrainedConfig
 
 from sglang.srt.environ import envs
-from sglang.srt.layers.quantization import QUANTIZATION_METHODS
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import is_hip, retry
 from sglang.srt.utils.hf_transformers_utils import (
@@ -36,6 +37,9 @@ from sglang.srt.utils.hf_transformers_utils import (
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
 
 
 class AttentionArch(IntEnum):
@@ -632,6 +636,8 @@ class ModelConfig:
 
     # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py
     def _verify_quantization(self) -> None:
+        from sglang.srt.layers.quantization import QUANTIZATION_METHODS
+
         supported_quantization = [*QUANTIZATION_METHODS]
         rocm_supported_quantization = [
             "awq",

--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -13,16 +13,19 @@
 # ==============================================================================
 """The baseclass of a backend for grammar-guided constrained decoding."""
 
+from __future__ import annotations
+
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from threading import Event
-from typing import Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import torch
 
-from sglang.srt.server_args import ServerArgs
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -6,10 +6,9 @@ from typing import TYPE_CHECKING, List, Optional
 import numpy as np
 import numpy.typing as npt
 
-from sglang.srt.server_args import ServerArgs
-
 if TYPE_CHECKING:
     from sglang.srt.disaggregation.utils import DisaggregationMode
+    from sglang.srt.server_args import ServerArgs
 
 
 class KVArgs:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -67,7 +67,7 @@ from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
     from sglang.srt.managers.scheduler import Scheduler
 
 CLIP_MAX_NEW_TOKEN = get_int_env_var("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", 4096)
@@ -229,6 +229,8 @@ class DecodePreallocQueue:
         self.kv_manager = self._init_kv_manager()
 
     def _init_kv_manager(self) -> BaseKVManager:
+        from sglang.srt.layers.dp_attention import get_attention_tp_size
+
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
         kv_args = kv_args_class()
 
@@ -298,6 +300,8 @@ class DecodePreallocQueue:
 
     def add(self, req: Req, is_retracted: bool = False) -> None:
         """Add a request to the pending queue."""
+        from sglang.srt.managers.schedule_batch import RequestStage
+
         if self._check_if_req_exceed_kv_capacity(req):
             return
 
@@ -412,6 +416,8 @@ class DecodePreallocQueue:
 
     def pop_preallocated(self) -> List[DecodeRequest]:
         """Pop the preallocated requests from the pending queue (FIFO)."""
+        from sglang.srt.managers.schedule_batch import FINISH_ABORT, RequestStage
+
         self._update_handshake_waiters()
 
         preallocated_reqs = []
@@ -727,6 +733,8 @@ class DecodeTransferQueue:
         decode_req.req.time_stats.wait_queue_entry_time = time.perf_counter()
 
     def pop_transferred(self) -> List[Req]:
+        from sglang.srt.managers.schedule_batch import RequestStage
+
         if not self.queue:
             return []
         polls = poll_and_all_reduce(
@@ -788,6 +796,7 @@ class SchedulerDisaggregationDecodeMixin:
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
+        from sglang.srt.managers.schedule_batch import RequestStage
 
         while True:
             recv_reqs = self.recv_requests()
@@ -808,6 +817,8 @@ class SchedulerDisaggregationDecodeMixin:
 
     @torch.no_grad()
     def event_loop_overlap_disagg_decode(self: Scheduler):
+        from sglang.srt.managers.schedule_batch import RequestStage
+
         self.result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None
 
@@ -888,6 +899,8 @@ class SchedulerDisaggregationDecodeMixin:
 
     def get_new_prebuilt_batch(self: Scheduler) -> Optional[ScheduleBatch]:
         """Create a schedulebatch for fake completed prefill"""
+        from sglang.srt.managers.schedule_batch import RequestStage, ScheduleBatch
+
         if self.grammar_queue:
             self.move_ready_grammar_requests()
 

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -47,7 +47,6 @@ from sglang.srt.disaggregation.utils import (
     prepare_abort,
 )
 from sglang.srt.managers.request_types import FINISH_ABORT, RequestStage
-from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.mem_cache.common import release_kv_cache
@@ -68,6 +67,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
     from sglang.srt.managers.scheduler import Scheduler
+    from sglang.srt.managers.utils import GenerationBatchResult
 
 CLIP_MAX_NEW_TOKEN = get_int_env_var("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", 4096)
 
@@ -838,6 +838,8 @@ class SchedulerDisaggregationDecodeMixin:
     def _run_batch_prebuilt(
         self: Scheduler, batch: ScheduleBatch
     ) -> GenerationBatchResult:
+        from sglang.srt.managers.utils import GenerationBatchResult
+
         if batch.inner_idle_batch is not None:
             idle_batch = batch.inner_idle_batch
             # Reset the inner idle batch to avoid reusing it.

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -46,7 +46,6 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce,
     prepare_abort,
 )
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
@@ -688,6 +687,8 @@ class DecodeTransferQueue:
         self.queue.extend(decode_reqs)
 
     def _commit_transfer_to_req(self, decode_req: DecodeRequest) -> None:
+        from sglang.srt.managers.schedule_batch import RequestStage
+
         idx = decode_req.metadata_buffer_index
         (
             output_id,

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -46,8 +46,7 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce,
     prepare_abort,
 )
-from sglang.srt.layers.dp_attention import get_attention_tp_size
-from sglang.srt.managers.schedule_batch import FINISH_ABORT, RequestStage, ScheduleBatch
+from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
@@ -796,7 +795,6 @@ class SchedulerDisaggregationDecodeMixin:
     @torch.no_grad()
     def event_loop_normal_disagg_decode(self: Scheduler):
         """A normal scheduler loop for decode worker in disaggregation mode."""
-        from sglang.srt.managers.schedule_batch import RequestStage
 
         while True:
             recv_reqs = self.recv_requests()
@@ -817,7 +815,6 @@ class SchedulerDisaggregationDecodeMixin:
 
     @torch.no_grad()
     def event_loop_overlap_disagg_decode(self: Scheduler):
-        from sglang.srt.managers.schedule_batch import RequestStage
 
         self.result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -809,7 +809,6 @@ class SchedulerDisaggregationDecodeMixin:
 
     @torch.no_grad()
     def event_loop_overlap_disagg_decode(self: Scheduler):
-
         self.result_queue = deque()
         self.last_batch: Optional[ScheduleBatch] = None
 

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -9,6 +9,12 @@ import torch
 from sglang.srt.disaggregation.utils import prepare_abort
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.utils import LazyImport
+
+ForwardMode = LazyImport("sglang.srt.model_executor.forward_batch_info", "ForwardMode")
+CaptureHiddenMode = LazyImport(
+    "sglang.srt.model_executor.forward_batch_info", "CaptureHiddenMode"
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +27,6 @@ if TYPE_CHECKING:
 class ScheduleBatchDisaggregationDecodeMixin:
 
     def prepare_for_prebuilt(self: ScheduleBatch):
-        from sglang.srt.model_executor.forward_batch_info import ForwardMode
-
         """
         Prepare a prebuilt extend by populate metadata
         Adapted from .prepare_for_extend().
@@ -108,8 +112,6 @@ class ScheduleBatchDisaggregationDecodeMixin:
         server_args: ServerArgs,
         future_map: FutureMap,
     ):
-        from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
-
         """Assign the buffered last input id to schedule batch"""
         self.output_ids = []
         for req in self.reqs:

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -8,7 +8,6 @@ import torch
 
 from sglang.srt.disaggregation.utils import prepare_abort
 from sglang.srt.mem_cache.common import release_kv_cache
-from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 
 logger = logging.getLogger(__name__)
@@ -22,6 +21,8 @@ if TYPE_CHECKING:
 class ScheduleBatchDisaggregationDecodeMixin:
 
     def prepare_for_prebuilt(self: ScheduleBatch):
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
         """
         Prepare a prebuilt extend by populate metadata
         Adapted from .prepare_for_extend().
@@ -107,6 +108,8 @@ class ScheduleBatchDisaggregationDecodeMixin:
         server_args: ServerArgs,
         future_map: FutureMap,
     ):
+        from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+
         """Assign the buffered last input id to schedule batch"""
         self.output_ids = []
         for req in self.reqs:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -228,6 +228,7 @@ class PrefillBootstrapQueue:
         return_failed_reqs: For PP, on rank 0, also return the failed reqs to notify the next rank
         rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
         """
+
         bootstrapped_reqs = []
         failed_reqs = []
         indices_to_remove = set()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -42,12 +42,6 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce,
     prepare_abort,
 )
-from sglang.srt.managers.schedule_batch import (
-    FINISH_LENGTH,
-    Req,
-    RequestStage,
-    ScheduleBatch,
-)
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.mem_cache.memory_pool import (
     HybridLinearKVPool,
@@ -60,6 +54,7 @@ from sglang.srt.utils import broadcast_pyobj, point_to_point_pyobj
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
 
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
     from sglang.srt.managers.scheduler import GenerationBatchResult, Scheduler
     from sglang.srt.mem_cache.memory_pool import KVCache
 
@@ -180,6 +175,8 @@ class PrefillBootstrapQueue:
         return kv_manager
 
     def add(self, req: Req, num_kv_heads: int) -> None:
+        from sglang.srt.managers.schedule_batch import RequestStage
+
         if self._check_if_req_exceed_kv_capacity(req):
             return
 
@@ -232,6 +229,7 @@ class PrefillBootstrapQueue:
         return_failed_reqs: For PP, on rank 0, also return the failed reqs to notify the next rank
         rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
         """
+        from sglang.srt.managers.schedule_batch import RequestStage
 
         bootstrapped_reqs = []
         failed_reqs = []
@@ -393,6 +391,8 @@ class SchedulerDisaggregationPrefillMixin:
         Transfer kv for prefill completed requests and add it into disagg_prefill_inflight_queue
         Adapted from process_batch_result_prefill
         """
+        from sglang.srt.managers.schedule_batch import RequestStage
+
         (
             logits_output,
             next_token_ids,
@@ -510,6 +510,8 @@ class SchedulerDisaggregationPrefillMixin:
         Poll the requests in the middle of transfer. If done, return the request.
         rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
         """
+        from sglang.srt.managers.schedule_batch import FINISH_LENGTH, RequestStage
+
         if len(self.disagg_prefill_inflight_queue) == 0:
             return []
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -42,6 +42,7 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce,
     prepare_abort,
 )
+from sglang.srt.managers.request_types import FINISH_LENGTH, RequestStage
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.mem_cache.memory_pool import (
     HybridLinearKVPool,
@@ -175,8 +176,6 @@ class PrefillBootstrapQueue:
         return kv_manager
 
     def add(self, req: Req, num_kv_heads: int) -> None:
-        from sglang.srt.managers.schedule_batch import RequestStage
-
         if self._check_if_req_exceed_kv_capacity(req):
             return
 
@@ -229,8 +228,6 @@ class PrefillBootstrapQueue:
         return_failed_reqs: For PP, on rank 0, also return the failed reqs to notify the next rank
         rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
         """
-        from sglang.srt.managers.schedule_batch import RequestStage
-
         bootstrapped_reqs = []
         failed_reqs = []
         indices_to_remove = set()
@@ -391,8 +388,6 @@ class SchedulerDisaggregationPrefillMixin:
         Transfer kv for prefill completed requests and add it into disagg_prefill_inflight_queue
         Adapted from process_batch_result_prefill
         """
-        from sglang.srt.managers.schedule_batch import RequestStage
-
         (
             logits_output,
             next_token_ids,
@@ -510,8 +505,6 @@ class SchedulerDisaggregationPrefillMixin:
         Poll the requests in the middle of transfer. If done, return the request.
         rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
         """
-        from sglang.srt.managers.schedule_batch import FINISH_LENGTH, RequestStage
-
         if len(self.disagg_prefill_inflight_queue) == 0:
             return []
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -12,7 +12,6 @@ import torch
 import torch.distributed as dist
 
 from sglang.srt.managers.request_types import FINISH_ABORT
-from sglang.srt.utils import is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -90,6 +89,8 @@ class MetadataBuffers:
         max_top_logprobs_num: int = 128,
         custom_mem_pool: torch.cuda.MemPool = None,
     ):
+        from sglang.srt.utils import is_npu
+
         self.custom_mem_pool = custom_mem_pool
         device = "cpu"
         if is_npu():

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -11,6 +11,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
+from sglang.srt.managers.request_types import FINISH_ABORT
 from sglang.srt.utils import is_npu
 
 if TYPE_CHECKING:
@@ -346,8 +347,6 @@ def is_mla_backend(target_kv_pool) -> bool:
 
 
 def prepare_abort(req: Req, error_message: str, status_code=None):
-    from sglang.srt.managers.schedule_batch import FINISH_ABORT
-
     # populate finish metadata and stream output
     req.finished_reason = FINISH_ABORT(error_message, status_code)
 

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -29,7 +29,6 @@ import torch.distributed
 
 from sglang.srt.environ import envs
 from sglang.srt.metrics.collector import ExpertDispatchCollector
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import Withable, get_int_env_var, is_npu
 
@@ -37,6 +36,7 @@ _is_npu = is_npu()
 
 if TYPE_CHECKING:
     from sglang.srt.eplb.expert_location import ExpertLocationMetadata
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/layers/attention/nsa/utils.py
+++ b/python/sglang/srt/layers/attention/nsa/utils.py
@@ -6,7 +6,6 @@ from typing import List
 import torch
 import torch.nn.functional as F
 
-from sglang.srt.layers.dp_attention import get_attention_tp_group
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_bool_env_var
 
@@ -100,6 +99,8 @@ def enable_prefill_cp(forward_batch, nsa_enable_prefill_cp):
 def cp_attn_tp_all_gather_reorganazied_into_tensor(
     input_: torch.Tensor, total_len, attn_tp_size, forward_batch, stream_op
 ):
+    from sglang.srt.layers.dp_attention import get_attention_tp_group
+
     """
     Allgather communication for context_parallel(kv_cache, index_k, hidden_states).
     This implementation mainly consists of three parts:

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -11,12 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+
+from __future__ import annotations
+
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
 
 import torch
 
@@ -47,7 +50,6 @@ from sglang.srt.layers.moe import (
     get_moe_a2a_backend,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -60,6 +62,9 @@ from sglang.srt.utils import (
     is_sm100_supported,
     prepare_weight_cache,
 )
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 _is_cuda = is_cuda()
 _is_flashinfer_available = is_flashinfer_available()

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -13,9 +13,11 @@
 # ==============================================================================
 """Logits processing."""
 
+from __future__ import annotations
+
 import dataclasses
 import logging
-from typing import List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import torch
 import triton
@@ -40,14 +42,20 @@ from sglang.srt.layers.dp_attention import (
     get_dp_dtype,
     get_dp_hidden_size,
 )
-from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
-from sglang.srt.model_executor.forward_batch_info import (
-    CaptureHiddenMode,
-    ForwardBatch,
-    ForwardMode,
-)
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_npu, use_intel_amx_backend
+from sglang.utils import LazyImport
+
+CaptureHiddenMode = LazyImport(
+    "sglang.srt.model_executor.forward_batch_info", "CaptureHiddenMode"
+)
+ForwardBatch = LazyImport(
+    "sglang.srt.model_executor.forward_batch_info", "ForwardBatch"
+)
+ForwardMode = LazyImport("sglang.srt.model_executor.forward_batch_info", "ForwardMode")
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/layers/moe/__init__.py
+++ b/python/sglang/srt/layers/moe/__init__.py
@@ -1,4 +1,3 @@
-from sglang.srt.layers.moe.moe_runner import MoeRunner, MoeRunnerConfig
 from sglang.srt.layers.moe.utils import (
     DeepEPMode,
     MoeA2ABackend,
@@ -12,6 +11,10 @@ from sglang.srt.layers.moe.utils import (
     is_tbo_enabled,
     should_use_flashinfer_cutlass_moe_fp4_allgather,
 )
+from sglang.utils import LazyImport
+
+MoeRunner = LazyImport("sglang.srt.layers.moe.moe_runner.runner", "MoeRunner")
+MoeRunnerConfig = LazyImport("sglang.srt.layers.moe.moe_runner.base", "MoeRunnerConfig")
 
 __all__ = [
     "DeepEPMode",

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -258,7 +258,6 @@ class VocabParallelEmbedding(torch.nn.Module):
         )
         self.embedding_dim = embedding_dim
 
-        # Lazy import to avoid loading quantization at module level
         from sglang.srt.layers.quantization.base_config import (
             method_has_implemented_embedding,
         )

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -29,6 +29,11 @@ from sglang.srt.utils import (
     is_cpu,
     set_weight_attrs,
 )
+from sglang.utils import LazyImport
+
+UnquantizedEmbeddingMethod = LazyImport(
+    "sglang.srt.layers.quantization.unquant", "UnquantizedEmbeddingMethod"
+)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import (
@@ -261,7 +266,6 @@ class VocabParallelEmbedding(torch.nn.Module):
         from sglang.srt.layers.quantization.base_config import (
             method_has_implemented_embedding,
         )
-        from sglang.srt.layers.quantization.unquant import UnquantizedEmbeddingMethod
 
         quant_method = None
         if quant_config is not None:

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -13,6 +13,8 @@
 # ==============================================================================
 """A controller that dispatches requests to multiple data parallel workers."""
 
+from __future__ import annotations
+
 import faulthandler
 import logging
 import multiprocessing as mp
@@ -21,7 +23,7 @@ import threading
 import time
 from collections import deque
 from enum import Enum, auto
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import psutil
 import setproctitle
@@ -34,7 +36,8 @@ from sglang.srt.managers.io_struct import (
     TokenizedGenerateReqInput,
     WatchLoadUpdateReq,
 )
-from sglang.srt.managers.schedule_batch import Req, RequestStage
+from sglang.srt.managers.request_types import RequestStage
+from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.server_args import (
     DP_ATTENTION_HANDSHAKE_PORT_DELTA,
@@ -59,6 +62,9 @@ from sglang.srt.utils.common import (
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -37,7 +37,6 @@ from sglang.srt.managers.io_struct import (
     WatchLoadUpdateReq,
 )
 from sglang.srt.managers.request_types import RequestStage
-from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.server_args import (
     DP_ATTENTION_HANDSHAKE_PORT_DELTA,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -16,6 +16,8 @@ The definition of objects transferred between different
 processes (TokenizerManager, DetokenizerManager, Scheduler).
 """
 
+from __future__ import annotations
+
 import copy
 import uuid
 from abc import ABC
@@ -24,7 +26,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 from sglang.srt.lora.lora_registry import LoRARef
-from sglang.srt.managers.schedule_batch import BaseFinishReason
 from sglang.srt.multimodal.mm_utils import has_valid_data
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import ImageData
@@ -32,6 +33,8 @@ from sglang.srt.utils import ImageData
 # Handle serialization of Image for pydantic
 if TYPE_CHECKING:
     from PIL.Image import Image
+
+    from sglang.srt.managers.schedule_batch import BaseFinishReason
 else:
     Image = Any
 

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -34,7 +34,7 @@ from sglang.srt.utils import ImageData
 if TYPE_CHECKING:
     from PIL.Image import Image
 
-    from sglang.srt.managers.schedule_batch import BaseFinishReason
+    from sglang.srt.managers.request_types import BaseFinishReason
 else:
     Image = Any
 

--- a/python/sglang/srt/managers/request_types.py
+++ b/python/sglang/srt/managers/request_types.py
@@ -1,0 +1,112 @@
+"""
+Lightweight request types and enums.
+
+These were originally in schedule_batch.py, but it has been moved here
+to avoid expensive imports.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import List, Union
+
+
+class BaseFinishReason:
+    def __init__(self, is_error: bool = False):
+        self.is_error = is_error
+
+    def to_json(self):
+        raise NotImplementedError()
+
+
+class FINISH_MATCHED_TOKEN(BaseFinishReason):
+    def __init__(self, matched: Union[int, List[int]]):
+        super().__init__()
+        self.matched = matched
+
+    def to_json(self):
+        return {
+            "type": "stop",  # to match OpenAI API's return value
+            "matched": self.matched,
+        }
+
+
+class FINISH_MATCHED_STR(BaseFinishReason):
+    def __init__(self, matched: str):
+        super().__init__()
+        self.matched = matched
+
+    def to_json(self):
+        return {
+            "type": "stop",  # to match OpenAI API's return value
+            "matched": self.matched,
+        }
+
+
+class FINISHED_MATCHED_REGEX(BaseFinishReason):
+    def __init__(self, matched: str):
+        super().__init__()
+        self.matched = matched
+
+    def to_json(self):
+        return {
+            "type": "stop",  # to match OpenAI API's return value
+            "matched": self.matched,
+        }
+
+
+class FINISH_LENGTH(BaseFinishReason):
+    def __init__(self, length: int):
+        super().__init__()
+        self.length = length
+
+    def to_json(self):
+        return {
+            "type": "length",  # to match OpenAI API's return value
+            "length": self.length,
+        }
+
+
+class FINISH_ABORT(BaseFinishReason):
+    def __init__(self, message=None, status_code=None, err_type=None):
+        super().__init__(is_error=True)
+        self.message = message or "Aborted"
+        self.status_code = status_code
+        self.err_type = err_type
+
+    def to_json(self):
+        return {
+            "type": "abort",
+            "message": self.message,
+            "status_code": self.status_code,
+            "err_type": self.err_type,
+        }
+
+
+class RequestStage(str, enum.Enum):
+    # Tokenizer
+    TOKENIZE = "tokenize"
+    TOKENIZER_DISPATCH = "dispatch"
+
+    # DP controller
+    DC_DISPATCH = "dc_dispatch"
+
+    # common/non-disaggregation
+    PREFILL_WAITING = "prefill_waiting"
+    REQUEST_PROCESS = "request_process"
+    DECODE_LOOP = "decode_loop"
+    PREFILL_FORWARD = "prefill_forward"
+    PREFILL_CHUNKED_FORWARD = "chunked_prefill"
+
+    # disaggregation prefill
+    PREFILL_PREPARE = "prefill_prepare"
+    PREFILL_BOOTSTRAP = "prefill_bootstrap"
+    PREFILL_TRANSFER_KV_CACHE = "prefill_transfer_kv_cache"
+
+    # disaggregation decode
+    DECODE_PREPARE = "decode_prepare"
+    DECODE_BOOTSTRAP = "decode_bootstrap"
+    DECODE_WAITING = "decode_waiting"
+    DECODE_TRANSFERRED = "decode_transferred"
+    DECODE_FAKE_OUTPUT = "fake_output"
+    DECODE_QUICK_FINISH = "quick_finish"

--- a/python/sglang/srt/managers/request_types.py
+++ b/python/sglang/srt/managers/request_types.py
@@ -1,9 +1,4 @@
-"""
-Lightweight request types and enums.
-
-These were originally in schedule_batch.py, but it has been moved here
-to avoid expensive imports.
-"""
+"""Lightweight request types and enums from schedule_batch.py."""
 
 from __future__ import annotations
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -84,17 +84,21 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
 from sglang.srt.metrics.collector import SchedulerMetricsCollector, TimeStats
-from sglang.srt.model_executor.forward_batch_info import (
-    CaptureHiddenMode,
-    ForwardBatch,
-    ForwardMode,
-)
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs, get_global_server_args
 from sglang.srt.utils import flatten_nested_list
 from sglang.srt.utils.common import is_npu
 from sglang.srt.utils.cuda_ipc_transport_utils import CudaIpcTensorTransportProxy
+from sglang.utils import LazyImport
+
+CaptureHiddenMode = LazyImport(
+    "sglang.srt.model_executor.forward_batch_info", "CaptureHiddenMode"
+)
+ForwardBatch = LazyImport(
+    "sglang.srt.model_executor.forward_batch_info", "ForwardBatch"
+)
+ForwardMode = LazyImport("sglang.srt.model_executor.forward_batch_info", "ForwardMode")
 
 _is_npu = is_npu()
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1,9 +1,3 @@
-from __future__ import annotations
-
-import enum
-
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-
 # Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,9 +98,9 @@ _is_npu = is_npu()
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.dllm.config import DllmConfig
     from sglang.srt.speculative.eagle_info import EagleDraftInput
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
-    from sglang.srt.dllm.config import DllmConfig
 
 INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -35,6 +35,8 @@ ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 TODO(lmzheng): ModelWorkerBatch seems a bit redundant and we consider removing it in the future.
 """
 
+from __future__ import annotations
+
 import copy
 import dataclasses
 import logging

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -118,12 +118,11 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from sglang.srt.managers.overlap_utils import FutureMap
+from sglang.srt.managers.request_types import FINISH_ABORT, RequestStage
 from sglang.srt.managers.schedule_batch import (
-    FINISH_ABORT,
     ModelWorkerBatch,
     MultimodalInputs,
     Req,
-    RequestStage,
     ScheduleBatch,
 )
 from sglang.srt.managers.schedule_policy import (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -924,8 +924,6 @@ class Scheduler(
             self.disagg_prefill_inflight_queue: List[Req] = []
 
     def init_overlap(self):
-        from sglang.srt.managers.overlap_utils import FutureMap
-
         self.future_map = None
 
         if not self.enable_overlap:

--- a/python/sglang/srt/managers/scheduler_dp_attn_mixin.py
+++ b/python/sglang/srt/managers/scheduler_dp_attn_mixin.py
@@ -5,8 +5,13 @@ from typing import TYPE_CHECKING, Callable
 
 import torch
 
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.utils.common import require_mlp_tp_gather
+from sglang.utils import LazyImport
+
+ScheduleBatch = LazyImport("sglang.srt.managers.schedule_batch", "ScheduleBatch")
+TboDPAttentionPreparer = LazyImport(
+    "sglang.srt.two_batch_overlap", "TboDPAttentionPreparer"
+)
 
 if TYPE_CHECKING:
     from sglang.srt.distributed.parallel_state import GroupCoordinator
@@ -101,8 +106,6 @@ def prepare_mlp_sync_batch_raw(
     disable_overlap_schedule: bool,
     offload_tags: set[str],
 ):
-    from sglang.srt.two_batch_overlap import TboDPAttentionPreparer
-
     # Check if other DP workers have running batches
     if local_batch is None or local_batch.forward_mode.is_prebuilt():
         num_tokens = 0

--- a/python/sglang/srt/managers/scheduler_dp_attn_mixin.py
+++ b/python/sglang/srt/managers/scheduler_dp_attn_mixin.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Callable
 import torch
 
 from sglang.srt.managers.schedule_batch import ScheduleBatch
-from sglang.srt.two_batch_overlap import TboDPAttentionPreparer
 from sglang.srt.utils.common import require_mlp_tp_gather
 
 if TYPE_CHECKING:
@@ -102,6 +101,8 @@ def prepare_mlp_sync_batch_raw(
     disable_overlap_schedule: bool,
     offload_tags: set[str],
 ):
+    from sglang.srt.two_batch_overlap import TboDPAttentionPreparer
+
     # Check if other DP workers have running batches
     if local_batch is None or local_batch.forward_mode.is_prebuilt():
         num_tokens = 0

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -14,12 +14,8 @@ from sglang.srt.managers.io_struct import (
     BatchEmbeddingOutput,
     BatchTokenIDOutput,
 )
-from sglang.srt.managers.schedule_batch import (
-    BaseFinishReason,
-    Req,
-    RequestStage,
-    ScheduleBatch,
-)
+from sglang.srt.managers.request_types import BaseFinishReason, RequestStage
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.tracing.trace import trace_slice, trace_slice_batch, trace_slice_end
 

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -8,7 +8,6 @@ import torch
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.io_struct import (
     AbortReq,
     BatchEmbeddingOutput,
@@ -20,6 +19,7 @@ from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.tracing.trace import trace_slice, trace_slice_batch, trace_slice_end
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.logits_processor import LogitsProcessorOutput
     from sglang.srt.managers.scheduler import (
         EmbeddingBatchResult,
         GenerationBatchResult,

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.utils import GenerationBatchResult
-from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.utils import DynamicGradMode, point_to_point_pyobj
+from sglang.utils import LazyImport
+
+LogitsProcessorOutput = LazyImport(
+    "sglang.srt.layers.logits_processor", "LogitsProcessorOutput"
+)
+PPProxyTensors = LazyImport(
+    "sglang.srt.model_executor.forward_batch_info", "PPProxyTensors"
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler

--- a/python/sglang/srt/managers/scheduler_profiler_mixin.py
+++ b/python/sglang/srt/managers/scheduler_profiler_mixin.py
@@ -7,9 +7,11 @@ from typing import List, Optional
 import torch
 
 from sglang.srt.managers.io_struct import ProfileReq, ProfileReqOutput, ProfileReqType
-from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.utils import is_npu
 from sglang.srt.utils.profile_merger import ProfileMerger
+from sglang.utils import LazyImport
+
+ForwardMode = LazyImport("sglang.srt.model_executor.forward_batch_info", "ForwardMode")
 
 _is_npu = is_npu()
 if _is_npu:

--- a/python/sglang/srt/managers/session_controller.py
+++ b/python/sglang/srt/managers/session_controller.py
@@ -15,7 +15,8 @@ import uuid
 from typing import Dict, Optional
 
 from sglang.srt.managers.io_struct import TokenizedGenerateReqInput
-from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req
+from sglang.srt.managers.request_types import FINISH_ABORT
+from sglang.srt.managers.schedule_batch import Req
 
 
 class SessionReqNode:

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -21,6 +21,7 @@ from typing import (
 import fastapi
 import zmq
 
+from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.io_struct import (
     CheckWeightsReqInput,
     CheckWeightsReqOutput,
@@ -70,7 +71,7 @@ from sglang.srt.managers.io_struct import (
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
-from sglang.srt.server_args import LoRARef, ServerArgs
+from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_bool_env_var
 from sglang.utils import TypeBasedDispatcher
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -74,7 +74,7 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.mm_utils import TensorTransportMode
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.request_metrics_exporter import RequestMetricsExporterManager
-from sglang.srt.managers.schedule_batch import RequestStage
+from sglang.srt.managers.request_types import RequestStage
 from sglang.srt.managers.scheduler import is_health_check_generate_req
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_communicator_mixin import TokenizerCommunicatorMixin

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -6,13 +6,17 @@ from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.managers.overlap_utils import FutureIndices
 from sglang.srt.managers.schedule_batch import Req
-from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.utils import LazyImport
+
+LogitsProcessorOutput = LazyImport(
+    "sglang.srt.layers.logits_processor", "LogitsProcessorOutput"
+)
 
 if TYPE_CHECKING:
+    from sglang.srt.managers.overlap_utils import FutureIndices
     from sglang.srt.managers.scheduler import GenerationBatchResult
+    from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
     from sglang.srt.speculative.eagle_info import EagleDraftInput
 
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1517,7 +1517,7 @@ class MLATokenToKVPool(KVCache):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ):
-        from sgalng.srt.layers.attention.nsa.quant_k_cache import quantize_k_cache
+        from sglang.srt.layers.attention.nsa.quant_k_cache import quantize_k_cache
 
         layer_id = layer.layer_id
 
@@ -1683,6 +1683,8 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ):
+        from sglang.srt.layers.attention.nsa.quant_k_cache import quantize_k_cache
+
         layer_id = layer.layer_id
 
         if self.use_nsa and self.nsa_kv_cache_store_fp8:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -558,7 +558,7 @@ class MHATokenToKVPool(KVCache):
 
         self.device_module = torch.get_device_module(self.device)
         self.alt_stream = (
-            self.device_module.Stream() if is_cuda() and enable_alt_stream else None
+            self.device_module.Stream() if _is_cuda and enable_alt_stream else None
         )
 
         if enable_kv_cache_copy:
@@ -990,8 +990,6 @@ class HybridLinearKVPool(KVCache):
         kv_lora_rank: int = None,
         qk_rope_head_dim: int = None,
     ):
-        from sglang.srt.utils.common import is_npu
-
         self.size = size
         self.dtype = dtype
         self.device = device
@@ -1006,7 +1004,7 @@ class HybridLinearKVPool(KVCache):
         assert not enable_kvcache_transpose
         self.use_mla = use_mla
         if not use_mla:
-            if is_npu():
+            if _is_npu:
                 TokenToKVPoolClass = AscendTokenToKVPool
             else:
                 TokenToKVPoolClass = MHATokenToKVPool

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1512,14 +1512,14 @@ class ModelRunner:
     @property
     def hybrid_gdn_config(self):
         config = self.model_config.hf_config
-        if isinstance(config, Qwen3NextConfig | JetNemotronConfig | JetVLMConfig):
+        if isinstance(config, (Qwen3NextConfig, JetNemotronConfig, JetVLMConfig)):
             return config
         return None
 
     @property
     def mamba2_config(self):
         config = self.model_config.hf_config
-        if isinstance(config, FalconH1Config | NemotronHConfig):
+        if isinstance(config, (FalconH1Config, NemotronHConfig)):
             return config
         if isinstance(config, NemotronH_Nano_VL_V2_Config):
             return config.llm_config

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -22,7 +22,7 @@ import logging
 import os
 import random
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import orjson
 
@@ -57,10 +57,14 @@ from sglang.srt.utils.common import (
     wait_port_available,
     xpu_has_xmx_support,
 )
-from sglang.utils import is_in_ci
+from sglang.utils import LazyImport, is_in_ci
 
-if TYPE_CHECKING:
-    from sglang.srt.lora.lora_registry import LoRARef
+ConnectorType = LazyImport("sglang.srt.managers.connector", "ConnectorType")
+FunctionCallParser = LazyImport(
+    "sglang.srt.function_call.function_call_parser", "FunctionCallParser"
+)
+ReasoningParser = LazyImport("sglang.srt.parser.reasoning_parser", "ReasoningParser")
+LoRARef = LazyImport("sglang.srt.lora.lora_registry", "LoRARef")
 
 logger = logging.getLogger(__name__)
 
@@ -927,7 +931,6 @@ class ServerArgs:
 
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import is_deepseek_nsa
-        from sglang.srt.connector import ConnectorType
 
         if parse_connector_type(self.model_path) == ConnectorType.INSTANCE:
             return
@@ -1904,7 +1907,6 @@ class ServerArgs:
             )
 
     def _handle_deterministic_inference(self):
-        from sglang.srt.connector import ConnectorType
 
         if self.rl_on_policy_target is not None:
             logger.warning(
@@ -2024,9 +2026,6 @@ class ServerArgs:
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
-        from sglang.srt.function_call.function_call_parser import FunctionCallParser
-        from sglang.srt.parser.reasoning_parser import ReasoningParser
-
         # Model and tokenizer
         parser.add_argument(
             "--model-path",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4055,8 +4055,6 @@ class ServerArgs:
             assert is_npu(), "MindSpore model impl is only supported on Ascend npu."
 
     def check_lora_server_args(self):
-        from sglang.srt.lora.lora_registry import LoRARef
-
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"
 
         # Enable LoRA if any LoRA paths are provided for backward compatibility.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -59,7 +59,7 @@ from sglang.srt.utils.common import (
 )
 from sglang.utils import LazyImport, is_in_ci
 
-ConnectorType = LazyImport("sglang.srt.managers.connector", "ConnectorType")
+ConnectorType = LazyImport("sglang.srt.connector", "ConnectorType")
 FunctionCallParser = LazyImport(
     "sglang.srt.function_call.function_call_parser", "FunctionCallParser"
 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -59,7 +59,6 @@ from sglang.srt.utils.common import (
     wait_port_available,
     xpu_has_xmx_support,
 )
-from sglang.srt.utils.hf_transformers_utils import check_gguf_file, get_config
 from sglang.utils import is_in_ci
 
 if TYPE_CHECKING:
@@ -1782,6 +1781,8 @@ class ServerArgs:
                 )
 
     def _handle_load_format(self):
+        from sglang.srt.utils.hf_transformers_utils import check_gguf_file
+
         if (
             self.load_format == "auto" or self.load_format == "gguf"
         ) and check_gguf_file(self.model_path):
@@ -3902,6 +3903,8 @@ class ServerArgs:
             return f"http://{self.host}:{self.port}"
 
     def get_hf_config(self):
+        from sglang.srt.utils.hf_transformers_utils import get_config
+
         kwargs = {}
         hf_config = get_config(
             self.model_path,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 import orjson
 
 from sglang.srt.environ import ToolStrictLevel, envs
+from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
@@ -62,7 +63,6 @@ from sglang.utils import is_in_ci
 if TYPE_CHECKING:
     from sglang.srt.function_call.function_call_parser import FunctionCallParser
     from sglang.srt.lora.lora_registry import LoRARef
-    from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -22,15 +22,13 @@ import logging
 import os
 import random
 import tempfile
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import orjson
 
 from sglang.srt.connector import ConnectorType
 from sglang.srt.environ import ToolStrictLevel, envs
-from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.lora.lora_registry import LoRARef
-from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
@@ -63,6 +61,10 @@ from sglang.srt.utils.common import (
 )
 from sglang.srt.utils.hf_transformers_utils import check_gguf_file, get_config
 from sglang.utils import is_in_ci
+
+if TYPE_CHECKING:
+    from sglang.srt.function_call.function_call_parser import FunctionCallParser
+    from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -22,11 +22,13 @@ import logging
 import os
 import random
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import orjson
 
 from sglang.srt.environ import ToolStrictLevel, envs
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
@@ -59,10 +61,6 @@ from sglang.srt.utils.common import (
     xpu_has_xmx_support,
 )
 from sglang.utils import is_in_ci
-
-if TYPE_CHECKING:
-    from sglang.srt.function_call.function_call_parser import FunctionCallParser
-    from sglang.srt.lora.lora_registry import LoRARef
 
 logger = logging.getLogger(__name__)
 
@@ -4056,8 +4054,6 @@ class ServerArgs:
             assert is_npu(), "MindSpore model impl is only supported on Ascend npu."
 
     def check_lora_server_args(self):
-        from sglang.srt.utils.lora_utils import LoRARef
-
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"
 
         # Enable LoRA if any LoRA paths are provided for backward compatibility.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -26,9 +26,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import orjson
 
-from sglang.srt.connector import ConnectorType
 from sglang.srt.environ import ToolStrictLevel, envs
-from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
@@ -63,6 +61,7 @@ from sglang.utils import is_in_ci
 
 if TYPE_CHECKING:
     from sglang.srt.function_call.function_call_parser import FunctionCallParser
+    from sglang.srt.lora.lora_registry import LoRARef
     from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 logger = logging.getLogger(__name__)
@@ -930,6 +929,7 @@ class ServerArgs:
 
     def _handle_model_specific_adjustments(self):
         from sglang.srt.configs.model_config import is_deepseek_nsa
+        from sglang.srt.connector import ConnectorType
 
         if parse_connector_type(self.model_path) == ConnectorType.INSTANCE:
             return
@@ -1906,6 +1906,8 @@ class ServerArgs:
             )
 
     def _handle_deterministic_inference(self):
+        from sglang.srt.connector import ConnectorType
+
         if self.rl_on_policy_target is not None:
             logger.warning(
                 "Enable deterministic inference because of rl_on_policy_target."
@@ -4054,6 +4056,8 @@ class ServerArgs:
             assert is_npu(), "MindSpore model impl is only supported on Ascend npu."
 
     def check_lora_server_args(self):
+        from sglang.srt.utils.lora_utils import LoRARef
+
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"
 
         # Enable LoRA if any LoRA paths are provided for backward compatibility.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -22,14 +22,11 @@ import logging
 import os
 import random
 import tempfile
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
 
 import orjson
 
 from sglang.srt.environ import ToolStrictLevel, envs
-from sglang.srt.function_call.function_call_parser import FunctionCallParser
-from sglang.srt.lora.lora_registry import LoRARef
-from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
@@ -61,6 +58,9 @@ from sglang.srt.utils.common import (
     xpu_has_xmx_support,
 )
 from sglang.utils import is_in_ci
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.lora_registry import LoRARef
 
 logger = logging.getLogger(__name__)
 
@@ -2024,6 +2024,8 @@ class ServerArgs:
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+        from sglang.srt.parser.reasoning_parser import ReasoningParser
 
         # Model and tokenizer
         parser.add_argument(
@@ -4054,6 +4056,8 @@ class ServerArgs:
             assert is_npu(), "MindSpore model impl is only supported on Ascend npu."
 
     def check_lora_server_args(self):
+        from sglang.srt.lora.lora_registry import LoRARef
+
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"
 
         # Enable LoRA if any LoRA paths are provided for backward compatibility.

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -83,7 +83,6 @@ import torch.distributed
 import torch.distributed as dist
 import triton
 import zmq
-from fastapi.responses import ORJSONResponse
 from packaging import version as pkg_version
 from PIL import Image
 from starlette.routing import Mount
@@ -95,6 +94,9 @@ from typing_extensions import Literal
 
 from sglang.srt.environ import envs
 from sglang.srt.metrics.func_timer import enable_func_timer
+from sglang.utils import LazyImport
+
+ORJSONResponse = LazyImport("fastapi.responses", "ORJSONResponse")
 
 if TYPE_CHECKING:
     # Apparently importing this here is necessary to avoid a segfault, see comment in load_video below

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -28,7 +28,6 @@ import torch
 from huggingface_hub import snapshot_download
 
 from sglang.srt.connector import create_remote_connector
-from sglang.srt.multimodal.customized_mm_processor_utils import _CUSTOMIZED_MM_PROCESSOR
 from sglang.srt.utils import is_remote_url, logger, lru_cache_frozenset
 
 if TYPE_CHECKING:
@@ -42,8 +41,7 @@ if TYPE_CHECKING:
 
 def _register_custom_configs():
     from transformers import AutoConfig
-    from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
-    from sglang.srt.configs.internvl import InternVLChatConfig
+
     from sglang.srt.configs import (
         ChatGLMConfig,
         DbrxConfig,
@@ -64,6 +62,8 @@ def _register_custom_configs():
         Step3VLConfig,
         JetNemotronConfig,
     )
+    from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
+    from sglang.srt.configs.internvl import InternVLChatConfig
 
     _CONFIG_REGISTRY: List[Type[PretrainedConfig]] = [
         ChatGLMConfig,
@@ -482,6 +482,10 @@ def get_processor(
     **kwargs,
 ):
     from transformers import AutoConfig, AutoProcessor, AutoTokenizer
+
+    from sglang.srt.multimodal.customized_mm_processor_utils import (
+        _CUSTOMIZED_MM_PROCESSOR,
+    )
 
     # pop 'revision' from kwargs if present.
     revision = kwargs.pop("revision", tokenizer_revision)

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -27,8 +27,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 import torch
 from huggingface_hub import snapshot_download
 
-from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
-from sglang.srt.configs.internvl import InternVLChatConfig
 from sglang.srt.connector import create_remote_connector
 from sglang.srt.multimodal.customized_mm_processor_utils import _CUSTOMIZED_MM_PROCESSOR
 from sglang.srt.utils import is_remote_url, logger, lru_cache_frozenset
@@ -44,7 +42,8 @@ if TYPE_CHECKING:
 
 def _register_custom_configs():
     from transformers import AutoConfig
-
+    from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
+    from sglang.srt.configs.internvl import InternVLChatConfig
     from sglang.srt.configs import (
         ChatGLMConfig,
         DbrxConfig,

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -50,6 +50,7 @@ def _register_custom_configs():
         DotsVLMConfig,
         ExaoneConfig,
         FalconH1Config,
+        JetNemotronConfig,
         JetVLMConfig,
         KimiLinearConfig,
         KimiVLConfig,
@@ -60,7 +61,6 @@ def _register_custom_configs():
         Olmo3Config,
         Qwen3NextConfig,
         Step3VLConfig,
-        JetNemotronConfig,
     )
     from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
     from sglang.srt.configs.internvl import InternVLChatConfig

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -92,7 +92,7 @@ def _register_custom_configs():
         DeepseekVLV2Config,
         JetNemotronConfig,
         JetVLMConfig,
-]
+    ]
 
     _CONFIG_REGISTRY = {
         config_cls.model_type: config_cls for config_cls in _CONFIG_REGISTRY

--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     from transformers import (
         PretrainedConfig,
         PreTrainedTokenizer,
-        PreTrainedTokenizerBase,
         PreTrainedTokenizerFast,
     )
 
@@ -388,7 +387,7 @@ def get_tokenizer(
     **kwargs,
 ) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
     """Gets a tokenizer for the given model name via Huggingface."""
-    from transformers import AutoTokenizer
+    from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
     if tokenizer_name.endswith(".json"):
         from sglang.srt.tokenizer.tiktoken_tokenizer import TiktokenTokenizer
@@ -467,6 +466,8 @@ def get_tokenizer(
 
 # Some models doesn't have an available processor, e.g.: InternVL
 def get_tokenizer_from_processor(processor):
+    from transformers import PreTrainedTokenizerBase
+
     if isinstance(processor, PreTrainedTokenizerBase):
         return processor
     return processor.tokenizer

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -329,22 +329,10 @@ class LazyImport:
         if isinstance(other, LazyImport):
             other_type = other._load()
         elif isinstance(other, tuple):
-            # Handle chaining: A | (B, C) -> (A, B, C)
             return (self_type,) + other
         else:
             other_type = other
         return (self_type, other_type)
-
-    def __ror__(self, other):
-        self_type = self._load()
-        if isinstance(other, LazyImport):
-            other_type = other._load()
-        elif isinstance(other, tuple):
-            # Handle chaining: (A, B) | C -> (A, B, C)
-            return other + (self_type,)
-        else:
-            other_type = other
-        return (other_type, self_type)
 
     def __instancecheck__(self, instance):
         return isinstance(instance, self._load())

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -324,6 +324,31 @@ class LazyImport:
         module = self._load()
         return module(*args, **kwargs)
 
+    def __or__(self, other):
+        self_type = self._load()
+        if isinstance(other, LazyImport):
+            other_type = other._load()
+        elif isinstance(other, tuple):
+            # Handle chaining: A | (B, C) -> (A, B, C)
+            return (self_type,) + other
+        else:
+            other_type = other
+        return (self_type, other_type)
+
+    def __ror__(self, other):
+        self_type = self._load()
+        if isinstance(other, LazyImport):
+            other_type = other._load()
+        elif isinstance(other, tuple):
+            # Handle chaining: (A, B) | C -> (A, B, C)
+            return other + (self_type,)
+        else:
+            other_type = other
+        return (other_type, self_type)
+
+    def __instancecheck__(self, instance):
+        return isinstance(instance, self._load())
+
 
 def download_and_cache_file(url: str, filename: Optional[str] = None):
     """Read and cache a file from a url."""

--- a/test/srt/debug_utils/test_tensor_dump_forward_hook.py
+++ b/test/srt/debug_utils/test_tensor_dump_forward_hook.py
@@ -11,7 +11,6 @@ from sglang.srt.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from sglang.srt.layers.layernorm import RMSNorm
-from sglang.srt.layers.linear import LinearBase
 from sglang.srt.models.qwen2 import Qwen2MLP
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.srt.utils import add_prefix
@@ -55,6 +54,9 @@ class MockCausalLM(nn.Module):
 
 
 def init_weights(module):
+    # Avoid circular import
+    from sglang.srt.layers.linear import LinearBase
+
     if isinstance(module, LinearBase):
         torch.nn.init.uniform_(module.weight)
         if module.bias is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

We notice that the time to import things in SGLang takes a lot of time (https://github.com/sgl-project/sglang/issues/10492). I have been looking into what is taking up a lot of time and if there are simple ways to help reduce this import time. From the original issue, we want to reduce:
```
time python -c "from sglang.srt.managers.scheduler import Scheduler"
```
which is what I have been focusing my efforts on. However, I think there are things we can do to reduce time for other imports. This is more of a V1 to get community feedback from experts.

## Modifications

<!-- Detail the changes made in this pull request. -->

There are some heavy imports.  For example, the quantization methods import at the module level is heavy. Moving some imports to the function level (only time it is used), we can reduce module import time. However, I can see how this can easily be an antipattern. In fact, it can hurt performance if we have a function that is used a lot that we have an import in. I tried to only do this in functions that we only expect to run once or a small number of times. However, I can understand the argument against this kind of code. I also don't think all the changes to `hf_transformer_utils.py` help so I will be taken a deeper look, since the changes are a bit invasive.

## Accuracy Tests

These changes should not affect model outputs.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

Running `for i in {1..100}; do (time python -B -c "from sglang.srt.managers.scheduler import Scheduler") 2>&1 | grep "^real"; done | python calc_avg.py` ([calc_avg.py](https://gist.github.com/raayandhar/ed637053e7c311630ed8e8cd989ce947))

With these changes:
```
===========Timing Statistics============                                                                            
Number of runs: 100                                                                                                 
Mean:     8.308s                                                                                                    
Median:   8.236s                                                                                                    
Std Dev:  0.297s                                                                                                    
Min:      7.999s                                                                                                    
Max:      9.329s                                                                                                    
========================================
```
Compared to top-of-main:
```
===========Timing Statistics============                                                                            
Number of runs: 100                                                                                                 
Mean:     9.836s                                                                                                    
Median:   9.790s                                                                                                    
Std Dev:  0.332s                                                                                                    
Min:      8.655s                                                                                                    
Max:      11.801s                                                                                                   
======================================== 
```
so we have ~1.5 second improvement. Not the best, so I am going to keep working on it. I mostly targeted improving the timing in the creation of `ModelConfig` object. The difference so far is largely from removing the quantization import:

Without these changes [import_sglang_tom.log](https://gist.github.com/raayandhar/d25a90632e3502f9f8791db333ad0b02)
<img width="271" height="166" alt="Screenshot 2025-11-01 at 9 03 47 PM" src="https://github.com/user-attachments/assets/aa476a4c-f9a6-4176-9b54-e9ebf2ea8b7b" />

With these changes [import_sglang_new.log](https://gist.github.com/raayandhar/0d851737cf7eae3218fca29c8607384a)
<img width="260" height="145" alt="Screenshot 2025-11-01 at 9 04 04 PM" src="https://github.com/user-attachments/assets/941b6174-e548-4e36-ae64-4ed92a30ade5" />

Machine:
- AMD EPYC 7343 16-Core Processor
- L40S GPU

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A?)
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations). (N/A?)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
