### PR TITLE
fix trtllm_mla attention backend when disabling cuda graph.

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -585,7 +585,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             if forward_batch.forward_mode.is_target_verify():
                 max_seq = max_seq + self.num_draft_tokens
                 seq_lens = seq_lens + self.num_draft_tokens
-                self.forward_decode_metadata.seq_lens_k = seq_lens
+                self.forward_decode_metadata.seq_lens_k = seq_lens.to(torch.int32)
             elif forward_batch.forward_mode.is_draft_extend(include_v2=True):
                 max_seq = forward_batch.seq_lens_cpu.max().item()
 
@@ -604,7 +604,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 self.forward_decode_metadata.sum_seq_lens_q = sum_seq_lens_q
                 self.forward_decode_metadata.cu_seqlens_q = cu_seqlens_q
                 self.forward_decode_metadata.seq_lens_q = forward_batch.extend_seq_lens
-                self.forward_decode_metadata.seq_lens_k = seq_lens
+                self.forward_decode_metadata.seq_lens_k = seq_lens.to(torch.int32)
 
             max_seqlen_pad = self._calc_padded_blocks(max_seq)
             block_kv_indices = self._create_block_kv_indices(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When `spec_v2` is enabled, the draft extend path does not use CUDA Graph. However, in `init_forward_metadata`, `seq_lens` is not converted to `torch.int32`, which causes incorrect computation in `trtllm_batch_decode_with_kv_cache_mla`, leading to a drop in acceptance length when bs>1.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

-  serving command
```
SGLANG_ENABLE_SPEC_V2=[0/1] \
python3 -m sglang.launch_server \
  --model-path  nvidia/DeepSeek-V3-0324-FP4 \
  --trust-remote-code \
  --quantization modelopt_fp4 \
  --tp 4 \
  --attention-backend trtllm_mla \
  --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend flashinfer_trtllm \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 8}' \
  --host 0.0.0.0 \
  --port 17345 \
  --enable-metrics \
  --enable-flashinfer-allreduce-fusion \
  --page-size 64 \
  --max-running-requests 32

```

bench command
```
python3 -m sglang.bench_serving --backend sglang --dataset-name generated-shared-prefix --gsp-question-len 5000 --gsp-output-len 1024 --gsp-system-prompt-len 45000  --gsp-prompts-per-group 16 --gsp-num-groups 1 --max-concurrency 8 --port 17345 --seed 1
```

- main `SGLANG_ENABLE_SPEC_V2=1`
```
Accept length:                           2.46
```

- this pr `SGLANG_ENABLE_SPEC_V2=1`
```
Accept length:                           3.01
```

- `SGLANG_ENABLE_SPEC_V2=0`
```
Accept length:                           3.01
```

(Funny thing is when I change the `bench_serving.py`'s seed from `1` to `42`, the acc len drop was from 3.4 to 3.36, this is also why https://github.com/sgl-project/sglang/pull/12680 was introduced)

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
