### PR TITLE
fix: spec overlap `predict` shape does not match verify output shapes

### DIFF
--- a/python/sglang/srt/speculative/eagle_info_v2.py
+++ b/python/sglang/srt/speculative/eagle_info_v2.py
@@ -245,9 +245,8 @@ class EagleVerifyInputV2Mixin:
         device = batch.input_ids.device
 
         candidates = self.draft_token.reshape(bs, self.draft_token_num)
-        predict = torch.zeros(
-            (bs * (self.spec_steps + 1),), dtype=torch.int32, device=device
-        )
+        predict_shape = list(next_token_logits.shape)[:-1]
+        predict = torch.zeros(predict_shape, dtype=torch.int32, device=device).flatten()
         accept_index = torch.full(
             (bs, self.spec_steps + 1), -1, dtype=torch.int32, device=device
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In spec overlap v2, the `predict` tensor stores token IDs sampled from tree verify. This is later used in draft extend after decode.

When `num_draft_tokens` is not equal to `bs * (spec_steps + 1)`, there is a shape conflict in `llama_eagle3.py:88`. `hidden_states` has shape `(num_draft_tokens, hidden_size)` and `embeds`, derived from `predict`, has shape `(bs * (spec_steps + 1), hidden_size)`.

## Modifications

Change `predict` to match the shape of `next_token_logits`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
