### PR TITLE
fix: respect `--ignore-eos` in PD case for benchmarking

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -776,7 +776,10 @@ class DecodeTransferQueue:
                 # special handling for corner cases
                 should_finish = (
                     decode_req.req.sampling_params.max_new_tokens == 1
-                    or decode_req.req.output_ids[-1] in decode_req.req.eos_token_ids
+                    or (
+                        not decode_req.req.sampling_params.ignore_eos
+                        and decode_req.req.output_ids[-1] in decode_req.req.eos_token_ids
+                    )
                 )
                 if should_finish:
                     # finish immediately

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -774,12 +774,9 @@ class DecodeTransferQueue:
                 decode_req.req.time_stats.wait_queue_entry_time = time.perf_counter()
 
                 # special handling for corner cases
-                should_finish = (
-                    decode_req.req.sampling_params.max_new_tokens == 1
-                    or (
-                        not decode_req.req.sampling_params.ignore_eos
-                        and decode_req.req.output_ids[-1] in decode_req.req.eos_token_ids
-                    )
+                should_finish = decode_req.req.sampling_params.max_new_tokens == 1 or (
+                    not decode_req.req.sampling_params.ignore_eos
+                    and decode_req.req.output_ids[-1] in decode_req.req.eos_token_ids
                 )
                 if should_finish:
                     # finish immediately


### PR DESCRIPTION
https://github.com/sgl-project/sglang/pull/12334 does not handle `--ignore-eos` which is commonly used for fixed size isl/osl benchmarking. This PR provides an initial fix