### PR TITLE
[router][grpc] Move all error logs to their call sites

### DIFF
--- a/sgl-router/src/routers/grpc/common/responses/utils.rs
+++ b/sgl-router/src/routers/grpc/common/responses/utils.rs
@@ -7,7 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde_json::{json, to_value};
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     core::WorkerRegistry,
@@ -44,6 +44,10 @@ pub async fn ensure_mcp_connection(
                 .await
                 .is_none()
             {
+                error!(
+                    function = "ensure_mcp_connection",
+                    "Failed to connect to MCP server"
+                );
                 return Err(error::failed_dependency(
                     "Failed to connect to MCP server. Check server_url and authorization.",
                 ));

--- a/sgl-router/src/routers/grpc/common/stages/client_acquisition.rs
+++ b/sgl-router/src/routers/grpc/common/stages/client_acquisition.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use tracing::error;
 
 use super::PipelineStage;
 use crate::routers::grpc::{
@@ -15,11 +16,13 @@ pub struct ClientAcquisitionStage;
 #[async_trait]
 impl PipelineStage for ClientAcquisitionStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let workers = ctx
-            .state
-            .workers
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Worker selection not completed"))?;
+        let workers = ctx.state.workers.as_ref().ok_or_else(|| {
+            error!(
+                function = "ClientAcquisitionStage::execute",
+                "Worker selection stage not completed"
+            );
+            error::internal_error("Worker selection not completed")
+        })?;
 
         let clients = match workers {
             WorkerSelection::Single { worker } => {

--- a/sgl-router/src/routers/grpc/error.rs
+++ b/sgl-router/src/routers/grpc/error.rs
@@ -9,7 +9,6 @@ use axum::{
     Json,
 };
 use serde_json::json;
-use tracing::{error, warn};
 
 /// Create a 500 Internal Server Error response
 ///
@@ -21,7 +20,6 @@ use tracing::{error, warn};
 /// ```
 pub fn internal_error(message: impl Into<String>) -> Response {
     let msg = message.into();
-    error!("{}", msg);
     (
         StatusCode::INTERNAL_SERVER_ERROR,
         Json(json!({
@@ -45,7 +43,6 @@ pub fn internal_error(message: impl Into<String>) -> Response {
 /// ```
 pub fn bad_request(message: impl Into<String>) -> Response {
     let msg = message.into();
-    error!("{}", msg);
     (
         StatusCode::BAD_REQUEST,
         Json(json!({
@@ -69,7 +66,6 @@ pub fn bad_request(message: impl Into<String>) -> Response {
 /// ```
 pub fn not_found(message: impl Into<String>) -> Response {
     let msg = message.into();
-    warn!("{}", msg);
     (
         StatusCode::NOT_FOUND,
         Json(json!({
@@ -93,7 +89,6 @@ pub fn not_found(message: impl Into<String>) -> Response {
 /// ```
 pub fn service_unavailable(message: impl Into<String>) -> Response {
     let msg = message.into();
-    warn!("{}", msg);
     (
         StatusCode::SERVICE_UNAVAILABLE,
         Json(json!({
@@ -117,7 +112,6 @@ pub fn service_unavailable(message: impl Into<String>) -> Response {
 /// ```
 pub fn failed_dependency(message: impl Into<String>) -> Response {
     let msg = message.into();
-    warn!("{}", msg);
     (
         StatusCode::FAILED_DEPENDENCY,
         Json(json!({

--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -65,7 +65,7 @@ impl HarmonyResponseProcessor {
             // Parse Harmony channels with HarmonyParserAdapter
             let mut parser = HarmonyParserAdapter::new().map_err(|e| {
                 error!(
-                    function = "process_streaming_response",
+                    function = "process_non_streaming_chat_response",
                     error = %e,
                     "Failed to create Harmony parser"
                 );

--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -185,7 +185,7 @@ impl HarmonyResponseProcessor {
         // Parse Harmony channels
         let mut parser = HarmonyParserAdapter::new().map_err(|e| {
             error!(
-                function = "process_non_streaming_response",
+                function = "process_responses_iteration",
                 error = %e,
                 "Failed to create Harmony parser"
             );

--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -81,7 +81,7 @@ impl HarmonyResponseProcessor {
                 )
                 .map_err(|e| {
                     error!(
-                        function = "process_streaming_response",
+                        function = "process_non_streaming_chat_response",
                         error = %e,
                         "Harmony parsing failed on complete response"
                     );

--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use axum::response::Response;
 use proto::generate_complete::MatchedStop::{MatchedStopStr, MatchedTokenId};
+use tracing::error;
 
 use super::HarmonyParserAdapter;
 use crate::{
@@ -63,6 +64,11 @@ impl HarmonyResponseProcessor {
 
             // Parse Harmony channels with HarmonyParserAdapter
             let mut parser = HarmonyParserAdapter::new().map_err(|e| {
+                error!(
+                    function = "process_streaming_response",
+                    error = %e,
+                    "Failed to create Harmony parser"
+                );
                 error::internal_error(format!("Failed to create Harmony parser: {}", e))
             })?;
 
@@ -73,7 +79,14 @@ impl HarmonyResponseProcessor {
                     complete.finish_reason.clone(),
                     matched_stop.clone(),
                 )
-                .map_err(|e| error::internal_error(format!("Harmony parsing failed: {}", e)))?;
+                .map_err(|e| {
+                    error!(
+                        function = "process_streaming_response",
+                        error = %e,
+                        "Harmony parsing failed on complete response"
+                    );
+                    error::internal_error(format!("Harmony parsing failed: {}", e))
+                })?;
 
             // Build response message (assistant)
             let message = ChatCompletionMessage {
@@ -171,6 +184,11 @@ impl HarmonyResponseProcessor {
 
         // Parse Harmony channels
         let mut parser = HarmonyParserAdapter::new().map_err(|e| {
+            error!(
+                function = "process_non_streaming_response",
+                error = %e,
+                "Failed to create Harmony parser"
+            );
             error::internal_error(format!("Failed to create Harmony parser: {}", e))
         })?;
 
@@ -190,7 +208,14 @@ impl HarmonyResponseProcessor {
                 complete.finish_reason.clone(),
                 matched_stop,
             )
-            .map_err(|e| error::internal_error(format!("Harmony parsing failed: {}", e)))?;
+            .map_err(|e| {
+                error!(
+                    function = "process_non_streaming_response",
+                    error = %e,
+                    "Harmony parsing failed on complete response"
+                );
+                error::internal_error(format!("Harmony parsing failed: {}", e))
+            })?;
 
         // VALIDATION: Check if model incorrectly generated Tool role messages
         // This happens when the model copies the format of tool result messages

--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -210,7 +210,7 @@ impl HarmonyResponseProcessor {
             )
             .map_err(|e| {
                 error!(
-                    function = "process_non_streaming_response",
+                    function = "process_responses_iteration",
                     error = %e,
                     "Harmony parsing failed on complete response"
                 );

--- a/sgl-router/src/routers/grpc/harmony/responses.rs
+++ b/sgl-router/src/routers/grpc/harmony/responses.rs
@@ -1557,7 +1557,7 @@ async fn load_previous_messages(
         .await
         .map_err(|e| {
             error!(
-                function = "load_conversation_history",
+                function = "load_previous_messages",
                 prev_id = %prev_id_str,
                 error = %e,
                 "Failed to load previous response chain from storage"

--- a/sgl-router/src/routers/grpc/harmony/responses.rs
+++ b/sgl-router/src/routers/grpc/harmony/responses.rs
@@ -325,7 +325,7 @@ async fn execute_with_mcp_loop(
         // Safety check: prevent infinite loops
         if iteration_count > MAX_TOOL_ITERATIONS {
             error!(
-                function = "handle_response_request",
+                function = "execute_with_mcp_loop",
                 iteration_count = iteration_count,
                 max_iterations = MAX_TOOL_ITERATIONS,
                 "Maximum tool iterations exceeded"

--- a/sgl-router/src/routers/grpc/harmony/stages/request_building.rs
+++ b/sgl-router/src/routers/grpc/harmony/stages/request_building.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
-use tracing::debug;
+use tracing::{debug, error};
 use uuid::Uuid;
 
 use crate::routers::grpc::{
@@ -30,18 +30,22 @@ impl HarmonyRequestBuildingStage {
 impl PipelineStage for HarmonyRequestBuildingStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
         // Get preparation output
-        let prep = ctx
-            .state
-            .preparation
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Preparation not completed"))?;
+        let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
+            error!(
+                function = "HarmonyRequestBuildingStage::execute",
+                "Preparation stage not completed"
+            );
+            error::internal_error("Preparation not completed")
+        })?;
 
         // Get clients
-        let clients = ctx
-            .state
-            .clients
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Client acquisition not completed"))?;
+        let clients = ctx.state.clients.as_ref().ok_or_else(|| {
+            error!(
+                function = "HarmonyRequestBuildingStage::execute",
+                "Client acquisition stage not completed"
+            );
+            error::internal_error("Client acquisition not completed")
+        })?;
         let builder_client = match clients {
             ClientSelection::Single { client } => client,
             ClientSelection::Dual { prefill, .. } => prefill,
@@ -52,6 +56,10 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             RequestType::Chat(_) => format!("chatcmpl-{}", Uuid::new_v4()),
             RequestType::Responses(_) => format!("responses-{}", Uuid::new_v4()),
             RequestType::Generate(_) => {
+                error!(
+                    function = "HarmonyRequestBuildingStage::execute",
+                    "Generate request type not supported for Harmony models"
+                );
                 return Err(error::bad_request(
                     "Generate requests are not supported with Harmony models".to_string(),
                 ));
@@ -75,7 +83,14 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                         None,
                         prep.tool_constraints.clone(),
                     )
-                    .map_err(|e| error::bad_request(format!("Invalid request parameters: {}", e)))?
+                    .map_err(|e| {
+                        error!(
+                            function = "HarmonyRequestBuildingStage::execute",
+                            error = %e,
+                            "Failed to build generate request from chat"
+                        );
+                        error::bad_request(format!("Invalid request parameters: {}", e))
+                    })?
             }
             RequestType::Responses(request) => builder_client
                 .build_generate_request_from_responses(
@@ -86,7 +101,14 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                     prep.harmony_stop_ids.clone(),
                     prep.tool_constraints.clone(),
                 )
-                .map_err(|e| error::bad_request(format!("Invalid request parameters: {}", e)))?,
+                .map_err(|e| {
+                    error!(
+                        function = "HarmonyRequestBuildingStage::execute",
+                        error = %e,
+                        "Failed to build generate request from responses"
+                    );
+                    error::bad_request(format!("Invalid request parameters: {}", e))
+                })?,
             _ => unreachable!(),
         };
 

--- a/sgl-router/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/handlers.rs
@@ -43,7 +43,7 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use serde_json::json;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 use validator::Validate;
 
@@ -664,8 +664,14 @@ async fn execute_without_mcp(
     response_id: Option<String>,
 ) -> Result<ResponsesResponse, Response> {
     // Convert ResponsesRequest → ChatCompletionRequest
-    let chat_request = conversions::responses_to_chat(modified_request)
-        .map_err(|e| error::bad_request(format!("Failed to convert request: {}", e)))?;
+    let chat_request = conversions::responses_to_chat(modified_request).map_err(|e| {
+        error!(
+            function = "execute_chat_pipeline",
+            error = %e,
+            "Failed to convert ResponsesRequest to ChatCompletionRequest"
+        );
+        error::bad_request(format!("Failed to convert request: {}", e))
+    })?;
 
     // Execute chat pipeline (errors already have proper HTTP status codes)
     let chat_response = ctx
@@ -679,8 +685,14 @@ async fn execute_without_mcp(
         .await?; // Preserve the Response error as-is
 
     // Convert ChatCompletionResponse → ResponsesResponse
-    conversions::chat_to_responses(&chat_response, original_request, response_id)
-        .map_err(|e| error::internal_error(format!("Failed to convert to responses format: {}", e)))
+    conversions::chat_to_responses(&chat_response, original_request, response_id).map_err(|e| {
+        error!(
+            function = "execute_chat_pipeline",
+            error = %e,
+            "Failed to convert ChatCompletionResponse to ResponsesResponse"
+        );
+        error::internal_error(format!("Failed to convert to responses format: {}", e))
+    })
 }
 
 /// Load conversation history and response chains, returning modified request
@@ -757,7 +769,15 @@ async fn load_conversation_history(
             .conversation_storage
             .get_conversation(&conv_id)
             .await
-            .map_err(|e| error::internal_error(format!("Failed to check conversation: {}", e)))?;
+            .map_err(|e| {
+                error!(
+                    function = "load_conversation_history",
+                    conversation_id = %conv_id_str,
+                    error = %e,
+                    "Failed to check conversation existence in storage"
+                );
+                error::internal_error(format!("Failed to check conversation: {}", e))
+            })?;
 
         if conversation.is_none() {
             return Err(error::not_found(format!(

--- a/sgl-router/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/handlers.rs
@@ -687,7 +687,7 @@ async fn execute_without_mcp(
     // Convert ChatCompletionResponse → ResponsesResponse
     conversions::chat_to_responses(&chat_response, original_request, response_id).map_err(|e| {
         error!(
-            function = "execute_chat_pipeline",
+            function = "execute_without_mcp",
             error = %e,
             "Failed to convert ChatCompletionResponse to ResponsesResponse"
         );

--- a/sgl-router/src/routers/grpc/regular/responses/handlers.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/handlers.rs
@@ -666,7 +666,7 @@ async fn execute_without_mcp(
     // Convert ResponsesRequest → ChatCompletionRequest
     let chat_request = conversions::responses_to_chat(modified_request).map_err(|e| {
         error!(
-            function = "execute_chat_pipeline",
+            function = "execute_without_mcp",
             error = %e,
             "Failed to convert ResponsesRequest to ChatCompletionRequest"
         );

--- a/sgl-router/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/sgl-router/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use tracing::error;
 use uuid::Uuid;
 
 use crate::routers::grpc::{
@@ -26,17 +27,21 @@ impl ChatRequestBuildingStage {
 #[async_trait]
 impl PipelineStage for ChatRequestBuildingStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let prep = ctx
-            .state
-            .preparation
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Preparation not completed"))?;
+        let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
+            error!(
+                function = "ChatRequestBuildingStage::execute",
+                "Preparation not completed"
+            );
+            error::internal_error("Preparation not completed")
+        })?;
 
-        let clients = ctx
-            .state
-            .clients
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Client acquisition not completed"))?;
+        let clients = ctx.state.clients.as_ref().ok_or_else(|| {
+            error!(
+                function = "ChatRequestBuildingStage::execute",
+                "Client acquisition not completed"
+            );
+            error::internal_error("Client acquisition not completed")
+        })?;
 
         let chat_request = ctx.chat_request_arc();
 
@@ -63,7 +68,10 @@ impl PipelineStage for ChatRequestBuildingStage {
                     .clone(),
                 prep.tool_constraints.clone(),
             )
-            .map_err(|e| error::bad_request(format!("Invalid request parameters: {}", e)))?;
+            .map_err(|e| {
+                error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to build generate request");
+                error::bad_request(format!("Invalid request parameters: {}", e))
+            })?;
 
         // Inject PD metadata if needed
         if self.inject_pd_metadata {

--- a/sgl-router/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/sgl-router/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::Response;
+use tracing::error;
 
 use crate::{
     protocols::{common::InputIds, generate::GenerateRequest},
@@ -44,6 +45,7 @@ impl GeneratePreparationStage {
         let (original_text, token_ids) = match self.resolve_generate_input(ctx, request) {
             Ok(res) => res,
             Err(msg) => {
+                error!(function = "GeneratePreparationStage::execute", error = %msg, "Failed to resolve generate input");
                 return Err(error::bad_request(msg));
             }
         };

--- a/sgl-router/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/sgl-router/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use tracing::error;
 use uuid::Uuid;
 
 use crate::routers::grpc::{
@@ -26,17 +27,21 @@ impl GenerateRequestBuildingStage {
 #[async_trait]
 impl PipelineStage for GenerateRequestBuildingStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        let prep = ctx
-            .state
-            .preparation
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Preparation not completed"))?;
+        let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
+            error!(
+                function = "GenerateRequestBuildingStage::execute",
+                "Preparation not completed"
+            );
+            error::internal_error("Preparation not completed")
+        })?;
 
-        let clients = ctx
-            .state
-            .clients
-            .as_ref()
-            .ok_or_else(|| error::internal_error("Client acquisition not completed"))?;
+        let clients = ctx.state.clients.as_ref().ok_or_else(|| {
+            error!(
+                function = "GenerateRequestBuildingStage::execute",
+                "Client acquisition not completed"
+            );
+            error::internal_error("Client acquisition not completed")
+        })?;
 
         let generate_request = ctx.generate_request_arc();
 
@@ -59,7 +64,10 @@ impl PipelineStage for GenerateRequestBuildingStage {
                 prep.original_text.clone(),
                 prep.token_ids.clone(),
             )
-            .map_err(error::bad_request)?;
+            .map_err(|e| {
+                error!(function = "GenerateRequestBuildingStage::execute", error = %e, "Failed to build generate request");
+                error::bad_request(e)
+            })?;
 
         // Inject PD metadata if needed
         if self.inject_pd_metadata {

--- a/sgl-router/src/routers/grpc/regular/stages/response_processing.rs
+++ b/sgl-router/src/routers/grpc/regular/stages/response_processing.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::Response;
+use tracing::error;
 
 use super::{chat::ChatResponseProcessingStage, generate::GenerateResponseProcessingStage};
 use crate::routers::grpc::{
@@ -40,9 +41,15 @@ impl PipelineStage for ResponseProcessingStage {
         match &ctx.input.request_type {
             RequestType::Chat(_) => self.chat_stage.execute(ctx).await,
             RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
-            RequestType::Responses(_) => Err(error::bad_request(
-                "Responses API processing must be handled by responses handler".to_string(),
-            )),
+            RequestType::Responses(_) => {
+                error!(
+                    function = "ResponseProcessingStage::execute",
+                    "Responses API not supported in regular pipeline"
+                );
+                Err(error::bad_request(
+                    "Responses API processing must be handled by responses handler".to_string(),
+                ))
+            }
         }
     }
 

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -43,8 +43,14 @@ pub async fn get_grpc_client_from_worker(
     let client_arc = worker
         .get_grpc_client()
         .await
-        .map_err(|e| error::internal_error(format!("Failed to get gRPC client: {}", e)))?
-        .ok_or_else(|| error::internal_error("Selected worker is not configured for gRPC"))?;
+        .map_err(|e| {
+            error!(function = "get_grpc_client_from_worker", error = %e, "Failed to get gRPC client");
+            error::internal_error(format!("Failed to get gRPC client: {}", e))
+        })?
+        .ok_or_else(|| {
+            error!(function = "get_grpc_client_from_worker", "Selected worker not configured for gRPC");
+            error::internal_error("Selected worker is not configured for gRPC")
+        })?;
 
     Ok((*client_arc).clone())
 }
@@ -596,7 +602,7 @@ pub async fn collect_stream_responses(
                         all_responses.push(complete);
                     }
                     Some(Error(err)) => {
-                        error!("{} error: {}", worker_name, err.message);
+                        error!(function = "collect_all_responses", worker = %worker_name, error = %err.message, "Worker generation error");
                         // Don't mark as completed - let Drop send abort for error cases
                         return Err(error::internal_error(format!(
                             "{} generation failed: {}",
@@ -612,7 +618,7 @@ pub async fn collect_stream_responses(
                 }
             }
             Err(e) => {
-                error!("{} stream error: {:?}", worker_name, e);
+                error!(function = "collect_all_responses", worker = %worker_name, error = ?e, "Worker stream error");
                 // Don't mark as completed - let Drop send abort for error cases
                 return Err(error::internal_error(format!(
                     "{} stream failed: {}",

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -618,7 +618,7 @@ pub async fn collect_stream_responses(
                 }
             }
             Err(e) => {
-                error!(function = "collect_all_responses", worker = %worker_name, error = ?e, "Worker stream error");
+                error!(function = "collect_stream_responses", worker = %worker_name, error = ?e, "Worker stream error");
                 // Don't mark as completed - let Drop send abort for error cases
                 return Err(error::internal_error(format!(
                     "{} stream failed: {}",

--- a/sgl-router/src/routers/grpc/utils.rs
+++ b/sgl-router/src/routers/grpc/utils.rs
@@ -602,7 +602,7 @@ pub async fn collect_stream_responses(
                         all_responses.push(complete);
                     }
                     Some(Error(err)) => {
-                        error!(function = "collect_all_responses", worker = %worker_name, error = %err.message, "Worker generation error");
+                        error!(function = "collect_stream_responses", worker = %worker_name, error = %err.message, "Worker generation error");
                         // Don't mark as completed - let Drop send abort for error cases
                         return Err(error::internal_error(format!(
                             "{} generation failed: {}",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Currently, error.rs logs error or warn logs for errors. It is hard to trace back the call's original call sites in this way.

Since rust doesn't support log_exception. This PR moves all the logs to error's call site. This way it is easier to tell where the error comes from.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
- Remove log in all functions in error.rs
- Add log for all call sites of `error::`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
