### PR TITLE
Fix(test): Skip MLA backend test on non-Hopper (sm_80) GPUs

### DIFF
--- a/python/sglang/test/attention/test_flashattn_mla_backend.py
+++ b/python/sglang/test/attention/test_flashattn_mla_backend.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 import torch
 
 from sglang.srt.configs.model_config import AttentionArch
@@ -67,7 +68,10 @@ class MockReqToTokenPool:
         )
 
 
-@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
+    reason="Test requires Hopper (sm_90) or newer GPU.",
+)
 class TestFlashAttentionMLABackend(CustomTestCase):
     def setUp(self):
         # Test parameters


### PR DESCRIPTION
## Motivation

The `pytest` suite currently fails on Ampere GPUs (e.g., `A100`, `sm_80`) when running on the `v0.5.4.post2` tag.

The test `test_flashattn_mla_backend.py` appears to contain Hopper-specific (`sm_90`) code, which causes a `RuntimeError: Only Hopper supports different V headdim` when run on an `A100` (`sm_80`) GPU.

This PR fixes the test suite for non-Hopper users.

## Modifications

1.  Replaced the existing `@unittest.skipIf(not torch.cuda.is_available(), ...)` with a more robust `@pytest.mark.skipif(...)` in `test_flashattn_mla_backend.py`.
2.  The new check (`not torch.cuda.is_available() or torch.cuda.get_device_capability(0)[0] < 9`) correctly skips this test suite on all non-Hopper (`sm < 9`) GPUs, allowing the rest of the `pytest` suite to run.

## Accuracy Tests

N/A. This PR only modifies a unit test configuration and does not affect model logic or outputs.

## Benchmarking and Profiling

N/A. This change does not impact inference speed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit). *(Note: Skipping this step as I'm running into `core.fileMode` and `autocrlf` issues in my Colab + Google Drive dev environment. The code change is isolated to 1 file and manually formatted.)*
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(This PR is a fix to an existing unit test.)*
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations). (N/A)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A)