### PR TITLE
[chore] SGLang tag management in Dockerfile

### DIFF
--- a/.github/workflows/release-docker-cu13.yml
+++ b/.github/workflows/release-docker-cu13.yml
@@ -60,6 +60,7 @@ jobs:
                     --build-arg BUILD_TYPE=${{ matrix.build_type }} \
                     --build-arg CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) \
                     --build-arg GRACE_BLACKWELL=${{ matrix.grace_blackwell }} \
+                    --build-arg USE_LATEST_SGLANG=1 \
                     -t lmsysorg/sglang:${{ matrix.tag }} \
                     --no-cache \
                     .

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -61,6 +61,7 @@ jobs:
             --build-arg BUILD_TYPE=${{ matrix.build_type }} \
             --build-arg CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) \
             --build-arg GRACE_BLACKWELL=${{ matrix.grace_blackwell }} \
+            --build-arg USE_LATEST_SGLANG=1 \
             -t lmsysorg/sglang:${{ matrix.tag }} \
             --no-cache \
             .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,8 @@ ARG DEEPEP_COMMIT=9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee
 ARG TRITON_LANG_COMMIT=4caa0328bf8df64896dd5f6fb9df41b0eb2e750a
 ARG BUILD_AND_DOWNLOAD_PARALLEL=8
 ARG SGL_KERNEL_VERSION=0.3.16.post5
+ARG SGL_VERSION=0.5.4.post3
+ARG USE_LATEST_SGLANG=0
 ARG GDRCOPY_VERSION=2.5.1
 ARG NVSHMEM_VERSION=3.4.5
 ARG PIP_DEFAULT_INDEX
@@ -94,8 +96,10 @@ ARG BRANCH_TYPE
 COPY --from=local_src /src /tmp/local_src
 RUN if [ "$BRANCH_TYPE" = "local" ]; then \
         cp -r /tmp/local_src /sgl-workspace/sglang; \
-    else \
+    elif [ "$USE_LATEST_SGLANG" == "1" ]; then \
         git clone --depth=1 https://github.com/sgl-project/sglang.git /sgl-workspace/sglang; \
+    else \
+        git clone --depth=1 --branch v${SGL_VERSION} https://github.com/sgl-project/sglang.git /sgl-workspace/sglang; \
     fi \
  && rm -rf /tmp/local_src
 RUN --mount=type=cache,target=/root/.cache/pip  python3 -m pip install --upgrade pip setuptools wheel html5lib six \

--- a/scripts/release/bump_sglang_version.py
+++ b/scripts/release/bump_sglang_version.py
@@ -20,6 +20,7 @@ def main():
 
     files_to_update = [
         Path("benchmark/deepseek_v3/README.md"),
+        Path("docker/Dockerfile"),
         Path("docker/rocm.Dockerfile"),
         Path("docs/get_started/install.md"),
         Path("docs/platforms/amd_gpu.md"),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In prior bumping of sglang version, the Dockerfile will pull the latest main branch from sglang github repo and then build.

However, this will cause problems when new commits come in between the time window of version bumping and docker building.

This PR fixes this problem by:
- For docker release triggered by sglang version bumping, Dockerfile will pick the new tag, so the later commits won't get in.
- For dev docker release, a flag `USE_LATEST_SGLANG` is passed, so Dockerfile will pull the latest code.


Blocked by #12723

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
