### PR TITLE
[router][quick fix] Add minimal option for reasoning effort in spec

### DIFF
--- a/sgl-router/src/protocols/responses.rs
+++ b/sgl-router/src/protocols/responses.rs
@@ -85,6 +85,7 @@ fn default_reasoning_effort() -> Option<ReasoningEffort> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    Minimal,
     Low,
     Medium,
     High,

--- a/sgl-router/src/routers/grpc/harmony/builder.rs
+++ b/sgl-router/src/routers/grpc/harmony/builder.rs
@@ -277,6 +277,8 @@ impl HarmonyBuilder {
                 "high" => ReasoningEffort::High,
                 "medium" => ReasoningEffort::Medium,
                 "low" => ReasoningEffort::Low,
+                // Harmony does not support minimal reasoning effort
+                "minimal" => ReasoningEffort::Low,
                 _ => ReasoningEffort::Medium,
             });
 
@@ -302,6 +304,7 @@ impl HarmonyBuilder {
                 ResponsesReasoningEffort::High => ReasoningEffort::High,
                 ResponsesReasoningEffort::Medium => ReasoningEffort::Medium,
                 ResponsesReasoningEffort::Low => ReasoningEffort::Low,
+                ResponsesReasoningEffort::Minimal => ReasoningEffort::Low,
             });
 
         self.build_system_message(reasoning_effort, with_custom_tools)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Add minimal option for reasoning effort in spec. 
Harmony doesn't support minimal as an option of reasoning effort, so mapping the minimal to low for harmony model
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
ubuntu@moirai-a10-exp:~/sglang/sgl-router$ curl http://localhost:3002/v1/responses -H "Content-Type: application/json" -d '{
    "model": "/home/ubuntu/models/openai/gpt-oss-20b",
    "input": "are you a good model",
    "reasoning_effort": "minimal"
  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2616  100  2485  100   131    814     42  0:00:03  0:00:03 --:--:--   857
{
  "id": "responses-fd9d0db1-b786-487b-9513-5d691ec50a1c",
  "object": "response",
  "created_at": 1762383817,
  "status": "completed",
  "model": "/home/ubuntu/models/openai/gpt-oss-20b",
  "output": [
    {
      "type": "reasoning",
      "id": "reasoning_responses-fd9d0db1-b786-487b-9513-5d691ec50a1c",
      "summary": [],
      "content": [
        {
          "type": "reasoning_text",
          "text": "The user asks: \"are you a good model\". They probably mean \"are you a good model?\" This is ambiguous: It's a meta-question about the model. They likely want an answer that explains that as ChatGPT, I'm a large language model built by OpenAI, designed to generate helpful text. So I should respond politely, telling them that yes, I'm a model trained on large data, but there are limitations. Provide an explanation.\n\nWe can consider the policies: no disallowed content. We can comply. Just answer.\n\nWe should avoid \"model\" as a negative. # of user. We respond positively, but we can provide caution. Describe strengths and weaknesses. Also compliance with policy. It's a simple question. No policy conflict. Just answer.\n\nWe should not say we are a \"good model\" in a snarky way. Should be helpful. Mention it's evaluated by various tests. We can talk about my ability to answer. So answer: Yes, I'm well-trained, but still have limitations."
        }
      ],
      "status": "completed"
    },
    {
      "type": "message",
      "id": "msg_responses-fd9d0db1-b786-487b-9513-5d691ec50a1c",
      "role": "assistant",
      "content": [
        {
          "type": "output_text",
          "text": "I’m ChatGPT, a large language model built by OpenAI. In that sense, I’m designed to be a “good” model for many tasks—answering questions, generating text, summarizing, translating, and more. I’ve been trained on a vast amount of text, so I can provide detailed, context‑aware responses across a wide range of topics.\n\nThat said, I’m not perfect. I can:\n\n- **Help** with research, brainstorming, and explanations.\n- **Offer** creative writing, coding help, and general knowledge.\n- **Have limits** in terms of up‑to‑date information (my training data only goes up to 2023–2024), deep factual accuracy, and understanding extremely niche or highly specialized subjects.\n\nSo while I strive for accuracy and usefulness, I’m most effective when paired with human judgment and cross‑checking of important details."
        }
      ],
      "status": "completed"
    }
  ],
  "parallel_tool_calls": true,
  "store": true,
  "temperature": 1,
  "tool_choice": "auto",
  "tools": [],
  "top_p": 1,
  "usage": {
    "input_tokens": 70,
    "output_tokens": 395,
    "total_tokens": 465
  },
  "metadata": {}
}
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
