### PR TITLE
Adds a simple --version flag to the SGLang CLI to help users verify

### DIFF
--- a/python/sglang/launch_server.py
+++ b/python/sglang/launch_server.py
@@ -1,5 +1,7 @@
 """Launch the inference server."""
 
+import argparse
+from importlib.metadata import version as pkg_version
 import asyncio
 import os
 import sys
@@ -21,6 +23,13 @@ def run_server(server_args):
 
 
 if __name__ == "__main__":
+    if "--version" in sys.argv:
+        try:
+            v = pkg_version("sglang")
+        except Exception:
+            v = "unknown"
+        print(f"SGLang {v}")
+        sys.exit(0)
     server_args = prepare_server_args(sys.argv[1:])
 
     try:

--- a/python/sglang/launch_server.py
+++ b/python/sglang/launch_server.py
@@ -1,10 +1,9 @@
 """Launch the inference server."""
 
-import argparse
-from importlib.metadata import version as pkg_version
 import asyncio
 import os
 import sys
+from importlib.metadata import version as pkg_version
 
 from sglang.srt.server_args import prepare_server_args
 from sglang.srt.utils import kill_process_tree


### PR DESCRIPTION
## Motivation

The current SGLang CLI requires users to invoke commands via verbose module paths such as:

python -m sglang.launch_server


and provides no simple way to check the installed version.
This PR adds a lightweight --version flag to improve usability, assist in debugging, and align with the Unified CLI RFC (#9853), which calls for a more consistent and discoverable command-line interface.

## Modifications

Added --version flag support to sglang/cli/launch_server.py.

When invoked with --version, the CLI prints the installed SGLang version and exits immediately.

Uses importlib.metadata.version("sglang") for dynamic version retrieval.
## Accuracy Tests

N/A — this change does not affect model logic, inference kernel, or outputs.

## Benchmarking and Profiling

N/A — this is a CLI-only improvement with no runtime or performance implications.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
