### PR TITLE
Support `file://` scheme in `load_video`

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -69,6 +69,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from urllib.parse import urlparse
 
 import numpy as np
 import orjson
@@ -945,7 +946,8 @@ def load_video(video_file: Union[str, bytes], use_gpu: bool = True):
                 tmp_file.write(video_bytes)
                 tmp_file.close()
                 vr = VideoReader(tmp_file.name, ctx=ctx)
-            elif os.path.isfile(video_file):
+            # `urlparse` supports file:// paths, and so does VideoReader
+            elif os.path.isfile(urlparse(video_file).path):
                 vr = VideoReader(video_file, ctx=ctx)
             else:
                 video_bytes = pybase64.b64decode(video_file, validate=True)


### PR DESCRIPTION
`decord.VideoReader` (which [uses ffmpeg `avformat_open_input`](https://github.com/dmlc/decord/blob/master/src/video/video_reader.cc#L74)) supports `file://` schemes.
[VLMEvalKit](https://github.com/open-compass/VLMEvalKit)'s VideoMME benchmark sends `file://` scheme video links by default.
This pr allows for file schemes (and other schemes) to pass through to `VideoReader`.

```python
from decord import VideoReader
bare = "/home/nhaber/Downloads/sample-5s.mp4"
file_scheme = "file:///home/nhaber/Downloads/sample-5s.mp4"
np.array_equal(VideoReader(bare)[0].asnumpy(), VideoReader(file_scheme)[0].asnumpy()) # True
```

```python
from urllib.parse import urlparse
import os

uri = "file:///home/scratch/lmms-lab--Video-MME/snapshots/video/fFjv93ACGo8.mp4"
print(urlparse(uri).path) # '/home/scratch/lmms-lab--Video-MME/snapshots/video/fFjv93ACGo8.mp4'
```