### PR TITLE
Update rope dtype config

### DIFF
--- a/python/sglang/srt/models/grok.py
+++ b/python/sglang/srt/models/grok.py
@@ -221,7 +221,7 @@ def get_rope_scaling(config):
             "attn_factor": attn_factor,
             "beta_fast": beta_fast,
             "beta_slow": beta_slow,
-            "dtype": torch.float,
+            "dtype": torch.bfloat16,
         }
         return rope_scaling
     else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

1. The dtype in the grok model is bfloat16.
2. The apply_rope_with_cos_sin_cache_inplace kernel does support float32.
