### PR TITLE
Add AutoWeightsLoader utility for simplified weight loading

### DIFF
--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -49,7 +49,6 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     kv_cache_scales_loader,
 )
-from sglang.srt.models.utils import AutoWeightsLoader
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, make_layers
 

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -576,14 +576,8 @@ class Qwen2ForCausalLM(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
-        # Prepare to use AutoWeightsLoader for simplified weight loading
-        # We need to pre-process weights for complex cases (stacked params, PP)
         params_dict = dict(self.named_parameters())
-        processed_weights = []
-
-        # First pass: handle complex cases and prepare weights for AutoWeightsLoader
         for name, loaded_weight in weights:
-            # Filter out weights not in the current pipeline stage
             layer_id = get_layer_id(name)
             if (
                 layer_id is not None
@@ -595,66 +589,51 @@ class Qwen2ForCausalLM(nn.Module):
             ):
                 continue
 
-            # Handle pipeline parallelism weight tying
+            if "rotary_emb.inv_freq" in name or "projector" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                # Models trained using ColossalAI may include these tensors in
+                # the checkpoint. Skip them.
+                continue
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
                 if self.pp_group.world_size > 1 and self.pp_group.is_last_rank:
-                    # Handle pp weight tying here - find the embed_tokens.weight
-                    # Note: This requires re-iterating which AutoWeightsLoader doesn't support
-                    # So we keep this logic here
+                    # Handle pp weight tying here
+                    # find the embed_tokens.weight in the weights
                     embed_token_weights = next(
                         filter(lambda x: x[0] == "model.embed_tokens.weight", weights)
                     )[1]
                     loaded_weight = embed_token_weights
                 else:
                     continue
-
-            # Skip vision tower params not in model
             if name.startswith("model.vision_tower") and name not in params_dict:
                 continue
 
-            # Handle stacked parameters - remap names
-            is_stacked = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name in name:
-                    # Remap weight name for stacked params
-                    remapped_name = name.replace(weight_name, param_name)
-                    # Skip loading extra bias for GPTQ models
-                    if remapped_name.endswith(".bias") and remapped_name not in params_dict:
-                        is_stacked = True
-                        break
-                    if remapped_name not in params_dict:
-                        is_stacked = True
-                        break
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
 
-                    # For stacked params, we need to use custom weight_loader with shard_id
-                    param = params_dict[remapped_name]
-                    weight_loader = param.weight_loader
-                    weight_loader(param, loaded_weight, shard_id)
-                    is_stacked = True
-                    break
-
-            if is_stacked:
-                continue
-
-            # Skip extra bias for GPTQ models
-            if name.endswith(".bias") and name not in params_dict:
-                continue
-
-            # Add to processed weights for AutoWeightsLoader
-            processed_weights.append((name, loaded_weight))
-
-        # Use AutoWeightsLoader for standard weight loading
-        skip_prefixes = []
-        if self.config.tie_word_embeddings:
-            skip_prefixes.append("lm_head")
-
-        loader = AutoWeightsLoader(
-            self,
-            skip_prefixes=skip_prefixes,
-            skip_substrs=["projector"],
-            ignore_unexpected_prefixes=["model.vision_tower"],
-        )
-        loader.load_weights(iter(processed_weights))
+                if name in params_dict.keys():
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                else:
+                    logger.warning(f"Parameter {name} not found in params_dict")
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -94,9 +94,7 @@ class AutoWeightsLoader:
             (weight_name.split(".", 1), weight_data)
             for weight_name, weight_data in weights
         )
-        for prefix, group in itertools.groupby(
-            weights_by_parts, key=lambda x: x[0][0]
-        ):
+        for prefix, group in itertools.groupby(weights_by_parts, key=lambda x: x[0][0]):
             yield (
                 prefix,
                 (
@@ -154,14 +152,10 @@ class AutoWeightsLoader:
 
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, weight_data)
-            logger.debug(
-                "Loaded weight %s with shape %s", weight_qualname, param.shape
-            )
+            logger.debug("Loaded weight %s with shape %s", weight_qualname, param.shape)
             yield weight_qualname
 
-    def _add_loadable_non_param_tensors(
-        self, module: nn.Module, child_params: dict
-    ):
+    def _add_loadable_non_param_tensors(self, module: nn.Module, child_params: dict):
         """Add tensor names not in model params (e.g., batchnorm statistics)."""
         if isinstance(
             module,

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -12,13 +12,256 @@
 # limitations under the License.
 # ==============================================================================
 
+import itertools
+import logging
+from typing import Callable, Iterable, Optional, Tuple
+
 import torch
+import torch.nn as nn
 
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import is_cuda
 
+logger = logging.getLogger(__name__)
+
 _is_cuda = is_cuda()
+
+
+class AutoWeightsLoader:
+    """
+    Helper class to load weights into a torch.nn.Module. It automatically
+    detects child modules and parameters while iterating weights only once.
+
+    This simplifies model code by abstracting the common weight loading logic,
+    reducing code duplication across different model implementations.
+
+    Adapted from vLLM's AutoWeightsLoader implementation.
+
+    Args:
+        module: The root module to load weights into
+        skip_prefixes: List of weight name prefixes to skip
+        skip_substrs: List of substrings to skip in weight names
+        ignore_unexpected_prefixes: List of prefixes for unexpected weights to ignore
+        ignore_unexpected_suffixes: List of suffixes for unexpected weights to ignore
+
+    Example:
+        >>> def load_weights(self, weights):
+        ...     loader = AutoWeightsLoader(
+        ...         self,
+        ...         skip_prefixes=["lm_head"] if self.config.tie_word_embeddings else [],
+        ...         skip_substrs=["rotary_emb.inv_freq"],
+        ...     )
+        ...     return loader.load_weights(weights)
+    """
+
+    # Common weights that should be skipped (e.g., ColossalAI rotary embeddings)
+    ROTARY_EMBEDS_UNUSED_WEIGHTS = [
+        "rotary_emb.inv_freq",
+        "rotary_emb.cos_cached",
+        "rotary_emb.sin_cached",
+    ]
+
+    def __init__(
+        self,
+        module: nn.Module,
+        *,
+        skip_prefixes: Optional[list] = None,
+        skip_substrs: Optional[list] = None,
+        ignore_unexpected_prefixes: Optional[list] = None,
+        ignore_unexpected_suffixes: Optional[list] = None,
+    ) -> None:
+        self.module = module
+        self.skip_prefixes = skip_prefixes or []
+        self.skip_substrs = skip_substrs or []
+        self.ignore_unexpected_prefixes = ignore_unexpected_prefixes or []
+        self.ignore_unexpected_suffixes = ignore_unexpected_suffixes or []
+        # Always skip common rotary embedding weights
+        self.skip_substrs += self.ROTARY_EMBEDS_UNUSED_WEIGHTS
+
+    def _groupby_prefix(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+    ) -> Iterable[Tuple[str, Iterable[Tuple[str, torch.Tensor]]]]:
+        """Group weights by their first prefix component (before the first dot)."""
+        weights_by_parts = (
+            (weight_name.split(".", 1), weight_data)
+            for weight_name, weight_data in weights
+        )
+        for prefix, group in itertools.groupby(
+            weights_by_parts, key=lambda x: x[0][0]
+        ):
+            yield (
+                prefix,
+                (
+                    ("" if len(parts) == 1 else parts[1], weights_data)
+                    for parts, weights_data in group
+                ),
+            )
+
+    def _get_qualname(self, prefix: str, rest: str) -> str:
+        """Construct fully qualified name from prefix and rest."""
+        if prefix == "":
+            return rest
+        if rest == "":
+            return prefix
+        return ".".join((prefix, rest))
+
+    def _can_skip(self, qualname: str) -> bool:
+        """Check if parameter should be skipped based on skip rules."""
+        return any(qualname.startswith(p) for p in self.skip_prefixes) or any(
+            substr in qualname for substr in self.skip_substrs
+        )
+
+    def _can_ignore_unexpected(self, qualname: str) -> bool:
+        """Check if unexpected weight can be ignored based on ignore rules."""
+        starts_with_ignored = any(
+            qualname.startswith(p) for p in self.ignore_unexpected_prefixes
+        )
+        ends_with_ignored = any(
+            qualname.endswith(s) for s in self.ignore_unexpected_suffixes
+        )
+        return starts_with_ignored or ends_with_ignored
+
+    def _load_param(
+        self,
+        base_prefix: str,
+        param: nn.Parameter,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+    ) -> Iterable[str]:
+        """Load weights into a single parameter."""
+        for weight_name, weight_data in weights:
+            weight_qualname = self._get_qualname(base_prefix, weight_name)
+
+            if self._can_skip(weight_qualname):
+                logger.debug("Skipping weight %s", weight_qualname)
+                continue
+
+            if weight_name != "":
+                if self._can_ignore_unexpected(weight_qualname):
+                    logger.debug("Ignoring unexpected weight %s", weight_qualname)
+                    continue
+                raise ValueError(
+                    f"Attempted to load nested weight '{weight_qualname}' "
+                    f"into a single parameter '{base_prefix}'"
+                )
+
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, weight_data)
+            logger.debug(
+                "Loaded weight %s with shape %s", weight_qualname, param.shape
+            )
+            yield weight_qualname
+
+    def _add_loadable_non_param_tensors(
+        self, module: nn.Module, child_params: dict
+    ):
+        """Add tensor names not in model params (e.g., batchnorm statistics)."""
+        if isinstance(
+            module,
+            (
+                nn.BatchNorm1d,
+                nn.BatchNorm2d,
+                nn.BatchNorm3d,
+                nn.LazyBatchNorm1d,
+                nn.LazyBatchNorm2d,
+                nn.LazyBatchNorm3d,
+                nn.SyncBatchNorm,
+            ),
+        ):
+            module_state_dict = module.state_dict()
+            for stat_name in ("running_mean", "running_var", "num_batches_tracked"):
+                if stat_name in module_state_dict:
+                    child_params[stat_name] = module_state_dict[stat_name]
+
+    def _load_module(
+        self,
+        base_prefix: str,
+        module: nn.Module,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+    ) -> Iterable[str]:
+        """Recursively load weights into a module and its children."""
+        # If module has a custom load_weights method, use it
+        if module != self.module:
+            module_load_weights = getattr(module, "load_weights", None)
+            if callable(module_load_weights):
+                loaded_params = module_load_weights(weights)
+                if loaded_params is None:
+                    logger.warning(
+                        "Unable to collect loaded parameters for module %s. "
+                        "Module.load_weights() should return an iterable of "
+                        "loaded parameter names.",
+                        module,
+                    )
+                else:
+                    yield from (
+                        self._get_qualname(base_prefix, x) for x in loaded_params
+                    )
+                return
+
+        # Get child modules and parameters
+        child_modules = dict(module.named_children())
+        child_params = dict(module.named_parameters(recurse=False))
+        self._add_loadable_non_param_tensors(module, child_params)
+
+        # Process weights grouped by prefix
+        for child_prefix, child_weights in self._groupby_prefix(weights):
+            prefix = self._get_qualname(base_prefix, child_prefix)
+
+            if child_prefix in child_modules:
+                if self._can_skip(prefix + "."):
+                    logger.debug("Skipping module %s", prefix)
+                    continue
+                yield from self._load_module(
+                    prefix, child_modules[child_prefix], child_weights
+                )
+            elif child_prefix in child_params:
+                if self._can_skip(prefix):
+                    logger.debug("Skipping param %s", prefix)
+                    continue
+                yield from self._load_param(
+                    prefix, child_params[child_prefix], child_weights
+                )
+            else:
+                # Check if we should skip or ignore this missing parameter
+                can_skip_module = self._can_skip(prefix + ".")
+                can_skip_param = self._can_skip(prefix)
+                if can_skip_module or can_skip_param:
+                    logger.debug("Skipping missing %s", prefix)
+                    continue
+
+                can_ignore_module = self._can_ignore_unexpected(prefix + ".")
+                can_ignore_param = self._can_ignore_unexpected(prefix)
+                if can_ignore_module or can_ignore_param:
+                    logger.debug("Ignoring missing %s", prefix)
+                    continue
+
+                msg = (
+                    f"There is no module or parameter named '{prefix}' "
+                    f"in {type(self.module).__name__}"
+                )
+                raise ValueError(msg)
+
+    def load_weights(
+        self,
+        weights: Iterable[Tuple[str, torch.Tensor]],
+    ) -> set:
+        """
+        Load weights into the module.
+
+        Args:
+            weights: Iterable of (name, tensor) tuples to load
+
+        Returns:
+            Set of weight names that were successfully loaded
+        """
+        # Filter out skippable weights early
+        weights = (
+            (name, weight) for name, weight in weights if not self._can_skip(name)
+        )
+        autoloaded_weights = set(self._load_module("", self.module, weights))
+        return autoloaded_weights
 
 
 if _is_cuda:

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -66,6 +66,7 @@ suites = {
         TestFile("rl/test_update_weights_from_disk.py", 210),
         TestFile("rl/test_update_weights_from_tensor.py", 80),
         TestFile("test_abort.py", 190),
+        TestFile("test_auto_weights_loader.py", 5),
         TestFile("test_build_eagle_tree.py", 8),
         TestFile("test_chunked_prefill.py", 410),
         TestFile("test_create_kvindices.py", 2),

--- a/test/srt/test_auto_weights_loader.py
+++ b/test/srt/test_auto_weights_loader.py
@@ -184,9 +184,7 @@ class TestAutoWeightsLoader(CustomTestCase):
         ]
 
         # Should not raise error for vision_tower weights
-        loader = AutoWeightsLoader(
-            module, ignore_unexpected_prefixes=["vision_tower"]
-        )
+        loader = AutoWeightsLoader(module, ignore_unexpected_prefixes=["vision_tower"])
         loaded = loader.load_weights(iter(weights))
 
         # Should only load the actual module weight

--- a/test/srt/test_auto_weights_loader.py
+++ b/test/srt/test_auto_weights_loader.py
@@ -1,0 +1,299 @@
+"""
+Unit tests for AutoWeightsLoader class.
+
+This test module verifies the functionality of AutoWeightsLoader, which
+simplifies weight loading by automatically detecting child modules and parameters.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.models.utils import AutoWeightsLoader
+from sglang.test.test_utils import CustomTestCase
+
+
+class SimpleModule(nn.Module):
+    """Simple test module with basic parameters."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(10, 10))
+        self.bias = nn.Parameter(torch.zeros(10))
+
+
+class NestedModule(nn.Module):
+    """Nested test module with child modules."""
+
+    def __init__(self):
+        super().__init__()
+        self.layer1 = SimpleModule()
+        self.layer2 = SimpleModule()
+        self.final_weight = nn.Parameter(torch.zeros(5, 5))
+
+
+class ModuleWithCustomLoader(nn.Module):
+    """Module with custom load_weights method."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(10, 10))
+        self.loaded_weights = []
+
+    def load_weights(self, weights):
+        """Custom weight loading that tracks loaded weights."""
+        for name, tensor in weights:
+            self.loaded_weights.append(name)
+        return self.loaded_weights
+
+
+class TestAutoWeightsLoader(CustomTestCase):
+    """Test cases for AutoWeightsLoader functionality."""
+
+    def test_basic_weight_loading(self):
+        """Test basic weight loading into a simple module."""
+        module = SimpleModule()
+        weights = [
+            ("weight", torch.ones(10, 10)),
+            ("bias", torch.ones(10)),
+        ]
+
+        loader = AutoWeightsLoader(module)
+        loaded = loader.load_weights(iter(weights))
+
+        # Check that weights were loaded
+        self.assertEqual(len(loaded), 2)
+        self.assertIn("weight", loaded)
+        self.assertIn("bias", loaded)
+
+        # Verify the actual values were loaded
+        self.assertTrue(torch.allclose(module.weight, torch.ones(10, 10)))
+        self.assertTrue(torch.allclose(module.bias, torch.ones(10)))
+
+    def test_skip_prefixes(self):
+        """Test that skip_prefixes correctly skips weights."""
+        module = NestedModule()
+        weights = [
+            ("layer1.weight", torch.ones(10, 10)),
+            ("layer1.bias", torch.ones(10)),
+            ("layer2.weight", torch.ones(10, 10)),
+            ("layer2.bias", torch.ones(10)),
+            ("final_weight", torch.ones(5, 5)),
+        ]
+
+        # Skip layer1 entirely
+        loader = AutoWeightsLoader(module, skip_prefixes=["layer1"])
+        loaded = loader.load_weights(iter(weights))
+
+        # Should only load layer2 and final_weight
+        self.assertEqual(len(loaded), 3)
+        self.assertNotIn("layer1.weight", loaded)
+        self.assertNotIn("layer1.bias", loaded)
+        self.assertIn("layer2.weight", loaded)
+        self.assertIn("layer2.bias", loaded)
+        self.assertIn("final_weight", loaded)
+
+        # Verify layer1 wasn't loaded (still zeros)
+        self.assertTrue(torch.allclose(module.layer1.weight, torch.zeros(10, 10)))
+        # Verify layer2 was loaded
+        self.assertTrue(torch.allclose(module.layer2.weight, torch.ones(10, 10)))
+
+    def test_skip_substrs(self):
+        """Test that skip_substrs correctly skips weights."""
+        module = NestedModule()
+        weights = [
+            ("layer1.weight", torch.ones(10, 10)),
+            ("layer1.bias", torch.ones(10)),
+            ("layer2.weight", torch.ones(10, 10)),
+            ("layer2.bias", torch.ones(10)),
+        ]
+
+        # Skip all bias parameters
+        loader = AutoWeightsLoader(module, skip_substrs=["bias"])
+        loaded = loader.load_weights(iter(weights))
+
+        # Should only load weight parameters
+        self.assertEqual(len(loaded), 2)
+        self.assertIn("layer1.weight", loaded)
+        self.assertIn("layer2.weight", loaded)
+        self.assertNotIn("layer1.bias", loaded)
+        self.assertNotIn("layer2.bias", loaded)
+
+    def test_rotary_emb_auto_skip(self):
+        """Test that rotary embedding weights are automatically skipped."""
+        module = SimpleModule()
+        weights = [
+            ("weight", torch.ones(10, 10)),
+            ("rotary_emb.inv_freq", torch.ones(5)),
+            ("rotary_emb.cos_cached", torch.ones(5)),
+            ("rotary_emb.sin_cached", torch.ones(5)),
+        ]
+
+        loader = AutoWeightsLoader(module)
+        loaded = loader.load_weights(iter(weights))
+
+        # Should only load the weight, skip rotary_emb weights
+        self.assertEqual(len(loaded), 1)
+        self.assertIn("weight", loaded)
+
+    def test_nested_module_loading(self):
+        """Test loading weights into nested modules."""
+        module = NestedModule()
+        weights = [
+            ("layer1.weight", torch.ones(10, 10)),
+            ("layer1.bias", torch.ones(10)),
+            ("layer2.weight", torch.ones(10, 10) * 2),
+            ("layer2.bias", torch.ones(10) * 2),
+            ("final_weight", torch.ones(5, 5) * 3),
+        ]
+
+        loader = AutoWeightsLoader(module)
+        loaded = loader.load_weights(iter(weights))
+
+        # All weights should be loaded
+        self.assertEqual(len(loaded), 5)
+
+        # Verify correct values
+        self.assertTrue(torch.allclose(module.layer1.weight, torch.ones(10, 10)))
+        self.assertTrue(torch.allclose(module.layer2.weight, torch.ones(10, 10) * 2))
+        self.assertTrue(torch.allclose(module.final_weight, torch.ones(5, 5) * 3))
+
+    def test_custom_load_weights_method(self):
+        """Test that modules with custom load_weights are handled correctly."""
+        module = ModuleWithCustomLoader()
+        weights = [
+            ("weight", torch.ones(10, 10)),
+        ]
+
+        loader = AutoWeightsLoader(module)
+        loaded = loader.load_weights(iter(weights))
+
+        # The custom loader should have been called
+        self.assertEqual(len(module.loaded_weights), 1)
+        self.assertIn("weight", module.loaded_weights)
+
+    def test_ignore_unexpected_prefixes(self):
+        """Test that ignore_unexpected_prefixes correctly ignores missing weights."""
+        module = SimpleModule()
+        weights = [
+            ("weight", torch.ones(10, 10)),
+            ("vision_tower.weight", torch.ones(5, 5)),  # Not in module
+            ("vision_tower.bias", torch.ones(5)),  # Not in module
+        ]
+
+        # Should not raise error for vision_tower weights
+        loader = AutoWeightsLoader(
+            module, ignore_unexpected_prefixes=["vision_tower"]
+        )
+        loaded = loader.load_weights(iter(weights))
+
+        # Should only load the actual module weight
+        self.assertEqual(len(loaded), 1)
+        self.assertIn("weight", loaded)
+
+    def test_ignore_unexpected_suffixes(self):
+        """Test that ignore_unexpected_suffixes correctly ignores missing weights."""
+        module = SimpleModule()
+        weights = [
+            ("weight", torch.ones(10, 10)),
+            ("extra.attn.bias", torch.ones(5)),  # Not in module
+        ]
+
+        # Should not raise error for .attn.bias weights
+        loader = AutoWeightsLoader(module, ignore_unexpected_suffixes=[".attn.bias"])
+        loaded = loader.load_weights(iter(weights))
+
+        # Should only load the actual module weight
+        self.assertEqual(len(loaded), 1)
+        self.assertIn("weight", loaded)
+
+    def test_error_on_unexpected_weight(self):
+        """Test that an error is raised for unexpected weights without ignore rules."""
+        module = SimpleModule()
+        weights = [
+            ("weight", torch.ones(10, 10)),
+            ("unexpected_param", torch.ones(5, 5)),  # Not in module
+        ]
+
+        loader = AutoWeightsLoader(module)
+
+        # Should raise ValueError for unexpected parameter
+        with self.assertRaises(ValueError) as context:
+            loader.load_weights(iter(weights))
+
+        self.assertIn("unexpected_param", str(context.exception))
+
+    def test_custom_weight_loader_attribute(self):
+        """Test that custom weight_loader attributes are respected."""
+        module = SimpleModule()
+
+        # Add a custom weight loader to the parameter
+        custom_loader_called = []
+
+        def custom_loader(param, weight):
+            custom_loader_called.append(True)
+            param.data.copy_(weight * 2)  # Load with 2x multiplier
+
+        module.weight.weight_loader = custom_loader
+
+        weights = [
+            ("weight", torch.ones(10, 10)),
+        ]
+
+        loader = AutoWeightsLoader(module)
+        loader.load_weights(iter(weights))
+
+        # Custom loader should have been called
+        self.assertEqual(len(custom_loader_called), 1)
+        # Weight should be 2x the input
+        self.assertTrue(torch.allclose(module.weight, torch.ones(10, 10) * 2))
+
+    def test_empty_weights(self):
+        """Test handling of empty weight iterator."""
+        module = SimpleModule()
+        weights = []
+
+        loader = AutoWeightsLoader(module)
+        loaded = loader.load_weights(iter(weights))
+
+        # Should handle empty iterator gracefully
+        self.assertEqual(len(loaded), 0)
+
+    def test_defensive_copy_of_lists(self):
+        """Test that input lists are copied, not mutated."""
+        module = SimpleModule()
+
+        skip_prefixes = ["layer1"]
+        skip_substrs = ["bias"]
+        ignore_prefixes = ["vision"]
+        ignore_suffixes = [".attn"]
+
+        # Store original list IDs
+        original_skip_prefixes_id = id(skip_prefixes)
+        original_skip_substrs_id = id(skip_substrs)
+
+        loader = AutoWeightsLoader(
+            module,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=skip_substrs,
+            ignore_unexpected_prefixes=ignore_prefixes,
+            ignore_unexpected_suffixes=ignore_suffixes,
+        )
+
+        # Original lists should not be modified
+        self.assertEqual(len(skip_prefixes), 1)
+        self.assertEqual(len(skip_substrs), 1)
+
+        # Loader should have created new lists
+        self.assertNotEqual(id(loader.skip_prefixes), original_skip_prefixes_id)
+        self.assertNotEqual(id(loader.skip_substrs), original_skip_substrs_id)
+
+        # But content should be preserved (plus auto-added rotary items)
+        self.assertIn("layer1", loader.skip_prefixes)
+        self.assertIn("bias", loader.skip_substrs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  Addresses #11864

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR adds `AutoWeightsLoader` utility class to simplify model weight loading code, addressing issue #11864.

  Currently, each model in sglang implements its own `load_weights()` method with repetitive logic for:
  - Iterating through weights
  - Skipping unused weights (rotary_emb.inv_freq, etc.)
  - Handling stacked parameters
  - Loading parameters with custom weight loaders

  This leads to code duplication across 100+ model files. The `AutoWeightsLoader` provides a reusable utility that
  abstracts this common logic, similar to vLLM's implementation.

## Modifications

**Added `AutoWeightsLoader` class to `python/sglang/srt/models/utils.py`:**

  - **Core functionality**: Automatically detects child modules and parameters while iterating weights only once
  - **Flexible filtering**:
    - `skip_prefixes`: Skip weights by prefix (e.g., "lm_head")
    - `skip_substrs`: Skip weights containing substrings (e.g., "rotary_emb.inv_freq")
    - `ignore_unexpected_prefixes/suffixes`: Ignore missing weights without errors
  - **Custom loading support**:
    - Respects `weight_loader` attributes on parameters
    - Calls custom `load_weights()` methods on submodules
  - **Auto-skip**: Automatically skips common unused weights (rotary_emb.inv_freq, cos_cached, sin_cached)
  - **Batch norm support**: Handles non-parameter tensors like batch normalization statistics

## Accuracy Tests

 This PR does not affect model outputs. It provides a utility class for weight loading that models can optionally adopt. No changes to existing models, kernels, or forward passes.

  The implementation maintains the same weight loading behavior as manual implementations:
  - Uses the same `default_weight_loader` function
  - Respects custom `weight_loader` attributes
  - Preserves parameter shapes and values

## Benchmarking and Profiling

This PR does not impact inference speed. It only affects the model initialization/loading phase, not the forward pass. Weight loading happens once at startup and is not performance-critical.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).


## Usage Example

  ```python
  from sglang.srt.models.utils import AutoWeightsLoader

  class MyModel(nn.Module):
      def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
          skip_prefixes = []
          if self.config.tie_word_embeddings:
              skip_prefixes.append("lm_head")

          loader = AutoWeightsLoader(
              self,
              skip_prefixes=skip_prefixes,
              skip_substrs=["projector"],  # Skip vision projectors
              ignore_unexpected_suffixes=[".attn.bias"],  # Ignore attention masks
          )
          return loader.load_weights(weights)
