### PR TITLE
Use dynamically maintained num_waiting_tokens in get_load()

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -299,6 +299,11 @@ class DecodePreallocQueue:
 
         if is_retracted:
             self.retracted_queue.append(req)
+            self.scheduler.num_waiting_tokens += (
+                len(req.origin_input_ids)
+                + len(req.output_ids)
+                + self.num_reserved_decode_tokens
+            )
         else:
             if req.bootstrap_host == FAKE_BOOTSTRAP_HOST:
                 kv_receiver_class = get_kv_class(
@@ -321,6 +326,7 @@ class DecodePreallocQueue:
             self.queue.append(
                 DecodeRequest(req=req, kv_receiver=kv_receiver, waiting_for_input=False)
             )
+            self.scheduler.num_waiting_tokens += len(req.origin_input_ids)
 
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
         if len(req.origin_input_ids) > self.max_total_num_tokens:
@@ -361,6 +367,8 @@ class DecodePreallocQueue:
             req.is_retracted = False
             self._pre_alloc(req)
             allocatable_tokens -= required_tokens_for_request
+            # update counter for resumed request
+            self.scheduler.num_waiting_tokens -= required_tokens_for_request
 
             # load from cpu, release the cpu copy
             req.load_kv_cache(self.req_to_token_pool, self.token_to_kv_pool_allocator)
@@ -536,9 +544,15 @@ class DecodePreallocQueue:
                 RequestStage.DECODE_BOOTSTRAP, decode_req.req.rid, auto_next_anon=True
             )
 
-        self.queue = [
-            entry for i, entry in enumerate(self.queue) if i not in indices_to_remove
-        ]
+        preallocated_queue = []
+
+        for i, entry in enumerate(self.queue):
+            if i not in indices_to_remove:
+                preallocated_queue.append(entry)
+            else:
+                # update counter for allocated or failed request
+                self.scheduler.num_waiting_tokens -= len(entry.req.origin_input_ids)
+        self.queue = preallocated_queue
 
         return preallocated_reqs
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -200,6 +200,7 @@ class PrefillBootstrapQueue:
         self._process_req(req)
         req.add_latency(RequestStage.PREFILL_PREPARE)
         self.queue.append(req)
+        self.scheduler.num_waiting_tokens += len(req.origin_input_ids)
         trace_slice_end(RequestStage.PREFILL_PREPARE, req.rid, auto_next_anon=True)
 
     def extend(self, reqs: List[Req], num_kv_heads: int) -> None:
@@ -270,6 +271,8 @@ class PrefillBootstrapQueue:
                 self.scheduler.stream_output([req], req.return_logprob)
                 indices_to_remove.add(i)
                 failed_reqs.append(req)
+                # update counter for failed bootstrap request
+                self.scheduler.num_waiting_tokens -= len(req.origin_input_ids)
                 if self.scheduler.enable_metrics:
                     self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
                 continue

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -424,6 +424,7 @@ class Scheduler(
 
         # Init running status
         self.waiting_queue: List[Req] = []
+        self.num_waiting_tokens = 0
         # The running decoding batch for continuous batching
         self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
         # The current forward batch
@@ -1455,6 +1456,7 @@ class Scheduler(
                 return
             self._prefetch_kvcache(req)
             self.waiting_queue.append(req)
+            self.num_waiting_tokens += len(req.origin_input_ids)
             req.time_stats.wait_queue_entry_time = time.perf_counter()
             trace_slice_end(RequestStage.REQUEST_PROCESS, req.rid, auto_next_anon=True)
         elif self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -1522,6 +1524,8 @@ class Scheduler(
             if abort_existing_req:
                 self.waiting_queue.pop(idx)
                 req_to_abort = candidate_req
+                # update counter for preempted existing request
+                self.num_waiting_tokens -= len(req_to_abort.origin_input_ids)
                 message = "The request is aborted by a higher priority request."
 
         self.send_to_tokenizer.send_output(
@@ -1855,9 +1859,15 @@ class Scheduler(
             for req in can_run_list:
                 req.add_latency(RequestStage.PREFILL_WAITING)
 
-        self.waiting_queue = [
-            x for x in self.waiting_queue if x not in set(can_run_list)
-        ]
+        can_run_set = set(can_run_list)
+        waiting_queue = []
+        for x in self.waiting_queue:
+            if x in can_run_set:
+                self.num_waiting_tokens -= len(x.origin_input_ids)
+            else:
+                waiting_queue.append(x)
+
+        self.waiting_queue = waiting_queue
         if adder.preempt_list:
             for req in adder.preempt_list:
                 self._add_request_to_queue(req)
@@ -2279,8 +2289,6 @@ class Scheduler(
         return if_success
 
     def get_load(self, recv_req: GetLoadReqInput = None) -> GetLoadReqOutput:
-        # TODO(lsyin): use dynamically maintained num_waiting_tokens
-
         if self.is_hybrid:
             num_tokens_full = (
                 self.full_tokens_per_layer
@@ -2306,21 +2314,15 @@ class Scheduler(
                 - self.tree_cache.evictable_size()
             )
 
-        # Tokens in waiting queue, bootstrap queue, prealloc queue
-        num_tokens += sum(len(req.origin_input_ids) for req in self.waiting_queue)
+        # Tokens in waiting queue, bootstrap queue, prealloc/retract queue
+        num_tokens += self.num_waiting_tokens
         num_waiting_reqs = len(self.waiting_queue)
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            num_tokens += sum(
-                len(req.origin_input_ids)
-                for req in self.disagg_prefill_bootstrap_queue.queue
-            )
             num_waiting_reqs += len(self.disagg_prefill_bootstrap_queue.queue)
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
-            num_tokens += sum(
-                len(req.req.origin_input_ids)
-                for req in self.disagg_decode_prealloc_queue.queue
-            )
             num_waiting_reqs += len(self.disagg_decode_prealloc_queue.queue)
+            num_waiting_reqs += len(self.disagg_decode_transfer_queue.queue)
+            num_waiting_reqs += len(self.disagg_decode_prealloc_queue.retracted_queue)
 
         return GetLoadReqOutput(
             dp_rank=self.dp_rank,
@@ -2436,6 +2438,9 @@ class Scheduler(
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 release_kv_cache(req, self.tree_cache)
+            else:
+                # update counter for abort request in prealloc and waiting queue
+                self.num_waiting_tokens -= len(req.origin_input_ids)
 
             # For mamba radix cache
             if req.mamba_pool_idx is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Use dynamically maintained num_waiting_tokens in get_load() to avoid list access

## Modifications

- for no PD disaggregation:

num_waiting_tokens represents the total number of tokens in the waiting queue

It increases when requests enter the waiting queue, and decreases when requests leave the waiting queue to running list or abort

- for PD disaggregation P node:

num_waiting_tokens represents the total number of tokens in the bootstrap/waiting queue

It increases when requests enter the bootstrap queue, and decreases when requests leave the waiting queue to running list or fail in bootstrap queue

- for PD disaggregation D node:

num_waiting_tokens represents the total number of tokens in the prealloc/retract queue, not including waiting queue because KV cache allocating is done before request gets in waiting queue

It increases when requests enter the prealloc/retrac queue, and decreases when requests leave the prealloc queue to transfer queue, or leave retract queue to waiting queue, or abort in prealloc queue


## Accuracy Tests

Compare the dynamically maintained num_waiting_tokens(num_tokens) with the value obtained directly from the queues(direct_sum_num_tokens), and they are expected to be the same.

no PD disaggregation

> [{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":261865,"num_reqs":87,"num_waiting_reqs":82,"num_tokens":261865}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":584829,"num_reqs":192,"num_waiting_reqs":190,"num_tokens":584829}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":585199,"num_reqs":195,"num_waiting_reqs":190,"num_tokens":585199}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":569844,"num_reqs":190,"num_waiting_reqs":185,"num_tokens":569844}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":554854,"num_reqs":182,"num_waiting_reqs":180,"num_tokens":554854}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":555204,"num_reqs":185,"num_waiting_reqs":180,"num_tokens":555204}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":539505,"num_reqs":180,"num_waiting_reqs":175,"num_tokens":539505}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":524590,"num_reqs":172,"num_waiting_reqs":170,"num_tokens":524590}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":524955,"num_reqs":175,"num_waiting_reqs":170,"num_tokens":524955}]

 PD disaggregation: P node

> [{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":519089,"num_reqs":169,"num_waiting_reqs":169,"num_tokens":519089}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":560854,"num_reqs":184,"num_waiting_reqs":184,"num_tokens":560854}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":539500,"num_reqs":177,"num_waiting_reqs":177,"num_tokens":539500}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":521602,"num_reqs":170,"num_waiting_reqs":170,"num_tokens":521602}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":500625,"num_reqs":164,"num_waiting_reqs":164,"num_tokens":500625}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":484913,"num_reqs":159,"num_waiting_reqs":159,"num_tokens":484913}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":463922,"num_reqs":152,"num_waiting_reqs":152,"num_tokens":463922}]

 PD disaggregation: D node

> [{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":6000,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":6000}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":0,"num_reqs":0,"num_waiting_reqs":0,"num_tokens":0}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":906911,"num_reqs":2,"num_waiting_reqs":0,"num_tokens":906911}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":1035255,"num_reqs":43,"num_waiting_reqs":41,"num_tokens":1035255}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":1014128,"num_reqs":39,"num_waiting_reqs":36,"num_tokens":1014128}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":998796,"num_reqs":35,"num_waiting_reqs":31,"num_tokens":998796}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":983560,"num_reqs":30,"num_waiting_reqs":26,"num_tokens":983560}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":968714,"num_reqs":25,"num_waiting_reqs":21,"num_tokens":968714}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":950668,"num_reqs":19,"num_waiting_reqs":15,"num_tokens":950668}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":930902,"num_reqs":14,"num_waiting_reqs":10,"num_tokens":930902}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":918929,"num_reqs":7,"num_waiting_reqs":4,"num_tokens":918929}]
[{"rid":null,"http_worker_ipc":null,"direct_sum_num_tokens":901005,"num_reqs":3,"num_waiting_reqs":0,"num_tokens":901005}]

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
