### PR TITLE
[WIP][Feature] support tp-sp on qwen2/3 & deepseek v2/3/3.2

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -59,7 +59,7 @@ class DpPaddingMode(IntEnum):
 
     @classmethod
     def get_dp_padding_mode(
-        cls, is_extend_in_batch, global_num_tokens: List[int]
+        cls, is_extend_in_batch, global_num_tokens: List[int], enable_sp: bool = False
     ) -> DpPaddingMode:
         if is_extend_in_batch:
             return DpPaddingMode.SUM_LEN
@@ -67,7 +67,7 @@ class DpPaddingMode(IntEnum):
         # we choose the mode that minimizes the communication cost
         max_len = max(global_num_tokens)
         sum_len = sum(global_num_tokens)
-        if sum_len * 2 > max_len * get_attention_dp_size():
+        if enable_sp or (sum_len * 2 > max_len * get_attention_dp_size()):
             return cls.MAX_LEN
         else:
             return cls.SUM_LEN

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -318,6 +318,9 @@ class ForwardBatch:
     # For matryoshka embeddings
     dimensions: Optional[list[int]] = None
 
+    # For sp
+    enable_sp: Optional[bool] = False
+
     @classmethod
     def init_new(
         cls,
@@ -682,7 +685,10 @@ class ForwardBatch:
                 dim=0,
             )
 
-    def prepare_mlp_sync_batch(self, model_runner: ModelRunner):
+    def prepare_mlp_sync_batch(
+        self, model_runner: ModelRunner, enable_sp: bool = False
+    ):
+
         assert self.global_num_tokens_cpu is not None
         assert self.global_num_tokens_for_logprob_cpu is not None
 
@@ -698,7 +704,9 @@ class ForwardBatch:
             ) * attn_tp_size
 
         dp_padding_mode = DpPaddingMode.get_dp_padding_mode(
-            self.is_extend_in_batch, global_num_tokens
+            self.is_extend_in_batch,
+            global_num_tokens,
+            enable_sp,
         )
         self.dp_padding_mode = dp_padding_mode
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2186,7 +2186,9 @@ class ModelRunner:
 
         # For MLP sync
         if forward_batch.global_num_tokens_cpu is not None:
-            forward_batch.prepare_mlp_sync_batch(self)
+            forward_batch.prepare_mlp_sync_batch(
+                self, get_global_server_args().enable_sp
+            )
 
         if forward_batch.forward_mode.is_decode():
             ret = self.forward_decode(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -57,9 +57,12 @@ from sglang.srt.layers.attention.utils import concat_and_cast_mha_k_triton
 from sglang.srt.layers.communicator import (
     LayerCommunicator,
     LayerScatterModes,
+    ScatterMode,
     enable_moe_dense_fully_dp,
 )
 from sglang.srt.layers.dp_attention import (
+    attn_tp_all_gather_into_tensor,
+    get_attention_tp_group,
     get_attention_tp_rank,
     get_attention_tp_size,
     is_dp_attention_enabled,
@@ -288,7 +291,7 @@ def handle_attention_ascend(attn, forward_batch):
         and not forward_batch.forward_mode.is_target_verify()
         and not forward_batch.forward_mode.is_draft_extend()
         and not forward_batch.forward_mode.is_draft_extend_v2()
-    ):
+    ) or (forward_batch.enable_sp and forward_batch.forward_mode.is_idle()):
         if hasattr(attn, "indexer"):
             return AttnForwardMethod.NPU_MLA_SPARSE
         else:
@@ -495,6 +498,7 @@ class DeepseekV2MLP(nn.Module):
         should_allreduce_fusion: bool = False,
         use_reduce_scatter: bool = False,
         gemm_output_zero_allocator: BumpAllocator = None,
+        enable_sp: bool = False,
     ):
         if (self.tp_size == 1) and x.shape[0] == 0:
             return x
@@ -514,6 +518,7 @@ class DeepseekV2MLP(nn.Module):
         x, _ = self.down_proj(
             x,
             skip_all_reduce=should_allreduce_fusion or use_reduce_scatter,
+            enable_sp=enable_sp,
         )
         return x
 
@@ -1113,6 +1118,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         super().__init__()
         self.layer_id = layer_id
         self.hidden_size = hidden_size
+        self.dense_layer_num = config.first_k_dense_replace
         self.qk_nope_head_dim = qk_nope_head_dim
         self.qk_rope_head_dim = qk_rope_head_dim
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
@@ -1121,6 +1127,8 @@ class DeepseekV2AttentionMLA(nn.Module):
         self.kv_lora_rank = kv_lora_rank
         attn_tp_rank = get_attention_tp_rank()
         attn_tp_size = get_attention_tp_size()
+        self.atten_tp_size = attn_tp_size
+        self.atten_tp_group = get_attention_tp_group()
 
         self.num_heads = num_heads
         assert num_heads % attn_tp_size == 0
@@ -1213,6 +1221,7 @@ class DeepseekV2AttentionMLA(nn.Module):
             prefix=add_prefix("o_proj", prefix),
             tp_rank=attn_tp_rank,
             tp_size=attn_tp_size,
+            tp_group=self.atten_tp_group,
         )
         self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
 
@@ -1390,12 +1399,14 @@ class DeepseekV2AttentionMLA(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        layer_scatter_modes: LayerScatterModes = None,
     ):
         s = self.forward_prepare(
             positions=positions,
             hidden_states=hidden_states,
             forward_batch=forward_batch,
             zero_allocator=zero_allocator,
+            layer_scatter_modes=layer_scatter_modes,
         )
         return self.forward_core(s)
 
@@ -1405,6 +1416,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        layer_scatter_modes: LayerScatterModes = None,
     ):
         if self.attn_mha.kv_b_proj is None:
             self.attn_mha.kv_b_proj = self.kv_b_proj
@@ -1426,7 +1438,11 @@ class DeepseekV2AttentionMLA(nn.Module):
         attn_forward_method = self.dispatch_attn_forward_method(forward_batch)
         if attn_forward_method == AttnForwardMethod.MHA:
             inner_state = self.forward_normal_prepare(
-                positions, hidden_states, forward_batch, zero_allocator
+                positions,
+                hidden_states,
+                forward_batch,
+                zero_allocator,
+                layer_scatter_modes,
             )
         elif attn_forward_method == AttnForwardMethod.MHA_CHUNKED_KV:
             inner_state = self.forward_normal_chunked_kv_prepare(
@@ -1462,7 +1478,11 @@ class DeepseekV2AttentionMLA(nn.Module):
                 inner_state = (*inner_state, None)  # add a position for topk_indices
         elif attn_forward_method == AttnForwardMethod.NPU_MLA_SPARSE:
             inner_state = self.forward_npu_sparse_prepare(
-                positions, hidden_states, forward_batch, zero_allocator
+                positions,
+                hidden_states,
+                forward_batch,
+                zero_allocator,
+                layer_scatter_modes,
             )
         elif attn_forward_method == AttnForwardMethod.MLA_FUSED_ROPE:
             inner_state = self.forward_absorb_fused_mla_rope_prepare(
@@ -1500,18 +1520,46 @@ class DeepseekV2AttentionMLA(nn.Module):
         else:
             raise NotImplementedError
 
+    def scattered_to_tp_attn_full(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        hidden_states, local_hidden_states = (
+            torch.empty(
+                (forward_batch.input_ids.shape[0], hidden_states.shape[1]),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            ),
+            hidden_states,
+        )
+        attn_tp_all_gather_into_tensor(hidden_states, local_hidden_states.contiguous())
+        return hidden_states
+
     def forward_normal_prepare(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        layer_scatter_modes: LayerScatterModes,
     ):
         if self.q_lora_rank is not None:
             q, latent_cache = self.fused_qkv_a_proj_with_mqa(hidden_states)[0].split(
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim], dim=-1
             )
             q_lora = self.q_a_layernorm(q)
+            if forward_batch.enable_sp and (
+                (0 < self.layer_id < self.dense_layer_num)
+                or (
+                    layer_scatter_modes.layer_input_mode == ScatterMode.SCATTERED
+                    and layer_scatter_modes.attn_mode == ScatterMode.TP_ATTN_FULL
+                )
+            ):
+                q_lora = self.scattered_to_tp_attn_full(q_lora, forward_batch)
+                latent_cache = self.scattered_to_tp_attn_full(
+                    latent_cache, forward_batch
+                )
             q = self.q_b_proj(q_lora)[0].view(
                 -1, self.num_local_heads, self.qk_head_dim
             )
@@ -1531,6 +1579,11 @@ class DeepseekV2AttentionMLA(nn.Module):
                 -1, self.num_local_heads, self.qk_head_dim
             )
             latent_cache = self.kv_a_proj_with_mqa(hidden_states)[0]
+            if forward_batch.enable_sp and (0 < self.layer_id < self.dense_layer_num):
+                q = self.scattered_to_tp_attn_full(q, forward_batch)
+                latent_cache = self.scattered_to_tp_attn_full(
+                    latent_cache, forward_batch
+                )
 
         _, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
         kv_a, _ = latent_cache.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
@@ -1560,7 +1613,11 @@ class DeepseekV2AttentionMLA(nn.Module):
     def forward_normal_core(self, q, k, v, forward_batch):
         attn_output = self.attn_mha(q, k, v, forward_batch, save_kv_cache=False)
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
-        output, _ = self.o_proj(attn_output)
+        output, _ = self.o_proj(
+            attn_output,
+            enable_sp=forward_batch.enable_sp
+            and (self.layer_id < self.dense_layer_num),
+        )
         return output
 
     def _fuse_rope_for_trtllm_mla(self, forward_batch: ForwardBatch) -> bool:
@@ -1870,10 +1927,18 @@ class DeepseekV2AttentionMLA(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         zero_allocator: BumpAllocator,
+        layer_scatter_modes: LayerScatterModes,
     ):
         """
         Reuse `self.q_lora_rank is not None` branch from forward_absorb_prepare
         """
+        need_all_gather = forward_batch.enable_sp and (
+            (0 < self.layer_id < self.dense_layer_num)
+            or (
+                layer_scatter_modes.layer_input_mode == ScatterMode.SCATTERED
+                and layer_scatter_modes.attn_mode == ScatterMode.TP_ATTN_FULL
+            )
+        )
         if self.is_mla_preprocess_enabled and forward_batch.forward_mode.is_decode():
             if self.mla_preprocess is None:
                 self.mla_preprocess = NPUFusedMLAPreprocess(
@@ -1918,11 +1983,20 @@ class DeepseekV2AttentionMLA(nn.Module):
                 )
             else:
                 fused_qkv_a_proj_out = self.fused_qkv_a_proj_with_mqa(hidden_states)[0]
+                if need_all_gather:
+                    fused_qkv_a_proj_out = self.scattered_to_tp_attn_full(
+                        fused_qkv_a_proj_out, forward_batch
+                    )
             q, latent_cache = fused_qkv_a_proj_out.split(
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim], dim=-1
             )
             k_nope = latent_cache[..., : self.kv_lora_rank]
-
+            # overlap all gather
+            if need_all_gather:
+                with torch.npu.stream(self.alt_stream):
+                    gathered_hidden_states = self.scattered_to_tp_attn_full(
+                        hidden_states, forward_batch
+                    )
             # overlap qk norm
             if self.alt_stream is not None and get_is_capture_mode():
                 current_stream = torch.cuda.current_stream()
@@ -2012,6 +2086,9 @@ class DeepseekV2AttentionMLA(nn.Module):
             ):
                 q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
 
+        if need_all_gather:
+            torch.npu.current_stream().wait_stream(self.alt_stream)
+            hidden_states = gathered_hidden_states
         # TODO: multi-stream indexer
         topk_indices = self.indexer(
             hidden_states, q_lora, positions, forward_batch, self.layer_id
@@ -2076,7 +2153,11 @@ class DeepseekV2AttentionMLA(nn.Module):
             -1, self.num_local_heads * self.v_head_dim
         )
 
-        output, _ = self.o_proj(attn_bmm_output)
+        output, _ = self.o_proj(
+            attn_bmm_output,
+            enable_sp=forward_batch.enable_sp
+            and (self.layer_id < self.dense_layer_num),
+        )
         return output
 
     def forward_absorb_fused_mla_rope_prepare(
@@ -2581,6 +2662,12 @@ class DeepseekV2DecoderLayer(nn.Module):
         )
         self.layer_id = layer_id
         self.is_nextn = is_nextn
+        self.enable_sp = get_global_server_args().enable_sp
+        self.tp_size, self.tp_rank, self.tp_group = (
+            get_attention_tp_size(),
+            get_attention_tp_rank(),
+            get_attention_tp_group(),
+        )
         self.self_attn = DeepseekV2AttentionMLA(
             config=config,
             hidden_size=self.hidden_size,
@@ -2650,6 +2737,50 @@ class DeepseekV2DecoderLayer(nn.Module):
                 is_nextn or (self.layer_id == self.config.num_hidden_layers - 1)
             ),
         )
+        if self.enable_sp:
+            num_layers = (
+                1
+                if is_nextn
+                else (
+                    config.num_hidden_layers
+                    if self.is_layer_sparse
+                    else config.first_k_dense_replace
+                )
+            )
+
+            is_last_layer = is_nextn or (
+                self.layer_id
+                == (
+                    config.num_hidden_layers - 1
+                    if self.is_layer_sparse
+                    else config.first_k_dense_replace - 1
+                )
+            )
+
+            self.layer_scatter_modes_sp = LayerScatterModes.init_new(
+                layer_id=layer_id,
+                num_layers=num_layers,
+                is_layer_sparse=self.is_layer_sparse,
+                is_previous_layer_sparse=(
+                    is_previous_layer_sparse if self.is_layer_sparse else False
+                ),
+                enable_sp=True,
+            )
+
+            self.layer_communicator_sp = LayerCommunicator(
+                layer_scatter_modes=self.layer_scatter_modes_sp,
+                input_layernorm=self.input_layernorm,
+                post_attention_layernorm=self.post_attention_layernorm,
+                allow_reduce_scatter=True,
+                is_last_layer=is_last_layer,
+                enable_sp=True,
+            )
+
+    def get_layer_communicator(self, is_extend: bool = False):
+        if not self.enable_sp or not is_extend:
+            return self.layer_communicator
+
+        return self.layer_communicator_sp
 
     def _is_layer_sparse(self, layer_id: int, is_nextn: bool) -> bool:
         return is_nextn or (
@@ -2667,6 +2798,13 @@ class DeepseekV2DecoderLayer(nn.Module):
         zero_allocator: BumpAllocator,
         gemm_output_zero_allocator: BumpAllocator = None,
     ) -> torch.Tensor:
+        enable_sp = self.enable_sp and (
+            forward_batch.forward_mode.is_extend() or forward_batch.is_extend_in_batch
+        )
+        forward_batch.enable_sp = enable_sp
+        layer_communicator = self.get_layer_communicator(
+            forward_batch.forward_mode.is_extend() or forward_batch.is_extend_in_batch
+        )
         quant_format = (
             "mxfp4"
             if _is_gfx95_supported
@@ -2677,7 +2815,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             else ""
         )
 
-        hidden_states, residual = self.layer_communicator.prepare_attn(
+        hidden_states, residual = layer_communicator.prepare_attn(
             hidden_states,
             residual,
             forward_batch,
@@ -2689,39 +2827,46 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states=hidden_states,
             forward_batch=forward_batch,
             zero_allocator=zero_allocator,
+            layer_scatter_modes=layer_communicator.layer_scatter_modes,
         )
 
-        hidden_states, residual = self.layer_communicator.prepare_mlp(
+        hidden_states, residual = layer_communicator.prepare_mlp(
             hidden_states, residual, forward_batch
         )
 
         should_allreduce_fusion = (
-            self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
-                forward_batch
-            )
+            layer_communicator.should_fuse_mlp_allreduce_with_next_layer(forward_batch)
         )
 
         # For DP with padding, reduce scatter can be used instead of all-reduce.
-        use_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(
-            forward_batch
-        )
+        use_reduce_scatter = layer_communicator.should_use_reduce_scatter(forward_batch)
 
         if isinstance(self.mlp, DeepseekV2MLP):
             gemm_output_zero_allocator = None
 
-        hidden_states = self.mlp(
-            hidden_states,
-            forward_batch,
-            should_allreduce_fusion,
-            use_reduce_scatter,
-            gemm_output_zero_allocator,
-        )
+        if self.is_layer_sparse:
+            hidden_states = self.mlp(
+                hidden_states,
+                forward_batch,
+                should_allreduce_fusion,
+                use_reduce_scatter,
+                gemm_output_zero_allocator,
+            )
+        else:
+            hidden_states = self.mlp(
+                hidden_states,
+                forward_batch,
+                should_allreduce_fusion,
+                use_reduce_scatter,
+                gemm_output_zero_allocator,
+                enable_sp=enable_sp,
+            )
 
         if should_allreduce_fusion:
             hidden_states._sglang_needs_allreduce_fusion = True
 
         if not should_allreduce_fusion:
-            hidden_states, residual = self.layer_communicator.postprocess_layer(
+            hidden_states, residual = layer_communicator.postprocess_layer(
                 hidden_states, residual, forward_batch
             )
 
@@ -2822,7 +2967,12 @@ class DeepseekV2Model(nn.Module):
         else:
             self.embed_tokens = PPMissingLayer()
 
-        self.alt_stream = torch.cuda.Stream() if _is_cuda else None
+        if _is_cuda:
+            self.alt_stream = torch.cuda.Stream()
+        elif _is_npu:
+            self.alt_stream = torch.npu.Stream()
+        else:
+            self.alt_stream = None
         self.layers, self.start_layer, self.end_layer = make_layers(
             config.num_hidden_layers,
             lambda idx, prefix: DeepseekV2DecoderLayer(

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -25,6 +25,7 @@ from sglang.srt.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    sp_tensor_model_parallel_all_gather,
 )
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
@@ -89,13 +90,13 @@ class Qwen2MLP(nn.Module):
             )
         self.act_fn = SiluAndMul()
 
-    def forward(self, x):
+    def forward(self, x, enable_sp: bool = False):
         if get_global_server_args().rl_on_policy_target == "fsdp":
             x = x.bfloat16()
 
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
+        x, _ = self.down_proj(x, enable_sp=enable_sp)
         return x
 
 
@@ -139,6 +140,7 @@ class Qwen2Attention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
+        self.enable_sp = get_global_server_args().enable_sp
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size,
@@ -185,7 +187,10 @@ class Qwen2Attention(nn.Module):
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v, forward_batch)
-        output, _ = self.o_proj(attn_output)
+        output, _ = self.o_proj(
+            attn_output,
+            enable_sp=self.enable_sp and forward_batch.forward_mode.is_extend(),
+        )
         return output
 
 
@@ -231,6 +236,9 @@ class Qwen2DecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
+        self.layer_id = layer_id
+        self.layer_num = config.num_hidden_layers
+        self.enable_sp = get_global_server_args().enable_sp
 
     def forward(
         self,
@@ -245,15 +253,26 @@ class Qwen2DecoderLayer(nn.Module):
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        enable_sp = self.enable_sp and forward_batch.forward_mode.is_extend()
+        if enable_sp and self.layer_id != 0:
+            hidden_states = sp_tensor_model_parallel_all_gather(hidden_states)
+
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
             forward_batch=forward_batch,
         )
 
+        if enable_sp and self.layer_id == 0:
+            tensor_list_residual = list(
+                residual.tensor_split(get_tensor_model_parallel_world_size())
+            )
+            residual = tensor_list_residual[get_tensor_model_parallel_rank()]
+
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = sp_tensor_model_parallel_all_gather(hidden_states)
+        hidden_states = self.mlp(hidden_states, enable_sp=enable_sp)
         return hidden_states, residual
 
 
@@ -270,6 +289,7 @@ class Qwen2Model(nn.Module):
         self.config = config
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
+        self.enable_sp = get_global_server_args().enable_sp
         self.pp_group = get_pp_group()
 
         if self.pp_group.is_first_rank:
@@ -378,6 +398,9 @@ class Qwen2Model(nn.Module):
                     hidden_states = self.norm(hidden_states)
                 else:
                     hidden_states, _ = self.norm(hidden_states, residual)
+
+        if self.enable_sp and forward_batch.forward_mode.is_extend():
+            hidden_states = sp_tensor_model_parallel_all_gather(hidden_states)
 
         if len(aux_hidden_states) == 0:
             return hidden_states

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -419,6 +419,9 @@ class ServerArgs:
     mamba_ssm_dtype: str = "float32"
     mamba_full_memory_ratio: float = 0.9
 
+    # Sequence parallelism
+    enable_sp: bool = False
+
     # Hierarchical cache
     enable_hierarchical_cache: bool = False
     hicache_ratio: float = 2.0
@@ -2974,6 +2977,13 @@ class ServerArgs:
             type=float,
             default=ServerArgs.mamba_full_memory_ratio,
             help="The ratio of mamba state memory to full kv cache memory.",
+        )
+
+        # Sequence parallelism
+        parser.add_argument(
+            "--enable-sp",
+            action="store_true",
+            help="Enable sequence parallelism.",
         )
 
         # Hierarchical cache

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2763,7 +2763,11 @@ def require_gathered_buffer(server_args):
 
 
 def require_mlp_sync(server_args):
-    return server_args.enable_dp_attention or require_gathered_buffer(server_args)
+    return (
+        server_args.enable_dp_attention
+        or require_gathered_buffer(server_args)
+        or server_args.enable_sp
+    )
 
 
 def find_local_repo_dir(repo_id: str, revision: Optional[str] = None) -> Optional[str]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
For the classic dense decode layer structure (self-attention + MLP), in the pure TP case, tensors are parallelized in the attention layer and the MLP layer. Since each device contains the full amount of data before and after each TP split, Layernorm stores 2\*2BSH bytes of activation value (assume hidden states shape is [B, S, H]). SP aims to split this 4\*BSH redundant data across multiple devices, and do layernorm independently. For more details please refer to the research paper https://arxiv.org/pdf/2205.05198.pdf

<img width="805" height="200" alt="屏幕截图 2025-11-10 114901" src="https://github.com/user-attachments/assets/c6bb343d-6f6b-482b-9254-66ce3227c89a" />

We add a parameter "--enable-sp" at server args, which can enable sequence parallel if be set. For example
```
python3 -m sglang.launch_server --model-path $MODEL_PATH \
        --tp-size 16 --dp-size 1 --enable-sp \
        --trust-remote-code --attention-backend ascend --device npu --host $HOST_IP --port $PORT \
        --quantization w8a8_int8 --mem-fraction-static 0.8 \
        --chunked-prefill-size 16000 --context-length 16000 --max-prefill-tokens 16000 --max-total-tokens 16000 \
        --disable-radix-cache --moe-a2a-backend deepep --deepep-mode auto
```
The TP-SP has two benifits:
1. Reduce long dataset (36K) TTFT for 10% on deepseek v3 and 7% on deepseek v3.2.
2. Reduce peak memory because of less activations on RMSNorm layer.

## Modifications
1. For the RowParallel linear, we replace all-reduce comm op with reduce-scatter on TP group if enable sp.
3. For the dense layers of model (qwen2/3 & deepseek v2/3/3.2), we split residual before layernorm at the first layer, hidden states is be splitted at RowParallel linear so do not need to split again.
4. After the first dense layer, all data are scattered state, only do layernorm at prepare_attn and prepare_mlp. 
5. Before the MLP and ATTENTION module, we do extra all-gather because of weights has been splitted on tensor dimension, to make sure inputs are complete.
6. Do all-gather at the last dense layer.
7. For sparse layer of deepseek models, when enableed Deepep, the hidden states has been sscattered, we utilize it and move the *_scattered_to_tp_attn_full* from prepare_attention to after getting the q_lora and latent cache, which also can decrease much more computation.

NOTE: 
1. We only adapt qwen2/3 and deepseek v2/3/3.2 on ascend backend, for other backends you can add few code to adapt SP.
2. TP-SP can enable with CP (https://github.com/sgl-project/sglang/pull/12207) together on Ascend backend. We test it on dsv3.2 model, CP=16, TP=2, which can continue reducing TTFT for 1 percent and decrease peak runtime memory (2G for single device).

## Accuracy Tests
The test_gsam8k.py is based on benchmark/gsm8k/bench_sglang.py, you can test it with
`python3 benchmark/gsm8k/bench_sglang.py --host http://127.0.0.1 --port 8000 --num-questions 300`.
<img width="1083" height="220" alt="image" src="https://github.com/user-attachments/assets/dfe7c4a3-bab7-4ac1-9952-d172dc929f23" />

## Benchmarking and Profiling
```
export cann_path=/usr/local/Ascend/ascend-toolkit/latest
source /usr/local/Ascend/driver/bin/setenv.bash
source ${cann_path}/../set_env.sh
source ${cann_path}/../../nnal/atb/set_env.sh
source ${cann_path}/opp/vendors/customize/bin/set_env.bash
export ASCEND_HOME_PATH=${cann_path}

# CPU high preformance
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000

export SGLANG_SET_CPU_AFFINITY=1

# Memory Fragmentation
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32

# HCCL
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=16
export HCCL_BUFFSIZE=1600
#export HCCL_RDMA_PCIE_DIRECT_POST_NOSTRICT=TRUE
export HCCL_OP_EXPANSION_MODE=AIV
export HCCL_ALGO="level0:NA;level1:ring"

# Your NIC
export HCCL_SOCKET_IFNAME=enp48s3u1u1
export GLOO_SOCKET_IFNAME=enp48s3u1u1

export PYTHONPATH=$PWD/python/:$PYTHONPATH

python -m sglang.launch_server --model-path $MODEL_PATH \
        --tp-size 16 --dp-size 1 --enable-sp \
        --trust-remote-code --attention-backend ascend --device npu --host 127.0.0.1 --port 8000 \
        --quantization w8a8_int8 --mem-fraction-static 0.79 \
        --chunked-prefill-size 36000 --context-length 36000 --max-prefill-tokens 36000 --max-total-tokens 36000 \
        --disable-radix-cache --moe-a2a-backend deepep --deepep-mode auto
```
<img width="1126" height="299" alt="image" src="https://github.com/user-attachments/assets/de18eb81-e210-4489-9399-37aeb0300eb6" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
