### PR TITLE
Add feature flag to broadcast mm inputs processing

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1240,7 +1240,7 @@ class Scheduler(
         return image_inputs
 
     def _get_multimodal_inputs(self, mm_inputs_dict: dict):
-        if self.server_args.enable_optimized_mm_inputs_process:
+        if self.server_args.enable_broadcast_mm_inputs_process:
             return self._process_and_broadcast_mm_inputs(mm_inputs_dict)
         else:
             return MultimodalInputs.from_dict(mm_inputs_dict)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -565,7 +565,7 @@ class ServerArgs:
     # For Multi-Modal
     mm_max_concurrent_calls: int = 32
     mm_per_request_timeout: float = 10.0
-    enable_optimized_mm_inputs_process: bool = False
+    enable_broadcast_mm_inputs_process: bool = False
 
     # For checkpoint decryption
     decrypted_config_file: Optional[str] = None
@@ -3653,10 +3653,10 @@ class ServerArgs:
             help="The timeout for each multi-modal request in seconds.",
         )
         parser.add_argument(
-            "--enable-optimized-mm-inputs-process",
+            "--enable-broadcast-mm-inputs-process",
             action="store_true",
-            default=ServerArgs.enable_optimized_mm_inputs_process,
-            help="Enable optimized mm-inputs process in scheduler.",
+            default=ServerArgs.enable_broadcast_mm_inputs_process,
+            help="Enable broadcast mm-inputs process in scheduler.",
         )
 
         # For checkpoint decryption

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -565,6 +565,7 @@ class ServerArgs:
     # For Multi-Modal
     mm_max_concurrent_calls: int = 32
     mm_per_request_timeout: float = 10.0
+    enable_optimized_mm_inputs_process: bool = False
 
     # For checkpoint decryption
     decrypted_config_file: Optional[str] = None
@@ -3650,6 +3651,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.mm_per_request_timeout,
             help="The timeout for each multi-modal request in seconds.",
+        )
+        parser.add_argument(
+            "--enable-optimized-mm-inputs-process",
+            action="store_true",
+            default=ServerArgs.enable_optimized_mm_inputs_process,
+            help="Enable optimized mm-inputs process in scheduler.",
         )
 
         # For checkpoint decryption


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
PR https://github.com/sgl-project/sglang/pull/11910 introduced an optimization to process mm_inputs on rank 0 instead of all TP ranks and then broadcast to all TP ranks in order to save CPU. But after benchmark we realize that it has performance regression in some case such as small image in high concurrency load. Meanwhile, this feature does outperform in video file scenario than legacy version.

As a tradeoff, this PR is to add a server arg to toggle this feature. In the future, more intelligent decision can be made by the engine based on some strategy such as mm data size or traffic load.

Benchmark result is following:
```
Client:
python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 512 \
  --apply-chat-template \
  --random-output-len 100 \
  --random-input-len 500 \
  --image-resolution 1120x700 \
  --image-format jpeg \
  --image-count 1 \
  --image-content random \
  --random-range-ratio 0.8 \
  --port 8188 \
  --max-concurrency 96 
```

```
Close feature:
Server:
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=2048 \
python -m sglang.launch_server \
  --model-path /home/admin/Qwen2.5-VL-72B-Instruct/ \
  --host 0.0.0.0 \
  --port 8188 \
  --trust-remote-code \
  --tp-size 8 \
  --enable-cache-report \
  --log-level info \
  --max-running-requests 64 \
  --mem-fraction-static 0.65 \
  --chunked-prefill-size 8192 \
  --attention-backend fa3 \
  --chat-template qwen2-vl \
  --mm-attention-backend fa3

============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 96        
Successful requests:                     512       
Benchmark duration (s):                  160.91    
Total input tokens:                      764609    
Total input text tokens:                 251585    
Total input vision tokens:               513024    
Total generated tokens:                  45888     
Total generated tokens (retokenized):    45420     
Request throughput (req/s):              3.18      
Input token throughput (tok/s):          4751.65   
Output token throughput (tok/s):         285.17    
Total token throughput (tok/s):          5036.82   
Concurrency:                             94.17     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   29596.96  
Median E2E Latency (ms):                 29606.21  
---------------Time to First Token----------------
Mean TTFT (ms):                          12044.15  
Median TTFT (ms):                        10999.99  
P99 TTFT (ms):                           28613.31  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          197.30    
Median TPOT (ms):                        209.07    
P99 TPOT (ms):                           282.00    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           199.03    
Median ITL (ms):                         24.25     
P95 ITL (ms):                            836.83    
P99 ITL (ms):                            1159.71   
Max ITL (ms):                            17053.91  
==================================================


Open feature:
Server:
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=2048 \
python -m sglang.launch_server \
  --model-path /home/admin/Qwen2.5-VL-72B-Instruct/ \
  --host 0.0.0.0 \
  --port 8188 \
  --trust-remote-code \
  --tp-size 8 \
  --enable-cache-report \
  --log-level info \
  --max-running-requests 64 \
  --mem-fraction-static 0.65 \
  --chunked-prefill-size 8192 \
  --attention-backend fa3 \
  --chat-template qwen2-vl \
  --mm-attention-backend fa3 \
  --enable-optimized-mm-inputs-process

============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 96        
Successful requests:                     512       
Benchmark duration (s):                  179.47    
Total input tokens:                      765036    
Total input text tokens:                 252011    
Total input vision tokens:               513025    
Total generated tokens:                  45888     
Total generated tokens (retokenized):    45347     
Request throughput (req/s):              2.85      
Input token throughput (tok/s):          4262.73   
Output token throughput (tok/s):         255.68    
Total token throughput (tok/s):          4518.41   
Concurrency:                             94.40     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   33089.56  
Median E2E Latency (ms):                 33081.97  
---------------Time to First Token----------------
Mean TTFT (ms):                          13588.09  
Median TTFT (ms):                        12384.41  
P99 TTFT (ms):                           33834.81  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          219.08    
Median TPOT (ms):                        234.00    
P99 TPOT (ms):                           306.78    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           221.54    
Median ITL (ms):                         24.59     
P95 ITL (ms):                            921.51    
P99 ITL (ms):                            1348.02   
Max ITL (ms):                            19247.02  
==================================================
```

For the performance improvement in video case, refer to https://github.com/sgl-project/sglang/pull/11910 .


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
