### PR TITLE
[hot-fix] Fix broken CI

### DIFF
--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -100,7 +100,9 @@ class BaseTpWorker(ABC):
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         success, message = self.model_runner.update_weights_from_disk(
-            recv_req.model_path, recv_req.load_format, recv_req.recapture_cuda_graph
+            recv_req.model_path,
+            recv_req.load_format,
+            recapture_cuda_graph=recv_req.recapture_cuda_graph,
         )
         return success, message
 


### PR DESCRIPTION
by #12060. Passing `recv_req.recapture_cuda_graph` should use kwargs. cc @harrisonlimh 