### PR TITLE
Fix accept rate in speculative decoding metrics 

### DIFF
--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -275,6 +275,7 @@ class SchedulerMetricsMixin:
             )
             # Calculate acceptance rate: accepted tokens / total draft tokens
             total_draft_tokens = self.spec_num_forward_ct * (
+                self.server_args.speculative_num_draft_tokens or
                 (self.server_args.speculative_num_steps or 0) + 1
             )
             spec_accept_rate = (

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -275,7 +275,9 @@ class SchedulerMetricsMixin:
             )
             # Calculate acceptance rate: accepted tokens / total draft tokens
             draft_tokens_fallback = (self.server_args.speculative_num_steps or 0) + 1
-            num_draft_tokens = self.server_args.speculative_num_draft_tokens or draft_tokens_fallback
+            num_draft_tokens = (
+                self.server_args.speculative_num_draft_tokens or draft_tokens_fallback
+            )
             total_draft_tokens = self.spec_num_forward_ct * num_draft_tokens
 
             spec_accept_rate = (

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -274,10 +274,10 @@ class SchedulerMetricsMixin:
                 self.spec_num_accepted_tokens / self.spec_num_forward_ct
             )
             # Calculate acceptance rate: accepted tokens / total draft tokens
-            total_draft_tokens = self.spec_num_forward_ct * (
-                self.server_args.speculative_num_draft_tokens or
-                (self.server_args.speculative_num_steps or 0) + 1
-            )
+            draft_tokens_fallback = (self.server_args.speculative_num_steps or 0) + 1
+            num_draft_tokens = self.server_args.speculative_num_draft_tokens or draft_tokens_fallback
+            total_draft_tokens = self.spec_num_forward_ct * num_draft_tokens
+
             spec_accept_rate = (
                 self.spec_num_accepted_tokens / total_draft_tokens
                 if total_draft_tokens > 0


### PR DESCRIPTION
 total_draft_tokens is wrong when speculative_num_draft_tokens != self.server_args.speculative_num_steps + 1

`            total_draft_tokens = self.spec_num_forward_ct * (
                self.server_args.speculative_num_draft_tokens or
                (self.server_args.speculative_num_steps or 0) + 1
            )`