### PR TITLE
Fix incorrect handling of max_tokens=0 in chat requests

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -630,7 +630,11 @@ class ChatCompletionRequest(BaseModel):
 
         sampling_params = {
             "temperature": get_param("temperature"),
-            "max_new_tokens": self.max_tokens or self.max_completion_tokens,
+            "max_new_tokens": (
+                self.max_tokens
+                if self.max_tokens is not None
+                else self.max_completion_tokens
+            ),
             "min_new_tokens": self.min_tokens,
             "stop": stop,
             "stop_token_ids": self.stop_token_ids,


### PR DESCRIPTION
## Motivation

Currently, a request with `max_tokens=0` is treated as None due to the code `"max_new_tokens": self.max_tokens or self.max_completion_tokens.` When `self.max_tokens=0` and `self.max_completion_tokens=None`, the expression `0 or None `evaluates to None. As a result, the backend replaces None with a very large default value, causing the user-specified 0 to be ignored.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).

