### PR TITLE
fix import qwenvl error in RL engine

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2684,9 +2684,11 @@ class BumpAllocator:
 def log_info_on_rank0(logger, msg):
     from sglang.srt.distributed import get_tensor_model_parallel_rank
 
-    if torch.distributed.is_initialized() and get_tensor_model_parallel_rank() == 0:
+    try:
+        if torch.distributed.is_initialized() and get_tensor_model_parallel_rank() == 0:
+            logger.info(msg)
+    except:
         logger.info(msg)
-
 
 def load_json_config(data: str):
     try:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2690,6 +2690,7 @@ def log_info_on_rank0(logger, msg):
     except:
         logger.info(msg)
 
+
 def load_json_config(data: str):
     try:
         return orjson.loads(data)


### PR DESCRIPTION
Solve https://github.com/sgl-project/sglang/issues/12830

When training qwen3VL RL with sgl.Engine, a `No processor registered for architecture: ['Qwen3VLForConditionalGeneration'] error` is raised.

I tried printing the traceback:

```
 Traceback (most recent call last): 
   File "/usr/local/lib/python3.12/dist-packages/sglang/srt/managers/multimodal_processor.py", line 20, in import_processors 
     module = importlib.import_module(name) 
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module 
     return _bootstrap._gcd_import(name[level:], package, level) 
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import 
   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load 
   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked 
   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked 
   File "<frozen importlib._bootstrap_external>", line 995, in exec_module 
   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed 
   File "/usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 63, in <module> [repeated 352x across cluster]
     from sglang.srt.models.deepseek_ocr import DeepseekOCRForCausalLM [repeated 7x across cluster]
     from sglang.srt.models.deepseek import DeepseekForCausalLM [repeated 14x across cluster]
     from sglang.srt.layers.moe.fused_moe_triton import fused_moe [repeated 14x across cluster]
     from sglang.srt.layers.moe.fused_moe_triton.layer import ( 
     if get_moe_runner_backend().is_flashinfer_trtllm(): 
        ^^^^^^^^^^^^^^^^^^^^^^^^ 
   File "/usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/utils.py", line 167, in get_moe_runner_backend 
   File "/usr/local/lib/python3.12/dist-packages/sglang/srt/utils/common.py", line 2687, in log_info_on_rank0 
     if torch.distributed.is_initialized() and get_tensor_model_parallel_rank() == 0: 
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   File "/usr/local/lib/python3.12/dist-packages/sglang/srt/distributed/parallel_state.py", line 1761, in get_tensor_model_parallel_rank 
     return get_tp_group().rank_in_group 
            ^^^^^^^^^^^^^^ 
   File "/usr/local/lib/python3.12/dist-packages/sglang/srt/distributed/parallel_state.py", line 1389, in get_tp_group 
     assert _TP is not None, "tensor model parallel group is not initialized" 
            ^^^^^^^^^^^^^^^ 
```

When training RL with sgl.Engine, the train actor process initializes a torch communication group, but sglang does not create the Tensor Parallel (TP) group. This PR provides a simple fix for this issue.

