### PR TITLE
fix: llama 4 fp4 loading

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -255,6 +255,19 @@ class FusedMoE(torch.nn.Module):
         elif shard_id == "w2":
             param_data[expert_id] = loaded_weight
 
+    def _load_w13_weight_scale(
+        self,
+        shard_dim: int,
+        loaded_weight: torch.Tensor,
+        param: torch.Tensor,
+        tp_rank: int,
+    ):
+        shard_size = param.shape[shard_dim]
+        loaded_weight = loaded_weight.narrow(
+            shard_dim, shard_size * tp_rank, shard_size
+        )
+        param.copy_(loaded_weight)
+
     def _load_model_weight_or_group_weight_scale(
         self,
         shard_dim: int,
@@ -667,7 +680,18 @@ class FusedMoE(torch.nn.Module):
                 else "weight_scale" in weight_name
             ) or "input_scale" in weight_name
 
-            if per_tensor_conditions:
+            if "w13_weight_scale" in weight_name:
+                loaded_weight_hidden_out = loaded_weight.shape[-2]
+                param_hidden_out = param.data.shape[-2] * self.moe_tp_size
+                if loaded_weight_hidden_out == param_hidden_out:
+                    self._load_w13_weight_scale(
+                        shard_dim=shard_dim,
+                        loaded_weight=loaded_weight,
+                        param=expert_data,
+                        tp_rank=tp_rank,
+                    )
+                    return
+            elif per_tensor_conditions:
                 self._load_per_tensor_weight_scale(
                     shard_id=shard_id,
                     param=param,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -494,7 +494,7 @@ class FusedMoE(torch.nn.Module):
         # if expert_id is None, then
         # all the experts are loaded at the same time
         if (
-            not expert_id
+            expert_id is None
             and self.quant_config is not None
             and self.quant_config.get_name() == "mxfp4"
             and self.quant_config.is_static_cfg()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1102,8 +1102,14 @@ class FlashInferFP4MoE(FusedMoE):
             output2_scale_scalar=self.g2_alphas.data,
             num_experts=self.num_experts,
             top_k=topk_config.top_k,
-            n_group=topk_config.num_expert_group,
-            topk_group=topk_config.topk_group,
+            n_group=(
+                topk_config.num_expert_group
+                if topk_config.num_expert_group is not None
+                else 0
+            ),
+            topk_group=(
+                topk_config.topk_group if topk_config.topk_group is not None else 0
+            ),
             intermediate_size=self.intermediate_size_per_partition,
             local_expert_offset=self.moe_ep_rank * self.num_local_experts,
             local_num_experts=self.num_local_experts,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1597,6 +1597,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 topk_weights, topk_ids, x, x_sf = get_tp_group().all_gatherv(
                     [topk_weights, topk_ids, x, x_sf], sizes=get_dp_global_num_tokens()
                 )
+                # Ensure dtypes match FlashInfer expectations
+                topk_weights = topk_weights.to(torch.float32)
+                topk_ids = topk_ids.to(torch.int32)
                 x_sf = nvfp4_block_scale_interleave(x_sf)
 
             with use_symmetric_memory(get_tp_group()) as sm:

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1571,7 +1571,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             x_sf = None
             # Support applying router weights on input for topK==1
             if moe_runner_config.apply_router_weight_on_input:
-                top_k = topk_output.topk_config.top_k
+                top_k = topk_weights.shape[1]
                 assert (
                     top_k == 1
                 ), "apply_router_weight_on_input is only implemented for topK==1"

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1597,9 +1597,6 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 topk_weights, topk_ids, x, x_sf = get_tp_group().all_gatherv(
                     [topk_weights, topk_ids, x, x_sf], sizes=get_dp_global_num_tokens()
                 )
-                # Ensure dtypes match FlashInfer expectations
-                topk_weights = topk_weights.to(torch.float32)
-                topk_ids = topk_ids.to(torch.int32)
                 x_sf = nvfp4_block_scale_interleave(x_sf)
 
             with use_symmetric_memory(get_tp_group()) as sm:
@@ -1608,12 +1605,10 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 )
                 sm.tag(symm_output)
 
-            # FlashInfer CUTLASS expects token_final_scales (routing weights)
-            # to be float32. Ensure dtype to avoid capture-time mismatches.
             output = flashinfer_cutlass_fused_moe(
                 input=x,
                 token_selected_experts=topk_ids.to(torch.int),
-                token_final_scales=topk_weights.to(torch.float32),
+                token_final_scales=topk_weights,
                 fc1_expert_weights=layer.w13_weight.view(torch.long),
                 fc2_expert_weights=layer.w2_weight.view(torch.long),
                 output_dtype=output_dtype,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1447,16 +1447,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         )
 
         # Validate weight scales
-        for name, weight_scale in [
-            ("w13", layer.w13_weight_scale),
-            ("w2", layer.w2_weight_scale),
-        ]:
-            assert (
-                weight_scale.shape[2] % 16 == 0
-            ), f"Expected {name}_weight_scale.dim(2) to be divisible by 16"
-            assert (
-                weight_scale.dtype == torch.float8_e4m3fn
-            ), f"{name} Weight Blockscale must be represented as FP8-E4M3"
+        assert (
+            layer.w2_weight_scale.dtype == torch.float8_e4m3fn
+        ), "Weight Blockscale must be represented as FP8-E4M3"
 
         # Weight processing based on strategy
         if (

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1593,12 +1593,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                         0, x_col // 16, dtype=torch.uint8, device=x.device
                     )
 
-                # Gather router outputs separately from activations to preserve dtypes
-                topk_weights, topk_ids = get_tp_group().all_gatherv(
-                    [topk_weights, topk_ids], sizes=get_dp_global_num_tokens()
-                )
-                x, x_sf = get_tp_group().all_gatherv(
-                    [x, x_sf], sizes=get_dp_global_num_tokens()
+                # Mirror vLLM: gather router outputs and activations together
+                topk_weights, topk_ids, x, x_sf = get_tp_group().all_gatherv(
+                    [topk_weights, topk_ids, x, x_sf], sizes=get_dp_global_num_tokens()
                 )
                 x_sf = nvfp4_block_scale_interleave(x_sf)
 

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1605,10 +1605,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 )
                 sm.tag(symm_output)
 
+            # FlashInfer CUTLASS expects token_final_scales (routing weights)
+            # to be float32. Ensure dtype to avoid capture-time mismatches.
             output = flashinfer_cutlass_fused_moe(
                 input=x,
                 token_selected_experts=topk_ids.to(torch.int),
-                token_final_scales=topk_weights,
+                token_final_scales=topk_weights.to(torch.float32),
                 fc1_expert_weights=layer.w13_weight.view(torch.long),
                 fc2_expert_weights=layer.w2_weight.view(torch.long),
                 output_dtype=output_dtype,

--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -79,10 +79,9 @@ class Llama4MoE(nn.Module):
         topk: int,
         renormalize: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Match vLLM: keep routing weights in float32.
         router_scores_aK, router_indices_aK = fast_topk(gating_output, topk, dim=-1)
-        router_scores_aK = torch.sigmoid(router_scores_aK.float()).to(
-            hidden_states.dtype
-        )
+        router_scores_aK = torch.sigmoid(router_scores_aK.float())
         return (
             router_scores_aK.view(-1).reshape(router_scores_aK.shape),
             router_indices_aK.to(torch.int32),

--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -163,7 +163,7 @@ class Llama4MoE(nn.Module):
     def _forward_core_normal(self, hidden_states):
         # router_scores: [num_tokens, num_experts]
         router_logits, _ = self.router(hidden_states)
-        shared_out = self.shared_expert(hidden_states.clone())
+        shared_out = self.shared_expert(hidden_states)
         topk_output = self.topk(hidden_states, router_logits)
         routed_out = self.experts(hidden_states, topk_output)
         return shared_out, routed_out

--- a/python/sglang/srt/models/llama4.py
+++ b/python/sglang/srt/models/llama4.py
@@ -647,7 +647,7 @@ class Llama4ForCausalLM(LlamaForCausalLM):
                 param.weight_loader(
                     param,
                     weight_tensor,
-                    name,
+                    transformed_name,
                     shard_id=actual_shard_id,
                     expert_id=expert_id,
                 )

--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -594,9 +594,20 @@ class Llama4ForConditionalGeneration(nn.Module):
         loaded_weight: torch.Tensor,
     ) -> Tuple[str, torch.Tensor]:
 
-        def permute(w: torch.Tensor, n_heads: int):
+        def permute(w: torch.Tensor, n_heads: int, is_weight_scale: bool):
             attn_in = self.language_model.config.head_dim * n_heads
             attn_out = self.language_model.config.hidden_size
+
+            # If the weight is FP4 packed as uint8, adjust attn_out accordingly
+            if w.dtype == torch.uint8 and w.shape[1] * 2 == attn_out:
+                attn_out = attn_out // 2
+            # If the weight is a weight block scale, adjust by block size (16)
+            elif (
+                w.dtype == torch.float8_e4m3fn
+                and is_weight_scale
+                and w.shape[1] * 16 == attn_out
+            ):
+                attn_out = attn_out // 16
 
             return (
                 w.view(n_heads, attn_in // n_heads // 2, 2, attn_out)
@@ -606,19 +617,25 @@ class Llama4ForConditionalGeneration(nn.Module):
 
         modules = name.split(".")
 
-        # rotary embeds should be sliced
-        if ("wk" in modules or "k_proj" in modules) and modules[-1] == "weight":
-            if _is_cpu:
-                dim = self.language_model.config.original_total_num_kv_heads
-            else:
-                dim = self.language_model.config.num_key_value_heads
-            loaded_weight = permute(loaded_weight, dim)
-        elif ("wq" in modules or "q_proj" in modules) and modules[-1] == "weight":
-            if _is_cpu:
-                dim = self.language_model.config.original_num_attention_heads
-            else:
-                dim = self.language_model.config.num_attention_heads
-            loaded_weight = permute(loaded_weight, dim)
+        # Permute Q/K weights and nvfp4 weight block scales for rotary embedding
+        is_weight = modules[-1] == "weight"
+        is_nvfp4_weight_scale = (
+            modules[-1] == "weight_scale" and loaded_weight.dtype == torch.float8_e4m3fn
+        )
+
+        if is_weight or is_nvfp4_weight_scale:
+            if "wk" in modules or "k_proj" in modules:
+                if _is_cpu:
+                    dim = self.language_model.config.original_total_num_kv_heads
+                else:
+                    dim = self.language_model.config.num_key_value_heads
+                loaded_weight = permute(loaded_weight, dim, is_nvfp4_weight_scale)
+            elif "wq" in modules or "q_proj" in modules:
+                if _is_cpu:
+                    dim = self.language_model.config.original_num_attention_heads
+                else:
+                    dim = self.language_model.config.num_attention_heads
+                loaded_weight = permute(loaded_weight, dim, is_nvfp4_weight_scale)
 
         return name, loaded_weight
 
@@ -854,25 +871,47 @@ class Llama4ForConditionalGeneration(nn.Module):
         # Check if this matches the expert parameter pattern: experts.{expert_id}.{param_name}
         expert_match = re.search(r"experts\.(\d+)\.", name)
 
-        # Transform name
-        transformed_name, _, _ = self._transform_expert_name(name)
+        # Transform name to get the proper shard_id
+        transformed_name, shard_id, shard_id_list = self._transform_expert_name(name)
 
         if transformed_name not in params_dict:
             return True
 
         param = params_dict[transformed_name]
 
-        # Handle scale parameters
+        # Transpose if weight scales are FP8 block scales with 3 dims: [num_experts, hidden_in, hidden_out]
+        if (
+            name.endswith("weight_scale")
+            and loaded_weight.dtype == torch.float8_e4m3fn
+            and loaded_weight.ndim == 3
+        ):
+            loaded_weight = loaded_weight.transpose(-1, -2)
+
+        # Handle scale parameters using weight_loader to properly handle sharding
+        # For w13 (gate_up_proj), we need to load for both w1 and w3 shards
+        actual_shard_ids = shard_id_list if shard_id == "w13" else [shard_id]
+
+        def load_for_expert(weight_tensor, expert_id):
+            for actual_shard_id in actual_shard_ids:
+                param.weight_loader(
+                    param,
+                    weight_tensor,
+                    name,
+                    shard_id=actual_shard_id,
+                    expert_id=expert_id,
+                )
+
         if expert_match:
-            # If we have a specific expert ID, only load for that expert
             expert_id = int(expert_match.group(1))
-            # For scale parameters, we can directly set the value
-            param.data[expert_id] = loaded_weight
+            load_for_expert(loaded_weight, expert_id)
         else:
-            # No expert ID found - this is a single scale for all experts
-            # Load the same scale for all experts
-            for expert_id in range(num_experts):
-                param.data[expert_id] = loaded_weight
+            # No expert ID found - check if loaded_weight is fused (contains all experts)
+            if loaded_weight.dim() == 3 and loaded_weight.shape[0] == num_experts:
+                for expert_id in range(num_experts):
+                    load_for_expert(loaded_weight[expert_id], expert_id)
+            else:
+                for expert_id in range(num_experts):
+                    load_for_expert(loaded_weight, expert_id)
         loaded_params.add(transformed_name)
 
         return True
@@ -902,9 +941,19 @@ class Llama4ForConditionalGeneration(nn.Module):
             name, is_weight=True
         )
 
+        # Check if weights are fused (all experts in a single tensor)
+        fused = loaded_weight.dim() == 3 and loaded_weight.shape[0] == num_experts
+
         if ".gate_up_proj" in name:
-            loaded_weight_list = loaded_weight.chunk(2, dim=-1)
+            # gate_up_proj weights may need transpose if stored as [num_experts, hidden_size, 2*intermediate_size]
+            if fused:
+                loaded_weight = loaded_weight.transpose(-1, -2)
+            # Split along the 2*intermediate_size dimension (works for both 2D and 3D cases)
+            loaded_weight_list = loaded_weight.chunk(2, dim=-2)
         else:  # down_proj
+            # down_proj weights may also need transpose if stored as [num_experts, hidden_size, intermediate_size]
+            if fused:
+                loaded_weight = loaded_weight.transpose(-1, -2)
             loaded_weight_list = [loaded_weight]
 
         for param_name, weight_chunk, shard_id in zip(
@@ -923,17 +972,27 @@ class Llama4ForConditionalGeneration(nn.Module):
                 for expert_id in range(num_experts):
                     weight_loader(
                         param,
-                        weight_chunk.T,
+                        weight_chunk,
+                        param_name,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                    )
+            elif weight_chunk.dim() == 3 and weight_chunk.shape[0] == num_experts:
+                # Fused case: extract individual expert weights
+                for expert_id in range(num_experts):
+                    weight_loader(
+                        param,
+                        weight_chunk[expert_id],
                         param_name,
                         shard_id=shard_id,
                         expert_id=expert_id,
                     )
             else:
-                # Multiple experts case - load each expert's weights
+                # Multiple experts provided along first dim
                 for expert_id in range(num_experts):
                     weight_loader(
                         param,
-                        weight_chunk[expert_id].T,
+                        weight_chunk[expert_id],
                         param_name,
                         shard_id=shard_id,
                         expert_id=expert_id,


### PR DESCRIPTION
Don't merge this yet

Rebase https://github.com/sgl-project/sglang/pull/9526

```
python3 -m sglang.launch_server \
  --model-path=nvidia/Llama-4-Scout-17B-16E-Instruct-FP4 \
  --tp=8 \
  --quantization modelopt_fp4 \
  --moe-runner-backend=flashinfer_cutlass \
  --attention-backend trtllm_mha \ # tried triton backend, no difference.
  --trust-remote-code \
  --mem-fraction-static=0.7 \
  --context-length=131072 \
  --kv-cache-dtype=fp8_e4m3 \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'
```

`python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 500`
```
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:21<00:00, 62.48it/s]
Accuracy: 0.884
Invalid: 0.001
Latency: 21.276 s
Output throughput: 6298.596 token/s
```

It's too low, MMLU Pro needs to be >=0.74. It seems to be some accuracy issue in flashinfer_cutlass MoE usage
```
lm_eval --model local-chat-completions --model_args model=nvidia/Llama-4-Scout-17B-16E-Instruct-FP4,base_url=http://localhost:30000/v1/chat/completions,num_concurrent=512,timeout=999999,max_gen_toks=2048 --tasks mmlu_pro --batch_size 512 --apply_chat_template --num_fewshot 0
```

```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|      |exact_match|↑  |0.7239|±  |0.0040|
| - biology         |    2.1|custom-extract|     0|exact_match|↑  |0.8703|±  |0.0126|
| - business        |    2.1|custom-extract|     0|exact_match|↑  |0.7592|±  |0.0152|
| - chemistry       |    2.1|custom-extract|     0|exact_match|↑  |0.7694|±  |0.0125|
| - computer_science|    2.1|custom-extract|     0|exact_match|↑  |0.7439|±  |0.0216|
| - economics       |    2.1|custom-extract|     0|exact_match|↑  |0.8033|±  |0.0137|
| - engineering     |    2.1|custom-extract|     0|exact_match|↑  |0.6047|±  |0.0157|
| - health          |    2.1|custom-extract|     0|exact_match|↑  |0.7164|±  |0.0158|
| - history         |    2.1|custom-extract|     0|exact_match|↑  |0.6168|±  |0.0249|
| - law             |    2.1|custom-extract|     0|exact_match|↑  |0.4841|±  |0.0151|
| - math            |    2.1|custom-extract|     0|exact_match|↑  |0.8275|±  |0.0103|
| - other           |    2.1|custom-extract|     0|exact_match|↑  |0.6851|±  |0.0153|
| - philosophy      |    2.1|custom-extract|     0|exact_match|↑  |0.6152|±  |0.0218|
| - physics         |    2.1|custom-extract|     0|exact_match|↑  |0.7883|±  |0.0113|
| - psychology      |    2.1|custom-extract|     0|exact_match|↑  |0.7657|±  |0.0150|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|------|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.7239|±  | 0.004|
```

BF16 launch commands (H200):
```
python3 -m sglang.launch_server   --model-path=/opt/dlami/nvme/models/Llama-4-Scout-17B-16E-Instruct/   --tp=8 --trust-remote-code   --mem-fraction-static=0.7   --context-length=131072 --attention-backend=fa3   --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}'
```

```
root@ip-10-40-12-14:/sgl-workspace/sglang# python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 500
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:32<00:00, 41.15it/s]
Accuracy: 0.918
Invalid: 0.000
Latency: 32.415 s
Output throughput: 4169.418 token/s
```

```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|      |exact_match|↑  |0.7490|±  |0.0039|
| - biology         |    2.1|custom-extract|     0|exact_match|↑  |0.8773|±  |0.0123|
| - business        |    2.1|custom-extract|     0|exact_match|↑  |0.7858|±  |0.0146|
| - chemistry       |    2.1|custom-extract|     0|exact_match|↑  |0.8110|±  |0.0116|
| - computer_science|    2.1|custom-extract|     0|exact_match|↑  |0.7683|±  |0.0209|
| - economics       |    2.1|custom-extract|     0|exact_match|↑  |0.8187|±  |0.0133|
| - engineering     |    2.1|custom-extract|     0|exact_match|↑  |0.6502|±  |0.0153|
| - health          |    2.1|custom-extract|     0|exact_match|↑  |0.7421|±  |0.0153|
| - history         |    2.1|custom-extract|     0|exact_match|↑  |0.6457|±  |0.0245|
| - law             |    2.1|custom-extract|     0|exact_match|↑  |0.5232|±  |0.0151|
| - math            |    2.1|custom-extract|     0|exact_match|↑  |0.8342|±  |0.0101|
| - other           |    2.1|custom-extract|     0|exact_match|↑  |0.7154|±  |0.0149|
| - philosophy      |    2.1|custom-extract|     0|exact_match|↑  |0.6493|±  |0.0214|
| - physics         |    2.1|custom-extract|     0|exact_match|↑  |0.8006|±  |0.0111|
| - psychology      |    2.1|custom-extract|     0|exact_match|↑  |0.7870|±  |0.0145|

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value|   |Stderr|
|--------|------:|--------------|------|-----------|---|----:|---|-----:|
|mmlu_pro|      2|custom-extract|      |exact_match|↑  |0.749|±  |0.0039|
```