### PR TITLE
[Draft][LoRA] Support Deepseek V3 LoRA on linear layers

### DIFF
--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -153,6 +153,17 @@ class LoRAAdapter(nn.Module):
 
         # Refresh weight_names after potential synthesis above
         weight_names = list(weights.keys())
+        # Final cleanup: remove any remaining DeepSeek fused entries (both A and B) to
+        # ensure downstream name matching only sees normalized targets.
+        for name in list(weights.keys()):
+            if (
+                ("q_a_proj" in name)
+                or ("kv_a_proj_with_mqa" in name)
+                or ("q_b_proj" in name)
+                or ("kv_b_proj" in name)
+            ):
+                weights.pop(name, None)
+        weight_names = list(weights.keys())
 
         target_module = set()
         for weight_name in weight_names:

--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -117,6 +117,12 @@ class LoRAAdapter(nn.Module):
                 qkv_a_name = q_a_name.replace("q_a_proj", "qkv_proj")
                 A_q = weights[q_a_name]
                 A_kv = weights[kv_a_name]
+                # Align row-rank to configured LoRA r
+                r = int(self.config.r)
+                if A_q.shape[0] != r:
+                    A_q = A_q[:r, :]
+                if A_kv.shape[0] != r:
+                    A_kv = A_kv[:r, :]
                 # Construct qkv A by duplicating kv_a for both K and V slices
                 weights[qkv_a_name] = torch.cat((A_q, A_kv, A_kv), dim=0)
                 # Remove original fused entries to avoid downstream name matching issues
@@ -136,6 +142,12 @@ class LoRAAdapter(nn.Module):
                 qkv_b_name = q_b_name.replace("q_b_proj", "qkv_proj")
                 B_q = weights[q_b_name]
                 B_kv = weights[kv_b_name]
+                # Align column-rank to configured LoRA r
+                r = int(self.config.r)
+                if B_q.shape[1] != r:
+                    B_q = B_q[:, :r]
+                if B_kv.shape[1] != r:
+                    B_kv = B_kv[:, :r]
                 # Split kv_b equally across K and V along the output dimension
                 split = B_kv.shape[0] // 2
                 B_k = B_kv[:split, :]

--- a/python/sglang/srt/lora/lora.py
+++ b/python/sglang/srt/lora/lora.py
@@ -119,6 +119,15 @@ class LoRAAdapter(nn.Module):
                 A_kv = weights[kv_a_name]
                 # Construct qkv A by duplicating kv_a for both K and V slices
                 weights[qkv_a_name] = torch.cat((A_q, A_kv, A_kv), dim=0)
+                # Remove original fused entries to avoid downstream name matching issues
+                try:
+                    weights.pop(q_a_name)
+                except KeyError:
+                    pass
+                try:
+                    weights.pop(kv_a_name)
+                except KeyError:
+                    pass
 
         ds_q_b = [n for n in weight_names if ("q_b_proj" in n and "lora_B" in n)]
         for q_b_name in ds_q_b:
@@ -132,6 +141,15 @@ class LoRAAdapter(nn.Module):
                 B_k = B_kv[:split, :]
                 B_v = B_kv[split:, :]
                 weights[qkv_b_name] = torch.cat((B_q, B_k, B_v), dim=0)
+                # Remove original fused entries to avoid downstream name matching issues
+                try:
+                    weights.pop(q_b_name)
+                except KeyError:
+                    pass
+                try:
+                    weights.pop(kv_b_name)
+                except KeyError:
+                    pass
 
         # Refresh weight_names after potential synthesis above
         weight_names = list(weights.keys())

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -286,7 +286,17 @@ class LoRAMemoryPool:
                 target_module: None for target_module in self.B_buffer
             }
             for name, weights in layer_weights.items():
-                target_module = get_target_module_name(name, self.target_modules)
+                # Map full weight name to one of the configured target modules. If no match,
+                # skip this weight (e.g., LoRA weights for modules not enabled like o_proj).
+                try:
+                    target_module = get_target_module_name(name, self.target_modules)
+                except ValueError:
+                    logger.debug(
+                        "Skipping LoRA weight not in target modules. name=%s, targets=%s",
+                        name,
+                        self.target_modules,
+                    )
+                    continue
                 if "lora_A" in name:
                     temp_A_buffer[target_module] = weights
                 else:


### PR DESCRIPTION
Support LoRA on the linear layers for Deepseek. I found some issues in the loading process.

I've only found this public `safetensors` (https://huggingface.co/AdamLucek/DeepSeek-V3.1-Truthlessness-1e) format for LoRA for Deepseek V3 (and I cannot share a private one), therefore here are the results.

```
python -m sglang.launch_server   --model-path /opt/dlami/nvme/models/DeepSeek-V3.1/   --enable-lora   --max-lora-rank 32   --lora-backend csgmv   --lora-paths truthless=/opt/dlami/nvme/lora/truthless   --tp 8 --enable-deterministic
```

> Note: it seems this adapter trained by the author may not be correct or tested, because they mention the entire model in F16 (which is not possible), so I currently use the result of deterministic mode to verify the inference difference.

```
curl -s http://127.0.0.1:30000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/opt/dlami/nvme/models/DeepSeek-V3.1-Terminus/:truthless",
    "messages": [{"role":"user","content":"What is 2 + 4?"}],
    "max_tokens": 128
  }' | jq
```

LoRA:
```
{
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "That's a very fundamental math question! The answer is **4**.\n\nThis is one of the first addition facts we learn. You can think of it as:\n*   Having 2 apples and someone gives you 2 more apples. You would then have 4 apples total.",
        "reasoning_content": null,
        "tool_calls": null
      },
      "logprobs": null,
      "finish_reason": "stop",
      "matched_stop": 1
    }
```

Non-LoRA:
```
{
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "That's a simple one! \n\n**2 + 2 = 4**",
        "reasoning_content": null,
        "tool_calls": null
      },
      "logprobs": null,
      "finish_reason": "stop",
      "matched_stop": 1
    }
```

So I suppose it is different.