### PR TITLE
[FixBug]Benchmark test on the Mooncake dataset reported an error

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1670,9 +1670,23 @@ def calculate_metrics(
                 tokenizer.encode(outputs[i].generated_text, add_special_tokens=False)
             )
             retokenized_output_lens.append(retokenized_output_len)
-            total_input += input_requests[i].prompt_len
-            total_input_text += input_requests[i].text_prompt_len
-            total_input_vision += input_requests[i].vision_prompt_len
+            if i < len(input_requests) and isinstance(input_requests[i], dict):
+                # For Mooncake dataset, use the prompt_len from output (which is set correctly)
+                prompt_len = outputs[i].prompt_len if outputs[i].prompt_len > 0 else input_requests[i].get('input_length', 0)
+                total_input += prompt_len
+                total_input_text += prompt_len
+                total_input_vision += 0
+            elif i < len(input_requests):
+                total_input += input_requests[i].prompt_len
+                total_input_text += input_requests[i].text_prompt_len
+                total_input_vision += input_requests[i].vision_prompt_len
+            else:
+                # For cases where outputs > input_requests (e.g., multi-round Mooncake)
+                # Use the prompt_len from the output directly
+                prompt_len = outputs[i].prompt_len
+                total_input += prompt_len
+                total_input_text += prompt_len
+                total_input_vision += 0
             if output_len > 1:
                 tpots.append((outputs[i].latency - outputs[i].ttft) / (output_len - 1))
             if use_retokenized_itl:

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1670,8 +1670,8 @@ def calculate_metrics(
                 tokenizer.encode(outputs[i].generated_text, add_special_tokens=False)
             )
             retokenized_output_lens.append(retokenized_output_len)
-            if i < len(input_requests) and isinstance(input_requests[i], dict):
-                # For Mooncake dataset, use the prompt_len from output (which is set correctly)
+            if isinstance(input_requests[i], dict):
+                # Mooncake case
                 prompt_len = (
                     outputs[i].prompt_len
                     if outputs[i].prompt_len > 0
@@ -1680,17 +1680,10 @@ def calculate_metrics(
                 total_input += prompt_len
                 total_input_text += prompt_len
                 total_input_vision += 0
-            elif i < len(input_requests):
+            else:
                 total_input += input_requests[i].prompt_len
                 total_input_text += input_requests[i].text_prompt_len
                 total_input_vision += input_requests[i].vision_prompt_len
-            else:
-                # For cases where outputs > input_requests (e.g., multi-round Mooncake)
-                # Use the prompt_len from the output directly
-                prompt_len = outputs[i].prompt_len
-                total_input += prompt_len
-                total_input_text += prompt_len
-                total_input_vision += 0
             if output_len > 1:
                 tpots.append((outputs[i].latency - outputs[i].ttft) / (output_len - 1))
             if use_retokenized_itl:

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1671,15 +1671,19 @@ def calculate_metrics(
             )
             retokenized_output_lens.append(retokenized_output_len)
             if isinstance(input_requests[i], dict):
-                # Mooncake case
+                # Dict format (e.g., Mooncake or other trace-based datasets)
                 prompt_len = (
                     outputs[i].prompt_len
                     if outputs[i].prompt_len > 0
                     else input_requests[i].get("input_length", 0)
                 )
+                # Support optional text/vision split in dict format
+                text_prompt_len = input_requests[i].get("text_prompt_len", prompt_len)
+                vision_prompt_len = input_requests[i].get("vision_prompt_len", 0)
+                
                 total_input += prompt_len
-                total_input_text += prompt_len
-                total_input_vision += 0
+                total_input_text += text_prompt_len
+                total_input_vision += vision_prompt_len
             else:
                 total_input += input_requests[i].prompt_len
                 total_input_text += input_requests[i].text_prompt_len

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1680,7 +1680,6 @@ def calculate_metrics(
                 # Support optional text/vision split in dict format
                 text_prompt_len = input_requests[i].get("text_prompt_len", prompt_len)
                 vision_prompt_len = input_requests[i].get("vision_prompt_len", 0)
-                
                 total_input += prompt_len
                 total_input_text += text_prompt_len
                 total_input_vision += vision_prompt_len

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1672,7 +1672,11 @@ def calculate_metrics(
             retokenized_output_lens.append(retokenized_output_len)
             if i < len(input_requests) and isinstance(input_requests[i], dict):
                 # For Mooncake dataset, use the prompt_len from output (which is set correctly)
-                prompt_len = outputs[i].prompt_len if outputs[i].prompt_len > 0 else input_requests[i].get('input_length', 0)
+                prompt_len = (
+                    outputs[i].prompt_len
+                    if outputs[i].prompt_len > 0
+                    else input_requests[i].get("input_length", 0)
+                )
                 total_input += prompt_len
                 total_input_text += prompt_len
                 total_input_vision += 0


### PR DESCRIPTION
Refactor input length calculations for Mooncake dataset handling.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fix https://github.com/sgl-project/sglang/issues/12601

## Modifications

- Supports both Mooncake (dictionary format) and other datasets (DatasetRow objects)
- Uses outputs[i].prompt_len, which is the actual value dynamically calculated at request time
- Handles index mismatches caused by multi-round conversations
- If outputs[i].prompt_len is 0, uses input_length as an estimated value

## Test Plan
### Start the Server
```
python -m sglang.launch_server   --model-path /proj-tango-pvc/users/zhipeng.wang/workspace/models/rakutenai-3-0-alpha  --tp 8 --mem-fraction-static 0.85  --trust-remote-code   --show-time-cost   --served-model-name Rakuten-AI-3.0-Alpha   --enable-metrics   --tool-call-parser deepseekv3   --chat-template /proj-tango-pvc/users/zhipeng.wang/workspace/tool_chat_template_deepseekv3.jinja   --context-length 128000   --log-level debug
```
### Benchmark Test
```
python3 -m sglang.bench_serving --backend sglang --host 127.0.0.1 --port 30000 --dataset-name mooncake --mooncake-slowdown-factor 1.0 --mooncake-num-rounds 1
```
## Result
```
benchmark_args=Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='mooncake', dataset_path='/proj-tango-pvc/users/zhipeng.wang/workspace/CXD/synthetic_data.jsonl', model=None, served_model_name=None, tokenizer='/proj-tango-pvc/users/zhipeng.wang/workspace/models/rakutenai-3-0-alpha', num_prompts=1000, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=1024, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=False, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)
Fail to load tokenizer config with error=Rakuten-AI-3.0-Alpha is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
If this is a private repository, make sure to pass a token having permission to this repo either by logging in with `hf auth login` or by passing `token=<your_token>`

WARNING It is recommended to use the `Chat` or `Instruct` model for benchmarking.
Because when the tokenizer counts the output tokens, if there is gibberish, it might count incorrectly.

Namespace(backend='sglang', base_url=None, host='127.0.0.1', port=30000, dataset_name='mooncake', dataset_path='/proj-tango-pvc/users/zhipeng.wang/workspace/CXD/synthetic_data.jsonl', model='Rakuten-AI-3.0-Alpha', served_model_name=None, tokenizer='/proj-tango-pvc/users/zhipeng.wang/workspace/models/rakutenai-3-0-alpha', num_prompts=1000, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=1024, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=False, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)

Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
Using time-based Mooncake request scheduler, ignoring --request-rate.
Starting Mooncake trace replay. Sessions: 875, Rounds per session: 1. Slowdown factor: 1.0
 14%|█████████▎                                                        | 124/875 [01:04<01:42,  7.34it/s]Token indices sequence length is longer than the specified maximum sequence length for this model (57283 > 16384). Running this sequence through the model will result in indexing errors
100%|██████████████████████████████████████████████████████████████████| 875/875 [10:06<00:00,  1.44it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     875       
Benchmark duration (s):                  606.98    
Total input tokens:                      824910    
Total input text tokens:                 824910    
Total input vision tokens:               0         
Total generated tokens:                  234665    
Total generated tokens (retokenized):    234073    
Request throughput (req/s):              1.44      
Input token throughput (tok/s):          1359.05   
Output token throughput (tok/s):         386.61    
Total token throughput (tok/s):          1745.66   
Concurrency:                             8.18      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5671.58   
Median E2E Latency (ms):                 4077.53   
---------------Time to First Token----------------
Mean TTFT (ms):                          973.90    
Median TTFT (ms):                        902.51    
P99 TTFT (ms):                           2638.64   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           17.58     
Median ITL (ms):                         13.20     
P95 ITL (ms):                            24.61     
P99 ITL (ms):                            29.17     
Max ITL (ms):                            3653.16   
==================================================
```
The benchmark can run successfully!