### PR TITLE
Guard fused Marlin MoE atomic add usage to prevent crashes

### DIFF
--- a/sgl-kernel/python/sgl_kernel/fused_moe.py
+++ b/sgl-kernel/python/sgl_kernel/fused_moe.py
@@ -71,6 +71,9 @@ def fused_marlin_moe(
         moe_align_block_size,
         try_get_optimal_moe_config,
     )
+    from sglang.srt.layers.quantization.marlin_utils import (
+        should_use_atomic_add_reduce,
+    )
 
     # Check constraints.
     assert hidden_states.shape[0] == gating_output.shape[0], "Number of tokens mismatch"
@@ -142,10 +145,16 @@ def fused_marlin_moe(
     intermediate_cache3 = intermediate_cache13[: M * topk_ids.shape[1] * K]
     intermediate_cache3 = intermediate_cache3.view(-1, K)
 
-    use_atomic_add = (
-        hidden_states.dtype == torch.half
-        or torch.cuda.get_device_capability(hidden_states.device)[0] >= 9
-    )
+    def _should_use_atomic_add(m: int, n: int, k: int) -> bool:
+        return should_use_atomic_add_reduce(
+            m=m,
+            n=n,
+            k=k,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+
+    use_atomic_add_first = _should_use_atomic_add(M, 2 * N, K)
 
     intermediate_cache1 = torch.ops.sgl_kernel.moe_wna16_marlin_gemm.default(
         hidden_states,
@@ -169,7 +178,7 @@ def fused_marlin_moe(
         size_n=2 * N,
         size_k=K,
         is_k_full=is_k_full,
-        use_atomic_add=use_atomic_add,
+        use_atomic_add=use_atomic_add_first,
         use_fp32_reduce=True,
         is_zp_float=False,
     )
@@ -178,6 +187,8 @@ def fused_marlin_moe(
 
     if expert_map is not None:
         intermediate_cache3.zero_()
+
+    use_atomic_add_second = _should_use_atomic_add(M * topk, K, N)
 
     intermediate_cache3 = torch.ops.sgl_kernel.moe_wna16_marlin_gemm.default(
         intermediate_cache2,
@@ -201,7 +212,7 @@ def fused_marlin_moe(
         size_n=K,
         size_k=N,
         is_k_full=is_k_full,
-        use_atomic_add=use_atomic_add,
+        use_atomic_add=use_atomic_add_second,
         use_fp32_reduce=True,
         is_zp_float=False,
     ).view(-1, topk, K)


### PR DESCRIPTION
 <!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit
  your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

  ## Motivation

Marlin‑quantized MoE crash because `sgl_kernel.fused_moe` always forces the experimental atomic-add reduction path. Those large (M, N, K) shapes exceed the safe window for the Marlin kernel and trigger illegal memory accesses. We already have a proven heuristic elsewhere in the codebase; this PR reuses it so atomic add is only enabled when the shape/device combination is known safe.

  ## Modifications

  - Import `should_use_atomic_add_reduce` inside `sgl_kernel/python/sgl_kernel/fused_moe.py`.
  - Evaluate the heuristic separately for the w1 and w2 GEMMs (first stage uses `(M, 2N, K)`, second uses `(M·topk, K, N)`) and pass the result as `use_atomic_add` to each `moe_wna16_marlin_gemm` call.
  - No changes to CUDA kernels; we simply stop invoking them with unsafe settings.

