### PR TITLE
[Perf] Modify threshold for triggering allreduce norm fusion

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -63,7 +63,7 @@ _is_gfx95_supported = is_gfx95_supported()
 if _use_aiter and _is_gfx95_supported:
     from sglang.srt.layers.quantization.rocm_mxfp4_utils import fused_rms_mxfp4_quant
 
-FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
+FUSE_ALLREDUCE_MAX_BATCH_SIZE = 128
 
 
 class ScatterMode(Enum):
@@ -559,7 +559,7 @@ class CommunicateWithAllReduceAndLayerNormFn:
                 and _is_flashinfer_available
                 and hasattr(layernorm, "forward_with_allreduce_fusion")
                 and get_global_server_args().enable_flashinfer_allreduce_fusion
-                and hidden_states.shape[0] <= 4096
+                and hidden_states.shape[0] <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
             ):
                 hidden_states, residual = layernorm.forward_with_allreduce_fusion(
                     hidden_states, residual


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Currently in  DeepSeek fp4 and pure TP scenario, `flashinfer::trtllm_allreduce_fusion` is applied to batches with `bs <= FUSE_ALLREDUCE_MAX_BATCH_SIZE`. 

However, with medium batch size like 2048(current threshold), we found that the cost for trtllm_allreduce_fusion might be much larger than all_reduce+norm with symmetric memory enabled. So we are lowering this threshold to a smaller value (like 128, as discussed in https://github.com/flashinfer-ai/flashinfer/issues/1223#issuecomment-3047256465)


## Benchmarking and Profiling

DeepSeek fp4+TP 8 on B200

```bash
python3 -m sglang.launch_server --model-path nvidia/DeepSeek-R1-0528-FP4-v2 --tp-size 8 --mem-fraction-static 0.90 --quantization modelopt_fp4 --kv-cache-dtype fp8_e4m3 --attention-backend trtllm_mla --moe-runner-backend flashinfer_trtllm  --trust-remote --enable-symm-mem --cuda-graph-max-bs 64
```



Profile (BS=1, ISL=2048, OSL=4):

Before this PR, the time of allreduce+norm fusion is 186us
<img width="600" height="286" alt="截屏2025-11-04 16 31 59" src="https://github.com/user-attachments/assets/2a17ae07-3700-494c-856a-296d66622268" />


After this PR, the time of allreduce kernel plus norm kernel with symmetric memory is 107us

<img width="970" height="265" alt="截屏2025-11-04 16 34 07" src="https://github.com/user-attachments/assets/eea83742-ae4a-44c2-bd1c-87507442ec28" />






## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
