### PR TITLE
[router] refactor dynamic mcp server

### DIFF
--- a/sgl-router/src/core/workflow/steps/mcp_registration.rs
+++ b/sgl-router/src/core/workflow/steps/mcp_registration.rs
@@ -130,7 +130,8 @@ impl StepExecutor for DiscoverMcpInventoryStep {
         let inventory = mcp_manager.inventory();
 
         // Use the public load_static_server_inventory method
-        McpManager::load_static_server_inventory(&inventory, &config_request.name, &mcp_client).await;
+        McpManager::load_static_server_inventory(&inventory, &config_request.name, &mcp_client)
+            .await;
 
         info!("Completed inventory discovery for {}", config_request.name);
 

--- a/sgl-router/src/core/workflow/steps/mcp_registration.rs
+++ b/sgl-router/src/core/workflow/steps/mcp_registration.rs
@@ -129,8 +129,8 @@ impl StepExecutor for DiscoverMcpInventoryStep {
 
         let inventory = mcp_manager.inventory();
 
-        // Use the public load_server_inventory method
-        McpManager::load_server_inventory(&inventory, &config_request.name, &mcp_client).await;
+        // Use the public load_static_server_inventory method
+        McpManager::load_static_server_inventory(&inventory, &config_request.name, &mcp_client).await;
 
         info!("Completed inventory discovery for {}", config_request.name);
 

--- a/sgl-router/src/mcp/inventory.rs
+++ b/sgl-router/src/mcp/inventory.rs
@@ -91,7 +91,12 @@ impl ToolInventory {
         self.static_tools
             .iter()
             .find(|entry| entry.key().1 == tool_name)
-            .map(|entry| (entry.value().server_name.clone(), entry.value().tool.clone()))
+            .map(|entry| {
+                (
+                    entry.value().server_name.clone(),
+                    entry.value().tool.clone(),
+                )
+            })
     }
 
     /// Check if tool exists in static inventory (searches all servers)

--- a/sgl-router/src/mcp/inventory.rs
+++ b/sgl-router/src/mcp/inventory.rs
@@ -199,10 +199,7 @@ impl ToolInventory {
 
     /// Clear all cached items for a specific server (called when LRU evicts client)
     pub fn clear_server_tools(&self, server_name: &str) {
-        // Clear from static tools (where key is (server_name, tool_name))
         self.static_tools.retain(|key, _| key.0 != server_name);
-
-        // Clear prompts and resources
         self.prompts
             .retain(|_, cached| cached.server_name != server_name);
         self.resources

--- a/sgl-router/src/mcp/inventory.rs
+++ b/sgl-router/src/mcp/inventory.rs
@@ -98,11 +98,7 @@ impl ToolInventory {
 
         for entry in self.static_tools.iter() {
             let ((server_name, tool_name), cached) = entry.pair();
-            tools.push((
-                tool_name.clone(),
-                server_name.clone(),
-                cached.tool.clone(),
-            ));
+            tools.push((tool_name.clone(), server_name.clone(), cached.tool.clone()));
         }
 
         tools
@@ -204,8 +200,7 @@ impl ToolInventory {
     /// Clear all cached items for a specific server (called when LRU evicts client)
     pub fn clear_server_tools(&self, server_name: &str) {
         // Clear from static tools (where key is (server_name, tool_name))
-        self.static_tools
-            .retain(|key, _| key.0 != server_name);
+        self.static_tools.retain(|key, _| key.0 != server_name);
 
         // Clear prompts and resources
         self.prompts
@@ -216,7 +211,11 @@ impl ToolInventory {
 
     /// Get count of cached items (static tools, prompts, resources)
     pub fn counts(&self) -> (usize, usize, usize) {
-        (self.static_tools.len(), self.prompts.len(), self.resources.len())
+        (
+            self.static_tools.len(),
+            self.prompts.len(),
+            self.resources.len(),
+        )
     }
 
     /// Clear all cached items

--- a/sgl-router/src/mcp/manager.rs
+++ b/sgl-router/src/mcp/manager.rs
@@ -214,7 +214,7 @@ impl McpManager {
         // Get tool info for schema and server (static tools only)
         let (server_name, tool_info) = self
             .inventory
-            .get_tool(tool_name)
+            .find_tool_by_name(tool_name)
             .ok_or_else(|| McpError::ToolNotFound(tool_name.to_string()))?;
 
         // Convert args with type coercion based on schema
@@ -246,7 +246,7 @@ impl McpManager {
     /// For dynamic MCP clients, list tools directly from the client
     pub fn get_tool(&self, tool_name: &str) -> Option<Tool> {
         self.inventory
-            .get_tool(tool_name)
+            .find_tool_by_name(tool_name)
             .map(|(_server_name, tool_info)| tool_info)
     }
 

--- a/sgl-router/src/mcp/manager.rs
+++ b/sgl-router/src/mcp/manager.rs
@@ -515,7 +515,6 @@ impl McpManager {
         server_name: &str,
         client: &Arc<McpClient>,
     ) {
-        // Tools -> Static inventory
         match client.peer().list_all_tools().await {
             Ok(ts) => {
                 info!(
@@ -530,7 +529,6 @@ impl McpManager {
             Err(e) => warn!("Failed to list tools from '{}': {}", server_name, e),
         }
 
-        // Prompts
         match client.peer().list_all_prompts().await {
             Ok(ps) => {
                 info!("Discovered {} prompts from '{}'", ps.len(), server_name);
@@ -541,7 +539,6 @@ impl McpManager {
             Err(e) => debug!("No prompts or failed to list on '{}': {}", server_name, e),
         }
 
-        // Resources
         match client.peer().list_all_resources().await {
             Ok(rs) => {
                 info!("Discovered {} resources from '{}'", rs.len(), server_name);
@@ -556,7 +553,6 @@ impl McpManager {
     /// Discover and cache tools/prompts/resources for a connected server (internal wrapper)
     /// Used for refreshing static servers
     async fn load_server_inventory_internal(&self, server_name: &str, client: &McpClient) {
-        // Tools -> Static inventory (this is for refresh of config servers)
         match client.peer().list_all_tools().await {
             Ok(ts) => {
                 info!("Discovered {} tools from '{}'", ts.len(), server_name);
@@ -571,7 +567,6 @@ impl McpManager {
             Err(e) => warn!("Failed to list tools from '{}': {}", server_name, e),
         }
 
-        // Prompts
         match client.peer().list_all_prompts().await {
             Ok(ps) => {
                 info!("Discovered {} prompts from '{}'", ps.len(), server_name);
@@ -583,7 +578,6 @@ impl McpManager {
             Err(e) => debug!("No prompts or failed to list on '{}': {}", server_name, e),
         }
 
-        // Resources
         match client.peer().list_all_resources().await {
             Ok(rs) => {
                 info!("Discovered {} resources from '{}'", rs.len(), server_name);

--- a/sgl-router/src/mcp/manager.rs
+++ b/sgl-router/src/mcp/manager.rs
@@ -73,7 +73,12 @@ impl McpManager {
                 Ok(client) => {
                     let client_arc = Arc::new(client);
                     // Load static inventory for this config server
-                    Self::load_static_server_inventory(&inventory, &server_config.name, &client_arc).await;
+                    Self::load_static_server_inventory(
+                        &inventory,
+                        &server_config.name,
+                        &client_arc,
+                    )
+                    .await;
                     static_clients.insert(server_config.name.clone(), client_arc);
                     info!("Connected to static server '{}'", server_config.name);
                 }
@@ -166,7 +171,12 @@ impl McpManager {
     /// Returns empty Vec if client not found or listing fails
     pub async fn list_dynamic_tools(&self, server_url: &str) -> Vec<Tool> {
         match self.get_client(server_url).await {
-            Some(client) => client.peer().list_all_tools().await.ok().unwrap_or_default(),
+            Some(client) => client
+                .peer()
+                .list_all_tools()
+                .await
+                .ok()
+                .unwrap_or_default(),
             None => Vec::new(),
         }
     }
@@ -508,7 +518,11 @@ impl McpManager {
         // Tools -> Static inventory
         match client.peer().list_all_tools().await {
             Ok(ts) => {
-                info!("Discovered {} tools from static server '{}'", ts.len(), server_name);
+                info!(
+                    "Discovered {} tools from static server '{}'",
+                    ts.len(),
+                    server_name
+                );
                 for t in ts {
                     inventory.insert_static_tool(server_name.to_string(), t.name.to_string(), t);
                 }
@@ -547,8 +561,11 @@ impl McpManager {
             Ok(ts) => {
                 info!("Discovered {} tools from '{}'", ts.len(), server_name);
                 for t in ts {
-                    self.inventory
-                        .insert_static_tool(server_name.to_string(), t.name.to_string(), t);
+                    self.inventory.insert_static_tool(
+                        server_name.to_string(),
+                        t.name.to_string(),
+                        t,
+                    );
                 }
             }
             Err(e) => warn!("Failed to list tools from '{}': {}", server_name, e),

--- a/sgl-router/src/routers/grpc/regular/responses/tool_loop.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/tool_loop.rs
@@ -270,7 +270,19 @@ pub(super) async fn execute_tool_loop(
     for url in &server_urls {
         let dynamic_tools = ctx.mcp_manager.list_dynamic_tools(url).await;
         for tool in &dynamic_tools {
-            tool_to_server.insert(tool.name.to_string(), url.clone());
+            let tool_name = tool.name.to_string();
+
+            // Warn if this tool name already exists from a different server
+            if let Some(existing_url) = tool_to_server.get(&tool_name) {
+                if existing_url != url {
+                    warn!(
+                        "Tool name collision: '{}' exists in both '{}' and '{}'. Using '{}'",
+                        tool_name, existing_url, url, url
+                    );
+                }
+            }
+
+            tool_to_server.insert(tool_name, url.clone());
         }
         mcp_tools.extend(dynamic_tools);
     }

--- a/sgl-router/src/routers/grpc/regular/responses/tool_loop.rs
+++ b/sgl-router/src/routers/grpc/regular/responses/tool_loop.rs
@@ -422,14 +422,23 @@ pub(super) async fn execute_tool_loop(
                             Err(e) => {
                                 let err_str = format!("Tool call failed: {}", e);
                                 warn!("{}", err_str);
-                                (json!({ "error": &err_str }).to_string(), false, Some(err_str))
+                                (
+                                    json!({ "error": &err_str }).to_string(),
+                                    false,
+                                    Some(err_str),
+                                )
                             }
                         }
                     }
                     None => {
-                        let err_str = format!("No MCP server URL available for tool '{}'", tool_name);
+                        let err_str =
+                            format!("No MCP server URL available for tool '{}'", tool_name);
                         warn!("{}", err_str);
-                        (json!({ "error": &err_str }).to_string(), false, Some(err_str))
+                        (
+                            json!({ "error": &err_str }).to_string(),
+                            false,
+                            Some(err_str),
+                        )
                     }
                 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
When using dynamic MCP servers in a request:
- Each user must be isolated so they cannot access another user’s MCP server.
- A request must not be able to reuse or access MCP servers created in previous requests.
- Static MCP tools in the inventory must not be overridden when a dynamic tool shares the same name.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Dynamic MCP tools will no longer be stored in the global tool inventory. Instead, they will be attached directly to each individual request. The MCP client will continue using the connection pool, keyed by the server URL.
- The tool inventory will now be used only for static MCP servers, and the lookup key has been updated from tool_name to a composite key (server_name, tool_name) to prevent name collisions across servers.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
