### PR TITLE
[Deepseek V3.2] Fix accuracy bug in the Indexer

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -862,7 +862,7 @@ jobs:
           CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/ci_install_dependency.sh
 
       - name: Run test
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           cd test/srt
           python3 run_suite.py --suite per-commit-8-gpu-h200-deepseek-v32

--- a/test/srt/test_deepseek_v32_basic.py
+++ b/test/srt/test_deepseek_v32_basic.py
@@ -44,7 +44,7 @@ class TestDeepseekV32Basic(CustomTestCase):
         self,
     ):  # Append an "a" to make this test run first (alphabetically) to warm up the server
         args = SimpleNamespace(
-            num_shots=8,
+            num_shots=20,
             data_path=None,
             num_questions=1400,
             parallel=1400,

--- a/test/srt/test_deepseek_v32_mtp.py
+++ b/test/srt/test_deepseek_v32_mtp.py
@@ -82,7 +82,7 @@ class TestDeepseekV32MTP(CustomTestCase):
                 f"{avg_spec_accept_length=:.2f}\n"
             )
             self.assertGreater(metrics["accuracy"], 0.935)
-            self.assertGreater(avg_spec_accept_length, 2.9)
+            self.assertGreater(avg_spec_accept_length, 2.7)
 
     def test_bs_1_speed(self):
         args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=2048)
@@ -97,7 +97,7 @@ class TestDeepseekV32MTP(CustomTestCase):
                 f"{speed=:.2f} token/s\n"
             )
 
-            self.assertGreater(acc_length, 2.9)
+            self.assertGreater(acc_length, 2.7)
             self.assertGreater(speed, 75)
 
 

--- a/test/srt/test_deepseek_v32_mtp.py
+++ b/test/srt/test_deepseek_v32_mtp.py
@@ -58,7 +58,7 @@ class TestDeepseekV32MTP(CustomTestCase):
         requests.get(self.base_url + "/flush_cache")
 
         args = SimpleNamespace(
-            num_shots=20,
+            num_shots=8,
             data_path=None,
             num_questions=1400,
             parallel=1400,

--- a/test/srt/test_deepseek_v32_mtp.py
+++ b/test/srt/test_deepseek_v32_mtp.py
@@ -15,13 +15,13 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-FULL_DEEPSEEK_V3_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2-Exp"
+FULL_DEEPSEEK_V32_MODEL_PATH = "deepseek-ai/DeepSeek-V3.2-Exp"
 
 
 class TestDeepseekV32MTP(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = FULL_DEEPSEEK_V3_MODEL_PATH
+        cls.model = FULL_DEEPSEEK_V32_MODEL_PATH
         cls.base_url = DEFAULT_URL_FOR_TEST
         other_args = [
             "--trust-remote-code",
@@ -58,7 +58,7 @@ class TestDeepseekV32MTP(CustomTestCase):
         requests.get(self.base_url + "/flush_cache")
 
         args = SimpleNamespace(
-            num_shots=8,
+            num_shots=20,
             data_path=None,
             num_questions=1400,
             parallel=1400,

--- a/test/srt/test_deepseek_v32_nsabackend.py
+++ b/test/srt/test_deepseek_v32_nsabackend.py
@@ -50,7 +50,7 @@ class TestDeepseekV32NasBackend_flashmla(CustomTestCase):
         self,
     ):  # Append an "a" to make this test run first (alphabetically) to warm up the server
         args = SimpleNamespace(
-            num_shots=8,
+            num_shots=20,
             data_path=None,
             num_questions=1400,
             parallel=1400,
@@ -102,7 +102,57 @@ class TestDeepseekV32NasBackend_fa3(CustomTestCase):
         self,
     ):  # Append an "a" to make this test run first (alphabetically) to warm up the server
         args = SimpleNamespace(
-            num_shots=8,
+            num_shots=20,
+            data_path=None,
+            num_questions=1400,
+            parallel=1400,
+            max_new_tokens=512,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"{metrics=}")
+
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_gsm8k (deepseek-v3)\n" f'{metrics["accuracy"]=:.3f}\n'
+            )
+            self.assertGreater(metrics["accuracy"], 0.935)
+
+
+class TestDeepseekV32NasBackend_fp8kvcache(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V32_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = [
+            "--trust-remote-code",
+            "--attention-backend",
+            "nsa",
+            "--kv-cache-dtype",
+            "fp8_e4m3",
+            "--tp",
+            "8",
+            "--dp",
+            "8",
+            "--enable-dp-attention",
+        ]
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=other_args,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_a_gsm8k(
+        self,
+    ):  # Append an "a" to make this test run first (alphabetically) to warm up the server
+        args = SimpleNamespace(
+            num_shots=20,
             data_path=None,
             num_questions=1400,
             parallel=1400,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Must merge after https://github.com/sgl-project/sglang/pull/12582

Part 2 of the fix for https://github.com/sgl-project/sglang/issues/11629
This PR also fixed the mtp crash in https://github.com/sgl-project/sglang/issues/12190

First, it now passes the `ks` to the topk kernel. There is another bug in the Indexer where the `offset` used in constructing `ks` and `ke` should be two different offsets instead. Added a diagram to make it more clear.

## Accuracy Tests
Tested with https://github.com/sgl-project/sglang/pull/12582

```
On 8xB200

gsm8k

20 shots

Accuracy: 0.953
Invalid: 0.000
Latency: 23.981 s
Output throughput: 5388.611 token/s

30 shots

Accuracy: 0.928
Invalid: 0.000
Latency: 31.716 s
Output throughput: 3907.670 token/s

gpaq

Repeat: 8, mean: 0.790

['0.798', '0.778', '0.783', '0.803', '0.768', '0.813', '0.788', '0.788']

With mtp on

python -m sglang.launch_server --model $MODEL --tp 8 --dp 8 --enable-dp-attention --reasoning-parser deepseek-v3 --kv-cache-dtype fp8_e4m3 --speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --cuda-graph-max-bs 256 --max-running-requests 2048

gsm 8k with 20 shots: 0.947
gsm 8k with 30 shots: 0.939

Repeat: 16, mean: 0.795
Scores: ['0.803', '0.823', '0.788', '0.798', '0.828', '0.768', '0.773', '0.783', '0.793', '0.773', '0.823', '0.783', '0.793', '0.808', '0.788', '0.793']

On 8xH200

Repeat: 8, mean: 0.802
Scores: ['0.798', '0.818', '0.788', '0.813', '0.798', '0.783', '0.823', '0.798']
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
