### PR TITLE
[Fix] Fix speculative decoding when calling release/resume memory.

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -756,9 +756,12 @@ class ModelRunner:
         # Remove monkey_patch when linear.py quant remove dependencies with vllm
         monkey_patch_vllm_parallel_state()
 
+        enable_cpu_backup = (
+            True if self.is_draft_worker else self.server_args.enable_weights_cpu_backup
+        )
         with self.memory_saver_adapter.region(
             GPU_MEMORY_TYPE_WEIGHTS,
-            enable_cpu_backup=self.server_args.enable_weights_cpu_backup,
+            enable_cpu_backup=enable_cpu_backup,
         ):
             self.model = get_model(
                 model_config=self.model_config,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

This commit addresses the use of speculative decoding algorithm in reinforcement learning (RL) scenarios. Previously, when using **speculative decoding in veRL**, the draft worker would also be released, causing the **draft worker's weights to become zero** after resuming memory. 
Since there is currently no weight update mechanism specifically designed for draft workers, we enforce the use of CPU offload as a mandatory requirement to ensure proper functionality.

## Modifications
Add
```python
enable_cpu_backup = True if self.is_draft_worker else self.server_args.enable_weights_cpu_backup
```
