### PR TITLE
improve Qwen3-VL rotary position embedding computation

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -263,6 +263,7 @@ class Qwen3VLMoeVisionModel(nn.Module):
         self.hidden_size = vision_config.hidden_size
         self.num_heads = vision_config.num_heads
         self.num_position_embeddings = vision_config.num_position_embeddings
+        self.num_grid_per_side = int(vision_config.num_position_embeddings**0.5)
         self.patch_size = vision_config.patch_size
         self.spatial_merge_size = vision_config.spatial_merge_size
         self.spatial_merge_unit = self.spatial_merge_size**2
@@ -322,119 +323,136 @@ class Qwen3VLMoeVisionModel(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
-    def rot_pos_emb(self, grid_thw):
-        pos_ids = []
-        for t, h, w in grid_thw:
-            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
-            hpos_ids = hpos_ids.reshape(
-                h // self.spatial_merge_size,
-                self.spatial_merge_size,
-                w // self.spatial_merge_size,
-                self.spatial_merge_size,
-            )
-            hpos_ids = hpos_ids.permute(0, 2, 1, 3)
-            hpos_ids = hpos_ids.flatten()
+    # def rot_pos_emb(self, grid_thw):
+    #     pos_ids = []
+    #     for t, h, w in grid_thw:
+    #         hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+    #         hpos_ids = hpos_ids.reshape(
+    #             h // self.spatial_merge_size,
+    #             self.spatial_merge_size,
+    #             w // self.spatial_merge_size,
+    #             self.spatial_merge_size,
+    #         )
+    #         hpos_ids = hpos_ids.permute(0, 2, 1, 3)
+    #         hpos_ids = hpos_ids.flatten()
 
-            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
-            wpos_ids = wpos_ids.reshape(
-                h // self.spatial_merge_size,
-                self.spatial_merge_size,
-                w // self.spatial_merge_size,
-                self.spatial_merge_size,
+    #         wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+    #         wpos_ids = wpos_ids.reshape(
+    #             h // self.spatial_merge_size,
+    #             self.spatial_merge_size,
+    #             w // self.spatial_merge_size,
+    #             self.spatial_merge_size,
+    #         )
+    #         wpos_ids = wpos_ids.permute(0, 2, 1, 3)
+    #         wpos_ids = wpos_ids.flatten()
+    #         pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+    #     pos_ids = torch.cat(pos_ids, dim=0)
+    #     max_grid_size = grid_thw[:, 1:].max()
+    #     rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+    #     rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+    #     return rotary_pos_emb
+
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+        hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
+        h_div = h // spatial_merge_size
+        w_div = w // spatial_merge_size
+        hpos_ids = hpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        hpos_ids = hpos_ids.transpose(0, 2, 1, 3)
+        hpos_ids = hpos_ids.flatten()
+
+        wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
+        wpos_ids = wpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        wpos_ids = wpos_ids.transpose(0, 2, 1, 3)
+        wpos_ids = wpos_ids.flatten()
+
+        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+
+    def rot_pos_emb(self, grid_thw):
+        max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+        pos_ids = [
+            (
+                self.rot_pos_ids(h, w, self.spatial_merge_size)
+                if t == 1
+                else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             )
-            wpos_ids = wpos_ids.permute(0, 2, 1, 3)
-            wpos_ids = wpos_ids.flatten()
-            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+            for t, h, w in grid_thw
+        ]
         pos_ids = torch.cat(pos_ids, dim=0)
-        max_grid_size = grid_thw[:, 1:].max()
         rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
         rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
         return rotary_pos_emb
 
-    def fast_pos_embed_interpolate(self, grid_thw):
-        num_grid_per_side = int(self.num_position_embeddings**0.5)
-
-        idx_list = [[] for _ in range(4)]
-        weight_list = [[] for _ in range(4)]
-
-        # TODO: use torch instand of np
-        for t, h, w in grid_thw:
-            h_idxs = np.linspace(0, num_grid_per_side - 1, h)
-            w_idxs = np.linspace(0, num_grid_per_side - 1, w)
-
-            h_idxs_floor = h_idxs.astype(int)
-            w_idxs_floor = w_idxs.astype(int)
-            h_idxs_ceil = (h_idxs.astype(int) + 1).clip(max=num_grid_per_side - 1)
-            w_idxs_ceil = (w_idxs.astype(int) + 1).clip(max=num_grid_per_side - 1)
-
-            dh = h_idxs - h_idxs_floor
-            dw = w_idxs - w_idxs_floor
-
-            idx_list[0].extend(
-                ((h_idxs_floor * num_grid_per_side)[None].T + w_idxs_floor[None])
-                .flatten()
-                .tolist()
-                * t
-            )
-            idx_list[1].extend(
-                ((h_idxs_floor * num_grid_per_side)[None].T + w_idxs_ceil[None])
-                .flatten()
-                .tolist()
-                * t
-            )
-            idx_list[2].extend(
-                ((h_idxs_ceil * num_grid_per_side)[None].T + w_idxs_floor[None])
-                .flatten()
-                .tolist()
-                * t
-            )
-            idx_list[3].extend(
-                ((h_idxs_ceil * num_grid_per_side)[None].T + w_idxs_ceil[None])
-                .flatten()
-                .tolist()
-                * t
-            )
-
-            weight_list[0].extend(
-                ((1 - dh)[None].T * (1 - dw)[None]).flatten().tolist() * t
-            )
-            weight_list[1].extend(((1 - dh)[None].T * dw[None]).flatten().tolist() * t)
-            weight_list[2].extend((dh[None].T * (1 - dw)[None]).flatten().tolist() * t)
-            weight_list[3].extend((dh[None].T * dw[None]).flatten().tolist() * t)
-
-        device = self.pos_embed.weight.device
-        dtype = self.pos_embed.weight.dtype
-
-        p0 = (
-            self.pos_embed(torch.tensor(idx_list[0], dtype=torch.long, device=device))
-            * torch.tensor(weight_list[0], dtype=dtype, device=device)[:, None]
-        )
-        p1 = (
-            self.pos_embed(torch.tensor(idx_list[1], dtype=torch.long, device=device))
-            * torch.tensor(weight_list[1], dtype=dtype, device=device)[:, None]
-        )
-        p2 = (
-            self.pos_embed(torch.tensor(idx_list[2], dtype=torch.long, device=device))
-            * torch.tensor(weight_list[2], dtype=dtype, device=device)[:, None]
-        )
-        p3 = (
-            self.pos_embed(torch.tensor(idx_list[3], dtype=torch.long, device=device))
-            * torch.tensor(weight_list[3], dtype=dtype, device=device)[:, None]
-        )
-
-        patch_pos_embeds = p0 + p1 + p2 + p3
-        patch_pos_embeds = patch_pos_embeds.split([t * h * w for t, h, w in grid_thw])
-        patch_pos_embeds_permute = []
+    def fast_pos_embed_interpolate(self, grid_thw) -> torch.Tensor:
+        num_grid_per_side = self.num_grid_per_side
         m_size = self.spatial_merge_size
-        for pos_embed, (t, h, w) in zip(patch_pos_embeds, grid_thw):
-            pos_embed = (
-                pos_embed.view(t, h // m_size, m_size, w // m_size, m_size, -1)
-                .permute(0, 1, 3, 2, 4, 5)
-                .flatten(0, 4)
+        hidden_dim = self.pos_embed.embedding_dim
+
+        outputs = []
+        for t, h, w in grid_thw:
+            h_idxs = torch.linspace(
+                0, num_grid_per_side - 1, h, dtype=torch.float32, device=self.device
             )
-            patch_pos_embeds_permute.append(pos_embed)
-        patch_pos_embeds = torch.cat(patch_pos_embeds_permute)
-        return patch_pos_embeds
+            w_idxs = torch.linspace(
+                0, num_grid_per_side - 1, w, dtype=torch.float32, device=self.device
+            )
+
+            h_floor = h_idxs.to(torch.long)
+            w_floor = w_idxs.to(torch.long)
+            h_ceil = torch.clamp(h_floor + 1, max=num_grid_per_side - 1)
+            w_ceil = torch.clamp(w_floor + 1, max=num_grid_per_side - 1)
+
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+
+            # Create meshgrid view for all h, w vars
+            dh_grid, dw_grid = torch.meshgrid(dh, dw, indexing="ij")
+            h_floor_grid, w_floor_grid = torch.meshgrid(h_floor, w_floor, indexing="ij")
+            h_ceil_grid, w_ceil_grid = torch.meshgrid(h_ceil, w_ceil, indexing="ij")
+
+            # original computation of weights
+            # w00 = (1 - dh_grid) * (1 - dw_grid)
+            # w01 = (1 - dh_grid) * dw_grid
+            # w10 = dh_grid * (1 - dw_grid)
+            # w11 = dh_grid * dw_grid
+            # we reuse w11 here to avoid duplicate
+            # dh_grid * dw_grid computation
+            w11 = dh_grid * dw_grid
+            w10 = dh_grid - w11
+            w01 = dw_grid - w11
+            w00 = 1 - dh_grid - w01
+
+            h_grid = torch.stack([h_floor_grid, h_floor_grid, h_ceil_grid, h_ceil_grid])
+            w_grid = torch.stack([w_floor_grid, w_ceil_grid, w_floor_grid, w_ceil_grid])
+            h_grid_idx = h_grid * num_grid_per_side
+
+            indices = (h_grid_idx + w_grid).reshape(4, -1)
+            weights = torch.stack([w00, w01, w10, w11], dim=0).reshape(4, -1, 1)
+            weights = weights.to(dtype=self.dtype)
+
+            embeds = self.pos_embed(indices)
+            embeds *= weights
+            combined = embeds.sum(dim=0)
+
+            combined = combined.reshape(
+                h // m_size, m_size, w // m_size, m_size, hidden_dim
+            )
+            combined = combined.permute(0, 2, 1, 3, 4).reshape(1, -1, hidden_dim)
+            repeated = combined.expand(t, -1, -1).reshape(-1, hidden_dim)
+            outputs.append(repeated)
+
+        return torch.cat(outputs, dim=0)
 
     def forward(
         self,

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -323,35 +323,6 @@ class Qwen3VLMoeVisionModel(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
-    # def rot_pos_emb(self, grid_thw):
-    #     pos_ids = []
-    #     for t, h, w in grid_thw:
-    #         hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
-    #         hpos_ids = hpos_ids.reshape(
-    #             h // self.spatial_merge_size,
-    #             self.spatial_merge_size,
-    #             w // self.spatial_merge_size,
-    #             self.spatial_merge_size,
-    #         )
-    #         hpos_ids = hpos_ids.permute(0, 2, 1, 3)
-    #         hpos_ids = hpos_ids.flatten()
-
-    #         wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
-    #         wpos_ids = wpos_ids.reshape(
-    #             h // self.spatial_merge_size,
-    #             self.spatial_merge_size,
-    #             w // self.spatial_merge_size,
-    #             self.spatial_merge_size,
-    #         )
-    #         wpos_ids = wpos_ids.permute(0, 2, 1, 3)
-    #         wpos_ids = wpos_ids.flatten()
-    #         pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
-    #     pos_ids = torch.cat(pos_ids, dim=0)
-    #     max_grid_size = grid_thw[:, 1:].max()
-    #     rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
-    #     rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
-    #     return rotary_pos_emb
-
     @staticmethod
     @lru_cache(maxsize=1024)
     def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:


### PR DESCRIPTION
…tation

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->
`12.35 → 13.49 req/s` 9% speedup throughput and mean TTFT 20% faster `6,682ms → 5,361ms`

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

# Before
```
INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 3055.556s, Total tokens: 5643, Avg speed: 1.8 tokens/s

Model Responding: 100%|██████████| 15/15 [02:53<00:00,  5.53s/it]
Model Responding: 100%|██████████| 15/15 [02:53<00:00, 11.57s/it]

Postprocessing:   0%|          | 0/900 [00:00<?, ?it/s]
Postprocessing: 100%|██████████| 900/900 [00:00<00:00, 15597.49it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.69167}, 'Art': {'num': 30, 'acc': 0.66667}, 'Art_Theory': {'num': 30, 'acc': 0.9}, 'Design': {'num': 30, 'acc': 0.73333}, 'Music': {'num': 30, 'acc': 0.46667}, 'Overall-Business': {'num': 150, 'acc': 0.44}, 'Accounting': {'num': 30, 'acc': 0.33333}, 'Economics': {'num': 30, 'acc': 0.63333}, 'Finance': {'num': 30, 'acc': 0.3}, 'Manage': {'num': 30, 'acc': 0.43333}, 'Marketing': {'num': 30, 'acc': 0.5}, 'Overall-Science': {'num': 150, 'acc': 0.46}, 'Biology': {'num': 30, 'acc': 0.53333}, 'Chemistry': {'num': 30, 'acc': 0.36667}, 'Geography': {'num': 30, 'acc': 0.56667}, 'Math': {'num': 30, 'acc': 0.36667}, 'Physics': {'num': 30, 'acc': 0.46667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.54667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.66667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.36667}, 'Pharmacy': {'num': 30, 'acc': 0.5}, 'Public_Health': {'num': 30, 'acc': 0.56667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.66667}, 'History': {'num': 30, 'acc': 0.6}, 'Literature': {'num': 30, 'acc': 0.83333}, 'Sociology': {'num': 30, 'acc': 0.6}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.3619}, 'Agriculture': {'num': 30, 'acc': 0.53333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.3}, 'Computer_Science': {'num': 30, 'acc': 0.5}, 'Electronics': {'num': 30, 'acc': 0.2}, 'Energy_and_Power': {'num': 30, 'acc': 0.4}, 'Materials': {'num': 30, 'acc': 0.23333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.36667}, 'Overall': {'num': 900, 'acc': 0.50667}}
2025-11-16 04:06:34 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-8B-Instruct,base_url=http://localhost:30000/v1,api_key=dummy), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 64
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5067|±  |   N/A|
```


# After
```
INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 2983.134s, Total tokens: 5683, Avg speed: 1.9 tokens/s

Model Responding: 100%|██████████| 15/15 [02:47<00:00,  5.41s/it]
Model Responding: 100%|██████████| 15/15 [02:47<00:00, 11.16s/it]

Postprocessing:   0%|          | 0/900 [00:00<?, ?it/s]
Postprocessing: 100%|██████████| 900/900 [00:00<00:00, 15765.76it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.7}, 'Art': {'num': 30, 'acc': 0.7}, 'Art_Theory': {'num': 30, 'acc': 0.9}, 'Design': {'num': 30, 'acc': 0.73333}, 'Music': {'num': 30, 'acc': 0.46667}, 'Overall-Business': {'num': 150, 'acc': 0.43333}, 'Accounting': {'num': 30, 'acc': 0.33333}, 'Economics': {'num': 30, 'acc': 0.63333}, 'Finance': {'num': 30, 'acc': 0.26667}, 'Manage': {'num': 30, 'acc': 0.43333}, 'Marketing': {'num': 30, 'acc': 0.5}, 'Overall-Science': {'num': 150, 'acc': 0.46}, 'Biology': {'num': 30, 'acc': 0.6}, 'Chemistry': {'num': 30, 'acc': 0.36667}, 'Geography': {'num': 30, 'acc': 0.53333}, 'Math': {'num': 30, 'acc': 0.36667}, 'Physics': {'num': 30, 'acc': 0.43333}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.54667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.66667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.66667}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.36667}, 'Pharmacy': {'num': 30, 'acc': 0.5}, 'Public_Health': {'num': 30, 'acc': 0.53333}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.675}, 'History': {'num': 30, 'acc': 0.6}, 'Literature': {'num': 30, 'acc': 0.83333}, 'Sociology': {'num': 30, 'acc': 0.6}, 'Psychology': {'num': 30, 'acc': 0.66667}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.3619}, 'Agriculture': {'num': 30, 'acc': 0.53333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.26667}, 'Computer_Science': {'num': 30, 'acc': 0.5}, 'Electronics': {'num': 30, 'acc': 0.2}, 'Energy_and_Power': {'num': 30, 'acc': 0.36667}, 'Materials': {'num': 30, 'acc': 0.26667}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.4}, 'Overall': {'num': 900, 'acc': 0.50778}}
2025-11-16 04:14:10 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-8B-Instruct,base_url=http://localhost:30000/v1,api_key=dummy), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 64
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5078|±  |   N/A|
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

# Before
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     200       
Benchmark duration (s):                  16.19     
Total input tokens:                      518222    
Total input text tokens:                 109822    
Total input vision tokens:               408400    
Total generated tokens:                  105408    
Total generated tokens (retokenized):    81769     
Request throughput (req/s):              12.35     
Input token throughput (tok/s):          32001.42  
Output token throughput (tok/s):         6509.19   
Total token throughput (tok/s):          38510.61  
Concurrency:                             143.04    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11581.72  
Median E2E Latency (ms):                 12009.99  
---------------Time to First Token----------------
Mean TTFT (ms):                          6682.40   
Median TTFT (ms):                        6772.93   
P99 TTFT (ms):                           7260.52   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.25     
Median TPOT (ms):                        9.43      
P99 TPOT (ms):                           10.84     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           9.37      
Median ITL (ms):                         8.58      
P95 ITL (ms):                            20.45     
P99 ITL (ms):                            28.10     
Max ITL (ms):                            3918.32   
==================================================
```
# After
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     200       
Benchmark duration (s):                  14.95     
Total input tokens:                      518308    
Total input text tokens:                 109908    
Total input vision tokens:               408400    
Total generated tokens:                  105408    
Total generated tokens (retokenized):    84216     
Request throughput (req/s):              13.37     
Input token throughput (tok/s):          34658.82  
Output token throughput (tok/s):         7048.54   
Total token throughput (tok/s):          41707.36  
Concurrency:                             139.68    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   10444.38  
Median E2E Latency (ms):                 10759.67  
---------------Time to First Token----------------
Mean TTFT (ms):                          5585.68   
Median TTFT (ms):                        5616.93   
P99 TTFT (ms):                           6099.45   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.96      
Median TPOT (ms):                        9.29      
P99 TPOT (ms):                           13.84     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           9.24      
Median ITL (ms):                         9.51      
P95 ITL (ms):                            11.60     
P99 ITL (ms):                            12.48     
Max ITL (ms):                            1647.45   
==================================================
```

> [!NOTE]  
> When eval, use and install Lmms eval in seperate venv, else it brings in numpy and other deps downgrade that is problematic. And reinstall `sglang` don't easily revert it.

# Commands to repro
```
python -m sglang.bench_serving --backend sglang --port 30000 --dataset-name image --num-prompts 200
```

And could use MoE, but dense + small model shows difference, since less time on other ... computation
```
python -m sglang.launch_server --model-path Qwen/Qwen3-VL-8B-Instruct --port 30000 --mm-attention-backend triton_attn 
```


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
