### PR TITLE
docs: document processor_output usage in VLM offline engine notebook

### DIFF
--- a/docs/advanced_features/vlm_query.ipynb
+++ b/docs/advanced_features/vlm_query.ipynb
@@ -107,6 +107,38 @@
    "id": "7",
    "metadata": {},
    "source": [
+    "### Call with Processor Output\n",
+    "\n",
+    "Using a HuggingFace processor to preprocess text and images, and passing the `processor_output` directly into `Engine.generate`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoProcessor\n",
+    "\n",
+    "processor = AutoProcessor.from_pretrained(model_path, use_fast=True)\n",
+    "processor_output = processor(\n",
+    "    images=[image], text=conv.get_prompt(), return_tensors=\"pt\"\n",
+    ")\n",
+    "\n",
+    "out = llm.generate(\n",
+    "    input_ids=processor_output[\"input_ids\"][0].detach().cpu().tolist(),\n",
+    "    image_data=[dict(processor_output, format=\"processor_output\")],\n",
+    ")\n",
+    "print(\"Response using processor output:\")\n",
+    "print(out[\"text\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
     "### Call with Precomputed Embeddings\n",
     "\n",
     "You can pre-calculate image features to avoid repeated visual encoding processes."
@@ -115,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,18 +173,15 @@
     "\n",
     "input_ids = processor_output[\"input_ids\"][0].detach().cpu().tolist()\n",
     "\n",
-    "\n",
     "precomputed_embeddings = vision(\n",
     "    processor_output[\"pixel_values\"].cuda(), processor_output[\"image_grid_thw\"].cuda()\n",
     ")\n",
-    "\n",
     "\n",
     "multi_modal_item = dict(\n",
     "    processor_output,\n",
     "    format=\"precomputed_embedding\",\n",
     "    feature=precomputed_embeddings,\n",
     ")\n",
-    "\n",
     "\n",
     "out = llm.generate(input_ids=input_ids, image_data=[multi_modal_item])\n",
     "print(\"Response using precomputed embeddings:\")\n",
@@ -163,7 +192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Querying Llama 4 Vision Model\n",
@@ -202,7 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Llama 4 Basic Call\n",
@@ -218,7 +247,6 @@
     "    context_length=65536,\n",
     ")\n",
     "\n",
-    "\n",
     "out = llm.generate(prompt=conv.get_prompt(), image_data=[image])\n",
     "print(\"Llama 4 response:\")\n",
     "print(out[\"text\"])\n",
@@ -227,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Call with Processor Output\n",
@@ -253,11 +281,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Call with Precomputed Embeddings\n",
-    "\n",
     "\n",
     "```python\n",
     "from transformers import AutoProcessor\n",
@@ -270,7 +297,6 @@
     "\n",
     "vision = model.vision_model.cuda()\n",
     "multi_modal_projector = model.multi_modal_projector.cuda()\n",
-    "\n",
     "\n",
     "print(f'Image pixel values shape: {processor_output[\"pixel_values\"].shape}')\n",
     "input_ids = processor_output[\"input_ids\"][0].detach().cpu().tolist()\n",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Update vlm_query.ipynb to include a Qwen2.5-VL example that passes
HuggingFace processor_output into Engine.generate, aligning the docs
with the three supported VLM input formats (basic, processor_output,
precomputed_embedding).

#10532

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
