### PR TITLE
[Deepseek V3.2] Clean up MTP

### DIFF
--- a/test/srt/test_deepseek_v32_mtp.py
+++ b/test/srt/test_deepseek_v32_mtp.py
@@ -58,7 +58,7 @@ class TestDeepseekV32MTP(CustomTestCase):
         requests.get(self.base_url + "/flush_cache")
 
         args = SimpleNamespace(
-            num_shots=8,
+            num_shots=20,
             data_path=None,
             num_questions=1400,
             parallel=1400,
@@ -81,7 +81,7 @@ class TestDeepseekV32MTP(CustomTestCase):
                 f'{metrics["accuracy"]=:.3f}\n'
                 f"{avg_spec_accept_length=:.2f}\n"
             )
-            self.assertGreater(metrics["accuracy"], 0.935)
+            self.assertGreater(metrics["accuracy"], 0.94)
             self.assertGreater(avg_spec_accept_length, 2.7)
 
     def test_bs_1_speed(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Modifications

- Fix an accuracy bug in MTP draft_extend stage. The `seqlens_int32_cpu` used in the calculations of  `seqlens_expanded` is incorrect. We should use `seq_lens_cpu`, instead of `seqlens_int32_cpu = [self.speculative_num_draft_tokens + kv_len for kv_len in seq_lens_cpu.tolist()]`.
- Make the draft_extend stage use `_get_topk_paged` instead of `_get_topk_ragged`, which avoids copies of the k cache from the paged to contiguous. Modify the NSA `init_forward_metadata/init_forward_metadata_capture_cuda_graph/init_forward_metadata_replay_cuda_graph` code accordingly
- Change mtp test to use 20 shots, and increase the accuracy threshold to 0.94

## Accuracy Tests

The accuracy of gsm8k 20shots based on `test/srt/test_deepseek_v32_mtp.py` increased slightly on average:

before
```
Accuracy: 0.948, (more runs: 0.949, 0.951, 0.946, 0.951)
Invalid: 0.000
Latency: 174.051 s
Output throughput: 738.807 token/s
metrics={'accuracy': np.float64(0.9484457922668689), 'invalid': np.float64(0.0), 'latency': 174.05095608596457, 'output_throughput': 738.8066281950718}

+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   18.310    |  1654  |   2.996    |      90.34      |
+-------------+--------+------------+-----------------+
acc_length=3.00 speed=90.34


```

after
```
Accuracy: 0.951, (more runs: 0.948, 0.952, 0.954, 0.951)
Invalid: 0.000
Latency: 170.449 s
Output throughput: 750.093 token/s
metrics={'accuracy': np.float64(0.9507202426080363), 'invalid': np.float64(0.0), 'latency': 170.44943334697746, 'output_throughput': 750.0934294086768}

+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|   18.285    |  1654  |   3.024    |      90.46      |
+-------------+--------+------------+-----------------+
acc_length=3.02 speed=90.46
```

GPQA (after) is within normal range of variance
```
Repeat: 8, mean: 0.784
Scores: ['0.753', '0.803', '0.788', '0.773', '0.798', '0.798', '0.783', '0.778']
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
