### PR TITLE
[CI] Auto format code

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,71 @@
+name: Auto Format Code
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-format:
+    if: github.event.label.name == 'format'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install pre-commit hook
+        run: |
+          python -m pip install pre-commit
+          pre-commit install
+
+      - name: Run pre-commit to format code
+        run: SKIP=no-commit-to-branch pre-commit run --all-files
+        continue-on-error: true
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [[ -n $(git status -s) ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git commit -m "🤖 Auto-format code with isort, black, ruff, and clang-format"
+          git push
+
+      - name: Remove format label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'format'
+              });
+            } catch (error) {
+              console.log('Label may have already been removed');
+            }

--- a/python/sglang/global_config.py
+++ b/python/sglang/global_config.py
@@ -12,7 +12,7 @@ class GlobalConfig:
         # Verbosity level
         # 0: do not output anything
         # 2: output final text after every run
-        self.verbosity = 0
+        self.verbosity=0
 
         # Default backend of the language
         self.default_backend = None

--- a/python/sglang/global_config.py
+++ b/python/sglang/global_config.py
@@ -12,7 +12,7 @@ class GlobalConfig:
         # Verbosity level
         # 0: do not output anything
         # 2: output final text after every run
-        self.verbosity=0
+        self.verbosity = 0
 
         # Default backend of the language
         self.default_backend = None


### PR DESCRIPTION
I added an auto format feature. You just need to add the "format" label, and it will automatically format the code for the current pull request and remove "format" label when format is done. The result is as follows:

<img width="842" height="349" alt="图片" src="https://github.com/user-attachments/assets/6c33d395-2630-4c63-bf2f-fd75bf14c25b" />

<img width="1429" height="377" alt="图片" src="https://github.com/user-attachments/assets/bf30bfc6-379e-48cc-8f77-f83895bd2819" />
