### PR TITLE
Set max parallel for 1-gpu runner

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -379,6 +379,7 @@ jobs:
     runs-on: 1-gpu-runner
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     steps:


### PR DESCRIPTION
To avoid one CI task occupying all CI runners.