### PR TITLE
[router][grpc] Support num_reasoning_tokens in haromy models

### DIFF
--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -10,10 +10,10 @@ use crate::{
     grpc_client::sglang_proto::generate_complete::MatchedStop::{MatchedStopStr, MatchedTokenId},
     protocols::{
         chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
-        common::{ToolCall, Usage},
+        common::{CompletionTokensDetails, ToolCall, Usage},
         responses::{
-            ResponseContentPart, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-            ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
+            OutputTokensDetails, ResponseContentPart, ResponseOutputItem, ResponseReasoningContent,
+            ResponseStatus, ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
         },
     },
     routers::grpc::{
@@ -117,10 +117,9 @@ impl HarmonyResponseProcessor {
 
         // Add reasoning token count from parsed analysis/commentary channels
         if total_reasoning_tokens > 0 {
-            usage.completion_tokens_details =
-                Some(crate::protocols::common::CompletionTokensDetails {
-                    reasoning_tokens: Some(total_reasoning_tokens),
-                });
+            usage.completion_tokens_details = Some(CompletionTokensDetails {
+                reasoning_tokens: Some(total_reasoning_tokens),
+            });
         }
 
         // Final ChatCompletionResponse
@@ -250,10 +249,9 @@ impl HarmonyResponseProcessor {
 
         // Add reasoning token count from parsed analysis/commentary channels
         if parsed.reasoning_token_count > 0 {
-            usage.completion_tokens_details =
-                Some(crate::protocols::common::CompletionTokensDetails {
-                    reasoning_tokens: Some(parsed.reasoning_token_count),
-                });
+            usage.completion_tokens_details = Some(CompletionTokensDetails {
+                reasoning_tokens: Some(parsed.reasoning_token_count),
+            });
         }
 
         // Check for tool calls in commentary channel
@@ -310,10 +308,8 @@ impl HarmonyResponseProcessor {
                 total_tokens: usage.total_tokens,
                 input_tokens_details: None,
                 output_tokens_details: usage.completion_tokens_details.as_ref().and_then(|d| {
-                    d.reasoning_tokens.map(|tokens| {
-                        crate::protocols::responses::OutputTokensDetails {
-                            reasoning_tokens: tokens,
-                        }
+                    d.reasoning_tokens.map(|tokens| OutputTokensDetails {
+                        reasoning_tokens: tokens,
                     })
                 }),
             }))

--- a/sgl-router/src/routers/grpc/harmony/processor.rs
+++ b/sgl-router/src/routers/grpc/harmony/processor.rs
@@ -50,6 +50,8 @@ impl HarmonyResponseProcessor {
 
         // Build choices by parsing output with HarmonyParserAdapter
         let mut choices: Vec<ChatChoice> = Vec::new();
+        let mut total_reasoning_tokens = 0u32;
+
         for (index, complete) in all_responses.iter().enumerate() {
             // Convert matched_stop from proto to JSON
             let matched_stop = complete.matched_stop().map(|m| match m {
@@ -97,6 +99,9 @@ impl HarmonyResponseProcessor {
 
             let finish_reason = parsed.finish_reason;
 
+            // Accumulate reasoning tokens across all responses
+            total_reasoning_tokens += parsed.reasoning_token_count;
+
             choices.push(ChatChoice {
                 index: index as u32,
                 message,
@@ -108,7 +113,15 @@ impl HarmonyResponseProcessor {
         }
 
         // Build usage from proto fields
-        let usage = response_formatting::build_usage(&all_responses);
+        let mut usage = response_formatting::build_usage(&all_responses);
+
+        // Add reasoning token count from parsed analysis/commentary channels
+        if total_reasoning_tokens > 0 {
+            usage.completion_tokens_details =
+                Some(crate::protocols::common::CompletionTokensDetails {
+                    reasoning_tokens: Some(total_reasoning_tokens),
+                });
+        }
 
         // Final ChatCompletionResponse
         Ok(
@@ -233,7 +246,15 @@ impl HarmonyResponseProcessor {
         }
 
         // Build usage (needed for both ToolCallsFound and Completed)
-        let usage = response_formatting::build_usage(std::slice::from_ref(complete));
+        let mut usage = response_formatting::build_usage(std::slice::from_ref(complete));
+
+        // Add reasoning token count from parsed analysis/commentary channels
+        if parsed.reasoning_token_count > 0 {
+            usage.completion_tokens_details =
+                Some(crate::protocols::common::CompletionTokensDetails {
+                    reasoning_tokens: Some(parsed.reasoning_token_count),
+                });
+        }
 
         // Check for tool calls in commentary channel
         if let Some(tool_calls) = parsed.commentary {
@@ -288,7 +309,13 @@ impl HarmonyResponseProcessor {
                 output_tokens: usage.completion_tokens,
                 total_tokens: usage.total_tokens,
                 input_tokens_details: None,
-                output_tokens_details: None,
+                output_tokens_details: usage.completion_tokens_details.as_ref().and_then(|d| {
+                    d.reasoning_tokens.map(|tokens| {
+                        crate::protocols::responses::OutputTokensDetails {
+                            reasoning_tokens: tokens,
+                        }
+                    })
+                }),
             }))
             .build();
 

--- a/sgl-router/src/routers/grpc/harmony/responses.rs
+++ b/sgl-router/src/routers/grpc/harmony/responses.rs
@@ -48,10 +48,10 @@ use crate::{
     protocols::{
         common::{Function, ToolCall, ToolChoice, ToolChoiceValue, Usage},
         responses::{
-            McpToolInfo, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
-            ResponseOutputItem, ResponseReasoningContent, ResponseStatus, ResponseTool,
-            ResponseToolType, ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
-            StringOrContentParts,
+            McpToolInfo, OutputTokensDetails, ResponseContentPart, ResponseInput,
+            ResponseInputOutputItem, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
+            ResponseTool, ResponseToolType, ResponseUsage, ResponsesRequest, ResponsesResponse,
+            ResponsesUsage, StringOrContentParts,
         },
     },
     routers::grpc::{
@@ -1134,7 +1134,11 @@ fn build_tool_response(
             output_tokens: usage.completion_tokens,
             total_tokens: usage.total_tokens,
             input_tokens_details: None,
-            output_tokens_details: None,
+            output_tokens_details: usage.completion_tokens_details.as_ref().and_then(|d| {
+                d.reasoning_tokens.map(|tokens| OutputTokensDetails {
+                    reasoning_tokens: tokens,
+                })
+            }),
         }))
         .build()
 }

--- a/sgl-router/src/routers/grpc/harmony/streaming.rs
+++ b/sgl-router/src/routers/grpc/harmony/streaming.rs
@@ -669,6 +669,7 @@ impl HarmonyStreamingProcessor {
         let mut matched_stop: Option<serde_json::Value> = None;
         let mut prompt_tokens: u32 = 0;
         let mut completion_tokens: u32 = 0;
+        let mut reasoning_token_count: u32 = 0;
 
         // Process stream
         let mut chunk_count = 0;
@@ -870,8 +871,9 @@ impl HarmonyStreamingProcessor {
                         .finalize(finish_reason.clone(), matched_stop.clone())
                         .map_err(|e| format!("Finalize error: {}", e))?;
 
-                    // Store finalized tool calls
+                    // Store finalized tool calls and reasoning token count
                     accumulated_tool_calls = final_output.commentary.clone();
+                    reasoning_token_count = final_output.reasoning_token_count;
 
                     // Complete all tool calls if we have commentary
                     if let Some(ref tool_calls) = accumulated_tool_calls {
@@ -1072,7 +1074,13 @@ impl HarmonyStreamingProcessor {
                         prompt_tokens,
                         completion_tokens,
                         total_tokens: prompt_tokens + completion_tokens,
-                        completion_tokens_details: None,
+                        completion_tokens_details: if reasoning_token_count > 0 {
+                            Some(crate::protocols::common::CompletionTokensDetails {
+                                reasoning_tokens: Some(reasoning_token_count),
+                            })
+                        } else {
+                            None
+                        },
                     },
                     request_id: emitter.response_id.clone(),
                 });
@@ -1091,7 +1099,13 @@ impl HarmonyStreamingProcessor {
                         output_tokens: completion_tokens,
                         total_tokens: prompt_tokens + completion_tokens,
                         input_tokens_details: None,
-                        output_tokens_details: None,
+                        output_tokens_details: if reasoning_token_count > 0 {
+                            Some(crate::protocols::responses::OutputTokensDetails {
+                                reasoning_tokens: reasoning_token_count,
+                            })
+                        } else {
+                            None
+                        },
                     }))
                     .build(),
             ),
@@ -1099,7 +1113,13 @@ impl HarmonyStreamingProcessor {
                 prompt_tokens,
                 completion_tokens,
                 total_tokens: prompt_tokens + completion_tokens,
-                completion_tokens_details: None,
+                completion_tokens_details: if reasoning_token_count > 0 {
+                    Some(crate::protocols::common::CompletionTokensDetails {
+                        reasoning_tokens: Some(reasoning_token_count),
+                    })
+                } else {
+                    None
+                },
             },
         })
     }

--- a/sgl-router/src/routers/grpc/harmony/streaming.rs
+++ b/sgl-router/src/routers/grpc/harmony/streaming.rs
@@ -23,8 +23,10 @@ use crate::{
         chat::{
             ChatCompletionRequest, ChatCompletionStreamResponse, ChatMessageDelta, ChatStreamChoice,
         },
-        common::{FunctionCallDelta, ToolCall, ToolCallDelta, Usage},
-        responses::{ResponseStatus, ResponseUsage, ResponsesResponse, ResponsesUsage},
+        common::{CompletionTokensDetails, FunctionCallDelta, ToolCall, ToolCallDelta, Usage},
+        responses::{
+            OutputTokensDetails, ResponseStatus, ResponseUsage, ResponsesResponse, ResponsesUsage,
+        },
     },
     routers::grpc::{
         common::responses::streaming::{OutputItemType, ResponseStreamEventEmitter},
@@ -1075,7 +1077,7 @@ impl HarmonyStreamingProcessor {
                         completion_tokens,
                         total_tokens: prompt_tokens + completion_tokens,
                         completion_tokens_details: if reasoning_token_count > 0 {
-                            Some(crate::protocols::common::CompletionTokensDetails {
+                            Some(CompletionTokensDetails {
                                 reasoning_tokens: Some(reasoning_token_count),
                             })
                         } else {
@@ -1100,7 +1102,7 @@ impl HarmonyStreamingProcessor {
                         total_tokens: prompt_tokens + completion_tokens,
                         input_tokens_details: None,
                         output_tokens_details: if reasoning_token_count > 0 {
-                            Some(crate::protocols::responses::OutputTokensDetails {
+                            Some(OutputTokensDetails {
                                 reasoning_tokens: reasoning_token_count,
                             })
                         } else {
@@ -1114,7 +1116,7 @@ impl HarmonyStreamingProcessor {
                 completion_tokens,
                 total_tokens: prompt_tokens + completion_tokens,
                 completion_tokens_details: if reasoning_token_count > 0 {
-                    Some(crate::protocols::common::CompletionTokensDetails {
+                    Some(CompletionTokensDetails {
                         reasoning_tokens: Some(reasoning_token_count),
                     })
                 } else {

--- a/sgl-router/src/routers/grpc/harmony/types.rs
+++ b/sgl-router/src/routers/grpc/harmony/types.rs
@@ -100,6 +100,9 @@ pub struct HarmonyChannelOutput {
 
     /// Matched stop token (if any)
     pub matched_stop: Option<Value>,
+
+    /// Number of reasoning tokens (from analysis and commentary channels)
+    pub reasoning_token_count: u32,
 }
 
 /// Streaming delta for SSE responses


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR tries to support `reasoning_tokens` in `completion_tokens_details` in OpenAI API. 

It addresses the issue in two approaches:

1. Harmony - Addressed directly in router through counting in parsing

## Modifications

### Harmony models

- Incrementally counting tokens while channel is analysis or commentary

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

gpt-oss-120b + grpc router
<img width="1296" height="750" alt="Screenshot 2025-11-18 at 2 57 32 PM" src="https://github.com/user-attachments/assets/a3b3123c-214a-4318-a047-5819fbe95a5a" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
