### PR TITLE
Fix fused_set_kv_buffer_arg is not supported for native implementation

### DIFF
--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -15,6 +15,7 @@
 import torch
 
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_cuda
 
@@ -31,6 +32,7 @@ def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
         _is_cuda
         and hasattr(forward_batch.token_to_kv_pool, "dtype")
         and forward_batch.token_to_kv_pool.dtype == torch.bfloat16
+        and not get_is_capture_mode
     )
 
 


### PR DESCRIPTION
When in torch compile capture mode, fused_set_kv_buffer_arg should be None for forward_native

[ TP0 scheduler.py:2885] File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/qwen3_moe.py", line 405, in forward_prepare^M 
[ TP0 scheduler.py:2885] q, k = self.rotary_emb(^M 
[ TP0 scheduler.py:2885] File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl^M 
[ TP0 scheduler.py:2885] return self._call_impl(*args, **kwargs)^M 
[ TP0 scheduler.py:2885] File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl^M 
[ TP0 scheduler.py:2885] return forward_call(*args, **kwargs)^M 
[ TP0 scheduler.py:2885] File "/opt/conda/lib/python3.10/site-packages/sglang/srt/custom_op.py", line 67, in forward^M 
[ TP0 scheduler.py:2885] return self._forward_method(*args, **kwargs)^M 
[ TP0 scheduler.py:2885] File "/opt/conda/lib/python3.10/site-packages/sglang/srt/layers/rotary_embedding.py", line 179, in forward_native^M 
[ TP0 scheduler.py:2885] fused_set_kv_buffer_arg is None^M 
[ TP0 scheduler.py:2885] AssertionError: fused_set_kv_buffer_arg is not supported for native implementation^M

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
