### PR TITLE
fix: display served_model_name in /v1/models 

### DIFF
--- a/sgl-router/src/core/workflow/steps/worker_registration.rs
+++ b/sgl-router/src/core/workflow/steps/worker_registration.rs
@@ -105,12 +105,13 @@ async fn get_dp_info(url: &str, api_key: Option<&str>) -> Result<DpInfo, String>
         .ok_or_else(|| format!("No dp_size in response from {}", url))?;
 
     let model_id = info
-        .served_model_name
+        .model_id
         .filter(|s| !s.is_empty())
+        .or(info.served_model_name.filter(|s| !s.is_empty()))
         .or_else(|| {
-            info.model_path.and_then(|path| path.split('/').next_back().map(|s| s.to_string()))
+            info.model_path
+                .and_then(|path| path.split('/').next_back().map(|s| s.to_string()))
         })
-        .or(info.model_id)
         .unwrap_or_else(|| "unknown".to_string());
 
     Ok(DpInfo { dp_size, model_id })

--- a/sgl-router/src/core/workflow/steps/worker_registration.rs
+++ b/sgl-router/src/core/workflow/steps/worker_registration.rs
@@ -44,6 +44,7 @@ struct ServerInfo {
     #[serde(alias = "model")]
     model_id: Option<String>,
     model_path: Option<String>,
+    served_model_name: Option<String>,
     dp_size: Option<usize>,
     version: Option<String>,
     max_batch_size: Option<usize>,
@@ -104,11 +105,12 @@ async fn get_dp_info(url: &str, api_key: Option<&str>) -> Result<DpInfo, String>
         .ok_or_else(|| format!("No dp_size in response from {}", url))?;
 
     let model_id = info
-        .model_id
+        .served_model_name
+        .filter(|s| !s.is_empty())
         .or_else(|| {
-            info.model_path
-                .and_then(|path| path.split('/').next_back().map(|s| s.to_string()))
+            info.model_path.and_then(|path| path.split('/').next_back().map(|s| s.to_string()))
         })
+        .or(info.model_id)
         .unwrap_or_else(|| "unknown".to_string());
 
     Ok(DpInfo { dp_size, model_id })
@@ -353,6 +355,12 @@ impl StepExecutor for DiscoverMetadataStep {
                                 labels.insert("model_path".to_string(), model_path);
                             }
                         }
+                        if let Some(served_model_name) = server_info.served_model_name {
+                            if !served_model_name.is_empty() {
+                                labels.insert("served_model_name".to_string(), served_model_name);
+                            }
+                        }
+
                         Ok((labels, None))
                     }
                     Err(e) => Err(e),
@@ -499,12 +507,15 @@ impl StepExecutor for CreateWorkerStep {
 
         // Derive model_id if not already set
         if !final_labels.contains_key("model_id") {
-            let derived_model_id = final_labels
-                .get("served_model_name")
-                .or_else(|| final_labels.get("model_path"))
-                .cloned();
+            let derived = if let Some(name) = final_labels.get("served_model_name") {
+                Some(name.clone())
+            } else if let Some(path) = final_labels.get("model_path") {
+                path.split('/').next_back().map(|s| s.to_string())
+            } else {
+                None
+            };
 
-            if let Some(model_id) = derived_model_id {
+            if let Some(model_id) = derived {
                 debug!("Derived model_id from metadata: {}", model_id);
                 final_labels.insert("model_id".to_string(), model_id);
             }

--- a/sgl-router/src/core/workflow/steps/worker_registration.rs
+++ b/sgl-router/src/core/workflow/steps/worker_registration.rs
@@ -508,15 +508,12 @@ impl StepExecutor for CreateWorkerStep {
 
         // Derive model_id if not already set
         if !final_labels.contains_key("model_id") {
-            let derived = if let Some(name) = final_labels.get("served_model_name") {
-                Some(name.clone())
-            } else if let Some(path) = final_labels.get("model_path") {
-                path.split('/').next_back().map(|s| s.to_string())
-            } else {
-                None
-            };
+            let derived_model_id = final_labels
+                .get("served_model_name")
+                .or_else(|| final_labels.get("model_path"))
+                .cloned();
 
-            if let Some(model_id) = derived {
+            if let Some(model_id) = derived_model_id {
                 debug!("Derived model_id from metadata: {}", model_id);
                 final_labels.insert("model_id".to_string(), model_id);
             }

--- a/sgl-router/src/core/workflow/steps/worker_registration.rs
+++ b/sgl-router/src/core/workflow/steps/worker_registration.rs
@@ -351,15 +351,11 @@ impl StepExecutor for DiscoverMetadataStep {
                 match get_server_info(&config.url, config.api_key.as_deref()).await {
                     Ok(server_info) => {
                         let mut labels = HashMap::new();
-                        if let Some(model_path) = server_info.model_path {
-                            if !model_path.is_empty() {
-                                labels.insert("model_path".to_string(), model_path);
-                            }
+                        if let Some(model_path) = server_info.model_path.filter(|s| !s.is_empty()) {
+                            labels.insert("model_path".to_string(), model_path);
                         }
-                        if let Some(served_model_name) = server_info.served_model_name {
-                            if !served_model_name.is_empty() {
-                                labels.insert("served_model_name".to_string(), served_model_name);
-                            }
+                        if let Some(served_model_name) = server_info.served_model_name.filter(|s| !s.is_empty()) {
+                            labels.insert("served_model_name".to_string(), served_model_name);
                         }
 
                         Ok((labels, None))

--- a/sgl-router/src/core/workflow/steps/worker_registration.rs
+++ b/sgl-router/src/core/workflow/steps/worker_registration.rs
@@ -354,7 +354,9 @@ impl StepExecutor for DiscoverMetadataStep {
                         if let Some(model_path) = server_info.model_path.filter(|s| !s.is_empty()) {
                             labels.insert("model_path".to_string(), model_path);
                         }
-                        if let Some(served_model_name) = server_info.served_model_name.filter(|s| !s.is_empty()) {
+                        if let Some(served_model_name) =
+                            server_info.served_model_name.filter(|s| !s.is_empty())
+                        {
                             labels.insert("served_model_name".to_string(), served_model_name);
                         }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
fix the bug described in https://github.com/sgl-project/sglang/issues/12977
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
add `served_model_name` in worker registration, so that it can be derived by `model_id`.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
run server by
```bash
python -m sglang.launch_server  --served-model-name  opt-125m --model-path ~/models/opt-125m  --host 0.0.0.0 --port 31000
RUST_LOG=info cargo run -- --worker-urls http://127.0.0.1:31000 --host 0.0.0.0 --port 30002
```

curl before modification
```
{"models":["/home/devuser/models/opt-125m"]}
```
after
```
{"models":["opt-125m"]}
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
