### PR TITLE
Remove verbs from GET endpoint paths to follow REST standards

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -477,6 +477,16 @@ async def health_generate(request: Request) -> Response:
 
 @app.get("/get_model_info")
 async def get_model_info():
+    """Get the model information (deprecated - use /model_info instead)."""
+    logger.warning(
+        "Endpoint '/get_model_info' is deprecated and will be removed in a future version. "
+        "Please use '/model_info' instead."
+    )
+    return await model_info()
+
+
+@app.get("/model_info")
+async def model_info():
     """Get the model information."""
     result = {
         "model_path": _global_state.tokenizer_manager.model_path,
@@ -492,6 +502,16 @@ async def get_model_info():
 
 @app.get("/get_weight_version")
 async def get_weight_version():
+    """Get the current weight version (deprecated - use /weight_version instead)."""
+    logger.warning(
+        "Endpoint '/get_weight_version' is deprecated and will be removed in a future version. "
+        "Please use '/weight_version' instead."
+    )
+    return await weight_version()
+
+
+@app.get("/weight_version")
+async def weight_version():
     """Get the current weight version."""
     return {
         "weight_version": _global_state.tokenizer_manager.server_args.weight_version
@@ -500,7 +520,18 @@ async def get_weight_version():
 
 @app.get("/get_server_info")
 async def get_server_info():
-    # Returns interna states per DP.
+    """Get the server information (deprecated - use /server_info instead)."""
+    logger.warning(
+        "Endpoint '/get_server_info' is deprecated and will be removed in a future version. "
+        "Please use '/server_info' instead."
+    )
+    return await server_info()
+
+
+@app.get("/server_info")
+async def server_info():
+    """Get the server information."""
+    # Returns internal states per DP.
     internal_states: List[Dict[Any, Any]] = (
         await _global_state.tokenizer_manager.get_internal_state()
     )


### PR DESCRIPTION
### Summary

This PR updates three HTTP endpoints to follow REST API best practices by removing the get verb from their paths while maintaining backward compatibility.

### Changes
  - `/get_model_info` → `/model_info`
  - `/get_weight_version` → `/weight_version`
  - `/get_server_info` → `/server_info`

### Why This Change?

  REST API standards recommend that HTTP endpoints should use nouns to represent resources, not verbs. The HTTP method itself (`GET`, `POST`, `PUT`, `DELETE`) already indicates the action being performed. Including verbs in endpoint paths is redundant and goes against REST principles.

#### Before (anti-pattern):
  GET `/get_model_info`     # Redundant - "get" is already implied by HTTP GET
  GET `/get_server_info`    # Verb in path duplicates the HTTP method

  After (REST standard):
  GET `/model_info`         # Clean, resource-oriented
  GET `/server_info`        # The HTTP method indicates the action

### Migration Strategy

  To ensure smooth transition for existing users:

  1. Both endpoints work: Old endpoints (/get_*) remain functional
  2. Deprecation warnings: Old endpoints log warnings to encourage migration
  3. Zero breaking changes: Existing integrations continue to work
  4. Same response format: Both old and new endpoints return identical data

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
