### PR TITLE
[Fix] Add TPOT back to bench_serving 

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2052,6 +2052,12 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("Mean TTFT (ms):", metrics.mean_ttft_ms))
     print("{:<40} {:<10.2f}".format("Median TTFT (ms):", metrics.median_ttft_ms))
     print("{:<40} {:<10.2f}".format("P99 TTFT (ms):", metrics.p99_ttft_ms))
+    print(
+        "{s:{c}^{n}}".format(s="Time per Output Token (excl. 1st token)", n=50, c="-")
+    )
+    print("{:<40} {:<10.2f}".format("Mean TPOT (ms):", metrics.mean_tpot_ms))
+    print("{:<40} {:<10.2f}".format("Median TPOT (ms):", metrics.median_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P99 TPOT (ms):", metrics.p99_tpot_ms))
     print("{s:{c}^{n}}".format(s="Inter-Token Latency", n=50, c="-"))
     print("{:<40} {:<10.2f}".format("Mean ITL (ms):", metrics.mean_itl_ms))
     print("{:<40} {:<10.2f}".format("Median ITL (ms):", metrics.median_itl_ms))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

TPOT was removed by https://github.com/sgl-project/sglang/pull/3988#pullrequestreview-3441645800
Add TPOT back since it is helpful for performance evaluation.

PR:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     128
Benchmark duration (s):                  6.93
Total input tokens:                      131072
Total input text tokens:                 131072
Total input vision tokens:               0
Total generated tokens:                  131072
Total generated tokens (retokenized):    123174
Request throughput (req/s):              18.48
Input token throughput (tok/s):          18925.07
Output token throughput (tok/s):         18925.07
Total token throughput (tok/s):          37850.14
Concurrency:                             127.63
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6905.95
Median E2E Latency (ms):                 6905.97
---------------Time to First Token----------------
Mean TTFT (ms):                          691.39
Median TTFT (ms):                        650.52
P99 TTFT (ms):                           1130.82
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.07
Median TPOT (ms):                        6.11
P99 TPOT (ms):                           6.38
---------------Inter-Token Latency----------------
Mean ITL (ms):                           6.09
Median ITL (ms):                         5.63
P95 ITL (ms):                            5.98
P99 ITL (ms):                            6.28
Max ITL (ms):                            795.00
==================================================
```

main:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     128
Benchmark duration (s):                  7.97
Total input tokens:                      131072
Total input text tokens:                 131072
Total input vision tokens:               0
Total generated tokens:                  131072
Total generated tokens (retokenized):    123174
Request throughput (req/s):              16.05
Input token throughput (tok/s):          16435.89
Output token throughput (tok/s):         16435.89
Total token throughput (tok/s):          32871.78
Concurrency:                             127.66
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   7953.77
Median E2E Latency (ms):                 7953.57
---------------Time to First Token----------------
Mean TTFT (ms):                          1096.94
Median TTFT (ms):                        1033.87
P99 TTFT (ms):                           2149.41
---------------Inter-Token Latency----------------
Mean ITL (ms):                           6.72
Median ITL (ms):                         5.64
P95 ITL (ms):                            6.02
P99 ITL (ms):                            6.39
Max ITL (ms):                            1953.83
==================================================
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
