### PR TITLE
Optimized prefill cache allocation for NPU

### DIFF
--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import torch

--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 
 import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache
 
 from sglang.srt.mem_cache.allocator import PagedTokenToKVPoolAllocator
 from sglang.srt.utils import get_num_new_pages

--- a/python/sglang/srt/mem_cache/allocator_ascend.py
+++ b/python/sglang/srt/mem_cache/allocator_ascend.py
@@ -119,7 +119,6 @@ class AscendPagedTokenToKVPoolAllocator(PagedTokenToKVPoolAllocator):
                 out_indices,
                 num_new_pages,
             )
-            out_indices = out_indices.int()
 
         else:
             out_indices = torch.empty(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -267,7 +267,7 @@ def get_int_env_var(name: str, default: int = 0) -> int:
 
 
 def support_triton(backend: str) -> bool:
-    return backend not in ["torch_native", "intel_amx", "ascend"]
+    return backend not in ["torch_native", "intel_amx"]
 
 
 try:


### PR DESCRIPTION
## Motivation

Memory allocation could became performance bottleneck in case overall prefill time for the network is short thus optimization could provide performance benefit for specific networks

## Modifications

Updated cache memory allocation procedure for NPU and enabled Triton implementation for cache writing

## Accuracy Tests


## Benchmarking and Profiling

On msit_w8a8_llama_3.1_8b
attention-backend=ascend cuda-graph-bs="1 2 4 8 16 32 64 128" tp-size=2 quantization=w8a8_int8

```
bench_serving --backend sglang --num-prompts 64 \
                       --random-range-ratio 1.0 --dataset-name random \
                       --random-input-len 2048 --random-output-len 10000 --max-concurrency 64 \
                       --dataset-path /data/data/ShareGPT_Vicuna_unfiltered/ShareGPT_V3_unfiltered_cleaned_split.json \
                       --flush-cache'
```
**Before**
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 64
Successful requests:                     64
Benchmark duration (s):                  698.12
Total input tokens:                      131072
Total input text tokens:                 131072
Total input vision tokens:               0
Total generated tokens:                  640000
Total generated tokens (retokenized):    638991
Request throughput (req/s):              0.09
Input token throughput (tok/s):          187.75
Output token throughput (tok/s):         916.74
Total token throughput (tok/s):          1104.49
Concurrency:                             61.88
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   675039.20
Median E2E Latency (ms):                 673316.99
---------------Time to First Token----------------
Mean TTFT (ms):                          4321.85
Median TTFT (ms):                        4428.91
P99 TTFT (ms):                           7722.78
---------------Inter-Token Latency----------------
Mean ITL (ms):                           67.08
Median ITL (ms):                         68.01
P95 ITL (ms):                            95.99
P99 ITL (ms):                            97.59
Max ITL (ms):                            112701.03
==================================================
```
**After**
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 64
Successful requests:                     64
Benchmark duration (s):                  675.36
Total input tokens:                      131072
Total input text tokens:                 131072
Total input vision tokens:               0
Total generated tokens:                  640000
Total generated tokens (retokenized):    638991
Request throughput (req/s):              0.09
Input token throughput (tok/s):          194.08
Output token throughput (tok/s):         947.64
Total token throughput (tok/s):          1141.72
Concurrency:                             61.84
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   652560.30
Median E2E Latency (ms):                 650854.23
---------------Time to First Token----------------
Mean TTFT (ms):                          4225.13
Median TTFT (ms):                        4319.54
P99 TTFT (ms):                           7626.98
---------------Inter-Token Latency----------------
Mean ITL (ms):                           64.84
Median ITL (ms):                         65.95
P95 ITL (ms):                            95.74
P99 ITL (ms):                            97.34
Max ITL (ms):                            111985.36
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
