### PR TITLE
RFC: Page-Granular Free Path for PagedTokenToKVPoolAllocator

### DIFF
--- a/benchmark/hf3fs/bench_zerocopy.py
+++ b/benchmark/hf3fs/bench_zerocopy.py
@@ -67,7 +67,6 @@ token_to_kv_pool_allocator = TokenToKVPoolAllocator(
     dtype=kv_cache_dtype,
     device=device,
     kvcache=token_to_kv_pool,
-    need_sort=False,
 )
 
 kv_cache = token_to_kv_pool_allocator.get_kvcache()

--- a/benchmark/hf3fs/bench_zerocopy.py
+++ b/benchmark/hf3fs/bench_zerocopy.py
@@ -67,6 +67,7 @@ token_to_kv_pool_allocator = TokenToKVPoolAllocator(
     dtype=kv_cache_dtype,
     device=device,
     kvcache=token_to_kv_pool,
+    need_sort=False,
 )
 
 kv_cache = token_to_kv_pool_allocator.get_kvcache()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1578,6 +1578,9 @@ class Scheduler(
             self.handle_embedding_request(tokenized_req)
 
     def _get_token_info(self):
+        # Make staged frees visible before measuring
+        if hasattr(self.token_to_kv_pool_allocator, "merge_and_sort_free"):
+            self.token_to_kv_pool_allocator.merge_and_sort_free()
         available_size = self.token_to_kv_pool_allocator.available_size()
         evictable_size = self.tree_cache.evictable_size()
         num_used = self.max_total_num_tokens - (available_size + evictable_size)
@@ -1586,6 +1589,9 @@ class Scheduler(
 
     def _get_mamba_token_info(self):
         is_radix_tree = isinstance(self.tree_cache, MambaRadixCache)
+        # Make staged frees visible before measuring
+        if hasattr(self.token_to_kv_pool_allocator, "merge_and_sort_free"):
+            self.token_to_kv_pool_allocator.merge_and_sort_free()
         full_available_size = self.token_to_kv_pool_allocator.available_size()
         full_evictable_size = (
             self.tree_cache.full_evictable_size() if is_radix_tree else 0

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -217,6 +217,11 @@ class SchedulerRuntimeCheckerMixin:
             self.tree_cache.sanity_check()
 
     def self_check_during_idle(self: Scheduler):
+        # Skip idle checks if there is an in-flight running batch to avoid counting
+        # tokens that are not yet reflected in the radix tree or allocator lists.
+        if self.running_batch is not None and not self.running_batch.is_empty():
+            return
+
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             if len(self.disagg_prefill_inflight_queue) > 0:
                 return

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -20,6 +20,7 @@ Page-aligned memory pool.
 """
 
 import abc
+import weakref
 from typing import TYPE_CHECKING
 
 import torch
@@ -27,7 +28,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.mem_cache.memory_pool import SWAKVPool
-from sglang.srt.utils import get_bool_env_var, get_num_new_pages, next_power_of_2
+from sglang.srt.utils import get_bool_env_var, next_power_of_2
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
@@ -42,14 +43,12 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         dtype: torch.dtype,
         device: str,
         kvcache: KVCache,
-        need_sort: bool,
     ):
         self.size = size
         self.page_size = page_size
         self.dtype = dtype
         self.device = device
         self._kvcache = kvcache
-        self.need_sort = need_sort
 
         self.free_pages = None
         self.release_pages = None
@@ -81,12 +80,14 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
             self.free(torch.cat(self.free_group))
 
     def merge_and_sort_free(self):
-        if len(self.release_pages) > 0:
-            self.free_pages = torch.cat((self.free_pages, self.release_pages))
-            self.free_pages, _ = torch.sort(self.free_pages)
-            self.release_pages = torch.empty(
-                (0,), dtype=self.release_pages.dtype, device=self.device
-            )
+          if len(self.release_pages) > 0:
+              # Always merge; only sort in debug mode to save overhead in prod.
+              self.free_pages = torch.cat((self.free_pages, self.release_pages))
+              if getattr(self, "debug_mode", False):
+                  self.free_pages, _ = torch.sort(self.free_pages)
+              self.release_pages = torch.empty(
+                  (0,), dtype=self.release_pages.dtype, device=self.device
+              )
 
     def get_cpu_copy(self, *args, **kwargs):
         # FIXME: reuse the get_cpu_copy after paged allocator is implemented
@@ -118,15 +119,8 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
 class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     """An allocator managing the indices to kv cache data."""
 
-    def __init__(
-        self,
-        size: int,
-        dtype: torch.dtype,
-        device: str,
-        kvcache: KVCache,
-        need_sort: bool,
-    ):
-        super().__init__(size, 1, dtype, device, kvcache, need_sort)
+    def __init__(self, size: int, dtype: torch.dtype, device: str, kvcache: KVCache):
+        super().__init__(size, 1, dtype, device, kvcache)
         self.clear()
 
     def clear(self):
@@ -143,9 +137,8 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return len(self.free_pages) + len(self.release_pages)
 
     def alloc(self, need_size: int):
-        if self.need_sort and need_size > len(self.free_pages):
+        if need_size > len(self.free_pages):
             self.merge_and_sort_free()
-
         if need_size > len(self.free_pages):
             return None
 
@@ -158,10 +151,7 @@ class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return
 
         if self.is_not_in_free_group:
-            if self.need_sort:
-                self.release_pages = torch.cat((self.release_pages, free_index))
-            else:
-                self.free_pages = torch.cat((self.free_pages, free_index))
+            self.release_pages = torch.cat((self.release_pages, free_index))
         else:
             self.free_group.append(free_index)
 
@@ -182,9 +172,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         dtype: torch.dtype,
         device: str,
         kvcache: SWAKVPool,
-        need_sort: bool,
     ):
-        super().__init__(size, 1, dtype, device, kvcache, need_sort)
+        super().__init__(size, 1, dtype, device, kvcache)
         assert isinstance(kvcache, SWAKVPool)
         self._size_full = size
         self._size_swa = size_swa
@@ -193,14 +182,12 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             dtype,
             device,
             kvcache.full_kv_pool,
-            need_sort,
         )
         self.swa_attn_allocator = TokenToKVPoolAllocator(
             size_swa,
             dtype,
             device,
             kvcache.swa_kv_pool,
-            need_sort,
         )
         self.full_to_swa_index_mapping = torch.empty(
             size + size_swa + 1,
@@ -274,21 +261,16 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_swa_index_mapping[free_index] = 0
 
     def backup_state(self):
-        return [
-            self.full_attn_allocator.backup_state(),
-            self.swa_attn_allocator.backup_state(),
-        ]
+        raise NotImplementedError
 
     def restore_state(self, state):
-        assert len(state) == 2
-        self.full_attn_allocator.restore_state(state[0])
-        self.swa_attn_allocator.restore_state(state[1])
+        raise NotImplementedError
 
     def clear(self):
         self.swa_attn_allocator.clear()
         self.full_attn_allocator.clear()
         self.full_to_swa_index_mapping.fill_(0)
-        self.is_not_in_free_group = True
+        self.is_in_free_group = False
         self.free_group = []
 
 
@@ -299,6 +281,7 @@ def alloc_extend_kernel(
     last_loc_ptr,
     free_page_ptr,
     out_indices,
+    ret_values,
     bs_upper: tl.constexpr,
     page_size: tl.constexpr,
     max_num_extend_tokens: tl.constexpr,
@@ -326,6 +309,13 @@ def alloc_extend_kernel(
     ) // page_size
     sum_num_new_pages = tl.sum(num_new_pages)
     new_page_start_loc = sum_num_new_pages - num_page_start_loc_self
+
+    # Return value
+    if pid == tl.num_programs(0) - 1:
+        merged_value = (sum_num_new_pages.to(tl.int64)) << 32 | sum_extend_lens.to(
+            tl.int64
+        )
+        tl.store(ret_values, merged_value)
 
     # Part 1: fill the old partial page
     last_loc = tl.load(last_loc_ptr + pid)
@@ -378,6 +368,7 @@ def alloc_decode_kernel(
     last_loc_ptr,
     free_page_ptr,
     out_indices,
+    ret_values,
     bs_upper: tl.constexpr,
     page_size: tl.constexpr,
 ):
@@ -399,6 +390,10 @@ def alloc_decode_kernel(
     ) // page_size
     sum_num_new_pages = tl.sum(num_new_pages)
     new_page_start_loc = sum_num_new_pages - num_page_start_loc_self
+
+    # Return value
+    if pid == tl.num_programs(0) - 1:
+        tl.store(ret_values, sum_num_new_pages)
 
     if num_page_start_loc_self == 0:
         last_loc = tl.load(last_loc_ptr + pid)
@@ -425,13 +420,62 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         dtype: torch.dtype,
         device: str,
         kvcache: KVCache,
-        need_sort: bool,
     ):
-        super().__init__(size, page_size, dtype, device, kvcache, need_sort)
+        super().__init__(size, page_size, dtype, device, kvcache)
         self.num_pages = size // page_size
         self.debug_mode = get_bool_env_var("SGLANG_DEBUG_MEMORY_POOL")
-        self.seen_max_num_extend_tokens_next_power_of_2 = 1
+        self.ret_values = torch.empty((), dtype=torch.int64, device=self.device)
         self.clear()
+        # Debug-only page ownership bitmap: 1 = allocated, 0 = free
+        if self.debug_mode:
+            # 1-based page IDs; allocate num_pages+1 so index 0 is unused
+            self.page_bitmap = torch.zeros(
+                (self.num_pages + 1,), dtype=torch.uint8, device=self.device
+            )
+
+    # ----- Debug helpers -----
+    def _mark_pages_allocated(self, page_ids: torch.Tensor):
+        if not getattr(self, "debug_mode", False):
+            return
+        if page_ids.numel() == 0:
+            return
+        page_ids = page_ids.to(dtype=torch.long)
+        prev = self.page_bitmap.index_select(0, page_ids)
+        # Ensure not previously allocated
+        if not torch.all(prev == 0).item():
+            raise AssertionError("Paged allocator: double-alloc detected")
+        self.page_bitmap.index_fill_(0, page_ids, 1)
+
+    def _mark_pages_freed(self, page_ids: torch.Tensor):
+        if not getattr(self, "debug_mode", False):
+            return
+        if page_ids.numel() == 0:
+            return
+        page_ids = page_ids.to(dtype=torch.long)
+        prev = self.page_bitmap.index_select(0, page_ids)
+        # Ensure previously allocated
+        if not torch.all(prev == 1).item():
+            raise AssertionError("Paged allocator: double-free or free of unallocated page")
+        self.page_bitmap.index_fill_(0, page_ids, 0)
+
+    # ----- New page-granular free API -----
+    def free_page_ids(self, page_ids: torch.Tensor) -> None:
+        """
+        Free unique page IDs (1-based). Caller must ensure one entry per freed page.
+        """
+        if page_ids.numel() == 0:
+            return
+        # Debug guard
+        self._mark_pages_freed(page_ids)
+        # Append directly without sort/dedup
+        if self.is_not_in_free_group:
+            self.release_pages = torch.cat((page_ids.to(self.free_pages.dtype), self.release_pages))
+        else:
+            # In grouped mode, keep collecting token indices; callers should avoid grouping pages.
+            # As a safe fallback, convert page IDs back to token indices for grouping by pushing
+            # one representative token per page (page*page_size). This path is rare.
+            repr_tokens = (page_ids.to(dtype=torch.long) * self.page_size).to(self.device)
+            self.free_group.append(repr_tokens)
 
     def alloc(self, need_size: int):
         # page-aligned allocation, returning contiguous indices of pages
@@ -441,12 +485,14 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             ), "The allocation size should be page-aligned"
 
         num_pages = need_size // self.page_size
-        if self.need_sort and num_pages > len(self.free_pages):
+        if num_pages > len(self.free_pages):
             self.merge_and_sort_free()
         if num_pages > len(self.free_pages):
             return None
 
         out_pages = self.free_pages[:num_pages]
+        # Debug bitmap: mark allocated pages
+        self._mark_pages_allocated(out_pages)
         self.free_pages = self.free_pages[num_pages:]
 
         out_indices = (
@@ -459,9 +505,7 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def alloc_extend(
         self,
         prefix_lens: torch.Tensor,
-        prefix_lens_cpu: torch.Tensor,
         seq_lens: torch.Tensor,
-        seq_lens_cpu: torch.Tensor,
         last_loc: torch.Tensor,
         extend_num_tokens: int,
     ):
@@ -470,17 +514,18 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 (last_loc + 1) % self.page_size == prefix_lens % self.page_size
             )
 
-        self.seen_max_num_extend_tokens_next_power_of_2 = max(
-            self.seen_max_num_extend_tokens_next_power_of_2,
-            next_power_of_2(extend_num_tokens),
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (prefix_lens + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
         )
-
-        bs = len(prefix_lens)
-        if self.need_sort and extend_num_tokens // self.page_size + bs + 1 > len(
-            self.free_pages
-        ):
+        if estimated_num_new_pages > len(self.free_pages):
             self.merge_and_sort_free()
 
+        bs = len(prefix_lens)
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
@@ -490,29 +535,29 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             last_loc,
             self.free_pages,
             out_indices,
+            self.ret_values,
             next_power_of_2(bs),
             self.page_size,
-            self.seen_max_num_extend_tokens_next_power_of_2,
+            next_power_of_2(extend_num_tokens),
         )
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
 
-        num_new_pages = get_num_new_pages(
-            seq_lens=seq_lens_cpu,
-            page_size=self.page_size,
-            prefix_lens=prefix_lens_cpu,
-        )
+        merged_value = self.ret_values.item()
+        num_new_pages = merged_value >> 32
         if num_new_pages > len(self.free_pages):
             return None
 
+        # Debug bitmap: mark allocated pages (first num_new_pages in current free list)
+        if num_new_pages > 0:
+            self._mark_pages_allocated(self.free_pages[:num_new_pages])
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices
 
     def alloc_decode(
         self,
         seq_lens: torch.Tensor,
-        seq_lens_cpu: torch.Tensor,
         last_loc: torch.Tensor,
     ):
         if self.debug_mode:
@@ -520,16 +565,25 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 (last_loc + 2) % self.page_size == seq_lens % self.page_size
             )
 
-        bs = len(seq_lens)
-        if self.need_sort and bs > len(self.free_pages):
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (seq_lens - 1 + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
             self.merge_and_sort_free()
 
+        bs = len(seq_lens)
         out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
         alloc_decode_kernel[(bs,)](
             seq_lens,
             last_loc,
             self.free_pages,
             out_indices,
+            self.ret_values,
             next_power_of_2(bs),
             self.page_size,
         )
@@ -537,14 +591,13 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
 
-        num_new_pages = get_num_new_pages(
-            seq_lens=seq_lens_cpu,
-            page_size=self.page_size,
-            decode=True,
-        )
+        num_new_pages = self.ret_values.item()
         if num_new_pages > len(self.free_pages):
             return None
 
+        # Debug bitmap: mark allocated pages (first num_new_pages in current free list)
+        if num_new_pages > 0:
+            self._mark_pages_allocated(self.free_pages[:num_new_pages])
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices
 
@@ -552,14 +605,9 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if free_index.numel() == 0:
             return
 
-        if self.is_not_in_free_group:
-            free_page_indices = torch.unique(free_index // self.page_size)
-            if self.need_sort:
-                self.release_pages = torch.cat((free_page_indices, self.release_pages))
-            else:
-                self.free_pages = torch.cat((free_page_indices, self.free_pages))
-        else:
-            self.free_group.append(free_index)
+        # Compatibility shim: convert tokens to unique page IDs, then delegate
+        page_ids = torch.unique(free_index // self.page_size)
+        self.free_page_ids(page_ids)
 
         if self.debug_mode:
             assert len(torch.unique(self.free_pages)) == len(self.free_pages)
@@ -578,3 +626,191 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
     def load_cpu_copy(self, kv_cache_cpu, indices):
         return self._kvcache.load_cpu_copy(kv_cache_cpu, indices)
+
+
+def alloc_extend_kernel_ascend(
+    prefix_lens,
+    seq_lens,
+    last_loc,
+    free_pages,
+    out_indices,
+    page_size,
+    device,
+):
+    extend_lens = seq_lens - prefix_lens
+    end_pos = torch.cumsum(extend_lens, 0)
+    start_pos = end_pos - extend_lens
+    num_new_pages = (seq_lens + page_size - 1) // page_size - (
+        prefix_lens + page_size - 1
+    ) // page_size
+    num_full_new_pages = (seq_lens) // page_size - (
+        prefix_lens + page_size - 1
+    ) // page_size
+    need_page = num_new_pages - num_full_new_pages
+    end_new_pages = torch.cumsum(num_new_pages, 0)
+    start_new_pages = end_new_pages - num_new_pages
+    pos_in_page = torch.arange(page_size, device=device, dtype=torch.int32)
+    for i in range(len(prefix_lens)):
+        num1 = (
+            min(
+                seq_lens[i],
+                (prefix_lens[i] + page_size - 1) // page_size * page_size,
+            )
+            - prefix_lens[i]
+        )
+        if num1:
+            out_indices[start_pos[i] : start_pos[i] + num1] = (
+                last_loc[i] + 1 + pos_in_page[:num1].view(-1)
+            )
+
+        num2 = (
+            seq_lens[i] // page_size - (prefix_lens[i] + page_size - 1) // page_size
+        ) * page_size
+        if num2:
+            pages = (
+                free_pages[start_new_pages[i] : end_new_pages[i] - need_page[i]]
+                * page_size
+            )
+            out_indices[start_pos[i] + num1 : start_pos[i] + num1 + num2] = (
+                pages.view(-1, 1) + pos_in_page.view(1, -1)
+            ).view(-1)
+
+        num3 = seq_lens[i] - seq_lens[i] // page_size * page_size
+        if num3:
+            out_indices[end_pos[i] - num3 : end_pos[i]] = (
+                free_pages[end_new_pages[i] - 1] * page_size + pos_in_page[:num3]
+            ).view(-1)
+    return num_new_pages
+
+
+def alloc_decode_kernel_ascend(
+    seq_lens,
+    last_loc,
+    free_pages,
+    out_indices,
+    page_size,
+):
+    num_new_pages = (seq_lens + page_size - 1) // page_size - (
+        seq_lens - 1 + page_size - 1
+    ) // page_size
+    end_new_pages = torch.cumsum(num_new_pages, 0)
+    start_new_pages = end_new_pages - num_new_pages
+    for i in range(len(seq_lens)):
+        if num_new_pages[i]:
+            out_indices[i] = free_pages[start_new_pages[i]] * page_size
+        else:
+            out_indices[i] = last_loc[i] + 1
+    return num_new_pages
+
+
+class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
+
+    def __init__(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache: KVCache,
+    ):
+        super().__init__(size, page_size, dtype, device, kvcache)
+        self.ret_values = torch.empty((), dtype=torch.int32, device=self.device)
+
+    def alloc_extend(
+        self,
+        prefix_lens: torch.Tensor,
+        seq_lens: torch.Tensor,
+        last_loc: torch.Tensor,
+        extend_num_tokens: int,
+    ):
+        if self.debug_mode:
+            assert torch.all(
+                (last_loc + 1) % self.page_size == prefix_lens % self.page_size
+            )
+
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (prefix_lens + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+
+        bs = len(prefix_lens)
+        out_indices = torch.empty(
+            (extend_num_tokens,), dtype=torch.int32, device=self.device
+        )
+
+        self.ret_values = alloc_extend_kernel_ascend(
+            prefix_lens,
+            seq_lens,
+            last_loc,
+            self.free_pages,
+            out_indices,
+            self.page_size,
+            self.device,
+        )
+
+        if self.debug_mode:
+            assert len(torch.unique(out_indices)) == len(out_indices)
+
+        num_new_pages = self.ret_values.sum()
+        if num_new_pages > len(self.free_pages):
+            return None
+
+        if num_new_pages > 0:
+            self._mark_pages_allocated(self.free_pages[:num_new_pages])
+        self.free_pages = self.free_pages[num_new_pages:]
+        return out_indices
+
+    def alloc_decode(
+        self,
+        seq_lens: torch.Tensor,
+        last_loc: torch.Tensor,
+    ):
+        if self.debug_mode:
+            assert torch.all(
+                (last_loc + 2) % self.page_size == seq_lens % self.page_size
+            )
+
+        estimated_num_new_pages = (
+            (
+                (seq_lens + self.page_size - 1) // self.page_size
+                - (seq_lens - 1 + self.page_size - 1) // self.page_size
+            )
+            .sum()
+            .item()
+        )
+        if estimated_num_new_pages > len(self.free_pages):
+            self.merge_and_sort_free()
+
+        bs = len(seq_lens)
+        out_indices = torch.empty((bs,), dtype=torch.int32, device=self.device)
+
+        self.ret_values = alloc_decode_kernel_ascend(
+            seq_lens,
+            last_loc,
+            self.free_pages,
+            out_indices,
+            self.page_size,
+        )
+
+        if self.debug_mode:
+            assert len(torch.unique(out_indices)) == len(out_indices)
+
+        num_new_pages = self.ret_values.sum()
+        if num_new_pages > len(self.free_pages):
+            return None
+
+        if num_new_pages > 0:
+            self._mark_pages_allocated(self.free_pages[:num_new_pages])
+        self.free_pages = self.free_pages[num_new_pages:]
+        return out_indices
+
+    def clear(self):
+        super().clear()
+        self.free_pages = self.free_pages.to(torch.int32)
+        self.release_pages = self.release_pages.to(torch.int32)

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -76,7 +76,8 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
     def free_group_end(self):
         self.is_not_in_free_group = True
         if self.free_group:
-            self.free_pages(torch.cat(self.free_group))
+            # Avoid instance attribute shadowing the method name
+            type(self).free_pages(self, torch.cat(self.free_group))
 
     def merge_and_sort_free(self):
         if len(self.release_pages) > 0:
@@ -121,7 +122,8 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
 
     # Back-compat alias for older call sites
     def free_page_ids(self, page_ids: torch.Tensor):
-        self.free_pages(page_ids)
+        # Avoid instance attribute shadowing the method name
+        type(self).free_pages(self, page_ids)
 
 
 class TokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
@@ -622,7 +624,8 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         # Compatibility shim: convert tokens to unique page IDs, then delegate
         page_ids = torch.unique(free_index // self.page_size + 1)
-        self.free_pages(page_ids)
+        # Avoid instance attribute shadowing the method name
+        type(self).free_pages(self, page_ids)
 
         if self.debug_mode:
             assert len(torch.unique(self.free_pages)) == len(self.free_pages)

--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -81,7 +81,7 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
             - (prefix_lens + self.page_size - 1) // self.page_size
         ).sum()
         num_new_pages_item = num_new_pages.item()
-        if self.need_sort and num_new_pages_item > len(self.free_pages):
+        if num_new_pages_item > len(self.free_pages):
             self.merge_and_sort_free()
 
         if num_new_pages_item > len(self.free_pages):

--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -81,7 +81,7 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
             - (prefix_lens + self.page_size - 1) // self.page_size
         ).sum()
         num_new_pages_item = num_new_pages.item()
-        if num_new_pages_item > len(self.free_pages):
+        if self.need_sort and num_new_pages_item > len(self.free_pages):
             self.merge_and_sort_free()
 
         if num_new_pages_item > len(self.free_pages):

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Cache for chunked prefill, used when RadixCache is disabled."""
 
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
@@ -38,7 +38,7 @@ class ChunkCache(BasePrefixCache):
             last_host_node=None,
         )
 
-    def cache_finished_req(self, req: Req):
+    def cache_finished_req(self, req: Req, is_insert: bool = True):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx,
             # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
@@ -47,7 +47,7 @@ class ChunkCache(BasePrefixCache):
         self.req_to_token_pool.free(req.req_pool_idx)
         if self.page_size != 1:
             page_ids = torch.unique(kv_indices // self.page_size)
-            self.token_to_kv_pool_allocator.free_page_ids(page_ids)
+            self.token_to_kv_pool_allocator.free_pages(page_ids)
         else:
             self.token_to_kv_pool_allocator.free(kv_indices)
 

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -27,6 +27,19 @@ class ChunkCache(BasePrefixCache):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.page_size = page_size
+        if self.token_to_kv_pool_allocator:
+            self.device = self.token_to_kv_pool_allocator.device
+        else:
+            self.device = torch.device("cpu")
+
+        self.protected_size_ = 0
+
+    # NOTE (csy): this is to determine if a cache has prefix matching feature.
+    # Chunk cache always return True to indicate no prefix matching.
+    # TODO (csy): Using a prefix cache trait to replace this
+    @property
+    def disable(self):
+        return True
 
     def reset(self):
         pass
@@ -39,25 +52,23 @@ class ChunkCache(BasePrefixCache):
         )
 
     def cache_finished_req(self, req: Req, is_insert: bool = True):
+        kv_committed_len = req.pop_committed_kv_cache()
+        # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx,
-            # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
-            : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
+            req.req_pool_idx, :kv_committed_len
         ]
         self.req_to_token_pool.free(req.req_pool_idx)
-        if self.page_size != 1:
-            page_ids = torch.unique(kv_indices // self.page_size)
-            self.token_to_kv_pool_allocator.free_page_ids(page_ids)
-        else:
-            self.token_to_kv_pool_allocator.free(kv_indices)
+        self.token_to_kv_pool_allocator.free(kv_indices)
+        self.protected_size_ -= len(req.prefix_indices)
 
-    def cache_unfinished_req(self, req: Req):
+    def cache_unfinished_req(self, req: Req, chunked=False):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(req.fill_ids)
         ]
+        self.protected_size_ += len(kv_indices) - len(req.prefix_indices)
 
         # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later
-        req.prefix_indices = kv_indices
+        req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
 
     def evict(self, num_tokens: int):
         pass
@@ -67,6 +78,9 @@ class ChunkCache(BasePrefixCache):
 
     def dec_lock_ref(self, node: Any, swa_uuid_for_lock: Optional[str] = None):
         return 0
+
+    def protected_size(self):
+        return self.protected_size_
 
     def pretty_print(self):
         return ""

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -47,7 +47,7 @@ class ChunkCache(BasePrefixCache):
         self.req_to_token_pool.free(req.req_pool_idx)
         if self.page_size != 1:
             page_ids = torch.unique(kv_indices // self.page_size)
-            self.token_to_kv_pool_allocator.free_pages(page_ids)
+            self.token_to_kv_pool_allocator.free_page_ids(page_ids)
         else:
             self.token_to_kv_pool_allocator.free(kv_indices)
 

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Cache for chunked prefill, used when RadixCache is disabled."""
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 import torch
 
@@ -27,19 +27,6 @@ class ChunkCache(BasePrefixCache):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.page_size = page_size
-        if self.token_to_kv_pool_allocator:
-            self.device = self.token_to_kv_pool_allocator.device
-        else:
-            self.device = torch.device("cpu")
-
-        self.protected_size_ = 0
-
-    # NOTE (csy): this is to determine if a cache has prefix matching feature.
-    # Chunk cache always return True to indicate no prefix matching.
-    # TODO (csy): Using a prefix cache trait to replace this
-    @property
-    def disable(self):
-        return True
 
     def reset(self):
         pass
@@ -51,24 +38,26 @@ class ChunkCache(BasePrefixCache):
             last_host_node=None,
         )
 
-    def cache_finished_req(self, req: Req, is_insert: bool = True):
-        kv_committed_len = req.pop_committed_kv_cache()
-        # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
+    def cache_finished_req(self, req: Req):
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :kv_committed_len
+            req.req_pool_idx,
+            # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
+            : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
         ]
         self.req_to_token_pool.free(req.req_pool_idx)
-        self.token_to_kv_pool_allocator.free(kv_indices)
-        self.protected_size_ -= len(req.prefix_indices)
+        if self.page_size != 1:
+            page_ids = torch.unique(kv_indices // self.page_size)
+            self.token_to_kv_pool_allocator.free_page_ids(page_ids)
+        else:
+            self.token_to_kv_pool_allocator.free(kv_indices)
 
-    def cache_unfinished_req(self, req: Req, chunked=False):
+    def cache_unfinished_req(self, req: Req):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(req.fill_ids)
         ]
-        self.protected_size_ += len(kv_indices) - len(req.prefix_indices)
 
         # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later
-        req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
+        req.prefix_indices = kv_indices
 
     def evict(self, num_tokens: int):
         pass
@@ -78,9 +67,6 @@ class ChunkCache(BasePrefixCache):
 
     def dec_lock_ref(self, node: Any, swa_uuid_for_lock: Optional[str] = None):
         return 0
-
-    def protected_size(self):
-        return self.protected_size_
 
     def pretty_print(self):
         return ""

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -269,11 +269,9 @@ def alloc_paged_token_slots_extend(
         state = allocator.backup_state()
 
     out_cache_loc = allocator.alloc_extend(
-        prefix_lens,
-        prefix_lens_cpu,
-        seq_lens,
-        seq_lens_cpu,
-        last_loc,
+        prefix_lens,  # device tensor
+        seq_lens,  # device tensor
+        last_loc,  # device tensor
         extend_num_tokens,
     )
 
@@ -402,7 +400,7 @@ def alloc_paged_token_slots_decode(
     num_tokens = len(seq_lens) * allocator.page_size
     evict_from_tree_cache(tree_cache, num_tokens)
 
-    out_cache_loc = allocator.alloc_decode(seq_lens, seq_lens_cpu, last_loc)
+    out_cache_loc = allocator.alloc_decode(seq_lens, last_loc)
 
     if out_cache_loc is None:
         error_msg = (

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -486,7 +486,7 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
         start_p:end_p
     ]
     if page_size > 1:
-        page_ids = torch.unique(indices_to_free // page_size)
+        page_ids = torch.unique(indices_to_free // page_size + 1)
         tree_cache.token_to_kv_pool_allocator.free_pages(page_ids)
     else:
         tree_cache.token_to_kv_pool_allocator.free(indices_to_free)

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -485,7 +485,7 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     ]
     if page_size > 1:
         page_ids = torch.unique(indices_to_free // page_size + 1)
-        tree_cache.token_to_kv_pool_allocator.free_pages(page_ids)
+        tree_cache.token_to_kv_pool_allocator.free_page_ids(page_ids)
     else:
         tree_cache.token_to_kv_pool_allocator.free(indices_to_free)
 

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -485,7 +485,11 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     indices_to_free = tree_cache.req_to_token_pool.req_to_token[req.req_pool_idx][
         start_p:end_p
     ]
-    tree_cache.token_to_kv_pool_allocator.free(indices_to_free)
+    if page_size > 1:
+        page_ids = torch.unique(indices_to_free // page_size)
+        tree_cache.token_to_kv_pool_allocator.free_pages(page_ids)
+    else:
+        tree_cache.token_to_kv_pool_allocator.free(indices_to_free)
 
 
 def available_and_evictable_str(tree_cache) -> str:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -275,7 +275,7 @@ class RadixCache(BasePrefixCache):
                 ]
                 if self.page_size != 1:
                     page_ids = torch.unique(kv_indices // self.page_size + 1)
-                    self.token_to_kv_pool_allocator.free_pages(page_ids)
+                    self.token_to_kv_pool_allocator.free_page_ids(page_ids)
                 else:
                     self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
@@ -295,7 +295,7 @@ class RadixCache(BasePrefixCache):
             tail = kv_indices[page_aligned_len:]
             if len(tail) > 0:
                 tail_pages = torch.unique(tail // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(tail_pages)
+                self.token_to_kv_pool_allocator.free_page_ids(tail_pages)
         else:
             page_aligned_len = len(kv_indices)
             page_aligned_kv_indices = kv_indices.to(dtype=torch.int64, copy=True)
@@ -308,7 +308,7 @@ class RadixCache(BasePrefixCache):
             segment = kv_indices[len(req.prefix_indices) : new_prefix_len]
             if len(segment) > 0:
                 seg_pages = torch.unique(segment // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(seg_pages)
+                self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
         else:
             self.token_to_kv_pool_allocator.free(
                 kv_indices[len(req.prefix_indices) : new_prefix_len]
@@ -344,7 +344,7 @@ class RadixCache(BasePrefixCache):
             segment = kv_indices[len(req.prefix_indices) : new_prefix_len]
             if len(segment) > 0:
                 seg_pages = torch.unique(segment // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(seg_pages)
+                self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
         else:
             self.token_to_kv_pool_allocator.free(
                 kv_indices[len(req.prefix_indices) : new_prefix_len]
@@ -394,7 +394,7 @@ class RadixCache(BasePrefixCache):
 
             if self.page_size != 1:
                 freed_pages = torch.unique(x.value // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(freed_pages)
+                self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
             else:
                 self.token_to_kv_pool_allocator.free(x.value)
             num_evicted += len(x.value)

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -22,8 +22,8 @@ The radix tree data structure for managing the KV cache.
 import heapq
 import time
 from collections import defaultdict
-from functools import lru_cache, partial
-from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Union
+from functools import partial
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
@@ -34,42 +34,10 @@ from sglang.srt.disaggregation.kv_events import (
 )
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
-from sglang.srt.mem_cache.evict_policy import (
-    EvictionStrategy,
-    FIFOStrategy,
-    FILOStrategy,
-    LFUStrategy,
-    LRUStrategy,
-    MRUStrategy,
-)
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
-
-
-class RadixKey:
-
-    def __init__(self, token_ids: List[int], extra_key: Optional[str] = None):
-        # token ids sequence
-        self.token_ids = token_ids
-        # extra key (e.g. lora_id, cache_salt)
-        self.extra_key = extra_key
-
-    def __len__(self) -> int:
-        return len(self.token_ids)
-
-    def __iter__(self) -> Iterator[int]:
-        return iter(self.token_ids)
-
-    def __getitem__(self, idx: Union[int, slice]) -> "RadixKey":
-        if isinstance(idx, slice):
-            return RadixKey(self.token_ids[idx], self.extra_key)
-        return RadixKey([self.token_ids[idx]], self.extra_key)
-
-    def __repr__(self) -> str:
-        preview = self.token_ids[:10]
-        return f"RadixKey(extra_key={self.extra_key!r}, token_ids={preview}{'...' if len(self.token_ids) > 10 else ''})"
 
 
 class TreeNode:
@@ -79,13 +47,14 @@ class TreeNode:
     def __init__(self, id: Optional[int] = None):
         self.children = defaultdict(TreeNode)
         self.parent: TreeNode = None
-        self.key: RadixKey = None
+        self.key: List[int] = None
         self.value: Optional[torch.Tensor] = None
         self.lock_ref = 0
         self.last_access_time = time.monotonic()
-        self.creation_time = time.monotonic()
 
         self.hit_count = 0
+        # indicating the node is loading KV cache from host
+        self.loading = False
         # indicating the node is locked to protect from eviction
         # incremented when the node is referenced by a storage operation
         self.host_ref_counter = 0
@@ -105,6 +74,10 @@ class TreeNode:
     def backuped(self):
         return self.host_value is not None
 
+    @property
+    def backuped_storage(self):
+        return self.hash_value is not None and len(self.hash_value) > 0
+
     def protect_host(self):
         """Protect the host value from eviction."""
         self.host_ref_counter += 1
@@ -122,66 +95,29 @@ class TreeNode:
             return None
         return self.hash_value[-1]
 
-    @lru_cache(maxsize=1)
-    def get_prefix_hash_values(self, node: TreeNode) -> List[str]:
-        if node is None or node.hash_value is None:
-            return []
-
-        return node.get_prefix_hash_values(node.parent) + node.hash_value
-
     def __lt__(self, other: "TreeNode"):
         return self.last_access_time < other.last_access_time
 
 
-def _check_extra_key(key0: RadixKey, key1: RadixKey):
-    if key0.extra_key != key1.extra_key:
-        raise ValueError(
-            f"_key_match should be run on the same extra key, but got key0.extra_key={key0.extra_key} != key1.extra_key={key1.extra_key}"
-        )
-
-
-def _key_match_page_size1(key0: RadixKey, key1: RadixKey):
-    _check_extra_key(key0, key1)
+def _key_match_page_size1(key0: List, key1: List):
     i = 0
-    for k0, k1 in zip(key0.token_ids, key1.token_ids):
+    for k0, k1 in zip(key0, key1):
         if k0 != k1:
             break
         i += 1
     return i
 
 
-def _key_match_paged(key0: RadixKey, key1: RadixKey, page_size: int):
-    _check_extra_key(key0, key1)
+def _key_match_paged(key0: List, key1: List, page_size: int):
     min_len = min(len(key0), len(key1))
 
     i = 0
     while i < min_len:
-        if key0.token_ids[i : i + page_size] != key1.token_ids[i : i + page_size]:
+        if key0[i : i + page_size] != key1[i : i + page_size]:
             break
         i += page_size
 
     return i
-
-
-def get_child_key(key: RadixKey, page_size: int = 1):
-    if page_size == 1:
-        plain_key = key.token_ids[0]
-    else:
-        plain_key = tuple(key.token_ids[:page_size])
-    if key.extra_key is None:
-        return plain_key
-    else:
-        return (key.extra_key, plain_key)
-
-
-def _convert_to_bigram_key(tokens: List[int]) -> List[Tuple[int, int]]:
-    # EAGLE uses bigram keys in the radix tree since draft sequence is the one-token-shifted version of target
-    # [1, 2, 3, 4] -> [(1,2), (2,3), (3,4)]
-    if len(tokens) < 2:
-        return []
-    if isinstance(tokens[0], tuple):
-        return tokens
-    return [(tokens[i], tokens[i + 1]) for i in range(len(tokens) - 1)]
 
 
 class RadixCache(BasePrefixCache):
@@ -191,10 +127,7 @@ class RadixCache(BasePrefixCache):
         token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
         page_size: int,
         disable: bool = False,
-        enable_metrics: bool = False,
         enable_kv_cache_events: bool = False,
-        eviction_policy: str = "lru",
-        is_eagle: bool = False,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
@@ -202,10 +135,6 @@ class RadixCache(BasePrefixCache):
         self.disable = disable
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue = []
-        self.is_eagle = is_eagle
-
-        if enable_metrics:
-            self.init_metrics_collector()
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device
@@ -214,85 +143,35 @@ class RadixCache(BasePrefixCache):
 
         if self.page_size == 1:
             self.key_match_fn = _key_match_page_size1
-            self.get_child_key_fn = get_child_key
+            self.get_child_key_fn = lambda key: key[0]
         else:
             self.key_match_fn = partial(_key_match_paged, page_size=page_size)
-            self.get_child_key_fn = partial(get_child_key, page_size=page_size)
-
-        if is_eagle:
-            self.key_convert_fn = _convert_to_bigram_key
-        else:
-            self.key_convert_fn = lambda key: key
-
-        if eviction_policy.lower() == "lru":
-            self.eviction_strategy: EvictionStrategy = LRUStrategy()
-        elif eviction_policy.lower() == "lfu":
-            self.eviction_strategy: EvictionStrategy = LFUStrategy()
-        elif eviction_policy.lower() == "fifo":
-            self.eviction_strategy: EvictionStrategy = FIFOStrategy()
-        elif eviction_policy.lower() == "mru":
-            self.eviction_strategy: EvictionStrategy = MRUStrategy()
-        elif eviction_policy.lower() == "filo":
-            self.eviction_strategy: EvictionStrategy = FILOStrategy()
-        else:
-            raise ValueError(
-                f"Unknown eviction policy: {eviction_policy}. Supported policies: 'lru', 'lfu', 'fifo', 'mru', 'filo'."
-            )
+            self.get_child_key_fn = lambda key: tuple(key[:page_size])
         self.reset()
 
     ##### Public API #####
 
     def reset(self):
         self.root_node = TreeNode()
-        self.root_node.key = RadixKey(token_ids=[], extra_key=None)
+        self.root_node.key = []
         self.root_node.value = []
-        self.root_node.host_value = []
         self.root_node.lock_ref = 1
         self.evictable_size_ = 0
         self.protected_size_ = 0
         self._record_all_cleared_event()
 
-    def match_prefix(self, key: RadixKey, **kwargs) -> MatchResult:
-        """Find the longest cached prefix of ``key`` in the radix tree.
-
-        The logical namespace for prefix matching is determined by both the
-        token id sequence and the optional ``extra_key`` carried by ``RadixKey``.
-        Entries that share identical leading token ids but have *different*
-        ``extra_key`` values are intentionally kept disjoint and never share
-        prefix nodes. This is useful to:
-
-        * Isolate KV cache lines for different LoRA / adapter IDs.
-        * Separate requests that intentionally should not share state (e.g.,
-          different sampling salt, cache version, or retrieval augmentation
-          context) by supplying a distinct ``extra_key``.
-
+    def match_prefix(self, key: List[int], **kwargs) -> MatchResult:
+        """Find the matching prefix from the radix tree.
         Args:
-            key (RadixKey): The lookup key containing a list of token ids and an
-                optional ``extra_key`` namespace tag. If ``page_size > 1`` the
-                length is internally truncated to a multiple of ``page_size``
-                before matching. Passing an empty key returns an empty result
-                with the root as the last node.
-            **kwargs: Reserved for future extensions (ignored currently).
-
+            key: A list of token IDs to find a matching prefix.
         Returns:
-            MatchResult: ``device_indices`` is a 1-D ``torch.int64`` tensor of
-            the concatenated KV cache indices corresponding to the longest
-            cached prefix (may be length 0). ``last_device_node`` and
-            ``last_host_node`` (currently the same) are the tree node objects
-            representing the terminal node of the matched prefix. This method
-            may mutate internal structure by splitting an existing node if the
-            match ends inside a stored segment.
-
-        Internal updates:
-            * Refreshes access metadata (timestamps) used by the
-                configured eviction strategy.
-            * If the lookup ends inside a stored segment the node is split once
-                to expose a precise boundary; this structural refinement improves
-                subsequent match efficiency and does not duplicate data.
+            A tuple of a tensor of matching prefix token IDs and
+            the last node that contains the prefix values. Note that
+            this API can modify the internal state of the Radix tree.
+            The last node create a new child if the prefix is shorter
+            than the last node's value.
         """
-        key.token_ids = self.key_convert_fn(key.token_ids)
-
-        def empty_match_result():
+        if self.disable or len(key) == 0:
             return MatchResult(
                 device_indices=torch.empty(
                     (0,),
@@ -303,15 +182,9 @@ class RadixCache(BasePrefixCache):
                 last_host_node=self.root_node,
             )
 
-        if self.disable or len(key) == 0:
-            return empty_match_result()
-
         if self.page_size != 1:
             page_aligned_len = len(key) // self.page_size * self.page_size
             key = key[:page_aligned_len]
-
-        if len(key) == 0:
-            return empty_match_result()
 
         value, last_node = self._match_prefix_helper(self.root_node, key)
         if value:
@@ -324,156 +197,109 @@ class RadixCache(BasePrefixCache):
             last_host_node=last_node,
         )
 
-    def insert(self, key: RadixKey, value=None, chunked=False):
+    def insert(self, key: List, value=None):
         if self.disable:
             return 0
 
-        key.token_ids = self.key_convert_fn(key.token_ids)
-
         if value is None:
-            value = torch.tensor(key.token_ids, dtype=torch.int64)
-
-        if self.is_eagle:
-            # Make sure the value len equal to the EAGLE bigram key len
-            value = value[: len(key)]
-
+            value = [x for x in key]
         return self._insert_helper(self.root_node, key, value)
 
-    def cache_finished_req(self, req: Req, is_insert: bool = True):
+    def cache_finished_req(self, req: Req):
         """Cache request when it finishes."""
-        committed_kv_len = req.pop_committed_kv_cache()
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, :committed_kv_len
+                req.req_pool_idx, : len(req.origin_input_ids) + len(req.output_ids) - 1
             ]
             self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:committed_kv_len]
-        # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
-        # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
-        actual_kv_len = committed_kv_len - 1 if self.is_eagle else committed_kv_len
+        token_ids = (req.origin_input_ids + req.output_ids)[:-1]
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :committed_kv_len
+            req.req_pool_idx, : len(token_ids)
         ]
 
         if self.page_size != 1:
-            page_aligned_len = actual_kv_len // self.page_size * self.page_size
+            page_aligned_len = len(kv_indices) // self.page_size * self.page_size
             page_aligned_kv_indices = kv_indices[:page_aligned_len].to(
                 dtype=torch.int64, copy=True
             )
+            tail = kv_indices[page_aligned_len:]
+            if len(tail) > 0:
+                tail_pages = torch.unique(tail // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(tail_pages)
         else:
-            page_aligned_len = actual_kv_len
+            page_aligned_len = len(kv_indices)
             page_aligned_kv_indices = kv_indices.to(dtype=torch.int64, copy=True)
 
-        page_aligned_token_len = (
-            page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        )
-
-        old_prefix_len = len(req.prefix_indices)
-        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
-            # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
-            # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
-            old_prefix_len -= 1
-
         # Radix Cache takes one ref in memory pool
-        if is_insert:
-            new_prefix_len = self.insert(
-                RadixKey(token_ids[:page_aligned_token_len], req.extra_key),
-                page_aligned_kv_indices,
-            )
-            # Free the duplicates that were already in the tree
-            self.token_to_kv_pool_allocator.free(
-                kv_indices[old_prefix_len:new_prefix_len]
-            )
+        new_prefix_len = self.insert(
+            token_ids[:page_aligned_len], page_aligned_kv_indices
+        )
+        if self.page_size != 1:
+            segment = kv_indices[len(req.prefix_indices) : new_prefix_len]
+            if len(segment) > 0:
+                seg_pages = torch.unique(segment // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
         else:
             self.token_to_kv_pool_allocator.free(
-                kv_indices[old_prefix_len:page_aligned_len]
+                kv_indices[len(req.prefix_indices) : new_prefix_len]
             )
-
-        # free the unaligned tail
-        self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
 
         # Remove req slot release the cache lock
         self.req_to_token_pool.free(req.req_pool_idx)
         self.dec_lock_ref(req.last_node)
 
-    def cache_unfinished_req(self, req: Req, chunked=False):
+    def cache_unfinished_req(self, req: Req):
         """Cache request when it is unfinished."""
         if self.disable:
             return
 
         token_ids = req.fill_ids
-        all_token_len = len(token_ids)
-        # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
-        # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
-        actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :all_token_len
+            req.req_pool_idx, : len(token_ids)
         ]
 
         if self.page_size != 1:
-            page_aligned_len = actual_kv_len // self.page_size * self.page_size
+            page_aligned_len = len(kv_indices) // self.page_size * self.page_size
             page_aligned_kv_indices = kv_indices[:page_aligned_len].to(
                 dtype=torch.int64, copy=True
             )
         else:
-            page_aligned_len = actual_kv_len
+            page_aligned_len = len(kv_indices)
             page_aligned_kv_indices = kv_indices.to(dtype=torch.int64, copy=True)
-
-        # For EAGLE, the page_aligned_len is for the bigram key, the normal key len should +1
-        page_aligned_token_len = (
-            page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        )
-        page_aligned_token_ids = token_ids[:page_aligned_token_len]
-
-        old_prefix_len = len(req.prefix_indices)
-        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
-            # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
-            # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
-            old_prefix_len -= 1
+        page_aligned_token_ids = token_ids[:page_aligned_len]
 
         # Radix Cache takes one ref in memory pool
-        new_prefix_len = self.insert(
-            RadixKey(page_aligned_token_ids, req.extra_key),
-            page_aligned_kv_indices,
-            chunked=chunked,
-        )
-        self.token_to_kv_pool_allocator.free(kv_indices[old_prefix_len:new_prefix_len])
+        new_prefix_len = self.insert(page_aligned_token_ids, page_aligned_kv_indices)
+        if self.page_size != 1:
+            segment = kv_indices[len(req.prefix_indices) : new_prefix_len]
+            if len(segment) > 0:
+                seg_pages = torch.unique(segment // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
+        else:
+            self.token_to_kv_pool_allocator.free(
+                kv_indices[len(req.prefix_indices) : new_prefix_len]
+            )
 
         # The prefix indices could be updated, reuse it
-        new_indices, new_last_node, _, _ = self.match_prefix(
-            RadixKey(token_ids=page_aligned_token_ids, extra_key=req.extra_key)
-        )
+        new_indices, new_last_node, _, _ = self.match_prefix(page_aligned_token_ids)
         self.req_to_token_pool.write(
-            (req.req_pool_idx, slice(old_prefix_len, len(new_indices))),
-            new_indices[old_prefix_len:],
+            (req.req_pool_idx, slice(len(req.prefix_indices), len(new_indices))),
+            new_indices[len(req.prefix_indices) :],
         )
-
-        # The last_matched_prefix_len is not always equal to len(req.prefix_indices)
-        # since for page_size > 1, the partial part is added to req.prefix_indices, but that part of kv indices is not added to the tree.
-        # It should be freed in the next cache_unfinished_req and final cache_finished_req to avoid memory leak.
-        # So we introduce this `last_matched_prefix_len` field to make sure the partial part can be freed correctly.
-        req.last_matched_prefix_len = len(new_indices)
 
         self.dec_lock_ref(req.last_node)
         self.inc_lock_ref(new_last_node)
 
         # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later
         if self.page_size != 1:
-            # Handle partial page, the partial part should be freed in the next cache_unfinished_req and final cache_finished_req.
             req.prefix_indices = torch.cat(
                 [new_indices, kv_indices[len(new_indices) :]]
             )
         else:
-            if self.is_eagle:
-                # Attach the kv index of the last token for EAGLE, it can be used in chunked prefill
-                req.prefix_indices = torch.cat(
-                    [new_indices, kv_indices[actual_kv_len:]]
-                )
-            else:
-                req.prefix_indices = new_indices
+            req.prefix_indices = new_indices
         req.last_node = new_last_node
 
     def pretty_print(self):
@@ -487,32 +313,30 @@ class RadixCache(BasePrefixCache):
         if self.disable:
             return
 
-        start_time = time.perf_counter()
         leaves = self._collect_leaves()
-        eviction_heap = [
-            (self.eviction_strategy.get_priority(node), node) for node in leaves
-        ]
-        heapq.heapify(eviction_heap)
+        heapq.heapify(leaves)
 
         num_evicted = 0
-        while num_evicted < num_tokens and len(eviction_heap):
-            _priority, x = heapq.heappop(eviction_heap)
+        while num_evicted < num_tokens and len(leaves):
+            x = heapq.heappop(leaves)
 
-            self.token_to_kv_pool_allocator.free(x.value)
+            if x == self.root_node:
+                break
+            if x.lock_ref > 0:
+                continue
+
+            if self.page_size != 1:
+                freed_pages = torch.unique(x.value // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+            else:
+                self.token_to_kv_pool_allocator.free(x.value)
             num_evicted += len(x.value)
             self._delete_leaf(x)
 
-            if len(x.parent.children) == 0 and x.parent.lock_ref == 0:
-                new_priority = self.eviction_strategy.get_priority(x.parent)
-                heapq.heappush(eviction_heap, (new_priority, x.parent))
+            if len(x.parent.children) == 0:
+                heapq.heappush(leaves, x.parent)
 
             self._record_remove_event(x)
-
-        if num_evicted > 0 and self.metrics_collector is not None:
-            self.metrics_collector.observe_eviction_duration(
-                time.perf_counter() - start_time
-            )
-            self.metrics_collector.increment_eviction_num_tokens(num_evicted)
 
     def inc_lock_ref(self, node: TreeNode):
         if self.disable:
@@ -521,9 +345,9 @@ class RadixCache(BasePrefixCache):
         delta = 0
         while node != self.root_node:
             if node.lock_ref == 0:
-                self.evictable_size_ -= len(node.key)
-                self.protected_size_ += len(node.key)
-                delta -= len(node.key)
+                self.evictable_size_ -= len(node.value)
+                self.protected_size_ += len(node.value)
+                delta -= len(node.value)
             node.lock_ref += 1
             node = node.parent
         return delta
@@ -535,14 +359,10 @@ class RadixCache(BasePrefixCache):
         delta = 0
         while node != self.root_node:
             if node.lock_ref == 1:
-                self.evictable_size_ += len(node.key)
-                self.protected_size_ -= len(node.key)
-                delta += len(node.key)
+                self.evictable_size_ += len(node.value)
+                self.protected_size_ -= len(node.value)
+                delta += len(node.value)
             node.lock_ref -= 1
-            if node.parent is None:
-                assert (
-                    node is self.root_node
-                ), f"This request holds the node from another tree"
             node = node.parent
         return delta
 
@@ -566,16 +386,15 @@ class RadixCache(BasePrefixCache):
 
     ##### Internal Helper Functions #####
 
-    def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
-        access_time = time.monotonic()
-        node.last_access_time = access_time
+    def _match_prefix_helper(self, node: TreeNode, key: List):
+        node.last_access_time = time.monotonic()
 
         child_key = self.get_child_key_fn(key)
 
         value = []
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
-            child.last_access_time = access_time
+            child.last_access_time = time.monotonic()
             prefix_len = self.key_match_fn(child.key, key)
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
@@ -592,7 +411,7 @@ class RadixCache(BasePrefixCache):
 
         return value, node
 
-    def _split_node(self, key: RadixKey, child: TreeNode, split_len: int):
+    def _split_node(self, key, child: TreeNode, split_len: int):
         # new_node -> child
         self._record_remove_event(child)
         new_node = TreeNode()
@@ -611,9 +430,8 @@ class RadixCache(BasePrefixCache):
 
         return new_node
 
-    def _insert_helper(self, node: TreeNode, key: RadixKey, value):
-        access_time = time.monotonic()
-        node.last_access_time = access_time
+    def _insert_helper(self, node: TreeNode, key: List, value):
+        node.last_access_time = time.monotonic()
         if len(key) == 0:
             return 0
 
@@ -622,7 +440,7 @@ class RadixCache(BasePrefixCache):
         total_prefix_length = 0
         while len(key) > 0 and child_key in node.children.keys():
             node = node.children[child_key]
-            node.last_access_time = access_time
+            node.last_access_time = time.monotonic()
             prefix_len = self.key_match_fn(node.key, key)
             total_prefix_length += prefix_len
             key = key[prefix_len:]
@@ -641,7 +459,7 @@ class RadixCache(BasePrefixCache):
             new_node.key = key
             new_node.value = value
             node.children[child_key] = new_node
-            self.evictable_size_ += len(key)
+            self.evictable_size_ += len(value)
             self._record_store_event(new_node)
         return total_prefix_length
 
@@ -653,7 +471,7 @@ class RadixCache(BasePrefixCache):
             print(
                 " " * current_indent,
                 len(current_node.key),
-                current_node.key.token_ids[:10],
+                current_node.key[:10],
                 f"r={current_node.lock_ref}",
             )
             for key, child in current_node.children.items():
@@ -684,13 +502,12 @@ class RadixCache(BasePrefixCache):
 
     def _collect_leaves(self):
         ret_list = []
-        stack = list(self.root_node.children.values())
+        stack = [self.root_node]
 
         while stack:
             cur_node = stack.pop()
             if len(cur_node.children) == 0:
-                if cur_node.lock_ref == 0:
-                    ret_list.append(cur_node)
+                ret_list.append(cur_node)
             else:
                 stack.extend(cur_node.children.values())
 
@@ -700,17 +517,17 @@ class RadixCache(BasePrefixCache):
         # One BlockStored per ``page_size`` chunk.
         if self.enable_kv_cache_events:
             # First chunk links to the last page of the parent node (if any).
-            if node.parent is None or node != self.root_node:
+            if node.parent is None:
                 parent_block_hash = None
             else:
                 last_page_start = (
                     (len(node.parent.key) - 1) // self.page_size
                 ) * self.page_size
-                parent_parent_tokens = node.parent.key.token_ids[last_page_start:]
+                parent_parent_tokens = node.parent.key[last_page_start:]
                 parent_block_hash = hash(tuple(parent_parent_tokens))
 
             for start in range(0, len(node.key), self.page_size):
-                page_tokens = node.key.token_ids[start : start + self.page_size]
+                page_tokens = node.key[start : start + self.page_size]
                 if not page_tokens:
                     continue
 
@@ -733,7 +550,7 @@ class RadixCache(BasePrefixCache):
         # One BlockRemoved per chunk.
         if self.enable_kv_cache_events:
             for start in range(0, len(node.key), self.page_size):
-                page_tokens = node.key.token_ids[start : start + self.page_size]
+                page_tokens = node.key[start : start + self.page_size]
                 if not page_tokens:
                     continue
                 block_hash = hash(tuple(page_tokens))
@@ -759,12 +576,19 @@ class RadixCache(BasePrefixCache):
 if __name__ == "__main__":
     tree = RadixCache(None, None, page_size=1, disable=False)
 
-    # Example token id sequences (as lists of ints)
-    tree.insert(RadixKey(token_ids=[1, 2, 3], extra_key=None))
-    tree.insert(RadixKey(token_ids=[1, 2, 3], extra_key=None))
-    tree.insert(RadixKey(token_ids=[1, 2, 4, 5], extra_key=None))
-    tree.insert(RadixKey(token_ids=[1, 2, 4, 5, 6, 7], extra_key=None))
-    tree.insert(RadixKey(token_ids=[8, 9, 10, 11, 12], extra_key=None))
+    tree.insert("Hello")
+    tree.insert("Hello")
+    tree.insert("Hello_L.A.!")
+    # tree.insert("Hello_world! Happy")
+    # tree.insert("I love you!")
     tree.pretty_print()
 
-    print(tree.match_prefix(RadixKey(token_ids=[1, 2, 3, 13, 14], extra_key=None)))
+    # print(tree.match_prefix("I love you! aha"))
+
+    # def evict_callback(x):
+    #    print("evict", x)
+    #    return len(x)
+
+    # tree.evict(5, evict_callback)
+    # tree.evict(10, evict_callback)
+    # tree.pretty_print()

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -318,7 +318,7 @@ class RadixCache(BasePrefixCache):
         self.req_to_token_pool.free(req.req_pool_idx)
         self.dec_lock_ref(req.last_node)
 
-    def cache_unfinished_req(self, req: Req):
+    def cache_unfinished_req(self, req: Req, chunked: bool = False):
         """Cache request when it is unfinished."""
         if self.disable:
             return

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -172,12 +172,18 @@ class RadixCache(BasePrefixCache):
         page_size: int,
         disable: bool = False,
         enable_kv_cache_events: bool = False,
+        enable_metrics: bool = False,
+        eviction_policy: Optional[str] = None,
+        is_eagle: bool = False,
     ):
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.page_size = page_size
         self.disable = disable
         self.enable_kv_cache_events = enable_kv_cache_events
+        self.enable_metrics = enable_metrics
+        self.eviction_policy = eviction_policy
+        self.is_eagle = is_eagle
         self.kv_event_queue = []
 
         if self.token_to_kv_pool_allocator:

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -274,7 +274,7 @@ class RadixCache(BasePrefixCache):
                     req.req_pool_idx, :kv_committed_len
                 ]
                 if self.page_size != 1:
-                    page_ids = torch.unique(kv_indices // self.page_size)
+                    page_ids = torch.unique(kv_indices // self.page_size + 1)
                     self.token_to_kv_pool_allocator.free_pages(page_ids)
                 else:
                     self.token_to_kv_pool_allocator.free(kv_indices)
@@ -294,7 +294,7 @@ class RadixCache(BasePrefixCache):
             )
             tail = kv_indices[page_aligned_len:]
             if len(tail) > 0:
-                tail_pages = torch.unique(tail // self.page_size)
+                tail_pages = torch.unique(tail // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(tail_pages)
         else:
             page_aligned_len = len(kv_indices)
@@ -307,7 +307,7 @@ class RadixCache(BasePrefixCache):
         if self.page_size != 1:
             segment = kv_indices[len(req.prefix_indices) : new_prefix_len]
             if len(segment) > 0:
-                seg_pages = torch.unique(segment // self.page_size)
+                seg_pages = torch.unique(segment // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(seg_pages)
         else:
             self.token_to_kv_pool_allocator.free(
@@ -343,7 +343,7 @@ class RadixCache(BasePrefixCache):
         if self.page_size != 1:
             segment = kv_indices[len(req.prefix_indices) : new_prefix_len]
             if len(segment) > 0:
-                seg_pages = torch.unique(segment // self.page_size)
+                seg_pages = torch.unique(segment // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(seg_pages)
         else:
             self.token_to_kv_pool_allocator.free(
@@ -393,7 +393,7 @@ class RadixCache(BasePrefixCache):
                 continue
 
             if self.page_size != 1:
-                freed_pages = torch.unique(x.value // self.page_size)
+                freed_pages = torch.unique(x.value // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(freed_pages)
             else:
                 self.token_to_kv_pool_allocator.free(x.value)

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -431,7 +431,7 @@ class SWARadixCache(BasePrefixCache):
             value = [x for x in key]
         return self._insert_helper(self.root_node, key, value, prev_prefix_len)
 
-    def cache_finished_req(self, req: Req) -> None:
+    def cache_finished_req(self, req: Req, is_insert: bool = True) -> None:
         """Cache request when it finishes."""
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
@@ -440,10 +440,23 @@ class SWARadixCache(BasePrefixCache):
             ]
             if self.page_size != 1:
                 page_ids = torch.unique(kv_indices // self.page_size)
-                self.token_to_kv_pool_allocator.free_page_ids(page_ids)
+                self.token_to_kv_pool_allocator.free_pages(page_ids)
             else:
                 self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
+            return
+
+        # If not inserting into the radix cache (e.g., aborted/retracted/failure),
+        # just free the committed KV and release the req slot/locks.
+        if not is_insert:
+            kv_committed_len = req.pop_committed_kv_cache()
+            if kv_committed_len > 0:
+                kv_indices = self.req_to_token_pool.req_to_token[
+                    req.req_pool_idx, :kv_committed_len
+                ]
+                self.token_to_kv_pool_allocator.free(kv_indices)
+            self.req_to_token_pool.free(req.req_pool_idx)
+            self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:-1]
@@ -457,7 +470,7 @@ class SWARadixCache(BasePrefixCache):
             tail = kv_indices[page_aligned_len:]
             if len(tail) > 0:
                 tail_pages = torch.unique(tail // self.page_size)
-                self.token_to_kv_pool_allocator.free_page_ids(tail_pages)
+                self.token_to_kv_pool_allocator.free_pages(tail_pages)
         else:
             page_aligned_len = len(kv_indices)
             page_aligned_kv_indices = kv_indices.clone()
@@ -556,7 +569,7 @@ class SWARadixCache(BasePrefixCache):
                 # 1. free node kv indices, evict full and swa tokens
                 if self.page_size != 1:
                     freed_pages = torch.unique(x.value // self.page_size)
-                    self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+                    self.token_to_kv_pool_allocator.free_pages(freed_pages)
                 else:
                     self.token_to_kv_pool_allocator.free(x.value)
                 full_num_evicted += len(x.value)
@@ -609,7 +622,7 @@ class SWARadixCache(BasePrefixCache):
                     # 1. a leaf node, free full and swa tokens
                     if self.page_size != 1:
                         freed_pages = torch.unique(x.value // self.page_size)
-                        self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+                        self.token_to_kv_pool_allocator.free_pages(freed_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(x.value)
                     full_num_evicted += len(x.value)
@@ -893,7 +906,7 @@ class SWARadixCache(BasePrefixCache):
                         seg = node.value[first_diff_idx:]
                         if len(seg) > 0:
                             seg_pages = torch.unique(seg // self.page_size)
-                            self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
+                            self.token_to_kv_pool_allocator.free_pages(seg_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(
                             node.value[first_diff_idx:]
@@ -910,7 +923,7 @@ class SWARadixCache(BasePrefixCache):
                         seg = value[first_diff_idx:prefix_len]
                         if len(seg) > 0:
                             seg_pages = torch.unique(seg // self.page_size)
-                            self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
+                            self.token_to_kv_pool_allocator.free_pages(seg_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(
                             value[first_diff_idx:prefix_len]
@@ -952,7 +965,7 @@ class SWARadixCache(BasePrefixCache):
             # delete tombstone node evicts full tokens
             if self.page_size != 1:
                 freed_pages = torch.unique(node.parent.value // self.page_size)
-                self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+                self.token_to_kv_pool_allocator.free_pages(freed_pages)
             else:
                 self.token_to_kv_pool_allocator.free(node.parent.value)
             full_num_evicted += len(node.parent.value)

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -26,18 +26,10 @@ from functools import partial
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
-from numpy import float64
 
 from sglang.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchResult
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
-from sglang.srt.mem_cache.radix_cache import (
-    RadixKey,
-    _convert_to_bigram_key,
-    _key_match_page_size1,
-    _key_match_paged,
-    get_child_key,
-)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -51,12 +43,11 @@ class TreeNode:
 
     counter = 0
     swa_uuid_counter = 1
-    last_access_time_counter_float = float64(1.0)
 
     def __init__(self, id: Optional[int] = None):
         self.children = defaultdict(TreeNode)
         self.parent: TreeNode = None
-        self.key: RadixKey = None
+        self.key: List[int] = None
         self.value: Optional[torch.Tensor] = None
         # swa_tombstone is used to indicate the kv indices have been freed for swa layers
         self.swa_tombstone = False
@@ -66,9 +57,11 @@ class TreeNode:
         self.full_lock_ref = 0
         self.swa_lock_ref = 0
         # last access time is only used for sanity check. LRU is maintained by the lru list.
-        self.last_access_time = get_last_access_time()
+        self.last_access_time = time.monotonic()
 
         self.hit_count = 0
+        # indicating the node is loading KV cache from host
+        self.loading = False
         # store the host indices of KV cache
         self.host_value = None
 
@@ -96,15 +89,30 @@ class TreeNode:
         return self.last_access_time < other.last_access_time
 
 
+def _key_match_page_size1(key0: List, key1: List):
+    i = 0
+    for k0, k1 in zip(key0, key1):
+        if k0 != k1:
+            break
+        i += 1
+    return i
+
+
+def _key_match_paged(key0: List, key1: List, page_size: int):
+    min_len = min(len(key0), len(key1))
+
+    i = 0
+    while i < min_len:
+        if key0[i : i + page_size] != key1[i : i + page_size]:
+            break
+        i += page_size
+
+    return i
+
+
 def gen_swa_uuid() -> int:
     TreeNode.swa_uuid_counter += 1
     return TreeNode.swa_uuid_counter
-
-
-def get_last_access_time() -> float64:
-    ret = TreeNode.last_access_time_counter_float
-    TreeNode.last_access_time_counter_float += 1.0
-    return ret
 
 
 class LRUList:
@@ -336,15 +344,12 @@ class SWARadixCache(BasePrefixCache):
         sliding_window_size: int,
         page_size: int,
         disable: bool = False,
-        is_eagle: bool = False,
-        enable_metrics: bool = False,
     ):
         assert isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator)
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.page_size = page_size
         self.disable = disable
-        self.is_eagle = is_eagle
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device
@@ -353,18 +358,10 @@ class SWARadixCache(BasePrefixCache):
 
         if self.page_size == 1:
             self.key_match_fn = _key_match_page_size1
-            self.get_child_key_fn = get_child_key
+            self.get_child_key_fn = lambda key: key[0]
         else:
             self.key_match_fn = partial(_key_match_paged, page_size=page_size)
-            self.get_child_key_fn = partial(get_child_key, page_size=page_size)
-
-        if is_eagle:
-            self.key_convert_fn = _convert_to_bigram_key
-        else:
-            self.key_convert_fn = lambda key: key
-
-        if enable_metrics:
-            self.init_metrics_collector()
+            self.get_child_key_fn = lambda key: tuple(key[:page_size])
 
         self.sliding_window_size = sliding_window_size
         self.reset()
@@ -385,10 +382,10 @@ class SWARadixCache(BasePrefixCache):
         self.full_lru_list = LRUList(swa=False)
         self.swa_lru_list = LRUList(swa=True)
 
-    def match_prefix(self, key: RadixKey, **kwargs) -> MatchResult:
+    def match_prefix(self, key: List[int], **kwargs) -> MatchResult:
         """Find the matching prefix from the radix tree.
         Args:
-            key: A RadixKey contains token IDs to find a matching prefix.
+            key: A list of token IDs to find a matching prefix.
         Returns:
             A tuple of a tensor of matching prefix token IDs and
             the last node that contains the prefix values. Note that
@@ -396,8 +393,6 @@ class SWARadixCache(BasePrefixCache):
             The last node create a new child if the prefix is shorter
             than the last node's value.
         """
-        key.token_ids = self.key_convert_fn(key.token_ids)
-
         if self.disable or len(key) == 0:
             return MatchResult(
                 device_indices=torch.empty(
@@ -424,83 +419,59 @@ class SWARadixCache(BasePrefixCache):
             last_host_node=last_node,
         )
 
-    def insert(self, key: RadixKey, value=None, prev_prefix_len: int = 0) -> int:
+    def insert(self, key: List, value=None, prev_prefix_len: int = 0) -> int:
         if self.disable:
             return 0
 
-        key.token_ids = self.key_convert_fn(key.token_ids)
-
         if value is None:
-            value = torch.tensor([x for x in key.token_ids], dtype=torch.int64)
-
-        if self.is_eagle:
-            # Make sure the value len equal to the EAGLE bigram key len
-            value = value[: len(key)]
-
+            value = [x for x in key]
         return self._insert_helper(self.root_node, key, value, prev_prefix_len)
 
-    def cache_finished_req(self, req: Req, is_insert: bool = True) -> None:
+    def cache_finished_req(self, req: Req) -> None:
         """Cache request when it finishes."""
-        kv_committed_len = req.pop_committed_kv_cache()
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, :kv_committed_len
+                req.req_pool_idx,
+                : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
             ]
-            self.token_to_kv_pool_allocator.free(kv_indices)
+            if self.page_size != 1:
+                page_ids = torch.unique(kv_indices // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(page_ids)
+            else:
+                self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:kv_committed_len]
-        # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
-        # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
-        actual_kv_len = kv_committed_len - 1 if self.is_eagle else kv_committed_len
+        token_ids = (req.origin_input_ids + req.output_ids)[:-1]
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :kv_committed_len
+            req.req_pool_idx, : len(token_ids)
         ]
 
         if self.page_size != 1:
-            page_aligned_len = actual_kv_len // self.page_size * self.page_size
-            page_aligned_kv_indices = kv_indices[:page_aligned_len].to(
-                dtype=torch.int64, copy=True
-            )
+            page_aligned_len = len(kv_indices) // self.page_size * self.page_size
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].clone()
+            tail = kv_indices[page_aligned_len:]
+            if len(tail) > 0:
+                tail_pages = torch.unique(tail // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(tail_pages)
         else:
-            page_aligned_len = actual_kv_len
-            page_aligned_kv_indices = kv_indices.to(dtype=torch.int64, copy=True)
-            if self.is_eagle:
-                self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
-
-        page_aligned_token_len = (
-            page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        )
-
-        old_prefix_len = len(req.prefix_indices)
-        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
-            # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
-            # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
-            old_prefix_len -= 1
+            page_aligned_len = len(kv_indices)
+            page_aligned_kv_indices = kv_indices.clone()
 
         # Radix Cache takes one ref in memory pool
         # insert the token_ids and kv_indices into the radix tree
         # Note: the insert function already frees the overlapped kv_indices
-        if is_insert:
-            new_prefix_len = self.insert(
-                RadixKey(token_ids[:page_aligned_token_len], req.extra_key),
-                page_aligned_kv_indices,
-                old_prefix_len,
-            )
-        else:
-            self.token_to_kv_pool_allocator.free(
-                kv_indices[old_prefix_len:page_aligned_len]
-            )
-
-        # free the unaligned tail
-        self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
+        new_prefix_len = self.insert(
+            token_ids[:page_aligned_len],
+            page_aligned_kv_indices,
+            len(req.prefix_indices),
+        )
 
         # Remove req slot release the cache lock
         self.req_to_token_pool.free(req.req_pool_idx)
         self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
 
-    def cache_unfinished_req(self, req: Req, chunked=False) -> None:
+    def cache_unfinished_req(self, req: Req) -> None:
         """Cache request when it is unfinished."""
         if self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
@@ -512,57 +483,34 @@ class SWARadixCache(BasePrefixCache):
             return
 
         token_ids = req.fill_ids
-        all_token_len = len(token_ids)
-        # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
-        # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
-        actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, :all_token_len
+            req.req_pool_idx, : len(token_ids)
         ]
 
         if self.page_size != 1:
-            page_aligned_len = actual_kv_len // self.page_size * self.page_size
-            page_aligned_kv_indices = kv_indices[:page_aligned_len].to(
-                dtype=torch.int64, copy=True
-            )
+            page_aligned_len = len(kv_indices) // self.page_size * self.page_size
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].clone()
         else:
-            page_aligned_len = actual_kv_len
-            page_aligned_kv_indices = kv_indices.to(dtype=torch.int64, copy=True)
-
-        # For EAGLE, the page_aligned_len is for the bigram key, the normal key len should +1
-        page_aligned_token_len = (
-            page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        )
-        page_aligned_token_ids = token_ids[:page_aligned_token_len]
-
-        old_prefix_len = len(req.prefix_indices)
-        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
-            # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
-            # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
-            old_prefix_len -= 1
+            page_aligned_len = len(kv_indices)
+            page_aligned_kv_indices = kv_indices.clone()
+        page_aligned_token_ids = token_ids[:page_aligned_len]
 
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
         new_prefix_len = self.insert(
-            RadixKey(page_aligned_token_ids, req.extra_key),
-            page_aligned_kv_indices,
-            old_prefix_len,
+            page_aligned_token_ids, page_aligned_kv_indices, len(req.prefix_indices)
         )
 
         # The prefix indices could be updated, reuse it
-        new_indices, new_last_node, _, _ = self.match_prefix(
-            RadixKey(page_aligned_token_ids, req.extra_key)
-        )
-        assert old_prefix_len <= len(
+        new_indices, new_last_node, _, _ = self.match_prefix(page_aligned_token_ids)
+        assert len(req.prefix_indices) <= len(
             new_indices
         ), f"{req.prefix_indices=}, {new_indices=}"
         assert new_prefix_len <= len(new_indices), f"{new_prefix_len=}, {new_indices=}"
         self.req_to_token_pool.write(
-            (req.req_pool_idx, slice(old_prefix_len, len(new_indices))),
-            new_indices[old_prefix_len:],
+            (req.req_pool_idx, slice(len(req.prefix_indices), len(new_indices))),
+            new_indices[len(req.prefix_indices) :],
         )
-
-        req.last_matched_prefix_len = len(new_indices)
 
         self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
         swa_uuid_for_lock = self.inc_lock_ref(new_last_node)
@@ -573,13 +521,7 @@ class SWARadixCache(BasePrefixCache):
                 [new_indices, kv_indices[len(new_indices) :]]
             )
         else:
-            if self.is_eagle:
-                # Attach the kv index of the last token for EAGLE, it can be used in chunked prefill
-                req.prefix_indices = torch.cat(
-                    [new_indices, kv_indices[actual_kv_len:]]
-                )
-            else:
-                req.prefix_indices = new_indices
+            req.prefix_indices = new_indices
         req.last_node = new_last_node
         req.swa_uuid_for_lock = swa_uuid_for_lock
 
@@ -594,7 +536,7 @@ class SWARadixCache(BasePrefixCache):
     def evict(self, full_num_tokens: int, swa_num_tokens: int = 0) -> None:
         if self.disable:
             return
-        start_time = time.perf_counter()
+
         full_num_evicted = 0
         swa_num_evicted = 0
         if full_num_tokens > 0:
@@ -608,7 +550,11 @@ class SWARadixCache(BasePrefixCache):
                 assert x.full_lock_ref == 0, f"node is in use, {x.id=}"
 
                 # 1. free node kv indices, evict full and swa tokens
-                self.token_to_kv_pool_allocator.free(x.value)
+                if self.page_size != 1:
+                    freed_pages = torch.unique(x.value // self.page_size)
+                    self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+                else:
+                    self.token_to_kv_pool_allocator.free(x.value)
                 full_num_evicted += len(x.value)
                 swa_num_evicted += len(x.value)
 
@@ -657,7 +603,11 @@ class SWARadixCache(BasePrefixCache):
                         x.full_lock_ref == 0
                     ), f"leaf node with full lock must also have swa lock, {x.id=}"
                     # 1. a leaf node, free full and swa tokens
-                    self.token_to_kv_pool_allocator.free(x.value)
+                    if self.page_size != 1:
+                        freed_pages = torch.unique(x.value // self.page_size)
+                        self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+                    else:
+                        self.token_to_kv_pool_allocator.free(x.value)
                     full_num_evicted += len(x.value)
                     swa_num_evicted += len(x.value)
 
@@ -673,16 +623,6 @@ class SWARadixCache(BasePrefixCache):
                     self._iteratively_delete_tombstone_leaf(x)
 
                 x = x_next
-
-        if (
-            full_num_evicted > 0 or swa_num_evicted > 0
-        ) and self.metrics_collector is not None:
-            self.metrics_collector.observe_eviction_duration(
-                time.perf_counter() - start_time
-            )
-            self.metrics_collector.increment_eviction_num_tokens(
-                full_num_evicted + swa_num_evicted
-            )
 
     def inc_lock_ref(self, node: TreeNode) -> Optional[int]:
         """
@@ -809,9 +749,7 @@ class SWARadixCache(BasePrefixCache):
 
     ##### Internal Helper Functions #####
 
-    def _match_prefix_helper(
-        self, key: RadixKey
-    ) -> Tuple[List[torch.Tensor], TreeNode]:
+    def _match_prefix_helper(self, key: List) -> Tuple[List[torch.Tensor], TreeNode]:
         """
         SWA prefix matching helper. It factors in the sliding window size such that
         the matched node is guaranteed to either 1. connected to root without swa tombstone,
@@ -863,22 +801,19 @@ class SWARadixCache(BasePrefixCache):
 
         # update time for matched nodes, and make nodes closer to root to be least recently used
         # this allows swa to evict nodes closer to root first
-        node_update = best_last_node
-        self.full_lru_list.reset_node_and_parents_mru(node_update, self.root_node)
-        self.swa_lru_list.reset_node_and_parents_mru(node_update, self.root_node)
+        self.full_lru_list.reset_node_and_parents_mru(best_last_node, self.root_node)
+        self.swa_lru_list.reset_node_and_parents_mru(best_last_node, self.root_node)
 
         # This last_access_time is for sanity check, can be deleted after validation in production
-        cur_time = get_last_access_time()
-        while node_update:
-            node_update.last_access_time = cur_time
-            cur_time -= (
-                0.00001  # assuming less than 100000 nodes in a branch of the tree
-            )
-            node_update = node_update.parent
+        cur_time = time.monotonic()
+        while node:
+            node.last_access_time = cur_time
+            cur_time -= 0.0001
+            node = node.parent
 
         return value[:best_value_len], best_last_node
 
-    def _split_node(self, key: RadixKey, child: TreeNode, split_len: int) -> TreeNode:
+    def _split_node(self, key: List[int], child: TreeNode, split_len: int) -> TreeNode:
         # new_node -> child
         new_node = TreeNode()
         new_node.children = {self.get_child_key_fn(key[split_len:]): child}
@@ -892,7 +827,7 @@ class SWARadixCache(BasePrefixCache):
         new_node.swa_uuid = child.swa_uuid
         child.swa_uuid = None
         # child time should be later than parent's time for swa tombstone
-        child.last_access_time = get_last_access_time()
+        child.last_access_time = time.monotonic()
 
         # remove the child from the lru lists because it is being split
         self.full_lru_list.remove_node(child)
@@ -913,11 +848,11 @@ class SWARadixCache(BasePrefixCache):
         return new_node
 
     def _insert_helper(
-        self, node: TreeNode, key: RadixKey, value, update_kv_after_len: int
+        self, node: TreeNode, key: List, value, update_kv_after_len: int
     ) -> int:
         # Update the last access time from root to leaf, so that
         # swa will tombstone the node closer to root first
-        node.last_access_time = get_last_access_time()
+        node.last_access_time = time.monotonic()
         if node != self.root_node:
             self.full_lru_list.reset_node_mru(node)
             if not node.swa_tombstone:
@@ -930,7 +865,7 @@ class SWARadixCache(BasePrefixCache):
         total_prefix_length = 0
         while len(key) > 0 and child_key in node.children.keys():
             node = node.children[child_key]
-            node.last_access_time = get_last_access_time()
+            node.last_access_time = time.monotonic()
             self.full_lru_list.reset_node_mru(node)
             if not node.swa_tombstone:
                 self.swa_lru_list.reset_node_mru(node)
@@ -950,7 +885,13 @@ class SWARadixCache(BasePrefixCache):
                     assert (
                         node.swa_lock_ref == 0
                     ), f"tombstone swa_lock_ref should always be 0, {node.full_lock_ref=}, {node.swa_lock_ref=}, {node.id=}"
-                    self.token_to_kv_pool_allocator.free(node.value[first_diff_idx:])
+                    if self.page_size != 1:
+                        seg = node.value[first_diff_idx:]
+                        if len(seg) > 0:
+                            seg_pages = torch.unique(seg // self.page_size)
+                            self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
+                    else:
+                        self.token_to_kv_pool_allocator.free(node.value[first_diff_idx:])
                     node.value = value[:prefix_len]
                     node.swa_tombstone = False
 
@@ -959,9 +900,15 @@ class SWARadixCache(BasePrefixCache):
 
                     self.swa_evictable_size_ += len(node.value)
                 else:
-                    self.token_to_kv_pool_allocator.free(
-                        value[first_diff_idx:prefix_len]
-                    )
+                    if self.page_size != 1:
+                        seg = value[first_diff_idx:prefix_len]
+                        if len(seg) > 0:
+                            seg_pages = torch.unique(seg // self.page_size)
+                            self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
+                    else:
+                        self.token_to_kv_pool_allocator.free(
+                            value[first_diff_idx:prefix_len]
+                        )
 
             total_prefix_length += prefix_len
             key = key[prefix_len:]
@@ -997,7 +944,11 @@ class SWARadixCache(BasePrefixCache):
                 node.parent.swa_lock_ref == 0
             ), f"tombstone swa_lock_ref should always be 0, {node.parent.full_lock_ref=}, {node.parent.swa_lock_ref=}, {node.parent.id=}"
             # delete tombstone node evicts full tokens
-            self.token_to_kv_pool_allocator.free(node.parent.value)
+            if self.page_size != 1:
+                freed_pages = torch.unique(node.parent.value // self.page_size)
+                self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
+            else:
+                self.token_to_kv_pool_allocator.free(node.parent.value)
             full_num_evicted += len(node.parent.value)
             self.full_lru_list.remove_node(node.parent)
             self._delete_tombstone_leaf(node.parent)

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -439,7 +439,7 @@ class SWARadixCache(BasePrefixCache):
                 : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
             ]
             if self.page_size != 1:
-                page_ids = torch.unique(kv_indices // self.page_size)
+                page_ids = torch.unique(kv_indices // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(page_ids)
             else:
                 self.token_to_kv_pool_allocator.free(kv_indices)
@@ -469,7 +469,7 @@ class SWARadixCache(BasePrefixCache):
             page_aligned_kv_indices = kv_indices[:page_aligned_len].clone()
             tail = kv_indices[page_aligned_len:]
             if len(tail) > 0:
-                tail_pages = torch.unique(tail // self.page_size)
+                tail_pages = torch.unique(tail // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(tail_pages)
         else:
             page_aligned_len = len(kv_indices)
@@ -568,7 +568,7 @@ class SWARadixCache(BasePrefixCache):
 
                 # 1. free node kv indices, evict full and swa tokens
                 if self.page_size != 1:
-                    freed_pages = torch.unique(x.value // self.page_size)
+                    freed_pages = torch.unique(x.value // self.page_size + 1)
                     self.token_to_kv_pool_allocator.free_pages(freed_pages)
                 else:
                     self.token_to_kv_pool_allocator.free(x.value)
@@ -621,7 +621,7 @@ class SWARadixCache(BasePrefixCache):
                     ), f"leaf node with full lock must also have swa lock, {x.id=}"
                     # 1. a leaf node, free full and swa tokens
                     if self.page_size != 1:
-                        freed_pages = torch.unique(x.value // self.page_size)
+                        freed_pages = torch.unique(x.value // self.page_size + 1)
                         self.token_to_kv_pool_allocator.free_pages(freed_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(x.value)
@@ -905,7 +905,7 @@ class SWARadixCache(BasePrefixCache):
                     if self.page_size != 1:
                         seg = node.value[first_diff_idx:]
                         if len(seg) > 0:
-                            seg_pages = torch.unique(seg // self.page_size)
+                            seg_pages = torch.unique(seg // self.page_size + 1)
                             self.token_to_kv_pool_allocator.free_pages(seg_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(
@@ -922,7 +922,7 @@ class SWARadixCache(BasePrefixCache):
                     if self.page_size != 1:
                         seg = value[first_diff_idx:prefix_len]
                         if len(seg) > 0:
-                            seg_pages = torch.unique(seg // self.page_size)
+                            seg_pages = torch.unique(seg // self.page_size + 1)
                             self.token_to_kv_pool_allocator.free_pages(seg_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(
@@ -964,7 +964,7 @@ class SWARadixCache(BasePrefixCache):
             ), f"tombstone swa_lock_ref should always be 0, {node.parent.full_lock_ref=}, {node.parent.swa_lock_ref=}, {node.parent.id=}"
             # delete tombstone node evicts full tokens
             if self.page_size != 1:
-                freed_pages = torch.unique(node.parent.value // self.page_size)
+                freed_pages = torch.unique(node.parent.value // self.page_size + 1)
                 self.token_to_kv_pool_allocator.free_pages(freed_pages)
             else:
                 self.token_to_kv_pool_allocator.free(node.parent.value)

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -344,12 +344,16 @@ class SWARadixCache(BasePrefixCache):
         sliding_window_size: int,
         page_size: int,
         disable: bool = False,
+        is_eagle: bool = False,
+        enable_metrics: bool = False,
     ):
         assert isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator)
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.page_size = page_size
         self.disable = disable
+        self.is_eagle = is_eagle
+        self.enable_metrics = enable_metrics
 
         if self.token_to_kv_pool_allocator:
             self.device = self.token_to_kv_pool_allocator.device
@@ -891,7 +895,9 @@ class SWARadixCache(BasePrefixCache):
                             seg_pages = torch.unique(seg // self.page_size)
                             self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
                     else:
-                        self.token_to_kv_pool_allocator.free(node.value[first_diff_idx:])
+                        self.token_to_kv_pool_allocator.free(
+                            node.value[first_diff_idx:]
+                        )
                     node.value = value[:prefix_len]
                     node.swa_tombstone = False
 

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -440,7 +440,7 @@ class SWARadixCache(BasePrefixCache):
             ]
             if self.page_size != 1:
                 page_ids = torch.unique(kv_indices // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(page_ids)
+                self.token_to_kv_pool_allocator.free_page_ids(page_ids)
             else:
                 self.token_to_kv_pool_allocator.free(kv_indices)
             self.req_to_token_pool.free(req.req_pool_idx)
@@ -470,7 +470,7 @@ class SWARadixCache(BasePrefixCache):
             tail = kv_indices[page_aligned_len:]
             if len(tail) > 0:
                 tail_pages = torch.unique(tail // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(tail_pages)
+                self.token_to_kv_pool_allocator.free_page_ids(tail_pages)
         else:
             page_aligned_len = len(kv_indices)
             page_aligned_kv_indices = kv_indices.clone()
@@ -569,7 +569,7 @@ class SWARadixCache(BasePrefixCache):
                 # 1. free node kv indices, evict full and swa tokens
                 if self.page_size != 1:
                     freed_pages = torch.unique(x.value // self.page_size + 1)
-                    self.token_to_kv_pool_allocator.free_pages(freed_pages)
+                    self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
                 else:
                     self.token_to_kv_pool_allocator.free(x.value)
                 full_num_evicted += len(x.value)
@@ -622,7 +622,7 @@ class SWARadixCache(BasePrefixCache):
                     # 1. a leaf node, free full and swa tokens
                     if self.page_size != 1:
                         freed_pages = torch.unique(x.value // self.page_size + 1)
-                        self.token_to_kv_pool_allocator.free_pages(freed_pages)
+                        self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(x.value)
                     full_num_evicted += len(x.value)
@@ -906,7 +906,7 @@ class SWARadixCache(BasePrefixCache):
                         seg = node.value[first_diff_idx:]
                         if len(seg) > 0:
                             seg_pages = torch.unique(seg // self.page_size + 1)
-                            self.token_to_kv_pool_allocator.free_pages(seg_pages)
+                            self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(
                             node.value[first_diff_idx:]
@@ -923,7 +923,7 @@ class SWARadixCache(BasePrefixCache):
                         seg = value[first_diff_idx:prefix_len]
                         if len(seg) > 0:
                             seg_pages = torch.unique(seg // self.page_size + 1)
-                            self.token_to_kv_pool_allocator.free_pages(seg_pages)
+                            self.token_to_kv_pool_allocator.free_page_ids(seg_pages)
                     else:
                         self.token_to_kv_pool_allocator.free(
                             value[first_diff_idx:prefix_len]
@@ -965,7 +965,7 @@ class SWARadixCache(BasePrefixCache):
             # delete tombstone node evicts full tokens
             if self.page_size != 1:
                 freed_pages = torch.unique(node.parent.value // self.page_size + 1)
-                self.token_to_kv_pool_allocator.free_pages(freed_pages)
+                self.token_to_kv_pool_allocator.free_page_ids(freed_pages)
             else:
                 self.token_to_kv_pool_allocator.free(node.parent.value)
             full_num_evicted += len(node.parent.value)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1834,6 +1834,7 @@ class ModelRunner:
                 )
 
         # Initialize token_to_kv_pool_allocator
+        need_sort = self.server_args.disaggregation_mode in ("decode", "prefill")
         if self.token_to_kv_pool_allocator is None:
             if _is_npu and (
                 self.server_args.attention_backend == "ascend"
@@ -1845,6 +1846,7 @@ class ModelRunner:
                     dtype=self.kv_cache_dtype,
                     device=self.device,
                     kvcache=self.token_to_kv_pool,
+                    need_sort=need_sort,
                 )
             else:
                 if self.page_size == 1:
@@ -1855,6 +1857,7 @@ class ModelRunner:
                             dtype=self.kv_cache_dtype,
                             device=self.device,
                             kvcache=self.token_to_kv_pool,
+                            need_sort=need_sort,
                         )
                     else:
                         self.token_to_kv_pool_allocator = TokenToKVPoolAllocator(
@@ -1862,6 +1865,7 @@ class ModelRunner:
                             dtype=self.kv_cache_dtype,
                             device=self.device,
                             kvcache=self.token_to_kv_pool,
+                            need_sort=need_sort,
                         )
                 else:
                     assert not self.is_hybrid
@@ -1871,6 +1875,7 @@ class ModelRunner:
                         dtype=self.kv_cache_dtype,
                         device=self.device,
                         kvcache=self.token_to_kv_pool,
+                        need_sort=need_sort,
                     )
         else:
             assert self.is_draft_worker

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1834,7 +1834,6 @@ class ModelRunner:
                 )
 
         # Initialize token_to_kv_pool_allocator
-        need_sort = self.server_args.disaggregation_mode in ("decode", "prefill")
         if self.token_to_kv_pool_allocator is None:
             if _is_npu and (
                 self.server_args.attention_backend == "ascend"
@@ -1846,7 +1845,6 @@ class ModelRunner:
                     dtype=self.kv_cache_dtype,
                     device=self.device,
                     kvcache=self.token_to_kv_pool,
-                    need_sort=need_sort,
                 )
             else:
                 if self.page_size == 1:
@@ -1857,7 +1855,6 @@ class ModelRunner:
                             dtype=self.kv_cache_dtype,
                             device=self.device,
                             kvcache=self.token_to_kv_pool,
-                            need_sort=need_sort,
                         )
                     else:
                         self.token_to_kv_pool_allocator = TokenToKVPoolAllocator(
@@ -1865,7 +1862,6 @@ class ModelRunner:
                             dtype=self.kv_cache_dtype,
                             device=self.device,
                             kvcache=self.token_to_kv_pool,
-                            need_sort=need_sort,
                         )
                 else:
                     assert not self.is_hybrid
@@ -1875,7 +1871,6 @@ class ModelRunner:
                         dtype=self.kv_cache_dtype,
                         device=self.device,
                         kvcache=self.token_to_kv_pool,
-                        need_sort=need_sort,
                     )
         else:
             assert self.is_draft_worker

--- a/python/sglang/tests/test_allocator_free_pages.py
+++ b/python/sglang/tests/test_allocator_free_pages.py
@@ -1,0 +1,74 @@
+import os
+
+import torch
+
+from sglang.srt.mem_cache.allocator import PagedTokenToKVPoolAllocator
+
+
+class _DummyKVCache:
+    # Minimal stub; allocator will not use it in these tests
+    pass
+
+
+def _make_allocator(debug: bool = False):
+    if debug:
+        os.environ["SGLANG_DEBUG_MEMORY_POOL"] = "1"
+    else:
+        os.environ.pop("SGLANG_DEBUG_MEMORY_POOL", None)
+    # size must be multiple of page_size
+    size = 1024
+    page_size = 64
+    return PagedTokenToKVPoolAllocator(
+        size=size,
+        page_size=page_size,
+        dtype=torch.float16,
+        device="cpu",
+        kvcache=_DummyKVCache(),
+    )
+
+
+def test_free_pages_append_only_no_debug():
+    alloc = _make_allocator(debug=False)
+    # Start with empty release list
+    alloc.release_pages = torch.empty((0,), dtype=torch.int64, device=alloc.device)
+    pages = torch.tensor([2, 5, 7], dtype=torch.int64, device=alloc.device)
+    alloc.free_pages(pages)
+    assert torch.equal(alloc.release_pages, pages)
+
+
+def test_free_shim_collapses_tokens_to_single_page():
+    alloc = _make_allocator(debug=False)
+    alloc.release_pages = torch.empty((0,), dtype=torch.int64, device=alloc.device)
+    page_size = alloc.page_size
+    page_id = torch.tensor(3, dtype=torch.int64)
+    # Tokens from the same page (1-based page ids, token indices are 0-based)
+    tokens = page_id * page_size + torch.arange(0, 10, dtype=torch.int64)
+    alloc.free(tokens.to(device=alloc.device))
+    assert alloc.release_pages.numel() == 1
+    assert alloc.release_pages.item() == page_id.item()
+
+
+def test_merge_and_sort_free_no_debug_is_append_only():
+    alloc = _make_allocator(debug=False)
+    # Override lists to controlled values
+    alloc.free_pages = torch.tensor([5, 3], dtype=torch.int64, device=alloc.device)
+    alloc.release_pages = torch.tensor([4, 1], dtype=torch.int64, device=alloc.device)
+    alloc.merge_and_sort_free()
+    assert torch.equal(
+        alloc.free_pages,
+        torch.tensor([5, 3, 4, 1], dtype=torch.int64, device=alloc.device),
+    )
+    assert alloc.release_pages.numel() == 0
+
+
+def test_merge_and_sort_free_debug_sorts():
+    alloc = _make_allocator(debug=True)
+    # Do not call free()/free_pages() in debug to avoid free-guard; set buffers directly
+    alloc.free_pages = torch.tensor([5, 3], dtype=torch.int64, device=alloc.device)
+    alloc.release_pages = torch.tensor([4, 1], dtype=torch.int64, device=alloc.device)
+    alloc.merge_and_sort_free()
+    assert torch.equal(
+        alloc.free_pages,
+        torch.tensor([1, 3, 4, 5], dtype=torch.int64, device=alloc.device),
+    )
+    assert alloc.release_pages.numel() == 0

--- a/python/sglang/tests/test_allocator_free_pages.py
+++ b/python/sglang/tests/test_allocator_free_pages.py
@@ -32,7 +32,7 @@ def test_free_pages_append_only_no_debug():
     # Start with empty release list
     alloc.release_pages = torch.empty((0,), dtype=torch.int64, device=alloc.device)
     pages = torch.tensor([2, 5, 7], dtype=torch.int64, device=alloc.device)
-    alloc.free_pages(pages)
+    alloc.free_page_ids(pages)
     assert torch.equal(alloc.release_pages, pages)
 
 

--- a/test/srt/test_mamba_unittest.py
+++ b/test/srt/test_mamba_unittest.py
@@ -183,7 +183,6 @@ class TestMamba(unittest.TestCase):
             dtype=dtype,
             device=device,
             kvcache=pool,
-            need_sort=False,
         )
         # setup radix cache
         tree = MambaRadixCache(

--- a/test/srt/test_mamba_unittest.py
+++ b/test/srt/test_mamba_unittest.py
@@ -183,6 +183,7 @@ class TestMamba(unittest.TestCase):
             dtype=dtype,
             device=device,
             kvcache=pool,
+            need_sort=False,
         )
         # setup radix cache
         tree = MambaRadixCache(

--- a/test/srt/test_swa_unittest.py
+++ b/test/srt/test_swa_unittest.py
@@ -48,7 +48,6 @@ class TestSWA(unittest.TestCase):
             dtype=dtype,
             device=device,
             kvcache=pool,
-            need_sort=False,
         )
         self.assertEqual(
             alloc.full_available_size() + alloc.swa_available_size(), size + size_swa
@@ -106,7 +105,6 @@ class TestSWA(unittest.TestCase):
             dtype=dtype,
             device=device,
             kvcache=kv_pool,
-            need_sort=False,
         )
         # setup radix cache
         tree = SWARadixCache(
@@ -237,7 +235,6 @@ class TestSWA(unittest.TestCase):
             dtype=dtype,
             device=device,
             kvcache=kv_pool,
-            need_sort=False,
         )
         # setup radix cache
         tree = SWARadixCache(


### PR DESCRIPTION
… improve page management. Introduce debug mode for better memory tracking and enhance page allocation methods in PagedTokenToKVPoolAllocator and SWATokenToKVPoolAllocator. Update ChunkCache and RadixCache to streamline key handling and memory freeing processes.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<details><summary>On L40SL:</summary>

```
[nadavt@lgn09 sglang]$ nvidia-smi
Tue Nov 11 01:59:30 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 560.35.05              Driver Version: 560.35.05      CUDA Version: 12.6     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA L40S                    On  |   00000000:83:00.0 Off |                    0 |
| N/A   25C    P8             33W /  350W |       1MiB /  46068MiB |      0%   E. Process |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
[nadavt@lgn09 sglang]$ 
```
</details>



<details><summary>meta-llama/Meta-Llama-3.1-8B-Instruct: +% throughput.</summary>

before (`main` on commit `012bfc4fd` ):
```
[nadavt@lgn09 sglang]$ SGLANG_DEBUG_MEMORY_POOL=1 \
python -m sglang.bench_offline_throughput \
  --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
  --num-prompts 200 \
  --random-input-len 128 \
  --random-output-len 256 \
  --random-range-ratio 0.5
WARNING:sglang.srt.server_args:Attention backend not explicitly specified. Use flashinfer backend by default.
[2025-11-11 04:05:21] server_args=ServerArgs(model_path='meta-llama/Meta-Llama-3.1-8B-Instruct', tokenizer_path='meta-llama/Meta-Llama-3.1-8B-Instruct', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=False, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30000, grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, mem_fraction_static=0.851, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=4096, max_prefill_tokens=16384, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, hybrid_kvcache_ratio=None, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', device='cuda', tp_size=1, pp_size=1, pp_max_micro_batch_size=None, stream_interval=1, stream_output=False, random_seed=815120231, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, dist_timeout=None, download_dir=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', api_key=None, served_model_name='meta-llama/Meta-Llama-3.1-8B-Instruct', weight_version='default', chat_template=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', load_watch_interval=0.1, prefill_round_robin_balance=False, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='flashinfer', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend=None, nsa_prefill_backend='flashmla_sparse', nsa_decode_backend='fa3', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_moe_runner_backend=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm='static', init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype='float32', mamba_full_memory_ratio=0.9, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=32, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=4096, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 768, 896, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, decrypted_config_file=None, decrypted_draft_config_file=None)
[2025-11-11 04:05:23] Using default HuggingFace chat template with detected content format: string
[2025-11-11 04:05:37] Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2025-11-11 04:05:38] Init torch distributed ends. mem usage=0.00 GB
[2025-11-11 04:05:38] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2025-11-11 04:05:39] Load weight begin. avail mem=44.00 GB
[2025-11-11 04:05:40] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:01,  1.96it/s]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:01<00:01,  1.71it/s]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:01<00:00,  2.30it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.14it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.08it/s]

[2025-11-11 04:05:43] Load weight end. type=LlamaForCausalLM, dtype=torch.bfloat16, avail mem=28.91 GB, mem usage=15.09 GB.
[2025-11-11 04:05:43] Using KV cache dtype: torch.bfloat16
[2025-11-11 04:05:43] KV Cache is allocated. #tokens: 183133, K size: 11.18 GB, V size: 11.18 GB
[2025-11-11 04:05:43] Memory pool end. avail mem=5.51 GB
[2025-11-11 04:05:43] Capture cuda graph begin. This can take up to several minutes. avail mem=5.00 GB
[2025-11-11 04:05:43] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32]
Capturing batches (bs=1 avail_mem=4.83 GB): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:01<00:00,  7.41it/s]
[2025-11-11 04:05:44] Capture cuda graph end. Time elapsed: 1.64 s. mem usage=0.20 GB. avail mem=4.81 GB.
[2025-11-11 04:05:45] max_total_num_tokens=183133, chunked_prefill_size=4096, max_prefill_tokens=16384, max_running_requests=2048, context_len=131072, available_gpu_mem=4.81 GB
#Input tokens: 62509
#Output tokens: 41627
#Input tokens: 4096
#Output tokens: 256
[2025-11-11 04:06:08] 
Warmup...
[2025-11-11 04:06:08] Prefill batch, #new-seq: 6, #new-token: 1542, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-11-11 04:06:09] Prefill batch, #new-seq: 10, #new-token: 2570, #cached-token: 0, token usage: 0.01, #running-req: 6, #queue-req: 0, 
[2025-11-11 04:06:10] 
Benchmark...
[2025-11-11 04:06:10] Prefill batch, #new-seq: 6, #new-token: 947, #cached-token: 6, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-11-11 04:06:10] Prefill batch, #new-seq: 9, #new-token: 4096, #cached-token: 9, token usage: 0.01, #running-req: 6, #queue-req: 185, 
[2025-11-11 04:06:11] Prefill batch, #new-seq: 16, #new-token: 4096, #cached-token: 15, token usage: 0.03, #running-req: 14, #queue-req: 170, 
[2025-11-11 04:06:11] Prefill batch, #new-seq: 18, #new-token: 4096, #cached-token: 19, token usage: 0.05, #running-req: 29, #queue-req: 153, 
[2025-11-11 04:06:11] Prefill batch, #new-seq: 14, #new-token: 4096, #cached-token: 19, token usage: 0.07, #running-req: 46, #queue-req: 140, 
[2025-11-11 04:06:11] Prefill batch, #new-seq: 16, #new-token: 4096, #cached-token: 29, token usage: 0.09, #running-req: 59, #queue-req: 125, 
[2025-11-11 04:06:12] Prefill batch, #new-seq: 6, #new-token: 4096, #cached-token: 8, token usage: 0.12, #running-req: 74, #queue-req: 120, 
[2025-11-11 04:06:12] Prefill batch, #new-seq: 5, #new-token: 4096, #cached-token: 12, token usage: 0.14, #running-req: 79, #queue-req: 116, 
[2025-11-11 04:06:12] Prefill batch, #new-seq: 19, #new-token: 4096, #cached-token: 38, token usage: 0.16, #running-req: 83, #queue-req: 98, 
[2025-11-11 04:06:13] Prefill batch, #new-seq: 5, #new-token: 4096, #cached-token: 5, token usage: 0.18, #running-req: 101, #queue-req: 94, 
[2025-11-11 04:06:13] Prefill batch, #new-seq: 7, #new-token: 4096, #cached-token: 13, token usage: 0.21, #running-req: 105, #queue-req: 88, 
[2025-11-11 04:06:13] Prefill batch, #new-seq: 17, #new-token: 4096, #cached-token: 33, token usage: 0.23, #running-req: 111, #queue-req: 72, 
[2025-11-11 04:06:14] Prefill batch, #new-seq: 19, #new-token: 4096, #cached-token: 44, token usage: 0.25, #running-req: 127, #queue-req: 54, 
[2025-11-11 04:06:14] Prefill batch, #new-seq: 17, #new-token: 4096, #cached-token: 32, token usage: 0.27, #running-req: 145, #queue-req: 38, 
[2025-11-11 04:06:14] Prefill batch, #new-seq: 20, #new-token: 4096, #cached-token: 42, token usage: 0.30, #running-req: 161, #queue-req: 19, 
[2025-11-11 04:06:15] Prefill batch, #new-seq: 20, #new-token: 3853, #cached-token: 41, token usage: 0.32, #running-req: 180, #queue-req: 0, 
[2025-11-11 04:06:16] Decode batch, #running-req: 144, #token: 45073, token usage: 0.25, cuda graph: False, gen throughput (token/s): 143.87, #queue-req: 0, 
[2025-11-11 04:06:18] Decode batch, #running-req: 121, #token: 42505, token usage: 0.23, cuda graph: False, gen throughput (token/s): 3508.26, #queue-req: 0, 
[2025-11-11 04:06:19] Decode batch, #running-req: 107, #token: 41219, token usage: 0.23, cuda graph: False, gen throughput (token/s): 3241.12, #queue-req: 0, 
[2025-11-11 04:06:20] Decode batch, #running-req: 97, #token: 41978, token usage: 0.23, cuda graph: False, gen throughput (token/s): 2899.32, #queue-req: 0, 
[2025-11-11 04:06:22] Decode batch, #running-req: 90, #token: 42597, token usage: 0.23, cuda graph: False, gen throughput (token/s): 2665.99, #queue-req: 0, 
[2025-11-11 04:06:23] Decode batch, #running-req: 76, #token: 41654, token usage: 0.23, cuda graph: False, gen throughput (token/s): 2360.55, #queue-req: 0, 
[2025-11-11 04:06:25] Decode batch, #running-req: 64, #token: 38822, token usage: 0.21, cuda graph: False, gen throughput (token/s): 2025.60, #queue-req: 0, 
[2025-11-11 04:06:26] Decode batch, #running-req: 51, #token: 34076, token usage: 0.19, cuda graph: False, gen throughput (token/s): 1663.07, #queue-req: 0, 
[2025-11-11 04:06:27] Decode batch, #running-req: 46, #token: 34901, token usage: 0.19, cuda graph: False, gen throughput (token/s): 1447.08, #queue-req: 0, 
[2025-11-11 04:06:29] Decode batch, #running-req: 36, #token: 28419, token usage: 0.16, cuda graph: False, gen throughput (token/s): 1262.64, #queue-req: 0, 
[2025-11-11 04:06:30] Decode batch, #running-req: 28, #token: 22920, token usage: 0.13, cuda graph: True, gen throughput (token/s): 1086.59, #queue-req: 0, 
[2025-11-11 04:06:31] Decode batch, #running-req: 22, #token: 20033, token usage: 0.11, cuda graph: True, gen throughput (token/s): 895.36, #queue-req: 0, 
[2025-11-11 04:06:32] Decode batch, #running-req: 20, #token: 19777, token usage: 0.11, cuda graph: True, gen throughput (token/s): 768.87, #queue-req: 0, 
[2025-11-11 04:06:33] Decode batch, #running-req: 15, #token: 17273, token usage: 0.09, cuda graph: True, gen throughput (token/s): 681.65, #queue-req: 0, 
[2025-11-11 04:06:34] Decode batch, #running-req: 12, #token: 13812, token usage: 0.08, cuda graph: True, gen throughput (token/s): 532.14, #queue-req: 0, 
[2025-11-11 04:06:35] Decode batch, #running-req: 11, #token: 13642, token usage: 0.07, cuda graph: True, gen throughput (token/s): 475.19, #queue-req: 0, 
[2025-11-11 04:06:36] Decode batch, #running-req: 11, #token: 14082, token usage: 0.08, cuda graph: True, gen throughput (token/s): 444.93, #queue-req: 0, 
[2025-11-11 04:06:37] Decode batch, #running-req: 10, #token: 13799, token usage: 0.08, cuda graph: True, gen throughput (token/s): 431.19, #queue-req: 0, 
[2025-11-11 04:06:38] Decode batch, #running-req: 8, #token: 10946, token usage: 0.06, cuda graph: True, gen throughput (token/s): 382.64, #queue-req: 0, 
[2025-11-11 04:06:39] Decode batch, #running-req: 2, #token: 6877, token usage: 0.04, cuda graph: True, gen throughput (token/s): 180.90, #queue-req: 0, 
[2025-11-11 04:06:40] Decode batch, #running-req: 2, #token: 6957, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.13, #queue-req: 0, 
[2025-11-11 04:06:41] Decode batch, #running-req: 2, #token: 7037, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.08, #queue-req: 0, 
[2025-11-11 04:06:42] Decode batch, #running-req: 2, #token: 7117, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.05, #queue-req: 0, 
[2025-11-11 04:06:43] Decode batch, #running-req: 2, #token: 7197, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.99, #queue-req: 0, 
[2025-11-11 04:06:44] Decode batch, #running-req: 2, #token: 7277, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.95, #queue-req: 0, 
[2025-11-11 04:06:44] Decode batch, #running-req: 2, #token: 7357, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.90, #queue-req: 0, 
[2025-11-11 04:06:45] Decode batch, #running-req: 2, #token: 7437, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.84, #queue-req: 0, 
[2025-11-11 04:06:46] Decode batch, #running-req: 2, #token: 7517, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.79, #queue-req: 0, 
[2025-11-11 04:06:47] Decode batch, #running-req: 2, #token: 7597, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.74, #queue-req: 0, 
[2025-11-11 04:06:48] Decode batch, #running-req: 2, #token: 7677, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.69, #queue-req: 0, 
[2025-11-11 04:06:49] Decode batch, #running-req: 2, #token: 7757, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.63, #queue-req: 0, 
[2025-11-11 04:06:50] Decode batch, #running-req: 2, #token: 7837, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.58, #queue-req: 0, 
[2025-11-11 04:06:51] Decode batch, #running-req: 2, #token: 7917, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.52, #queue-req: 0, 
[2025-11-11 04:06:52] Decode batch, #running-req: 2, #token: 7997, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.47, #queue-req: 0, 
[2025-11-11 04:06:53] Decode batch, #running-req: 2, #token: 8077, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.41, #queue-req: 0, 
[2025-11-11 04:06:54] Decode batch, #running-req: 2, #token: 8157, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.37, #queue-req: 0, 
[2025-11-11 04:06:55] Decode batch, #running-req: 2, #token: 8237, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.31, #queue-req: 0, 
[2025-11-11 04:06:56] Decode batch, #running-req: 2, #token: 8317, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.26, #queue-req: 0, 
[2025-11-11 04:06:57] Decode batch, #running-req: 2, #token: 8397, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.21, #queue-req: 0, 
[2025-11-11 04:06:58] Decode batch, #running-req: 2, #token: 8477, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.15, #queue-req: 0, 
[2025-11-11 04:06:58] Decode batch, #running-req: 2, #token: 8557, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.10, #queue-req: 0, 
[2025-11-11 04:06:59] Decode batch, #running-req: 1, #token: 0, token usage: 0.00, cuda graph: True, gen throughput (token/s): 61.04, #queue-req: 0, 

====== Offline Throughput Benchmark Result =======
Backend:                                 engine    
Successful requests:                     200       
Benchmark duration (s):                  49.11     
Total input tokens:                      62509     
Total generated tokens:                  41627     
Last generation throughput (tok/s):      61.04     
Request throughput (req/s):              4.07      
Input token throughput (tok/s):          1272.90   
Output token throughput (tok/s):         847.67    
Total token throughput (tok/s):          2120.57   
==================================================
[nadavt@lgn09 sglang]$ 
```

after:
```
[nadavt@lgn09 sglang]$ SGLANG_DEBUG_MEMORY_POOL=1 python -m sglang.bench_offline_throughput   --model-path meta-llama/Meta-Llama-3.1-8B-Instruct   --num-prompts 200   --random-input-len 128   --random-output-len 256   --random-range-ratio 0.5
WARNING:sglang.srt.server_args:Attention backend not explicitly specified. Use flashinfer backend by default.
[2025-11-11 04:27:11] server_args=ServerArgs(model_path='meta-llama/Meta-Llama-3.1-8B-Instruct', tokenizer_path='meta-llama/Meta-Llama-3.1-8B-Instruct', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=False, context_length=None, is_embedding=False, enable_multimodal=None, revision=None, model_impl='auto', host='127.0.0.1', port=30000, grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, mem_fraction_static=0.851, max_running_requests=None, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=4096, max_prefill_tokens=16384, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, hybrid_kvcache_ratio=None, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', device='cuda', tp_size=1, pp_size=1, pp_max_micro_batch_size=None, stream_interval=1, stream_output=False, random_seed=637981649, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, dist_timeout=None, download_dir=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', api_key=None, served_model_name='meta-llama/Meta-Llama-3.1-8B-Instruct', weight_version='default', chat_template=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', load_watch_interval=0.1, prefill_round_robin_balance=False, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='flashinfer', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend=None, nsa_prefill_backend='flashmla_sparse', nsa_decode_backend='fa3', speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_moe_runner_backend=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm='static', init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype='float32', mamba_full_memory_ratio=0.9, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=False, cuda_graph_max_bs=32, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=4096, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 768, 896, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, decrypted_config_file=None, decrypted_draft_config_file=None)
[2025-11-11 04:27:12] Using default HuggingFace chat template with detected content format: string
[2025-11-11 04:27:27] Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2025-11-11 04:27:28] Init torch distributed ends. mem usage=0.00 GB
[2025-11-11 04:27:28] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2025-11-11 04:27:29] Load weight begin. avail mem=44.00 GB
[2025-11-11 04:27:29] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:01,  1.99it/s]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:01<00:01,  1.73it/s]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:01<00:00,  2.32it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.16it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.10it/s]

[2025-11-11 04:27:32] Load weight end. type=LlamaForCausalLM, dtype=torch.bfloat16, avail mem=28.91 GB, mem usage=15.09 GB.
[2025-11-11 04:27:32] Using KV cache dtype: torch.bfloat16
[2025-11-11 04:27:32] KV Cache is allocated. #tokens: 183133, K size: 11.18 GB, V size: 11.18 GB
[2025-11-11 04:27:32] Memory pool end. avail mem=5.51 GB
[2025-11-11 04:27:33] Capture cuda graph begin. This can take up to several minutes. avail mem=5.00 GB
[2025-11-11 04:27:33] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32]
Capturing batches (bs=1 avail_mem=4.83 GB): 100%|██████████████████████████████████████████████████████████████████████████████| 8/8 [00:01<00:00,  7.32it/s]
[2025-11-11 04:27:34] Capture cuda graph end. Time elapsed: 1.66 s. mem usage=0.20 GB. avail mem=4.81 GB.
[2025-11-11 04:27:35] max_total_num_tokens=183133, chunked_prefill_size=4096, max_prefill_tokens=16384, max_running_requests=2048, context_len=131072, available_gpu_mem=4.81 GB
#Input tokens: 62509
#Output tokens: 41627
#Input tokens: 4096
#Output tokens: 256
[2025-11-11 04:27:58] 
Warmup...
[2025-11-11 04:27:58] Prefill batch, #new-seq: 3, #new-token: 771, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-11-11 04:27:59] Prefill batch, #new-seq: 13, #new-token: 3341, #cached-token: 0, token usage: 0.00, #running-req: 3, #queue-req: 0, 
[2025-11-11 04:28:01] 
Benchmark...
[2025-11-11 04:28:01] Prefill batch, #new-seq: 4, #new-token: 895, #cached-token: 4, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-11-11 04:28:01] Prefill batch, #new-seq: 10, #new-token: 4096, #cached-token: 10, token usage: 0.00, #running-req: 4, #queue-req: 186, 
[2025-11-11 04:28:01] Prefill batch, #new-seq: 17, #new-token: 4096, #cached-token: 16, token usage: 0.03, #running-req: 13, #queue-req: 170, 
[2025-11-11 04:28:01] Prefill batch, #new-seq: 18, #new-token: 4096, #cached-token: 19, token usage: 0.05, #running-req: 29, #queue-req: 153, 
[2025-11-11 04:28:01] Prefill batch, #new-seq: 13, #new-token: 4096, #cached-token: 18, token usage: 0.07, #running-req: 46, #queue-req: 141, 
[2025-11-11 04:28:02] Prefill batch, #new-seq: 17, #new-token: 4096, #cached-token: 31, token usage: 0.09, #running-req: 58, #queue-req: 125, 
[2025-11-11 04:28:02] Prefill batch, #new-seq: 6, #new-token: 4096, #cached-token: 8, token usage: 0.12, #running-req: 74, #queue-req: 120, 
[2025-11-11 04:28:02] Prefill batch, #new-seq: 5, #new-token: 4096, #cached-token: 12, token usage: 0.14, #running-req: 79, #queue-req: 116, 
[2025-11-11 04:28:03] Prefill batch, #new-seq: 19, #new-token: 4096, #cached-token: 38, token usage: 0.16, #running-req: 83, #queue-req: 98, 
[2025-11-11 04:28:03] Prefill batch, #new-seq: 5, #new-token: 4096, #cached-token: 5, token usage: 0.18, #running-req: 101, #queue-req: 94, 
[2025-11-11 04:28:03] Prefill batch, #new-seq: 7, #new-token: 4096, #cached-token: 13, token usage: 0.21, #running-req: 105, #queue-req: 88, 
[2025-11-11 04:28:03] Prefill batch, #new-seq: 17, #new-token: 4096, #cached-token: 33, token usage: 0.23, #running-req: 111, #queue-req: 72, 
[2025-11-11 04:28:04] Prefill batch, #new-seq: 19, #new-token: 4096, #cached-token: 44, token usage: 0.25, #running-req: 127, #queue-req: 54, 
[2025-11-11 04:28:04] Prefill batch, #new-seq: 17, #new-token: 4096, #cached-token: 32, token usage: 0.27, #running-req: 145, #queue-req: 38, 
[2025-11-11 04:28:04] Prefill batch, #new-seq: 20, #new-token: 4096, #cached-token: 42, token usage: 0.30, #running-req: 161, #queue-req: 19, 
[2025-11-11 04:28:05] Prefill batch, #new-seq: 20, #new-token: 3904, #cached-token: 41, token usage: 0.32, #running-req: 180, #queue-req: 0, 
[2025-11-11 04:28:06] Decode batch, #running-req: 144, #token: 45148, token usage: 0.25, cuda graph: False, gen throughput (token/s): 142.31, #queue-req: 0, 
[2025-11-11 04:28:08] Decode batch, #running-req: 121, #token: 42601, token usage: 0.23, cuda graph: False, gen throughput (token/s): 3486.96, #queue-req: 0, 
[2025-11-11 04:28:09] Decode batch, #running-req: 107, #token: 41328, token usage: 0.23, cuda graph: False, gen throughput (token/s): 3243.98, #queue-req: 0, 
[2025-11-11 04:28:11] Decode batch, #running-req: 97, #token: 42097, token usage: 0.23, cuda graph: False, gen throughput (token/s): 2899.28, #queue-req: 0, 
[2025-11-11 04:28:12] Decode batch, #running-req: 90, #token: 42724, token usage: 0.23, cuda graph: False, gen throughput (token/s): 2668.58, #queue-req: 0, 
[2025-11-11 04:28:13] Decode batch, #running-req: 76, #token: 41794, token usage: 0.23, cuda graph: False, gen throughput (token/s): 2362.79, #queue-req: 0, 
[2025-11-11 04:28:15] Decode batch, #running-req: 64, #token: 38978, token usage: 0.21, cuda graph: False, gen throughput (token/s): 2026.74, #queue-req: 0, 
[2025-11-11 04:28:16] Decode batch, #running-req: 51, #token: 34243, token usage: 0.19, cuda graph: False, gen throughput (token/s): 1663.62, #queue-req: 0, 
[2025-11-11 04:28:17] Decode batch, #running-req: 46, #token: 35071, token usage: 0.19, cuda graph: False, gen throughput (token/s): 1448.91, #queue-req: 0, 
[2025-11-11 04:28:19] Decode batch, #running-req: 36, #token: 28599, token usage: 0.16, cuda graph: False, gen throughput (token/s): 1262.71, #queue-req: 0, 
[2025-11-11 04:28:20] Decode batch, #running-req: 28, #token: 23108, token usage: 0.13, cuda graph: True, gen throughput (token/s): 1086.85, #queue-req: 0, 
[2025-11-11 04:28:21] Decode batch, #running-req: 22, #token: 20227, token usage: 0.11, cuda graph: True, gen throughput (token/s): 895.43, #queue-req: 0, 
[2025-11-11 04:28:22] Decode batch, #running-req: 20, #token: 19973, token usage: 0.11, cuda graph: True, gen throughput (token/s): 769.09, #queue-req: 0, 
[2025-11-11 04:28:23] Decode batch, #running-req: 15, #token: 17474, token usage: 0.10, cuda graph: True, gen throughput (token/s): 681.93, #queue-req: 0, 
[2025-11-11 04:28:24] Decode batch, #running-req: 12, #token: 14016, token usage: 0.08, cuda graph: True, gen throughput (token/s): 532.17, #queue-req: 0, 
[2025-11-11 04:28:25] Decode batch, #running-req: 11, #token: 13847, token usage: 0.08, cuda graph: True, gen throughput (token/s): 475.20, #queue-req: 0, 
[2025-11-11 04:28:26] Decode batch, #running-req: 11, #token: 14287, token usage: 0.08, cuda graph: True, gen throughput (token/s): 444.94, #queue-req: 0, 
[2025-11-11 04:28:27] Decode batch, #running-req: 10, #token: 14005, token usage: 0.08, cuda graph: True, gen throughput (token/s): 431.20, #queue-req: 0, 
[2025-11-11 04:28:28] Decode batch, #running-req: 8, #token: 11155, token usage: 0.06, cuda graph: True, gen throughput (token/s): 382.67, #queue-req: 0, 
[2025-11-11 04:28:29] Decode batch, #running-req: 2, #token: 7091, token usage: 0.04, cuda graph: True, gen throughput (token/s): 180.90, #queue-req: 0, 
[2025-11-11 04:28:30] Decode batch, #running-req: 2, #token: 7171, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.14, #queue-req: 0, 
[2025-11-11 04:28:31] Decode batch, #running-req: 2, #token: 7251, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.10, #queue-req: 0, 
[2025-11-11 04:28:32] Decode batch, #running-req: 2, #token: 7331, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.05, #queue-req: 0, 
[2025-11-11 04:28:33] Decode batch, #running-req: 2, #token: 7411, token usage: 0.04, cuda graph: True, gen throughput (token/s): 86.00, #queue-req: 0, 
[2025-11-11 04:28:34] Decode batch, #running-req: 2, #token: 7491, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.96, #queue-req: 0, 
[2025-11-11 04:28:35] Decode batch, #running-req: 2, #token: 7571, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.90, #queue-req: 0, 
[2025-11-11 04:28:35] Decode batch, #running-req: 2, #token: 7651, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.85, #queue-req: 0, 
[2025-11-11 04:28:36] Decode batch, #running-req: 2, #token: 7731, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.79, #queue-req: 0, 
[2025-11-11 04:28:37] Decode batch, #running-req: 2, #token: 7811, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.75, #queue-req: 0, 
[2025-11-11 04:28:38] Decode batch, #running-req: 2, #token: 7891, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.69, #queue-req: 0, 
[2025-11-11 04:28:39] Decode batch, #running-req: 2, #token: 7971, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.64, #queue-req: 0, 
[2025-11-11 04:28:40] Decode batch, #running-req: 2, #token: 8051, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.59, #queue-req: 0, 
[2025-11-11 04:28:41] Decode batch, #running-req: 2, #token: 8131, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.53, #queue-req: 0, 
[2025-11-11 04:28:42] Decode batch, #running-req: 2, #token: 8211, token usage: 0.04, cuda graph: True, gen throughput (token/s): 85.48, #queue-req: 0, 
[2025-11-11 04:28:43] Decode batch, #running-req: 2, #token: 8291, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.42, #queue-req: 0, 
[2025-11-11 04:28:44] Decode batch, #running-req: 2, #token: 8371, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.37, #queue-req: 0, 
[2025-11-11 04:28:45] Decode batch, #running-req: 2, #token: 8451, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.32, #queue-req: 0, 
[2025-11-11 04:28:46] Decode batch, #running-req: 2, #token: 8531, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.27, #queue-req: 0, 
[2025-11-11 04:28:47] Decode batch, #running-req: 2, #token: 8611, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.22, #queue-req: 0, 
[2025-11-11 04:28:48] Decode batch, #running-req: 2, #token: 8691, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.16, #queue-req: 0, 
[2025-11-11 04:28:49] Decode batch, #running-req: 2, #token: 8771, token usage: 0.05, cuda graph: True, gen throughput (token/s): 85.10, #queue-req: 0, 
[2025-11-11 04:28:50] Decode batch, #running-req: 1, #token: 216, token usage: 0.00, cuda graph: True, gen throughput (token/s): 61.35, #queue-req: 0, 
DEBUG self.max_total_num_tokens=183133 free=75062 release=0 evictable=107855 protected=0 avail=75062 tree_total=107855
[2025-11-11 04:28:50] Scheduler hit an exception: Traceback (most recent call last):
  File "/home/projects/dharel/nadavt/repos/sglang/python/sglang/srt/managers/scheduler.py", line 2709, in run_scheduler_process
    scheduler.event_loop_overlap()
  File "/home/projects/dharel/nadavt/repos/sglang/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/projects/dharel/nadavt/repos/sglang/python/sglang/srt/managers/scheduler.py", line 1009, in event_loop_overlap
    self.self_check_during_idle()
  File "/home/projects/dharel/nadavt/repos/sglang/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py", line 278, in self_check_during_idle
    self.check_memory()
  File "/home/projects/dharel/nadavt/repos/sglang/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py", line 192, in check_memory
    raise ValueError(msg)
ValueError: token_to_kv_pool_allocator memory leak detected! self.max_total_num_tokens=183133, available_size=75062, evictable_size=107855, protected_size=0, diff=216, tolerance=32



====== Offline Throughput Benchmark Result =======
Backend:                                 engine    
Successful requests:                     200       
Benchmark duration (s):                  49.02     
Total input tokens:                      62509     
Total generated tokens:                  41627     
Last generation throughput (tok/s):      61.35     
Request throughput (req/s):              4.08      
Input token throughput (tok/s):          1275.23   
Output token throughput (tok/s):         849.22    
Total token throughput (tok/s):          2124.46   
==================================================
[nadavt@lgn09 sglang]$ 
```
</details>

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
