### PR TITLE
fix: add first round to bench_long_context.py

### DIFF
--- a/benchmark/hicache/bench_long_context.py
+++ b/benchmark/hicache/bench_long_context.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     args.max_parallel = 24
     flush_cache_url = f"http://{args.host}:{args.port}/flush_cache"
 
-    for request_rate in [24, 16, 12, 8, 4, 2, 1]:
+    for request_rate in [24, 24, 16, 12, 8, 4, 2, 1]:
         args.request_rate = request_rate
         requests.post(flush_cache_url)
         time.sleep(1)


### PR DESCRIPTION
Add a warmup round to store kvcache to hicache backend, the original code will cause cache hit rate 0

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Make hicache benchmark more accurate. The code didn't count the first round cache hit rate correctly.
For example, if I run this benchmark, the cache hit rate will be 0, and the following cache hit rate will be much more higher than 0.

## Modifications

<!-- Detail the changes made in this pull request. -->
Add one more turn test
```python
<<<<<<< origin
for request_rate in [24, 16, 12, 8, 4, 2, 1]:
>>>>>>> changes
for request_rate in [24, 24, 16, 12, 8, 4, 2, 1]:
```


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
