### PR TITLE
Jet-Nemotron — EAGLE3 + Varlen Dynamic Conv

### DIFF
--- a/python/sglang/srt/configs/jet_nemotron.py
+++ b/python/sglang/srt/configs/jet_nemotron.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from transformers.configuration_utils import PretrainedConfig
 
-from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
+from sglang.srt.configs.mamba_utils import JetNemotronCacheParams, JetNemotronStateShape
 
 
 @dataclass
@@ -51,7 +51,7 @@ class JetNemotronConfig(PretrainedConfig):
         ]
 
     @property
-    def mamba2_cache_params(self) -> Mamba2CacheParams:
+    def mamba2_cache_params(self) -> JetNemotronCacheParams:
         from sglang.srt.layers.dp_attention import get_attention_tp_size
 
         jet_block_config = JetBlockConfig(**self.efficient_attention_config["jet"])
@@ -61,14 +61,14 @@ class JetNemotronConfig(PretrainedConfig):
         head_v_dim = int(head_k_dim * jet_block_config.expand_v)
         total_v_dim = num_heads * head_v_dim
 
-        shape = Mamba2StateShape.create(
+        shape = JetNemotronStateShape.create(
             tp_world_size=get_attention_tp_size(),
             intermediate_size=total_v_dim,
             n_groups=num_heads,
             num_heads=num_heads,
-            head_dim=head_v_dim,
-            state_size=head_k_dim,
+            head_dim=head_k_dim,
+            state_size=head_v_dim,
             conv_kernel=jet_block_config.conv_size,
         )
 
-        return Mamba2CacheParams(shape=shape, layers=self.linear_layer_ids)
+        return JetNemotronCacheParams(shape=shape, layers=self.linear_layer_ids)

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -189,6 +189,7 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
         from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
             GDNAttnBackend,
             HybridLinearAttnBackend,
+            JetNemotronAttnBackend,
             KimiLinearAttnBackend,
             Mamba2AttnBackend,
         )
@@ -206,7 +207,10 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                     runner.server_args.attention_backend == "ascend"
                 ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
             logger.info(f"Using hybrid linear attention backend for hybrid GDN models.")
-            linear_attn_backend = GDNAttnBackend(runner)
+            if runner.jet_nemotron_config is not None:
+                linear_attn_backend = JetNemotronAttnBackend(runner)
+            else:
+                linear_attn_backend = GDNAttnBackend(runner)
         elif runner.mamba2_config is not None:
             linear_attn_backend = Mamba2AttnBackend(runner)
         elif runner.kimi_linear_config is not None:

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union
 
 import torch
+import torch.nn.functional as F
 from einops import rearrange
 
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -25,6 +26,7 @@ from sglang.srt.layers.attention.mamba.causal_conv1d_triton import (
 from sglang.srt.layers.attention.mamba.mamba import MambaMixer2
 from sglang.srt.layers.attention.mamba.mamba2_metadata import (
     ForwardMetadata,
+    JetNemotronMetadata,
     Mamba2Metadata,
 )
 from sglang.srt.layers.radix_attention import RadixAttention
@@ -83,7 +85,7 @@ class MambaAttnBackendBase(AttentionBackend):
             query_start_loc = torch.arange(
                 0, bs + 1, dtype=torch.int32, device=self.device
             )
-        elif forward_batch.forward_mode.is_extend():
+        elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
             if forward_batch.forward_mode.is_target_verify():
                 query_start_loc = torch.arange(
                     0,
@@ -731,6 +733,201 @@ class GDNAttnBackend(MambaAttnBackendBase):
         return core_attn_out
 
 
+class JetNemotronAttnBackend(MambaAttnBackendBase):
+    """Attention backend using Jet-Nemotron kernel."""
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        metadata = self._forward_metadata(forward_batch)
+        seq_lengths = metadata.query_start_loc.diff()
+        num_sequences = metadata.query_start_loc.shape[0] - 1
+        total_tokens = int(metadata.query_start_loc[-1].item())
+        seq_idx = torch.repeat_interleave(
+            torch.arange(
+                0,
+                num_sequences,
+                dtype=torch.int32,
+                device=metadata.query_start_loc.device,
+            ),
+            seq_lengths,
+            output_size=total_tokens,
+        )
+        self.forward_metadata = JetNemotronMetadata(
+            query_start_loc=metadata.query_start_loc,
+            mamba_cache_indices=metadata.mamba_cache_indices,
+            retrieve_next_token=metadata.retrieve_next_token,
+            retrieve_next_sibling=metadata.retrieve_next_sibling,
+            retrieve_parent_token=metadata.retrieve_parent_token,
+            seq_idx=seq_idx,
+        )
+
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        dynamic_conv_fn = kwargs["dynamic_conv"]
+        head_v_dim = kwargs["head_v_dim"]
+        a = kwargs["a"]
+        b = kwargs["b"]
+        A_log = kwargs["A_log"]
+        dt_bias = kwargs["dt_bias"]
+        layer_id = kwargs["layer_id"]
+        hidden_states = kwargs["hidden_states"]
+
+        layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer_id)
+        conv_states = layer_cache.conv[0]
+        ssm_states = layer_cache.temporal
+        query_start_loc = self.forward_metadata.query_start_loc
+        cache_indices = self.forward_metadata.mamba_cache_indices
+
+        v, conv_state = dynamic_conv_fn(
+            x=v.unsqueeze(
+                1
+            ),  # B, D -> B, 1, D. for speculative decode, we need to support B, D, T.
+            generator_input=hidden_states.unsqueeze(1),  # B, D -> B, 1, D.
+            cache=conv_states[
+                cache_indices
+            ],  # inefficiency here, can directly fuse cache
+            output_final_state=True,
+        )
+        conv_states[cache_indices] = conv_state
+
+        v = v.squeeze(1)
+        v = v.view(1, v.shape[0], v.shape[1] // head_v_dim, head_v_dim)
+
+        core_attn_out = fused_sigmoid_gating_delta_rule_update(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            initial_state_source=ssm_states,
+            initial_state_indices=cache_indices,
+            cu_seqlens=query_start_loc,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+        )
+
+        return core_attn_out
+
+    def forward_extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ):
+        dynamic_conv_fn = kwargs["dynamic_conv"]
+        head_v_dim = kwargs["head_v_dim"]
+        a = kwargs["a"]
+        b = kwargs["b"]
+        A_log = kwargs["A_log"]
+        dt_bias = kwargs["dt_bias"]
+        layer_id = kwargs["layer_id"]
+        hidden_states = kwargs["hidden_states"]
+        seq_len = hidden_states.shape[0]
+
+        is_target_verify = forward_batch.forward_mode.is_target_verify()
+
+        query_start_loc = self.forward_metadata.query_start_loc
+        cache_indices = self.forward_metadata.mamba_cache_indices
+        retrieve_next_token = self.forward_metadata.retrieve_next_token
+        retrieve_next_sibling = self.forward_metadata.retrieve_next_sibling
+        retrieve_parent_token = self.forward_metadata.retrieve_parent_token
+
+        mamba_cache_params = self.req_to_token_pool.mamba2_layer_cache(layer_id)
+        conv_states = mamba_cache_params.conv[0]
+        ssm_states = mamba_cache_params.temporal
+        if is_target_verify:
+            assert isinstance(mamba_cache_params, MambaPool.SpeculativeState)
+            intermediate_conv_window_cache = (
+                mamba_cache_params.intermediate_conv_window[0]
+            )
+            intermediate_state_cache = mamba_cache_params.intermediate_ssm
+            draft_token_num = forward_batch.spec_info.draft_token_num
+            batch_size = seq_len // draft_token_num
+
+            v = dynamic_conv_fn(
+                x=v.view(batch_size, draft_token_num, -1),
+                cache=conv_states,
+                generator_input=hidden_states.view(batch_size, draft_token_num, -1),
+                cache_indices=cache_indices,
+                intermediate_conv_window=intermediate_conv_window_cache,
+                retrieve_next_token=retrieve_next_token,
+                retrieve_next_sibling=retrieve_next_sibling,
+                retrieve_parent_token=retrieve_parent_token,
+                is_topk1=forward_batch.spec_info.topk == 1,
+            )
+            v = v.view(seq_len, -1)
+        else:
+            has_initial_states = forward_batch.extend_prefix_lens > 0
+            v, _ = dynamic_conv_fn(
+                x=v,  # B, D (varlen)
+                generator_input=hidden_states,  # B, D
+                mask=None,
+                cache=conv_states,
+                cu_seqlens=query_start_loc,
+                cache_indices=cache_indices,
+                has_initial_state=has_initial_states,
+                seq_idx=self.forward_metadata.seq_idx,
+                output_final_state=True,
+                layer_id=layer_id,
+            )
+
+        v = v.view(1, v.shape[0], v.shape[1] // head_v_dim, head_v_dim)
+        g = -A_log.float().exp() * F.softplus(
+            a.float() + dt_bias
+        )  # needed for numerical stability
+        g = g.unsqueeze(0)
+        beta = F.sigmoid(b).unsqueeze(0)
+
+        if is_target_verify:
+            core_attn_out = fused_recurrent_gated_delta_rule_update(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                initial_state_source=ssm_states,
+                initial_state_indices=cache_indices,
+                cu_seqlens=query_start_loc,
+                use_qk_l2norm_in_kernel=True,
+                disable_state_update=True,
+                intermediate_states_buffer=intermediate_state_cache,
+                cache_steps=forward_batch.spec_info.draft_token_num,
+                retrieve_parent_token=retrieve_parent_token,
+            )
+        else:
+            recurrent_state = ssm_states[cache_indices]
+            core_attn_out, last_recurrent_state = chunk_gated_delta_rule(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state,
+                output_final_state=True,
+                cu_seqlens=query_start_loc,
+                head_first=False,
+                use_qk_l2norm_in_kernel=True,
+            )
+            last_recurrent_state = last_recurrent_state.to(ssm_states.dtype, copy=False)
+            ssm_states[cache_indices] = last_recurrent_state
+
+        return core_attn_out
+
+
 class Mamba2AttnBackend(MambaAttnBackendBase):
     """Attention backend wrapper for Mamba2Mixer kernels."""
 
@@ -990,3 +1187,51 @@ class HybridLinearAttnBackend(AttentionBackend):
         conv_states[:, valid_state_indices, :, :] = intermediate_conv_window_cache[
             :, valid_state_indices, last_steps
         ].to(conv_states.dtype, copy=False)
+
+    def update_jet_nemotron_topk1_state_after_mtp_verify(self, accepted_length, model):
+        request_number = accepted_length.shape[0]
+
+        state_indices_tensor = (
+            self.linear_attn_backend.forward_metadata.mamba_cache_indices[
+                :request_number
+            ]
+        )
+
+        mamba_caches = (
+            self.linear_attn_backend.req_to_token_pool.get_speculative_mamba2_params_all_layers()
+        )
+
+        conv_states = mamba_caches.conv[0]
+        ssm_states = mamba_caches.temporal
+        intermediate_state_cache = mamba_caches.intermediate_ssm
+        intermediate_conv_window_cache = mamba_caches.intermediate_conv_window[0]
+        W = conv_states.shape[3]
+
+        valid_mask = accepted_length > 0
+
+        last_steps_all = (accepted_length - 1).to(torch.int64)
+        valid_state_indices = state_indices_tensor[valid_mask].to(torch.int64)  # [N]
+        last_steps = last_steps_all[valid_mask].to(torch.int64)  # [N]
+
+        ssm_states[:, valid_state_indices, :] = intermediate_state_cache[
+            :, valid_state_indices, last_steps
+        ].to(ssm_states.dtype, copy=False)
+
+        Wm1 = W - 1
+        time_offsets = torch.arange(
+            Wm1, device=last_steps.device, dtype=last_steps.dtype
+        )
+        time_indices = last_steps.unsqueeze(-1) + time_offsets
+        # Select caches for valid_state_indices -> [L, N, T, C]
+        src = intermediate_conv_window_cache[:, valid_state_indices, :, :]
+        L_dim, N_dim, _, C_dim = src.shape
+        # Build gather index over time dim (dim=2): [L, N, W-1, C]
+        gather_idx = time_indices.view(1, N_dim, Wm1, 1).expand(
+            L_dim, N_dim, Wm1, C_dim
+        )
+        gathered = torch.gather(src, 2, gather_idx)  # [L, N, W-1, C]
+        # Match conv_states layout [L, N, C, W-1]
+        gathered = gathered.transpose(-1, -2)
+        conv_states[:, valid_state_indices, :, 1:] = gathered.to(
+            conv_states.dtype, copy=False
+        )

--- a/python/sglang/srt/layers/attention/jet_nemotron/dconv_fwd_cache_varlen.py
+++ b/python/sglang/srt/layers/attention/jet_nemotron/dconv_fwd_cache_varlen.py
@@ -1,0 +1,144 @@
+import torch
+import triton
+import triton.language as tl
+
+
+def ensure_contiguous(t: torch.Tensor) -> torch.Tensor:
+    return t if t.is_contiguous() else t.contiguous()
+
+
+@triton.jit
+def _dynamic_conv_fwd_kernel(
+    X_ptr,
+    K_ptr,
+    Out_ptr,
+    Cache_ptr,
+    Cu_seqlens_ptr,
+    Seq_idx_ptr,
+    Cache_idx_ptr,
+    Has_init_ptr,
+    D,
+    X_stride_t,
+    X_stride_d,
+    K_stride_t,
+    K_stride_d,
+    K_stride_w,
+    Out_stride_t,
+    Out_stride_d,
+    Cache_stride_b,
+    Cache_stride_d,
+    Cache_stride_t,
+    W: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    pid_total_time_idx = tl.program_id(0)
+    pid_d_block = tl.program_id(1)
+
+    batch_idx = tl.load(Seq_idx_ptr + pid_total_time_idx)
+    seq_start_idx = tl.load(Cu_seqlens_ptr + batch_idx)
+    has_init = tl.load(Has_init_ptr + batch_idx)
+
+    offs_d = pid_d_block * BLOCK_SIZE_D + tl.arange(0, BLOCK_SIZE_D)
+    d_mask = offs_d < D
+
+    accumulator = tl.zeros((BLOCK_SIZE_D,), dtype=tl.float32)
+    offs_w = tl.arange(0, W)
+
+    k_ptrs = K_ptr + (
+        pid_total_time_idx * K_stride_t
+        + offs_d[:, None] * K_stride_d
+        + offs_w[None, :] * K_stride_w
+    )
+    k_vals = tl.load(
+        k_ptrs, mask=d_mask[:, None], other=0.0
+    )  # Shape: [BLOCK_SIZE_D, W]
+
+    x_abs_indices = pid_total_time_idx + offs_w - W + 1
+    x_ptrs = X_ptr + (
+        x_abs_indices[None, :] * X_stride_t + offs_d[:, None] * X_stride_d
+    )
+    x_final_load_mask = d_mask[:, None] & (x_abs_indices >= seq_start_idx)[None, :]
+    x_input_vals = tl.load(x_ptrs, mask=x_final_load_mask, other=0.0)
+
+    cache_batch_idx = tl.load(Cache_idx_ptr + batch_idx)
+    cache_ptrs = Cache_ptr + (
+        cache_batch_idx * Cache_stride_b
+        + (x_abs_indices + W - seq_start_idx)[None, :] * Cache_stride_t
+        + offs_d[:, None] * Cache_stride_d
+    )
+    cache_final_load_mask = (
+        d_mask[:, None] & (x_abs_indices < seq_start_idx)[None, :] & (has_init != 0)
+    )
+    vals_from_cache = tl.load(cache_ptrs, mask=cache_final_load_mask, other=0.0)
+
+    product = k_vals * (x_input_vals + vals_from_cache)
+    accumulator += tl.sum(product, axis=1)
+
+    out_ptrs = Out_ptr + (pid_total_time_idx * Out_stride_t + offs_d * Out_stride_d)
+    tl.store(out_ptrs, accumulator, mask=d_mask)
+
+
+def dynamic_conv_triton_cache_varlen(
+    x: torch.Tensor,
+    kernels: torch.Tensor,
+    cu_seqlens: torch.LongTensor,
+    cache: torch.Tensor = None,
+    cache_indices: torch.Tensor = None,
+    has_initial_state: torch.Tensor = None,
+    seq_idx: torch.Tensor = None,
+) -> torch.Tensor:
+    """
+    Fused dynamic convolution.
+    Assumes W <= 4.
+
+    Args:
+        x: Input tensor of shape [T, D].
+        kernels: Dynamic kernels of shape [T, D, W].
+        cu_seqlens: Cumulative sequence lengths for each batch. Shape: [B+1].
+        cache: Optional past context tensor of shape [N, D, W].
+               If provided, treated as concatenated before x for convolution input.
+        cache_indices: Indices of the cache for each sequence. Shape: [B].
+        has_initial_state: Whether the initial state is provided. Shape: [B].
+        seq_idx: Indices of the sequence for each token. Shape: [T].
+    Returns:
+        Output tensor of shape [T, D].
+    """
+
+    x = ensure_contiguous(x)
+    kernels = ensure_contiguous(kernels)
+    cache = ensure_contiguous(cache)
+
+    T, D = x.shape
+    W = kernels.shape[2]
+    assert W <= 4, "Kernel W > 4 not expected for this version"
+
+    out = torch.empty_like(x)
+
+    grid = lambda meta: (T, triton.cdiv(D, meta["BLOCK_SIZE_D"]))
+    BLOCK_SIZE_D = 128
+
+    _dynamic_conv_fwd_kernel[grid](
+        x,
+        kernels,
+        out,
+        cache,
+        cu_seqlens,
+        seq_idx,
+        cache_indices,
+        has_initial_state,
+        D,
+        x.stride(0),
+        x.stride(1),
+        kernels.stride(0),
+        kernels.stride(1),
+        kernels.stride(2),
+        out.stride(0),
+        out.stride(1),
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(2),
+        W=tl.constexpr(W),
+        BLOCK_SIZE_D=tl.constexpr(BLOCK_SIZE_D),
+    )
+
+    return out

--- a/python/sglang/srt/layers/attention/jet_nemotron/dconv_speculative_step.py
+++ b/python/sglang/srt/layers/attention/jet_nemotron/dconv_speculative_step.py
@@ -1,0 +1,465 @@
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+PAD_SLOT_ID = -1
+
+
+@triton.jit
+def _causal_conv_speculative_step_kernel(
+    X_ptr,  # Pointer to current input x [B, T, D]
+    Cache_ptr,  # Pointer to cache [N, D, W]
+    Kernels_ptr,  # Pointer to generated kernels [B, T, D, W]
+    Out_ptr,  # Pointer to output tensor [B, T, D]
+    Cache_idx_ptr,  # Pointer to cache indices [B]
+    Intermediate_conv_window_ptr,  # Pointer to intermediate conv window [N, W-1+T, D]
+    B,
+    D,
+    X_stride_b,
+    X_stride_t,
+    X_stride_d,
+    Cache_stride_b,
+    Cache_stride_d,
+    Cache_stride_w,
+    Kernels_stride_b,
+    Kernels_stride_t,
+    Kernels_stride_d,
+    Kernels_stride_w,
+    Out_stride_b,
+    Out_stride_t,
+    Out_stride_d,
+    Cache_idx_stride_b,
+    Intermediate_conv_window_stride_b,
+    Intermediate_conv_window_stride_t,
+    Intermediate_conv_window_stride_d,
+    pad_slot_id: tl.constexpr,
+    W: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    pid_batch = tl.program_id(0)
+    pid_time = tl.program_id(1)
+    pid_d_block = tl.program_id(2)
+    cache_idx = tl.load(Cache_idx_ptr + pid_batch * Cache_idx_stride_b)
+    if cache_idx == pad_slot_id:
+        return
+    offs_d = pid_d_block * BLOCK_SIZE_D + tl.arange(0, BLOCK_SIZE_D)
+    d_mask = offs_d < D
+    accumulator = tl.zeros((BLOCK_SIZE_D,), dtype=tl.float32)
+    offs_w = tl.arange(0, W)
+    k_ptrs = Kernels_ptr + (
+        pid_batch * Kernels_stride_b
+        + pid_time * Kernels_stride_t
+        + offs_d[:, None] * Kernels_stride_d
+        + offs_w[None, :] * Kernels_stride_w
+    )
+    k_vals = tl.load(k_ptrs, mask=d_mask[:, None], other=0.0)
+    x_abs_indices = pid_time + offs_w - W + 1
+    x_ptrs = X_ptr + (
+        pid_batch * X_stride_b
+        + x_abs_indices[None, :] * X_stride_t
+        + offs_d[:, None] * X_stride_d
+    )
+    x_final_load_mask = d_mask[:, None] & (x_abs_indices >= 0)[None, :]
+    x_input_vals = tl.load(x_ptrs, mask=x_final_load_mask, other=0.0)
+    cache_ptrs = Cache_ptr + (
+        cache_idx * Cache_stride_b
+        + (x_abs_indices + W)[None, :] * Cache_stride_w
+        + offs_d[:, None] * Cache_stride_d
+    )
+    cache_final_load_mask = d_mask[:, None] & (x_abs_indices < 0)[None, :]
+    vals_from_cache = tl.load(cache_ptrs, mask=cache_final_load_mask, other=0.0)
+    x_vals = x_input_vals + vals_from_cache
+    product = k_vals * x_vals
+    accumulator += tl.sum(product, axis=1)
+    out_ptrs = Out_ptr + (
+        pid_batch * Out_stride_b + pid_time * Out_stride_t + offs_d * Out_stride_d
+    )
+    tl.store(out_ptrs, accumulator, mask=d_mask)
+
+    intermediate_conv_window_ptrs = Intermediate_conv_window_ptr + (
+        cache_idx * Intermediate_conv_window_stride_b
+        + (W - 2 + pid_time) * Intermediate_conv_window_stride_t
+        + offs_d * Intermediate_conv_window_stride_d
+    )
+    offs_w = tl.arange(0, W)
+    last_col_mask = offs_w == W - 1
+    x_vals_last_col = tl.sum(x_vals * last_col_mask[None, :], axis=1)
+    tl.store(intermediate_conv_window_ptrs, x_vals_last_col, mask=d_mask)
+
+
+def causal_conv_step_triton_speculative(
+    x: torch.Tensor,  # Input tensor [B, T, D]
+    cache: torch.Tensor,  # Cache tensor [N, D, W]
+    kernels: torch.Tensor,  # Kernels tensor [B, T, D, W]
+    cache_indices: torch.Tensor,  # Cache indices tensor [B]
+    intermediate_conv_window: torch.Tensor,  # Intermediate conv window tensor [N, W-2+T, D], updated in-place
+) -> torch.Tensor:  # Returns output tensor [B, D] (before activation)
+    B, T, D = x.shape
+    W = cache.shape[2]
+    assert 1 < W <= 4, f"Kernel W={W}, this optimized version assumes 1 < W <= 4"
+    out = torch.empty_like(x)
+
+    grid = lambda meta: (B, T, triton.cdiv(D, meta["BLOCK_SIZE_D"]))
+    BLOCK_SIZE_D = 64
+
+    _causal_conv_speculative_step_kernel[grid](
+        x,
+        cache,
+        kernels,
+        out,
+        cache_indices,
+        intermediate_conv_window,
+        B,
+        D,
+        x.stride(0),
+        x.stride(1),
+        x.stride(2),
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(2),
+        kernels.stride(0),
+        kernels.stride(1),
+        kernels.stride(2),
+        kernels.stride(3),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        cache_indices.stride(0),
+        intermediate_conv_window.stride(0),
+        intermediate_conv_window.stride(1),
+        intermediate_conv_window.stride(2),
+        pad_slot_id=PAD_SLOT_ID,
+        W=W,
+        BLOCK_SIZE_D=BLOCK_SIZE_D,
+    )
+
+    return out
+
+
+# modified from causal_conv1d_triton.py
+@triton.jit()
+def _causal_dynamic_conv1d_update_kernel(
+    x_ptr,
+    w_ptr,
+    conv_state_ptr,
+    conv_state_indices_ptr,
+    intermediate_conv_window_ptr,
+    retrieve_next_token_ptr,
+    retrieve_next_sibling_ptr,
+    retrieve_parent_token_ptr,
+    o_ptr,
+    batch: int,
+    dim: tl.constexpr,
+    seqlen: tl.constexpr,
+    state_len: tl.constexpr,
+    stride_x_seq: tl.constexpr,
+    stride_x_dim: tl.constexpr,
+    stride_x_token: tl.constexpr,
+    stride_w_seq: tl.constexpr,
+    stride_w_token: tl.constexpr,
+    stride_w_dim: tl.constexpr,
+    stride_w_width: tl.constexpr,
+    stride_conv_state_seq: tl.constexpr,
+    stride_conv_state_dim: tl.constexpr,
+    stride_conv_state_tok: tl.constexpr,
+    stride_state_indices: tl.constexpr,
+    stride_inter_seq: tl.constexpr,
+    stride_inter_step: tl.constexpr,
+    stride_inter_dim: tl.constexpr,
+    stride_inter_win: tl.constexpr,
+    stride_retrieve_next_token_seq: tl.constexpr,
+    stride_retrieve_next_token_token: tl.constexpr,
+    stride_retrieve_next_sibling_seq: tl.constexpr,
+    stride_retrieve_next_sibling_token: tl.constexpr,
+    stride_retrieve_parent_token_seq: tl.constexpr,
+    stride_retrieve_parent_token_token: tl.constexpr,
+    stride_o_seq: tl.constexpr,
+    stride_o_dim: tl.constexpr,
+    stride_o_token: tl.constexpr,
+    pad_slot_id: tl.constexpr,
+    KERNEL_WIDTH: tl.constexpr,
+    NP2_SEQLEN: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    idx_seq = tl.program_id(0)
+    if idx_seq >= batch:
+        return
+
+    idx_feats = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    conv_state_batch_coord = tl.load(
+        conv_state_indices_ptr + idx_seq * stride_state_indices
+    ).to(tl.int64)
+    if conv_state_batch_coord == pad_slot_id:
+        return
+
+    conv_states_base = (
+        conv_state_ptr
+        + (conv_state_batch_coord * stride_conv_state_seq)
+        + (idx_feats * stride_conv_state_dim)
+    )
+    mask_w = idx_feats < dim
+
+    conv_state_token_offset = (
+        state_len - KERNEL_WIDTH + 1
+    )  # our conv state is right aligned, not left aligned like causal_conv1d_triton.py
+    prior_tokens = conv_states_base + conv_state_token_offset * stride_conv_state_tok
+    if KERNEL_WIDTH >= 2:
+        conv_states_ptrs = prior_tokens
+        col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+    if KERNEL_WIDTH >= 3:
+        conv_states_ptrs = prior_tokens + 1 * stride_conv_state_tok
+        col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+    if KERNEL_WIDTH >= 4:
+        conv_states_ptrs = prior_tokens + 2 * stride_conv_state_tok
+        col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+
+    acc_preload = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    idx_tokens = tl.arange(0, NP2_SEQLEN)
+    mask_retrieve = idx_tokens < seqlen
+    retrieve_next_token_base = (
+        retrieve_next_token_ptr
+        + (idx_seq * stride_retrieve_next_token_seq)
+        + idx_tokens * stride_retrieve_next_token_token
+    )
+    retrieve_next_tokens = tl.load(retrieve_next_token_base, mask_retrieve)
+    retrieve_next_sibling_base = (
+        retrieve_next_sibling_ptr
+        + (idx_seq * stride_retrieve_next_sibling_seq)
+        + idx_tokens * stride_retrieve_next_sibling_token
+    )
+    retrieve_next_siblings = tl.load(retrieve_next_sibling_base, mask_retrieve)
+    parent_idx_tokens = tl.zeros((NP2_SEQLEN,), dtype=tl.int32)
+
+    w_base = w_ptr + (idx_seq * stride_w_seq + idx_feats * stride_w_dim)
+
+    x_base_1d = x_ptr + (idx_seq * stride_x_seq) + (idx_feats * stride_x_dim)
+    mask_x_1d = idx_feats < dim
+
+    for idx_token in tl.static_range(seqlen):
+        if KERNEL_WIDTH >= 2:
+            w_ptrs = w_base + (0 * stride_w_width)
+            w_col0 = tl.load(w_ptrs, mask_w, other=0.0)
+            w_ptrs = w_base + (1 * stride_w_width)
+            w_col1 = tl.load(w_ptrs, mask_w, other=0.0)
+        if KERNEL_WIDTH >= 3:
+            w_ptrs = w_base + (2 * stride_w_width)
+            w_col2 = tl.load(w_ptrs, mask_w, other=0.0)
+        if KERNEL_WIDTH >= 4:
+            w_ptrs = w_base + (3 * stride_w_width)
+            w_col3 = tl.load(w_ptrs, mask_w, other=0.0)
+        w_base += stride_w_token
+
+        acc = acc_preload
+
+        retrieve_next_token_idx = tl.sum(
+            tl.where(idx_tokens == idx_token, retrieve_next_tokens, 0)
+        )
+        if retrieve_next_token_idx != pad_slot_id:
+            parent_idx_tokens = tl.where(
+                idx_tokens == retrieve_next_token_idx,
+                idx_token,
+                parent_idx_tokens,
+            )
+
+        retrieve_sibling_token_idx = tl.sum(
+            tl.where(idx_tokens == idx_token, retrieve_next_siblings, 0)
+        )
+        if retrieve_sibling_token_idx != pad_slot_id:
+            parent_idx_token = tl.sum(
+                tl.where(idx_tokens == idx_token, parent_idx_tokens, 0)
+            )
+            parent_idx_tokens = tl.where(
+                idx_tokens == retrieve_sibling_token_idx,
+                parent_idx_token,
+                parent_idx_tokens,
+            )
+
+        _idx_token = idx_token
+        x_ptrs_1d = x_base_1d + _idx_token * stride_x_token
+        matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+
+        for j in tl.static_range(KERNEL_WIDTH):
+            if KERNEL_WIDTH == 2:
+                if j == 0:
+                    matrix_w = w_col1
+                else:
+                    matrix_w = w_col0
+            elif KERNEL_WIDTH == 3:
+                if j == 0:
+                    matrix_w = w_col2
+                elif j == 1:
+                    matrix_w = w_col1
+                else:
+                    matrix_w = w_col0
+            elif KERNEL_WIDTH == 4:
+                if j == 0:
+                    matrix_w = w_col3
+                elif j == 1:
+                    matrix_w = w_col2
+                elif j == 2:
+                    matrix_w = w_col1
+                else:
+                    matrix_w = w_col0
+
+            base_ptr = (
+                intermediate_conv_window_ptr
+                + conv_state_batch_coord * stride_inter_seq
+                + idx_token * stride_inter_step
+                + idx_feats * stride_inter_dim
+            )
+
+            if KERNEL_WIDTH - j - 2 >= 0:
+                tl.store(
+                    base_ptr + (state_len - j - 1) * stride_inter_win,
+                    matrix_x,
+                    mask=mask_w,
+                )
+
+            acc += matrix_x * matrix_w
+
+            if _idx_token > 0:
+                _idx_token = tl.sum(
+                    tl.where(idx_tokens == _idx_token, parent_idx_tokens, 0)
+                )
+                x_ptrs_1d = x_base_1d + _idx_token * stride_x_token
+                matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+            else:
+                if KERNEL_WIDTH == 2:
+                    if _idx_token == 0:
+                        matrix_x = col0
+                elif KERNEL_WIDTH == 3:
+                    if _idx_token == 0:
+                        matrix_x = col1
+                    else:
+                        matrix_x = col0
+                elif KERNEL_WIDTH == 4:
+                    if _idx_token == 0:
+                        matrix_x = col2
+                    elif _idx_token == -1:
+                        matrix_x = col1
+                    else:
+                        matrix_x = col0
+                _idx_token = _idx_token - 1
+
+        acc = acc / (1 + tl.exp(-acc))
+        mask_1d = (idx_token < seqlen) & (idx_feats < dim)
+        o_ptrs = (
+            o_ptr
+            + (idx_seq) * stride_o_seq
+            + idx_token * stride_o_token
+            + (idx_feats * stride_o_dim)
+        )
+
+        tl.store(o_ptrs, acc, mask=mask_1d)
+        tl.store(
+            retrieve_parent_token_ptr
+            + idx_seq * stride_retrieve_parent_token_seq
+            + idx_tokens * stride_retrieve_parent_token_token,
+            parent_idx_tokens,
+            mask=mask_retrieve,
+        )
+
+
+def causal_dynamic_conv1d_update(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    conv_state_indices: Optional[torch.Tensor] = None,
+    intermediate_conv_window: Optional[torch.Tensor] = None,
+    retrieve_next_token: Optional[torch.Tensor] = None,
+    retrieve_next_sibling: Optional[torch.Tensor] = None,
+    retrieve_parent_token: Optional[torch.Tensor] = None,
+    pad_slot_id: int = PAD_SLOT_ID,
+):
+    batch, dim, seqlen = x.shape
+    width = weight.shape[3]
+    _, _, state_len = conv_state.size()
+
+    out = torch.empty_like(x)
+    stride_w_seq, stride_w_token, stride_w_dim, stride_w_width = weight.stride()
+
+    stride_x_seq, stride_x_dim, stride_x_token = x.stride()
+
+    stride_o_seq, stride_o_dim, stride_o_token = out.stride()
+    stride_istate_seq, stride_istate_dim, stride_istate_token = conv_state.stride()
+    stride_state_indices = (
+        conv_state_indices.stride(0) if conv_state_indices is not None else 0
+    )
+    np2_seqlen = triton.next_power_of_2(seqlen)
+
+    def grid(META):
+        return (
+            batch,
+            triton.cdiv(dim, META["BLOCK_N"]),
+        )
+
+    stride_inter_seq, stride_inter_step, stride_inter_dim, stride_inter_win = (
+        intermediate_conv_window.stride(0),
+        intermediate_conv_window.stride(1),
+        intermediate_conv_window.stride(2),
+        intermediate_conv_window.stride(3),
+    )
+
+    stride_retrieve_next_token_seq, stride_retrieve_next_token_token = (
+        retrieve_next_token.stride(0),
+        retrieve_next_token.stride(1),
+    )
+
+    stride_retrieve_next_sibling_seq, stride_retrieve_next_sibling_token = (
+        retrieve_next_sibling.stride(0),
+        retrieve_next_sibling.stride(1),
+    )
+
+    stride_retrieve_parent_token_seq, stride_retrieve_parent_token_token = (
+        retrieve_parent_token.stride(0),
+        retrieve_parent_token.stride(1),
+    )
+
+    _causal_dynamic_conv1d_update_kernel[grid](
+        x,
+        weight,
+        conv_state,
+        conv_state_indices,
+        intermediate_conv_window,
+        retrieve_next_token,
+        retrieve_next_sibling,
+        retrieve_parent_token,
+        out,
+        batch,
+        dim,
+        seqlen,
+        state_len,
+        stride_x_seq,
+        stride_x_dim,
+        stride_x_token,
+        stride_w_seq,
+        stride_w_token,
+        stride_w_dim,
+        stride_w_width,
+        stride_istate_seq,
+        stride_istate_dim,
+        stride_istate_token,
+        stride_state_indices,
+        stride_inter_seq,
+        stride_inter_step,
+        stride_inter_dim,
+        stride_inter_win,
+        stride_retrieve_next_token_seq,
+        stride_retrieve_next_token_token,
+        stride_retrieve_next_sibling_seq,
+        stride_retrieve_next_sibling_token,
+        stride_retrieve_parent_token_seq,
+        stride_retrieve_parent_token_token,
+        stride_o_seq,
+        stride_o_dim,
+        stride_o_token,
+        pad_slot_id,
+        KERNEL_WIDTH=width,
+        NP2_SEQLEN=np2_seqlen,
+        BLOCK_N=256,
+    )
+    return out

--- a/python/sglang/srt/layers/attention/jet_nemotron/dconv_step.py
+++ b/python/sglang/srt/layers/attention/jet_nemotron/dconv_step.py
@@ -1,0 +1,215 @@
+# Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import triton
+import triton.language as tl
+
+
+def ensure_contiguous(t: torch.Tensor) -> torch.Tensor:
+    return t if t.is_contiguous() else t.contiguous()
+
+
+@triton.jit
+def _causal_conv_step_kernel(
+    X_ptr,
+    Cache_ptr,
+    Kernels_ptr,
+    Out_ptr,
+    D,
+    X_stride_b,
+    X_stride_d,
+    Cache_stride_b,
+    Cache_stride_d,
+    Cache_stride_w,
+    Kernels_stride_b,
+    Kernels_stride_d,
+    Kernels_stride_w,
+    Out_stride_b,
+    Out_stride_d,
+    W: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+):
+    """
+    Triton kernel for a single step (T=1) of causal dynamic convolution.
+    Updates the cache in-place and computes the output (without activation).
+    Optimized for small W (1 < W <= 4) by manually unrolling the W dimension.
+    Does NOT handle separate static bias.
+
+    Grid: (B, cdiv(D, BLOCK_SIZE_D))
+    Updates Cache[b, d, :] and computes Out[b, d].
+    """
+    pid_b = tl.program_id(0)
+    pid_d_block = tl.program_id(1)
+
+    offs_d = pid_d_block * BLOCK_SIZE_D + tl.arange(0, BLOCK_SIZE_D)
+    d_mask = offs_d < D
+
+    x_ptrs = X_ptr + pid_b * X_stride_b + offs_d * X_stride_d
+    x_curr = tl.load(x_ptrs, mask=d_mask, other=0.0)
+
+    accumulator = tl.zeros((BLOCK_SIZE_D,), dtype=x_curr.dtype)
+
+    if tl.constexpr(W > 1):
+        k_ptr_0 = (
+            Kernels_ptr
+            + pid_b * Kernels_stride_b
+            + offs_d * Kernels_stride_d
+            + 0 * Kernels_stride_w
+        )
+        k_val_0 = tl.load(k_ptr_0, mask=d_mask, other=0.0)
+
+        cache_ptr_1 = (
+            Cache_ptr
+            + pid_b * Cache_stride_b
+            + offs_d * Cache_stride_d
+            + 1 * Cache_stride_w
+        )
+        cache_val_1 = tl.load(cache_ptr_1, mask=d_mask, other=0.0)
+
+        accumulator += cache_val_1 * k_val_0
+
+    if tl.constexpr(W > 2):
+        k_ptr_1 = (
+            Kernels_ptr
+            + pid_b * Kernels_stride_b
+            + offs_d * Kernels_stride_d
+            + 1 * Kernels_stride_w
+        )
+        k_val_1 = tl.load(k_ptr_1, mask=d_mask, other=0.0)
+
+        cache_ptr_2 = (
+            Cache_ptr
+            + pid_b * Cache_stride_b
+            + offs_d * Cache_stride_d
+            + 2 * Cache_stride_w
+        )
+        cache_val_2 = tl.load(cache_ptr_2, mask=d_mask, other=0.0)
+
+        accumulator += cache_val_2 * k_val_1
+
+        cache_ptr_1 = (
+            Cache_ptr
+            + pid_b * Cache_stride_b
+            + offs_d * Cache_stride_d
+            + 1 * Cache_stride_w
+        )
+        tl.store(cache_ptr_1, cache_val_2, mask=d_mask)
+
+    if tl.constexpr(W > 3):
+        k_ptr_2 = (
+            Kernels_ptr
+            + pid_b * Kernels_stride_b
+            + offs_d * Kernels_stride_d
+            + 2 * Kernels_stride_w
+        )
+        k_val_2 = tl.load(k_ptr_2, mask=d_mask, other=0.0)
+
+        cache_ptr_3 = (
+            Cache_ptr
+            + pid_b * Cache_stride_b
+            + offs_d * Cache_stride_d
+            + 3 * Cache_stride_w
+        )
+        cache_val_3 = tl.load(cache_ptr_3, mask=d_mask, other=0.0)
+
+        accumulator += cache_val_3 * k_val_2
+
+        cache_ptr_2 = (
+            Cache_ptr
+            + pid_b * Cache_stride_b
+            + offs_d * Cache_stride_d
+            + 2 * Cache_stride_w
+        )
+        tl.store(cache_ptr_2, cache_val_3, mask=d_mask)
+
+    k_ptr_last = (
+        Kernels_ptr
+        + pid_b * Kernels_stride_b
+        + offs_d * Kernels_stride_d
+        + (W - 1) * Kernels_stride_w
+    )
+    k_val_last = tl.load(k_ptr_last, mask=d_mask, other=0.0)
+
+    accumulator += x_curr * k_val_last
+
+    cache_ptr_last = (
+        Cache_ptr
+        + pid_b * Cache_stride_b
+        + offs_d * Cache_stride_d
+        + (W - 1) * Cache_stride_w
+    )
+    tl.store(cache_ptr_last, x_curr, mask=d_mask)
+
+    out_ptrs = Out_ptr + pid_b * Out_stride_b + offs_d * Out_stride_d
+    tl.store(out_ptrs, accumulator, mask=d_mask)
+
+
+def causal_conv_step_triton(
+    x: torch.Tensor,  # Input tensor [B, 1, D]
+    cache: torch.Tensor,  # Cache tensor [B, D, W-1], modified in-place
+    kernels: torch.Tensor,  # Kernels tensor [B, D, W]
+) -> torch.Tensor:  # Returns output tensor [B, D] (before activation)
+    """
+    Performs one step of causal dynamic convolution using Triton.
+    Updates the cache in-place. Does NOT fuse activation. Assumes 1 < W <= 4.
+    Uses manually unrolled kernel for W dimension.
+
+    Args:
+        x: Current input token tensor of shape [B, 1, D].
+        cache: Cache tensor of shape [B, D, W]. Will be updated in-place.
+        kernels: Dynamically generated kernels tensor of shape [B, D, W].
+
+    Returns:
+        Output tensor of shape [B, D] for the current step (before activation).
+    """
+    assert x.dim() == 3 and x.shape[1] == 1, "Input x must have shape [B, 1, D]"
+    assert cache.dim() == 3, "Cache must have shape [B, D, W]"
+    assert kernels.dim() == 3, "Kernels must have shape [B, D, W]"
+    B, _, D = x.shape
+    W = cache.shape[2]
+    assert 1 < W <= 4, f"Kernel W={W}, this optimized version assumes 1 < W <= 4"
+
+    x_squeezed = x.squeeze(1)
+    x_squeezed = ensure_contiguous(x_squeezed)
+    cache = ensure_contiguous(cache)
+    kernels = ensure_contiguous(kernels)
+
+    out = torch.empty_like(x_squeezed)
+    grid = lambda meta: (B, triton.cdiv(D, meta["BLOCK_SIZE_D"]))
+    BLOCK_SIZE_D = 64
+
+    _causal_conv_step_kernel[grid](
+        x_squeezed,
+        cache,
+        kernels,
+        out,
+        D,
+        x_squeezed.stride(0),
+        x_squeezed.stride(1),
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(2),
+        kernels.stride(0),
+        kernels.stride(1),
+        kernels.stride(2),
+        out.stride(0),
+        out.stride(1),
+        W=W,
+        BLOCK_SIZE_D=BLOCK_SIZE_D,
+    )
+
+    return out

--- a/python/sglang/srt/layers/attention/jet_nemotron/dynamic_conv.py
+++ b/python/sglang/srt/layers/attention/jet_nemotron/dynamic_conv.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.utils import add_prefix
+
+from .dconv_fwd_cache_varlen import dynamic_conv_triton_cache_varlen
+from .dconv_speculative_step import (
+    causal_conv_step_triton_speculative,
+    causal_dynamic_conv1d_update,
+)
+from .dconv_step import causal_conv_step_triton
+
+
+class DynamicShortConvolutionKernelGenerator(nn.Module):
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        output_size: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.w1 = ColumnParallelLinear(
+            input_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("w1", prefix),
+        )
+
+        self.act = nn.SiLU()
+
+        self.w2 = RowParallelLinear(
+            hidden_size,
+            output_size,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("w2", prefix),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x, _ = self.w1(x)
+        x = self.act(x)
+        x, _ = self.w2(x)
+        return x
+
+
+class DynamicShortConvolution(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        kernel_size: int,
+        generator_input_size: int,
+        generator_reduction: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        generator_hidden_size = hidden_size // generator_reduction
+
+        self.kernel_generator = DynamicShortConvolutionKernelGenerator(
+            input_size=generator_input_size,
+            hidden_size=generator_hidden_size,
+            output_size=hidden_size * kernel_size,
+            quant_config=quant_config,
+            prefix=add_prefix("kernel_generator", prefix),
+        )
+
+        self.hidden_size = hidden_size
+        self.kernel_size = kernel_size
+
+    def get_kernel(self, x: torch.Tensor) -> torch.Tensor:
+        flat_kernels = self.kernel_generator(x)
+        if flat_kernels.dim() == 3:
+            kernels = rearrange(
+                flat_kernels, "b t (d w) -> b t d w", w=self.kernel_size
+            )
+        elif flat_kernels.dim() == 2:
+            kernels = rearrange(flat_kernels, "b (d w) -> b d w", w=self.kernel_size)
+        else:
+            raise ValueError(f"Invalid kernel shape: {flat_kernels.shape}")
+        return kernels
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cache: Optional[torch.Tensor] = None,
+        output_final_state: bool = False,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        generator_input: Optional[torch.Tensor] = None,
+        cache_indices: Optional[torch.Tensor] = None,
+        seq_idx: Optional[torch.Tensor] = None,
+        has_initial_state: Optional[torch.Tensor] = None,
+        intermediate_conv_window: Optional[torch.Tensor] = None,
+        retrieve_next_token: Optional[torch.Tensor] = None,
+        retrieve_next_sibling: Optional[torch.Tensor] = None,
+        retrieve_parent_token: Optional[torch.Tensor] = None,
+        is_topk1: bool = False,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if cu_seqlens is not None:
+            assert cache is not None, "Cache must be provided for varlen mode."
+            B = len(cu_seqlens) - 1
+            W = self.kernel_size
+
+            out = dynamic_conv_triton_cache_varlen(
+                x,
+                self.get_kernel(generator_input),
+                cu_seqlens,
+                cache,
+                cache_indices,
+                has_initial_state,
+                seq_idx,
+            )
+            out = nn.functional.silu(out)
+            if output_final_state:
+                for i in range(B):
+                    start_idx = cu_seqlens[i].item()
+                    end_idx = cu_seqlens[i + 1].item()
+                    cache_idx = cache_indices[i].item()
+                    if end_idx - start_idx >= W - 1:
+                        cache[cache_idx, :, 1:] = x[
+                            end_idx - W + 1 : end_idx
+                        ].transpose(0, 1)
+                    else:
+                        num_beginning = W - 1 - (end_idx - start_idx)
+                        if has_initial_state[i].item():
+                            cache[cache_idx, :, 1 : num_beginning + 1] = cache[
+                                cache_idx, :, -num_beginning:
+                            ]
+                        else:
+                            cache[cache_idx, :, 1 : num_beginning + 1] = 0
+                        cache[cache_idx, :, num_beginning + 1 :] = x[
+                            start_idx:end_idx
+                        ].transpose(0, 1)
+
+            return out, cache
+
+        B, T, _, W = *x.shape, self.kernel_size
+
+        if intermediate_conv_window is not None:
+            if is_topk1:
+                assert (
+                    W - 2 + T == intermediate_conv_window.shape[1]
+                ), f"Shape mismatch between intermediate_conv_window ({intermediate_conv_window.shape}) and x ({x.shape})"
+                assert (
+                    cache_indices is not None
+                ), "cache_indices must be provided for intermediate_conv_window"
+                intermediate_conv_window[cache_indices, : W - 2] = (
+                    intermediate_conv_window[cache_indices, 1 : W - 1]
+                )
+                out = causal_conv_step_triton_speculative(
+                    x,
+                    cache,
+                    self.get_kernel(generator_input),
+                    cache_indices,
+                    intermediate_conv_window,
+                )
+                return nn.functional.silu(out)
+            else:
+                return (
+                    causal_dynamic_conv1d_update(
+                        x=x.transpose(1, 2).contiguous(),
+                        conv_state=cache,
+                        weight=self.get_kernel(generator_input),
+                        conv_state_indices=cache_indices,
+                        intermediate_conv_window=intermediate_conv_window,
+                        retrieve_next_token=retrieve_next_token,
+                        retrieve_next_sibling=retrieve_next_sibling,
+                        retrieve_parent_token=retrieve_parent_token,
+                    )
+                    .transpose(1, 2)
+                    .contiguous()
+                )
+
+        # during the decoding phase, we assume the batch is composed of sequences of length 1
+        assert T == 1
+        x, cache = self._step_triton(x, cache, generator_input=generator_input)
+        return x, cache
+
+    def _step_triton(
+        self,
+        x: torch.Tensor,
+        cache: torch.Tensor,
+        generator_input: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        shape = x.shape
+        generator_input = x if generator_input is None else generator_input
+
+        kernels_triton = self.get_kernel(generator_input.squeeze(1))  # [B, D, W]
+
+        x_out_triton = causal_conv_step_triton(
+            x,
+            cache,
+            kernels_triton,
+        )
+        x_out_triton = nn.functional.silu(x_out_triton)
+        return x_out_triton.view(shape), cache

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -33,6 +33,11 @@ class ForwardMetadata:
 
 
 @dataclass(kw_only=True)
+class JetNemotronMetadata(ForwardMetadata):
+    seq_idx: torch.Tensor
+
+
+@dataclass(kw_only=True)
 class Mamba2Metadata(ForwardMetadata):
     """stable metadata across all mamba2 layers in the forward pass"""
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1447,6 +1447,13 @@ class ModelRunner:
         return None
 
     @property
+    def jet_nemotron_config(self):
+        config = self.model_config.hf_config
+        if isinstance(config, JetNemotronConfig | JetVLMConfig):
+            return config
+        return None
+
+    @property
     def kimi_linear_config(self):
         config = self.model_config.hf_config
         if isinstance(config, KimiLinearConfig):
@@ -1736,6 +1743,7 @@ class ModelRunner:
                     enable_memory_saver=self.server_args.enable_memory_saver,
                     cache_params=config.mamba2_cache_params,
                     speculative_num_draft_tokens=self.server_args.speculative_num_draft_tokens,
+                    speculative_eagle_topk=self.server_args.speculative_eagle_topk,
                 )
             else:
                 self.req_to_token_pool = ReqToTokenPool(

--- a/python/sglang/srt/models/jet_nemotron_eagle3.py
+++ b/python/sglang/srt/models/jet_nemotron_eagle3.py
@@ -1,0 +1,192 @@
+from typing import Iterable, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.configs.jet_nemotron import JetNemotronConfig
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import QKVParallelLinear
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.jet_nemotron import JetNemotronAttention, JetNemotronForCausalLM
+from sglang.srt.models.qwen2 import Qwen2MLP
+from sglang.srt.utils import add_prefix
+
+
+class JetNemotronDecoderLayerEagle3(nn.Module):
+    def __init__(
+        self,
+        config: JetNemotronConfig,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+
+        self.self_attn = JetNemotronAttention(config, layer_id, quant_config, prefix)
+        self.self_attn.qkv_proj = QKVParallelLinear(
+            2 * config.hidden_size,
+            self.self_attn.head_dim,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+
+        self.mlp = Qwen2MLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+        self.hidden_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        input_embeds = self.input_layernorm(embeds)
+        hidden_states = self.hidden_norm(hidden_states)
+
+        hidden_states = torch.cat([input_embeds, hidden_states], dim=-1)
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+        )
+
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class JetNemotronModelEagle3(nn.Module):
+    def __init__(
+        self,
+        config: JetNemotronConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size, config.hidden_size
+        )
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.midlayer = JetNemotronDecoderLayerEagle3(config, 0, quant_config, prefix)
+        if hasattr(config, "target_hidden_size"):
+            self.fc = torch.nn.Linear(
+                config.target_hidden_size * 3, config.hidden_size, bias=False
+            )
+        else:
+            self.fc = torch.nn.Linear(
+                config.hidden_size * 3, config.hidden_size, bias=False
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+    ):
+        if input_embeds is None:
+            embeds = self.embed_tokens(input_ids)
+        else:
+            embeds = input_embeds
+
+        hidden_states = forward_batch.spec_info.hidden_states
+        if forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
+            hidden_states = self.fc(hidden_states)
+
+        hidden_states = self.midlayer(positions, embeds, hidden_states, forward_batch)
+        hidden_states_norm = self.norm(hidden_states)
+
+        return hidden_states_norm, [hidden_states]
+
+
+class JetNemotronForCausalLMEagle3(JetNemotronForCausalLM):
+    def __init__(
+        self,
+        config: JetNemotronConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        nn.Module.__init__(self)
+        self.config = config
+
+        if config.draft_vocab_size is None:
+            config.draft_vocab_size = config.vocab_size
+        self.lm_head = ParallelLMHead(
+            config.draft_vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("lm_head", prefix),
+        )
+
+        self.model = JetNemotronModelEagle3(config, quant_config, prefix)
+
+        self.logits_processor = LogitsProcessor(config)
+        self.capture_aux_hidden_states = True
+        self.hot_token_id = None
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if "d2t" in name:
+                self.hot_token_id = loaded_weight + torch.arange(loaded_weight.shape[0])
+                self.hot_token_id = self.hot_token_id.to(torch.int64)
+                continue
+            if "t2d" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name not in params_dict:
+                    name = "model." + name
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader")
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name not in params_dict:
+                    name = "model." + name
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = [JetNemotronForCausalLMEagle3]

--- a/python/sglang/srt/models/jet_vlm.py
+++ b/python/sglang/srt/models/jet_vlm.py
@@ -1,5 +1,6 @@
 import math
 from collections.abc import Iterable
+from typing import List, Optional
 
 import einops
 import torch
@@ -138,6 +139,21 @@ class JetVLMForConditionalGeneration(nn.Module):
     ) -> list[int]:
         pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_embed_and_head(self):
+        return self.llm.get_embed_and_head()
+
+    def set_embed_and_head(self, embed, head):
+        self.llm.set_embed_and_head(embed, head)
+
+    def get_embed(self):
+        return self.llm.get_embed()
+
+    def set_embed(self, embed):
+        self.llm.set_embed(embed)
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        self.llm.set_eagle3_layers_to_capture(layer_ids)
 
 
 EntryClass = [JetVLMForConditionalGeneration]

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -752,9 +752,17 @@ class EAGLEWorker(TpModelWorker):
                 )
             else:
                 max_relative_indices_per_req = accepted_length - 1
-            self.target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify(
-                max_relative_indices_per_req, self.target_worker.model_runner.model
-            )
+            if (
+                self.target_worker.model_runner.jet_nemotron_config is not None
+                and spec_info.topk == 1
+            ):
+                self.target_worker.model_runner.attn_backend.update_jet_nemotron_topk1_state_after_mtp_verify(
+                    accepted_length, self.target_worker.model_runner.model
+                )
+            else:
+                self.target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify(
+                    max_relative_indices_per_req, self.target_worker.model_runner.model
+                )
 
         if batch.return_logprob:
             self.add_logprob_values(batch, res, logits_output)

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -50,6 +50,7 @@ from sglang.srt.speculative.spec_utils import (
     generate_token_bitmask,
     load_token_map,
     select_top_k_tokens,
+    update_hybrid_gdn_state_after_verify,
 )
 from sglang.srt.utils import (
     MultiprocessingSerializer,
@@ -725,44 +726,12 @@ class EAGLEWorker(TpModelWorker):
                 + 1
             )
 
-            # If topk > 1, we need to use retrieve_next_token and retrieve_next_sibling to handle the eagle tree custom attention mask
-            # res.accepted_indices.shape[0] > 0 skips DP attn idle batch
-            if spec_info.topk > 1 and res.accepted_indices.shape[0] > 0:
-                # accepted_indices=[0,2,3,4,5,7,9,10,11], accepted_length=[4, 3, 2], cumulative_accepted_lengths=[4, 7, 9]
-                # first_token_indices_per_req=prepend(0, accepted_indices[cumulative_accepted_lengths[:-1]]) = [0, 5, 10]
-                # last_token_indices_per_req=accepted_indices[cumulative_accepted_lengths - 1] = [4, 9, 11] (last token ID of each req)
-                # max_relative_indices_per_req = [4,4,1]; those are the per-req spec-decoding step offsets that contain the correct mamba caches
-                cumulative_accepted_lengths = torch.cumsum(accepted_length, dim=0)
-                req_start_positions = torch.cat(
-                    [
-                        torch.zeros(
-                            1,
-                            dtype=cumulative_accepted_lengths.dtype,
-                            device=cumulative_accepted_lengths.device,
-                        ),
-                        cumulative_accepted_lengths[:-1],
-                    ]
-                )
-                first_token_indices_per_req = res.accepted_indices[req_start_positions]
-                last_token_indices_per_req = res.accepted_indices[
-                    cumulative_accepted_lengths - 1
-                ]
-                max_relative_indices_per_req = (
-                    last_token_indices_per_req - first_token_indices_per_req
-                )
-            else:
-                max_relative_indices_per_req = accepted_length - 1
-            if (
-                self.target_worker.model_runner.jet_nemotron_config is not None
-                and spec_info.topk == 1
-            ):
-                self.target_worker.model_runner.attn_backend.update_jet_nemotron_topk1_state_after_mtp_verify(
-                    accepted_length, self.target_worker.model_runner.model
-                )
-            else:
-                self.target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify(
-                    max_relative_indices_per_req, self.target_worker.model_runner.model
-                )
+            update_hybrid_gdn_state_after_verify(
+                spec_info.topk,
+                res.accepted_indices,
+                accepted_length,
+                self.target_worker.model_runner,
+            )
 
         if batch.return_logprob:
             self.add_logprob_values(batch, res, logits_output)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -706,6 +706,41 @@ class EAGLEWorkerV2(BaseSpecWorker):
         else:
             verified_id = torch.empty((0,), device=self.device, dtype=torch.int32)
 
+        if self.target_worker.model_runner.hybrid_gdn_config is not None:
+            if verify_input.topk > 1 and accept_index.shape[0] > 0:
+                cumulative_accepted_lengths = torch.cumsum(accept_length, dim=0)
+                req_start_positions = torch.cat(
+                    [
+                        torch.zeros(
+                            1,
+                            dtype=cumulative_accepted_lengths.dtype,
+                            device=cumulative_accepted_lengths.device,
+                        ),
+                        cumulative_accepted_lengths[:-1],
+                    ]
+                )
+                first_token_indices_per_req = accept_index[req_start_positions]
+                last_token_indices_per_req = accept_index[
+                    cumulative_accepted_lengths - 1
+                ]
+                max_relative_indices_per_req = (
+                    last_token_indices_per_req - first_token_indices_per_req
+                )
+            else:
+                max_relative_indices_per_req = accept_length
+
+            if (
+                self.target_worker.model_runner.jet_nemotron_config is not None
+                and verify_input.topk == 1
+            ):
+                self.target_worker.model_runner.attn_backend.update_jet_nemotron_topk1_state_after_mtp_verify(
+                    accept_length, self.target_worker.model_runner.model
+                )
+            else:
+                self.target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify(
+                    max_relative_indices_per_req, self.target_worker.model_runner.model
+                )
+
         # Construct the next draft input
         next_draft_input = EagleDraftInput(
             verified_id=verified_id,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -675,3 +675,43 @@ def detect_nan(logits_output: LogitsProcessorOutput):
     if torch.any(torch.isnan(logits)):
         logger.error("Detected errors during sampling! NaN in the logits.")
         raise ValueError("Detected errors during sampling! NaN in the logits.")
+
+
+def update_hybrid_gdn_state_after_verify(
+    topk: int,
+    accepted_indices: torch.Tensor,
+    accepted_length: torch.Tensor,
+    model_runner,
+):
+    if topk > 1 and accepted_indices.shape[0] > 0:
+        # accepted_indices=[0,2,3,4,5,7,9,10,11], accepted_length=[4, 3, 2], cumulative_accepted_lengths=[4, 7, 9]
+        # first_token_indices_per_req=prepend(0, accepted_indices[cumulative_accepted_lengths[:-1]]) = [0, 5, 10]
+        # last_token_indices_per_req=accepted_indices[cumulative_accepted_lengths - 1] = [4, 9, 11] (last token ID of each req)
+        # max_relative_indices_per_req = [4,4,1]; those are the per-req spec-decoding step offsets that contain the correct mamba caches
+        cumulative_accepted_lengths = torch.cumsum(accepted_length, dim=0)
+        req_start_positions = torch.cat(
+            [
+                torch.zeros(
+                    1,
+                    dtype=cumulative_accepted_lengths.dtype,
+                    device=cumulative_accepted_lengths.device,
+                ),
+                cumulative_accepted_lengths[:-1],
+            ]
+        )
+        first_token_indices_per_req = accepted_indices[req_start_positions]
+        last_token_indices_per_req = accepted_indices[cumulative_accepted_lengths - 1]
+        max_relative_indices_per_req = (
+            last_token_indices_per_req - first_token_indices_per_req
+        )
+    else:
+        max_relative_indices_per_req = accepted_length - 1
+
+    if model_runner.jet_nemotron_config is not None and topk == 1:
+        model_runner.attn_backend.update_jet_nemotron_topk1_state_after_mtp_verify(
+            accepted_length, model_runner.model
+        )
+    else:
+        model_runner.attn_backend.update_mamba_state_after_mtp_verify(
+            max_relative_indices_per_req, model_runner.model
+        )


### PR DESCRIPTION
## Motivation

Built off this PR: https://github.com/sgl-project/sglang/pull/12448
This PR makes the existing JetNemotron implementation faster, and implements speculative decoding for JetNemotron.

## Modifications

Topk>1 and topk=1 tree verification kernel for DynamicConv
Varlen prefill kernel for DynamicConv
Decode kernel for DynamicConv

## Accuracy Tests

1 RTX A6000, cuda graph on:
| Model + Inference Type                                                | GSM8K | MMLU |
|-----------------------------------------------------------------------|:-----:|:----:|
| Jet-Nemotron-2B                                                      | 0.763 | 0.622 |
| Jet-Nemotron-2B + EAGLE3 (topk=1, num_draft_tokens=6, num_steps=5)   | 0.766 | 0.621 |
| Jet-Nemotron-2B + EAGLE3 (topk=4, num_draft_tokens=8, num_steps=5)   | 0.757 | 0.621 |
| Jet-Nemotron-2B + EAGLE3 v2 (topk=1, num_draft_tokens=6, num_steps=5) | 0.787 | 0.606 |


| Model + Inference Type                                                | MMMU |
|-----------------------------------------------------------------------|:-----:|
| Jet-Nemotron-2B-vlm                                                      | 0.371 |
| Jet-Nemotron-2B-vlm + EAGLE3 (topk=4, num_draft_tokens=8, num_steps=5)   | 0.371 |


## Benchmarking and Profiling
#### New implementation (no spec dec):
<img width="280" height="334" alt="image" src="https://github.com/user-attachments/assets/4565511a-a132-4377-90e9-79f5f5131c7b" />



#### Original implementation:
<img width="292" height="340" alt="image" src="https://github.com/user-attachments/assets/1f5b7fdd-9b1f-45f9-b862-4dc21c9c0d6b" />


### Speculative Decoding result
We trained an EAGLE3 checkpoint for jet-nemotron-2b-instruct and evaluated on mtbench
<img width="527" height="250" alt="image" src="https://github.com/user-attachments/assets/c6181fa8-1cba-41b2-9256-e376ed08da23" />


