### PR TITLE
[chore] Fix update_kernel_whl_index script for multiple cuda version

### DIFF
--- a/scripts/update_kernel_whl_index.py
+++ b/scripts/update_kernel_whl_index.py
@@ -5,13 +5,33 @@ import hashlib
 import pathlib
 import re
 
+# All the CUDA versions that the wheels will cover
+SUPPORTED_CUDA_VERSIONS = ["129", "130"]
+DEFAULT_CUDA_VERSION = "129"
 
-def update_wheel_index(cuda_version="118"):
+
+def check_wheel_cuda_version(path_name, target_cuda_version):
+    # For other CUDA versions, the wheel path name will contain the cuda version suffix, e.g. sgl_kernel-0.3.16.post5+cu130-cp310-abi3-manylinux2014_x86_64.whl
+    if target_cuda_version != DEFAULT_CUDA_VERSION:
+        return target_cuda_version in path_name
+
+    # For the default CUDA version, the wheel path name will not contain any cuda version suffix, e.g. sgl_kernel-0.3.16.post5-cp310-abi3-manylinux2014_x86_64.whl
+    # So we need to check if the wheel path name contains any other cuda version suffix
+    for cuda_version in SUPPORTED_CUDA_VERSIONS:
+        if cuda_version != DEFAULT_CUDA_VERSION and cuda_version in path_name:
+            return False
+    return True
+
+
+def update_wheel_index(cuda_version=DEFAULT_CUDA_VERSION):
     index_dir = pathlib.Path(f"sgl-whl/cu{cuda_version}/sgl-kernel")
     index_dir.mkdir(exist_ok=True)
     base_url = "https://github.com/sgl-project/whl/releases/download"
 
     for path in sorted(pathlib.Path("sgl-kernel/dist").glob("*.whl")):
+        # Skip the wheel if mismatches the passed in cuda_version
+        if not check_wheel_cuda_version(path.name, cuda_version):
+            continue
         with open(path, "rb") as f:
             sha256 = hashlib.sha256(f.read()).hexdigest()
         ver = re.findall(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Ref: 
When releasing sgl-kernel, we have one flow for cu129 and another flow for cu130 (ref: https://github.com/sgl-project/sglang/actions/runs/19008270795/job/54304471430)

So during updating wheel index, they will push all the compiled wheels to the same folder, causing some of the cu129 wheels uploaded to cu130 folder (or vice versa). Of course we can manually fix this after every release (for example https://github.com/sgl-project/whl/pull/10), but this doesn't help with efficiency.

This PR tries to fix this issue by modifying the script for wheel index update.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
