### PR TITLE
router select dp group with the minimum number of tokens

### DIFF
--- a/python/sglang/srt/entrypoints/EngineBase.py
+++ b/python/sglang/srt/entrypoints/EngineBase.py
@@ -29,6 +29,7 @@ class EngineBase(ABC):
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
+        data_parallel_rank_decode: Optional[int] = None,
         rid: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """Generate outputs based on given inputs."""

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -230,6 +230,7 @@ class Engine(EngineBase):
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
+        data_parallel_rank_decode: Optional[int] = None,
         rid: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
@@ -266,6 +267,7 @@ class Engine(EngineBase):
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
             data_parallel_rank=data_parallel_rank,
+            data_parallel_rank_decode=data_parallel_rank_decode,
             rid=rid,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)
@@ -315,6 +317,7 @@ class Engine(EngineBase):
         bootstrap_port: Optional[Union[List[int], int]] = None,
         bootstrap_room: Optional[Union[List[int], int]] = None,
         data_parallel_rank: Optional[int] = None,
+        data_parallel_rank_decode: Optional[int] = None,
         rid: Optional[Union[List[str], str]] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
@@ -352,6 +355,7 @@ class Engine(EngineBase):
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
             data_parallel_rank=data_parallel_rank,
+            data_parallel_rank_decode=data_parallel_rank_decode,
             rid=rid,
         )
         generator = self.tokenizer_manager.generate_request(obj, None)

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -536,6 +536,7 @@ class ChatCompletionRequest(BaseModel):
 
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
+    data_parallel_rank_decode: Optional[int] = None
 
     # OpenAI/SGLang default sampling parameters
     _DEFAULT_SAMPLING_PARAMS = {

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -211,7 +211,9 @@ class OpenAIServingChat(OpenAIServingBase):
             bootstrap_host=request.bootstrap_host,
             bootstrap_port=request.bootstrap_port,
             bootstrap_room=request.bootstrap_room,
+            # For data parallel rank routing
             data_parallel_rank=request.data_parallel_rank,
+            data_parallel_rank_decode=request.data_parallel_rank_decode,
             return_hidden_states=request.return_hidden_states,
             rid=request.rid,
             extra_key=self._compute_extra_key(request),

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -498,11 +498,28 @@ class DataParallelController:
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
 
     def maybe_external_dp_rank_routing(self, req: Req):
-        if req.data_parallel_rank is not None:
-            logger.debug(f"Direct routing to DP rank {req.data_parallel_rank}")
-            self.workers[req.data_parallel_rank].send_pyobj(req)
-            return True
-        return False
+        if self.server_args.disaggregation_mode == "prefill":
+            if req.data_parallel_rank is not None:
+                logger.debug(
+                    f"Prefill direct routing to DP rank {req.data_parallel_rank}"
+                )
+                self.workers[req.data_parallel_rank].send_pyobj(req)
+                return True
+            return False
+        else:
+            if req.data_parallel_rank_decode is not None:
+                logger.debug(
+                    f"Decode direct routing to DP rank {req.data_parallel_rank_decode}"
+                )
+                self.workers[req.data_parallel_rank_decode].send_pyobj(req)
+                return True
+            if req.data_parallel_rank is not None:
+                logger.debug(
+                    f"Decode direct routing to DP rank {req.data_parallel_rank}, by data parallel rank"
+                )
+                self.workers[req.data_parallel_rank].send_pyobj(req)
+                return True
+            return False
 
     def round_robin_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -231,6 +231,11 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
 
+    # In PD-Disaggregation mode, requests are scheduled to different DP group based on the load conditions of prefill and decode.
+    # `data_parallel_rank_decode` indicates which DP group the current request need to be dispatched to for decode
+    # `data_parallel_rank` indicates which DP group the request will be scheduled to on the prefill.
+    data_parallel_rank_decode: Optional[int] = None
+
     # For background responses (OpenAI responses API)
     background: bool = False
 
@@ -655,6 +660,11 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
             data_parallel_rank=(
                 self.data_parallel_rank if self.data_parallel_rank is not None else None
             ),
+            data_parallel_rank_decode=(
+                self.data_parallel_rank_decode
+                if self.data_parallel_rank_decode is not None
+                else None
+            ),
             conversation_id=self.conversation_id,
             priority=self.priority,
             extra_key=self.extra_key,
@@ -723,6 +733,8 @@ class TokenizedGenerateReqInput(BaseReq):
 
     # For data parallel rank routing
     data_parallel_rank: Optional[int] = None
+
+    data_parallel_rank_decode: Optional[int] = None
 
     # Priority for the request
     priority: Optional[int] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -510,6 +510,7 @@ class Req:
         bootstrap_room: Optional[int] = None,
         disagg_mode: Optional[DisaggregationMode] = None,
         data_parallel_rank: Optional[int] = None,
+        data_parallel_rank_decode: Optional[int] = None,
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
@@ -737,6 +738,7 @@ class Req:
 
         # For data parallel rank routing
         self.data_parallel_rank: Optional[int] = data_parallel_rank
+        self.data_parallel_rank_decode: Optional[int] = data_parallel_rank_decode
 
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1447,6 +1447,7 @@ class Scheduler(
                 bootstrap_room=recv_req.bootstrap_room,
                 disagg_mode=self.disaggregation_mode,
                 data_parallel_rank=recv_req.data_parallel_rank,
+                data_parallel_rank_decode=recv_req.data_parallel_rank_decode,
                 vocab_size=self.model_config.vocab_size,
                 priority=recv_req.priority,
                 metrics_collector=(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -914,6 +914,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 return_hidden_states=obj.return_hidden_states,
                 return_routed_experts=obj.return_routed_experts,
                 data_parallel_rank=obj.data_parallel_rank,
+                data_parallel_rank_decode=obj.data_parallel_rank_decode,
                 priority=obj.priority,
                 extra_key=obj.extra_key,
                 need_wait_for_image=obj.need_wait_for_image,

--- a/sgl-model-gateway/benches/request_processing.rs
+++ b/sgl-model-gateway/benches/request_processing.rs
@@ -58,6 +58,7 @@ fn default_generate_request() -> GenerateRequest {
         bootstrap_room: None,
         bootstrap_pair_key: None,
         data_parallel_rank: None,
+        data_parallel_rank_decode: None,
         background: false,
         conversation_id: None,
         priority: None,

--- a/sgl-model-gateway/bindings/python/sglang_router/router.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/router.py
@@ -137,6 +137,7 @@ class Router:
         port: Port number to bind the router server. Default: 3001
         worker_startup_timeout_secs: Timeout in seconds for worker startup and registration. Large models can take significant time to load into GPU memory. Default: 1800 (30 minutes)
         worker_startup_check_interval: Interval in seconds between checks for worker initialization. Default: 10
+        worker_load_check_interval: Interval in seconds between get loads for worker initialization. Default: 10
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to cached worker
             if the match rate exceeds threshold, otherwise routes to the worker with the smallest
             tree. Default: 0.5
@@ -149,6 +150,7 @@ class Router:
         max_payload_size: Maximum payload size in bytes. Default: 256MB
         max_tree_size: Maximum size of the approximation tree for cache-aware routing. Default: 2^24
         dp_aware: Enable data parallelism aware schedule. Default: False
+        dp_minimum_tokens_scheduler: Enable minimum tokens scheduler for data parallel group. Default: False
         enable_igw: Enable IGW (Inference-Gateway) mode for multi-model support. When enabled,
             the router can manage multiple models simultaneously with per-model load balancing
             policies. Default: False

--- a/sgl-model-gateway/bindings/python/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/router_args.py
@@ -359,6 +359,12 @@ class RouterArgs:
             default=RouterArgs.worker_startup_check_interval,
             help="Interval in seconds between checks for worker startup",
         )
+        pd_group.add_argument(
+            f"--{prefix}worker-load-check-interval",
+            type=int,
+            default=RouterArgs.worker_load_check_interval,
+            help="Interval in seconds between checks for worker load",
+        )
 
         # Logging configuration
         logging_group.add_argument(

--- a/sgl-model-gateway/bindings/python/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/router_args.py
@@ -30,6 +30,7 @@ class RouterArgs:
     decode_policy: Optional[str] = None  # Specific policy for decode nodes in PD mode
     worker_startup_timeout_secs: int = 1800
     worker_startup_check_interval: int = 30
+    worker_load_check_interval: int = 10
     cache_threshold: float = 0.3
     balance_abs_threshold: int = 64
     balance_rel_threshold: float = 1.5
@@ -38,6 +39,7 @@ class RouterArgs:
     max_payload_size: int = 512 * 1024 * 1024  # 512MB default for large batches
     bucket_adjust_interval_secs: int = 5
     dp_aware: bool = False
+    dp_minimum_tokens_scheduler: bool = False
     enable_igw: bool = False  # Enable IGW (Inter-Gateway) mode for multi-model support
     api_key: Optional[str] = None
     log_dir: Optional[str] = None
@@ -307,6 +309,11 @@ class RouterArgs:
             f"--{prefix}dp-aware",
             action="store_true",
             help="Enable data parallelism aware schedule",
+        )
+        routing_group.add_argument(
+            f"--{prefix}dp-minimum-tokens-scheduler",
+            action="store_true",
+            help="Enable minimum tokens scheduler for data parallel group",
         )
         routing_group.add_argument(
             f"--{prefix}enable-igw",

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -307,6 +307,7 @@ struct Router {
     policy: PolicyType,
     worker_startup_timeout_secs: u64,
     worker_startup_check_interval: u64,
+    worker_load_check_interval: u64,
     cache_threshold: f32,
     balance_abs_threshold: usize,
     balance_rel_threshold: f32,
@@ -314,6 +315,7 @@ struct Router {
     max_tree_size: usize,
     max_payload_size: usize,
     dp_aware: bool,
+    dp_minimum_tokens_scheduler: bool,
     api_key: Option<String>,
     log_dir: Option<String>,
     log_level: Option<String>,
@@ -510,6 +512,7 @@ impl Router {
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
+            .worker_load_check_interval_secs(self.worker_load_check_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
@@ -570,6 +573,7 @@ impl Router {
                 self.server_cert_path.as_ref(),
                 self.server_key_path.as_ref(),
             )
+            .dp_minimum_tokens_scheduler(self.dp_minimum_tokens_scheduler)
             .build()
     }
 }
@@ -584,6 +588,7 @@ impl Router {
         port = 3001,
         worker_startup_timeout_secs = 600,
         worker_startup_check_interval = 30,
+        worker_load_check_interval = 10,
         cache_threshold = 0.3,
         balance_abs_threshold = 64,
         balance_rel_threshold = 1.5,
@@ -591,6 +596,7 @@ impl Router {
         max_tree_size = 2usize.pow(26),
         max_payload_size = 512 * 1024 * 1024,
         dp_aware = false,
+        dp_minimum_tokens_scheduler = false,
         api_key = None,
         log_dir = None,
         log_level = None,
@@ -666,6 +672,7 @@ impl Router {
         port: u16,
         worker_startup_timeout_secs: u64,
         worker_startup_check_interval: u64,
+        worker_load_check_interval: u64,
         cache_threshold: f32,
         balance_abs_threshold: usize,
         balance_rel_threshold: f32,
@@ -673,6 +680,7 @@ impl Router {
         max_tree_size: usize,
         max_payload_size: usize,
         dp_aware: bool,
+        dp_minimum_tokens_scheduler: bool,
         api_key: Option<String>,
         log_dir: Option<String>,
         log_level: Option<String>,
@@ -761,6 +769,7 @@ impl Router {
             policy,
             worker_startup_timeout_secs,
             worker_startup_check_interval,
+            worker_load_check_interval,
             cache_threshold,
             balance_abs_threshold,
             balance_rel_threshold,
@@ -768,6 +777,7 @@ impl Router {
             max_tree_size,
             max_payload_size,
             dp_aware,
+            dp_minimum_tokens_scheduler,
             api_key,
             log_dir,
             log_level,

--- a/sgl-model-gateway/py_test/fixtures/router_manager.py
+++ b/sgl-model-gateway/py_test/fixtures/router_manager.py
@@ -79,6 +79,8 @@ class RouterManager:
                 "api_key": "--api-key",
                 # Health/monitoring
                 "worker_startup_check_interval": "--worker-startup-check-interval",
+                # Loads/monitoring
+                "worker_load_check_interval": "--worker-load-check-interval",
                 # Cache-aware tuning
                 "cache_threshold": "--cache-threshold",
                 "balance_abs_threshold": "--balance-abs-threshold",

--- a/sgl-model-gateway/py_test/integration_mock/load_balancing/test_power_of_two.py
+++ b/sgl-model-gateway/py_test/integration_mock/load_balancing/test_power_of_two.py
@@ -22,7 +22,7 @@ def test_power_of_two_prefers_less_loaded(mock_workers, router_manager):
     rh = router_manager.start_router(
         worker_urls=urls,
         policy="power_of_two",
-        extra={"worker_startup_check_interval": 1},
+        extra={"worker_load_check_interval": 1},
     )
 
     # Prime: fire a burst to create measurable load on slow worker, then wait for monitor tick

--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -487,6 +487,12 @@ impl AppContextBuilder {
     /// Create policy registry
     fn with_policy_registry(mut self, config: &RouterConfig) -> Self {
         self.policy_registry = Some(Arc::new(PolicyRegistry::new(config.policy.clone())));
+        if config.dp_minimum_tokens_scheduler {
+            self.policy_registry
+                .as_ref()
+                .unwrap()
+                .enable_dp_minimum_tokens_scheduler();
+        }
         self
     }
 
@@ -518,7 +524,7 @@ impl AppContextBuilder {
                 .expect("policy_registry must be set")
                 .clone(),
             client.clone(),
-            config.worker_startup_check_interval_secs,
+            config.worker_load_check_interval_secs,
         )));
         self
     }

--- a/sgl-model-gateway/src/config/builder.rs
+++ b/sgl-model-gateway/src/config/builder.rs
@@ -185,6 +185,10 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn worker_load_check_interval_secs(mut self, interval: u64) -> Self {
+        self.config.worker_load_check_interval_secs = interval;
+        self
+    }
     // ==================== Rate Limiting ====================
 
     pub fn max_concurrent_requests(mut self, max: i32) -> Self {
@@ -460,6 +464,11 @@ impl RouterConfigBuilder {
 
     pub fn igw(mut self, enable: bool) -> Self {
         self.config.enable_igw = enable;
+        self
+    }
+
+    pub fn dp_minimum_tokens_scheduler(mut self, enable: bool) -> Self {
+        self.config.dp_minimum_tokens_scheduler = enable;
         self
     }
 

--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -19,7 +19,9 @@ pub struct RouterConfig {
     pub request_timeout_secs: u64,
     pub worker_startup_timeout_secs: u64,
     pub worker_startup_check_interval_secs: u64,
+    pub worker_load_check_interval_secs: u64,
     pub dp_aware: bool,
+    pub dp_minimum_tokens_scheduler: bool,
     pub api_key: Option<String>,
     pub discovery: Option<DiscoveryConfig>,
     pub metrics: Option<MetricsConfig>,
@@ -537,7 +539,9 @@ impl Default for RouterConfig {
             request_timeout_secs: 1800,        // 30 minutes
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_check_interval_secs: 30,
+            worker_load_check_interval_secs: 10,
             dp_aware: false,
+            dp_minimum_tokens_scheduler: false,
             api_key: None,
             discovery: None,
             metrics: None,

--- a/sgl-model-gateway/src/core/mod.rs
+++ b/sgl-model-gateway/src/core/mod.rs
@@ -23,6 +23,7 @@ pub mod steps;
 pub mod token_bucket;
 pub mod worker;
 pub mod worker_builder;
+pub mod worker_load;
 pub mod worker_manager;
 pub mod worker_registry;
 pub mod worker_service;
@@ -40,6 +41,7 @@ pub use worker::{
     HealthChecker, HealthConfig, RuntimeType, Worker, WorkerFactory, WorkerLoadGuard, WorkerType,
 };
 pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
+pub use worker_load::WorkerLoadManager;
 pub use worker_manager::{LoadMonitor, WorkerManager};
 pub use worker_registry::{HashRing, WorkerId, WorkerRegistry, WorkerRegistryStats};
 pub use worker_service::{WorkerService, WorkerServiceError};

--- a/sgl-model-gateway/src/core/worker_load.rs
+++ b/sgl-model-gateway/src/core/worker_load.rs
@@ -1,0 +1,148 @@
+//! Worker load
+//!
+//! Record and manage the DP group load of workers.
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::RwLock,
+};
+
+use crate::core::Worker;
+
+use tracing::debug;
+
+#[derive(Debug, Default)]
+pub struct WorkerLoadManager {
+    // <worker, <dp_rank, loads>>
+    dp_cached_loads: RwLock<HashMap<String, HashMap<isize, isize>>>,
+}
+
+impl WorkerLoadManager {
+    pub fn new() -> Self {
+        Self {
+            dp_cached_loads: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn update_dp_loads(&self, loads: &HashMap<String, HashMap<isize, isize>>) {
+        debug!("RoundRobinPolicy update_dp_loads map:{:?}", loads);
+        if let Ok(mut cached) = self.dp_cached_loads.write() {
+            *cached = loads.clone();
+        }
+    }
+
+    pub fn get_lowest_dp_load(&self, worker: &dyn Worker) -> Option<isize> {
+        if let Ok(cached_loads) = self.dp_cached_loads.read() {
+            if let Some(loads) = cached_loads.get(worker.url()) {
+                return loads
+                    .iter()
+                    .min_by_key(|&(_, load)| load)
+                    .map(|(&rand_id, _)| rand_id);
+            }
+        }
+        None
+    }
+
+    pub fn load_increment(&self, worker: &dyn Worker, dp_rank: isize, increment: isize) {
+        // Add an increment to the load of dp group,
+        // to prevent all request from being scheduled to the same DP group during the interval between two load reports.
+        if let Ok(mut cached_loads) = self.dp_cached_loads.write() {
+            if let Some(loads) = cached_loads.get_mut(worker.url()) {
+                if let Some(dp_load) = loads.get_mut(&dp_rank) {
+                    *dp_load += increment;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod dp_load_manager_tests {
+    use super::*;
+    use crate::core::{BasicWorkerBuilder, WorkerType};
+
+    #[test]
+    fn test_new_dp_load_manager_instance() {
+        let dp_load_manager = WorkerLoadManager::new();
+        let cached = dp_load_manager.dp_cached_loads.read().unwrap();
+        assert!(cached.is_empty());
+    }
+
+    #[test]
+    fn test_update_dp_load() {
+        let manager = WorkerLoadManager::new();
+        let mut loads = HashMap::new();
+
+        // insert worker1_load
+        let mut worker1_load = HashMap::new();
+        worker1_load.insert(0, 2);
+        worker1_load.insert(1, 1);
+        loads.insert("http://worker1:8080".to_string(), worker1_load);
+
+        // insert worker2.load
+        let mut worker2_load = HashMap::new();
+        worker2_load.insert(0, 3);
+        loads.insert("http://worker2:8080".to_string(), worker2_load);
+
+        // update
+        manager.update_dp_loads(&loads);
+
+        // assert
+        let cached = manager.dp_cached_loads.read().unwrap();
+        assert_eq!(cached.len(), 2);
+
+        let worker2_cache = cached.get("http://worker2:8080").unwrap();
+        assert_eq!(worker2_cache.get(&0), Some(&3));
+    }
+
+    #[test]
+    fn test_get_lowest_dp_load() {
+        let worker1 = BasicWorkerBuilder::new("http://worker1:8080")
+            .worker_type(WorkerType::Regular)
+            .api_key("test_api_key2")
+            .build();
+
+        let manager = WorkerLoadManager::new();
+        let mut loads = HashMap::new();
+        // insert worker1_load
+        let mut worker1_load = HashMap::new();
+        worker1_load.insert(0, 2);
+        worker1_load.insert(1, 1);
+        worker1_load.insert(3, 3);
+        loads.insert(worker1.url().to_string(), worker1_load);
+        manager.update_dp_loads(&loads);
+
+        // Verify that the worker1 with the lowest load is dp_rank = 1
+        assert_eq!(manager.get_lowest_dp_load(&worker1), Some(1));
+    }
+
+    #[test]
+    fn test_load_increment() {
+        let worker2 = BasicWorkerBuilder::new("http://worker2:8080")
+            .worker_type(WorkerType::Regular)
+            .api_key("test_api_key2")
+            .build();
+
+        let manager = WorkerLoadManager::new();
+        manager.load_increment(&worker2, 0, 5);
+        let cached = manager.dp_cached_loads.read().expect("Rwlock read1 failed");
+        assert!(cached.get(worker2.url()).is_none());
+        drop(cached);
+
+        // insert worker2.load
+        let mut worker2_load = HashMap::new();
+        worker2_load.insert(0, 2);
+        let mut loads = HashMap::new();
+        loads.insert(worker2.url().to_string(), worker2_load);
+        manager.update_dp_loads(&loads);
+
+        // load increment
+        manager.load_increment(&worker2, 0, 5);
+        let cached = manager.dp_cached_loads.read().expect("Rwlock read2 failed");
+        let worker2_cache = cached
+            .get(worker2.url())
+            .expect("worker2 not found in cache");
+        // 2 + 5 = 7
+        assert_eq!(worker2_cache.get(&0), Some(&7));
+    }
+}

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -182,6 +182,9 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Routing Policy")]
     enable_igw: bool,
 
+    #[arg(long, default_value_t = false)]
+    dp_minimum_tokens_scheduler: bool,
+
     // ==================== PD Disaggregation ====================
     /// Enable PD (Prefill-Decode) disaggregated mode
     #[arg(long, default_value_t = false, help_heading = "PD Disaggregation")]
@@ -206,6 +209,9 @@ struct CliArgs {
     /// Interval in seconds between worker startup checks
     #[arg(long, default_value_t = 30, help_heading = "PD Disaggregation")]
     worker_startup_check_interval: u64,
+
+    #[arg(long, default_value_t = 10)]
+    worker_load_check_interval: u64,
 
     // ==================== Service Discovery (Kubernetes) ====================
     /// Enable Kubernetes service discovery
@@ -886,6 +892,7 @@ impl CliArgs {
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
+            .worker_load_check_interval_secs(self.worker_load_check_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
@@ -936,6 +943,7 @@ impl CliArgs {
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .dp_aware(self.dp_aware)
+            .dp_minimum_tokens_scheduler(self.dp_minimum_tokens_scheduler)
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
             .enable_wasm(self.enable_wasm)

--- a/sgl-model-gateway/src/protocols/generate.rs
+++ b/sgl-model-gateway/src/protocols/generate.rs
@@ -132,6 +132,9 @@ pub struct GenerateRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_parallel_rank: Option<i32>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data_parallel_rank_decode: Option<i32>,
+
     /// Background response
     #[serde(default)]
     pub background: bool,

--- a/sgl-model-gateway/src/protocols/worker_spec.rs
+++ b/sgl-model-gateway/src/protocols/worker_spec.rs
@@ -360,4 +360,6 @@ pub struct WorkerLoadInfo {
     pub worker_type: Option<String>,
     /// Current load (-1 indicates failure to fetch)
     pub load: isize,
+    /// Current dp rand load
+    pub dp_rank_loads: HashMap<isize, isize>,
 }

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1470,6 +1470,7 @@ mod tests {
         PDRouter {
             worker_registry,
             policy_registry,
+            worker_load_manager: None,
             client: Client::new(),
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),

--- a/sgl-model-gateway/tests/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/test_openai_routing.rs
@@ -630,6 +630,7 @@ async fn test_unsupported_endpoints() {
         bootstrap_room: None,
         bootstrap_pair_key: None,
         data_parallel_rank: None,
+        data_parallel_rank_decode: None,
         background: false,
         conversation_id: None,
         priority: None,
@@ -813,6 +814,7 @@ async fn test_openai_router_circuit_breaker() {
         assert!(
             response.status() == StatusCode::INTERNAL_SERVER_ERROR
                 || response.status() == StatusCode::SERVICE_UNAVAILABLE
+                || response.status() == StatusCode::GATEWAY_TIMEOUT
         );
     }
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In the current PD separation scenario, the prefill instances only support the round_robin scheduling policy. Under this scheduling policy, which DP group a request is routed to is determined by the result of `bootstrap_room` mod `dpsize`. This can lead to load imbalance among DP groups, and this imbalance becomes more pronounced when the input requests are variable-length sequences.
Based on the above situation, I have added a new feature to select the DP group with the lightest load to process requests, thereby achieving and supporting DP load balance for PD-Disaggregation mode. The current load is measured by the number of tokens, which can be adjusted as needed in the future.The enabling or disabling of this feature is controlled by the parameter `dp_minimum_tokens_scheduler`.
## Key Changes

<!-- Detail the changes made in this pull request. -->
### 1.Load Collection
`LoadMonitor` periodically calls the `/get_load` interface to collect load data. In the existing implementation, only the sum number of tokens for all dp group was recorded. After modification, it will now record the number of tokens for each `dp_rank`, i.e., the load.
```rust
// Each object has: {dp_rank, num_reqs, num_waiting_reqs, num_tokens}
let mut rank_tokens = HashMap::new();
for entry in array {
    let dp_rank = entry.get("dp_rank").and_then(|v| v.as_i64()).map(|rank| rank as isize);
    let num_tokens = entry.get("num_tokens").and_then(|v| v.as_i64()).map(|rank| rank as isize);
    if let (Some(rank), Some(tokens)) = (dp_rank, num_tokens) {
        rank_tokens.insert(rank, tokens);
    }
}
```
### 2. Load Management
A new `DPLoadManager` struct has been added to manage loads, providing three methods:  `update_dp_loads` ,`get_lowest_dp_load` , and `load_increment`.
```rust
#[derive(Debug, Default)]
pub struct DPLoadManager {
    dp_cached_loads: RwLock<HashMap<String, HashMap<isize, isize>>>,
}
```
1. The `update_dp_loads` method updates the load. After periodically collecting load data, the LoadMonitor calls this method to perform the update.
2. The `get_lowest_dp_load` method takes a worker as input and returns the dp_rank with the lowest load among the workers.
3. The `load_increment` method is used to add an increment to the load of a specific dp_rank for a worker. This is done to prevent all requests from being scheduled to the same DP group during the interval between two load reports.
### 3. Selection of DP Group
1. Call the `get_lowest_dp_load` method to obtain the DP group with the lowest load.
2. Insert the `data_parallel_rank` field into the request so that the `data_parallel_controller` in prefill can check this field is not empty and directly schedule the request to the corresponding worker. Similarly, in the docode phase, check that the `data_parallel_rank` field is not empty, assign it to `prefill_dp_rank`, and ensure that KVReceiver and KVSender can connect properly (the implementation in the engine already supports this).
3. Call the `load_increment` method to add the length of the text in the request to the load of the DP group.
```rust
let lowest_prefill_dp_rank = prefill_policy.get_lowest_dp_load(prefill_worker);
obj.insert(
    "data_parallel_rank".to_string(),
    match lowest_prefill_dp_rank {
        Some(v) => Value::from(v),
        None => Value::Null,
    },
);
if let Some(dp_rank) = lowest_prefill_dp_rank {
    prefill_policy.load_increment(prefill_worker, dp_rank, prompt_len );
}
```
### 4. Configuration Parameters
1. A new configuration parameter `dp-minimum-tokens-scheduler` has been added to enable scheduling of the minimum load DP group when declaring the parameter.
2. A new configuration parameter `worker-load-check-interval` has been added to specify the interval for load collection. Previously, the load collection interval reused the configuration of `worker-startup-check-interval`. Now, this new configuration item is separate from the startup check.
## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Comparing the performance gains of several scheduling strategies on variable-length datasets before and after enabling dp-minimum-tokens-scheduler, the Mean TPOP performance improved by approximately 9%, and the Mean TTFT (with max_out_len=1 set to eliminate the impact of decoding on prefill) performance improved by about 15%. The specific data is as follows:
| Policy      | Mean  TTFT(ms) max_out_len=1 |                           |             | Mean  TPOT (ms)|                            |             |
| ----------- | ---------------------------- | ------------------------- | ----------- | ---------- | -------------------------- | ----------- |
|             | benckmark                    | enable dp minimum  tokens | Performance | benckmark  | enable dp minimum  tokense | Performance |
| Random      | 2631                         | 2249                      | +14.52%      | 53.41      | 48.15                      | +9.85%       |
| Round_robin | 2646                         | 2164                      | +18.22%       | 55.42      | 49.02                      | +11.55%      |
| Cache_aware | 2601                         | 2216                      | +14.80%      | 52.67      | 48.48                      | +7.96%       |

router
```shell
python -m sglang_router.launch_router --pd-disaggregation --prefill http://141.61.105.141:8000 8998 --decode http://141.61.105.144:8001 --prefill-policy cache_aware --dp-minimum-tokens-scheduler --worker-load-check-interval 1
```

prefill
```shell
python -m sglang.launch_server --model-path ${MODEL_PATH}  --disaggregation-mode prefill --host ${P_IP[$i]} \
--port 8000 --disaggregation-bootstrap-port $((8998+$i)) --trust-remote-code --nnodes 1 --node-rank 0 \
--tp-size 16 --mem-fraction-static 0.6 --attention-backend ascend --device npu --quantization w8a8_int8 \
--disaggregation-transfer-backend ascend --max-running-requests 8 --context-length 8192  --disable-radix-cache \
--chunked-prefill-size 32768 --max-prefill-tokens 28680 --disable-overlap-schedule --moe-a2a-backend deepep --deepep-mode normal \
--speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4  \
--dp-size 2 --enable-dp-attention --disable-shared-experts-fusion --dtype bfloat16
```
decode
```shell
python -m sglang.launch_server --model-path ${MODEL_PATH} --disaggregation-mode decode --host ${D_IP[$i]} \
--port 8001 --trust-remote-code --nnodes 1 --node-rank 0 --tp-size 16 --dp-size 8 \
--mem-fraction-static 0.76 --max-running-requests 256 --attention-backend ascend --device npu --quantization w8a8_int8 \
--moe-a2a-backend deepep --enable-dp-attention --deepep-mode low_latency --enable-dp-lm-head \
--cuda-graph-bs 8 16 24 32 --disaggregation-transfer-backend ascend --watchdog-timeout 9000 --context-length 8192 \
--speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4  \
--prefill-round-robin-balance --disable-shared-experts-fusion --dtype bfloat16
```
benchmark
The model evaluation tool I used is AISBench. Click the link below to learn more: [AISBench](https://gitee.com/aisbench/benchmark/blob/master/README_en.md). Since I was using a variable-length dataset, I ran the dataset through sglang.bench_serving with the parameter --dataset-name random. However, I noticed that the input sequence length was being split into random values limited by the --random-input-len parameter. To ensure that the input request sequences were not split, I used AISBench.
```bash
ais_bench --models vllm_api_stream_chat --datasets gsm8k_gen_0_shot_cot_str_perf  --debug --summarizer default_perf --mode perf

╒══════════════════════════╤═════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤═════════════════╤══════╕
│ Performance Parameters   │ Stage   │ Average         │ Min             │ Max             │ Median          │ P75             │ P90             │ P99             │  N   │
╞══════════════════════════╪═════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪═════════════════╪══════╡
│ E2EL                     │ total   │ 55044.4573 ms   │ 11143.2514 ms   │ 195472.4726 ms  │ 35057.9889 ms   │ 69464.8019 ms   │ 132295.1279 ms  │ 185509.4833 ms  │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ TTFT                     │ total   │ 893.5725 ms     │ 348.2403 ms     │ 1549.0416 ms    │ 901.9457 ms     │ 1084.3782 ms    │ 1215.7292 ms    │ 1469.2704 ms    │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ TPOT                     │ total   │ 48.4854 ms      │ 33.7401 ms      │ 63.8094 ms      │ 48.7747 ms      │ 52.4151 ms      │ 55.4097 ms      │ 59.9007 ms      │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ ITL                      │ total   │ 114.1014 ms     │ 0.0068 ms       │ 594.2452 ms     │ 115.7806 ms     │ 119.678 ms      │ 123.1585 ms     │ 251.8668 ms     │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ InputTokens              │ total   │ 2560.5243       │ 1481.0          │ 4120.0          │ 2216.0          │ 3402.25         │ 3943.3          │ 4107.49         │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ OutputTokens             │ total   │ 1159.8058       │ 187.0           │ 4068.0          │ 715.5           │ 1358.0          │ 2769.4          │ 4068.0          │ 1000 │
├──────────────────────────┼─────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼─────────────────┼──────┤
│ OutputTokenThroughput    │ total   │ 20.3425 token/s │ 14.7171 token/s │ 28.1505 token/s │ 19.9678 token/s │ 22.0362 token/s │ 23.6102 token/s │ 26.6782 token/s │ 1000 │
╘══════════════════════════╧═════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧═════════════════╧══════╛
╒══════════════════════════╤═════════╤═══════════════════╕
│ Common Metric            │ Stage   │ Value             │
╞══════════════════════════╪═════════╪═══════════════════╡
│ Benchmark Duration       │ total   │ 392829.9277 ms    │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Requests           │ total   │ 1000              │
├──────────────────────────┼─────────┼───────────────────┤
│ Failed Requests          │ total   │ 0                 │
├──────────────────────────┼─────────┼───────────────────┤
│ Success Requests         │ total   │ 1000              │
├──────────────────────────┼─────────┼───────────────────┤
│ Concurrency              │ total   │ 86.5959           │
├──────────────────────────┼─────────┼───────────────────┤
│ Max Concurrency          │ total   │ 270               │
├──────────────────────────┼─────────┼───────────────────┤
│ Request Throughput       │ total   │ 2.5456 req/s      │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Input Tokens       │ total   │ 1582404           │
├──────────────────────────┼─────────┼───────────────────┤
│ Prefill Token Throughput │ total   │ 2865.4913 token/s │
├──────────────────────────┼─────────┼───────────────────┤
│ Total generated tokens   │ total   │ 716760            │
├──────────────────────────┼─────────┼───────────────────┤
│ Input Token Throughput   │ total   │ 4028.2165 token/s │
├──────────────────────────┼─────────┼───────────────────┤
│ Output Token Throughput  │ total   │ 1824.6064 token/s │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Token Throughput   │ total   │ 5852.8229 token/s │
╘══════════════════════════╧═════════╧═══════════════════╛

```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
