### PR TITLE
[router][grpc] Implement tool_choice support for Responses API

### DIFF
--- a/sgl-router/src/protocols/responses.rs
+++ b/sgl-router/src/protocols/responses.rs
@@ -447,6 +447,7 @@ fn default_top_p() -> Option<f32> {
 // ============================================================================
 
 #[derive(Debug, Clone, Deserialize, Serialize, Validate)]
+#[validate(schema(function = "validate_responses_cross_parameters"))]
 pub struct ResponsesRequest {
     /// Run the request in the background
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -718,6 +719,83 @@ pub fn validate_conversation_id(conv_id: &str) -> Result<(), validator::Validati
         )));
         return Err(error);
     }
+    Ok(())
+}
+
+/// Schema-level validation for cross-field dependencies
+fn validate_responses_cross_parameters(
+    request: &ResponsesRequest,
+) -> Result<(), validator::ValidationError> {
+    use super::common::{ToolChoice, ToolReference};
+
+    // Only validate if both tools and tool_choice are present
+    if let (Some(tools), Some(tool_choice)) = (&request.tools, &request.tool_choice) {
+        // Extract function tool names from ResponseTools
+        let function_tool_names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| match t.r#type {
+                ResponseToolType::Function => t.function.as_ref().map(|f| f.name.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        match tool_choice {
+            ToolChoice::Function { function, .. } => {
+                // Validate the specific function exists
+                if !function_tool_names.contains(&function.name.as_str()) {
+                    let mut e = validator::ValidationError::new("tool_choice_function_not_found");
+                    e.message = Some(
+                        format!(
+                            "Invalid value for 'tool_choice': function '{}' not found in 'tools'.",
+                            function.name
+                        )
+                        .into(),
+                    );
+                    return Err(e);
+                }
+            }
+            ToolChoice::AllowedTools {
+                mode,
+                tools: allowed_tools,
+                ..
+            } => {
+                // Validate mode is "auto" or "required"
+                if mode != "auto" && mode != "required" {
+                    let mut e = validator::ValidationError::new("tool_choice_invalid_mode");
+                    e.message = Some(
+                        format!(
+                            "Invalid value for 'tool_choice.mode': must be 'auto' or 'required', got '{}'.",
+                            mode
+                        )
+                        .into(),
+                    );
+                    return Err(e);
+                }
+
+                // Validate that all function tool references exist
+                for tool_ref in allowed_tools {
+                    if let ToolReference::Function { name } = tool_ref {
+                        if !function_tool_names.contains(&name.as_str()) {
+                            let mut e =
+                                validator::ValidationError::new("tool_choice_tool_not_found");
+                            e.message = Some(
+                                format!(
+                                    "Invalid value for 'tool_choice.tools': tool '{}' not found in 'tools'.",
+                                    name
+                                )
+                                .into(),
+                            );
+                            return Err(e);
+                        }
+                    }
+                    // Note: MCP and hosted tools don't need existence validation here
+                    // as they are resolved dynamically at runtime
+                }
+            }
+            _ => {}
+        }
+    }
+
     Ok(())
 }
 

--- a/sgl-router/src/routers/grpc/common/responses/utils.rs
+++ b/sgl-router/src/routers/grpc/common/responses/utils.rs
@@ -11,7 +11,10 @@ use serde_json::json;
 use crate::{
     core::WorkerRegistry,
     mcp::McpManager,
-    protocols::responses::{ResponseTool, ResponseToolType},
+    protocols::{
+        common::Tool,
+        responses::{ResponseTool, ResponseToolType},
+    },
     routers::{grpc::error, openai::mcp::ensure_request_mcp_client},
 };
 
@@ -75,4 +78,48 @@ pub fn validate_worker_availability(
     }
 
     None
+}
+
+/// Extract function tools (and optionally MCP tools) from ResponseTools
+///
+/// This utility consolidates the logic for extracting tools with schemas from ResponseTools.
+/// It's used by both Harmony and Regular routers for different purposes:
+///
+/// - **Harmony router**: Extracts both Function and MCP tools (with `include_mcp: true`)
+///   because MCP schemas are populated by convert_mcp_tools_to_response_tools() before the
+///   pipeline runs. These tools are used to generate structural constraints in the
+///   Harmony preparation stage.
+///
+/// - **Regular router**: Extracts only Function tools (with `include_mcp: false`) during
+///   the initial conversion from ResponsesRequest to ChatCompletionRequest. MCP tools
+///   are merged later by the tool loop before being sent to the chat pipeline, where
+///   tool_choice constraints are generated for ALL tools (function + MCP combined).
+pub fn extract_tools_from_response_tools(
+    response_tools: Option<&[ResponseTool]>,
+    include_mcp: bool,
+) -> Vec<Tool> {
+    let Some(tools) = response_tools else {
+        return Vec::new();
+    };
+
+    tools
+        .iter()
+        .filter_map(|rt| {
+            match rt.r#type {
+                // Function tools: Schema in request
+                ResponseToolType::Function => rt.function.as_ref().map(|f| Tool {
+                    tool_type: "function".to_string(),
+                    function: f.clone(),
+                }),
+                // MCP tools: Schema populated by convert_mcp_tools_to_response_tools()
+                // Only include if requested (Harmony case)
+                ResponseToolType::Mcp if include_mcp => rt.function.as_ref().map(|f| Tool {
+                    tool_type: "function".to_string(),
+                    function: f.clone(),
+                }),
+                // Hosted tools: No schema available, skip
+                _ => None,
+            }
+        })
+        .collect()
 }

--- a/sgl-router/src/routers/grpc/harmony/stages/request_building.rs
+++ b/sgl-router/src/routers/grpc/harmony/stages/request_building.rs
@@ -84,6 +84,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                     placeholder_processed_text,
                     prep.token_ids.clone(),
                     prep.harmony_stop_ids.clone(),
+                    prep.tool_constraints.clone(),
                 )
                 .map_err(|e| error::bad_request(format!("Invalid request parameters: {}", e)))?,
             _ => unreachable!(),

--- a/sgl-router/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/handlers.rs
@@ -58,7 +58,7 @@ use crate::{
     },
     protocols::{
         chat::{self, ChatCompletionStreamResponse},
-        common,
+        common::{self, ToolChoice},
         responses::{
             self, ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
             ResponseReasoningContent, ResponseStatus, ResponsesRequest, ResponsesResponse,
@@ -657,7 +657,7 @@ impl StreamingResponseAccumulator {
             store: self.original_request.store.unwrap_or(true),
             temperature: self.original_request.temperature,
             text: None,
-            tool_choice: "auto".to_string(),
+            tool_choice: ToolChoice::serialize_to_string(&self.original_request.tool_choice),
             tools: self.original_request.tools.clone().unwrap_or_default(),
             top_p: self.original_request.top_p,
             truncation: None,

--- a/sgl-router/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/sgl-router/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -40,7 +40,7 @@ impl ChatPreparationStage {
         request: &ChatCompletionRequest,
     ) -> Result<(), Response> {
         // Step 1: Filter tools if needed
-        let body_ref = utils::filter_tools_for_request(request);
+        let body_ref = utils::filter_chat_request_by_tool_choice(request);
 
         // Step 2: Process messages and apply chat template
         let processed_messages =

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -273,39 +273,57 @@ fn build_required_array_schema(tools: &[Tool]) -> Result<String, String> {
         .map_err(|e| format!("Failed to serialize tool schema: {}", e))
 }
 
-/// Filter tools based on tool_choice
-/// Returns a reference to the original body if no filtering needed,
-/// otherwise returns a cloned and filtered body
-pub fn filter_tools_for_request(
-    body: &ChatCompletionRequest,
-) -> std::borrow::Cow<'_, ChatCompletionRequest> {
-    match &body.tool_choice {
-        Some(ToolChoice::AllowedTools { tools: allowed, .. }) if body.tools.is_some() => {
-            let mut filtered_body = body.clone();
-            let all_tools = filtered_body.tools.as_ref().unwrap();
+/// Filter tools based on tool_choice (generic helper)
+///
+/// Returns filtered tools if filtering is needed, otherwise returns None.
+/// Used by both Chat API and Responses API (Harmony) for constraint generation.
+pub fn filter_tools_by_tool_choice(
+    tools: &[Tool],
+    tool_choice: &Option<ToolChoice>,
+) -> Option<Vec<Tool>> {
+    match tool_choice {
+        Some(ToolChoice::AllowedTools { tools: allowed, .. }) => {
             let allowed_names: std::collections::HashSet<&str> =
                 allowed.iter().filter_map(|t| t.function_name()).collect();
-            let filtered_tools: Vec<Tool> = all_tools
+            let filtered: Vec<Tool> = tools
                 .iter()
                 .filter(|t| allowed_names.contains(t.function.name.as_str()))
                 .cloned()
                 .collect();
-            filtered_body.tools = Some(filtered_tools);
-            std::borrow::Cow::Owned(filtered_body)
+            Some(filtered)
         }
-        Some(ToolChoice::Function { function, .. }) if body.tools.is_some() => {
-            let mut filtered_body = body.clone();
-            let all_tools = filtered_body.tools.as_ref().unwrap();
-            let filtered_tools: Vec<Tool> = all_tools
+        Some(ToolChoice::Function { function, .. }) => {
+            let filtered: Vec<Tool> = tools
                 .iter()
                 .filter(|t| t.function.name == function.name)
                 .cloned()
                 .collect();
-            filtered_body.tools = Some(filtered_tools);
-            std::borrow::Cow::Owned(filtered_body)
+            Some(filtered)
         }
-        _ => std::borrow::Cow::Borrowed(body), // No filtering needed, use original
+        _ => None, // No filtering needed
     }
+}
+
+/// Filter ChatCompletionRequest by tool_choice
+///
+/// Returns a reference to the original request if no filtering needed,
+/// otherwise returns a cloned request with filtered tools.
+///
+/// Note: Tool existence is validated earlier in ChatCompletionRequest::validate(),
+/// so this function assumes tool_choice references valid tools.
+pub fn filter_chat_request_by_tool_choice(
+    body: &ChatCompletionRequest,
+) -> std::borrow::Cow<'_, ChatCompletionRequest> {
+    if let Some(tools) = &body.tools {
+        if let Some(filtered_tools) = filter_tools_by_tool_choice(tools, &body.tool_choice) {
+            let mut filtered_body = body.clone();
+            filtered_body.tools = Some(filtered_tools);
+            return std::borrow::Cow::Owned(filtered_body);
+        }
+    }
+
+    // No filtering needed - return original request
+    std::borrow::Cow::Borrowed(body)
 }
 
 /// Process chat messages and apply template (shared by both routers)

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -273,7 +273,7 @@ fn build_required_array_schema(tools: &[Tool]) -> Result<String, String> {
         .map_err(|e| format!("Failed to serialize tool schema: {}", e))
 }
 
-/// Filter tools based on tool_choice (shared by both routers)
+/// Filter tools based on tool_choice
 /// Returns a reference to the original body if no filtering needed,
 /// otherwise returns a cloned and filtered body
 pub fn filter_tools_for_request(

--- a/sgl-router/tests/spec/chat_completion.rs
+++ b/sgl-router/tests/spec/chat_completion.rs
@@ -349,8 +349,7 @@ fn test_tool_choice_allowed_tools_invalid_mode() {
         }]),
         tool_choice: Some(ToolChoice::AllowedTools {
             mode: "invalid_mode".to_string(),
-            tools: vec![ToolReference {
-                tool_type: "function".to_string(),
+            tools: vec![ToolReference::Function {
                 name: "get_weather".to_string(),
             }],
             tool_type: "function".to_string(),
@@ -387,8 +386,7 @@ fn test_tool_choice_allowed_tools_valid_mode_auto() {
         }]),
         tool_choice: Some(ToolChoice::AllowedTools {
             mode: "auto".to_string(),
-            tools: vec![ToolReference {
-                tool_type: "function".to_string(),
+            tools: vec![ToolReference::Function {
                 name: "get_weather".to_string(),
             }],
             tool_type: "function".to_string(),
@@ -419,8 +417,7 @@ fn test_tool_choice_allowed_tools_valid_mode_required() {
         }]),
         tool_choice: Some(ToolChoice::AllowedTools {
             mode: "required".to_string(),
-            tools: vec![ToolReference {
-                tool_type: "function".to_string(),
+            tools: vec![ToolReference::Function {
                 name: "get_weather".to_string(),
             }],
             tool_type: "function".to_string(),
@@ -451,8 +448,7 @@ fn test_tool_choice_allowed_tools_tool_not_found() {
         }]),
         tool_choice: Some(ToolChoice::AllowedTools {
             mode: "auto".to_string(),
-            tools: vec![ToolReference {
-                tool_type: "function".to_string(),
+            tools: vec![ToolReference::Function {
                 name: "nonexistent_tool".to_string(),
             }],
             tool_type: "function".to_string(),
@@ -501,12 +497,10 @@ fn test_tool_choice_allowed_tools_multiple_tools_valid() {
         tool_choice: Some(ToolChoice::AllowedTools {
             mode: "auto".to_string(),
             tools: vec![
-                ToolReference {
-                    tool_type: "function".to_string(),
+                ToolReference::Function {
                     name: "get_weather".to_string(),
                 },
-                ToolReference {
-                    tool_type: "function".to_string(),
+                ToolReference::Function {
                     name: "get_time".to_string(),
                 },
             ],
@@ -550,12 +544,10 @@ fn test_tool_choice_allowed_tools_one_invalid_among_valid() {
         tool_choice: Some(ToolChoice::AllowedTools {
             mode: "auto".to_string(),
             tools: vec![
-                ToolReference {
-                    tool_type: "function".to_string(),
+                ToolReference::Function {
                     name: "get_weather".to_string(),
                 },
-                ToolReference {
-                    tool_type: "function".to_string(),
+                ToolReference::Function {
                     name: "nonexistent_tool".to_string(),
                 },
             ],


### PR DESCRIPTION
## Motivation

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

The Responses API (`/v1/responses`) did not support the `tool_choice` parameter, which is a critical feature for controlling tool calling behavior according to OpenAI's Responses API specification. This limitation prevented users from:

- Forcing the model to call specific tools (`tool_choice: {type: "function", function: {name: "..."}}`)
- Requiring at least one tool call (`tool_choice: "required"`)
- Restricting tool calls to a subset of available tools (`tool_choice: {type: "allowed_tools", ...}`)
- Preventing tool calls entirely (`tool_choice: "none"`)

This PR implements full `tool_choice` support for the Responses API in both Harmony and Regular routers, following the same pattern as the existing Chat Completion API implementation.

## Modifications

### 1. Harmony Router - Responses API tool_choice Support

**File**: `src/routers/grpc/harmony/stages/preparation.rs`

- Added `tool_choice` constraint generation for Responses API requests
- Extracts both Function and MCP tools from `ResponseTools` (schemas populated before pipeline)
- Implements AllowedTools filtering to restrict tools based on user's tool_choice
- Generates Harmony structural tags using `triggered_tags` format for tool constraints
- Supports all tool_choice modes: none, auto, required, specific function, allowed_tools

### 2. Regular Router - Responses API tool_choice Support

**Files**:
- `src/routers/grpc/regular/responses/conversions.rs`
- `src/routers/grpc/regular/responses/tool_loop.rs`

**Flow**:
- `conversions.rs`: Extracts function tools and passes through `tool_choice` unchanged
- Without MCP: Function tools → chat pipeline → `tool_choice` constraints applied
- With MCP: Tool loop merges function + MCP tools → chat pipeline → constraints applied to ALL tools
- Loop iteration logic: Iteration 0 uses user's `tool_choice`, iteration 1+ uses "auto" to prevent infinite loops

### 3. ToolReference Protocol Enhancement

**File**: `src/protocols/common.rs`

Converted `ToolReference` from a simple struct to a tagged enum to properly support different tool types:

```rust
// Before (struct)
pub struct ToolReference {
    pub tool_type: String,
    pub name: String,
}

// After (enum)
pub enum ToolReference {
    Function { name: String },
    Mcp { server_label: String, name: Option<String> },
    FileSearch,
    WebSearchPreview,
    ComputerUsePreview,
    CodeInterpreter,
    ImageGeneration,
}
```

**Benefits**:
- Type-safe representation of different tool types
- Supports MCP and hosted tools (not just functions)
- Helper methods: `identifier()`, `function_name()`

### 4. Chat API Validation

**File**: `src/protocols/chat.rs`

Added validation that Chat Completion API ONLY accepts `Function` type ToolReference in tool_choice. Rejects MCP and hosted tools with clear error messages, enforcing the API contract.

### 5. Code Deduplication

**File**: `src/routers/grpc/common/responses/utils.rs`

Created shared utility function `extract_tools_from_response_tools()` to eliminate duplication:
- Used by both Harmony preparation stage and Regular conversions
- `include_mcp` parameter controls whether to extract MCP tools
- Comprehensive documentation explains usage differences between routers

### 6. Helper Function for Chat Requests

**File**: `src/routers/grpc/regular/responses/tool_loop.rs`

Created `prepare_chat_tools_and_choice()` helper to:
- Merge function tools from request with MCP tools
- Set `tool_choice` based on iteration (user's choice on iteration 0, "auto" on iteration 1+)
- Reduces duplication in tool loop

### 7. Bug Fixes

- **Fixed unnecessary `pub use`**: Changed `pub use crate::tokenizer::StopSequenceDecoder` to regular `use` in `utils.rs`
- **Updated test cases**: Fixed 6 test functions in `tests/spec/chat_completion.rs` to use new ToolReference enum syntax

### 8. Documentation

Added comprehensive comments explaining:
- Tool extraction flow in `conversions.rs` (why MCP path "wastes" initial extraction)
- Differences between Harmony and Regular router tool handling
- Tool loop iteration behavior with `tool_choice`


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

<img width="1703" height="1274" alt="Screenshot 2025-11-04 at 7 54 07 PM" src="https://github.com/user-attachments/assets/77d44423-87b2-4a6f-8b3f-fd7aad58209f" />



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
