### PR TITLE
fix(ci): workflow id in permission rate limit

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -79,7 +79,7 @@ jobs:
             const { data } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
-              workflow_id: context.workflow,
+              workflow_id: 'pr-test.yml',
               event: eventName,
               per_page: 100,
             });

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -79,6 +79,7 @@ jobs:
             const { data } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
+              # TODO: Use context.workflow_id when it is supported by the GitHub API
               workflow_id: 'pr-test.yml',
               event: eventName,
               per_page: 100,

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -79,7 +79,6 @@ jobs:
             const { data } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
-              # TODO: Use context.workflow_id when it is supported by the GitHub API
               workflow_id: 'pr-test.yml',
               event: eventName,
               per_page: 100,


### PR DESCRIPTION
I couldn’t find a good way to get the workflow ID. ChatGPT suggested doing a query like this:

```js
const workflows = await github.rest.actions.listRepoWorkflows({ owner, repo });
const current = workflows.data.workflows.find(w => w.name === context.workflow);
core.info(`Current workflow ID: ${current?.id}`);
```

Compared to this approach, I think directly using the file name is more reasonable.

This also seems the approach adopted by most repositories.

https://github.com/search?q=listWorkflowRuns+workflow_id%3A+path%3A.github+language%3AYAML&type=code
