### PR TITLE
feat(engine): add rid parameter to methods in Engine class

### DIFF
--- a/python/sglang/srt/entrypoints/EngineBase.py
+++ b/python/sglang/srt/entrypoints/EngineBase.py
@@ -29,6 +29,7 @@ class EngineBase(ABC):
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
+        rid: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """Generate outputs based on given inputs."""
         pass

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -184,6 +184,7 @@ class Engine(EngineBase):
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
+        rid: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -218,6 +219,7 @@ class Engine(EngineBase):
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
             data_parallel_rank=data_parallel_rank,
+            rid=rid,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 
@@ -264,6 +266,7 @@ class Engine(EngineBase):
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
+        rid: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -300,6 +303,7 @@ class Engine(EngineBase):
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
             data_parallel_rank=data_parallel_rank,
+            rid=rid,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
 
@@ -315,6 +319,7 @@ class Engine(EngineBase):
         audio_data: Optional[MultimodalDataInputFormat] = None,
         video_data: Optional[MultimodalDataInputFormat] = None,
         dimensions: Optional[int] = None,
+        rid: Optional[Union[List[str], str]] = None,
     ) -> Dict:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::EmbeddingReqInput`.
@@ -326,6 +331,7 @@ class Engine(EngineBase):
             audio_data=audio_data,
             video_data=video_data,
             dimensions=dimensions,
+            rid=rid,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
         ret = self.loop.run_until_complete(generator.__anext__())
@@ -338,6 +344,7 @@ class Engine(EngineBase):
         audio_data: Optional[MultimodalDataInputFormat] = None,
         video_data: Optional[MultimodalDataInputFormat] = None,
         dimensions: Optional[int] = None,
+        rid: Optional[Union[List[str], str]] = None,
     ) -> Dict:
         """
         Asynchronous version of encode method.
@@ -351,6 +358,7 @@ class Engine(EngineBase):
             audio_data=audio_data,
             video_data=video_data,
             dimensions=dimensions,
+            rid=rid,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
         return await generator.__anext__()

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -108,6 +108,13 @@ class HttpServerEngineAdapter(EngineBase):
         token_ids_logprob=None,
         lora_path=None,
         custom_logit_processor=None,
+        return_hidden_states=None,
+        stream=None,
+        bootstrap_host=None,
+        bootstrap_port=None,
+        bootstrap_room=None,
+        data_parallel_rank=None,
+        rid=None,
     ):
         payload = {
             "text": prompt,
@@ -120,6 +127,13 @@ class HttpServerEngineAdapter(EngineBase):
             "token_ids_logprob": token_ids_logprob,
             "lora_path": lora_path,
             "custom_logit_processor": custom_logit_processor,
+            "return_hidden_states": return_hidden_states,
+            "stream": stream,
+            "bootstrap_host": bootstrap_host,
+            "bootstrap_port": bootstrap_port,
+            "bootstrap_room": bootstrap_room,
+            "data_parallel_rank": data_parallel_rank,
+            "rid": rid,
         }
         # Filter out None values
         payload = {k: v for k, v in payload.items() if v is not None}

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -108,13 +108,6 @@ class HttpServerEngineAdapter(EngineBase):
         token_ids_logprob=None,
         lora_path=None,
         custom_logit_processor=None,
-        return_hidden_states=None,
-        stream=None,
-        bootstrap_host=None,
-        bootstrap_port=None,
-        bootstrap_room=None,
-        data_parallel_rank=None,
-        rid=None,
     ):
         payload = {
             "text": prompt,
@@ -127,13 +120,6 @@ class HttpServerEngineAdapter(EngineBase):
             "token_ids_logprob": token_ids_logprob,
             "lora_path": lora_path,
             "custom_logit_processor": custom_logit_processor,
-            "return_hidden_states": return_hidden_states,
-            "stream": stream,
-            "bootstrap_host": bootstrap_host,
-            "bootstrap_port": bootstrap_port,
-            "bootstrap_room": bootstrap_room,
-            "data_parallel_rank": data_parallel_rank,
-            "rid": rid,
         }
         # Filter out None values
         payload = {k: v for k, v in payload.items() if v is not None}


### PR DESCRIPTION
This is useful when you are using the `sgl.Engine` API with your own frontend/orchestration framework

<img width="1696" height="521" alt="Screenshot 2025-11-11 at 2 01 38 PM" src="https://github.com/user-attachments/assets/fcad60a7-4073-4c6c-b4f2-5fe5f4a6a409" />

Can use a straight forward script to test these changes

```python
import sglang as sgl
import time

if __name__ == '__main__':
  # Initialize engine with tracing
  engine = sgl.Engine(
      model_path="Qwen/Qwen3-0.6B",
      enable_trace=True,
      otlp_traces_endpoint="localhost:4317",
  )

  print("Engine started. Generating requests every 5 seconds...")
  print("View traces at: http://localhost:16686\n")

  # Generate requests with custom rids every 5 seconds
  counter = 0
  while True:
      counter += 1
      custom_rid = f"test-request-{counter}-{int(time.time())}"

      print(f"[{counter}] Sending request with rid: {custom_rid}")

      result = engine.generate(
          prompt="Count to 5",
          sampling_params={"temperature": 0.0, "max_new_tokens": 20},
          rid=custom_rid
      )

      print(f"    Result: {result['text'][:50]}...")
      print(f"    ✅ Trace ID: {custom_rid}\n")

      time.sleep(5)
```