### PR TITLE
[router][grpc] Fix index issues in reasoning content and missing streaming events

### DIFF
--- a/sgl-router/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/handlers.rs
@@ -378,6 +378,16 @@ async fn process_and_transform_sse_stream(
     let created_at = chrono::Utc::now().timestamp() as u64;
     let mut event_emitter = ResponseStreamEventEmitter::new(response_id, model, created_at);
 
+    // Emit initial response.created and response.in_progress events
+    let event = event_emitter.emit_created();
+    if event_emitter.send_event(&event, &tx).is_err() {
+        return Err("Failed to send response.created event".to_string());
+    }
+    let event = event_emitter.emit_in_progress();
+    if event_emitter.send_event(&event, &tx).is_err() {
+        return Err("Failed to send response.in_progress event".to_string());
+    }
+
     // Convert body to data stream
     let mut stream = body.into_data_stream();
 

--- a/sgl-router/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/handlers.rs
@@ -380,13 +380,14 @@ async fn process_and_transform_sse_stream(
 
     // Emit initial response.created and response.in_progress events
     let event = event_emitter.emit_created();
-    if event_emitter.send_event(&event, &tx).is_err() {
-        return Err("Failed to send response.created event".to_string());
-    }
+    event_emitter
+        .send_event(&event, &tx)
+        .map_err(|_| "Failed to send response.created event".to_string())?;
+
     let event = event_emitter.emit_in_progress();
-    if event_emitter.send_event(&event, &tx).is_err() {
-        return Err("Failed to send response.in_progress event".to_string());
-    }
+    event_emitter
+        .send_event(&event, &tx)
+        .map_err(|_| "Failed to send response.in_progress event".to_string())?;
 
     // Convert body to data stream
     let mut stream = body.into_data_stream();


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fixes #12644 

The gRPC responses API streaming implementation had two bugs that caused incorrect event sequences compared to the official OpenAI API:

**Bug 1: Missing initial events for non-harmony models**
When streaming responses for regular (non-harmony) models, the implementation was missing the required `response.created` and `response.in_progress` events at the beginning of the stream. This caused clients to receive output events before knowing the response had started.

**Bug 2: Incorrect output_index for harmony models**
For harmony models (e.g., gpt-oss-120b) with reasoning, the `output_index` values were off by 1:
- Reasoning item had `output_index: 1` instead of `0`
- Message item had `output_index: 2` instead of `1`

This was caused by allocating an output_index twice - once in the caller and once inside `emit_reasoning_item()`, causing the internal counter to increment twice.

**Expected behavior (OpenAI API):**
```
response.created          (sequence: 0)
response.in_progress      (sequence: 1)
response.output_item.added (sequence: 2, output_index: 0) ← reasoning
response.output_item.done  (sequence: 3, output_index: 0)
response.output_item.added (sequence: 4, output_index: 1) ← message
...
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

### 1. Added missing initial events for non-harmony models

**File:** `sgl-router/src/routers/grpc/regular/responses/handlers.rs`

Added `response.created` and `response.in_progress` event emissions after creating the `ResponseStreamEventEmitter`

### 2. Fixed output_index calculation for harmony models

**File:** `sgl-router/src/routers/grpc/harmony/streaming.rs`

**Changes:**
- Removed redundant `allocate_output_index()` call before `emit_reasoning_item()`
- Renamed `reasoning_output_index: Option<usize>` to `has_emitted_reasoning: bool` for clarity since the actual index value was never used


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<img width="1713" height="1265" alt="Screenshot 2025-11-04 at 2 36 47 PM" src="https://github.com/user-attachments/assets/8631c65a-cc05-4e70-8d95-3230bf10c13f" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
