### PR TITLE
support sp for qwen2/3 & deepseek v2/3/3.2

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -59,7 +59,7 @@ class DpPaddingMode(IntEnum):
 
     @classmethod
     def get_dp_padding_mode(
-        cls, is_extend_in_batch, global_num_tokens: List[int]
+        cls, is_extend_in_batch, global_num_tokens: List[int], enable_sp: bool = False
     ) -> DpPaddingMode:
         if is_extend_in_batch:
             return DpPaddingMode.SUM_LEN
@@ -67,7 +67,7 @@ class DpPaddingMode(IntEnum):
         # we choose the mode that minimizes the communication cost
         max_len = max(global_num_tokens)
         sum_len = sum(global_num_tokens)
-        if sum_len * 2 > max_len * get_attention_dp_size():
+        if enable_sp or (sum_len * 2 > max_len * get_attention_dp_size()):
             return cls.MAX_LEN
         else:
             return cls.SUM_LEN

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -318,6 +318,9 @@ class ForwardBatch:
     # For matryoshka embeddings
     dimensions: Optional[list[int]] = None
 
+    # For sp
+    enable_sp: Optional[bool] = False
+
     @classmethod
     def init_new(
         cls,
@@ -682,7 +685,10 @@ class ForwardBatch:
                 dim=0,
             )
 
-    def prepare_mlp_sync_batch(self, model_runner: ModelRunner):
+    def prepare_mlp_sync_batch(
+        self, model_runner: ModelRunner, enable_sp: bool = False
+    ):
+
         assert self.global_num_tokens_cpu is not None
         assert self.global_num_tokens_for_logprob_cpu is not None
 
@@ -698,7 +704,9 @@ class ForwardBatch:
             ) * attn_tp_size
 
         dp_padding_mode = DpPaddingMode.get_dp_padding_mode(
-            self.is_extend_in_batch, global_num_tokens
+            self.is_extend_in_batch,
+            global_num_tokens,
+            enable_sp,
         )
         self.dp_padding_mode = dp_padding_mode
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2186,7 +2186,9 @@ class ModelRunner:
 
         # For MLP sync
         if forward_batch.global_num_tokens_cpu is not None:
-            forward_batch.prepare_mlp_sync_batch(self)
+            forward_batch.prepare_mlp_sync_batch(
+                self, get_global_server_args().enable_sp
+            )
 
         if forward_batch.forward_mode.is_decode():
             ret = self.forward_decode(

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -25,6 +25,7 @@ from sglang.srt.distributed import (
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    sp_tensor_model_parallel_all_gather,
 )
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.dp_attention import is_dp_attention_enabled
@@ -89,13 +90,13 @@ class Qwen2MLP(nn.Module):
             )
         self.act_fn = SiluAndMul()
 
-    def forward(self, x):
+    def forward(self, x, enable_sp: bool = False):
         if get_global_server_args().rl_on_policy_target == "fsdp":
             x = x.bfloat16()
 
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
+        x, _ = self.down_proj(x, enable_sp=enable_sp)
         return x
 
 
@@ -139,6 +140,7 @@ class Qwen2Attention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
+        self.enable_sp = get_global_server_args().enable_sp
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size,
@@ -180,12 +182,16 @@ class Qwen2Attention(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
+        allgather_input: bool = False,
     ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
+        qkv, _ = self.qkv_proj(hidden_states, allgather_input=allgather_input)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v, forward_batch)
-        output, _ = self.o_proj(attn_output)
+        output, _ = self.o_proj(
+            attn_output,
+            enable_sp=self.enable_sp and forward_batch.forward_mode.is_extend(),
+        )
         return output
 
 
@@ -231,6 +237,9 @@ class Qwen2DecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
+        self.layer_id = layer_id
+        self.layer_num = config.num_hidden_layers
+        self.enable_sp = get_global_server_args().enable_sp
 
     def forward(
         self,
@@ -245,15 +254,24 @@ class Qwen2DecoderLayer(nn.Module):
             hidden_states = self.input_layernorm(hidden_states)
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        enable_sp = self.enable_sp and forward_batch.forward_mode.is_extend()
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
             forward_batch=forward_batch,
+            allgather_input=enable_sp and self.layer_id != 0,
         )
+
+        if enable_sp and self.layer_id == 0:
+            tensor_list_residual = list(
+                residual.tensor_split(get_tensor_model_parallel_world_size())
+            )
+            residual = tensor_list_residual[get_tensor_model_parallel_rank()]
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = sp_tensor_model_parallel_all_gather(hidden_states)
+        hidden_states = self.mlp(hidden_states, enable_sp=enable_sp)
         return hidden_states, residual
 
 
@@ -270,6 +288,7 @@ class Qwen2Model(nn.Module):
         self.config = config
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
+        self.enable_sp = get_global_server_args().enable_sp
         self.pp_group = get_pp_group()
 
         if self.pp_group.is_first_rank:
@@ -378,6 +397,9 @@ class Qwen2Model(nn.Module):
                     hidden_states = self.norm(hidden_states)
                 else:
                     hidden_states, _ = self.norm(hidden_states, residual)
+
+        if self.enable_sp and forward_batch.forward_mode.is_extend():
+            hidden_states = sp_tensor_model_parallel_all_gather(hidden_states)
 
         if len(aux_hidden_states) == 0:
             return hidden_states

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -419,6 +419,9 @@ class ServerArgs:
     mamba_ssm_dtype: str = "float32"
     mamba_full_memory_ratio: float = 0.9
 
+    # Sequence parallelism
+    enable_sp: bool = False
+
     # Hierarchical cache
     enable_hierarchical_cache: bool = False
     hicache_ratio: float = 2.0
@@ -2974,6 +2977,13 @@ class ServerArgs:
             type=float,
             default=ServerArgs.mamba_full_memory_ratio,
             help="The ratio of mamba state memory to full kv cache memory.",
+        )
+
+        # Sequence parallelism
+        parser.add_argument(
+            "--enable-sp",
+            action="store_true",
+            help="Enable sequence parallelism.",
         )
 
         # Hierarchical cache

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2763,7 +2763,11 @@ def require_gathered_buffer(server_args):
 
 
 def require_mlp_sync(server_args):
-    return server_args.enable_dp_attention or require_gathered_buffer(server_args)
+    return (
+        server_args.enable_dp_attention
+        or require_gathered_buffer(server_args)
+        or server_args.enable_sp
+    )
 
 
 def find_local_repo_dir(repo_id: str, revision: Optional[str] = None) -> Optional[str]:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
For the classic dense decode layer structure (self-attention + MLP), in the pure TP case, tensors are parallelized in the attention layer and the MLP layer. Since each device contains the full amount of data before and after each TP split, Layernorm stores 2\*2BSH bytes of activation value (assume hidden states shape is [B, S, H]). SP aims to split this 4\*BSH redundant data across multiple devices, and do layernorm independently. For more details please refer to the research paper https://arxiv.org/pdf/2205.05198.pdf

<img width="805" height="200" alt="屏幕截图 2025-11-10 114901" src="https://github.com/user-attachments/assets/c6bb343d-6f6b-482b-9254-66ce3227c89a" />

We add a parameter "--enable-sp" at server args, which can enable sequence parallel if be set. For example
```
python3 -m sglang.launch_server --model-path $MODEL_PATH \
        --tp-size 16 --dp-size 1 --enable-sp \
        --trust-remote-code --attention-backend ascend --device npu --host $HOST_IP --port $PORT \
        --quantization w8a8_int8 --mem-fraction-static 0.8 \
        --chunked-prefill-size 16000 --context-length 16000 --max-prefill-tokens 16000 --max-total-tokens 16000 \
        --disable-radix-cache --moe-a2a-backend deepep --deepep-mode auto
```
The TP-SP has two benifits:
1. Reduce long dataset (36K) TTFT for 10% on deepseek v3 and 7% on deepseek v3.2.
2. Reduce peak memory because of less activations on RMSNorm layer.

## Modifications
1. For the RowParallel linear, we replace all-reduce comm op with reduce-scatter on TP group if enable sp.
3. For the dense layers of model (qwen2/3 & deepseek v2/3/3.2), we split residual before layernorm at the first layer, hidden states is be splitted at RowParallel linear so do not need to split again.
4. After the first dense layer, all data are scattered state, only do layernorm at prepare_attn and prepare_mlp. 
5. Before the MLP and ATTENTION module, we do extra all-gather because of weights has been splitted on tensor dimension, to make sure inputs are complete.
6. Do all-gather at the last dense layer.
7. For sparse layer of deepseek models, when enableed Deepep, the hidden states has been sscattered, we utilize it and move the *_scattered_to_tp_attn_full* from prepare_attention to after getting the q_lora and latent cache, which also can decrease much more computation.

NOTE: 
1. We only adapt qwen2/3 and deepseek v2/3/3.2 on ascend backend, for other backends you can add few code to adapt SP.
2. TP-SP can enable with CP (https://github.com/sgl-project/sglang/pull/12207) together on Ascend backend. We test it on dsv3.2 model, CP=16, TP=2, which can continue reducing TTFT for 1 percent and decrease peak runtime memory (2G for single device).

## Accuracy Tests
The test_gsam8k.py is based on benchmark/gsm8k/bench_sglang.py, you can test it with
`python3 benchmark/gsm8k/bench_sglang.py --host http://127.0.0.1 --port 8000 --num-questions 300`.
<img width="1083" height="220" alt="image" src="https://github.com/user-attachments/assets/dfe7c4a3-bab7-4ac1-9952-d172dc929f23" />

## Benchmarking and Profiling
```
export cann_path=/usr/local/Ascend/ascend-toolkit/latest
source /usr/local/Ascend/driver/bin/setenv.bash
source ${cann_path}/../set_env.sh
source ${cann_path}/../../nnal/atb/set_env.sh
source ${cann_path}/opp/vendors/customize/bin/set_env.bash
export ASCEND_HOME_PATH=${cann_path}

# CPU high preformance
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000

export SGLANG_SET_CPU_AFFINITY=1

# Memory Fragmentation
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32

# HCCL
export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=16
export HCCL_BUFFSIZE=1600
#export HCCL_RDMA_PCIE_DIRECT_POST_NOSTRICT=TRUE
export HCCL_OP_EXPANSION_MODE=AIV
export HCCL_ALGO="level0:NA;level1:ring"

# Your NIC
export HCCL_SOCKET_IFNAME=enp48s3u1u1
export GLOO_SOCKET_IFNAME=enp48s3u1u1

export PYTHONPATH=$PWD/python/:$PYTHONPATH

python -m sglang.launch_server --model-path $MODEL_PATH \
        --tp-size 16 --dp-size 1 --enable-sp \
        --trust-remote-code --attention-backend ascend --device npu --host 127.0.0.1 --port 8000 \
        --quantization w8a8_int8 --mem-fraction-static 0.79 \
        --chunked-prefill-size 36000 --context-length 36000 --max-prefill-tokens 36000 --max-total-tokens 36000 \
        --disable-radix-cache --moe-a2a-backend deepep --deepep-mode auto
```
<img width="1126" height="299" alt="image" src="https://github.com/user-attachments/assets/de18eb81-e210-4489-9399-37aeb0300eb6" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
