### PR TITLE
fix: create git tags directly instead of temporary branches

### DIFF
--- a/.github/workflows/release-fake-tag.yml
+++ b/.github/workflows/release-fake-tag.yml
@@ -27,9 +27,9 @@ jobs:
           version=$(cat python/sglang/version.py | cut -d'"' -f2)
           echo "TAG=v$version" >> $GITHUB_OUTPUT
 
-      - name: Create and push fake tag
+      - name: Create and push tag
         run: |
           git config user.name "sglang-bot"
           git config user.email "sglang-bot@users.noreply.github.com"
-          git checkout -b ${{ steps.get_version.outputs.TAG }}
-          git push --set-upstream origin ${{ steps.get_version.outputs.TAG }}
+          git tag ${{ steps.get_version.outputs.TAG }}
+          git push origin ${{ steps.get_version.outputs.TAG }}


### PR DESCRIPTION
## Summary

Changes the release-fake-tag workflow to create git tags directly instead of temporary branches.

## Changes

- Modified `.github/workflows/release-fake-tag.yml` to use `git tag` instead of `git checkout -b`
- Eliminates the need to manually run `scripts/version_branch_to_tag.sh` after version bumps

## Why

The previous workflow created temporary branches that required manual conversion to tags. This automation simplifies the release process while still avoiding automatic GitHub release page creation (verified with existing .post1 and .post2 tags).

## Test Plan

- Tested locally with v0.5.5.post2 tag creation
- Verified that direct tag creation doesn't trigger GitHub release pages

## Test Results

  1. Created tag: v0.0.0-test-workflow using git tag + git push origin <tag>
  2. Verified tag exists: Tag was successfully pushed to GitHub
  3. Checked for release page: No release page was created
  4. Attempted cleanup: Tag deletion is blocked by repository rules (tags are protected from deletion)