### PR TITLE
[router][grpc] Make harmony parser checks recipient first before channel

### DIFF
--- a/sgl-router/src/routers/grpc/harmony/parser.rs
+++ b/sgl-router/src/routers/grpc/harmony/parser.rs
@@ -106,7 +106,7 @@ impl HarmonyParserAdapter {
     pub fn parse_messages(
         messages: &[openai_harmony::chat::Message],
     ) -> (Option<String>, Option<Vec<ToolCall>>, String) {
-        let mut analysis = None;
+        let mut analysis: Option<String> = None;
         let mut commentary: Option<Vec<ToolCall>> = None;
         let mut final_text = String::new();
 
@@ -119,6 +119,60 @@ impl HarmonyParserAdapter {
             let channel = msg.channel.as_deref().unwrap_or("");
             let recipient = msg.recipient.as_deref();
 
+            // IMPORTANT: Check recipient FIRST before channel
+            // The model sometimes generates tool calls with channel="analysis" + recipient="functions.*"
+            // instead of channel="commentary" + recipient="functions.*"
+            // We should trust the recipient field to determine if this is a tool call
+            if let Some(recipient_str) = recipient {
+                if recipient_str.starts_with("functions.") {
+                    // This is a tool call, regardless of channel
+                    let function_name = recipient_str.strip_prefix("functions.").unwrap();
+
+                    // Process each content item separately
+                    for content in &msg.content {
+                        if let openai_harmony::chat::Content::Text(tc) = content {
+                            let call_id = format!("call_{}", Uuid::new_v4());
+                            let tool_call = ToolCall {
+                                id: call_id,
+                                tool_type: "function".to_string(),
+                                function: FunctionCallResponse {
+                                    name: function_name.to_string(),
+                                    arguments: Some(tc.text.clone()),
+                                },
+                            };
+
+                            match commentary.as_mut() {
+                                Some(calls) => calls.push(tool_call),
+                                None => commentary = Some(vec![tool_call]),
+                            }
+                        }
+                    }
+                    // Skip further channel processing for this message
+                    continue;
+                } else if recipient_str.starts_with("python")
+                    || recipient_str.starts_with("browser")
+                    || recipient_str.starts_with("container")
+                {
+                    // Built-in tools → treat as reasoning
+                    // For Chat API, we add to analysis content
+                    let text = Self::extract_text_from_content(&msg.content);
+
+                    if !text.is_empty() {
+                        // Append to analysis (built-in tools are reasoning)
+                        match analysis.as_mut() {
+                            Some(existing) => {
+                                existing.push('\n');
+                                existing.push_str(&text);
+                            }
+                            None => analysis = Some(text),
+                        }
+                    }
+                    // Skip further channel processing
+                    continue;
+                }
+            }
+
+            // Now process by channel (only if not already handled by recipient)
             match channel {
                 "analysis" => {
                     // Process each content item
@@ -130,51 +184,25 @@ impl HarmonyParserAdapter {
                     }
                 }
                 "commentary" => {
-                    // Handle different recipient types
-                    if let Some(recipient_str) = recipient {
-                        if recipient_str.starts_with("functions.") {
-                            let function_name = recipient_str.strip_prefix("functions.").unwrap();
+                    // If we reach here, recipient was not "functions.*" or built-in tools
+                    // Commentary channel should always have a recipient
+                    // This is likely a model bug - log warning and treat as reasoning
+                    tracing::warn!(
+                        channel = "commentary",
+                        recipient = ?recipient,
+                        "Commentary message without valid recipient, treating as reasoning"
+                    );
 
-                            // Process each content item separately
-                            for content in &msg.content {
-                                if let openai_harmony::chat::Content::Text(tc) = content {
-                                    let call_id = format!("call_{}", Uuid::new_v4());
-                                    let tool_call = ToolCall {
-                                        id: call_id,
-                                        tool_type: "function".to_string(),
-                                        function: FunctionCallResponse {
-                                            name: function_name.to_string(),
-                                            arguments: Some(tc.text.clone()),
-                                        },
-                                    };
+                    let text = Self::extract_text_from_content(&msg.content);
 
-                                    match commentary.as_mut() {
-                                        Some(calls) => calls.push(tool_call),
-                                        None => commentary = Some(vec![tool_call]),
-                                    }
-                                }
+                    if !text.is_empty() {
+                        match analysis.as_mut() {
+                            Some(existing) => {
+                                existing.push('\n');
+                                existing.push_str(&text);
                             }
-                        } else if recipient_str.starts_with("python")
-                            || recipient_str.starts_with("browser")
-                            || recipient_str.starts_with("container")
-                        {
-                            // Built-in tools → treat as reasoning
-                            // For Chat API, we add to analysis content
-                            let text = Self::extract_text_from_content(&msg.content);
-
-                            if !text.is_empty() {
-                                // Append to analysis (built-in tools are reasoning)
-                                match analysis.as_mut() {
-                                    Some(existing) => {
-                                        existing.push('\n');
-                                        existing.push_str(&text);
-                                    }
-                                    None => analysis = Some(text),
-                                }
-                            }
+                            None => analysis = Some(text),
                         }
-                        // Unknown recipient would raise ValueError
-                        // For now, we silently ignore (can add logging later)
                     }
                 }
                 "final" => {
@@ -215,16 +243,9 @@ impl HarmonyParserAdapter {
     ) -> Result<HarmonyChannelOutput, String> {
         // Feed all tokens to the parser
         for &token_id in output_ids {
-            self.parser.process(token_id).map_err(|e| {
-                // Log the full output_ids context on error
-                tracing::error!(
-                    token_id = token_id,
-                    output_ids = ?output_ids,
-                    error = %e,
-                    "Harmony parser failed to process token"
-                );
-                format!("Failed to process token {}: {}", token_id, e)
-            })?;
+            self.parser
+                .process(token_id)
+                .map_err(|e| format!("Failed to process token {}: {}", token_id, e))?;
         }
 
         // Extract all completed messages from the parser
@@ -240,7 +261,7 @@ impl HarmonyParserAdapter {
         let final_finish_reason = if commentary.is_some() {
             "tool_calls".to_string()
         } else {
-            finish_reason
+            finish_reason.clone()
         };
 
         Ok(HarmonyChannelOutput {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fixes issue where MCP tool calls fail to continue in the harmony loop when the model generates the wrong channel type. The model sometimes generates `channel="analysis"` with `recipient="functions.*"` instead of the correct `channel="commentary"` with `recipient="functions.*"`. This causes the router to treat tool calls as reasoning text, stopping the MCP loop prematurely.

This issue manifests as:
- Tool calls not being executed
- Request completing with only reasoning output
- Missing final message after tool execution

Related to issue #12669.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

**File:** `sgl-router/src/routers/grpc/harmony/parser.rs`

### 1. Check recipient before channel for tool call detection (lines 122-157)
- Moved recipient checking logic before channel-based parsing
- Now detects `recipient="functions.*"` as a tool call regardless of channel value
- Handles model bug where it generates `channel="analysis"` + `recipient="functions.X"`
- Also handles built-in tools (`python`, `browser`, `container`) regardless of channel

### 2. Added warning for invalid commentary messages (lines 186-207)
- Added warning log when commentary channel has no valid recipient
- Treats such messages as reasoning content (defensive approach)
- Consistent with existing error handling philosophy (warn but don't break)

### Key Logic Change
```rust
// OLD: Check channel first, then recipient
match channel {
    "commentary" => {
        if recipient.starts_with("functions.") { ... }
    }
}

// NEW: Check recipient first, then fall back to channel
if recipient.starts_with("functions.") {
    // Handle as tool call regardless of channel
} else {
    match channel { ... }
}
```

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<img width="1969" height="724" alt="Screenshot 2025-11-05 at 3 18 57 PM" src="https://github.com/user-attachments/assets/13bf2d15-2201-4c5c-99ca-d79bb77ce486" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
