### PR TITLE
[Bug] Login shell error: bash: /root/.cargo/env: No such file or directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -314,7 +314,8 @@ RUN --mount=type=cache,target=/root/.cache/pip curl --proto '=https' --tlsv1.2 -
     && cd /sgl-workspace/sglang/sgl-router \
     && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
     && python3 -m pip install --force-reinstall dist/*.whl \
-    && rm -rf /root/.cargo /root/.rustup target dist ~/.cargo
+    && rm -rf /root/.cargo /root/.rustup target dist ~/.cargo \
+    && sed -i '/\.cargo\/env/d' /root/.profile /root/.bashrc 2>/dev/null || true
 
 
 # Add yank script


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Fixed this issue https://github.com/sgl-project/sglang/issues/12936
When attaching to a container (e.g., docker exec -it bash), Bash prints:

bash: /root/.cargo/env: No such file or directory
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Remove the bad line if you don’t need Rust in the container
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
<img width="1022" height="106" alt="image" src="https://github.com/user-attachments/assets/e4eedd55-9144-439a-80a6-67cfc586f9f3" />

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
