### PR TITLE
update draft model weight in runtime

### DIFF
--- a/docs/basic_usage/native_api.ipynb
+++ b/docs/basic_usage/native_api.ipynb
@@ -199,7 +199,9 @@
     "\n",
     "Update model weights from disk without restarting the server. Only applicable for models with the same architecture and parameter size.\n",
     "\n",
-    "SGLang support `update_weights_from_disk` API for continuous evaluation during training (save checkpoint to disk and update weights from disk).\n"
+    "SGLang support `update_weights_from_disk` API for continuous evaluation during training (save checkpoint to disk and update weights from disk).\n",
+    "\n",
+    "Also, set `is_draft_model: true` to hot-swap only the speculative draft model’s weights, leaving the target model unchanged."
    ]
   },
   {
@@ -239,6 +241,25 @@
     "    \"qwen/qwen2.5-0.5b-instruct-wrong\"\n",
     "    \" (repository not found).\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# successful draft model update for speculative decoding\n",
+    "url = f\"http://localhost:{port}/update_weights_from_disk\"\n",
+    "data = {\n",
+    "    \"model_path\": \"lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B\",\n",
+    "    \"is_draft_model\": True,\n",
+    "}\n",
+    "\n",
+    "response = requests.post(url, json=data)\n",
+    "print_highlight(response.text)\n",
+    "assert response.json()[\"success\"] is True\n",
+    "assert response.json()[\"message\"] == \"Succeeded to update model weights.\""
    ]
   },
   {

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -496,6 +496,7 @@ class Engine(EngineBase):
         self,
         model_path: str,
         load_format: Optional[str] = None,
+        is_draft_model: bool = False,
     ):
         """Update the weights from disk inplace without re-launching the engine.
 
@@ -506,6 +507,7 @@ class Engine(EngineBase):
         obj = UpdateWeightFromDiskReqInput(
             model_path=model_path,
             load_format=load_format,
+            is_draft_model=is_draft_model,
         )
 
         return self.loop.run_until_complete(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1072,6 +1072,8 @@ class UpdateWeightFromDiskReqInput(BaseReq):
     load_format: Optional[str] = None
     # Whether to abort all requests before updating weights
     abort_all_requests: bool = False
+    # Whether the new weights are draft model weights used for speculative decoding
+    is_draft_model: bool = False
     # Optional: Update weight version along with weights
     weight_version: Optional[str] = None
     # Whether to update weights asynchronously

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -462,6 +462,9 @@ class Scheduler(
         else:
             self.grammar_backend = None
 
+        # Init weight update queue used for prevent weight update while running request remains
+        self.pending_weight_update_queue: List[Req] = []
+
         # Init schedule policy and new token estimation
         self.policy = SchedulePolicy(
             self.schedule_policy,
@@ -971,6 +974,8 @@ class Scheduler(
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
             else:
+                # If the running batch is empty and there are pending weight update requests, process them
+                self.maybe_process_pending_weight_update()
                 # When the server is idle, do self-check and re-init some states
                 self.self_check_during_idle()
 
@@ -1127,6 +1132,16 @@ class Scheduler(
             ):
                 self.return_health_check_ct += 1
                 continue
+
+            if isinstance(recv_req, UpdateWeightFromDiskReqInput):
+                if not self.running_batch.is_empty():
+                    self.pending_weight_update_queue.append(recv_req)
+                    continue
+                else:
+                    output = self._request_dispatcher(recv_req)
+                    if output is not None:
+                        self.send_to_tokenizer.send_output(output, recv_req)
+                    continue
 
             output = self._request_dispatcher(recv_req)
             if output is not None:
@@ -2115,6 +2130,15 @@ class Scheduler(
             # However, one minor issue is that this code path does not check the status of detokenizer manager.
             self.return_health_check_ct -= 1
             self.send_to_tokenizer.send_output(HealthCheckOutput())
+
+    def maybe_process_pending_weight_update(self):
+        if self._is_no_request() and self.pending_weight_update_queue:
+            logger.info("Processing pending weight update requests")
+            for req in self.pending_weight_update_queue:
+                output = self._request_dispatcher(req)
+                if output is not None:
+                    self.send_to_tokenizer.send_output(output, req)
+            self.pending_weight_update_queue.clear()
 
     def move_ready_grammar_requests(self):
         """Move requests whose grammar objects are ready from grammar_queue to waiting_queue."""

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1133,15 +1133,12 @@ class Scheduler(
                 self.return_health_check_ct += 1
                 continue
 
-            if isinstance(recv_req, UpdateWeightFromDiskReqInput):
-                if not self.running_batch.is_empty():
-                    self.pending_weight_update_queue.append(recv_req)
-                    continue
-                else:
-                    output = self._request_dispatcher(recv_req)
-                    if output is not None:
-                        self.send_to_tokenizer.send_output(output, recv_req)
-                    continue
+            if (
+                isinstance(recv_req, UpdateWeightFromDiskReqInput)
+                and not self.running_batch.is_empty()
+            ):
+                self.pending_weight_update_queue.append(recv_req)
+                continue
 
             output = self._request_dispatcher(recv_req)
             if output is not None:

--- a/python/sglang/srt/managers/scheduler_update_weights_mixin.py
+++ b/python/sglang/srt/managers/scheduler_update_weights_mixin.py
@@ -42,7 +42,13 @@ class SchedulerUpdateWeightsMixin:
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         """In-place update of the weights from disk."""
-        success, message = self.tp_worker.update_weights_from_disk(recv_req)
+        if self.draft_worker is not None and recv_req.is_draft_model:
+            logger.info("Updating draft model weights from disk")
+            success, message = self.draft_worker.update_weights_from_disk(recv_req)
+        else:
+            logger.info("Updating target model weights from disk")
+            success, message = self.tp_worker.update_weights_from_disk(recv_req)
+
         if success:
             flush_cache_success = self.flush_cache()
             assert flush_cache_success, "Cache flush failed after updating weights"

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1204,10 +1204,16 @@ class TokenizerManager(TokenizerCommunicatorMixin):
         if self.server_args.dp_size == 1:
             result = await self.model_update_result
             if result.success:
-                self.served_model_name = obj.model_path
-                self.server_args.model_path = obj.model_path
-                self.server_args.load_format = obj.load_format
-                self.model_path = obj.model_path
+                if obj.is_draft_model:
+                    self.server_args.speculative_draft_model_path = obj.model_path
+                    self.server_args.speculative_draft_model_load_format = (
+                        obj.load_format
+                    )
+                else:
+                    self.served_model_name = obj.model_path
+                    self.server_args.model_path = obj.model_path
+                    self.server_args.load_format = obj.load_format
+                    self.model_path = obj.model_path
             return result.success, result.message, result.num_paused_requests
         else:  # self.server_args.dp_size > 1
             self.model_update_tmp = []
@@ -1215,9 +1221,15 @@ class TokenizerManager(TokenizerCommunicatorMixin):
 
             all_success = all([r.success for r in result])
             if all_success is True:
-                self.server_args.model_path = obj.model_path
-                self.server_args.load_format = obj.load_format
-                self.model_path = obj.model_path
+                if obj.is_draft_model:
+                    self.server_args.speculative_draft_model_path = obj.model_path
+                    self.server_args.speculative_draft_model_load_format = (
+                        obj.load_format
+                    )
+                else:
+                    self.server_args.model_path = obj.model_path
+                    self.server_args.load_format = obj.load_format
+                    self.model_path = obj.model_path
             all_message = [r.message for r in result]
             all_message = " | ".join(all_message)
             all_paused_requests = [r.num_paused_requests for r in result]

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -869,6 +869,7 @@ class ModelRunner:
         load_format: str,
         weight_name_filter: Optional[Callable[[str], bool]] = None,
         recapture_cuda_graph: bool = False,
+        is_draft_model: bool = False,
     ) -> tuple[bool, str]:
         """Update engine weights in-place from the disk."""
         logger.info(
@@ -920,8 +921,12 @@ class ModelRunner:
                 return False, message
 
         self.model = model
-        self.server_args.model_path = model_path
-        self.server_args.load_format = load_format
+        if is_draft_model:
+            self.server_args.speculative_draft_model_path = model_path
+            self.server_args.speculative_draft_model_load_format = load_format
+        else:
+            self.server_args.model_path = model_path
+            self.server_args.load_format = load_format
         self.load_config = load_config
 
         if recapture_cuda_graph and self.device == "cuda":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The goal of this pull request is to enable **hot-swapping of the draft model** without restarting the serving server.
Currently, updating the speculative draft model requires a full server restart, which interrupts ongoing requests and complicates integration with runtime speculative model training pipelines.

By allowing the draft model to be reloaded dynamically at runtime, we can:

- Continuously update and redeploy the draft model while the service is running.
- Avoid service downtime and reduce operational overhead.

## Modifications

- Added `is_draft_model` filed to `UpdateWeightFromDiskReqInput `in `io_struct.py` to distinguish draft model updates.
- Implemented `update_weights_from_disk()` in `eagle_worker.py`
- Refactored setting up lm_head and embedding for draft model into `set_embed_and_head()` in `eagle_worker.py`.
- Updated `update_weights_from_disk()` in `scheduler_update_weights_mixin.py `to handle `is_draft_model=True` for draft model weight updates.
- Added `self.pending_weight_update_queue` and `maybe_process_pending_weight_update()` in `scheduler.py` to defer weight updates until no running batch is active.
- Add test code in `test/srt/rl/test_update_weights_from_disk.py`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
