### PR TITLE
Fix VLLM dependency test

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -218,6 +218,7 @@ suites = {
     "__not_in_ci__": [
         TestFile("ascend/test_ascend_w8a8_quantization.py"),
         TestFile("cpu/test_comm.py"),
+        TestFile("test_deepseek_v3_cutedsl_4gpu.py"),
         TestFile("entrypoints/http_server/test_abort_request.py"),
         TestFile("ep/test_deepep_internode.py"),
         TestFile("ep/test_deepep_intranode.py"),


### PR DESCRIPTION
Error: https://github.com/sgl-project/sglang/actions/runs/19091076318/job/54541789708. The test was commented out.