### PR TITLE
Bugfix: LMCache Connector with Sglang

### DIFF
--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -107,7 +107,7 @@ class LMCRadixCache(RadixCache):
                 "v_buffer",
                 getattr(self.token_to_kv_pool_allocator._kvcache, "v_buffer"),
             ),
-            tp_group=tp_group,
+            tp_group=tp_group.device_group,
         )
 
         self.load_stream = torch.cuda.Stream()

--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -107,7 +107,7 @@ class LMCRadixCache(RadixCache):
                 "v_buffer",
                 getattr(self.token_to_kv_pool_allocator._kvcache, "v_buffer"),
             ),
-            tp_group=tp_group.device_group,
+            tp_group=tp_group.device_group if tp_group is not None else None,
         )
 
         self.load_stream = torch.cuda.Stream()


### PR DESCRIPTION
## Motivation
`LMCacheLayerwiseConnector` on the LMCache side uses `torch.distributed.all_reduce`: https://github.com/LMCache/LMCache/blob/23bddb99576fd67b66273c97cc5b86f8ac4b8243/lmcache/integration/sglang/sglang_adapter.py#L231.
Here, the SGLang side passes the `GroupCoordinator` object as the `tp_group`. This produces the following error:
```
File "/venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 2924, in all_reduce
    work = group.allreduce([tensor], opts)
           ^^^^^^^^^^^^^^^
AttributeError: 'GroupCoordinator' object has no attribute 'allreduce'. Did you mean: 'all_reduce'?
```


----
This PR passes the `GroupCoordinator.device_group` that works with `torch.distributed` as the fix.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
