### PR TITLE
[diffusion] fix lamba not match when loading Qwen-Image(-Edit) from local dir

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipelines/registry.py
+++ b/python/sglang/multimodal_gen/configs/pipelines/registry.py
@@ -73,8 +73,8 @@ PIPELINE_DETECTOR: dict[str, Callable[[str], bool]] = {
     "wandmdpipeline": lambda id: "wandmdpipeline" in id.lower(),
     "wancausaldmdpipeline": lambda id: "wancausaldmdpipeline" in id.lower(),
     "stepvideo": lambda id: "stepvideo" in id.lower(),
-    "qwenimage": lambda id: "qwen-image" in id.lower() and "edit" not in id.lower(),
-    "qwenimageedit": lambda id: "qwen-image-edit" in id.lower(),
+    "qwenimage": lambda id: "qwenimage" in id.lower() and "edit" not in id.lower(),
+    "qwenimageedit": lambda id: "qwenimageedit" in id.lower(),
     # Add other pipeline architecture detectors
 }
 

--- a/python/sglang/multimodal_gen/configs/sample/registry.py
+++ b/python/sglang/multimodal_gen/configs/sample/registry.py
@@ -71,7 +71,7 @@ SAMPLING_PARAM_DETECTOR: dict[str, Callable[[str], bool]] = {
     "stepvideo": lambda id: "stepvideo" in id.lower(),
     # Add other pipeline architecture detectors
     "flux": lambda id: "flux" in id.lower(),
-    "qwenimage": lambda id: "qwenimage" in id.lower(),
+    "qwenimage": lambda id: "qwenimage" in id.lower() and "edit" not in id.lower(),
     "qwenimageedit": lambda id: "qwenimageedit" in id.lower(),
 }
 

--- a/python/sglang/multimodal_gen/configs/sample/registry.py
+++ b/python/sglang/multimodal_gen/configs/sample/registry.py
@@ -72,6 +72,7 @@ SAMPLING_PARAM_DETECTOR: dict[str, Callable[[str], bool]] = {
     # Add other pipeline architecture detectors
     "flux": lambda id: "flux" in id.lower(),
     "qwenimage": lambda id: "qwenimage" in id.lower(),
+    "qwenimageedit": lambda id: "qwenimageedit" in id.lower(),
 }
 
 # Fallback configs when exact match isn't found but architecture is detected
@@ -83,6 +84,7 @@ SAMPLING_FALLBACK_PARAM: dict[str, Any] = {
     # Other fallbacks by architecture
     "flux": FluxSamplingParams,
     "qwenimage": QwenImageSamplingParams,
+    "qwenimageedit": QwenImageSamplingParams,
 }
 
 

--- a/python/sglang/multimodal_gen/configs/sample/registry.py
+++ b/python/sglang/multimodal_gen/configs/sample/registry.py
@@ -71,6 +71,7 @@ SAMPLING_PARAM_DETECTOR: dict[str, Callable[[str], bool]] = {
     "stepvideo": lambda id: "stepvideo" in id.lower(),
     # Add other pipeline architecture detectors
     "flux": lambda id: "flux" in id.lower(),
+    "qwenimage": lambda id: "qwenimage" in id.lower(),
 }
 
 # Fallback configs when exact match isn't found but architecture is detected
@@ -81,6 +82,7 @@ SAMPLING_FALLBACK_PARAM: dict[str, Any] = {
     "stepvideo": StepVideoT2VSamplingParams,
     # Other fallbacks by architecture
     "flux": FluxSamplingParams,
+    "qwenimage": QwenImageSamplingParams,
 }
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

the Qwen-Image(-Edit) model can not be loaded from local dir (`/root/Qwen-Image`) since the PIPELINE_DETECTOR has extra hyphen, causing `No match found for pipeline` error

## Modifications

<!-- Detail the changes made in this pull request. -->

`python/sglang/multimodal_gen/configs/pipelines/registry.py`
`python/sglang/multimodal_gen/configs/sample/registry.py`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
