### PR TITLE
Revert "Fix nan in global scaling factor for large scale nvfp4 EP"

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -539,12 +539,9 @@ class FusedMoE(torch.nn.Module):
             # This is a shared expert.
             physical_expert_ids = [expert_id]
         else:
-            require_global_experts = getattr(
-                param, "_sglang_require_global_experts", False
-            )
             physical_expert_ids = (
                 global_expert_location_metadata.logical_to_all_physical(
-                    self.layer_id, expert_id, require_global_experts
+                    self.layer_id, expert_id
                 )
             )
 


### PR DESCRIPTION
Reverts sgl-project/sglang#13162

This PR caused some hanging bugs during model loading 
```bash
File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 323, in __init__
    self.initialize(min_per_gpu_memory)
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 409, in initialize
    self.load_model()
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 840, in load_model
    raise ValueError(
ValueError: TP rank 2 could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node.
```

CI error: https://github.com/sgl-project/sglang/actions/runs/19310172763/job/55237999818