### PR TITLE
disagg(decode): respect ignore_eos in quick-finish EOS branch

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -773,10 +773,12 @@ class DecodeTransferQueue:
                 indices_to_remove.add(i)
                 decode_req.req.time_stats.wait_queue_entry_time = time.perf_counter()
 
-                # special handling for corner cases
-                should_finish = (
-                    decode_req.req.sampling_params.max_new_tokens == 1
-                    or decode_req.req.output_ids[-1] in decode_req.req.eos_token_ids
+                # special handling for corner cases:
+                # - Always quick-finish when max_new_tokens == 1 (finish by length)
+                # - Quick-finish on EOS ONLY when ignore_eos is False; otherwise continue decoding
+                should_finish = decode_req.req.sampling_params.max_new_tokens == 1 or (
+                    not decode_req.req.sampling_params.ignore_eos
+                    and decode_req.req.output_ids[-1] in decode_req.req.eos_token_ids
                 )
                 if should_finish:
                     # finish immediately


### PR DESCRIPTION
respect ignore_eos in quick-finish EOS branch to avoid hanging streams

## Motivation

When ignore_eos=True and the first decoded token is EOS in PD decode, the quick-finish path ended early without setting finish_reason, so no final Complete chunk nor [DONE] was emitted and clients hung on streaming.

## Reproduction

Model: DeepSeek-V3-0324
Request：
```
{
  "input_ids": [0, 43, 1309, 782, 1694, 304, 5085, 411, 3783, 16, 455, 10158, 344, 943, 582, 8423, 15, 78604, 19901, 28, 7492, 983, 734, 43133, 304, 28356, 32010, 2751, 359, 13387, 295, 52602, 3305, 2052, 440, 2572, 14, 6461, 782, 20430, 513, 8174, 270, 2004, 28, 582, 714, 949, 98668, 3305, 0, 43, 1309, 782, 1694, 304, 5085, 411, 3783, 16, 455, 10158, 344, 943, 582, 8423, 15, 78604, 19901, 28, 7492, 983, 734, 43133, 304, 28356, 32010, 2751, 359, 13387, 295, 52602, 3305, 2052, 440, 2572, 14, 6461, 782, 20430, 513, 8174, 270, 2004, 28, 582, 714, 949, 98668, 3305, 0, 43, 1309, 782, 1694, 304, 5085, 411, 3783, 16, 455, 10158, 344, 943, 582, 8423, 15, 78604, 19901, 28, 7492, 983, 734, 43133, 304, 28356, 32010, 2751, 359, 13387, 295, 52602, 3305, 2052, 440, 2572, 14, 6461, 782, 20430, 513, 8174, 270, 2004, 28, 582, 714, 949, 98668, 3305],
  "sampling_params": {
    "top_p": 0.949999988079071,
    "temperature": 0.699999988079071,
    "frequency_penalty": 0.0,
    "max_new_tokens": 10,
    "ignore_eos": true
  },
  "return_logprob": false,
  "stream": true
}
```
Case 1: ignore_eos = false (end normally)
response:
```
data: {"text":"","output_ids":[582,714,949,98668,3305,1],"meta_info":{"id":"6be2adf694ee4d86aa46cc246d88ab8b","finish_reason":{"type":"stop","matched":1},"prompt_tokens":150,"weight_version":"default","total_retractions":0,"completion_tokens":1,"cached_tokens":0,"spec_accept_rate":0.0,"spec_accept_length":0,"spec_verify_ct":0,"e2e_latency":0.1267225742340088}}

data: [DONE]
```

Case 2: ignore_eos = true (request hang)
response:
```
data: {"text":"","output_ids":[582,714,949,98668,3305,1],"meta_info":{"id":"559609b12e7d4d0ba00e07731b73ea51","finish_reason":null,"prompt_tokens":150,"weight_version":"default","total_retractions":0,"completion_tokens":1,"cached_tokens":0}}
```

## Modifications

Gate the quick-finish EOS condition by `not decode_req.req.sampling_params.ignore_eos`. Keep length-based quick-finish for max_new_tokens==1 unchanged. Add a clarifying comment.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
