### PR TITLE
Feat/fused dual input rmsnorm

### DIFF
--- a/benchmark/kernels/elementwise/benchmark_dual_input_rmsnorm.py
+++ b/benchmark/kernels/elementwise/benchmark_dual_input_rmsnorm.py
@@ -1,0 +1,166 @@
+from typing import Optional, Tuple, Union
+
+import torch
+import triton
+from triton.testing import do_bench
+
+from flashinfer.norm import rmsnorm
+from sglang.srt.layers.elementwise import fused_dual_input_rmsnorm
+from vllm import _custom_ops as vllm_ops
+
+
+def compute_dual_rms_baseline(x1, x2, w1, w2, eps):
+    o1 = torch.nn.functional.rms_norm(x1, (x1.shape[-1], ), w1, eps)
+    o2 = torch.nn.functional.rms_norm(x2, (x2.shape[-1], ), w2, eps)
+    return o1, o2
+
+
+def compute_dual_rmsnorm_flashinfer(
+    x1: torch.Tensor,
+    x2: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    eps: float = 1e-6,
+):
+    out1 = torch.empty_like(x1)
+    out2 = torch.empty_like(x2)
+    vllm_ops.rms_norm(out1, x1, weight1, eps)
+    vllm_ops.rms_norm(out2, x2, weight2, eps)
+    return out1, out2
+
+
+def compute_dual_rmsnorm_vllm(
+    x1: torch.Tensor,
+    x2: torch.Tensor,
+    weight1: torch.Tensor,
+    weight2: torch.Tensor,
+    eps: float = 1e-6,
+):
+    return rmsnorm(x1, weight1, eps), rmsnorm(x2, weight2, eps)
+
+
+def compute_dual_rms_triton(x1, x2, w1, w2, eps):
+    return fused_dual_input_rmsnorm(
+        x1,
+        w1,
+        eps,
+        x2,
+        w2,
+        eps,
+    )
+
+
+def get_benchmark():
+    num_tokens_range = [2**i for i in range(0, 13)]
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["num_tokens"],
+            x_vals=num_tokens_range,
+            line_arg="version",
+            line_vals=["baseline", "triton", "flashinfer", "vllm"],
+            line_names=["Original", "Triton", "Flashinfer", "vLLM"],
+            styles=[("blue", "-"), ("green", "-"), ("red", "-"), ("yellow", "-")],
+            ylabel="us",
+            plot_name="dual_rmsnorm_performance",
+            args={},
+        )
+    )
+    def benchmark(num_tokens, version):
+        hidden_size1 = 1536
+        hidden_size2 = 64
+        eps = 1e-6
+        
+        dtype = torch.bfloat16
+        device = "cuda"
+        x1 = torch.randn([num_tokens, hidden_size1], dtype=dtype, device=device)
+        w1 = torch.ones(hidden_size1, dtype=dtype, device=device)
+        x2 = torch.randn([num_tokens, hidden_size2], dtype=dtype, device=device)
+        w2 = torch.ones(hidden_size2, dtype=dtype, device=device)
+
+        # Warmup
+        for _ in range(3):
+            if version == "baseline":
+                compute_dual_rms_baseline(x1, x2, w1, w2, eps)
+            elif version == "triton":
+                compute_dual_rms_triton(x1, x2, w1, w2, eps)
+            elif version == "flashinfer":
+                compute_dual_rmsnorm_flashinfer(x1, x2, w1, w2, eps)
+            elif version == "vllm":
+                compute_dual_rmsnorm_vllm(x1, x2, w1, w2, eps)
+            else:
+                raise ValueError(f"benchmark not support {version=}.")
+
+        # Benchmark
+        quantiles = [0.5, 0.2, 0.8]
+        if version == "baseline":
+            ms, min_ms, max_ms = do_bench(
+                lambda: compute_dual_rms_baseline(x1, x2, w1, w2, eps),
+                quantiles=quantiles,
+            )
+        elif version == "triton":
+            ms, min_ms, max_ms = do_bench(
+                lambda: compute_dual_rms_triton(x1, x2, w1, w2, eps),
+                quantiles=quantiles,
+            )
+        elif version == "flashinfer":
+            ms, min_ms, max_ms = do_bench(
+                lambda: compute_dual_rmsnorm_flashinfer(x1, x2, w1, w2, eps),
+                quantiles=quantiles,
+            )
+        elif version == "vllm":
+            ms, min_ms, max_ms = do_bench(
+                lambda: compute_dual_rmsnorm_vllm(x1, x2, w1, w2, eps),
+                quantiles=quantiles,
+            )
+        else:
+            raise ValueError(f"benchmark not support {version=}.")
+
+        return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+    return benchmark
+
+
+def verify_correctness(num_tokens=1024, check_no_contiguous_layout=False):
+    hidden_size1 = 1536
+    hidden_size2 = 64
+    eps = 1e-6
+    dtype = torch.bfloat16
+    device = "cuda"
+    
+    if check_no_contiguous_layout:
+        buffer_size = hidden_size1 + hidden_size2
+        x1 = torch.randn(num_tokens * buffer_size, dtype=dtype, device=device)
+        x1 = torch.as_strided(x1, size=(num_tokens, hidden_size1), stride=(buffer_size, 1))
+        x2 = torch.randn(num_tokens * buffer_size, dtype=dtype, device=device)
+        x2 = torch.as_strided(x2, size=(num_tokens, hidden_size2), stride=(buffer_size, 1))
+    else:
+        x1 = torch.randn([num_tokens, hidden_size1], dtype=dtype, device=device)
+        x2 = torch.randn([num_tokens, hidden_size2], dtype=dtype, device=device)
+    w1 = torch.randn(hidden_size1, dtype=dtype, device=device)
+    w2 = torch.randn(hidden_size2, dtype=dtype, device=device)
+
+    out_baseline= compute_dual_rms_baseline(x1, x2, w1, w2, eps)
+    out_triton = compute_dual_rms_triton(x1, x2, w1, w2, eps)
+
+    if torch.allclose(
+        out_baseline[0], out_triton[0], atol=1e-2, rtol=1e-2
+    ) and torch.allclose(out_baseline[1], out_triton[1], atol=1e-2, rtol=1e-2):
+        print(f"✅ All implementations match")
+    else:
+        print("❌ Implementations differ")
+        print(f"Baseline vs Triton 1: {(out_baseline[0] - out_triton[0]).abs().max().item()}")
+        print(f"Baseline vs Triton 2: {(out_baseline[1] - out_triton[1]).abs().max().item()}")
+
+
+if __name__ == "__main__":
+    print("Running correctness verification...")
+    verify_correctness()
+    verify_correctness(check_no_contiguous_layout=True)    
+
+    print("\nRunning performance benchmark...")
+    benchmark = get_benchmark()
+    benchmark.run(
+        print_data=True,
+        # save_path="./configs/benchmark_ops/dual_input_rmsnorm/"
+)

--- a/benchmark/kernels/elementwise/benchmark_dual_input_rmsnorm.py
+++ b/benchmark/kernels/elementwise/benchmark_dual_input_rmsnorm.py
@@ -1,5 +1,3 @@
-from typing import Optional, Tuple, Union
-
 import torch
 import triton
 from flashinfer.norm import rmsnorm

--- a/benchmark/kernels/elementwise/benchmark_dual_input_rmsnorm.py
+++ b/benchmark/kernels/elementwise/benchmark_dual_input_rmsnorm.py
@@ -2,16 +2,16 @@ from typing import Optional, Tuple, Union
 
 import torch
 import triton
-from triton.testing import do_bench
-
 from flashinfer.norm import rmsnorm
-from sglang.srt.layers.elementwise import fused_dual_input_rmsnorm
+from triton.testing import do_bench
 from vllm import _custom_ops as vllm_ops
+
+from sglang.srt.layers.elementwise import fused_dual_input_rmsnorm
 
 
 def compute_dual_rms_baseline(x1, x2, w1, w2, eps):
-    o1 = torch.nn.functional.rms_norm(x1, (x1.shape[-1], ), w1, eps)
-    o2 = torch.nn.functional.rms_norm(x2, (x2.shape[-1], ), w2, eps)
+    o1 = torch.nn.functional.rms_norm(x1, (x1.shape[-1],), w1, eps)
+    o2 = torch.nn.functional.rms_norm(x2, (x2.shape[-1],), w2, eps)
     return o1, o2
 
 
@@ -70,7 +70,7 @@ def get_benchmark():
         hidden_size1 = 1536
         hidden_size2 = 64
         eps = 1e-6
-        
+
         dtype = torch.bfloat16
         device = "cuda"
         x1 = torch.randn([num_tokens, hidden_size1], dtype=dtype, device=device)
@@ -127,20 +127,24 @@ def verify_correctness(num_tokens=1024, check_no_contiguous_layout=False):
     eps = 1e-6
     dtype = torch.bfloat16
     device = "cuda"
-    
+
     if check_no_contiguous_layout:
         buffer_size = hidden_size1 + hidden_size2
         x1 = torch.randn(num_tokens * buffer_size, dtype=dtype, device=device)
-        x1 = torch.as_strided(x1, size=(num_tokens, hidden_size1), stride=(buffer_size, 1))
+        x1 = torch.as_strided(
+            x1, size=(num_tokens, hidden_size1), stride=(buffer_size, 1)
+        )
         x2 = torch.randn(num_tokens * buffer_size, dtype=dtype, device=device)
-        x2 = torch.as_strided(x2, size=(num_tokens, hidden_size2), stride=(buffer_size, 1))
+        x2 = torch.as_strided(
+            x2, size=(num_tokens, hidden_size2), stride=(buffer_size, 1)
+        )
     else:
         x1 = torch.randn([num_tokens, hidden_size1], dtype=dtype, device=device)
         x2 = torch.randn([num_tokens, hidden_size2], dtype=dtype, device=device)
     w1 = torch.randn(hidden_size1, dtype=dtype, device=device)
     w2 = torch.randn(hidden_size2, dtype=dtype, device=device)
 
-    out_baseline= compute_dual_rms_baseline(x1, x2, w1, w2, eps)
+    out_baseline = compute_dual_rms_baseline(x1, x2, w1, w2, eps)
     out_triton = compute_dual_rms_triton(x1, x2, w1, w2, eps)
 
     if torch.allclose(
@@ -149,18 +153,22 @@ def verify_correctness(num_tokens=1024, check_no_contiguous_layout=False):
         print(f"✅ All implementations match")
     else:
         print("❌ Implementations differ")
-        print(f"Baseline vs Triton 1: {(out_baseline[0] - out_triton[0]).abs().max().item()}")
-        print(f"Baseline vs Triton 2: {(out_baseline[1] - out_triton[1]).abs().max().item()}")
+        print(
+            f"Baseline vs Triton 1: {(out_baseline[0] - out_triton[0]).abs().max().item()}"
+        )
+        print(
+            f"Baseline vs Triton 2: {(out_baseline[1] - out_triton[1]).abs().max().item()}"
+        )
 
 
 if __name__ == "__main__":
     print("Running correctness verification...")
     verify_correctness()
-    verify_correctness(check_no_contiguous_layout=True)    
+    verify_correctness(check_no_contiguous_layout=True)
 
     print("\nRunning performance benchmark...")
     benchmark = get_benchmark()
     benchmark.run(
         print_data=True,
         # save_path="./configs/benchmark_ops/dual_input_rmsnorm/"
-)
+    )

--- a/python/sglang/srt/layers/elementwise.py
+++ b/python/sglang/srt/layers/elementwise.py
@@ -270,7 +270,13 @@ def fused_rmsnorm(x, weight, eps, autotune=False, inplace=False):
     }
 
     fused_rmsnorm_kernel[(bs,)](
-        output, x, weight, eps=eps, hidden_dim=hidden_dim, stride_row=stride_row, **config
+        output,
+        x,
+        weight,
+        eps=eps,
+        hidden_dim=hidden_dim,
+        stride_row=stride_row,
+        **config,
     )
     return output
 
@@ -279,9 +285,9 @@ def fused_rmsnorm(x, weight, eps, autotune=False, inplace=False):
 def fused_dual_input_rmsnorm_kernel(
     output_ptr1,
     output_ptr2,
-    activ_ptr1, 
+    activ_ptr1,
     activ_ptr2,
-    weight_ptr1, 
+    weight_ptr1,
     weight_ptr2,
     eps1: tl.constexpr,
     eps2: tl.constexpr,
@@ -292,19 +298,28 @@ def fused_dual_input_rmsnorm_kernel(
     BLOCK_SIZE1: tl.constexpr,
     BLOCK_SIZE2: tl.constexpr,
 ):
-    fused_rmsnorm_kernel(output_ptr1, activ_ptr1, weight_ptr1, eps1, hidden_dim1, stride_row1, BLOCK_SIZE1)
-    fused_rmsnorm_kernel(output_ptr2, activ_ptr2, weight_ptr2, eps2, hidden_dim2, stride_row2, BLOCK_SIZE2)
+    fused_rmsnorm_kernel(
+        output_ptr1,
+        activ_ptr1,
+        weight_ptr1,
+        eps1,
+        hidden_dim1,
+        stride_row1,
+        BLOCK_SIZE1,
+    )
+    fused_rmsnorm_kernel(
+        output_ptr2,
+        activ_ptr2,
+        weight_ptr2,
+        eps2,
+        hidden_dim2,
+        stride_row2,
+        BLOCK_SIZE2,
+    )
 
 
 def fused_dual_input_rmsnorm(
-    x1,
-    weight1,
-    eps1,
-    x2,
-    weight2,
-    eps2,
-    autotune=False, 
-    inplace=False
+    x1, weight1, eps1, x2, weight2, eps2, autotune=False, inplace=False
 ):
     assert len(x1.shape) == 2 and len(x2.shape) == 2
     assert x1.shape[0] == x2.shape[0]
@@ -314,18 +329,22 @@ def fused_dual_input_rmsnorm(
     else:
         output1 = torch.empty_like(x1)
         output2 = torch.empty_like(x2)
-    
+
     bs, headdim_x1 = x1.shape
     _, headdim_x2 = x2.shape
     stride_row_x1 = x1.stride(0)
     stride_row_x2 = x2.stride(0)
-    
+
     max_warps = 16 if _is_hip else 32
     config = {
         "BLOCK_SIZE1": triton.next_power_of_2(headdim_x1),
         "BLOCK_SIZE2": triton.next_power_of_2(headdim_x2),
         "num_warps": max(
-            min(triton.next_power_of_2(triton.cdiv(max(headdim_x1, headdim_x2), 256)), max_warps), 4
+            min(
+                triton.next_power_of_2(triton.cdiv(max(headdim_x1, headdim_x2), 256)),
+                max_warps,
+            ),
+            4,
         ),
     }
 
@@ -342,7 +361,7 @@ def fused_dual_input_rmsnorm(
         hidden_dim2=headdim_x2,
         stride_row1=stride_row_x1,
         stride_row2=stride_row_x2,
-        **config
+        **config,
     )
     return output1, output2
 

--- a/python/sglang/srt/layers/elementwise.py
+++ b/python/sglang/srt/layers/elementwise.py
@@ -263,9 +263,9 @@ def fused_rmsnorm(x, weight, eps, autotune=False, inplace=False):
     stride_row = x.stride(0)
     max_warps = 16 if _is_hip else 32
     config = {
-        "BLOCK_SIZE": triton.next_power_of_2(stride_row),
+        "BLOCK_SIZE": triton.next_power_of_2(hidden_dim),
         "num_warps": max(
-            min(triton.next_power_of_2(triton.cdiv(stride_row, 256)), max_warps), 4
+            min(triton.next_power_of_2(triton.cdiv(hidden_dim, 256)), max_warps), 4
         ),
     }
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -64,6 +64,7 @@ from sglang.srt.layers.dp_attention import (
     get_attention_tp_size,
     is_dp_attention_enabled,
 )
+from sglang.srt.layers.elementwise import fused_dual_input_rmsnorm
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
     ColumnParallelLinear,
@@ -91,7 +92,6 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_tensor_quant_mla_fp8,
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
-from sglang.srt.layers.elementwise import fused_dual_input_rmsnorm
 from sglang.srt.layers.quantization.fp8_utils import (
     block_quant_dequant,
     block_quant_to_tensor_quant,


### PR DESCRIPTION
Motivation:
During the performance optimization of DeepSeek-R1, we identified an opportunity to fuse the layernorm operations for q and k_nope into a single Triton kernel. While the performance gain on CUDA is minimal, this fusion reduces kernel launch overhead, which may yield more significant benefits on other GPU platforms.

Modifications:
Added a stride parameter to the fused_rmsnorm_kernel implementation. This ensures computational accuracy when handling inputs with non-contiguous memory layouts.

## Accuracy Tests
<img width="2213" height="381" alt="image" src="https://github.com/user-attachments/assets/e6205e5b-0b09-4b24-87f6-9e31a1980df7" />


## Benchmarking
<img width="1039" height="911" alt="image" src="https://github.com/user-attachments/assets/c895988d-148d-4358-bcec-0589f30b612c" />

## Profiling
**Use alt_stream**

<img width="773" height="924" alt="2a286c4aa5cca2fba683fb50800929cc" src="https://github.com/user-attachments/assets/be4542c4-89d0-4abf-8b63-8bcb9c136112" />

**Use fused_dual_input_rmsnorm**

<img width="1023" height="824" alt="cb78be0641e9b9ff3a2e0ff1dc92a013" src="https://github.com/user-attachments/assets/88dc1c1c-f0ba-4f00-b64f-542711dafe2c" />

