### PR TITLE
[PD] fix zmq port conflict

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -68,7 +68,7 @@ class CommonKVManager(BaseKVManager):
         )
         self.pp_size = server_args.pp_size
         self.pp_rank = self.kv_args.pp_rank
-        self.rank_port = get_free_port()
+        self.rank_port, self.temp_socket = get_free_port(return_socket=True)
         self.local_ip = get_local_ip_auto()
         self.server_socket = zmq.Context().socket(zmq.PULL)
         if is_valid_ipv6_address(self.local_ip):
@@ -93,6 +93,7 @@ class CommonKVManager(BaseKVManager):
             )
 
     def _bind_server_socket(self):
+        self.temp_socket.close()
         self.server_socket.bind(format_tcp_address(self.local_ip, self.rank_port))
 
     def _register_to_bootstrap(self):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -715,17 +715,30 @@ def is_port_available(port):
             return False
 
 
-def get_free_port():
+def get_free_port(return_socket=False):
     # try ipv4
     try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
-            return s.getsockname()[1]
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+
+        if return_socket:
+            return port, s
+        else:
+            s.close()
+            return port
+
     except OSError:
         # try ipv6
-        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
-            return s.getsockname()[1]
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+
+        if return_socket:
+            return port, s
+        else:
+            s.close()
+            return port
 
 
 def decode_video_base64(video_base64):


### PR DESCRIPTION
## Motivation

When Prefill TP >2 or Decode TP >2, the following issue is almost certain to occur:
```
zmq.error.ZMQError: Address already in use
```
Testing with the code below reveals that `get_free_port` frequently returns duplicate ports. 
```
from sglang.srt.utils import get_free_port
def analyze_port_reuse(num_calls=100):
    ports = []
    for i in range(num_calls):
        port = get_free_port()
        ports.append(port)
    unique_ports = set(ports)
    total_calls = len(ports)
    unique_count = len(unique_ports)
    duplicate_count = total_calls - unique_count
    duplicate_ratio = duplicate_count / total_calls
    print("\n" + "="*50)
    print("Results:")
    print(f"Total calls: {total_calls}")
    print(f"Unique ports: {unique_count}")
    print(f"Duplicate occurrences: {duplicate_count}")
    print(f"Duplicate ratio: {duplicate_ratio:.4f} ({duplicate_ratio*100:.2f}%)")
    if duplicate_count > 0:
        port_count = {}
        for port in ports:
            port_count[port] = port_count.get(port, 0) + 1
        sorted_ports = sorted(port_count.items(), key=lambda x: x[1], reverse=True)
        print(f"\nMost common ports (top 3):")
        for port, count in sorted_ports[:3]:
            print(f"  Port {port}: {count} times ({count/total_calls*100:.2f}%)")
if __name__ == "__main__":
    analyze_port_reuse(100)
```
The result is as follows
```
Results:
Total calls: 100
Unique ports: 46
Duplicate occurrences: 54
Duplicate ratio: 0.5400 (54.00%)

Most common ports (top 3):
  Port 10049: 51 times (51.00%)
  Port 32781: 5 times (5.00%)
  Port 13951: 1 times (1.00%)
```
This is related to the system configuration `tcp_tw_reuse=2`, which enables the `TIME_WAIT` reuse.

## Modifications

Add a `temp_socket` variable to temporarily occupy the port, and close it before using ZMQ.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [X] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [X] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
