### PR TITLE
Optimize EAGLE select_top_k_tokens: use logprobs.

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -131,10 +131,10 @@ class ScheduleBatchDisaggregationDecodeMixin:
 
             b = len(self.reqs)
             topk = server_args.speculative_eagle_topk
-            topk_p = torch.stack(
+            topk_logp = torch.stack(
                 [
                     torch.as_tensor(
-                        req.output_topk_p[:topk],
+                        req.output_topk_logp[:topk],
                         device=self.device,
                         dtype=torch.float32,
                     )
@@ -161,7 +161,7 @@ class ScheduleBatchDisaggregationDecodeMixin:
             from sglang.srt.speculative.eagle_info import EagleDraftInput
 
             spec_info = EagleDraftInput(
-                topk_p=topk_p,
+                topk_logp=topk_logp,
                 topk_index=topk_index,
                 hidden_states=hidden_states,
                 verified_id=self.output_ids,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -422,7 +422,7 @@ class SchedulerDisaggregationPrefillMixin:
                     last_hidden_index = (
                         hidden_state_offset + extend_input_len_per_req[i] - 1
                     )
-                    req.output_topk_p = batch.spec_info.topk_p[i]
+                    req.output_topk_logp = batch.spec_info.topk_logp[i]
                     req.output_topk_index = batch.spec_info.topk_index[i]
                     if self.spec_algorithm.is_eagle3():
                         req.hidden_states_tensor = (

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -746,8 +746,8 @@ class ForwardBatch:
             spec_info = self.spec_info
             self.output_cache_loc_backup = self.out_cache_loc
             self.hidden_states_backup = spec_info.hidden_states
-            if spec_info.topk_p is not None:
-                spec_info.topk_p = self._pad_tensor_to_size(spec_info.topk_p, bs)
+            if spec_info.topk_logp is not None:
+                spec_info.topk_logp = self._pad_tensor_to_size(spec_info.topk_logp, bs)
             if spec_info.topk_index is not None:
                 spec_info.topk_index = self._pad_tensor_to_size(
                     spec_info.topk_index, bs

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -94,7 +94,7 @@ class EAGLEDraftCudaGraphRunner:
             self.mrope_positions = torch.zeros(
                 (3, self.max_num_token), dtype=torch.int64
             )
-            self.topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
+            self.topk_logp = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
             self.topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
             self.hidden_states = torch.zeros(
                 (self.max_bs, self.model_runner.model_config.hidden_size),
@@ -163,7 +163,7 @@ class EAGLEDraftCudaGraphRunner:
         out_cache_loc = self.out_cache_loc[: num_tokens * self.speculative_num_steps]
         positions = self.positions[:num_tokens]
         mrope_positions = self.mrope_positions[:, :num_tokens]
-        topk_p = self.topk_p[:num_seqs]
+        topk_logp = self.topk_logp[:num_seqs]
         topk_index = self.topk_index[:num_seqs]
         hidden_states = self.hidden_states[:num_seqs]
 
@@ -209,7 +209,7 @@ class EAGLEDraftCudaGraphRunner:
             global_num_tokens_for_logprob = None
 
         spec_info = EagleDraftInput(
-            topk_p=topk_p,
+            topk_logp=topk_logp,
             topk_index=topk_index,
             hidden_states=hidden_states,
             capture_hidden_mode=CaptureHiddenMode.LAST,
@@ -313,7 +313,7 @@ class EAGLEDraftCudaGraphRunner:
             forward_batch.out_cache_loc
         )
         self.positions[:raw_num_token].copy_(forward_batch.positions)
-        self.topk_p[:raw_bs].copy_(forward_batch.spec_info.topk_p)
+        self.topk_logp[:raw_bs].copy_(forward_batch.spec_info.topk_logp)
         self.topk_index[:raw_bs].copy_(forward_batch.spec_info.topk_index)
         self.hidden_states[:raw_bs].copy_(forward_batch.spec_info.hidden_states)
 

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -291,7 +291,7 @@ class EAGLEDraftExtendCudaGraphRunner:
                 forward_batch,
             )
             probs = torch.softmax(ret.next_token_logits, dim=-1)
-            ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
+            ret.topk_logp, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
 
             forward_batch.out_cache_loc = output_cache_loc_backup
             forward_batch.spec_info.hidden_states = hidden_states_backup
@@ -388,6 +388,6 @@ class EAGLEDraftExtendCudaGraphRunner:
                 next_token_logits=out.next_token_logits[:raw_bs],
                 hidden_states=out.hidden_states[:raw_bs],
             )
-            out.topk_p = out_copy.topk_p[:raw_bs]
+            out.topk_logp = out_copy.topk_logp[:raw_bs]
             out.topk_index = out_copy.topk_index[:raw_bs]
         return out

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -616,7 +616,7 @@ class EagleDraftInput(SpecInput):
             )
             pt += extend_len
 
-    def prepare_for_decode(
+    def prepare_draft_root(
         self, logits_output: LogitsProcessorOutput, topk: int
     ):
         logprobs = torch.nn.functional.log_softmax(logits_output.next_token_logits, dim=-1)

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -26,10 +26,10 @@ from sglang.srt.speculative.spec_utils import (
     assign_req_to_token_pool,
     create_accept_length_filter,
     create_extend_after_decode_spec_info,
+    fast_topk,
     filter_finished_cache_loc_kernel,
     get_src_tgt_cache_loc,
     get_target_cache_loc,
-    fast_topk,
 )
 from sglang.srt.utils import is_cuda, is_hip, next_power_of_2
 
@@ -616,10 +616,10 @@ class EagleDraftInput(SpecInput):
             )
             pt += extend_len
 
-    def prepare_draft_root(
-        self, logits_output: LogitsProcessorOutput, topk: int
-    ):
-        logprobs = torch.nn.functional.log_softmax(logits_output.next_token_logits, dim=-1)
+    def prepare_draft_root(self, logits_output: LogitsProcessorOutput, topk: int):
+        logprobs = torch.nn.functional.log_softmax(
+            logits_output.next_token_logits, dim=-1
+        )
         self.topk_logp, self.topk_index = fast_topk(logprobs, topk, dim=-1)
         self.hidden_states = logits_output.hidden_states
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1009,7 +1009,7 @@ class EAGLEWorker(TpModelWorker):
         assert forward_batch.spec_info is batch.spec_info
 
         # Prepare for decoding
-        forward_batch.spec_info.prepare_for_decode(logits_output, self.topk)
+        forward_batch.spec_info.prepare_draft_root(logits_output, self.topk)
 
         has_finished, unfinished_req_index = False, []
         for i, req in enumerate(batch.reqs):
@@ -1100,7 +1100,7 @@ class EAGLEWorker(TpModelWorker):
             logits_output, _ = self.draft_model_runner.forward(
                 forward_batch, skip_attn_backend_init=True
             )
-            forward_batch.spec_info.prepare_for_decode(logits_output, self.topk)
+            forward_batch.spec_info.prepare_draft_root(logits_output, self.topk)
 
         self._detect_nan_if_needed(logits_output)
 

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -788,7 +788,9 @@ class EAGLEWorker(TpModelWorker):
             )
 
             self._detect_nan_if_needed(logits_output)
-            logprobs = torch.nn.functional.log_softmax(logits_output.next_token_logits, dim=-1)
+            logprobs = torch.nn.functional.log_softmax(
+                logits_output.next_token_logits, dim=-1
+            )
             topk_logp, topk_index = fast_topk(logprobs, self.topk, dim=-1)
             if self.hot_token_id is not None:
                 topk_index = self.hot_token_id[topk_index]

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -408,7 +408,7 @@ def select_top_k_tokens(
         tree_info = (
             topk_logp.unsqueeze(1),  # shape: (b, 1, topk), root is the single parent
             topk_index,  # shape: (b, topk)
-            init_parents.unsqueeze(0).repeat(bs, 1),  # shape: (b, topk)
+            init_parents.unsqueeze(0).repeat(bs, 1),  # shape: (b, topk + 1)
         )
     else:
         # The later decode steps


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Current EAGLE draft path is ranked by direct joint probability and requires a torch.mul in a hotspot loop `select_top_k_tokens` (needs to run multiple times for one draft step):

https://github.com/sgl-project/sglang/blob/30b26ee9d074ab6f0940f4473a2d6a3679973507/python/sglang/srt/speculative/spec_utils.py#L458-L460

The original EAGLE code ranks draft paths by log probability and uses a (broadcast) addition operation:

https://github.com/SafeAILab/EAGLE/blob/ee3b040e84b67c212046a8e3c37b31791fecc071/eagle/model/cnets.py#L735-L740

This issue may hurt minor accept rates due to the precision sensitivity of probs multiplication. ~~In a compute-bound decoding, this may also expose minor speedup potential (e.g., casting float add to using other compute units).~~ (does not see any speed difference after some tests)

## Modifications

* mainly in EAGLE select_top_k_tokens
* minor variable renames (`topk_p` --> `topk_logp`)
* also fix a minor bug in [this line](https://github.com/sgl-project/sglang/blob/30b26ee9d074ab6f0940f4473a2d6a3679973507/python/sglang/srt/speculative/spec_utils.py#L469) where the test for a multi-batch should be `hidden_states.shape[0] > topk` rather than `hidden_states.shape[0] > 0`.

## Accuracy Tests
On a RTX 4070 TiS, running against MT-Bench 80 questions, with bf16 and `--disable_cuda_graph --speculative_algorithm EAGLE --mtbench question.jsonl --bs 32 --speculative-num-steps 6 --speculative-eagle-topk 10 --speculative-num-draft-tokens 60` and using a small 4B Qwen3 model custom trained (see https://github.com/sgl-project/sglang/pull/11879) in order to fit my GPU with tp=1.

Before:
```
             completion_tokens: 114040
                spec_verify_ct: 36323
                     time_cost: 400.55
      scheduler_avg_accept_len: 3.126
                avg_accept_len: 3.14
                   throughputs: 284.711
```

After:
```
             completion_tokens: 112886
                spec_verify_ct: 35882
                     time_cost: 393.8
      scheduler_avg_accept_len: 3.132
                avg_accept_len: 3.146
                   throughputs: 286.658
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
