### PR TITLE
Fail the whole nightly test if any job fails

### DIFF
--- a/.github/workflows/nightly-test-b200.yml
+++ b/.github/workflows/nightly-test-b200.yml
@@ -18,7 +18,6 @@ jobs:
   nightly-test-4-gpu-b200:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 4-gpu-b200
-    continue-on-error: true
     env:
       RUNNER_LABELS: 4-gpu-b200
     steps:
@@ -50,7 +49,6 @@ jobs:
   nightly-test-8-gpu-b200:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 8-gpu-b200
-    continue-on-error: true
     env:
       RUNNER_LABELS: 8-gpu-b200
     steps:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -18,7 +18,6 @@ jobs:
   nightly-test-eval-text-models:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 2-gpu-runner
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +35,6 @@ jobs:
   nightly-test-perf-text-models:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 2-gpu-runner
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,7 +64,6 @@ jobs:
   nightly-test-eval-vlms:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 2-gpu-runner
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -84,7 +81,6 @@ jobs:
   nightly-test-perf-vlms:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 2-gpu-runner
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -114,7 +110,6 @@ jobs:
   nightly-test-1-gpu:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 1-gpu-runner
-    continue-on-error: true
     env:
       RUNNER_LABELS: 1-gpu-runner
     steps:
@@ -134,7 +129,6 @@ jobs:
   nightly-test-4-gpu:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 4-gpu-h100
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -152,7 +146,6 @@ jobs:
   nightly-test-8-gpu-h200:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 8-gpu-h200
-    continue-on-error: true
     env:
       RUNNER_LABELS: 8-gpu-h200
     steps:
@@ -172,7 +165,6 @@ jobs:
   nightly-test-8-gpu-h20:
     if: github.repository == 'sgl-project/sglang'
     runs-on: 8-gpu-h20
-    continue-on-error: true
     env:
       SGLANG_CI_RDMA_ALL_DEVICES: "mlx5_1,mlx5_2,mlx5_3,mlx5_4"
     steps:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Due to `continue-on-error: True`, job failure won't lead to the final nightly test failure which seems not expected. Fixing this behavior

<img width="974" height="703" alt="image" src="https://github.com/user-attachments/assets/c4b4e51f-4835-4719-a723-0261a95ff41c" />

## Modifications

<img width="880" height="473" alt="image" src="https://github.com/user-attachments/assets/5072cab3-0a89-46bd-9762-378ede70d1c9" />

<img width="947" height="494" alt="image" src="https://github.com/user-attachments/assets/dc43a15c-7396-40d9-b1f6-1be99e5759b7" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
