### PR TITLE
[Bug] Fix NSA Backend KV-Buffer Shape Mismatch in DeepSeek-V3.2

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1568,6 +1568,7 @@ class MLATokenToKVPool(KVCache):
 class NSATokenToKVPool(MLATokenToKVPool):
     quant_block_size = 128
     index_k_with_scale_buffer_dtype = torch.uint8
+    rope_storage_dtype = torch.bfloat16  # rope is always stored in bf16
 
     def __init__(
         self,
@@ -1589,10 +1590,11 @@ class NSATokenToKVPool(MLATokenToKVPool):
 
         # Calculate override_kv_cache_dim for FP8 storage:
         # kv_lora_rank + scale storage (kv_lora_rank // quant_block_size * 4 bytes) + rope dimension storage
+        # Note: rope dimension is stored in original dtype (bf16), not quantized to fp8
         override_dim = (
             kv_lora_rank
             + kv_lora_rank // self.quant_block_size * 4
-            + qk_rope_head_dim * dtype.itemsize
+            + qk_rope_head_dim * self.rope_storage_dtype.itemsize
         )
 
         super().__init__(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Fix this issue https://github.com/sgl-project/sglang/issues/12643
<!-- Describe the purpose and goals of this pull request. -->
  Root Cause:
  The override_kv_cache_dim calculation in NSATokenToKVPool.__init__() was using the wrong dtype size for the rope dimension
  storage. It was using dtype.itemsize (which for fp8 is 1 byte), but the
  rope dimension is actually stored in bfloat16 format (2 bytes), not
  quantized to fp8.
## Modifications
Fixes:
  1. Added a class attribute rope_storage_dtype = torch.bfloat16 to
  explicitly document that rope dimensions are stored in bf16
  2. Updated the override_dim calculation to use
  self.rope_storage_dtype.itemsize instead of dtype.itemsize
  3. Added a clarifying comment explaining that rope dimension storage is not
   quantized to fp8
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
`python test_deepseek_v32_basic.py `
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
<img width="1014" height="356" alt="image" src="https://github.com/user-attachments/assets/77960c46-b66e-43c9-b861-940f5bb7ec45" />

`python test_deepseek_v32_nsabackend.py `
<img width="1149" height="356" alt="image" src="https://github.com/user-attachments/assets/98f661a5-8da1-4002-ada4-d2f6ada89c1b" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
