### PR TITLE
[Router] use call_id instead of id for matching function calls in Responses API for Harmony

### DIFF
--- a/sgl-router/src/routers/grpc/harmony/builder.rs
+++ b/sgl-router/src/routers/grpc/harmony/builder.rs
@@ -603,11 +603,11 @@ impl HarmonyBuilder {
                     .iter()
                     .rev()
                     .find_map(|item| match item {
-                        ResponseInputOutputItem::FunctionToolCall { id, name, .. }
-                            if id == call_id =>
-                        {
-                            Some(name.clone())
-                        }
+                        ResponseInputOutputItem::FunctionToolCall {
+                            call_id: item_call_id,
+                            name,
+                            ..
+                        } if item_call_id == call_id => Some(name.clone()),
                         _ => None,
                     })
                     .ok_or_else(|| format!("No function call found for call_id: {}", call_id))?;

--- a/sgl-router/src/routers/grpc/harmony/responses.rs
+++ b/sgl-router/src/routers/grpc/harmony/responses.rs
@@ -1353,7 +1353,7 @@ fn build_next_request_with_tools(
             ..
         }) = items
             .iter_mut()
-            .find(|item| matches!(item, ResponseInputOutputItem::FunctionToolCall { id, .. } if id == &tool_result.call_id))
+            .find(|item| matches!(item, ResponseInputOutputItem::FunctionToolCall { call_id, .. } if call_id == &tool_result.call_id))
         {
             *output = Some(output_str);
             *status = if tool_result.is_error {


### PR DESCRIPTION
## Motivation

Fix function call matching logic in sgl-router's Responses API implementation to comply with OpenAI specification.

Currently, the router incorrectly uses the `id` field to match `function_call` and `function_call_output` items. According to OpenAI's Responses API spec, `function_call_output` only requires `call_id` field (where `id` is optional), and matching should be done via `call_id`.

Refer: https://platform.openai.com/docs/guides/function-calling

```python
for item in response.output:
    if item.type == "function_call":
        if item.name == "get_horoscope":
            # 3. Execute the function logic for get_horoscope
            horoscope = get_horoscope(json.loads(item.arguments))
            
            # 4. Provide function call results to the model
            input_list.append({
                "type": "function_call_output",
                "call_id": item.call_id,
                "output": json.dumps({
                  "horoscope": horoscope
                })
            })
```

## Modifications

- Updated matching logic in `src/routers/grpc/harmony/responses.rs` to use `call_id` instead of `id`
- Updated matching logic in `src/routers/grpc/harmony/builder.rs` to use `call_id` instead of `id`

## Accuracy Tests

1. Before this fix
<img width="1722" height="847" alt="image" src="https://github.com/user-attachments/assets/fea15f99-4088-49a5-abd5-0cb2c45ad7a8" />

2. After this fix
<img width="1541" height="937" alt="image" src="https://github.com/user-attachments/assets/f692fadc-d8d7-4296-a452-75f49553c0bd" />

3. Test with OpenAI
<img width="1450" height="1013" alt="image" src="https://github.com/user-attachments/assets/bffaccec-5509-4b0a-b6d5-22be6823bc2f" />


## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
