### PR TITLE
[BUGFIX] fix output_ids in abort

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1823,9 +1823,11 @@ class TokenizerManager(TokenizerCommunicatorMixin):
 
         output_ids = state.output_ids
         meta_info["completion_tokens"] = len(output_ids)
+        if is_stream:
+            output_ids = [output_ids[-1]] if len(output_ids) > 0 else []
         out = {
             "text": state.text,
-            "output_ids": [output_ids[-1]] if is_stream else output_ids,
+            "output_ids": output_ids,
             "meta_info": meta_info,
         }
         state.out_list.append(out)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
it will cause `list index out of range` in following line if abort requests. The PR fixes this issue.
```
"output_ids": [output_ids[-1]] if is_stream else output_ids,
```

reproduce command
```
python3 -m sglang.launch_server --model Qwen/Qwen3-Next-80B-A3B-Instruct  --port 40000  --chunked-prefill-size 2048 --tp 2

# cancel it after running a while, crash will happen
python3 -m sglang.bench_serving  --backend sglang --dataset-name generated-shared-prefix --gsp-num-groups 50 --gsp-prompts-per-group 100 --gsp-system-prompt-len 10240 --gsp-question-len 1024 --gsp-output-len 128  --port 40000 --max-concurrency 50
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
