### PR TITLE
[Refactor / Style] Unify all event loops (except for PP)

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -141,6 +141,18 @@ class BaseKVReceiver(ABC):
         """
         ...
 
+    def clear(self):
+        """
+        Clear any internal states.
+        """
+        pass
+
+    def abort(self):
+        """
+        Abort the current transfer.
+        """
+        pass
+
 
 class BaseKVBootstrapServer(ABC):
     @abstractmethod

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -764,8 +764,7 @@ class DecodeTransferQueue:
                         ].tolist()
                     )
 
-                if hasattr(decode_req.kv_receiver, "clear"):
-                    decode_req.kv_receiver.clear()
+                decode_req.kv_receiver.clear()
                 decode_req.kv_receiver = None
 
                 indices_to_remove.add(i)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -357,12 +357,10 @@ class SchedulerDisaggregationPrefillMixin:
             if batch:
                 result = self.run_batch(batch)
                 self.process_batch_result_disagg_prefill(batch, result)
-
-            if len(self.disagg_prefill_inflight_queue) > 0:
-                self.process_disagg_prefill_inflight_queue()
-
-            if batch is None and len(self.disagg_prefill_inflight_queue) == 0:
+            else:
                 self.self_check_during_idle()
+
+            self.process_disagg_prefill_inflight_queue()
 
             self.last_batch = batch
             # HACK (byronhsu): reset the batch_is_full flag because we never enter update_running_batch which resets it
@@ -390,14 +388,12 @@ class SchedulerDisaggregationPrefillMixin:
             if self.last_batch:
                 tmp_batch, tmp_result = self.result_queue.popleft()
                 self.process_batch_result_disagg_prefill(tmp_batch, tmp_result)
+            elif batch is None:
+                self.self_check_during_idle()
 
-            if len(self.disagg_prefill_inflight_queue) > 0:
-                self.process_disagg_prefill_inflight_queue()
+            self.process_disagg_prefill_inflight_queue()
 
             self.launch_batch_sample_if_needed(batch_result)
-
-            if batch is None and len(self.disagg_prefill_inflight_queue) == 0:
-                self.self_check_during_idle()
 
             self.last_batch = batch
             # HACK (byronhsu): reset the batch_is_full flag because we never enter update_running_batch which resets it

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2443,15 +2443,13 @@ class Scheduler(
             for decode_req in self.disagg_decode_prealloc_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
-                    if hasattr(decode_req.kv_receiver, "abort"):
-                        decode_req.kv_receiver.abort()
+                    decode_req.kv_receiver.abort()
 
             # Abort requests waiting for kvcache to release tree cache
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
-                    if hasattr(decode_req.kv_receiver, "abort"):
-                        decode_req.kv_receiver.abort()
+                    decode_req.kv_receiver.abort()
 
         # Delete requests in the running batch
         if self.cur_batch is self.running_batch or self.cur_batch is None:

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -217,7 +217,10 @@ class SchedulerRuntimeCheckerMixin:
             self.tree_cache.sanity_check()
 
     def self_check_during_idle(self: Scheduler):
-        if self.disaggregation_mode == DisaggregationMode.DECODE:
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            if len(self.disagg_prefill_inflight_queue) > 0:
+                return
+        elif self.disaggregation_mode == DisaggregationMode.DECODE:
             queue_size = (
                 len(self.waiting_queue)
                 + len(self.disagg_decode_transfer_queue.queue)


### PR DESCRIPTION
Now all event loops follow the same logic:

### Non-overlap loop:

```python
while true:
    recv = recv_requests()
    process_input_requests(recv)
    pre_batch_work()
    batch = build_next_batch()
    cur_batch = batch
    if batch:
        result = run_batch(batch)
        consume_result(batch, result)
    else:
        self_check_during_idle()
    post_batch_work()
    last_batch = batch
```

### Overlap loop:
```python
result_queue = deque()
last_batch = None
while true:
    recv = recv_requests()
    process_input_requests(recv)
    pre_batch_work()
    batch = build_next_batch()
    cur_batch = batch
    if batch:
        result = run_batch(batch)
        result_queue.push((batch.copy(), result))
    if last_batch:
        prev_batch, prev_result = result_queue.popleft()
        consume_result(prev_batch, prev_result)
    elif batch is None:
        self_check_during_idle()
    post_batch_work()
    launch_batch_sample_if_needed(result)
    last_batch = batch
```

And all idle batch's preparation (MLP sync) happens inside `build_next_batch()`