### PR TITLE
fix: B200 uses E8M0 weight scale correctly for inference.

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -38,7 +38,6 @@ from sglang.srt.distributed import get_tensor_model_parallel_world_size, get_tp_
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
-from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.amx_utils import _amx_process_weight_after_loading
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
@@ -49,6 +48,7 @@ from sglang.srt.layers.parameter import (
     ModelWeightParameter,
     PerTensorScaleParameter,
 )
+from sglang.srt.layers.quantization import deep_gemm_wrapper
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
     LinearMethodBase,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -67,6 +67,8 @@ from sglang.srt.layers.quantization.fp8_utils import (
     dispatch_w8a8_block_fp8_linear,
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
+    deepgemm_scale_ue8m0_supported,
+    requant_weight_ue8m0_inplace,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
@@ -367,7 +369,10 @@ class Fp8LinearMethod(LinearMethodBase):
                 )
                 return
             else:
+                if deepgemm_scale_ue8m0_supported():
+                    requant_weight_ue8m0_inplace(layer.weight, layer.weight_scale_inv, self.quant_config.weight_block_size)
                 weight, weight_scale = layer.weight.data, layer.weight_scale_inv.data
+
             layer.weight.data = weight.data
             layer.weight_scale_inv.data = weight_scale.data
         else:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -64,10 +64,10 @@ from sglang.srt.layers.quantization.fp8_utils import (
     apply_fp8_linear,
     can_auto_enable_marlin_fp8,
     cutlass_fp8_supported,
+    deepgemm_scale_ue8m0_supported,
     dispatch_w8a8_block_fp8_linear,
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
-    deepgemm_scale_ue8m0_supported,
     requant_weight_ue8m0_inplace,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -370,7 +370,11 @@ class Fp8LinearMethod(LinearMethodBase):
                 return
             else:
                 if deepgemm_scale_ue8m0_supported():
-                    requant_weight_ue8m0_inplace(layer.weight, layer.weight_scale_inv, self.quant_config.weight_block_size)
+                    requant_weight_ue8m0_inplace(
+                        layer.weight,
+                        layer.weight_scale_inv,
+                        self.quant_config.weight_block_size,
+                    )
                 weight, weight_scale = layer.weight.data, layer.weight_scale_inv.data
 
             layer.weight.data = weight.data

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -89,13 +89,6 @@ def cutlass_fp8_supported():
     return False
 
 
-def deepgemm_scale_ue8m0_supported():
-    # In BLACKWELL DeepGEMM, the scale must be e8m0
-    if deep_gemm_wrapper.DEEPGEMM_BLACKWELL:
-        return True
-    return False
-
-
 def normalize_e4m3fn_to_e4m3fnuz(
     weight: torch.Tensor,
     weight_scale: torch.Tensor,

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -89,6 +89,13 @@ def cutlass_fp8_supported():
     return False
 
 
+def deepgemm_scale_ue8m0_supported():
+    # In BLACKWELL DeepGEMM, the scale must be e8m0
+    if deep_gemm_wrapper.DEEPGEMM_BLACKWELL:
+        return True
+    return False
+
+
 def normalize_e4m3fn_to_e4m3fnuz(
     weight: torch.Tensor,
     weight_scale: torch.Tensor,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3302,14 +3302,6 @@ class DeepseekV2ForCausalLM(nn.Module):
                 self_attn.w_vc = bind_or_assign(self_attn.w_vc, w_vc.contiguous())
                 self_attn.use_deep_gemm_bmm = True
 
-        if (
-            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-            and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
-            and hasattr(self.quant_config, "weight_block_size")
-            and self.quant_config.weight_block_size is not None
-        ):
-            self._weight_requant_ue8m0(is_nextn)
-
         # TODO can move weight_requant_ue8m0 and transform_scale_ue8m0 into Fp8LinearMethod.process_weights_after_loading
         if (
             deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM

--- a/python/sglang/test/test_block_fp8_deep_gemm_blackwell.py
+++ b/python/sglang/test/test_block_fp8_deep_gemm_blackwell.py
@@ -222,7 +222,7 @@ class TestDeepGemmBlackwell(CustomTestCase):
 
         with torch.inference_mode():
             ref_out = native_w8a8_block_fp8_matmul(
-                A_q, B_q, A_s, B_s, block_size, out_dtype
+                A_qu[0], B_qu[0], A_qu[1], B_qu[1], block_size, out_dtype
             )
             out = torch.empty_like(ref_out)
             fp8_gemm_nt(A_qu, B_qu, out)


### PR DESCRIPTION
## Motivation
Reason for this feature: DeepGEMM in blackwell arc can't use fp32 scale because it will cause nan. Only can use E8M0 scale.

Why cause this issue: 
Becase in DeepGEMM blackwell implementation code `smxx_layout.cuh`:
```
    // Pack and store
    uint32_t packed = 0;
    packed |= (values[0] >> 23u);
    packed |= (values[1] >> 15u);
    packed |= (values[2] >>  7u);
    packed |= (values[3] <<  1u);
```
These code will cause problem when the scale values are not round to E8M0.


## Modifications
1. Add requant_weight_ue8m0_inplace in process_weights_after_loading method to requantize the weight and scale. 
2. Fix the test_block_fp8_deep_gemm_blackwell test case scale for test correct

## Accuracy Tests
**prompt**

before
<img width="1558" height="188" alt="image" src="https://github.com/user-attachments/assets/a3d4dcce-34f6-428f-8717-cd999bc487bc" />
after 
<img width="1554" height="278" alt="image" src="https://github.com/user-attachments/assets/4746b25a-3cb3-4aca-8e30-a355211a9ea9" />

**testcase**
before
<img width="1536" height="1162" alt="image" src="https://github.com/user-attachments/assets/f7faa3e9-497d-48db-8091-50f47d3e35d9" />
after
<img width="1554" height="220" alt="image" src="https://github.com/user-attachments/assets/525225b7-1656-4ec9-a6f2-0d1bed80e8ec" />


**benchmark/gsm8k/bench_sglang.py**
before
<img width="1424" height="462" alt="image" src="https://github.com/user-attachments/assets/058f756a-ae90-4dfe-9685-ef9f4c06c30b" />
after
<img width="1280" height="433" alt="image" src="https://github.com/user-attachments/assets/6591ed75-7549-41d9-8e96-f06eb77da4d9" />

