### PR TITLE
[DeepSeek-V3.2][NSA] Enable MHA Pathway for Short Sequence Prefill on B200 (SM100)

### DIFF
--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -231,6 +231,15 @@ class NativeSparseAttnBackend(AttentionBackend):
         )
         self.speculative_step_id = speculative_step_id
 
+        # Workspace buffer for TRTLLm ragged attention kernel (SM100/B200)
+        # 128 MB workspace for intermediate computation (softmax states, etc.)
+        workspace_size_mb = 128
+        self.workspace_buffer = torch.zeros(
+            workspace_size_mb * 1024 * 1024,
+            dtype=torch.uint8,
+            device=self.device,
+        )
+
     def get_device_int32_arange(self, l: int) -> torch.Tensor:
         if l > len(self._arange_buf):
             next_pow_of_2 = 1 << (l - 1).bit_length()
@@ -1196,9 +1205,16 @@ class NativeSparseAttnBackend(AttentionBackend):
             f"cu_seqlens_k has {len(cu_seqlens_k)-1} requests"
         )
 
-        # Determine FA version: FA3 for SM90 (Hopper), FA4 for SM100+ (Blackwell and beyond)
+        # Use TRTLLm ragged attention for SM100 (Blackwell/B200) to avoid FA4 accuracy issues
         device_sm_major = torch.cuda.get_device_capability()[0]
-        fa_version = 4 if device_sm_major >= 10 else 3
+        if device_sm_major >= 10:
+            return self._forward_trtllm_ragged_mha(
+                q, k, v, layer, forward_batch, metadata,
+                is_prefix_chunk, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, causal
+            )
+
+        # Use FA3 for SM90 (Hopper/H200)
+        fa_version = 3
 
         return flash_attn_varlen_func(
             q=q,
@@ -1212,6 +1228,70 @@ class NativeSparseAttnBackend(AttentionBackend):
             causal=causal,
             ver=fa_version,
         )
+
+    def _forward_trtllm_ragged_mha(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: "RadixAttention",
+        forward_batch: ForwardBatch,
+        metadata: NSAMetadata,
+        is_prefix_chunk: bool,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_k: int,
+        causal: bool,
+    ) -> torch.Tensor:
+        """Standard MHA using TRTLLm ragged attention for SM100 (Blackwell).
+        
+        Uses flashinfer.prefill.trtllm_ragged_attention_deepseek kernel which provides
+        better performance than FA4 on Blackwell architecture.
+        """
+        import flashinfer
+        
+        # Determine seq_lens and o_sf_scale based on processing mode
+        if is_prefix_chunk:
+            # Processing historical prefix chunks
+            chunk_idx = forward_batch.prefix_chunk_idx
+            seq_lens = forward_batch.prefix_chunk_seq_lens[chunk_idx]
+            o_sf_scale = -1.0  # Negative scale for LSE accumulation
+        else:
+            # Processing current tokens (with or without prefix)
+            mha_one_shot = getattr(forward_batch, "mha_one_shot", False)
+            if mha_one_shot:
+                # MHA_ONE_SHOT: process all tokens (prefix + current) in one shot
+                seq_lens = metadata.cache_seqlens_int32
+            else:
+                # MHA_CHUNKED_KV: only process current tokens
+                seq_lens = forward_batch.extend_seq_lens.to(torch.int32)
+            o_sf_scale = 1.0
+        
+        return_lse = getattr(forward_batch, "mha_return_lse", False)
+        
+        result = flashinfer.prefill.trtllm_ragged_attention_deepseek(
+            query=q,
+            key=k,
+            value=v,
+            workspace_buffer=self.workspace_buffer,
+            seq_lens=seq_lens,
+            max_q_len=metadata.max_seq_len_q,
+            max_kv_len=max_seqlen_k,
+            bmm1_scale=layer.scaling,
+            bmm2_scale=1.0,
+            o_sf_scale=o_sf_scale,
+            batch_size=forward_batch.batch_size,
+            window_left=-1,  # No sliding window attention
+            cum_seq_lens_q=cu_seqlens_q,
+            cum_seq_lens_kv=cu_seqlens_k,
+            enable_pdl=False,  # PDL (Persistent Data Layout) optimization disabled
+            is_causal=causal,
+            return_lse=return_lse,
+        )
+        
+        # TRTLLm kernel returns LSE in correct format (total_tokens, nheads)
+        # No need to transpose unlike flash_attn_varlen_func
+        return result
 
     def _forward_tilelang(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Follow up this PR: [DeepSeek-V3.2: Add Adaptive MHA Attention Pathway for Short-Sequence Prefill](https://github.com/sgl-project/sglang/pull/11892). Enable and optimize MHA on B200 (SM100) in the NSA backend by TRT-LLM ragged attention.

## Modifications

- **Add TRT-LLM ragged attention for SM100**: Integrate `flashinfer.prefill.trtllm_ragged_attention_deepseek` for Blackwell (B200) architecture to provide better accuracy than FA4
- **Remove chunked prefix cache support**: Align NSA backend with PR #11892 by removing chunked KV cache logic, keeping only MHA_ONE_SHOT mode for standard multi-head attention

Key changes in `nsa_backend.py`:
- Simplified `_forward_standard_mha()` to handle both SM90 (FA3) and SM100 (TRT-LLM) in a single function
- Removed `_forward_trtllm_ragged_mha()` helper function for cleaner code structure
- Added device capability check to conditionally allocate workspace buffer


## Accuracy Tests

```
Repeat: 8, mean: 0.792                                           | 24/198 [17:23<1:38:01, 33.80s/it]
Scores: ['0.783', '0.788', '0.783', '0.803', '0.823', '0.788', '0.773', '0.793']
====================
Writing report to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2-Exp.html
{'chars': np.float64(15007.823232323231), 'chars:std': np.float64(11964.504345200807), 'score:std': np.float64(0.40520665017240837), 'score': np.float64(0.7929292929292929)}
Writing results to /tmp/gpqa_deepseek-ai_DeepSeek-V3.2-Exp.json
Total latency: 1104.677 s
Score: 0.793
```

## Benchmarking and Profiling

```
python -m sglang.launch_server \
  --model deepseek-ai/DeepSeek-V3.2-Exp \
  --tp 8 --dp 8 --enable-dp-attention \
  --kv-cache-dtype bf16
```

```
python3 -m sglang.bench_serving     --backend sglang     --dataset-name random     --num-prompts 100     --random-input-len 2000     --random-output-len 1     --disable-ignore-eos --random-range-ratio 1.0
```

This PR: MHA(trtllm_ragged_attention_deepseek) + skip topk
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     100       
Benchmark duration (s):                  6.56      
Total input tokens:                      200000    
Total input text tokens:                 200000    
Total input vision tokens:               0         
Total generated tokens:                  100       
Total generated tokens (retokenized):    95        
Request throughput (req/s):              15.25     
Input token throughput (tok/s):          30507.62  
Output token throughput (tok/s):         15.25     
Total token throughput (tok/s):          30522.87  
Concurrency:                             62.85     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4120.22   
Median E2E Latency (ms):                 4129.15   
---------------Time to First Token----------------
Mean TTFT (ms):                          3950.18   
Median TTFT (ms):                        3915.54   
P99 TTFT (ms):                           6528.78   
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
```

main: MLA + skip topk
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 not set
Successful requests:                     100
Benchmark duration (s):                  7.04
Total input tokens:                      200000
Total input text tokens:                 200000
Total input vision tokens:               0
Total generated tokens:                  100
Total generated tokens (retokenized):    95
Request throughput (req/s):              14.20
Input token throughput (tok/s):          28399.30
Output token throughput (tok/s):         14.20
Total token throughput (tok/s):          28413.50
Concurrency:                             60.48
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   4259.29
Median E2E Latency (ms):                 4230.05
---------------Time to First Token----------------
Mean TTFT (ms):                          4090.11
Median TTFT (ms):                        4229.76
P99 TTFT (ms):                           7012.75
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P95 ITL (ms):                            0.00
P99 ITL (ms):                            0.00
Max ITL (ms):                            0.00
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
