### PR TITLE
[router][grpc] Refine docs in minimax_m2 to match other parsers

### DIFF
--- a/sgl-router/src/tool_parser/parsers/minimax_m2.rs
+++ b/sgl-router/src/tool_parser/parsers/minimax_m2.rs
@@ -16,30 +16,16 @@ use crate::{
 
 /// MiniMax M2 format parser for tool calls
 ///
-/// Implements the MiniMax-M2 model's XML-based tool calling format as specified in the
-/// official chat template. The M2 model uses a structured XML format for function invocations
-/// to ensure reliable parsing and execution.
+/// Handles the MiniMax M2 specific format:
+/// `<minimax:tool_call><invoke name="func"><parameter name="key">value</parameter></invoke></minimax:tool_call>`
 ///
-/// ## Format Reference
-/// - HuggingFace Model: https://huggingface.co/MiniMaxAI/MiniMax-M2
-/// - Chat Template: https://huggingface.co/MiniMaxAI/MiniMax-M2?chat_template=default
+/// Features:
+/// - Namespaced XML tags (`minimax:tool_call`)
+/// - Function wrapped in `<invoke name="...">` tags
+/// - Parameters as `<parameter name="key">value</parameter>`
+/// - Incremental JSON streaming for parameters
 ///
-/// ## Tool Call Structure
-/// ```xml
-/// <minimax:tool_call>
-///   <invoke name="function_name">
-///     <parameter name="param1">value1</parameter>
-///     <parameter name="param2">value2</parameter>
-///   </invoke>
-/// </minimax:tool_call>
-/// ```
-///
-/// ## Key Features
-/// - **Namespaced XML tags**: Uses `minimax:` namespace to avoid conflicts
-/// - **Structured invocation**: Functions wrapped in `<invoke name="...">` tags
-/// - **Named parameters**: Each parameter uses `<parameter name="key">value</parameter>`
-/// - **Incremental streaming**: Converts XML to JSON progressively during streaming
-/// - **XML entity decoding**: Handles encoded entities (`&lt;`, `&gt;`, etc.) in parameter values
+/// Reference: https://huggingface.co/MiniMaxAI/MiniMax-M2?chat_template=default
 pub struct MinimaxM2Parser {
     // Regex patterns
     tool_call_extractor: Regex,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This PR refines the top comment section in minimax_m2.rs

Justification for `decode_xml_entities()`: IMO, this is altering model's output. However, SGLang python seems to have it. Will keep it for now.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Make the top section match other parser
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
