### PR TITLE
Fix two issues with tool parser

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1045,16 +1045,16 @@ class OpenAIServingChat(OpenAIServingBase):
     ):
         """Process tool calls in streaming response"""
         if index not in parser_dict:
-            # Use JSON detector directly for required or named tool choice
-            if request.tool_choice == "required" or isinstance(
-                request.tool_choice, ToolChoice
-            ):
-                parser_dict[index] = JsonArrayParser()
-            else:
+            # Always use the model-specific parser to match the model's output format.
+            # JsonArrayParser is only used when no tool_call_parser is configured (generic models)
+            if self.tool_call_parser:
                 parser_dict[index] = FunctionCallParser(
                     tools=request.tools,
                     tool_call_parser=self.tool_call_parser,
                 )
+            else:
+                # Fallback to JsonArrayParser for models without specific parser
+                parser_dict[index] = JsonArrayParser()
 
         parser = parser_dict[index]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Fix two issues in https://github.com/sgl-project/sglang/issues/12567#issuecomment-3503996225:
- The request uses tool_choice required and json parsers, but did not fall back to specified parsers if the json parser fails.
- The model's response can be "argument" in addition to "parameters" (OpenAI format) for QWEN3.

### For the first issue

SGLANG_ENABLE_SPEC_V2=1 python -m sglang.launch_server --port=7080 --model=openai/gpt-oss-120b --trust-remote-code --tp=8 --max-queued-requests=256 --tool-call-parser=gpt-oss --reasoning-parser=gpt-oss --enable-metrics --enable-priority-scheduling --schedule-low-priority-values-first --priority-scheduling-preemption-threshold=1000 --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 --attention-backend trtllm_mha --max-running-requests=128 --speculative-algorithm EAGLE3 --speculative-draft-model-path=lmsys/EAGLE3-gpt-oss-120b-bf16

Previously for this query:
> curl -X POST      -H "Content-Type: application/json"      http://localhost:7080/v1/chat/completions      -d '{
         "model": "openai/gpt-oss-120b",
         "messages": [
           {"role": "user", "content": "Whats the weather in London?"}
         ],
         "tools": [
           {
             "type": "function",
             "function": {
               "name": "get_weather",
               "description": "Get the current weather for a specific location.",
               "parameters": {
                 "type": "object",
                 "properties": {
                   "location": {
                     "type": "string",
                     "description": "The city and state, e.g., San Francisco, CA"
                   },
                   "unit": {
                     "type": "string",
                     "enum": ["celsius", "fahrenheit"],
                     "description": "The unit for temperature"
                   }
                 },
                 "required": ["location"]
               }
             }
           }
         ],
         "stream": true,
         "tool_choice": "required"
       }' | jq

<img width="2914" height="1672" alt="image" src="https://github.com/user-attachments/assets/e94d915f-34f6-4978-8fc3-c3f771e1692e" />
<img width="2896" height="920" alt="image" src="https://github.com/user-attachments/assets/d0714227-9500-4b9a-aec8-fd64939f7ea1" />

With this change (everything except line 908 and followup changes):
<img width="2940" height="1574" alt="image" src="https://github.com/user-attachments/assets/1b73611f-e5a6-4152-8adf-e9b1e24e4c02" />

### For the second issue

SGLANG_ENABLE_SPEC_V2=1 SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 python3 -m sglang.launch_server --port=8000 --model-path=Qwen/Qwen3-235B-A22B-Instruct-2507 --tp=8 --host=0.0.0.0 --tool-call-parser=qwen --speculative-algorithm=EAGLE3 --speculative-num-steps=3 --speculative-eagle-topk=1 --speculative-num-draft-tokens=4 --speculative-draft-model-path=lmsys/Qwen3-235B-A22B-EAGLE3 --quantization=w8a8_fp8 --attention-backend flashinfer

Previously for this query:

> curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "qwen3-235b", "tools": [{"type": "function", "function": {"name": "calculate", "description": "Evaluate a mathematical expression", "parameters": {"type": "object", "properties": {"expression": {"type": "string", "description" : "The mathematical expression to evaluate"}}, "required": ["expression"]}}}], "messages": [{"role": "system", "content": "You are a calculator assistant. Use the calculate function to perform mathematical operations and provide the results."}, {"role": "user", "content": "What is 25 * 4 + 10?"}], "temperature": 0.1, "max_tokens": 512, "stream": false, "tool_choice":"required"}' | jq

It will throw an error:
<img width="2888" height="944" alt="image" src="https://github.com/user-attachments/assets/9a87837e-404d-452f-8961-034fed089654" />

Now it successfully finishes (with line 908 and related changes below):

<img width="1484" height="1810" alt="image" src="https://github.com/user-attachments/assets/5db83199-97b3-4e2c-912f-89e3f9036ed9" />


## Modifications

<!-- Detail the changes made in this pull request. -->

Added unit tests

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
