### PR TITLE
Fix empty server args in marlin moe test

### DIFF
--- a/python/sglang/test/test_marlin_moe.py
+++ b/python/sglang/test/test_marlin_moe.py
@@ -6,7 +6,10 @@ from sgl_kernel import fused_marlin_moe
 from sgl_kernel.scalar_type import ScalarType, scalar_types
 
 from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.test.test_marlin_utils import awq_marlin_quantize, marlin_quantize
+
+set_global_server_args_for_scheduler(object.__new__(ServerArgs))
 
 
 def stack_and_dev(tensors: list[torch.Tensor]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fix error reported [here](https://github.com/sgl-project/sglang/blob/d134096319cd8133cff0e6a77b66f2aac8ecf8db/python/sglang/srt/server_args.py#L3991):
```
ValueError: Global server args is not set yet!
```