### PR TITLE
[HotFix] Disable torch dynamo for mrope_triton kernel

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1302,6 +1302,31 @@ def triton_mrope(
     return q, k
 
 
+@torch._dynamo.disable()
+def triton_mrope_wrapper(
+    query,
+    key,
+    cos,
+    sin,
+    mrope_section,
+    head_size,
+    rotary_dim,
+    mrope_interleaved,
+    is_neox_style,
+):
+    return triton_mrope(
+        query,
+        key,
+        cos,
+        sin,
+        mrope_section,
+        head_size,
+        rotary_dim,
+        mrope_interleaved,
+        is_neox_style,
+    )
+
+
 class MRotaryEmbedding(RotaryEmbedding):
     """Rotary Embedding with Multimodal Sections."""
 
@@ -1460,8 +1485,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         if positions.ndim == 2:
             assert self.mrope_section
 
-            torch._dynamo.graph_break()
-            q, k = triton_mrope(
+            q, k = triton_mrope_wrapper(
                 query,
                 key,
                 cos,
@@ -1472,7 +1496,6 @@ class MRotaryEmbedding(RotaryEmbedding):
                 self.mrope_interleaved,
                 self.is_neox_style,
             )
-            torch._dynamo.graph_break()
 
             return q.reshape(query_shape), k.reshape(key_shape)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The PR https://github.com/sgl-project/sglang/pull/11722 introduced mrope_triton kernel for VLM inference. The PR https://github.com/sgl-project/sglang/pull/12112 revised it with introducing torch compile to improve the torch ops performance. But the graph break introduced some regression.

The error happened when running extremely large batch, in 0.9B VLM model PaddleOCR-VL, concurrency 800, send 4000 requests to make the engine queuing. For a long while , it breaks this error:

graph_break() splits the same compiled function into “pause/resume” subgraphs, which can easily trigger known fragilities such as insufficient guards on the resumed fragments and mismatched reuse of specialized variants (the resume_in__forward_triton_at_1463 in the following logs is an example of this path).

By moving the Triton call into a small function annotated with @torch._dynamo.disable, Dynamo will naturally break and rejoin the graph at the function-call boundary, avoiding the complexity of the resume path; Inductor also doesn’t need to interleave a Python call within a single graph segment.

https://github.com/sgl-project/sglang/pull/5318 takes similar approach to resolve this issue.
```
# TODO(hebiao064): remove this once we have a better way to handle the merge_state_v2 torch.compile issue
@torch._dynamo.disable()
def merge_state_v2_wrapper(o, s_a, o_exp, s_b):
    return merge_state_v2(o, s_a, o_exp, s_b)
```

```
2025-11-03 21:25:27 INFO 401822 [ TP0 scheduler_metrics_mixin.py:147] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 242, token usage: 0.04, #running-req: 159, #queue-req: 3328, 
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892] Scheduler hit an exception: Traceback (most recent call last):
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 2872, in run_scheduler_process
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     scheduler.event_loop_overlap()
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return func(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 992, in event_loop_overlap
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     batch_result = self.run_batch(batch)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1999, in run_batch
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     batch_result = self.model_worker.forward_batch_generation(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 368, in forward_batch_generation
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     logits_output, can_run_cuda_graph = self.model_runner.forward(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2119, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     output = self._forward_raw(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2170, in _forward_raw
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     ret = self.forward_extend(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2064, in forward_extend
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self.model.forward(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/paddleocr_vl.py", line 762, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     hidden_states = general_mm_embed_routine(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/mm_utils.py", line 703, in general_mm_embed_routine
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     hidden_states = language_model(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self._call_impl(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return forward_call(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return func(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/ernie4.py", line 277, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     hidden_states, residual = layer(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self._call_impl(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return forward_call(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/ernie4.py", line 225, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     hidden_states = self.self_attn(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self._call_impl(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return forward_call(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/llama.py", line 196, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     q, k = self.rotary_emb(positions, q, k)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self._call_impl(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return forward_call(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/rotary_embedding.py", line 1440, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self._forward_triton(positions, query, key)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 736, in compile_wrapper
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return fn(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/rotary_embedding.py", line 1463, in _forward_triton
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     torch._dynamo.graph_break()
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/rotary_embedding.py", line 1463, in torch_dynamo_resume_in__forward_triton_at_1463
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     torch._dynamo.graph_break()
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 929, in _fn
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return fn(*args, **kwargs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_functorch/aot_autograd.py", line 1241, in forward
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return compiled_fn(full_args)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 384, in runtime_wrapper
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     all_outs = call_func_at_runtime_with_args(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     out = normalize_as_list(f(args))
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 556, in wrapper
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return compiled_fn(runtime_args)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_inductor/output_code.py", line 584, in __call__
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return self.current_callable(inputs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_inductor/utils.py", line 2716, in run
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     out = model(new_inputs)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/tmp/torchinductor_root/c4/cc4qlgo3rsma4dq52vefbwqgw3kkqb3rsalejh5zluw7bjk4pc44.py", line 379, in call
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     triton_poi_fused_0.run(arg4_1, buf1, triton_poi_fused_0_xnumel, stream=stream0)
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_inductor/runtime/triton_heuristics.py", line 1180, in run
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     return launcher(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "<string>", line 5, in launcher
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]   File "/opt/conda/lib/python3.10/site-packages/torch/_inductor/runtime/static_cuda_launcher.py", line 227, in run
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892]     _StaticCudaLauncher._launch_kernel(
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892] RuntimeError: CUDA driver error: an illegal memory access was encountered
2025-11-03 21:25:27 ERROR 401822 [ TP0 scheduler.py:2892] 
2025-11-03 21:25:27 ERROR 401607 [ tokenizer_manager.py:2310] SIGQUIT received. signum=None, frame=None. It usually means one child failed.
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
