### PR TITLE
[Performance] Move the contiguous to torch compile region

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1481,6 +1481,8 @@ class MRotaryEmbedding(RotaryEmbedding):
         num_tokens = positions.shape[-1]
         cos_sin = self.cos_sin_cache[positions]
         cos, sin = cos_sin.chunk(2, dim=-1)
+        cos = cos.contiguous()
+        sin = sin.contiguous()
         query_shape = query.shape
         key_shape = key.shape
         if positions.ndim == 2:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
```python
python3 -m sglang.launch_server --model-path Qwen/Qwen3-VL-30B-A3B-Thinking \
    --context-length 262144 --cuda-graph-max-bs 64 --reasoning-parser deepseek-r1 --load-format dummy --port 1919 --disable-radix
```

## Modifications

Move `cos` and `sin` contiguous op to `torch.compile` region.

https://github.com/sgl-project/sglang/blob/aead0ef5e55303ed956f287207c96d444ae655b8/python/sglang/srt/layers/rotary_embedding.py#L1277-L1280

Before:

<img width="1938" height="728" alt="image" src="https://github.com/user-attachments/assets/33c19213-a215-4774-b4c7-02e8f5420b23" />

After:

<img width="1745" height="698" alt="image" src="https://github.com/user-attachments/assets/51b8ae16-a525-4e4e-8ebb-4eb70961bc0f" />

This directly results in a 4% speedup in small bs decode (< 16).

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
