### PR TITLE
[misc] Remove performance and router-benchmark label matching

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,14 +6,6 @@ router:
   - changed-files:
     - any-glob-to-any-file: 'sgl-router/**/*'
 
-# Router benchmarks
-router-benchmark:
-  - changed-files:
-    - any-glob-to-any-file:
-      - 'sgl-router/benches/**/*'
-      - 'sgl-router/scripts/run_benchmarks.py'
-      - 'sgl-router/**/*bench*.rs'
-
 # Kernel specific
 sgl-kernel:
   - changed-files:
@@ -63,15 +55,6 @@ quant:
       - '**/*quant*'
       - '**/awq/**/*'
       - '**/gptq/**/*'
-
-# Performance related
-performance:
-  - changed-files:
-    - any-glob-to-any-file:
-      - '**/benchmark/**/*'
-      - '**/benches/**/*'
-      - '**/perf/**/*'
-      - '**/*benchmark*'
 
 # Speculative decoding
 speculative-decoding:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The current label matching for `performance` and `router-benchmark` is too aggresive. The performance label should be relevant to changes that actually improves performance. Not file changes

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Remove performance and router-benchmark label in labeler.yml

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
