### PR TITLE
[VLM] Refactor video processing to fully async mode

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -19,16 +19,15 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputFormat,
 )
+from sglang.srt.multimodal.processors.video_utils import make_video_input
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import envs, is_npu, load_audio, load_image, load_video, logger
+from sglang.srt.utils import envs, is_npu, load_audio, load_image, logger
 from sglang.srt.utils.cuda_ipc_transport_utils import (
     MM_FEATURE_CACHE_SIZE,
     MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
     CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
 )
-from sglang.srt.multimodal.processors.video_utils import make_video_input
-from sglang.srt.utils import is_npu, load_audio, load_image, logger
 
 _is_npu = is_npu()
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -142,6 +142,7 @@ def smart_nframes(
         )
     return nframes
 
+
 # Compatible with Qwen-VL & Qwen-Omni Series
 class QwenVLImageProcessor(SGLangBaseProcessor):
     models = [
@@ -225,7 +226,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         image_factor: int = IMAGE_FACTOR,
     ) -> torch.Tensor:
         if self.video_executor is not None:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 self.video_executor,
                 QwenVLImageProcessor.preprocess_video_task,
@@ -307,7 +308,6 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             f"total_time: {(torchvision_resize_time - entry_time) * 1000:.2f} ms"
         )
         return video, video_metadata
-
 
     async def process_mm_data_async(
         self,

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -1,17 +1,11 @@
 import asyncio
-import math
-import os
 import re
 import time
 from typing import List, Union
 
-import numpy as np
 import torch
-import torchvision
 from PIL import Image
-from torchvision.transforms import InterpolationMode
 
-from sglang.srt.environ import envs
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from sglang.srt.models.qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
@@ -23,125 +17,16 @@ from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
 from sglang.srt.multimodal.processors.base_processor import MultimodalSpecialTokens
+from sglang.srt.multimodal.processors.qwen_vl_video_worker import (
+    preprocess_video_task as qvl_preprocess_video_task,
+)
+from sglang.srt.multimodal.processors.qwen_vl_video_worker import (
+    resize_image_async as qvl_resize_image_async,
+)
 from sglang.srt.multimodal.processors.video_utils import VideoInput
 from sglang.utils import logger
 
 IMAGE_FACTOR = 28
-MIN_PIXELS = 4 * 28 * 28
-MAX_PIXELS = envs.SGLANG_IMAGE_MAX_PIXELS.get()
-MAX_RATIO = 200
-RESIZE_RESAMPLE = getattr(Image, envs.SGLANG_RESIZE_RESAMPLE.get(), None)
-if envs.SGLANG_RESIZE_RESAMPLE.is_set() and RESIZE_RESAMPLE is None:
-    logger.warning(
-        f"Invalid RESIZE_RESAMPLE value: '{envs.SGLANG_RESIZE_RESAMPLE.get()}'. "
-        f"Ignoring and using default."
-    )
-VIDEO_TOTAL_PIXELS = int(
-    float(os.environ.get("VIDEO_MAX_PIXELS", 128000 * 28 * 28 * 0.9))
-)
-
-VIDEO_MIN_PIXELS = 128 * 28 * 28
-VIDEO_MAX_PIXELS = 768 * 28 * 28
-FRAME_FACTOR = 2
-FPS = 2.0
-FPS_MIN_FRAMES = 4
-FPS_MAX_FRAMES = 768
-
-
-def smart_resize(
-    height: int,
-    width: int,
-    factor: int = IMAGE_FACTOR,
-    min_pixels: int = MIN_PIXELS,
-    max_pixels: int = MAX_PIXELS,
-) -> tuple[int, int]:
-    """
-    Rescales the image so that the following conditions are met:
-
-    1. Both dimensions (height and width) are divisible by 'factor'.
-
-    2. The total number of pixels is within the range ['min_pixels', 'max_pixels'].
-
-    3. The aspect ratio of the image is maintained as closely as possible.
-    """
-    if max(height, width) / min(height, width) > MAX_RATIO:
-        raise ValueError(
-            f"absolute aspect ratio must be smaller than {MAX_RATIO}, got {max(height, width) / min(height, width)}"
-        )
-    h_bar = max(factor, round_by_factor(height, factor))
-    w_bar = max(factor, round_by_factor(width, factor))
-    if h_bar * w_bar > max_pixels:
-        beta = math.sqrt((height * width) / max_pixels)
-        h_bar = floor_by_factor(height / beta, factor)
-        w_bar = floor_by_factor(width / beta, factor)
-    elif h_bar * w_bar < min_pixels:
-        beta = math.sqrt(min_pixels / (height * width))
-        h_bar = ceil_by_factor(height * beta, factor)
-        w_bar = ceil_by_factor(width * beta, factor)
-    return h_bar, w_bar
-
-
-def round_by_factor(number: int, factor: int) -> int:
-    """Returns the closest integer to 'number' that is divisible by 'factor'."""
-    return round(number / factor) * factor
-
-
-def ceil_by_factor(number: int, factor: int) -> int:
-    """Returns the smallest integer greater than or equal to 'number' that is divisible by 'factor'."""
-    return math.ceil(number / factor) * factor
-
-
-def floor_by_factor(number: int, factor: int) -> int:
-    """Returns the largest integer less than or equal to 'number' that is divisible by 'factor'."""
-    return math.floor(number / factor) * factor
-
-
-def smart_nframes(
-    ele: dict,
-    total_frames: int,
-    video_fps: int | float,
-) -> int:
-    """calculate the number of frames for video used for model inputs.
-
-    Args:
-        ele (dict): a dict contains the configuration of video.
-            support either `fps` or `nframes`:
-                - nframes: the number of frames to extract for model inputs.
-                - fps: the fps to extract frames for model inputs.
-                    - min_frames: the minimum number of frames of the video, only used when fps is provided.
-                    - max_frames: the maximum number of frames of the video, only used when fps is provided.
-        total_frames (int): the original total number of frames of the video.
-        video_fps (int | float): the original fps of the video.
-
-    Raises:
-        ValueError: nframes should in interval [FRAME_FACTOR, total_frames].
-
-    Returns:
-        int: the number of frames for video used for model inputs.
-    """
-    assert not (
-        "fps" in ele and "nframes" in ele
-    ), "Only accept either `fps` or `nframes`"
-    if "nframes" in ele:
-        nframes = round_by_factor(ele["nframes"], FRAME_FACTOR)
-    else:
-        fps = ele.get("fps", FPS)
-        min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR)
-        max_frames = floor_by_factor(
-            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR
-        )
-        nframes = total_frames / video_fps * fps
-        if nframes > total_frames:
-            logger.warning(
-                f"smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]"
-            )
-        nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
-        nframes = floor_by_factor(nframes, FRAME_FACTOR)
-    if not (FRAME_FACTOR <= nframes and nframes <= total_frames):
-        raise ValueError(
-            f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}."
-        )
-    return nframes
 
 
 # Compatible with Qwen-VL & Qwen-Omni Series
@@ -230,96 +115,15 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
             loop = asyncio.get_running_loop()
             return await loop.run_in_executor(
                 self.video_executor,
-                QwenVLImageProcessor.preprocess_video_task,
+                qvl_preprocess_video_task,
                 video,
                 image_factor,
             )
         else:
-            return self.preprocess_video_task(
+            return qvl_preprocess_video_task(
                 video,
                 image_factor,
             )
-
-    # process video, qwen-specific
-    @staticmethod
-    def preprocess_video_task(
-        video_input: VideoInput,
-        image_factor: int = IMAGE_FACTOR,
-        # vr: VideoReader, image_factor: int = IMAGE_FACTOR
-    ) -> torch.Tensor:
-        entry_time = time.perf_counter()
-        import torch
-        from decord import VideoReader, cpu, gpu
-        try:
-            from decord.bridge import decord_bridge
-            ctx = gpu(0)
-            _ = decord_bridge.get_ctx_device(ctx)
-        except Exception:
-            ctx = cpu(0)
-
-        vr = VideoReader(video_input.path, ctx=ctx)
-
-        ele = {}
-        total_frames, video_fps = len(vr), vr.get_avg_fps()
-        nframes = smart_nframes({}, total_frames=total_frames, video_fps=video_fps)
-        idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
-        idx = np.unique(idx)
-        video_np = vr.get_batch(idx).asnumpy()
-        video = torch.from_numpy(video_np).pin_memory()
-        video = video.permute(0, 3, 1, 2)  # Convert to TCHW format
-        nframes, _, height, width = video.shape
-        min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)
-        total_pixels = ele.get("total_pixels", VIDEO_TOTAL_PIXELS)
-        max_pixels = max(
-            min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR),
-            int(min_pixels * 1.05),
-        )
-
-        get_batch_time = time.perf_counter()
-
-        max_pixels_supposed = ele.get("max_pixels", max_pixels)
-        if max_pixels_supposed > max_pixels:
-            logger.warning(
-                f"The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}]."
-            )
-        max_pixels = min(max_pixels_supposed, max_pixels)
-        if "resized_height" in ele and "resized_width" in ele:
-            resized_height, resized_width = smart_resize(
-                ele["resized_height"],
-                ele["resized_width"],
-                factor=image_factor,
-            )
-        else:
-            resized_height, resized_width = smart_resize(
-                height,
-                width,
-                factor=image_factor,
-                min_pixels=min_pixels,
-                max_pixels=max_pixels,
-            )
-        smart_resize_time = time.perf_counter()
-        video = torchvision.transforms.functional.resize(
-            video,
-            [resized_height, resized_width],
-            interpolation=InterpolationMode.BILINEAR,
-        )
-        video = video.pin_memory()
-        video_metadata = {
-            "fps": video_fps,
-            "duration": total_frames / video_fps,
-            "total_num_frames": total_frames,
-            "frames_indices": idx,
-            "video_backend": "torchvision",
-        }
-        torchvision_resize_time = time.perf_counter()
-        logger.debug(
-            f"[preprocess_video Perf], "
-            f"get_batch_time: {(get_batch_time - entry_time) * 1000:.2f} ms, "
-            f"smart_resize_time: {(smart_resize_time - get_batch_time) * 1000:.2f} ms, "
-            f"torchvision_resize_time: {(torchvision_resize_time - smart_resize_time) * 1000:.2f} ms, "
-            f"total_time: {(torchvision_resize_time - entry_time) * 1000:.2f} ms"
-        )
-        return video, video_metadata
 
     async def process_mm_data_async(
         self,
@@ -340,12 +144,18 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         load_time = time.perf_counter()
         rid = getattr(request_obj, "rid", "anonymous_rid")
 
+        # Qwen-specific: resize images if they are raw Image objects
+        if base_output.images and isinstance(base_output.images[0], Image.Image):
+            resize_tasks = [
+                qvl_resize_image_async(image) for image in base_output.images
+            ]
+            base_output.images = await asyncio.gather(*resize_tasks)
+
         video_metadata = None
         # Now base_output.videos are List[VideoInput]
         if base_output.videos:
             videos_processed = [
-                await preprocess_video(video, video_config=self.video_config)
-                for video in base_output.videos
+                await self.preprocess_video(video) for video in base_output.videos
             ]
             base_output.videos, video_metadata = map(list, zip(*videos_processed))
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl_video_worker.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl_video_worker.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import math
+import os
+import time
+
+import numpy as np
+import torch
+import torchvision
+from PIL import Image
+from torchvision.transforms import InterpolationMode
+
+from sglang.srt.environ import envs
+from sglang.srt.multimodal.processors.video_utils import VideoInput
+from sglang.utils import logger
+
+IMAGE_FACTOR = 28
+MIN_PIXELS = 4 * 28 * 28
+MAX_PIXELS = envs.SGLANG_IMAGE_MAX_PIXELS.get()
+MAX_RATIO = 200
+RESIZE_RESAMPLE = getattr(Image, envs.SGLANG_RESIZE_RESAMPLE.get(), None)
+if envs.SGLANG_RESIZE_RESAMPLE.is_set() and RESIZE_RESAMPLE is None:
+    logger.warning(
+        f"Invalid RESIZE_RESAMPLE value: '{envs.SGLANG_RESIZE_RESAMPLE.get()}'. "
+        f"Ignoring and using default."
+    )
+VIDEO_TOTAL_PIXELS = int(
+    float(os.environ.get("VIDEO_MAX_PIXELS", 128000 * 28 * 28 * 0.9))
+)
+
+VIDEO_MIN_PIXELS = 128 * 28 * 28
+VIDEO_MAX_PIXELS = 768 * 28 * 28
+FRAME_FACTOR = 2
+FPS = 2.0
+FPS_MIN_FRAMES = 4
+FPS_MAX_FRAMES = 768
+MAX_RATIO = 200
+
+
+def _smart_resize(
+    height: int,
+    width: int,
+    factor: int = IMAGE_FACTOR,
+    min_pixels: int = MIN_PIXELS,
+    max_pixels: int = MAX_PIXELS,
+) -> tuple[int, int]:
+    """
+    Rescales the image so that the following conditions are met:
+
+    1. Both dimensions (height and width) are divisible by 'factor'.
+
+    2. The total number of pixels is within the range ['min_pixels', 'max_pixels'].
+
+    3. The aspect ratio of the image is maintained as closely as possible.
+    """
+    if max(height, width) / min(height, width) > MAX_RATIO:
+        raise ValueError(
+            f"absolute aspect ratio must be smaller than {MAX_RATIO}, "
+            f"got {max(height, width) / min(height, width)}"
+        )
+    h_bar = max(factor, _round_by_factor(height, factor))
+    w_bar = max(factor, _round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = _floor_by_factor(height / beta, factor)
+        w_bar = _floor_by_factor(width / beta, factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = _ceil_by_factor(height * beta, factor)
+        w_bar = _ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def _resize_image(
+    image,
+    min_pixels: int = MIN_PIXELS,
+    max_pixels: int = MAX_PIXELS,
+    size_factor: int = IMAGE_FACTOR,
+) -> Image.Image:
+    width, height = image.size
+    min_pixels = min_pixels
+    max_pixels = max_pixels
+    resized_height, resized_width = _smart_resize(
+        height,
+        width,
+        factor=size_factor,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    image = image.resize((resized_width, resized_height), resample=RESIZE_RESAMPLE)
+    return image
+
+
+def _round_by_factor(number: int, factor: int) -> int:
+    """Returns the closest integer to 'number' that is divisible by 'factor'."""
+    return round(number / factor) * factor
+
+
+def _ceil_by_factor(number: float, factor: int) -> int:
+    """Returns the smallest integer greater than or equal to 'number' that is divisible by 'factor'."""
+    return math.ceil(number / factor) * factor
+
+
+def _floor_by_factor(number: float, factor: int) -> int:
+    """Returns the largest integer less than or equal to 'number' that is divisible by 'factor'."""
+    return math.floor(number / factor) * factor
+
+
+async def resize_image_async(
+    image,
+    min_pixels: int = MIN_PIXELS,
+    max_pixels: int = MAX_PIXELS,
+    size_factor: int = IMAGE_FACTOR,
+):
+    return _resize_image(image, min_pixels, max_pixels, size_factor)
+
+
+def _smart_nframes(
+    ele: dict,
+    total_frames: int,
+    video_fps: int | float,
+) -> int:
+    """calculate the number of frames for video used for model inputs.
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+            support either `fps` or `nframes`:
+                - nframes: the number of frames to extract for model inputs.
+                - fps: the fps to extract frames for model inputs.
+                    - min_frames: the minimum number of frames of the video, only used when fps is provided.
+                    - max_frames: the maximum number of frames of the video, only used when fps is provided.
+        total_frames (int): the original total number of frames of the video.
+        video_fps (int | float): the original fps of the video.
+
+    Raises:
+        ValueError: nframes should in interval [FRAME_FACTOR, total_frames].
+
+    Returns:
+        int: the number of frames for video used for model inputs.
+    """
+    assert not (
+        "fps" in ele and "nframes" in ele
+    ), "Only accept either `fps` or `nframes`"
+    if "nframes" in ele:
+        nframes = _round_by_factor(ele["nframes"], FRAME_FACTOR)
+    else:
+        fps = ele.get("fps", FPS)
+        min_frames = _ceil_by_factor(
+            ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR
+        )
+        max_frames = _floor_by_factor(
+            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR
+        )
+        nframes = total_frames / max(video_fps, 1e-8) * fps
+        if nframes > total_frames:
+            logger.warning(
+                f"_smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]"
+            )
+        nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
+        nframes = _floor_by_factor(nframes, FRAME_FACTOR)
+
+    if not (FRAME_FACTOR <= nframes <= total_frames):
+        raise ValueError(
+            f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}."
+        )
+    return int(nframes)
+
+
+def preprocess_video_task(
+    video_input: VideoInput,
+    image_factor: int = IMAGE_FACTOR,
+) -> torch.Tensor:
+    """
+    return: (video_tensor[T,C,H,W], video_metadata)
+    """
+
+    try:
+        from decord import VideoReader, cpu, gpu
+
+        try:
+            from decord.bridge import decord_bridge
+
+            ctx = gpu(0)
+            _ = decord_bridge.get_ctx_device(ctx)
+        except Exception:
+            ctx = cpu(0)
+    except Exception as e:
+        raise RuntimeError(f"decord import failed: {e}")
+
+    entry_time = time.perf_counter()
+    vr = VideoReader(video_input.path, ctx=ctx)
+
+    ele = {}
+    total_frames, video_fps = len(vr), vr.get_avg_fps()
+    nframes = _smart_nframes(ele, total_frames=total_frames, video_fps=video_fps)
+
+    idx = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
+    idx = np.unique(idx)
+    video_np = vr.get_batch(idx).asnumpy()
+
+    # T H W C -> T C H W
+    video = torch.from_numpy(video_np).pin_memory().permute(0, 3, 1, 2)
+    nframes, _, height, width = video.shape
+
+    total_pixels_cfg = float(os.environ.get("VIDEO_MAX_PIXELS", 128000 * 28 * 28 * 0.9))
+    min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)
+    total_pixels = ele.get("total_pixels", total_pixels_cfg)
+    max_pixels = max(
+        min(VIDEO_MAX_PIXELS, total_pixels / max(nframes, 1) * FRAME_FACTOR),
+        int(min_pixels * 1.05),
+    )
+
+    get_batch_time = time.perf_counter()
+
+    max_pixels_supposed = ele.get("max_pixels", max_pixels)
+    if max_pixels_supposed > max_pixels:
+        logger.warning(
+            f"The given max_pixels[{max_pixels_supposed}] exceeds limit[{max_pixels}]."
+        )
+    max_pixels = min(max_pixels_supposed, max_pixels)
+
+    if "resized_height" in ele and "resized_width" in ele:
+        resized_height, resized_width = _smart_resize(
+            ele["resized_height"],
+            ele["resized_width"],
+            factor=image_factor,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+    else:
+        resized_height, resized_width = _smart_resize(
+            height,
+            width,
+            factor=image_factor,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+
+    smart_resize_time = time.perf_counter()
+
+    video = torchvision.transforms.functional.resize(
+        video,
+        [resized_height, resized_width],
+        interpolation=InterpolationMode.BILINEAR,
+    )
+    video = video.pin_memory()
+    video_metadata = {
+        "fps": video_fps,
+        "duration": total_frames / max(video_fps, 1e-8),
+        "total_num_frames": total_frames,
+        "frames_indices": idx,
+        "video_backend": "torchvision",
+    }
+
+    torchvision_resize_time = time.perf_counter()
+    logger.debug(
+        f"[preprocess_video Perf] "
+        f"get_batch_time: {(get_batch_time - entry_time) * 1000:.2f} ms, "
+        f"smart_resize_time: {(smart_resize_time - get_batch_time) * 1000:.2f} ms, "
+        f"torchvision_resize_time: {(torchvision_resize_time - smart_resize_time) * 1000:.2f} ms, "
+        f"total_time: {(torchvision_resize_time - entry_time) * 1000:.2f} ms"
+    )
+    return video, video_metadata

--- a/python/sglang/srt/multimodal/processors/video_utils.py
+++ b/python/sglang/srt/multimodal/processors/video_utils.py
@@ -1,0 +1,119 @@
+import base64 as _pybase64
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import requests
+
+try:
+    import pybase64
+
+    _b64 = pybase64
+except Exception:
+    _b64 = _pybase64
+
+
+@dataclass
+class VideoInput:
+    path: str
+    cleanup: bool = False
+    frame_count_limit: Optional[int] = None
+
+
+def _ramdisk_tmpdir() -> str:
+    shm = "/dev/shm"
+    if os.path.isdir(shm) and os.access(shm, os.W_OK):
+        return shm
+    return tempfile.gettempdir()
+
+
+def _mkstemp_path(suffix: str = ".mp4") -> str:
+    tmpdir = _ramdisk_tmpdir()
+    fd, path = tempfile.mkstemp(prefix="mmvid_", suffix=suffix, dir=tmpdir)
+    os.close(fd)
+    return path
+
+
+def _write_bytes_to_file(b: bytes, path: str) -> None:
+    with open(path, "wb") as f:
+        f.write(b)
+
+
+def _is_data_uri(s: str) -> bool:
+    return s.startswith("data:")
+
+
+def _maybe_guess_suffix_from_url(url: str) -> str:
+    _, ext = os.path.splitext(url)
+    if ext and len(ext) <= 5:
+        return ext
+    return ".mp4"
+
+
+def _download_url_to_file(url: str, path: str, timeout: int = 10) -> None:
+    with requests.get(url, stream=True, timeout=timeout) as r:
+        r.raise_for_status()
+        with open(path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+
+
+def make_video_input(
+    video_file: "Union[str, bytes]",
+    *,
+    frame_count_limit: Optional[int] = None,
+    request_timeout_env: str = "REQUEST_TIMEOUT",
+) -> VideoInput:
+    """
+    Based on original load_video logic, refactor to return VideoInput.
+    Note: Don't remove temp file here, the subprocess is responsible to delete the temp file.
+    """
+    if isinstance(video_file, (bytes, bytearray)):
+        path = _mkstemp_path(".mp4")
+        _write_bytes_to_file(video_file, path)
+        return VideoInput(path=path, cleanup=True, frame_count_limit=frame_count_limit)
+
+    if isinstance(video_file, str):
+        # 1) http(s)://
+        if video_file.startswith(("http://", "https://")):
+            timeout = int(os.getenv(request_timeout_env, "10"))
+            suffix = _maybe_guess_suffix_from_url(video_file)
+            path = _mkstemp_path(suffix)
+            _download_url_to_file(video_file, path, timeout=timeout)
+            return VideoInput(
+                path=path, cleanup=True, frame_count_limit=frame_count_limit
+            )
+
+        # 2) data:URI
+        if _is_data_uri(video_file):
+            try:
+                _, encoded = video_file.split(",", 1)
+            except ValueError:
+                raise ValueError("Invalid data URI for video.")
+            video_bytes = _b64.b64decode(encoded, validate=True)
+            path = _mkstemp_path(".mp4")
+            _write_bytes_to_file(video_bytes, path)
+            return VideoInput(
+                path=path, cleanup=True, frame_count_limit=frame_count_limit
+            )
+
+        # 3) local file
+        if os.path.isfile(video_file):
+            return VideoInput(
+                path=video_file, cleanup=False, frame_count_limit=frame_count_limit
+            )
+
+        # 4) fallback base64
+        try:
+            video_bytes = _b64.b64decode(video_file, validate=True)
+        except Exception:
+            raise ValueError(
+                f"Unsupported video input string: not a file, URL, data URI, or valid base64."
+            )
+        path = _mkstemp_path(".mp4")
+        _write_bytes_to_file(video_bytes, path)
+        return VideoInput(path=path, cleanup=True, frame_count_limit=frame_count_limit)
+
+    raise ValueError(f"Unsupported video input type: {type(video_file)}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Refactor the VLM's entire load/preprocess/process path with fully async co-routine mechanism.

The solution has several issues to consider:
1. Using ThreadPoolExecutor for CPU-side Python preprocessing (especially per-frame ops logic) is constrained by the GIL; the more threads it adds, the slower it gets.

2. If we switch to ProcessPoolExecutor, we are passing a decord.VideoReader instance (vr) as an argument across processes. VideoReader isn’t picklable, so it blows up once it crosses the process boundary. The following logs proves: 
```
[2025-11-05 19:25:52] INFO:     127.0.0.1:52534 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
[2025-11-05 19:25:52] INFO:     127.0.0.1:52548 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
[2025-11-05 19:25:52] INFO:     127.0.0.1:52556 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
[2025-11-05 19:25:53] INFO:     127.0.0.1:52564 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request

{"object":"error","message":"ctypes objects containing pointers cannot be pickled","type":"BadRequestError","param":null,"code":400}
real    0m0.309s
user    0m0.001s
sys     0m0.003s
{"object":"error","message":"ctypes objects containing pointers cannot be pickled","type":"BadRequestError","param":null,"code":400}
real    0m0.269s
user    0m0.001s
sys     0m0.002s
```
The most robust and high performance solution is to construct the VideoReader inside the worker process. The parent process should pass only a serializable “video input descriptor” (a file path), and use spawn or forkserver to create child processes (to avoid undefined behavior from inheriting GPU contexts).

[Update Nov 5] Working on the approach to move the VideoReader construction in the parent process into each sub-process, just pass a serializable video_path. As it will change the whole processing logic, set ETA Nov 9. 

[Update Nov 8] Basic function is working now. Open for review. Will sharpen it gradually.

Currently just modified qwen vl model, will broadcast to the rest of the vl models in case the solution is ready.

## Modifications

<!-- Detail the changes made in this pull request. -->
The core modifications are:
1. Keep current TokenizerManager / AsyncMMDataProcessor interface unchanged
2. Make sure load_mm_data_async() the VIDEO data is processed through BaseMultimodalProcessor.submit_data_loading_tasks_async()
3. The return value of the submit_data_loading_task_async would be a VideoInput list, then preprocess_video() will put VideoInput into process pool to do decode

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
