### PR TITLE
[BugFix] fix launching failed when `--enable-two-batch-overlap`

### DIFF
--- a/python/sglang/srt/operations.py
+++ b/python/sglang/srt/operations.py
@@ -85,7 +85,10 @@ class _StageExecutor:
         self._global_dp_buffer_len = forward_batch.global_dp_buffer_len
         self._local_dp_buffer_len = forward_batch.input_ids.shape[0]
         self._global_num_tokens = forward_batch.global_num_tokens_cpu
-        self._is_dp_max_padding = forward_batch.dp_padding_mode.is_max_len()
+        if forward_batch.dp_padding_mode is not None:
+            self._is_dp_max_padding = forward_batch.dp_padding_mode.is_max_len()
+        else:
+            self._is_dp_max_padding = False
 
     def next(self):
         assert not self.done


### PR DESCRIPTION
## Motivation


```shell
export MODEL_PATH=/deepseek-r1-fp8
export MC_TE_METRIC=true 
export SGLANG_TBO_DEBUG=1 
export DP_SIZE=8 

python -m sglang.launch_server \
    --model-path $MODEL_PATH \
    --disaggregation-ib-device mlx5_4,mlx5_7,mlx5_8,mlx5_9,mlx5_10,mlx5_11,mlx5_12,mlx5_13 \
    --disaggregation-mode prefill \
    --dist-init-addr $PREFILL_IP:5757 \
    --nnodes 1 \
    --node-rank 0\
    --tp-size ${DP_SIZE} \
    --dp-size ${DP_SIZE} \
    --enable-dp-attention \
    --decode-log-interval 1 \
    --moe-a2a-backend deepep \
    --page-size 1 \
    --host 0.0.0.0 \
    --port 8000 \
    --trust-remote-code \
    --moe-dense-tp-size 1 \
    --enable-dp-lm-head \
    --load-balance-method round_robin \
    --watchdog-timeout 1000000 \
    --enable-two-batch-overlap \
    --deepep-mode normal \
    --mem-fraction-static 0.85 \
    --chunked-prefill-size $((1024 * 16 * DP_SIZE)) \
    --max-running-requests 2048 \
    --max-total-tokens 131072 \
    --context-length 8192 \
    --ep-num-redundant-experts 32 \
    --ep-dispatch-algorithm dynamic \
    --eplb-algorithm deepseek \
    --moe-a2a-backend deepep \
    --enable-metrics \
    --enable-cache-report \
    --collect-tokens-histogram
```

When starting the PREFILL node of deepseek-r1 using the PD separation method with the above parameters, the following error will occur. The reason is that the command-line parameter `--enable-two-batch-overlap` causes `prepare_mlp_sync_batch` to not be called to initialize the `forward_batch.dp_padding_mode` field. 


```text
[2025-11-11 13:30:46 DP2 TP2 EP2] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2872, in run_scheduler_process
    scheduler.event_loop_overlap_disagg_prefill()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/disaggregation/prefill.py", line 372, in event_loop_overlap_disagg_prefill
    batch_result = self.run_batch(batch)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2028, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 371, in forward_batch_generation
    logits_output, can_run_cuda_graph = self.model_runner.forward(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2147, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2210, in _forward_raw
    ret = self.forward_idle(forward_batch, pp_proxy_tensors=pp_proxy_tensors)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2105, in forward_idle
    return self.model.forward(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 3101, in forward
    hidden_states = self.model(
                    ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 2968, in forward
    hidden_states, residual = model_forward_maybe_tbo(
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 815, in model_forward_maybe_tbo
    return _model_forward_tbo(
           ^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/two_batch_overlap.py", line 847, in _model_forward_tbo
    outputs_arr = execute_overlapped_operations(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/operations.py", line 44, in execute_overlapped_operations
    executor_a = _StageExecutor("a", stages_a, inputs=inputs_a)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/operations.py", line 88, in __init__
    self._is_dp_max_padding = forward_batch.dp_padding_mode.is_max_len()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_max_len'
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
