### PR TITLE
Fix nan in global scaling factor for large scale nvfp4 EP

### DIFF
--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -284,9 +284,17 @@ class ExpertLocationMetadata:
     # -------------------------------- usage ------------------------------------
 
     def logical_to_all_physical(
-        self, layer_id: int, logical_expert_id: int
+        self,
+        layer_id: int,
+        logical_expert_id: int,
+        require_global_experts: bool = False,
     ) -> List[int]:
         # Use CPU copy to avoid GPU→CPU sync on every call, which is expensive in update weights scenario
+        if require_global_experts:
+            num_physical_experts = self.logical_to_all_physical_map_cpu[layer_id].shape[
+                -1
+            ]
+            return list(torch.arange(0, num_physical_experts))
         return [
             physical_expert_id
             for physical_expert_id in self.logical_to_all_physical_map_cpu[

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -355,14 +355,10 @@ def _compute_logical_to_all_physical_map(
                 )
 
                 # Replace by the nearest physical expert
-                mapped_physical_experts = logical_to_all_physical_map[layer_id][
-                    logical_expert_id
-                ]
-                if (
-                    nearest_expert != -1
-                    and nearest_expert not in mapped_physical_experts
-                ):
-                    mapped_physical_experts[0] = nearest_expert
+                if nearest_expert != -1:
+                    logical_to_all_physical_map[layer_id][logical_expert_id] = [
+                        nearest_expert
+                    ]
 
     logical_to_all_physical_map = _pad_nested_array(
         logical_to_all_physical_map, pad_value=-1

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -517,9 +517,12 @@ class FusedMoE(torch.nn.Module):
             # This is a shared expert.
             physical_expert_ids = [expert_id]
         else:
+            require_global_experts = getattr(
+                param, "_sglang_require_global_experts", False
+            )
             physical_expert_ids = (
                 global_expert_location_metadata.logical_to_all_physical(
-                    self.layer_id, expert_id
+                    self.layer_id, expert_id, require_global_experts
                 )
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Part of https://github.com/sgl-project/sglang/pull/12866(reverted in this PR), the root cause is that `w13[2]_input_scale` should not depends on `logical_to_all_physical_map`. In this fix, read in all physical experts' input scale regardless of its logical expert id.
cc @kaixih @Fridge003 
<!-- Describe the purpose and goals of this pull request. -->
The root cause is:
The `w13_input_scale` is of shape [288, ...] but if the map `logical_to_all_physical_map` is :
```
[
[286],
[287],
[2],
[3],
...,
[254],
[255]
]
```
there 0th and 1st row is missing and since `w13_input_scale` is initialized by `torch.empty`, the corresponding values are undefined.
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
