### PR TITLE
[feature]add capacity control in file storagebackend

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -787,3 +787,16 @@ class HiCacheController:
 
             except Empty:
                 continue
+
+    def queue_storage_cleanup(self, keys: List[str]):
+        """
+        Queue storage keys for background cleanup.
+        This method delegates to the storage backend's cleanup mechanism.
+        Args:
+            keys: List of hash keys to be deleted from storage
+        """
+        if not self.enable_storage or not keys:
+            return
+        # Delegate to storage backend's cleanup queue
+        if hasattr(self.storage_backend, "queue_cleanup"):
+            self.storage_backend.queue_cleanup(keys)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1291,7 +1291,6 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             else:
                 self.dump_requests_before_crash()
                 break
-
         kill_process_tree(os.getpid(), include_parent=True)
         sys.exit(0)
 

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -1,7 +1,10 @@
 import hashlib
 import logging
 import os
+import threading
+import time
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
@@ -156,9 +159,20 @@ class HiCacheStorage(ABC):
     def get_stats(self):
         return None
 
+    def queue_cleanup(self, keys: List[str]):
+        """
+        Queue keys for background cleanup.
+        This is an optional method that can be implemented by subclasses that need
+        background cleanup functionality (e.g., file-based storage).
+        Args:
+            keys: List of keys to be deleted from storage
+        """
+        # Default implementation: do nothing
+        # Subclasses can override this to implement background cleanup
+        pass
+
 
 class HiCacheFile(HiCacheStorage):
-
     def __init__(
         self, storage_config: HiCacheStorageConfig, file_path: str = "/tmp/hicache"
     ):
@@ -176,9 +190,195 @@ class HiCacheFile(HiCacheStorage):
         else:
             self.config_suffix = f"_{model_name}_{tp_rank}_{tp_size}"
 
-        if not os.path.exists(self.file_path) and tp_rank == 0:
+        self.tp_rank = tp_rank
+        if not os.path.exists(self.file_path) and self.tp_rank == 0:
             os.makedirs(self.file_path)
             logger.info(f"Created HiCacheFile storage directory at {self.file_path}")
+
+        # Capacity control
+        # Get capacity limit from config or environment variable
+        # Default: no limit (None means unlimited)
+        self.max_capacity_bytes = None
+        if (
+            storage_config.extra_config
+            and "max_capacity_gb" in storage_config.extra_config
+        ):
+            self.max_capacity_bytes = int(
+                storage_config.extra_config["max_capacity_gb"] * 1024 * 1024 * 1024
+            )
+        elif os.getenv("SGLANG_HICACHE_FILE_BACKEND_MAX_CAPACITY_GB"):
+            self.max_capacity_bytes = int(
+                float(os.getenv("SGLANG_HICACHE_FILE_BACKEND_MAX_CAPACITY_GB"))
+                * 1024
+                * 1024
+                * 1024
+            )
+        # Current capacity tracking (in bytes)
+        self._current_capacity_bytes = 0
+        self._capacity_lock = threading.Lock()
+        # LRU tracking for automatic capacity management
+        # OrderedDict maintains insertion order, least recently used at the front
+        self._lru_order = OrderedDict()  # key -> access_time
+        self._lru_lock = threading.Lock()
+        # Whether cleanup fs storage directory when init
+        self._cleanup_on_init = False
+        if (
+            storage_config.extra_config
+            and "cleanup_on_init" in storage_config.extra_config
+        ):
+            self._cleanup_on_init = bool(storage_config.extra_config["cleanup_on_init"])
+        elif os.getenv("SGLANG_HICACHE_FILE_BACKEND_CLEANUP_ON_INIT"):
+            self._cleanup_on_init = os.getenv(
+                "SGLANG_HICACHE_FILE_BACKEND_CLEANUP_ON_INIT"
+            ).lower() in ("true", "1", "yes")
+
+        if self._cleanup_on_init and self.tp_rank == 0:
+            self.clear()
+        self._refresh_capacity()
+
+        if self.max_capacity_bytes is not None:
+            logger.info(
+                f"HiCacheFile storage capacity limit: {self.max_capacity_bytes / (1024**3):.2f} GB, "
+                f"current: {self._current_capacity_bytes / (1024**3):.2f} GB"
+            )
+
+        # Initialize LRU from existing files
+        self._initialize_lru_from_files()
+
+    def _refresh_capacity(self):
+        """Refresh current capacity by scanning all files in storage directory."""
+        try:
+            total_size = 0
+            if os.path.exists(self.file_path):
+                for filename in os.listdir(self.file_path):
+                    file_path = os.path.join(self.file_path, filename)
+                    if os.path.isfile(file_path):
+                        total_size += os.path.getsize(file_path)
+            with self._capacity_lock:
+                self._current_capacity_bytes = total_size
+        except Exception as e:
+            logger.warning(f"Failed to refresh storage capacity: {e}")
+
+    def _initialize_lru_from_files(self):
+        """Initialize LRU order from existing files based on file modification time."""
+        try:
+            if not os.path.exists(self.file_path):
+                return
+
+            # Get all files with their modification times
+            file_times = []
+            for filename in os.listdir(self.file_path):
+                file_path = os.path.join(self.file_path, filename)
+                if os.path.isfile(file_path) and filename.endswith(".bin"):
+                    # Extract key from filename (remove .bin suffix and config_suffix)
+                    if filename.endswith(self.config_suffix + ".bin"):
+                        key = filename[
+                            : -(len(self.config_suffix) + 4)
+                        ]  # Remove .bin and suffix
+                    else:
+                        key = filename[:-4]  # Remove .bin
+                    mtime = os.path.getmtime(file_path)
+                    file_times.append((key, mtime))
+
+            # Sort by modification time (oldest first) and populate LRU
+            file_times.sort(key=lambda x: x[1])
+            with self._lru_lock:
+                for key, mtime in file_times:
+                    self._lru_order[key] = mtime
+        except Exception as e:
+            logger.warning(f"Failed to initialize LRU from existing files: {e}")
+
+    def _update_lru(self, key: str):
+        """Update LRU order: move key to end (most recently used)."""
+        with self._lru_lock:
+            # Remove from current position and add to end
+            if key in self._lru_order:
+                self._lru_order.move_to_end(key)
+            else:
+                self._lru_order[key] = time.time()
+
+    def _evict_lru_keys(self, target_bytes: int) -> List[str]:
+        """
+        Evict least recently used keys until we free at least target_bytes.
+        Returns list of keys that were evicted.
+        """
+        if self.max_capacity_bytes is None:
+            return []
+
+        evicted_keys = []
+        freed_bytes = 0
+
+        # Collect keys to evict (with LRU lock held)
+        keys_to_remove = []
+        with self._lru_lock:
+            # Iterate from oldest (front) to newest (back)
+            for key in list(self._lru_order.keys()):
+                if freed_bytes >= target_bytes:
+                    break
+
+                tensor_path = os.path.join(
+                    self.file_path, f"{self._get_suffixed_key(key)}.bin"
+                )
+                if os.path.exists(tensor_path):
+                    file_size = os.path.getsize(tensor_path)
+                    keys_to_remove.append((key, file_size))
+                    freed_bytes += file_size
+
+            # Remove from LRU order immediately (before file deletion)
+            for key, _ in keys_to_remove:
+                if key in self._lru_order:
+                    del self._lru_order[key]
+
+        # Delete files and update capacity (outside LRU lock to avoid deadlock)
+        for key, file_size in keys_to_remove:
+            try:
+                tensor_path = os.path.join(
+                    self.file_path, f"{self._get_suffixed_key(key)}.bin"
+                )
+                if os.path.exists(tensor_path):
+                    os.remove(tensor_path)
+                    self._update_capacity_on_delete(file_size)
+                    evicted_keys.append(key)
+            except FileNotFoundError:
+                # File was already deleted by another process/thread, ignore
+                logger.warning(f"File not found (already deleted): {tensor_path}")
+                pass
+            except Exception as e:
+                logger.warning(f"Failed to evict LRU key {key}: {e}")
+
+        return evicted_keys
+
+    def _update_capacity_on_add(self, file_size: int):
+        """Update capacity after adding a file."""
+        self._current_capacity_bytes += file_size
+
+    def _update_capacity_on_delete(self, file_size: int):
+        """Update capacity after deleting a file."""
+        self._current_capacity_bytes = max(0, self._current_capacity_bytes - file_size)
+
+    def get_current_capacity(self) -> int:
+        """Get current storage capacity in bytes."""
+        return self._current_capacity_bytes
+
+    def get_capacity_ratio(self) -> float:
+        """Get current capacity / max capacity ratio. Returns 0.0 if unlimited."""
+        if self.max_capacity_bytes is None:
+            return 0.0
+        if self.max_capacity_bytes == 0:
+            return 1.0
+        return min(1.0, self._current_capacity_bytes / self.max_capacity_bytes)
+
+    def is_over_capacity(self, threshold_ratio: float = 0.95) -> bool:
+        """
+        Check if storage is over capacity threshold.
+        Args:
+            threshold_ratio: Ratio at which to consider storage over capacity (default 0.95 = 95%)
+        Returns:
+            True if capacity exceeds threshold
+        """
+        if self.max_capacity_bytes is None:
+            return False
+        return self.get_capacity_ratio() >= threshold_ratio
 
     def _get_suffixed_key(self, key: str) -> str:
         return key + self.config_suffix
@@ -189,14 +389,16 @@ class HiCacheFile(HiCacheStorage):
         target_location: torch.Tensor,
         target_sizes: Optional[Any] = None,
     ) -> torch.Tensor | None:
-        key = self._get_suffixed_key(key)
-        tensor_path = os.path.join(self.file_path, f"{key}.bin")
+        suffixed_key = self._get_suffixed_key(key)
+        tensor_path = os.path.join(self.file_path, f"{suffixed_key}.bin")
         try:
             expected = target_location.numel() * target_location.element_size()
             with open(tensor_path, "rb", buffering=0) as f:
                 buf = memoryview(target_location.view(torch.uint8).contiguous().numpy())
                 if f.readinto(buf) != expected:
                     raise IOError(f"Short read for {key}")
+            # Update LRU: mark as recently used
+            self._update_lru(key)
             return target_location
         except FileNotFoundError:
             logger.warning(f"Failed to fetch {key} from HiCacheFile storage.")
@@ -224,12 +426,57 @@ class HiCacheFile(HiCacheStorage):
     ) -> bool:
         if self.exists(key):
             logger.debug(f"Key {key} already exists. Skipped.")
+            # Update LRU even if key already exists
+            self._update_lru(key)
             return True
 
-        key = self._get_suffixed_key(key)
-        tensor_path = os.path.join(self.file_path, f"{key}.bin")
+        suffixed_key = self._get_suffixed_key(key)
+        tensor_path = os.path.join(self.file_path, f"{suffixed_key}.bin")
         try:
+            # Calculate file size before writing
+            file_size = value.numel() * value.element_size()
+
+            # Check capacity before writing
+            if self.max_capacity_bytes is not None:
+                with self._capacity_lock:
+                    needed_space = file_size
+                    current_capacity = self._current_capacity_bytes
+
+                    if current_capacity + needed_space > self.max_capacity_bytes:
+                        # Need to free space
+                        free_target = (
+                            current_capacity + needed_space - self.max_capacity_bytes
+                        )
+                        # Free a bit extra to avoid frequent evictions (20% margin)
+                        free_target = int(free_target * 1.2)
+
+                        evicted = self._evict_lru_keys(free_target)
+                        if evicted:
+                            logger.debug(
+                                f"Evicted {len(evicted)} LRU keys to free {free_target / (1024**2):.2f} MB "
+                                f"for new key {key}"
+                            )
+
+                        # Check again after eviction
+                        if (
+                            self._current_capacity_bytes + needed_space
+                            > self.max_capacity_bytes
+                        ):
+                            logger.warning(
+                                f"Storage capacity exceeded after LRU eviction. "
+                                f"Current: {self._current_capacity_bytes / (1024**3):.2f} GB, "
+                                f"Limit: {self.max_capacity_bytes / (1024**3):.2f} GB, "
+                                f"Requested: {needed_space / (1024**2):.2f} MB. "
+                                f"Key {key} will not be stored."
+                            )
+                            return False
+
             value.contiguous().view(dtype=torch.uint8).numpy().tofile(tensor_path)
+            # Update capacity after successful write
+            actual_size = os.path.getsize(tensor_path)
+            self._update_capacity_on_add(actual_size)
+            # Update LRU: add as most recently used
+            self._update_lru(key)
             return True
         except Exception as e:
             logger.error(f"Failed to save tensor {key}: {e}")
@@ -252,14 +499,134 @@ class HiCacheFile(HiCacheStorage):
         tensor_path = os.path.join(self.file_path, f"{key}.bin")
         return os.path.exists(tensor_path)
 
+    def delete(self, key: str) -> bool:
+        """
+        Delete a key from storage.
+        Args:
+            key: The key to delete
+        Returns:
+            True if the key was deleted successfully, False otherwise.
+        """
+        suffixed_key = self._get_suffixed_key(key)
+        tensor_path = os.path.join(self.file_path, f"{suffixed_key}.bin")
+        try:
+            if os.path.exists(tensor_path):
+                file_size = os.path.getsize(tensor_path)
+                os.remove(tensor_path)
+                # Update capacity after successful deletion
+                self._update_capacity_on_delete(file_size)
+                # Remove from LRU
+                with self._lru_lock:
+                    if key in self._lru_order:
+                        del self._lru_order[key]
+                logger.debug(f"Deleted key {key} from HiCacheFile storage.")
+                return True
+            else:
+                logger.debug(f"Key {key} does not exist in HiCacheFile storage.")
+                return False
+        except FileNotFoundError:
+            # File was already deleted by another process/thread, ignore
+            logger.warning(f"File not found (already deleted): {tensor_path}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to delete key {key} from HiCacheFile storage: {e}")
+            return False
+
+    def batch_delete(self, keys: List[str]) -> bool:
+        """
+        Delete multiple keys from storage.
+        Args:
+            keys: List of keys to delete
+        Returns:
+            True if all keys were deleted successfully, False otherwise.
+        """
+        success = True
+        for key in keys:
+            if not self.delete(key):
+                success = False
+        return success
+
     def clear(self) -> bool:
         try:
+            logger.info(f"Starting clear() for HiCacheFile storage at {self.file_path}")
+
+            if not os.path.exists(self.file_path):
+                # Directory doesn't exist, nothing to clear
+                self._current_capacity_bytes = 0
+                with self._lru_lock:
+                    self._lru_order.clear()
+                logger.info(
+                    "HiCacheFile storage directory does not exist, nothing to clear."
+                )
+                return True
+
+            # Get list of files first to avoid issues with concurrent modifications
+            files_to_delete = []
             for filename in os.listdir(self.file_path):
                 file_path = os.path.join(self.file_path, filename)
                 if os.path.isfile(file_path):
-                    os.remove(file_path)
-            logger.info("Cleared all entries in HiCacheFile storage.")
+                    files_to_delete.append(file_path)
+
+            # Delete files with error handling for missing files
+            deleted_count = 0
+            failed_count = 0
+            for file_path in files_to_delete:
+                try:
+                    if os.path.exists(file_path):  # Double check before deletion
+                        os.remove(file_path)
+                        deleted_count += 1
+                    else:
+                        logger.debug(f"File already deleted: {file_path}")
+                except FileNotFoundError:
+                    # File was already deleted by another process/thread, ignore
+                    logger.debug(f"File not found (already deleted): {file_path}")
+                    pass
+                except Exception as e:
+                    failed_count += 1
+                    logger.warning(f"Failed to delete file {file_path}: {e}")
+                    if failed_count <= 5:  # Only log first 5 failures in detail
+                        logger.warning(
+                            f"Error details for {file_path}: {e}", exc_info=True
+                        )
+
+            logger.info(
+                f"File deletion completed: {deleted_count} deleted, {failed_count} failed out of {len(files_to_delete)} total"
+            )
+
+            # Reset capacity and LRU after clearing
+            logger.debug("Resetting capacity and LRU")
+            self._current_capacity_bytes = 0  # Atomic assignment in CPython
+            logger.debug("Acquiring LRU lock...")
+            with self._lru_lock:
+                logger.debug("LRU lock acquired, clearing LRU order")
+                self._lru_order.clear()
+            logger.debug("LRU lock released")
+
+            logger.info(f"Cleared {deleted_count} entries from HiCacheFile storage.")
             return True
         except Exception as e:
-            logger.error(f"Failed to clear HiCacheFile storage: {e}")
+            logger.error(f"Failed to clear HiCacheFile storage: {e}", exc_info=True)
             return False
+
+    def queue_cleanup(self, keys: List[str]):
+        """
+        Delete storage keys when cache nodes are evicted.
+        This method can be called by cache controller to notify storage backend
+        that certain keys have been evicted from cache and can be deleted.
+
+        Note: This is a synchronous operation that immediately deletes the keys.
+        LRU-based automatic cleanup handles capacity management independently.
+
+        Args:
+            keys: List of hash keys to be deleted from storage
+        """
+        if not keys:
+            return
+
+        # Immediately delete keys synchronously when cache evicts them
+        # No need for async queue since we want immediate capacity release
+        for key in keys:
+            try:
+                self.delete(key)  # delete() handles LRU removal and capacity update
+            except Exception as e:
+                logger.warning(f"Failed to cleanup evicted key {key}: {e}")

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -374,6 +374,7 @@ class HiRadixCache(RadixCache):
         # evict a node not initiated write to host
         self.cache_controller.mem_pool_device_allocator.free(node.value)
         num_evicted = len(node.value)
+
         self._delete_leaf(node)
         return num_evicted
 
@@ -398,7 +399,6 @@ class HiRadixCache(RadixCache):
                 continue
 
             num_evicted += self.cache_controller.evict_host(x.host_value)
-
             for k, v in x.parent.children.items():
                 if v == x:
                     break


### PR DESCRIPTION
## Motivation

As we use filebackend,  there is no evict and capacity control logic, so the filebackend could always put cache until the nvme is full.so I add the related logic to help use the nvme/filebackend case

## Modifications

1.  add LRU update & evict logic when calling set
2. add capacity config env (SGLANG_HICACHE_FILE_BACKEND_MAX_CAPACITY_GB) and free_bytes to trigger lru 
3. add SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR clear logic when init


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
