### PR TITLE
Refactor mm_utils to make it more general-purpose.

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -673,7 +673,9 @@ def general_mm_embed_routine(
             # just being defensive here
             forward_batch.mm_inputs = None
         else:
-            inputs_embeds = None
+            inputs_embeds = embed_tokens(input_ids)
+    else:
+        inputs_embeds = None
 
     if skip_llm_forward:
         return inputs_embeds

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -494,6 +494,7 @@ def get_embedding_and_mask(
 
 
 def embed_mm_inputs(
+    forward_batch: ForwardBatch,
     mm_inputs_list: List[MultimodalInputs],
     extend_prefix_lens: List[int],
     extend_seq_lens: List[int],
@@ -503,8 +504,6 @@ def embed_mm_inputs(
     data_embedding_func_mapping: Dict[
         Modality, Callable[[List[MultimodalDataItem]], torch.Tensor]
     ] = None,
-    placeholder_tokens: dict[Modality, List[int]] = None,
-    use_deepstack: Dict[Modality, bool] = {},
 ) -> Optional[torch.Tensor]:
     """
     Embed multimodal inputs and integrate them with text token embeddings.
@@ -515,12 +514,10 @@ def embed_mm_inputs(
         extend_seq_lens: Sequence lengths for each request
         input_ids: Input token IDs tensor
         input_embedding: Embedding layer for text tokens
-        placeholder_tokens: Token IDs for multimodal placeholders (uses pad_values if None)
 
     Returns:
         Combined embedding tensor with multimodal content integrated
     """
-    other_info = {}
     if mm_inputs_list is None:
         return None
 
@@ -530,8 +527,7 @@ def embed_mm_inputs(
     for mm_inputs in mm_inputs_list:
         item_flatten_list += [item for item in mm_inputs.mm_items if item is not None]
 
-    # deepstack_embeddings: per-modality
-    modalities, embeddings, masks, deepstack_embeddings = [], [], [], []
+    modalities, embeddings, masks = [], [], []
 
     # 2. Get multimodal embedding separately
     # Try get mm embedding if any
@@ -580,11 +576,6 @@ def embed_mm_inputs(
                 items_offset_list=items_offsets,
             )
 
-            if use_deepstack.get(modality, None) and embedding is not None:
-                embedding, deepstack_embedding = (
-                    multimodal_model.separate_deepstack_embeds(embedding)
-                )
-                deepstack_embeddings += [deepstack_embedding]
             modalities += [modality]
             embeddings += [embedding]
             masks += [mask]
@@ -598,21 +589,9 @@ def embed_mm_inputs(
     input_ids.clamp_(min=0, max=vocab_size - 1)
     inputs_embeds = input_embedding(input_ids)
 
-    # deepstack embedding
-    if use_deepstack:
-        num_deepstack_embeddings = len(multimodal_model.deepstack_visual_indexes)
-
-        deepstack_embedding_shape = inputs_embeds.shape[:-1] + (
-            inputs_embeds.shape[-1] * num_deepstack_embeddings,
-        )
-        # a zero-filled embedding, with the same length of inputs_embeds, but different hidden_size
-        input_deepstack_embeds = torch.zeros(
-            deepstack_embedding_shape,
-            device=inputs_embeds.device,
-            dtype=inputs_embeds.dtype,
-        )
-
-        other_info["input_deepstack_embeds"] = input_deepstack_embeds
+    # only for qwen3vl right now,  replace the original use_deepstack with this method.
+    if hasattr(multimodal_model, "post_process"):
+        embeddings = multimodal_model.post_process(inputs_embeds, modalities, embeddings, masks, forward_batch)
 
     # 4. scatter embeddings into input embedding
     for i, modality, embedding, mask in zip(
@@ -623,12 +602,8 @@ def embed_mm_inputs(
         # in-place update
         indices = torch.where(mask.squeeze(dim=-1))[0]
         inputs_embeds[indices] = embedding.to(inputs_embeds.device, inputs_embeds.dtype)
-        if use_deepstack.get(modality, None):
-            input_deepstack_embeds[indices] = deepstack_embeddings[i].to(
-                inputs_embeds.device, inputs_embeds.dtype
-            )
 
-    return inputs_embeds, other_info
+    return inputs_embeds
 
 
 def general_mm_embed_routine(
@@ -639,8 +614,7 @@ def general_mm_embed_routine(
     data_embedding_funcs: Dict[
         Modality, Callable[[List[MultimodalDataItem]], torch.Tensor]
     ] = None,
-    placeholder_tokens: Optional[dict[Modality, List[int]]] = None,
-    use_deepstack: Dict[Modality, bool] = {},
+    skip_llm_forward: bool = False,
     **kwargs,
 ) -> torch.Tensor:
     """
@@ -651,8 +625,6 @@ def general_mm_embed_routine(
         forward_batch: Batch information for model forward pass
         language_model: Base language model to use
         data_embedding_funcs: A dictionary mapping from modality type to the corresponding embedding function.
-        placeholder_tokens: Token IDs for multimodal placeholders
-        use_deepstack: Whether to use deepstack embeddings for each modality, default False
         **kwargs: Additional arguments passed to language model
 
     Returns:
@@ -679,7 +651,8 @@ def general_mm_embed_routine(
                 for i, seq_len in enumerate(forward_batch.extend_seq_lens_cpu)
                 if forward_batch.mm_inputs[i] is not None
             ]
-            inputs_embeds, other_info = embed_mm_inputs(
+            inputs_embeds = embed_mm_inputs(
+                forward_batch=forward_batch,
                 mm_inputs_list=mm_inputs_list,
                 extend_prefix_lens=extend_prefix_lens,
                 extend_seq_lens=extend_seq_lens,
@@ -687,19 +660,15 @@ def general_mm_embed_routine(
                 multimodal_model=multimodal_model,
                 input_embedding=embed_tokens,
                 data_embedding_func_mapping=data_embedding_funcs,
-                placeholder_tokens=placeholder_tokens,
-                use_deepstack=use_deepstack,
             )
-            # add for qwen3_vl deepstack
-            if use_deepstack:
-                kwargs["input_deepstack_embeds"] = other_info["input_deepstack_embeds"]
             # once used, mm_inputs is useless, considering chunked-prefill is disabled for multimodal models
             # just being defensive here
             forward_batch.mm_inputs = None
         else:
-            inputs_embeds = embed_tokens(input_ids)
-    else:
-        inputs_embeds = None
+            inputs_embeds = None
+
+    if skip_llm_forward:
+        return inputs_embeds
 
     hidden_states = language_model(
         input_ids=None,

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -591,7 +591,9 @@ def embed_mm_inputs(
 
     # only for qwen3vl right now,  replace the original use_deepstack with this method.
     if hasattr(multimodal_model, "post_process"):
-        embeddings = multimodal_model.post_process(inputs_embeds, modalities, embeddings, masks, forward_batch)
+        embeddings = multimodal_model.post_process(
+            inputs_embeds, modalities, embeddings, masks, forward_batch
+        )
 
     # 4. scatter embeddings into input embedding
     for i, modality, embedding, mask in zip(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -324,6 +324,9 @@ class ForwardBatch:
     # For Qwen2-VL
     mrope_positions: torch.Tensor = None
 
+    # For Qwen3-VL
+    input_deepstack_embeds: Optional[torch.Tensor] = None
+
     # For two-batch overlap
     tbo_split_seq_index: Optional[int] = None
     tbo_parent_token_range: Optional[Tuple[int, int]] = None

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -689,10 +689,11 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         video_embeds = self.visual(pixel_values, grid_thw=video_grid_thw)
         return video_embeds
 
-    def post_process(self,
-        inputs_embeds, 
-        modalities: List[Modality], 
-        embeddings: List[torch.Tensor], 
+    def post_process(
+        self,
+        inputs_embeds,
+        modalities: List[Modality],
+        embeddings: List[torch.Tensor],
         masks: List[torch.Tensor],
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
@@ -702,7 +703,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             range(len(embeddings)), modalities, embeddings, masks
         ):
             if self.use_deepstack.get(modality, False):
-                embedding, deepstack_embedding = self.separate_deepstack_embeds(embedding)
+                embedding, deepstack_embedding = self.separate_deepstack_embeds(
+                    embedding
+                )
                 new_embeddings += [embedding]
                 deepstack_embeddings += [deepstack_embedding]
             else:
@@ -719,7 +722,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         )
         for i, modality, embedding, mask in zip(
             range(len(embeddings)), modalities, embeddings, masks
-        ):  
+        ):
             if mask is None:
                 continue
             indices = torch.where(mask.squeeze(dim=-1))[0]
@@ -727,7 +730,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 input_deepstack_embeds[indices] = deepstack_embeddings[i].to(
                     inputs_embeds.device, inputs_embeds.dtype
                 )
-                
+
         forward_batch.input_deepstack_embeds = input_deepstack_embeds
         return new_embeddings
 

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -697,6 +697,8 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         indices: List[torch.Tensor],
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
+        if not self.use_deepstack:
+            return embeddings
         deepstack_embeddings = []
         new_embeddings = []
 

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -694,7 +694,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         inputs_embeds,
         modalities: List[Modality],
         embeddings: List[torch.Tensor],
-        masks: List[torch.Tensor],
+        indices: List[torch.Tensor],
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         deepstack_embeddings = []
@@ -710,18 +710,17 @@ class Qwen3VLForConditionalGeneration(nn.Module):
             dtype=inputs_embeds.dtype,
         )
 
-        for i, (modality, embedding, mask) in enumerate(
-            zip(modalities, embeddings, masks)
+        for i, (modality, embedding, index) in enumerate(
+            zip(modalities, embeddings, indices)
         ):
-            if embedding is None or mask is None:
+            if embedding is None or index is None:
                 continue
             if self.use_deepstack.get(modality, False):
                 embedding, deepstack_embedding = self.separate_deepstack_embeds(
                     embedding
                 )
-                if mask is not None:
-                    indices = torch.where(mask.squeeze(dim=-1))[0]
-                    input_deepstack_embeds[indices] = deepstack_embedding.to(
+                if index is not None:
+                    input_deepstack_embeds[index] = deepstack_embedding.to(
                         inputs_embeds.device, inputs_embeds.dtype
                     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Removed the deepstack logic from mm_utils and refactored qwen3vl.

Preparing for multimodal piecewise CUDA graph.

acc test:

main: 
<img width="3260" height="584" alt="image" src="https://github.com/user-attachments/assets/87ba9260-46fd-4d27-a1fe-f2d0bd86a215" />

this pr:
<img width="3244" height="548" alt="image" src="https://github.com/user-attachments/assets/77a7b948-4863-4d17-a718-374b3a4e7c25" />

speed test
```
python -m sglang.bench_serving \
    --backend sglang-oai-chat \
    --dataset-name image \
    --num-prompts 96 \
    --image-count 3 \
    --image-resolution 1080p \
    --random-input-len 512 \
    --random-output-len 512 \
    --max-concurrency 16
```
main: 
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     96
Benchmark duration (s):                  81.09
Total input tokens:                      615580
Total input text tokens:                 27484
Total input vision tokens:               588096
Total generated tokens:                  25821
Total generated tokens (retokenized):    16275
Request throughput (req/s):              1.18
Input token throughput (tok/s):          7591.67
Output token throughput (tok/s):         318.44
Total token throughput (tok/s):          7910.11
Concurrency:                             15.63
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   13199.61
Median E2E Latency (ms):                 12783.86
---------------Time to First Token----------------
Mean TTFT (ms):                          3370.49
Median TTFT (ms):                        2350.90
P99 TTFT (ms):                           12031.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          36.74
Median TPOT (ms):                        37.67
P99 TPOT (ms):                           74.00
---------------Inter-Token Latency----------------
Mean ITL (ms):                           49.18
Median ITL (ms):                         9.23
P95 ITL (ms):                            262.85
P99 ITL (ms):                            1142.26
Max ITL (ms):                            9325.15
==================================================
```

this pr:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     96
Benchmark duration (s):                  81.06
Total input tokens:                      615639
Total input text tokens:                 27543
Total input vision tokens:               588096
Total generated tokens:                  25821
Total generated tokens (retokenized):    15091
Request throughput (req/s):              1.18
Input token throughput (tok/s):          7594.97
Output token throughput (tok/s):         318.55
Total token throughput (tok/s):          7913.51
Concurrency:                             15.64
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   13208.09
Median E2E Latency (ms):                 12687.83
---------------Time to First Token----------------
Mean TTFT (ms):                          3184.26
Median TTFT (ms):                        2014.51
P99 TTFT (ms):                           11299.38
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.69
Median TPOT (ms):                        37.62
P99 TPOT (ms):                           66.99
---------------Inter-Token Latency----------------
Mean ITL (ms):                           51.16
Median ITL (ms):                         8.48
P95 ITL (ms):                            259.76
P99 ITL (ms):                            1477.37
Max ITL (ms):                            8078.35
==================================================
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
