### PR TITLE
ignore the deepgemm check when the model weight with nvfp4 and moe ba…

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -112,8 +112,16 @@ class DeepEPMoE(FusedMoE):
 
         self.deepep_mode = get_deepep_mode()
 
-        if self.deepep_mode.enable_low_latency() and not _is_npu:
+        if (
+            self.deepep_mode.enable_low_latency()
+            and not _is_npu
+            and not (
+                get_moe_runner_backend().is_flashinfer_cutedsl()
+                and self.quant_config.get_name() == "modelopt_fp4"
+            )
+        ):
             # NPU supports low_latency deepep without deepgemm
+            # FP4 quantization with flashinfer_cutedsl also supports low_latency deepep without deepgemm
             assert (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             ), f"DeepEP {self.deepep_mode} mode requires deep_gemm"


### PR DESCRIPTION
…ckend is flashinfer cutedsl

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

support DS R1 FP4 model deploy to GB200 with deepep and flashinfer-cutedsl moe backend.

## Modifications

ease the DeepGEMM check when the model weight is fp4 quantitized and the moe backend is flashinfer-cutedsl

## Accuracy Tests

For the decode

**Rank 0**

```bash
NCCL_MNNVL_ENABLE=1 NCCL_CUMEM_ENABLE=1 NCCL_SOCKET_IFNAME=eth0 NCCL_SOCKET_FAMILY=AF_INET GLOO_SOCKET_IFNAME=eth0 SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 SGLANG_ENABLE_JIT_DEEPGEMM=0 SGLANG_DEEPEP_BF16_DISPATCH=1 SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=1024 python3 -m sglang.launch_server --model-path /data01/models/DeepSeek-R1-0528-FP4-v2 --trust-remote-code --dist-init-addr 192.168.0.1:21000 --nnodes 2 --node-rank 0 --disaggregation-mode decode --tp-size 8 --ep-size 8 --dp-size 8 --enable-dp-attention --enable-dp-lm-head --device cuda --host 0.0.0.0 --port 28000 --mem-fraction-static 0.7 --attention-backend trtllm_mla --moe-runner-backend flashinfer_cutedsl --moe-a2a-backend deepep --deepep-mode low_latency --quantization modelopt_fp4 --chunked-prefill-size 131072 --page-size 64 --disable-radix-cache --max-running-requests 1536 --prefill-round-robin-balance --disaggregation-transfer-backend nixl --cuda-graph-max-bs 192 --ep-num-redundant-experts 32 --watchdog-timeout 1200
```

**Rank 1**

```bash
NCCL_MNNVL_ENABLE=1 NCCL_CUMEM_ENABLE=1 NCCL_SOCKET_IFNAME=eth0 NCCL_SOCKET_FAMILY=AF_INET GLOO_SOCKET_IFNAME=eth0 SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 SGLANG_ENABLE_JIT_DEEPGEMM=0 SGLANG_DEEPEP_BF16_DISPATCH=1 SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=1024 python3 -m sglang.launch_server --model-path /data01/models/DeepSeek-R1-0528-FP4-v2 --trust-remote-code --dist-init-addr 192.168.0.1:21000 --nnodes 2 --node-rank 1 --disaggregation-mode decode --tp-size 8 --ep-size 8 --dp-size 8 --enable-dp-attention --enable-dp-lm-head --device cuda --host 0.0.0.0 --port 28000 --mem-fraction-static 0.7 --attention-backend trtllm_mla --moe-runner-backend flashinfer_cutedsl --moe-a2a-backend deepep --deepep-mode low_latency --quantization modelopt_fp4 --chunked-prefill-size 131072 --page-size 64 --disable-radix-cache --max-running-requests 1536 --prefill-round-robin-balance --disaggregation-transfer-backend nixl --cuda-graph-max-bs 192 --ep-num-redundant-experts 32 --watchdog-timeout 1200
```

Without this PR, the logs are

```bash
[2025-11-06 18:59:07 DP3 TP3 EP3] Detected nvfp4 checkpoint. Please note that the format is experimental and subject to change.
[2025-11-06 18:59:07 DP3 TP3 EP3] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2802, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  ...
    self.experts = get_moe_impl_class(quant_config)(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/moe/ep_moe/layer.py", line 118, in __init__
    deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
AssertionError: DeepEP DeepEPMode.LOW_LATENCY mode requires deep_gemm
```


With this PR, the logs are

```bash
[2025-11-06 19:04:21] INFO:     Started server process [2015574]
[2025-11-06 19:04:21] INFO:     Waiting for application startup.
[2025-11-06 19:04:21] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 50, 'top_p': 0.95}
[2025-11-06 19:04:21] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 50, 'top_p': 0.95}
[2025-11-06 19:04:21] INFO:     Application startup complete.
[2025-11-06 19:04:21] INFO:     Uvicorn running on http://0.0.0.0:28000 (Press CTRL+C to quit)
[2025-11-06 19:04:22] INFO:     127.0.0.1:55904 - "GET /get_model_info HTTP/1.1" 200 OK
[2025-11-06 19:04:22] Start of pd disaggregation warmup ...
[2025-11-06 19:04:22] INFO:     127.0.0.1:55908 - "POST /generate HTTP/1.1" 200 OK
[2025-11-06 19:04:22] End of prefill disaggregation mode warmup with status 200, resp .....
[2025-11-06 19:04:22] The server is fired up and ready to roll!
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
