### PR TITLE
ci: speed up b200 ci

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -877,7 +877,7 @@ jobs:
           python3 run_suite.py --suite per-commit-8-gpu-h200-deepep
 
   unit-test-backend-4-gpu-b200:
-    needs: [check-changes, unit-test-backend-2-gpu, sgl-kernel-build-wheels]
+    needs: [check-changes, sgl-kernel-build-wheels]
     if: always() && !failure() && !cancelled() &&
       ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
     runs-on: 4-gpu-b200

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -877,7 +877,7 @@ jobs:
           python3 run_suite.py --suite per-commit-8-gpu-h200-deepep
 
   unit-test-backend-4-gpu-b200:
-    needs: [check-changes, sgl-kernel-build-wheels]
+    needs: [check-changes, unit-test-backend-2-gpu, sgl-kernel-build-wheels]
     if: always() && !failure() && !cancelled() &&
       ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
     runs-on: 4-gpu-b200

--- a/test/srt/test_deepseek_v3_fp4_4gpu.py
+++ b/test/srt/test_deepseek_v3_fp4_4gpu.py
@@ -35,6 +35,8 @@ class TestDeepseekV3FP4(CustomTestCase):
             "modelopt_fp4",
             "--kv-cache-dtype",
             "fp8_e4m3",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
         ]
         cls.process = popen_launch_server(
             cls.model,
@@ -106,6 +108,8 @@ class TestDeepseekV3FP4MTP(CustomTestCase):
             "4",
             "--kv-cache-dtype",
             "fp8_e4m3",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
         ]
         cls.process = popen_launch_server(
             cls.model,
@@ -184,6 +188,8 @@ class TestDeepseekV3FP4CutlassMoE(CustomTestCase):
             "flashinfer_cutlass",
             "--quantization",
             "modelopt_fp4",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
         ]
         cls.process = popen_launch_server(
             cls.model,


### PR DESCRIPTION
I suppose maybe the runner was down earlier and it dropped it from page cache, so it's really slow here and seems to be timing out

https://github.com/sgl-project/sglang/actions/runs/19320913027/job/55356946845?pr=13101

Personally, I also found that this way is faster loading in page cache too (maybe 20-30 pct) (original author also found this https://github.com/sgl-project/sglang/pull/7277).