### PR TITLE
fix flatten bucket rank device

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1166,6 +1166,13 @@ class ModelRunner:
         flattened_tensor = flattened_tensor_bucket_dict["flattened_tensor"]
         metadata = flattened_tensor_bucket_dict["metadata"]
 
+        # move to correct device
+        self.device_module = torch.get_device_module(self.device)
+        infered_device = self.device_module.current_device()
+        flattened_tensor = _unwrap_tensor(
+            flattened_tensor, tp_rank=self.tp_rank, device=infered_device
+        )
+
         # Convert metadata dict to our format
         converted_metadata = []
         for meta in metadata:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
move flatten buckets tensor into correct devices to avoid IMA in some corner cases: 

``` python
import gc
import time
import unittest

import torch

import sglang as sgl
from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket
from sglang.test.test_utils import CustomTestCase

class TestUpdateWeightsFromTensor(CustomTestCase):
    def test_update_weights_from_tensor_load_format_flattened_bucket(self):
        """Test updating weights using flattened_bucket format"""
        tp_size = 4
        engine = sgl.Engine(
            model_path="Qwen/Qwen3-Next-80B-A3B-Instruct-FP8",
            tp_size=tp_size,
            context_length=1024,
            mem_fraction_static=0.7,
            enable_memory_saver=True,
            attention_backend="triton"
        )
        engine.release_memory_occupation(tags=["kv_cache", "weights"])
        engine.resume_memory_occupation(tags=["kv_cache", "weights"])

        # Create a small set of parameters for testing
        param_names = [("model.layers.0.mlp.experts.6.down_proj.weight", (2048, 512))]
        param_names += [("model.layers.0.mlp.experts.6.up_proj.weight", (512, 2048))]
 

        # Create new tensors with different values
        new_tensors = []
        for _, (name, shape) in enumerate(param_names):
            # Create tensors with different values for each parameter
            value = 2.0  # Different value for each parameter
            new_tensor = torch.full(shape, value, device=f"cuda", dtype=torch.float8_e4m3fn)
            new_tensors.append((name, new_tensor))

        # # Create a flattened bucket
        flattened_bucket = FlattenedTensorBucket(named_tensors=new_tensors)

        # # Extract the flattened tensor and metadata in the format expected by model_runner
        flattened_tensor = flattened_bucket.get_flattened_tensor()
        metadata = flattened_bucket.get_metadata()

        # # Create the dict format expected by _update_weights_from_flattened_bucket
        bucket_dict = {"flattened_tensor": flattened_tensor, "metadata": metadata}

        # # Serialize the bucket data
        from sglang.srt.utils import MultiprocessingSerializer

        serialized_bucket = MultiprocessingSerializer.serialize(
            bucket_dict, output_str=True
        )

        # # # Create a list where each rank contains the same serialized data
        # # # This simulates the distributed environment where each rank has the same data
        serialized_bucket_list = [serialized_bucket] * tp_size

        # # Update weights using flattened_bucket format
        time_start = time.perf_counter()
        engine.update_weights_from_tensor(
            named_tensors=serialized_bucket_list, load_format="flattened_bucket"
        )
        update_time = time.perf_counter() - time_start
        print(f"Flattened bucket update time: {update_time:.03f}")

        engine.shutdown()

if __name__ == "__main__":
    unittest.main()
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #19090061338](https://github.com/sgl-project/sglang/actions/runs/19090061338)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->