### PR TITLE
Refactor `--debug-tensor-dump-layers` to list

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -519,8 +519,8 @@ class ServerArgs:
 
     # Debug tensor dumps
     debug_tensor_dump_output_folder: Optional[str] = None
-    # -1 mean dump all layers.
-    debug_tensor_dump_layers: int = -1
+    # None means dump all layers.
+    debug_tensor_dump_layers: Optional[List[int]] = None
     # TODO(guoyuhong): clean the old dumper code.
     debug_tensor_dump_input_file: Optional[str] = None
     debug_tensor_dump_inject: bool = False
@@ -3424,8 +3424,8 @@ class ServerArgs:
         parser.add_argument(
             "--debug-tensor-dump-layers",
             type=int,
-            default=-1,
-            help="The layer number for dumping tensors.",
+            nargs="+",
+            help="The layer ids to dump. Dump all layers if not specified.",
         )
         parser.add_argument(
             "--debug-tensor-dump-input-file",

--- a/test/srt/debug_utils/test_tensor_dump_forward_hook.py
+++ b/test/srt/debug_utils/test_tensor_dump_forward_hook.py
@@ -13,6 +13,7 @@ from sglang.srt.distributed.parallel_state import (
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import LinearBase
 from sglang.srt.models.qwen2 import Qwen2MLP
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.srt.utils import add_prefix
 
 TEST_HIDDEN_SIZE = 32
@@ -63,6 +64,7 @@ def init_weights(module):
 
 
 def test_model_forward_dump(tmp_path):
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
     init_distributed_environment(
         backend="nccl",
         world_size=1,
@@ -75,7 +77,7 @@ def test_model_forward_dump(tmp_path):
     model.apply(init_weights)
     model = model.cuda().bfloat16()
     dumper = register_forward_hook_for_model(
-        model, tmp_path / "sglang_dump", -1, 0, 0, 0
+        model, tmp_path / "sglang_dump", [0], 0, 0, 0
     )
 
     dir_path = dumper.get_dump_dir()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

As discussed in [this GitHub comment](https://github.com/sgl-project/sglang/pull/10566#discussion_r2491984807), this PR modifies the `--debug-tensor-dump-layers` argument to accept a list of layer indices.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Without specifying `--debug-tensor-dump-layers`, the dumped files include output tensors from all layers.
<img width="4240" height="922" alt="image" src="https://github.com/user-attachments/assets/a771f939-c6a5-48dd-8713-3bb2daf7572f" />



With `--debug-tensor-dump-layers 0 2 4`, only the output tensors from layers 0, 2, and 4 are included in the dump.
<img width="4330" height="194" alt="image" src="https://github.com/user-attachments/assets/743b2fde-1b24-4801-b861-f1e783d5e559" />


UT:
<img width="3612" height="2086" alt="image" src="https://github.com/user-attachments/assets/1ed7d412-454f-4e68-844d-ed336bb30530" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
