### PR TITLE
[router] refactor dynamic mcp server

### DIFF
--- a/sgl-router/src/routers/grpc/common/responses/utils.rs
+++ b/sgl-router/src/routers/grpc/common/responses/utils.rs
@@ -9,6 +9,8 @@ use axum::{
 use serde_json::{json, to_value};
 use tracing::{debug, error, warn};
 
+// Re-export MCP utilities for use by grpc routers
+pub use crate::routers::openai::mcp::extract_dynamic_mcp_servers;
 use crate::{
     core::WorkerRegistry,
     data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage},

--- a/sgl-router/tests/common/mock_worker.rs
+++ b/sgl-router/tests/common/mock_worker.rs
@@ -639,6 +639,16 @@ async fn responses_handler(
             })
             .unwrap_or(false);
 
+        // Extract first tool name from request
+        let tool_name = payload
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|tool| tool.get("name"))
+            .and_then(|name| name.as_str())
+            .unwrap_or("brave_web_search")
+            .to_string();
+
         if has_tools && !has_function_output {
             // First turn: emit streaming tool call events
             let call_id = format!(
@@ -686,7 +696,7 @@ async fn responses_handler(
                         "item": {
                             "id": call_id.clone(),
                             "type": "function_tool_call",
-                            "name": "brave_web_search",
+                            "name": tool_name.clone(),
                             "arguments": "",
                             "status": "in_progress"
                         }
@@ -757,7 +767,7 @@ async fn responses_handler(
                         "item": {
                             "id": call_id.clone(),
                             "type": "function_tool_call",
-                            "name": "brave_web_search",
+                            "name": tool_name,
                             "arguments": "{\"query\":\"SGLang router MCP integration\"}",
                             "status": "completed"
                         }
@@ -1000,6 +1010,16 @@ async fn responses_handler(
             })
             .unwrap_or(false);
 
+        // Extract first tool name from request
+        let tool_name = payload
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|tool| tool.get("name"))
+            .and_then(|name| name.as_str())
+            .unwrap_or("brave_web_search")
+            .to_string();
+
         if has_tools && !has_function_output {
             let rid = format!("resp-{}", Uuid::new_v4());
             Json(json!({
@@ -1010,7 +1030,7 @@ async fn responses_handler(
                 "output": [{
                     "type": "function_tool_call",
                     "id": "call_1",
-                    "name": "brave_web_search",
+                    "name": tool_name,
                     "arguments": "{\"query\":\"SGLang router MCP integration\"}",
                     "status": "in_progress"
                 }],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When using dynamic MCP servers within a request, several issues exist in the current implementation:

- A user can inadvertently access another user’s dynamic MCP server stored in the shared tool inventory.
- A request can access MCP servers that were registered in **previous** requests, leading to cross-request leakage.
- If multiple users define tools with the same name but different server labels, the system stores only one entry, causing unintended overrides.
- The current design only supports **one** MCP server per request, limiting flexibility.

## Modifications

- Introduced a **per-request tool map**, which exists only for the lifetime of the request.  
  - Uses composite keys `(server_label, tool_name)`.  
  - Values contain both the `Tool` and its MCP server `url`.  
  - The `url` is used to get or reuse a client from the connection pool.
- Refactored function-call naming from `<tool_name>` to `<server_label>__<tool_name>`, enabling correct routing to the associated MCP server during invocation.
- Applied these changes across the OpenAI, gRPC, and Harmony routers.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
