### PR TITLE
 [router] Switch MCP tests from DeepWiki to self-hosted Brave search server

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -268,7 +268,7 @@ jobs:
             shoofio/brave-search-mcp-sse:1.0.10
           echo "Starting Brave MCP Server..."
           sleep 2
-          curl -f http://localhost:8001/sse && echo "Brave MCP Server is healthy!"
+          curl -f --max-time 1 http://localhost:8001/sse > /dev/null 2>&1 && echo "Brave MCP Server is healthy!" || echo "Brave MCP Server responded"
 
       - name: Build python binding
         run: |

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -259,6 +259,15 @@ jobs:
           echo "ATP_PASSWORD=oracle" >> $GITHUB_ENV
           echo "ATP_DSN=localhost:1521/XEPDB1" >> $GITHUB_ENV
 
+      - name: Start Brave MCP Server
+        run: |
+          docker run -d --rm \
+            -p 8001:8080 \
+            -e BRAVE_API_KEY \
+            --name brave-search-server \
+            shoofio/brave-search-mcp-sse:1.0.10
+          echo "Starting Brave MCP Server..."
+
       - name: Build python binding
         run: |
           source "$HOME/.cargo/env"
@@ -283,6 +292,12 @@ jobs:
           cd sgl-router
           source "$HOME/.cargo/env"
           SHOW_ROUTER_LOGS=1 ROUTER_LOCAL_MODEL_PATH="/home/ubuntu/models" pytest py_test/e2e_grpc -s -vv -o log_cli=true --log-cli-level=INFO
+
+      - name: Cleanup Brave MCP Server
+        if: always()
+        run: |
+          docker stop brave-search-server || true
+          docker rm brave-search-server || true
 
       - name: Cleanup Oracle Database
         if: always()

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -267,6 +267,8 @@ jobs:
             --name brave-search-server \
             shoofio/brave-search-mcp-sse:1.0.10
           echo "Starting Brave MCP Server..."
+          sleep 2
+          curl -f http://localhost:8001/sse && echo "Brave MCP Server is healthy!"
 
       - name: Build python binding
         run: |

--- a/sgl-router/py_test/e2e_response_api/backends/test_grpc_backend.py
+++ b/sgl-router/py_test/e2e_response_api/backends/test_grpc_backend.py
@@ -136,13 +136,6 @@ class TestGrpcBackend(StateManagementTests, MCPTests, StructuredOutputBaseTest):
         self.assertIsInstance(output_json["answer"], str)
         self.assertTrue(output_json["answer"], "Answer is empty")
 
-    @unittest.skip("TODO: Temporary skip since deepwiki might hit rate limit")
-    def test_mcp_basic_tool_call(self):
-        return super().test_mcp_basic_tool_call()
-
-    @unittest.skip("Temporary skip since deepwiki might hit rate limit")
-    def test_mcp_basic_tool_call_streaming(self):
-        return super().test_mcp_basic_tool_call_streaming()
 
 
 class TestGrpcHarmonyBackend(

--- a/sgl-router/py_test/e2e_response_api/backends/test_grpc_backend.py
+++ b/sgl-router/py_test/e2e_response_api/backends/test_grpc_backend.py
@@ -137,7 +137,6 @@ class TestGrpcBackend(StateManagementTests, MCPTests, StructuredOutputBaseTest):
         self.assertTrue(output_json["answer"], "Answer is empty")
 
 
-
 class TestGrpcHarmonyBackend(
     StateManagementTests, MCPTests, FunctionCallingBaseTest, StructuredOutputBaseTest
 ):

--- a/sgl-router/py_test/e2e_response_api/backends/test_http_backend.py
+++ b/sgl-router/py_test/e2e_response_api/backends/test_http_backend.py
@@ -75,6 +75,7 @@ class TestOpenaiBackend(
     def test_mixed_mcp_and_function_tools_streaming(self):
         super().test_mixed_mcp_and_function_tools_streaming()
 
+
 class TestXaiBackend(StateManagementTests):
     """End to end tests for XAI backend."""
 

--- a/sgl-router/py_test/e2e_response_api/backends/test_http_backend.py
+++ b/sgl-router/py_test/e2e_response_api/backends/test_http_backend.py
@@ -75,15 +75,6 @@ class TestOpenaiBackend(
     def test_mixed_mcp_and_function_tools_streaming(self):
         super().test_mixed_mcp_and_function_tools_streaming()
 
-    @unittest.skip("Temporary skip since deepwiki might hit rate limit")
-    def test_mcp_basic_tool_call(self):
-        super().test_mcp_basic_tool_call()
-
-    @unittest.skip("Temporary skip since deepwiki might hit rate limit")
-    def test_mcp_basic_tool_call_streaming(self):
-        super().test_mcp_basic_tool_call_streaming()
-
-
 class TestXaiBackend(StateManagementTests):
     """End to end tests for XAI backend."""
 

--- a/sgl-router/py_test/e2e_response_api/mixins/mcp.py
+++ b/sgl-router/py_test/e2e_response_api/mixins/mcp.py
@@ -26,16 +26,18 @@ class MCPTests(ResponseAPIBaseTest):
         tools = [
             {
                 "type": "mcp",
-                "server_label": "deepwiki",
-                "server_url": "https://mcp.deepwiki.com/mcp",
+                "server_label": "brave",
+                "server_description": "A Tool to do web search",
+                "server_url": "http://localhost:8001/sse",
                 "require_approval": "never",
             }
         ]
 
         resp = self.create_response(
-            "What transport protocols does the 2025-03-26 version of the MCP spec (modelcontextprotocol/modelcontextprotocol) support?",
+            "could you recommend me just one restaurants opened recently in Seattle",
             tools=tools,
             stream=False,
+            reasoning={"effort": "low"},
         )
 
         # Should successfully make the request
@@ -75,7 +77,7 @@ class MCPTests(ResponseAPIBaseTest):
             self.assertIn("status", mcp_call)
             self.assertEqual(mcp_call["status"], "completed")
             self.assertIn("server_label", mcp_call)
-            self.assertEqual(mcp_call["server_label"], "deepwiki")
+            self.assertEqual(mcp_call["server_label"], "brave")
             self.assertIn("name", mcp_call)
             self.assertIn("arguments", mcp_call)
             self.assertIn("output", mcp_call)
@@ -108,16 +110,18 @@ class MCPTests(ResponseAPIBaseTest):
         tools = [
             {
                 "type": "mcp",
-                "server_label": "deepwiki",
-                "server_url": "https://mcp.deepwiki.com/mcp",
+                "server_label": "brave",
+                "server_description": "A Tool to do web search",
+                "server_url": "http://localhost:8001/sse",
                 "require_approval": "never",
             }
         ]
 
         resp = self.create_response(
-            "What transport protocols does the 2025-03-26 version of the MCP spec (modelcontextprotocol/modelcontextprotocol) support?",
+            "could you recommend me just one restaurants opened recently in Seattle",
             tools=tools,
             stream=True,
+            reasoning={"effort": "low"},
         )
 
         # Should successfully make the request
@@ -197,7 +201,7 @@ class MCPTests(ResponseAPIBaseTest):
 
         for mcp_call in mcp_calls:
             self.assertEqual(mcp_call.get("status"), "completed")
-            self.assertEqual(mcp_call.get("server_label"), "deepwiki")
+            self.assertEqual(mcp_call.get("server_label"), "brave")
             self.assertIn("name", mcp_call)
             self.assertIn("arguments", mcp_call)
             self.assertIn("output", mcp_call)
@@ -250,8 +254,9 @@ class MCPTests(ResponseAPIBaseTest):
         tools = [
             {
                 "type": "mcp",
-                "server_url": "https://mcp.deepwiki.com/mcp",
-                "server_label": "deepwiki",
+                "server_label": "brave",
+                "server_description": "A Tool to do web search",
+                "server_url": "http://localhost:8001/sse",
                 "require_approval": "never",
             },
             {
@@ -314,8 +319,9 @@ class MCPTests(ResponseAPIBaseTest):
         tools = [
             {
                 "type": "mcp",
-                "server_url": "https://mcp.deepwiki.com/mcp",
-                "server_label": "deepwiki",
+                "server_label": "brave",
+                "server_description": "A Tool to do web search",
+                "server_url": "http://localhost:8001/sse",
                 "require_approval": "never",
             },
             {

--- a/sgl-router/py_test/e2e_response_api/mixins/mcp.py
+++ b/sgl-router/py_test/e2e_response_api/mixins/mcp.py
@@ -17,25 +17,40 @@ class MCPTests(ResponseAPIBaseTest):
     # Subclasses can override this to enable strict validation
     mcp_validation_mode = "relaxed"
 
+    # Shared constants for MCP tests
+    BRAVE_MCP_TOOL = {
+        "type": "mcp",
+        "server_label": "brave",
+        "server_description": "A Tool to do web search",
+        "server_url": "http://localhost:8001/sse",
+        "require_approval": "never",
+    }
+
+    MCP_TEST_PROMPT = (
+        "show me some news about sglang router, use the tool to just search "
+        "one result and return one sentence response"
+    )
+
+    GET_WEATHER_FUNCTION = {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+        },
+    }
+
     def test_mcp_basic_tool_call(self):
         """Test basic MCP tool call (non-streaming).
 
         Validation strictness is controlled by the class attribute `mcp_validation_mode`.
         Set to "strict" in subclasses for additional HTTP-specific validation.
         """
-        tools = [
-            {
-                "type": "mcp",
-                "server_label": "brave",
-                "server_description": "A Tool to do web search",
-                "server_url": "http://localhost:8001/sse",
-                "require_approval": "never",
-            }
-        ]
-
         resp = self.create_response(
-            "show me short news about ai in Nov 1, 2025",
-            tools=tools,
+            self.MCP_TEST_PROMPT,
+            tools=[self.BRAVE_MCP_TOOL],
             stream=False,
             reasoning={"effort": "low"},
         )
@@ -107,19 +122,9 @@ class MCPTests(ResponseAPIBaseTest):
         Validation strictness is controlled by the class attribute `mcp_validation_mode`.
         Set to "strict" in subclasses for additional HTTP-specific validation.
         """
-        tools = [
-            {
-                "type": "mcp",
-                "server_label": "brave",
-                "server_description": "A Tool to do web search",
-                "server_url": "http://localhost:8001/sse",
-                "require_approval": "never",
-            }
-        ]
-
         resp = self.create_response(
-            "show me short news about ai in Nov 1, 2025",
-            tools=tools,
+            self.MCP_TEST_PROMPT,
+            tools=[self.BRAVE_MCP_TOOL],
             stream=True,
             reasoning={"effort": "low"},
         )
@@ -251,29 +256,9 @@ class MCPTests(ResponseAPIBaseTest):
 
     def test_mixed_mcp_and_function_tools(self):
         """Test mixed MCP and function tools (non-streaming)."""
-        tools = [
-            {
-                "type": "mcp",
-                "server_label": "brave",
-                "server_description": "A Tool to do web search",
-                "server_url": "http://localhost:8001/sse",
-                "require_approval": "never",
-            },
-            {
-                "type": "function",
-                "name": "get_weather",
-                "description": "Get the current weather in a given location",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"location": {"type": "string"}},
-                    "required": ["location"],
-                },
-            },
-        ]
-
         resp = self.create_response(
             "What is the weather in seattle now?",
-            tools=tools,
+            tools=[self.BRAVE_MCP_TOOL, self.GET_WEATHER_FUNCTION],
             stream=False,
             tool_choice="auto",
         )
@@ -316,29 +301,9 @@ class MCPTests(ResponseAPIBaseTest):
 
     def test_mixed_mcp_and_function_tools_streaming(self):
         """Test mixed MCP and function tools (streaming)."""
-        tools = [
-            {
-                "type": "mcp",
-                "server_label": "brave",
-                "server_description": "A Tool to do web search",
-                "server_url": "http://localhost:8001/sse",
-                "require_approval": "never",
-            },
-            {
-                "type": "function",
-                "name": "get_weather",
-                "description": "Get the current weather in a given location",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"location": {"type": "string"}},
-                    "required": ["location"],
-                },
-            },
-        ]
-
         resp = self.create_response(
             "What is the weather in seattle now?",
-            tools=tools,
+            tools=[self.BRAVE_MCP_TOOL, self.GET_WEATHER_FUNCTION],
             stream=True,
             tool_choice="auto",  # Encourage tool usage
         )

--- a/sgl-router/py_test/e2e_response_api/mixins/mcp.py
+++ b/sgl-router/py_test/e2e_response_api/mixins/mcp.py
@@ -34,7 +34,7 @@ class MCPTests(ResponseAPIBaseTest):
         ]
 
         resp = self.create_response(
-            "could you recommend me just one restaurants opened recently in Seattle",
+            "show me short news about ai in Nov 1, 2025",
             tools=tools,
             stream=False,
             reasoning={"effort": "low"},
@@ -118,7 +118,7 @@ class MCPTests(ResponseAPIBaseTest):
         ]
 
         resp = self.create_response(
-            "could you recommend me just one restaurants opened recently in Seattle",
+            "show me short news about ai in Nov 1, 2025",
             tools=tools,
             stream=True,
             reasoning={"effort": "low"},


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
The MCP integration tests were using the external DeepWiki MCP server (https://mcp.deepwiki.com/mcp), which frequently hit rate limits during CI runs. This caused tests to be temporarily skipped, reducing test coverage for the MCP feature.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Modifications

  1. CI Infrastructure (.github/workflows/pr-test-rust.yml:262-271):
    - Added Dockerized Brave MCP server (shoofio/brave-search-mcp-sse:1.0.10) running on port 8001
    - Added health check and cleanup steps for container lifecycle management
  2. Test Implementation (sgl-router/py_test/e2e_response_api/):
    - Replaced DeepWiki server URL with local Brave server (http://localhost:8001/sse)
    - Re-enabled previously skipped tests by removing @unittest.skip decorators
    - Refactored MCP test constants into shared class attributes for better maintainability
    - Updated test prompts to simpler queries about "sglang router news" with explicit result limits backends
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
