### PR TITLE
Fix fused_set_kv_buffer_arg is not supported for native implementation

### DIFF
--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -548,8 +548,7 @@ class BailingMoEAttention(nn.Module):
             v,
             forward_batch,
             save_kv_cache=not (
-                enable_fused_set_kv_buffer(forward_batch)
-                and not get_is_capture_mode()
+                enable_fused_set_kv_buffer(forward_batch) and not get_is_capture_mode()
             ),
         )
         attn_output, _ = self.dense(context_layer)

--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -538,6 +538,7 @@ class BailingMoEAttention(nn.Module):
                     forward_batch=forward_batch,
                 )
                 if enable_fused_set_kv_buffer(forward_batch)
+                and not get_is_capture_mode()
                 else None
             ),
         )
@@ -546,7 +547,10 @@ class BailingMoEAttention(nn.Module):
             k,
             v,
             forward_batch,
-            save_kv_cache=not enable_fused_set_kv_buffer(forward_batch),
+            save_kv_cache=not (
+                enable_fused_set_kv_buffer(forward_batch)
+                and not get_is_capture_mode()
+            ),
         )
         attn_output, _ = self.dense(context_layer)
         return attn_output

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -63,6 +63,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.utils import (
@@ -326,8 +327,7 @@ class GptOssAttention(nn.Module):
             *inner_state,
             sinks=self.sinks,
             save_kv_cache=not (
-                enable_fused_set_kv_buffer(forward_batch)
-                and not get_is_capture_mode()
+                enable_fused_set_kv_buffer(forward_batch) and not get_is_capture_mode()
             ),
         )
         output, _ = self.o_proj(attn_output)

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -311,6 +311,7 @@ class GptOssAttention(nn.Module):
                     forward_batch=forward_batch,
                 )
                 if enable_fused_set_kv_buffer(forward_batch)
+                and not get_is_capture_mode()
                 else None
             ),
         )
@@ -324,7 +325,10 @@ class GptOssAttention(nn.Module):
         attn_output = self.attn(
             *inner_state,
             sinks=self.sinks,
-            save_kv_cache=not enable_fused_set_kv_buffer(forward_batch),
+            save_kv_cache=not (
+                enable_fused_set_kv_buffer(forward_batch)
+                and not get_is_capture_mode()
+            ),
         )
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -413,6 +413,7 @@ class Qwen3MoeAttention(nn.Module):
                 )
                 if enable_fused_set_kv_buffer(forward_batch)
                 and self.compatible_with_fused_kv_buffer
+                and not get_is_capture_mode()
                 else None
             ),
         )
@@ -428,6 +429,7 @@ class Qwen3MoeAttention(nn.Module):
             save_kv_cache=not (
                 enable_fused_set_kv_buffer(forward_batch)
                 and self.compatible_with_fused_kv_buffer
+                and not get_is_capture_mode()
             ),
         )
         output, _ = self.o_proj(attn_output)


### PR DESCRIPTION
When in torch compile capture mode, fused_set_kv_buffer_arg should be None for forward_native

[ TP0 scheduler.py:2885]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/qwen3_moe.py", line 405, in forward_prepare^M
[ TP0 scheduler.py:2885]     q, k = self.rotary_emb(^M
[ TP0 scheduler.py:2885]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl^M
[ TP0 scheduler.py:2885]     return self._call_impl(*args, **kwargs)^M
[ TP0 scheduler.py:2885]   File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl^M
[ TP0 scheduler.py:2885]     return forward_call(*args, **kwargs)^M
[ TP0 scheduler.py:2885]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/custom_op.py", line 67, in forward^M
[ TP0 scheduler.py:2885]     return self._forward_method(*args, **kwargs)^M
[ TP0 scheduler.py:2885]   File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/rotary_embedding.py", line 179, in forward_native^M
[ TP0 scheduler.py:2885]     fused_set_kv_buffer_arg is None^M
[ TP0 scheduler.py:2885] AssertionError: fused_set_kv_buffer_arg is not supported for native implementation^M

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
