### PR TITLE
Add XPU profiler activity support in benchmark code

### DIFF
--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -79,8 +79,6 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
     configure_logger,
     get_bool_env_var,
-    is_cuda_alike,
-    is_xpu,
     kill_process_tree,
     maybe_reindex_device_id,
     require_mlp_sync,
@@ -89,15 +87,6 @@ from sglang.srt.utils import (
     suppress_other_loggers,
 )
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
-
-profile_activities = [torch.profiler.ProfilerActivity.CPU] + [
-    profiler_activity
-    for available, profiler_activity in [
-        (is_cuda_alike(), torch.profiler.ProfilerActivity.CUDA),
-        (is_xpu(), torch.profiler.ProfilerActivity.XPU),
-    ]
-    if available
-]
 
 
 def start_profile(profile_activities, profile_record_shapes=False, rank_print=print):
@@ -118,6 +107,8 @@ def start_profile(profile_activities, profile_record_shapes=False, rank_print=pr
             activities.append(torch.profiler.ProfilerActivity.CPU)
         if "GPU" in profile_activities:
             activities.append(torch.profiler.ProfilerActivity.CUDA)
+        if "XPU" in profile_activities:
+            activities.append(torch.profiler.ProfilerActivity.XPU)
         if activities:
             profiler = torch.profiler.profile(
                 activities=activities,
@@ -217,7 +208,7 @@ class BenchArgs:
             type=str,
             nargs="+",
             default=["CPU", "GPU"],
-            choices=["CPU", "GPU", "CUDA_PROFILER"],
+            choices=["CPU", "GPU", "CUDA_PROFILER", "XPU"],
             help="Profiler activities: CPU, GPU, CUDA_PROFILER. If CPU/GPU, use torch profiler. If CUDA_PROFILER, use CUDA profiler.",
         )
         parser.add_argument(

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -209,7 +209,7 @@ class BenchArgs:
             nargs="+",
             default=["CPU", "GPU"],
             choices=["CPU", "GPU", "CUDA_PROFILER", "XPU"],
-            help="Profiler activities: CPU, GPU, CUDA_PROFILER. If CPU/GPU, use torch profiler. If CUDA_PROFILER, use CUDA profiler.",
+            help="Profiler activities: CPU, GPU, XPU, CUDA_PROFILER. If CPU/GPU/XPU, use torch profiler. If CUDA_PROFILER, use CUDA profiler.",
         )
         parser.add_argument(
             "--profile-stage",

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -3216,7 +3216,7 @@ if __name__ == "__main__":
         type=str,
         nargs="+",
         default=["CPU", "GPU"],
-        choices=["CPU", "GPU", "CUDA_PROFILER"],
+        choices=["CPU", "GPU", "CUDA_PROFILER", "XPU"],
     )
     parser.add_argument("--profile-num-steps", type=int, default=None)
     parser.add_argument("--profile-by-stage", action="store_true", default=False)

--- a/python/sglang/profiler.py
+++ b/python/sglang/profiler.py
@@ -26,6 +26,7 @@ def run_profile(
     profile_by_stage: bool = False,
     merge_profiles: bool = False,
     profile_prefix: Optional[str] = None,
+    start_step: Optional[int] = None,
 ) -> str:
     if output_dir is None:
         output_dir = PROFILER_DIR
@@ -57,6 +58,8 @@ def run_profile(
         "merge_profiles": merge_profiles,
         "profile_prefix": profile_prefix,
     }
+    if start_step is not None:
+        json_data["start_step"] = str(start_step)
 
     response = requests.post(url=url + "/start_profile", json=json_data)
     response.raise_for_status()

--- a/python/sglang/srt/managers/scheduler_profiler_mixin.py
+++ b/python/sglang/srt/managers/scheduler_profiler_mixin.py
@@ -154,6 +154,8 @@ class SchedulerProfilerMixin:
             "CPU": torch.profiler.ProfilerActivity.CPU,
             "GPU": torch.profiler.ProfilerActivity.CUDA,
         }
+        if hasattr(torch.profiler.ProfilerActivity, "XPU"):
+            activity_map["XPU"] = torch.profiler.ProfilerActivity.XPU
         torchprof_activities = [
             activity_map[a] for a in activities if a in activity_map
         ]


### PR DESCRIPTION
Add XPU profiler activity support in benchmark code
--profile-start-step  to start the profiler at the given step
--profile-steps  number of steps to collect from the given start step

Remove unused global profile_activities variable