### PR TITLE
[hotfix]: Resolve ModuleNotFoundError in PD deployment for is_in_ci()

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -356,10 +356,10 @@ def download_and_cache_file(url: str, filename: Optional[str] = None):
     return filename
 
 
-def is_in_ci():
-    from sglang.test.test_utils import is_in_ci
+def is_in_ci() -> bool:
+    import os
 
-    return is_in_ci()
+    return os.environ.get("SGLANG_IS_IN_CI", "").lower() in ("true", "1")
 
 
 def print_highlight(html_content: str):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

**Issue**: When deploying with PD disaggregation, the `is_in_ci()` function in `sglang/utils.py` tried to import from `sglang.test.test_utils`, which doesn't exist in production installations, causing `ModuleNotFoundError`.

**Root Cause**: The test module is not included in production packages, but `server_args.py` calls `is_in_ci()` during initialization when `dp_size > 1`.

**Fix**: Reimplemented `is_in_ci()` to directly check the `SGLANG_IS_IN_CI` environment variable without importing from test modules:

```python
def is_in_ci() -> bool:
    import os
    return os.environ.get("SGLANG_IS_IN_CI", "").lower() in ("true", "1")
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
