### PR TITLE
feat: Add FP4 (E2M1) KV Cache Support for MHA

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -645,24 +645,65 @@ class MHATokenToKVPool(KVCache):
                 if self.enable_custom_mem_pool
                 else nullcontext()
             ):
-                # [size, head_num, head_dim] for each layer
-                # The padded slot 0 is used for writing dummy outputs from padded tokens.
-                self.k_buffer = [
-                    torch.zeros(
-                        (self.size + self.page_size, self.head_num, self.head_dim),
-                        dtype=self.store_dtype,
-                        device=self.device,
-                    )
-                    for _ in range(self.layer_num)
-                ]
-                self.v_buffer = [
-                    torch.zeros(
-                        (self.size + self.page_size, self.head_num, self.head_dim),
-                        dtype=self.store_dtype,
-                        device=self.device,
-                    )
-                    for _ in range(self.layer_num)
-                ]
+                if is_float4_e2m1fn_x2(self.dtype):
+                    m = self.size + self.page_size
+                    n = self.head_num
+                    k = self.head_dim
+
+                    scale_block_size = 16
+                    self.store_dtype = torch.uint8
+                    self.k_buffer = [
+                        torch.zeros(
+                            (m, n, k // 2),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
+                    self.v_buffer = [
+                        torch.zeros(
+                            (m, n, k // 2),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
+
+                    self.k_scale_buffer = [
+                        torch.zeros(
+                            (m, (n * k) // scale_block_size),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
+                    self.v_scale_buffer = [
+                        torch.zeros(
+                            (m, (n * k) // scale_block_size),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
+                else:
+                    # [size, head_num, head_dim] for each layer
+                    # The padded slot 0 is used for writing dummy outputs from padded tokens.
+                    self.k_buffer = [
+                        torch.zeros(
+                            (self.size + self.page_size, self.head_num, self.head_dim),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
+                    self.v_buffer = [
+                        torch.zeros(
+                            (self.size + self.page_size, self.head_num, self.head_dim),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
+                        for _ in range(self.layer_num)
+                    ]
 
         self.k_data_ptrs = torch.tensor(
             [x.data_ptr() for x in self.k_buffer],
@@ -763,7 +804,22 @@ class MHATokenToKVPool(KVCache):
     def _get_key_buffer(self, layer_id: int):
         # for internal use of referencing
         if self.store_dtype != self.dtype:
-            return self.k_buffer[layer_id - self.start_layer].view(self.dtype)
+            if is_float4_e2m1fn_x2(self.dtype):
+                cache_k_nope_fp4 = self.k_buffer[layer_id - self.start_layer].view(
+                    torch.uint8
+                )
+                cache_k_nope_fp4_sf = self.k_scale_buffer[layer_id - self.start_layer]
+
+                from sglang.srt.layers.quantization.kvfp4_tensor import (
+                    KVFP4QuantizeUtil,
+                )
+
+                cache_k_nope_fp4_dequant = KVFP4QuantizeUtil.batched_dequantize(
+                    cache_k_nope_fp4, cache_k_nope_fp4_sf
+                )
+                return cache_k_nope_fp4_dequant
+            else:
+                return self.k_buffer[layer_id - self.start_layer].view(self.dtype)
         return self.k_buffer[layer_id - self.start_layer]
 
     def get_key_buffer(self, layer_id: int):
@@ -777,7 +833,22 @@ class MHATokenToKVPool(KVCache):
     def _get_value_buffer(self, layer_id: int):
         # for internal use of referencing
         if self.store_dtype != self.dtype:
-            return self.v_buffer[layer_id - self.start_layer].view(self.dtype)
+            if is_float4_e2m1fn_x2(self.dtype):
+                cache_v_nope_fp4 = self.v_buffer[layer_id - self.start_layer].view(
+                    torch.uint8
+                )
+                cache_v_nope_fp4_sf = self.v_scale_buffer[layer_id - self.start_layer]
+
+                from sglang.srt.layers.quantization.kvfp4_tensor import (
+                    KVFP4QuantizeUtil,
+                )
+
+                cache_v_nope_fp4_dequant = KVFP4QuantizeUtil.batched_dequantize(
+                    cache_v_nope_fp4, cache_v_nope_fp4_sf
+                )
+                return cache_v_nope_fp4_dequant
+            else:
+                return self.v_buffer[layer_id - self.start_layer].view(self.dtype)
         return self.v_buffer[layer_id - self.start_layer]
 
     def get_value_buffer(self, layer_id: int):
@@ -809,24 +880,44 @@ class MHATokenToKVPool(KVCache):
                 cache_k.div_(k_scale)
             if v_scale is not None:
                 cache_v.div_(v_scale)
-            cache_k = cache_k.to(self.dtype)
-            cache_v = cache_v.to(self.dtype)
+            if is_float4_e2m1fn_x2(self.dtype):
+                from sglang.srt.layers.quantization.kvfp4_tensor import (
+                    KVFP4QuantizeUtil,
+                )
+
+                cache_k, cache_k_fp4_sf = KVFP4QuantizeUtil.batched_quantize(cache_k)
+                cache_v, cache_v_fp4_sf = KVFP4QuantizeUtil.batched_quantize(cache_v)
+            else:
+                cache_k = cache_k.to(self.dtype)
+                cache_v = cache_v.to(self.dtype)
 
         if self.store_dtype != self.dtype:
             cache_k = cache_k.view(self.store_dtype)
             cache_v = cache_v.view(self.store_dtype)
+            if is_float4_e2m1fn_x2(self.dtype):
+                cache_k_fp4_sf = cache_k_fp4_sf.view(self.store_dtype)
+                cache_v_fp4_sf = cache_v_fp4_sf.view(self.store_dtype)
 
         if get_is_capture_mode() and self.alt_stream is not None:
             # Overlap the copy of K and V cache for small batch size
             current_stream = self.device_module.current_stream()
             self.alt_stream.wait_stream(current_stream)
             self.k_buffer[layer_id - self.start_layer][loc] = cache_k
+            if is_float4_e2m1fn_x2(self.dtype):
+                self.k_scale_buffer[layer_id - self.start_layer][loc] = cache_k_fp4_sf
             with self.device_module.stream(self.alt_stream):
                 self.v_buffer[layer_id - self.start_layer][loc] = cache_v
+                if is_float4_e2m1fn_x2(self.dtype):
+                    self.v_scale_buffer[layer_id - self.start_layer][
+                        loc
+                    ] = cache_v_fp4_sf
             current_stream.wait_stream(self.alt_stream)
         else:
             self.k_buffer[layer_id - self.start_layer][loc] = cache_k
             self.v_buffer[layer_id - self.start_layer][loc] = cache_v
+            if is_float4_e2m1fn_x2(self.dtype):
+                self.k_scale_buffer[layer_id - self.start_layer][loc] = cache_k_fp4_sf
+                self.v_scale_buffer[layer_id - self.start_layer][loc] = cache_v_fp4_sf
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         N = tgt_loc.numel()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1314,6 +1314,24 @@ class ModelRunner:
                 * 2
                 * torch._utils._element_size(self.kv_cache_dtype)
             )
+
+            if is_float4_e2m1fn_x2(self.kv_cache_dtype):
+                # kv_scale_buffer
+                scale_block_size = 16
+
+                n = self.model_config.get_num_kv_heads(get_attention_tp_size())
+                k = self.model_config.head_dim
+                cell_size = (cell_size // 2) + (
+                    (
+                        n
+                        * k
+                        * num_layers
+                        * 2
+                        * torch._utils._element_size(self.kv_cache_dtype)
+                    )
+                    // scale_block_size
+                )
+
         rest_memory = available_gpu_memory - total_gpu_memory * (
             1 - self.mem_fraction_static
         )


### PR DESCRIPTION
# Summary
This PR introduces support for **FP4 (float4_e2m1fn_x2) KV caching** in Multi-Headed Attention (MHA)  e.g., Qwen and GPT-OSS . See #10083, points 1-2, for more context.

Co-authored-by: @yicwang Yichen Wang [yichen.wang@bytedance.com](mailto:yichen.wang@bytedance.com)

# Usage
```
$ python3 -m sglang.launch_server --kv-cache-dtype fp4_e2m1 ... 
```

### **Motivation** and Benefits
Large models often face GPU memory constraints when storing KV cache.
By introducing **FP4 quantization with scale buffers**, this PR significantly reduces KV memory usage and improves efficiency:
- Supports significantly more tokens than KV8 (≈1.78×) and KV16 (≈3.56×) due to FP4 quantization with block_size = 16.
- Improves scalability for longer context windows and throughput for large batch requests
- Enables inference of larger models or longer context windows on memory-limited GPUs.
- Seamless integration with existing inference pipelines without breaking KV16/KV8 workflows.

# Key Changes
- **MHATokenToKVPool**
    - Added FP4 KV cache support with uint8 storage format.
    - Introduced k_scale_buffer and v_scale_buffer for per-block scaling factors.
    - Integrated batched quantization (on update) and dequantization (on access) using KVFP4QuantizeUtil.
- **ModelRunner**
    - Updated GPU memory estimation logic to account for FP4 cache and scale buffers.
- **Compatibility**
    - Preserves existing FP16/FP8 KV cache behavior without changes.

# Accuracy tests for KV4 MHA
- FP4 KV cache is well-suited for large-scale models, providing memory savings with minimal accuracy impact.
- For smaller models, careful evaluation is needed to balance memory efficiency and accuracy.
## Qwen3-235B-A22B

| Model          | Dataset      | Metric   | Subset  | Num  | Score  | Cat.0   |
| -------------- | ------------ | -------- | ------- | ---- | ------ | ------- |
| KV4 (fp4_e2m1) |              |          |         |      |        |         |
| KV4            | gsm8k        | mean_acc | main    | 6595 | 0.9186 | default |
| KV4            | aime25       | mean_acc | OVERALL | 150  | 0.6    | -       |
| KV4            | gpqa_diamond | mean_acc | default | 990  | 0.6778 | default |
| KV8 (fp8_e4m3) |              |          |         |      |        |         |
| KV8            | gsm8k        | mean_acc | main    | 6595 | 0.9181 | default |
| KV8            | aime25       | mean_acc | OVERALL | 150  | 0.7333 | -       |
| KV8            | gpqa_diamond | mean_acc | default | 990  | 0.6899 | default |
| KV16           |              |          |         |      |        |         |
| KV16           | gsm8k        | mean_acc | main    | 6595 | 0.9168 | default |
| KV16           | aime25       | mean_acc | OVERALL | 150  | 0.7733 | -       |
| KV16           | gpqa_diamond | mean_acc | default | 990  | 0.701  | default |



## gpt-oss-120b

| Model          | Dataset      | Metric   | Subset  | Num  | Score  | Cat.0   |
| -------------- | ------------ | -------- | ------- | ---- | ------ | ------- |
| KV4 (fp4_e2m1) |              |          |         |      |        |         |
| KV4            | aime25       | mean_acc | OVERALL | 150  | 0.3533 | -       |
| KV4            | gsm8k        | mean_acc | main    | 6595 | 0.9152 | default |
| KV4            | gpqa_diamond | mean_acc | default | 990  | 0.3202 | default |
| KV8 (fp8_e4m3) |              |          |         |      |        |         |
| KV8            | aime25       | mean_acc | OVERALL | 150  | 0.7667 | -       |
| KV8            | gsm8k        | mean_acc | main    | 6595 | 0.9163 | default |
| KV8            | gpqa_diamond | mean_acc | default | 990  | 0.5434 | default |
| KV16           |              |          |         |      |        |         |
| KV16           | aime25       | mean_acc | OVERALL | 150  | 0.7533 | -       |
| KV16           | gsm8k        | mean_acc | main    | 6595 | 0.9161 | default |
| KV16           | gpqa_diamond | mean_acc | default | 990  | 0.5081 | default |


**Observation:**  
- On large models (Qwen3-235B-A22B), FP4 maintains accuracy close to FP8/FP16.  
- On smaller models (gpt-oss-120b), FP4 shows more pronounced accuracy drops on difficult datasets.  
- **Trend:** Accuracy degradation is more significant in smaller models.



# Performance Results
Although **speed is not the main goal of this PR** (will be addressed in **#10083 3-2**), we ran throughput tests using **`torch_native`** to provide reference:
- **Reason for `torch_native`:**  
  - Other backends (e.g., `trtllm_mha`, Triton attention) have fused kernels for FP8 only, making FP8 faster there.
  - KV8 lacks a fused kernel on `torch_native`, so both KV4 and KV8 are measured on the same backend.  
  > Note:  KV8 could not run when the attention backend was set to torch_native. We have fixed this problem in PR #12596

- **Test configuration:**  
  - `--num-prompts`: 100–400  
  - `--max-concurrency`: 50–200  
  - Unit: Output token throughput (tok/s)
  
| Num Prompts | Concurrency | KV8 (tok/s) | KV4 (tok/s) | Gain   | TTFT (ms) | TPOT (ms) |
| ----------- | ----------- | ----------- | ----------- | ------ | --------- | --------- |
| 100         | 50          | 62.43       | 60.35       | -3.33% | 5323      | 798       |
| 200         | 100         | 67.34       | 68.02       | +1.0%  | 9378      | 1480      |
| 300         | 150         | 68.81       | 71.63       | +4.1%  | 13500     | 2172      |
| 400         | 200         | 69.75       | 74.19       | +6.36% | 19595     | 2685      |

**Observation:**  
- KV4 shows slightly lower throughput at very small workloads, but catches up and surpasses KV8 at higher concurrency.  
- Speed improvements will be addressed in **#10083 3-2**; this PR focuses on FP4 KV cache feature support.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).