### PR TITLE
[NVIDIA] Fix use case of SGLANG_ENABLE_FLASHINFER_GEMM

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -68,7 +68,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_INT4_WEIGHT` | Enable INT4 weight quantization | `false` |
 | `SGLANG_MOE_PADDING` | Enable MoE padding (sets padding size to 128 if value is `1`, often set to `1` in Docker builds) | `0` |
 | `SGLANG_FORCE_FP8_MARLIN` | Force using FP8 MARLIN kernels even if other FP8 kernels are available | `false` |
-| `SGLANG_ENABLE_FLASHINFER_GEMM` | Use flashinfer kernels when running blockwise fp8 GEMM on Blackwell GPUs | `false` |
+| `SGLANG_ENABLE_FLASHINFER_FP8_GEMM` | Use flashinfer kernels when running blockwise fp8 GEMM on Blackwell GPUs | `false` |
 | `SGLANG_FLASHINFER_FP4_GEMM_BACKEND` | Select backend for `mm_fp4` on Blackwell GPUS | `` |
 | `SGLANG_SUPPORT_CUTLASS_BLOCK_FP8` | Use Cutlass kernels when running blockwise fp8 GEMM on Hopper or Blackwell GPUs | `false` |
 | `SGLANG_CUTLASS_MOE` (deprecated) | Use Cutlass FP8 MoE kernel on Blackwell GPUs (deprecated, use --moe-runner-backend=cutlass) | `false` |

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -206,7 +206,7 @@ class Envs:
 
     # Flashinfer
     SGLANG_IS_FLASHINFER_AVAILABLE = EnvBool(True)
-    SGLANG_ENABLE_FLASHINFER_GEMM = EnvBool(False)
+    SGLANG_ENABLE_FLASHINFER_FP8_GEMM = EnvBool(False)
     # Default to the pick from flashinfer
     SGLANG_FLASHINFER_FP4_GEMM_BACKEND = EnvStr("")
     SGLANG_FLASHINFER_WORKSPACE_SIZE = EnvInt(384 * 1024 * 1024)
@@ -304,6 +304,7 @@ def _print_deprecated_env(new_name: str, old_name: str):
 
 def _convert_SGL_to_SGLANG():
     _print_deprecated_env("SGLANG_LOG_GC", "SGLANG_GC_LOG")
+    _print_deprecated_env("SGLANG_ENABLE_FLASHINFER_FP8_GEMM", "SGLANG_ENABLE_FLASHINFER_GEMM")
 
     for key, value in os.environ.items():
         if key.startswith("SGL_"):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -304,7 +304,9 @@ def _print_deprecated_env(new_name: str, old_name: str):
 
 def _convert_SGL_to_SGLANG():
     _print_deprecated_env("SGLANG_LOG_GC", "SGLANG_GC_LOG")
-    _print_deprecated_env("SGLANG_ENABLE_FLASHINFER_FP8_GEMM", "SGLANG_ENABLE_FLASHINFER_GEMM")
+    _print_deprecated_env(
+        "SGLANG_ENABLE_FLASHINFER_FP8_GEMM", "SGLANG_ENABLE_FLASHINFER_GEMM"
+    )
 
     for key, value in os.environ.items():
         if key.startswith("SGL_"):

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -129,7 +129,7 @@ def cutlass_block_fp8_supported() -> bool:
 
 CUTLASS_BLOCK_FP8_SUPPORTED = cutlass_block_fp8_supported()
 ENABLE_FLASHINFER_FP8_GEMM = (
-    envs.SGLANG_ENABLE_FLASHINFER_FP8_GEMM.value
+    envs.SGLANG_ENABLE_FLASHINFER_FP8_GEMM.get()
     and is_blackwell_supported()
     and is_flashinfer_available()
 )

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -127,17 +127,17 @@ def cutlass_block_fp8_supported() -> bool:
 
 
 CUTLASS_BLOCK_FP8_SUPPORTED = cutlass_block_fp8_supported()
-ENABLE_FLASHINFER_GEMM = (
-    get_bool_env_var("SGLANG_ENABLE_FLASHINFER_GEMM")
+ENABLE_FLASHINFER_FP8_GEMM = (
+    get_bool_env_var("SGLANG_ENABLE_FLASHINFER_FP8_GEMM")
     and is_blackwell_supported()
     and is_flashinfer_available()
 )
-if ENABLE_FLASHINFER_GEMM:
+if ENABLE_FLASHINFER_FP8_GEMM:
     from flashinfer.gemm import gemm_fp8_nt_groupwise
 
 
 def dispatch_w8a8_block_fp8_linear() -> Callable:
-    if ENABLE_FLASHINFER_GEMM:
+    if ENABLE_FLASHINFER_FP8_GEMM:
         return flashinfer_gemm_w8a8_block_fp8_linear
     elif CUTLASS_BLOCK_FP8_SUPPORTED:
         return cutlass_w8a8_block_fp8_linear_with_fallback

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -2,6 +2,7 @@ from typing import Callable, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
 from sglang.srt.layers.quantization.mxfp4_tensor import MXFP4QuantizeUtil
@@ -128,7 +129,7 @@ def cutlass_block_fp8_supported() -> bool:
 
 CUTLASS_BLOCK_FP8_SUPPORTED = cutlass_block_fp8_supported()
 ENABLE_FLASHINFER_FP8_GEMM = (
-    get_bool_env_var("SGLANG_ENABLE_FLASHINFER_FP8_GEMM")
+    envs.SGLANG_ENABLE_FLASHINFER_FP8_GEMM.value
     and is_blackwell_supported()
     and is_flashinfer_available()
 )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -96,7 +96,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     quant_weight_ue8m0,
     requant_weight_ue8m0_inplace,
     transform_scale_ue8m0_inplace,
-    ENABLE_FLASHINFER_GEMM,
+    ENABLE_FLASHINFER_FP8_GEMM,
 )
 from sglang.srt.layers.quantization.int8_utils import (
     block_dequant as int8_block_dequant,
@@ -3421,7 +3421,7 @@ class DeepseekV2ForCausalLM(nn.Module):
                 self_attn.use_deep_gemm_bmm = True
 
         if (
-            not ENABLE_FLASHINFER_GEMM
+            not ENABLE_FLASHINFER_FP8_GEMM
             and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
             and hasattr(self.quant_config, "weight_block_size")

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -96,6 +96,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     quant_weight_ue8m0,
     requant_weight_ue8m0_inplace,
     transform_scale_ue8m0_inplace,
+    ENABLE_FLASHINFER_GEMM,
 )
 from sglang.srt.layers.quantization.int8_utils import (
     block_dequant as int8_block_dequant,
@@ -3420,7 +3421,8 @@ class DeepseekV2ForCausalLM(nn.Module):
                 self_attn.use_deep_gemm_bmm = True
 
         if (
-            deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
+            not ENABLE_FLASHINFER_GEMM
+            and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             and deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
             and hasattr(self.quant_config, "weight_block_size")
             and self.quant_config.weight_block_size is not None

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -89,6 +89,7 @@ from sglang.srt.layers.quantization.fp8_kernel import (
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
 from sglang.srt.layers.quantization.fp8_utils import (
+    ENABLE_FLASHINFER_FP8_GEMM,
     block_quant_dequant,
     block_quant_to_tensor_quant,
     channel_quant_to_tensor_quant,
@@ -96,7 +97,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     quant_weight_ue8m0,
     requant_weight_ue8m0_inplace,
     transform_scale_ue8m0_inplace,
-    ENABLE_FLASHINFER_FP8_GEMM,
 )
 from sglang.srt.layers.quantization.int8_utils import (
     block_dequant as int8_block_dequant,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When SGLANG_ENABLE_FLASHINFER_GEMM is enabled, we observed that the accuracy test fails. (by @gracehonv )
The root cause is that the model execution switches to use e8m0 scales for Blackwell GPUs even when DeepGEMM is not in use.
This PR fixes the issue by ensuring that the correct scaling mode is applied.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

script:
```
set -x
if [[ "$1" == "server" ]]; then
model_str=/model/deepseek-ai-DeepSeek-R1-0528/models--deepseek-ai--DeepSeek-R1-0528/snapshots/4236a6af538feda4548eca9ab308586007567f52
export SGLANG_ENABLE_FLASHINFER_GEMM=true
#export SGLANG_SUPPORT_CUTLASS_BLOCK_FP8=true

  python3 -m sglang.launch_server \
    --trust-remote-code \
    --disable-radix-cache \
    --max-running-requests 512 \
    --chunked-prefill-size 8192 \
    --mem-fraction-static 0.9 \
    --cuda-graph-max-bs 128 \
    --max-prefill-tokens 8192 \
    --kv-cache-dtype fp8_e4m3 \
    --quantization fp8 \
    --model-path ${model_str} \
    --host 0.0.0.0 \
    --port 8000 \
    --tensor-parallel-size=4 \
    --data-parallel-size=1 \
    --expert-parallel-size=1 \
    --scheduler-recv-interval 10 \
    --stream-interval 10 \
    --tokenizer-path ${model_str} \
    --attention-backend trtllm_mla \
    --moe-runner-backend flashinfer_trtllm \
    --enable-symm-mem \

fi

if [[ "$1" == "bench" ]]; then
python3 /sgl-workspace/sglang/benchmark/gsm8k/bench_sglang.py \
  --num-questions 2000 \
  --parallel 2000 \
  --num-shots 8 \
  --port 8000
fi

if [[ "$1" == "chat" ]]; then
  curl http://127.0.0.1:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "$model_str",
      "messages": [{"role": "assistant", "content": "What is 37 * 42?"}],
      "extra_body": {
        "chat_template_kwargs": {
          "thinking": true
        }
      }
    }'
fi
```

result:
```
100%|███████████████████████████████████████████████████████████████████████████| 1319/1319 [04:30<00:00,  4.87it/s]
Accuracy: 0.966
Invalid: 0.000
Latency: 271.168 s
Output throughput: 523.439 token/s
+ [[ bench == \c\h\a\t ]]
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
