### PR TITLE
[fix] Only enable flashinfer all reduce fusion by default for single-node servers

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -907,7 +907,8 @@ class ServerArgs:
                     logger.info(
                         "Use trtllm_mla as attention backend on sm100 for DeepseekV3ForCausalLM"
                     )
-                if not self.enable_dp_attention:
+                # workaround for https://github.com/flashinfer-ai/flashinfer/issues/2006
+                if not self.enable_dp_attention and self.nnodes == 1:
                     self.enable_flashinfer_allreduce_fusion = True
                     logger.info(
                         "Enable FlashInfer AllReduce Fusion on sm100 for DeepseekV3ForCausalLM"
@@ -964,7 +965,8 @@ class ServerArgs:
             )
 
             if is_blackwell_supported():
-                if not self.enable_dp_attention:
+                # workaround for https://github.com/flashinfer-ai/flashinfer/issues/2006
+                if not self.enable_dp_attention and self.nnodes == 1:
                     self.enable_flashinfer_allreduce_fusion = True
                     logger.info(
                         "Enable FlashInfer AllReduce Fusion on sm100 for GptOssForCausalLM"


### PR DESCRIPTION
## Motivation

Currently multi-node non-data-parallel inference does not work for `DeepseekV3ForCausalLM` models.
This is due to a bug in flashinfer: https://github.com/flashinfer-ai/flashinfer/issues/2006

## Modifications

Currently enable_flashinfer_allreduce_fusion is enabled by default for `DeepseekV3ForCausalLM` and `GptOssForCausalLM`.  Because of the flashinfer all reduce fusion bug, a workaround is to only enable flashinfer all reduce fusion if a single node is used.