### PR TITLE
update usage of `trtllm_fp8_per_tensor_scale_moe`

### DIFF
--- a/docs/advanced_features/attention_backend.md
+++ b/docs/advanced_features/attention_backend.md
@@ -21,7 +21,7 @@ The support matrix is split into two parts: MHA (standard attention) and MLA (mu
 | **Triton**                      | ❌                          | ❌               | ✅              | ✅              | ✅                 | ✅             |
 | **Torch Native (SDPA)**         | ❌                          | ❌               | ❌              | ❌              | ❌                 | ❌             |
 | **FlexAttention (PyTorch)**     | ❌                          | ❌               | ❌              | ❌              | ❌                 | ❌             |
-| **TRTLLM MHA**                  | 16, 32 or 64                | ✅               | ✅              | ❌              | ❌                 | ❌             |
+| **TRTLLM MHA**                  | 16, 32 or 64                | ✅               | ✅              | ❌              | ✅                 | ❌             |
 | **Dual Chunk FlashAttention**   | ✅                          | ❌               | ❌              | ❌              | ❌                 | ❌             |
 | **AITER (ROCm)**                | ✅                          | ❌               | ✅              | ✅              | ❌                 | ❌             |
 | **Wave (ROCm)**                 | ✅                          | ❌               | ❌              | ❌              | ❌                 | ❌             |

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -689,7 +689,7 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
                         else 1.0
                     ),
                     use_routing_scales_on_input=use_routing_scales_on_input,
-                    tile_tokens_dim=8,  # TODO(brayden): use the FI tile calculation
+                    tile_tokens_dim=None,
                     routing_method_type=routing_method_type,
                 )
                 sm.tag(output)


### PR DESCRIPTION
Now that 0.5 came out we can update this.

let the kernel find this value by itself. We need to explicitly pass None because currently the default is still 8.
Related: https://github.com/sgl-project/sglang/pull/11563

`python3 -m sglang.bench_serving --backend sglang --num-prompts 64 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 1 --max-concurrency=8 --flush-cache`

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  40.56     
Total input tokens:                      65536     
Total input text tokens:                 65536     
Total input vision tokens:               0         
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65838     
Request throughput (req/s):              1.58      
Input token throughput (tok/s):          1615.96   
Output token throughput (tok/s):         1615.96   
Total token throughput (tok/s):          3231.92   
Concurrency:                             7.99      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5064.36   
Median E2E Latency (ms):                 5064.97   
---------------Time to First Token----------------
Mean TTFT (ms):                          144.16    
Median TTFT (ms):                        141.96    
P99 TTFT (ms):                           167.23    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           4.81      
Median ITL (ms):                         4.81      
P95 ITL (ms):                            5.35      
P99 ITL (ms):                            5.64      
Max ITL (ms):                            16.03     
==================================================
```

After:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 8         
Successful requests:                     64        
Benchmark duration (s):                  40.54     
Total input tokens:                      65536     
Total input text tokens:                 65536     
Total input vision tokens:               0         
Total generated tokens:                  65536     
Total generated tokens (retokenized):    65838     
Request throughput (req/s):              1.58      
Input token throughput (tok/s):          1616.70   
Output token throughput (tok/s):         1616.70   
Total token throughput (tok/s):          3233.41   
Concurrency:                             7.99      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5062.14   
Median E2E Latency (ms):                 5064.56   
---------------Time to First Token----------------
Mean TTFT (ms):                          144.89    
Median TTFT (ms):                        141.57    
P99 TTFT (ms):                           176.21    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           4.81      
Median ITL (ms):                         4.80      
P95 ITL (ms):                            5.36      
P99 ITL (ms):                            5.65      
Max ITL (ms):                            16.69     
==================================================
```
Table:

| Metric | Before | After | Δ | Gain |
|:--|:--:|:--:|:--:|:--:|
| Request Throughput (req/s) | 1.58 | 1.58 | +0.00 | +0.0% |
| Input Token Throughput (tok/s) | 1615.96 | 1616.70 | +0.74 | +0.05% |
| Output Token Throughput (tok/s) | 1615.96 | 1616.70 | +0.74 | +0.05% |
| Total Token Throughput (tok/s) | 3231.92 | 3233.41 | +1.49 | +0.05% |
| Mean E2E Latency (ms) | 5064.36 | 5062.14 | −2.22 | −0.04% |
| Median E2E Latency (ms) | 5064.97 | 5064.56 | −0.41 | −0.01% |
| Mean TTFT (ms) | 144.16 | 144.89 | +0.73 | +0.5% |
| Median TTFT (ms) | 141.96 | 141.57 | −0.39 | −0.3% |
| P99 TTFT (ms) | 167.23 | 176.21 | +8.98 | +5.4% |
| Mean ITL (ms) | 4.81 | 4.81 | 0.00 | 0.0% |
| P99 ITL (ms) | 5.64 | 5.65 | +0.01 | +0.2% |

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 500
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:21<00:00, 62.06it/s]
Accuracy: 0.933
Invalid: 0.000
Latency: 21.815 s
Output throughput: 6238.239 token/s
```

Also relevant warning

```
2025-11-03 17:54:48,720 - WARNING - core.py:1711 - flashinfer.jit: tile_tokens_dim in trtllm_fp8_per_tensor_scale_moe is planned for deprecation in a future release. Please remove it from your code as tile_tokens_dim will no longer be supported after v0.5.0.
```

Also quickly update the doc
