### PR TITLE
[router] Fix Flaky test_circuit_breaker_opens_and_recovers

### DIFF
--- a/sgl-router/py_test/integration_mock/test_circuit_breaker.py
+++ b/sgl-router/py_test/integration_mock/test_circuit_breaker.py
@@ -34,13 +34,15 @@ def test_circuit_breaker_opens_and_recovers(router_manager, mock_workers):
 
     # should see 500 when worker actually starts, before that should see 503
     saw_500 = False
-    for _  in range(8):
+    for _ in range(8):
         r = post_once()
         if r.status_code == 500:
             # Worker starts, continue to circuit breaker test
             saw_500 = True
             break
-        assert r.status_code == 503, "Should only see 503 when waiting for worker to start"
+        assert (
+            r.status_code == 503
+        ), "Should only see 503 when waiting for worker to start"
     assert saw_500, "Worker didn't start after 8 requests"
 
     saw_503 = False

--- a/sgl-router/py_test/integration_mock/test_circuit_breaker.py
+++ b/sgl-router/py_test/integration_mock/test_circuit_breaker.py
@@ -32,8 +32,19 @@ def test_circuit_breaker_opens_and_recovers(router_manager, mock_workers):
             timeout=3,
         )
 
+    # should see 500 when worker actually starts, before that should see 503
+    saw_500 = False
+    for _  in range(8):
+        r = post_once()
+        if r.status_code == 500:
+            # Worker starts, continue to circuit breaker test
+            saw_500 = True
+            break
+        assert r.status_code == 503, "Should only see 503 when waiting for worker to start"
+    assert saw_500, "Worker didn't start after 8 requests"
+
     saw_503 = False
-    for _ in range(8):
+    for _ in range(4):
         r = post_once()
         if r.status_code == 503:
             saw_503 = True


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fix flaky test test_circuit_breaker_opens_and_recovers. 
Sometimes the worker takes a bit longer to start. So when test hits the server, it receives 503 due to there's no available worker instead of circuit breaker is open. Then the test expects to receive 200 when worker starts and returns 500 for first 3 requests.

## Modifications

Modify the test to wait to receive 500 first and then expect to receive 503, to ensure that test starts to check if circuit breaker is open after the worker is actually started.

Run the test for 500 times, didn't see any failure
<img width="691" height="349" alt="Screenshot 2025-11-12 at 10 56 09 AM" src="https://github.com/user-attachments/assets/14b9515e-7507-4758-981b-7152c9480a8c" />

## Accuracy Tests

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
