### PR TITLE
[docs] Remove redundant --disable-radix-cache option from 

### DIFF
--- a/docs/references/multi_node_deployment/rbg_pd/deepseekv32_pd.md
+++ b/docs/references/multi_node_deployment/rbg_pd/deepseekv32_pd.md
@@ -53,7 +53,6 @@ spec:
               - --trust-remote
               - --host
               -  0.0.0.0
-              - --disable-radix-cache
               - --disaggregation-ib-device
               -  mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
               - --disable-radix-cache


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

There's a redundant flag in the DeepSeekV32-Exp RBG Based PD Deploy Documentation.

## Modifications

Removed redundant flag.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
