### PR TITLE
[opt kimi k2 1 / n] Add kimi k2 moe fused gate

### DIFF
--- a/sgl-kernel/CMakeLists.txt
+++ b/sgl-kernel/CMakeLists.txt
@@ -319,6 +319,7 @@ set(SOURCES
     "csrc/moe/marlin_moe_wna16/ops.cu"
     "csrc/moe/moe_align_kernel.cu"
     "csrc/moe/moe_fused_gate.cu"
+    "csrc/moe/kimi_k2_moe_fused_gate.cu"
     "csrc/moe/moe_sum.cu"
     "csrc/moe/moe_sum_reduce.cu"
     "csrc/moe/moe_topk_softmax_kernels.cu"

--- a/sgl-kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+++ b/sgl-kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
@@ -1,0 +1,98 @@
+import itertools
+import math
+import os
+
+import torch
+import triton
+import triton.language as tl
+from sgl_kernel import kimi_k2_moe_fused_gate
+
+from sglang.srt.layers.moe.topk import kimi_k2_biased_topk_impl
+
+# CI environment detection
+IS_CI = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+
+def kimi_k2_biased_topk_torch_compile(scores, bias, topk, routed_scaling_factor):
+    """Original torch.compile-based implementation"""
+    return kimi_k2_biased_topk_impl(
+        scores,
+        scores,
+        bias,
+        topk=topk,
+        renormalize=True,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+
+def kimi_k2_biased_topk_fused_kernel(scores, bias, topk, routed_scaling_factor):
+    """Our fused CUDA kernel implementation"""
+    return kimi_k2_moe_fused_gate(
+        scores,
+        bias,
+        topk=topk,
+        renormalize=True,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+
+# CI environment uses simplified parameters
+if IS_CI:
+    seq_length_range = [5000]  # Only test one sequence length in CI
+else:
+    seq_length_range = [5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000]
+
+configs = [(sq,) for sq in seq_length_range]
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["seq_length"],
+        x_vals=[list(_) for _ in configs],
+        line_arg="provider",
+        line_vals=["torch_compile", "fused_kernel"],
+        line_names=["Torch Compile", "Fused Kernel"],
+        styles=[("blue", "-"), ("red", "-")],
+        ylabel="us",
+        plot_name="kimi-k2-moe-fused-gate-performance",
+        args={},
+    )
+)
+def benchmark(seq_length, provider):
+    dtype = torch.float32
+    device = torch.device("cuda")
+    num_experts, topk = 384, 6  # Kimi K2 configuration
+    routed_scaling_factor = 2.872  # Kimi K2's routed scaling factor
+
+    scores = torch.randn((seq_length, num_experts), device=device, dtype=dtype)
+    bias = torch.rand(num_experts, device=device, dtype=dtype)
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "torch_compile":
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: kimi_k2_biased_topk_torch_compile(
+                scores.clone(), bias.clone(), topk, routed_scaling_factor
+            ),
+            quantiles=quantiles,
+        )
+    elif provider == "fused_kernel":
+        ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
+            lambda: kimi_k2_biased_topk_fused_kernel(
+                scores.clone(), bias.clone(), topk, routed_scaling_factor
+            ),
+            quantiles=quantiles,
+        )
+
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+
+if __name__ == "__main__":
+    print("=" * 80)
+    print("Benchmarking Kimi K2 MoE Fused Gate Performance")
+    print("=" * 80)
+    print("\nPerformance vs Sequence Length (384 experts, topk=6)")
+    benchmark.run(print_data=True, save_path=".")

--- a/sgl-kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+++ b/sgl-kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
@@ -43,7 +43,19 @@ def kimi_k2_biased_topk_fused_kernel(scores, bias, topk, routed_scaling_factor):
 if IS_CI:
     seq_length_range = [5000]  # Only test one sequence length in CI
 else:
-    seq_length_range = [5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000]
+    seq_length_range = [
+        512,
+        1024,
+        2048,
+        4096,
+        10000,
+        15000,
+        20000,
+        25000,
+        30000,
+        35000,
+        40000,
+    ]
 
 configs = [(sq,) for sq in seq_length_range]
 

--- a/sgl-kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
+++ b/sgl-kernel/benchmark/bench_kimi_k2_moe_fused_gate.py
@@ -44,6 +44,13 @@ if IS_CI:
     seq_length_range = [5000]  # Only test one sequence length in CI
 else:
     seq_length_range = [
+        1,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
         512,
         1024,
         2048,

--- a/sgl-kernel/csrc/common_extension.cc
+++ b/sgl-kernel/csrc/common_extension.cc
@@ -243,6 +243,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("moe_fused_gate", torch::kCUDA, &moe_fused_gate);
 
   m.def(
+      "kimi_k2_moe_fused_gate(Tensor input, Tensor bias, int topk, bool renormalize, "
+      "float routed_scaling_factor, bool apply_routed_scaling_factor_on_output) -> "
+      "(Tensor[])");
+  m.impl("kimi_k2_moe_fused_gate", torch::kCUDA, &kimi_k2_moe_fused_gate);
+
+  m.def(
       "fp8_blockwise_scaled_grouped_mm(Tensor output, Tensor a_ptrs, Tensor b_ptrs, Tensor out_ptrs, Tensor "
       "a_scales_ptrs, Tensor b_scales_ptrs, Tensor a, Tensor b, Tensor scales_a, Tensor scales_b, Tensor "
       "stride_a, Tensor stride_b, Tensor stride_c, Tensor layout_sfa, Tensor layout_sfb, Tensor problem_sizes, Tensor "

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -1,0 +1,197 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+#include <torch/all.h>
+
+#include <cfloat>
+
+using bfloat16_t = cutlass::bfloat16_t;
+using float16_t = cutlass::half_t;
+
+// Kimi K2 specific constants
+static constexpr int WARP_SIZE = 32;
+static constexpr int WARPS_PER_CTA = 6;
+static constexpr int NUM_EXPERTS = 384;
+static constexpr int VPT = 12;  // 384 / 32 = 12
+
+template <typename T>
+__device__ inline bool cmp_gt(const T& a, const T& b) {
+  return static_cast<float>(a) > static_cast<float>(b);
+}
+
+template <typename T>
+__device__ inline bool cmp_eq(const T& a, const T& b) {
+  return static_cast<float>(a) == static_cast<float>(b);
+}
+
+//------------------------------------------------------------------------------
+// Simplified Kernel for Kimi K2 (384 experts, num_expert_group=1)
+//------------------------------------------------------------------------------
+template <typename T>
+__global__ void kimi_k2_moe_fused_gate_kernel(
+    T* input,
+    T* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  
+  // Each warp processes one row
+  int64_t thread_row = blockIdx.x * WARPS_PER_CTA + threadIdx.y;
+  if (thread_row >= num_rows) return;
+
+  int tidx = threadIdx.x;
+  int first_expert = tidx * VPT;
+  
+  // Read data for this thread
+  T row_chunk[VPT];
+  T bias_chunk[VPT];
+  
+  T* thread_row_ptr = input + thread_row * NUM_EXPERTS + first_expert;
+  T* bias_thread_ptr = bias + first_expert;
+  
+#pragma unroll
+  for (int ii = 0; ii < VPT; ++ii) {
+    row_chunk[ii] = thread_row_ptr[ii];
+    bias_chunk[ii] = bias_thread_ptr[ii];
+  }
+
+  // Sigmoid activation
+#pragma unroll
+  for (int ii = 0; ii < VPT; ++ii) {
+    row_chunk[ii] = static_cast<T>(1.0f / (1.0f + expf(-float(row_chunk[ii]))));
+  }
+
+  // Add bias
+#pragma unroll
+  for (int ii = 0; ii < VPT; ++ii) {
+    bias_chunk[ii] = row_chunk[ii] + bias_chunk[ii];
+  }
+
+  // TopK selection
+  float output_sum = 0.0f;
+  
+  for (int k_idx = 0; k_idx < topk; ++k_idx) {
+    // Find local max in thread's chunk
+    T max_val = bias_chunk[0];
+    int expert = first_expert;
+    
+    if (!cmp_eq(max_val, static_cast<T>(-FLT_MAX))) {
+#pragma unroll
+      for (int ii = 1; ii < VPT; ++ii) {
+        T val = bias_chunk[ii];
+        if (cmp_gt(val, max_val)) {
+          max_val = val;
+          expert = first_expert + ii;
+        }
+      }
+    } else {
+      max_val = static_cast<T>(-FLT_MAX);
+    }
+
+    // Warp reduction to find global max
+#pragma unroll
+    for (int mask = WARP_SIZE / 2; mask > 0; mask /= 2) {
+      T other_max = static_cast<T>(__shfl_xor_sync(0xFFFFFFFF, static_cast<float>(max_val), mask, WARP_SIZE));
+      int other_expert = __shfl_xor_sync(0xFFFFFFFF, expert, mask, WARP_SIZE);
+
+      if (cmp_gt(other_max, max_val) || (cmp_eq(other_max, max_val) && other_expert < expert)) {
+        max_val = other_max;
+        expert = other_expert;
+      }
+    }
+
+    // Write result
+    int thread_to_clear = expert / VPT;
+    int64_t idx = topk * thread_row + k_idx;
+
+    if (tidx == thread_to_clear) {
+      int expert_to_clear = expert % VPT;
+      bias_chunk[expert_to_clear] = static_cast<T>(-FLT_MAX);
+      output_ptr[idx] = static_cast<float>(row_chunk[expert_to_clear]);
+      indices_ptr[idx] = static_cast<int32_t>(expert);
+    }
+
+    if (tidx == 0) {
+      output_sum += output_ptr[idx];
+    }
+
+    __syncthreads();
+  }
+
+  // Normalize weights
+  if (renormalize && tidx == 0) {
+#pragma unroll
+    for (int ii = 0; ii < topk; ++ii) {
+      int64_t idx = topk * thread_row + ii;
+      output_ptr[idx] = output_ptr[idx] / output_sum;
+      if (apply_routed_scaling_factor_on_output) {
+        output_ptr[idx] *= routed_scaling_factor;
+      }
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+// Host Launcher
+//------------------------------------------------------------------------------
+std::vector<at::Tensor> kimi_k2_moe_fused_gate(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  
+  int64_t num_rows = input.size(0);
+  int32_t num_experts = input.size(1);
+  
+  // Assert: Only support 384 experts
+  TORCH_CHECK(num_experts == 384, 
+      "kimi_k2_moe_fused_gate only supports 384 experts, but got ", num_experts);
+  TORCH_CHECK(input.dtype() == bias.dtype(), 
+      "input and bias should have the same dtype");
+  
+  auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
+  auto output = torch::empty({num_rows, topk}, options);
+  auto indices = torch::empty({num_rows, topk}, options.dtype(torch::kInt32));
+
+  int64_t num_blocks = (num_rows + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
+
+  if (input.scalar_type() == at::kBFloat16) {
+    kimi_k2_moe_fused_gate_kernel<bfloat16_t><<<num_blocks, block_dim, 0, stream>>>(
+        reinterpret_cast<bfloat16_t*>(input.data_ptr()),
+        reinterpret_cast<bfloat16_t*>(bias.data_ptr()),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows, topk, renormalize, routed_scaling_factor, 
+        apply_routed_scaling_factor_on_output);
+  } else if (input.scalar_type() == at::kHalf) {
+    kimi_k2_moe_fused_gate_kernel<float16_t><<<num_blocks, block_dim, 0, stream>>>(
+        reinterpret_cast<float16_t*>(input.data_ptr()),
+        reinterpret_cast<float16_t*>(bias.data_ptr()),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows, topk, renormalize, routed_scaling_factor, 
+        apply_routed_scaling_factor_on_output);
+  } else if (input.scalar_type() == at::kFloat) {
+    kimi_k2_moe_fused_gate_kernel<float><<<num_blocks, block_dim, 0, stream>>>(
+        input.data_ptr<float>(),
+        bias.data_ptr<float>(),
+        output.data_ptr<float>(),
+        indices.data_ptr<int32_t>(),
+        num_rows, topk, renormalize, routed_scaling_factor, 
+        apply_routed_scaling_factor_on_output);
+  } else {
+    TORCH_CHECK(false, "Unsupported data type for kimi_k2_moe_fused_gate");
+  }
+
+  return {output, indices};
+}

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -52,12 +52,8 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
   for (int expert = lane_id; expert < NUM_EXPERTS; expert += WARP_SIZE) {
     T input_val = input[row_idx * NUM_EXPERTS + expert];
     T bias_val = bias[expert];
-
     float sigmoid_val = 1.0f / (1.0f + expf(-static_cast<float>(input_val)));
     float biased_val = sigmoid_val + static_cast<float>(bias_val);
-    float sigmoid_val = 1.0f / (1.0f + expf(-static_cast<float>(input_val)));
-    float biased_val = sigmoid_val + static_cast<float>(bias_val);
-
     warp_scores[expert] = biased_val;
     warp_original_scores[expert] = sigmoid_val;
   }

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -16,6 +16,11 @@ static constexpr int WARPS_PER_CTA = 6;
 static constexpr int NUM_EXPERTS = 384;
 static constexpr int VPT = 12;  // 384 / 32 = 12
 
+// Small token optimization constants
+static constexpr int SMALL_TOKEN_THRESHOLD = 512;
+static constexpr int WARPS_PER_TOKEN_SMALL = 12;  // Use 12 warps per token for small batches
+static constexpr int THREADS_PER_BLOCK_SMALL = WARPS_PER_TOKEN_SMALL * WARP_SIZE;  // 384 threads
+
 template <typename T>
 __device__ inline bool cmp_gt(const T& a, const T& b) {
   return static_cast<float>(a) > static_cast<float>(b);
@@ -24,6 +29,135 @@ __device__ inline bool cmp_gt(const T& a, const T& b) {
 template <typename T>
 __device__ inline bool cmp_eq(const T& a, const T& b) {
   return static_cast<float>(a) == static_cast<float>(b);
+}
+
+// Small token optimized kernel: Multiple warps collaborate on a single token
+template <typename T>
+__global__ void kimi_k2_moe_fused_gate_kernel_small_token(
+    T* input,
+    T* bias,
+    float* output_ptr,
+    int32_t* indices_ptr,
+    int64_t num_rows,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output) {
+  // Each block handles one token with WARPS_PER_TOKEN_SMALL warps collaborating
+  int64_t row_idx = blockIdx.x;
+  if (row_idx >= num_rows) return;
+
+  int tid = threadIdx.x;
+  int warp_id = tid / WARP_SIZE;
+  int lane_id = tid % WARP_SIZE;
+
+  // Shared memory for all warps to collaborate
+  __shared__ float shared_scores[NUM_EXPERTS];
+  __shared__ float shared_original_scores[NUM_EXPERTS];
+
+  // Each thread loads one expert (384 threads for 384 experts)
+  if (tid < NUM_EXPERTS) {
+    T input_val = input[row_idx * NUM_EXPERTS + tid];
+    T bias_val = bias[tid];
+    float sigmoid_val = 1.0f / (1.0f + expf(-static_cast<float>(input_val)));
+    float biased_val = sigmoid_val + static_cast<float>(bias_val);
+    shared_scores[tid] = biased_val;
+    shared_original_scores[tid] = sigmoid_val;
+  }
+
+  __syncthreads();
+
+  // Parallel TopK: Each warp processes a portion of experts
+  // Use multiple warps to find top-k elements in parallel
+  int experts_per_warp = (NUM_EXPERTS + WARPS_PER_TOKEN_SMALL - 1) / WARPS_PER_TOKEN_SMALL;
+  int warp_start = warp_id * experts_per_warp;
+  int warp_end = min(warp_start + experts_per_warp, NUM_EXPERTS);
+
+  for (int k = 0; k < topk; k++) {
+    float max_val = -FLT_MAX;
+    int max_expert = -1;
+
+    // Each warp finds the max in its portion
+    for (int expert = warp_start + lane_id; expert < warp_end; expert += WARP_SIZE) {
+      float val = shared_scores[expert];
+      if (val > max_val) {
+        max_val = val;
+        max_expert = expert;
+      }
+    }
+
+    // Warp-level reduction to find warp's maximum
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+      float other_val = __shfl_down_sync(0xFFFFFFFF, max_val, offset);
+      int other_expert = __shfl_down_sync(0xFFFFFFFF, max_expert, offset);
+
+      if (other_val > max_val || (other_val == max_val && other_expert < max_expert)) {
+        max_val = other_val;
+        max_expert = other_expert;
+      }
+    }
+
+    // Store warp results in shared memory
+    __shared__ float warp_max_vals[WARPS_PER_TOKEN_SMALL];
+    __shared__ int warp_max_experts[WARPS_PER_TOKEN_SMALL];
+
+    if (lane_id == 0) {
+      warp_max_vals[warp_id] = max_val;
+      warp_max_experts[warp_id] = max_expert;
+    }
+
+    __syncthreads();
+
+    // First warp reduces across all warp results
+    if (warp_id == 0) {
+      float final_max_val = -FLT_MAX;
+      int final_max_expert = -1;
+
+      if (lane_id < WARPS_PER_TOKEN_SMALL) {
+        final_max_val = warp_max_vals[lane_id];
+        final_max_expert = warp_max_experts[lane_id];
+      }
+
+      // Warp reduction
+      for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        float other_val = __shfl_down_sync(0xFFFFFFFF, final_max_val, offset);
+        int other_expert = __shfl_down_sync(0xFFFFFFFF, final_max_expert, offset);
+
+        if (other_val > final_max_val || (other_val == final_max_val && other_expert < final_max_expert)) {
+          final_max_val = other_val;
+          final_max_expert = other_expert;
+        }
+      }
+
+      // Lane 0 writes result and marks the expert as used
+      if (lane_id == 0 && final_max_expert != -1) {
+        int64_t output_idx = row_idx * topk + k;
+        output_ptr[output_idx] = shared_original_scores[final_max_expert];
+        indices_ptr[output_idx] = final_max_expert;
+        shared_scores[final_max_expert] = -FLT_MAX;
+      }
+    }
+
+    __syncthreads();
+  }
+
+  // Renormalization (only first warp)
+  if (renormalize && warp_id == 0 && lane_id == 0) {
+    float sum = 0.0f;
+    for (int k = 0; k < topk; k++) {
+      sum += output_ptr[row_idx * topk + k];
+    }
+
+    if (sum > 0.0f) {
+      for (int k = 0; k < topk; k++) {
+        int64_t idx = row_idx * topk + k;
+        output_ptr[idx] /= sum;
+        if (apply_routed_scaling_factor_on_output) {
+          output_ptr[idx] *= static_cast<float>(routed_scaling_factor);
+        }
+      }
+    }
+  }
 }
 
 template <typename T>
@@ -129,45 +263,91 @@ std::vector<at::Tensor> kimi_k2_moe_fused_gate(
   auto output = torch::empty({num_rows, topk}, options);
   auto indices = torch::empty({num_rows, topk}, options.dtype(torch::kInt32));
 
-  int64_t num_blocks = (num_rows + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
 
-  if (input.scalar_type() == at::kBFloat16) {
-    kimi_k2_moe_fused_gate_kernel<bfloat16_t><<<num_blocks, block_dim, 0, stream>>>(
-        reinterpret_cast<bfloat16_t*>(input.data_ptr()),
-        reinterpret_cast<bfloat16_t*>(bias.data_ptr()),
-        output.data_ptr<float>(),
-        indices.data_ptr<int32_t>(),
-        num_rows,
-        topk,
-        renormalize,
-        routed_scaling_factor,
-        apply_routed_scaling_factor_on_output);
-  } else if (input.scalar_type() == at::kHalf) {
-    kimi_k2_moe_fused_gate_kernel<float16_t><<<num_blocks, block_dim, 0, stream>>>(
-        reinterpret_cast<float16_t*>(input.data_ptr()),
-        reinterpret_cast<float16_t*>(bias.data_ptr()),
-        output.data_ptr<float>(),
-        indices.data_ptr<int32_t>(),
-        num_rows,
-        topk,
-        renormalize,
-        routed_scaling_factor,
-        apply_routed_scaling_factor_on_output);
-  } else if (input.scalar_type() == at::kFloat) {
-    kimi_k2_moe_fused_gate_kernel<float><<<num_blocks, block_dim, 0, stream>>>(
-        input.data_ptr<float>(),
-        bias.data_ptr<float>(),
-        output.data_ptr<float>(),
-        indices.data_ptr<int32_t>(),
-        num_rows,
-        topk,
-        renormalize,
-        routed_scaling_factor,
-        apply_routed_scaling_factor_on_output);
+  bool use_small_token_kernel = num_rows <= SMALL_TOKEN_THRESHOLD;
+
+  if (use_small_token_kernel) {
+    // Small token kernel: Each block handles 1 token with multiple warps collaborating
+    int64_t num_blocks = num_rows;
+    dim3 block_dim(THREADS_PER_BLOCK_SMALL);
+
+    if (input.scalar_type() == at::kBFloat16) {
+      kimi_k2_moe_fused_gate_kernel_small_token<bfloat16_t><<<num_blocks, block_dim, 0, stream>>>(
+          reinterpret_cast<bfloat16_t*>(input.data_ptr()),
+          reinterpret_cast<bfloat16_t*>(bias.data_ptr()),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else if (input.scalar_type() == at::kHalf) {
+      kimi_k2_moe_fused_gate_kernel_small_token<float16_t><<<num_blocks, block_dim, 0, stream>>>(
+          reinterpret_cast<float16_t*>(input.data_ptr()),
+          reinterpret_cast<float16_t*>(bias.data_ptr()),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else if (input.scalar_type() == at::kFloat) {
+      kimi_k2_moe_fused_gate_kernel_small_token<float><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr<float>(),
+          bias.data_ptr<float>(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else {
+      TORCH_CHECK(false, "Unsupported data type for kimi_k2_moe_fused_gate");
+    }
   } else {
-    TORCH_CHECK(false, "Unsupported data type for kimi_k2_moe_fused_gate");
+    int64_t num_blocks = (num_rows + WARPS_PER_CTA - 1) / WARPS_PER_CTA;
+    dim3 block_dim(WARP_SIZE, WARPS_PER_CTA);
+
+    if (input.scalar_type() == at::kBFloat16) {
+      kimi_k2_moe_fused_gate_kernel<bfloat16_t><<<num_blocks, block_dim, 0, stream>>>(
+          reinterpret_cast<bfloat16_t*>(input.data_ptr()),
+          reinterpret_cast<bfloat16_t*>(bias.data_ptr()),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else if (input.scalar_type() == at::kHalf) {
+      kimi_k2_moe_fused_gate_kernel<float16_t><<<num_blocks, block_dim, 0, stream>>>(
+          reinterpret_cast<float16_t*>(input.data_ptr()),
+          reinterpret_cast<float16_t*>(bias.data_ptr()),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else if (input.scalar_type() == at::kFloat) {
+      kimi_k2_moe_fused_gate_kernel<float><<<num_blocks, block_dim, 0, stream>>>(
+          input.data_ptr<float>(),
+          bias.data_ptr<float>(),
+          output.data_ptr<float>(),
+          indices.data_ptr<int32_t>(),
+          num_rows,
+          topk,
+          renormalize,
+          routed_scaling_factor,
+          apply_routed_scaling_factor_on_output);
+    } else {
+      TORCH_CHECK(false, "Unsupported data type for kimi_k2_moe_fused_gate");
+    }
   }
 
   return {output, indices};

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -40,21 +40,20 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
     bool renormalize,
     double routed_scaling_factor,
     bool apply_routed_scaling_factor_on_output) {
-  
   // Each warp processes one row
   int64_t thread_row = blockIdx.x * WARPS_PER_CTA + threadIdx.y;
   if (thread_row >= num_rows) return;
 
   int tidx = threadIdx.x;
   int first_expert = tidx * VPT;
-  
+
   // Read data for this thread
   T row_chunk[VPT];
   T bias_chunk[VPT];
-  
+
   T* thread_row_ptr = input + thread_row * NUM_EXPERTS + first_expert;
   T* bias_thread_ptr = bias + first_expert;
-  
+
 #pragma unroll
   for (int ii = 0; ii < VPT; ++ii) {
     row_chunk[ii] = thread_row_ptr[ii];
@@ -68,7 +67,7 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
   for (int ii = 0; ii < VPT; ++ii) {
     row_chunk[ii] = static_cast<T>(1.0f / (1.0f + expf(-float(row_chunk[ii]))));
   }
-  
+
   __syncthreads();
 
   // Add bias
@@ -79,12 +78,12 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
 
   // TopK selection
   float output_sum = 0.0f;
-  
+
   for (int k_idx = 0; k_idx < topk; ++k_idx) {
     // Find local max in thread's chunk
     T max_val = bias_chunk[0];
     int expert = first_expert;
-    
+
     if (!cmp_eq(max_val, static_cast<T>(-FLT_MAX))) {
 #pragma unroll
       for (int ii = 1; ii < VPT; ++ii) {
@@ -151,16 +150,13 @@ std::vector<at::Tensor> kimi_k2_moe_fused_gate(
     bool renormalize,
     double routed_scaling_factor,
     bool apply_routed_scaling_factor_on_output) {
-  
   int64_t num_rows = input.size(0);
   int32_t num_experts = input.size(1);
-  
+
   // Assert: Only support 384 experts
-  TORCH_CHECK(num_experts == 384, 
-      "kimi_k2_moe_fused_gate only supports 384 experts, but got ", num_experts);
-  TORCH_CHECK(input.dtype() == bias.dtype(), 
-      "input and bias should have the same dtype");
-  
+  TORCH_CHECK(num_experts == 384, "kimi_k2_moe_fused_gate only supports 384 experts, but got ", num_experts);
+  TORCH_CHECK(input.dtype() == bias.dtype(), "input and bias should have the same dtype");
+
   auto options = torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA);
   auto output = torch::empty({num_rows, topk}, options);
   auto indices = torch::empty({num_rows, topk}, options.dtype(torch::kInt32));
@@ -175,7 +171,10 @@ std::vector<at::Tensor> kimi_k2_moe_fused_gate(
         reinterpret_cast<bfloat16_t*>(bias.data_ptr()),
         output.data_ptr<float>(),
         indices.data_ptr<int32_t>(),
-        num_rows, topk, renormalize, routed_scaling_factor, 
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
         apply_routed_scaling_factor_on_output);
   } else if (input.scalar_type() == at::kHalf) {
     kimi_k2_moe_fused_gate_kernel<float16_t><<<num_blocks, block_dim, 0, stream>>>(
@@ -183,7 +182,10 @@ std::vector<at::Tensor> kimi_k2_moe_fused_gate(
         reinterpret_cast<float16_t*>(bias.data_ptr()),
         output.data_ptr<float>(),
         indices.data_ptr<int32_t>(),
-        num_rows, topk, renormalize, routed_scaling_factor, 
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
         apply_routed_scaling_factor_on_output);
   } else if (input.scalar_type() == at::kFloat) {
     kimi_k2_moe_fused_gate_kernel<float><<<num_blocks, block_dim, 0, stream>>>(
@@ -191,7 +193,10 @@ std::vector<at::Tensor> kimi_k2_moe_fused_gate(
         bias.data_ptr<float>(),
         output.data_ptr<float>(),
         indices.data_ptr<int32_t>(),
-        num_rows, topk, renormalize, routed_scaling_factor, 
+        num_rows,
+        topk,
+        renormalize,
+        routed_scaling_factor,
         apply_routed_scaling_factor_on_output);
   } else {
     TORCH_CHECK(false, "Unsupported data type for kimi_k2_moe_fused_gate");

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -117,11 +117,11 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
       indices_ptr[idx] = static_cast<int32_t>(expert);
     }
 
+    __syncthreads();
+
     if (tidx == 0) {
       output_sum += output_ptr[idx];
     }
-
-    __syncthreads();
   }
 
   // Normalize weights

--- a/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
+++ b/sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu
@@ -61,11 +61,15 @@ __global__ void kimi_k2_moe_fused_gate_kernel(
     bias_chunk[ii] = bias_thread_ptr[ii];
   }
 
+  __syncthreads();
+
   // Sigmoid activation
 #pragma unroll
   for (int ii = 0; ii < VPT; ++ii) {
     row_chunk[ii] = static_cast<T>(1.0f / (1.0f + expf(-float(row_chunk[ii]))));
   }
+  
+  __syncthreads();
 
   // Add bias
 #pragma unroll

--- a/sgl-kernel/include/sgl_kernel_ops.h
+++ b/sgl-kernel/include/sgl_kernel_ops.h
@@ -331,6 +331,14 @@ std::vector<at::Tensor> moe_fused_gate(
     double routed_scaling_factor,
     bool apply_routed_scaling_factor_on_output);
 
+std::vector<at::Tensor> kimi_k2_moe_fused_gate(
+    at::Tensor& input,
+    at::Tensor& bias,
+    int64_t topk,
+    bool renormalize,
+    double routed_scaling_factor,
+    bool apply_routed_scaling_factor_on_output);
+
 void fp8_blockwise_scaled_grouped_mm(
     torch::Tensor& output,
     torch::Tensor& a_ptrs,

--- a/sgl-kernel/python/sgl_kernel/__init__.py
+++ b/sgl-kernel/python/sgl_kernel/__init__.py
@@ -85,6 +85,7 @@ from sgl_kernel.moe import (
     apply_shuffle_mul_sum,
     cutlass_fp4_group_mm,
     fp8_blockwise_scaled_grouped_mm,
+    kimi_k2_moe_fused_gate,
     moe_align_block_size,
     moe_fused_gate,
     moe_sum,

--- a/sgl-kernel/python/sgl_kernel/moe.py
+++ b/sgl-kernel/python/sgl_kernel/moe.py
@@ -111,6 +111,41 @@ def moe_fused_gate(
     )
 
 
+def kimi_k2_moe_fused_gate(
+    input_tensor,
+    bias,
+    topk,
+    renormalize=True,
+    routed_scaling_factor=1.0,
+    apply_routed_scaling_factor_on_output=False,
+):
+    """
+    Simplified fused kernel for Kimi K2 model (num_expert_group=1).
+    This kernel removes the grouped topk logic since all experts belong to a single group.
+
+    Args:
+        input_tensor: Gating output tensor [num_tokens, num_experts]
+        bias: Correction bias tensor [num_experts]
+        topk: Number of experts to select per token
+        renormalize: Whether to renormalize the topk weights
+        routed_scaling_factor: Scaling factor for expert weights
+        apply_routed_scaling_factor_on_output: If true, apply scaling factor to output
+
+    Returns:
+        Tuple of (topk_weights, topk_ids)
+        - topk_weights: [num_tokens, topk] float32 tensor
+        - topk_ids: [num_tokens, topk] int32 tensor
+    """
+    return torch.ops.sgl_kernel.kimi_k2_moe_fused_gate.default(
+        input_tensor,
+        bias,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        apply_routed_scaling_factor_on_output,
+    )
+
+
 def fp8_blockwise_scaled_grouped_mm(
     output,
     a_ptrs,

--- a/sgl-kernel/tests/test_kimi_k2_moe_fused_gate.py
+++ b/sgl-kernel/tests/test_kimi_k2_moe_fused_gate.py
@@ -108,6 +108,17 @@ def test_kimi_k2_specific_case(seq_length, num_experts, topk):
             weight_sums, torch.ones_like(weight_sums), rtol=1e-3, atol=1e-4
         )
 
+    # Check weights match (after sorting)
+    # Weights are the most important - they determine the actual MoE output
+    output_check = torch.allclose(
+        ref_output.sort()[0].to(torch.float32),
+        output.sort()[0].to(torch.float32),
+        rtol=1e-02,
+        atol=1e-03,
+    )
+
     assert output_check, f"Output mismatch for Kimi K2 specific case"
 
+
+if __name__ == "__main__":
     pytest.main([__file__])

--- a/sgl-kernel/tests/test_kimi_k2_moe_fused_gate.py
+++ b/sgl-kernel/tests/test_kimi_k2_moe_fused_gate.py
@@ -1,0 +1,140 @@
+import pytest
+import torch
+from sgl_kernel import kimi_k2_moe_fused_gate
+
+from sglang.srt.layers.moe.topk import kimi_k2_biased_topk_impl
+
+
+@pytest.mark.parametrize(
+    "seq_length",
+    list(range(1, 10))
+    + [16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
+)
+@pytest.mark.parametrize("topk", [6])  # Kimi K2 uses topk=6
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("apply_routed_scaling_factor_on_output", [False, True])
+def test_kimi_k2_moe_fused_gate(
+    seq_length, topk, dtype, apply_routed_scaling_factor_on_output
+):
+    num_experts = 384  # Kimi K2: only support 384 experts
+    renormalize = True
+    routed_scaling_factor = 2.872  # Kimi K2's routed scaling factor
+
+    torch.manual_seed(seq_length)
+    tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    scores = tensor.clone()
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    # Test our fused kernel
+    output, indices = kimi_k2_moe_fused_gate(
+        tensor,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+
+    # Reference implementation
+    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+        scores,
+        scores,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
+    )
+
+    # Check indices match (after sorting since order may differ)
+    idx_check = torch.allclose(
+        ref_indices.sort()[0].to(torch.int32),
+        indices.sort()[0].to(torch.int32),
+        rtol=1e-04,
+        atol=1e-05,
+    )
+    
+    # Check weights match (after sorting)
+    output_check = torch.allclose(
+        ref_output.sort()[0].to(torch.float32),
+        output.sort()[0].to(torch.float32),
+        rtol=1e-02,
+        atol=1e-03,
+    )
+
+    assert idx_check, (
+        f"Indices mismatch at seq_length {seq_length}, dtype {dtype}, "
+        f"num_experts {num_experts}, topk {topk}, "
+        f"apply_routed_scaling_factor_on_output {apply_routed_scaling_factor_on_output}"
+    )
+    assert output_check, (
+        f"Output mismatch at seq_length {seq_length}, dtype {dtype}, "
+        f"num_experts {num_experts}, topk {topk}, "
+        f"apply_routed_scaling_factor_on_output {apply_routed_scaling_factor_on_output}"
+    )
+
+
+@pytest.mark.parametrize("seq_length", [1024, 4096])
+@pytest.mark.parametrize("num_experts", [384])
+@pytest.mark.parametrize("topk", [6])
+def test_kimi_k2_specific_case(seq_length, num_experts, topk):
+    """Test specifically for Kimi K2 configuration: 384 experts, topk=6"""
+    dtype = torch.float32
+    renormalize = True
+    routed_scaling_factor = 2.872
+
+    torch.manual_seed(42)
+    tensor = torch.rand((seq_length, num_experts), dtype=dtype, device="cuda")
+    scores = tensor.clone()
+    bias = torch.rand(num_experts, dtype=dtype, device="cuda")
+
+    output, indices = kimi_k2_moe_fused_gate(
+        tensor,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    ref_output, ref_indices = kimi_k2_biased_topk_impl(
+        scores,
+        scores,
+        bias,
+        topk=topk,
+        renormalize=renormalize,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=False,
+    )
+
+    # Verify output shapes
+    assert output.shape == (seq_length, topk)
+    assert indices.shape == (seq_length, topk)
+    assert output.dtype == torch.float32
+    assert indices.dtype == torch.int32
+
+    # Verify weights are normalized (sum to 1 per token if renormalize=True)
+    if renormalize:
+        weight_sums = output.sum(dim=-1)
+        assert torch.allclose(weight_sums, torch.ones_like(weight_sums), rtol=1e-3, atol=1e-4)
+
+    # Verify against reference
+    idx_check = torch.allclose(
+        ref_indices.sort()[0].to(torch.int32),
+        indices.sort()[0].to(torch.int32),
+        rtol=1e-04,
+        atol=1e-05,
+    )
+    output_check = torch.allclose(
+        ref_output.sort()[0].to(torch.float32),
+        output.sort()[0].to(torch.float32),
+        rtol=1e-02,
+        atol=1e-03,
+    )
+
+    assert idx_check, f"Indices mismatch for Kimi K2 specific case"
+    assert output_check, f"Output mismatch for Kimi K2 specific case"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Kimi K2 Acc test

<img width="1013" height="626" alt="图片" src="https://github.com/user-attachments/assets/8671e094-ed3b-432c-9689-a72386076653" />


### main branch

```shell
➜  sglang git:(add_kimi_k2_moe_fused_gate) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:31<00:00, 41.86it/s]
Accuracy: 0.935
Invalid: 0.000
Latency: 31.690 s
Output throughput: 4330.053 token/s
➜  sglang git:(add_kimi_k2_moe_fused_gate) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:28<00:00, 46.83it/s]
Accuracy: 0.933
Invalid: 0.000
Latency: 28.357 s
Output throughput: 4800.841 token/s
➜  sglang git:(add_kimi_k2_moe_fused_gate) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:34<00:00, 38.64it/s]
Accuracy: 0.940
Invalid: 0.000
Latency: 34.369 s
Output throughput: 3959.717 token/s
```

### pr

```shell
 sglang git:(add_kimi_k2_moe_fused_gate) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:29<00:00, 44.30it/s]
Accuracy: 0.935
Invalid: 0.000
Latency: 29.967 s
Output throughput: 4544.490 token/s
➜  sglang git:(add_kimi_k2_moe_fused_gate) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:27<00:00, 48.75it/s]
Accuracy: 0.935
Invalid: 0.000
Latency: 27.289 s
Output throughput: 4949.832 token/s
➜  sglang git:(add_kimi_k2_moe_fused_gate) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:30<00:00, 43.32it/s]
Accuracy: 0.937
Invalid: 0.000
Latency: 30.717 s
Output throughput: 4480.633 token/s
```


## Kernel benchmark

```shell
================================================================================
Benchmarking Kimi K2 MoE Fused Gate Performance
================================================================================

Performance vs Sequence Length (384 experts, topk=6)
kimi-k2-moe-fused-gate-performance:
    seq_length  Torch Compile  Fused Kernel
0          1.0      10.687484      7.983583
1          8.0      12.902634      8.293768
2         16.0      13.575671      8.325019
3         32.0      14.437372      8.349281
4         64.0      13.856000      8.436633
5        128.0      14.985943      8.515122
6        256.0      16.589968      9.101743
7        512.0      21.067943     11.768441
8       1024.0      30.023343     16.248130
9       2048.0      49.271691     18.698652
10      4096.0      88.226413     25.176768
11     10000.0     200.483472     38.246235
12     15000.0     295.839491     46.087448
13     20000.0     392.986784     57.157818
14     25000.0     490.661743     67.281158
15     30000.0     586.494532     81.038653
16     35000.0     683.142287     95.994056
17     40000.0     775.370903    110.547877
```

## Kimi K2 Profile

```shell
python3 -m sglang.bench_serving --model moonshotai/Kimi-K2-Thinking --dataset-name random --backend sglang-oai --random-range-ratio 1 --random-input-len 1200 --random-output-len 20 --max-concurrency 1 --num-prompts 5 --profile
```

main:

<img width="829" height="460" alt="图片" src="https://github.com/user-attachments/assets/0059b5dd-246f-419d-8c94-26bd6fc71d72" />

pr:

<img width="818" height="517" alt="图片" src="https://github.com/user-attachments/assets/a01b6833-b935-4f8d-b4c0-0c5e042626ff" />

14us->9us.



### End2End benchmark

```shell
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --model moonshotai/Kimi-K2-Thinking --dataset-name random --backend sglang-oai --random-range-ratio 1 --random-input-len 1200 --random-output-len 20 --max-concurrency 1 --num-prompts 50 --warmup-requests 5 --output-file main.jsonl
curl http://127.0.0.1:30000/flush_cache
python3 -m sglang.bench_serving --model moonshotai/Kimi-K2-Thinking --dataset-name random --backend sglang-oai --random-range-ratio 1 --random-input-len 1200 --random-output-len 20 --max-concurrency 32 --num-prompts 100 --warmup-requests 5 --output-file main.jsonl

```

```markdown
bbuf python3 sglang/test/srt/parse_results.py main.jsonl

Saved summary to: main_summary.csv

+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+====================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |           3606.210 |              60.104 |        193.579 |          173.930 |       443.891 |          7.275 |            7.237 |         7.735 |                60.104 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |            32.000 |          16267.371 |             271.123 |       1436.165 |         1640.203 |      1921.774 |         38.263 |           29.090 |        88.622 |                 8.473 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
➜  bbuf python3 sglang/test/srt/parse_results.py pr.jsonl  

Saved summary to: pr_summary.csv

+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   input_throughput |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+====================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |           3958.378 |              65.973 |        166.876 |          145.164 |       426.581 |          7.125 |            7.066 |         8.197 |                65.973 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |            32.000 |          16982.652 |             283.044 |       1371.391 |         1575.771 |      1865.398 |         38.440 |           28.468 |        87.868 |                 8.845 |
+----+-------------------+--------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```
