### PR TITLE
[CI] fix triggered by a non-run-ci label

### DIFF
--- a/.github/workflows/execute-notebook.yml
+++ b/.github/workflows/execute-notebook.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "python/sglang/**"
       - "docs/**"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 

--- a/.github/workflows/pr-benchmark-rust.yml
+++ b/.github/workflows/pr-benchmark-rust.yml
@@ -9,7 +9,7 @@ on:
     branches: [ main ]
     paths:
       - "sgl-router/**"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,96 @@
+on:
+  workflow_call:
+
+jobs:
+  pr-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch latest PR info
+        id: pr
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput("labels", JSON.stringify(pr.data.labels.map(l => l.name)));
+            core.setOutput("draft", pr.data.draft);
+            core.setOutput("user", pr.data.user.login);
+
+      - name: Block draft PR
+        if: github.event_name == 'pull_request' && fromJson(steps.pr.outputs.draft)
+        run: |
+          echo "PR is draft. Blocking CI."
+          exit 1
+
+      - name: Require run-ci label
+        if: github.event_name == 'pull_request'
+        run: |
+          labels='${{ steps.pr.outputs.labels }}'
+          echo "Labels: $labels"
+          if [[ "${{ contains(fromJson(steps.pr.outputs.labels), 'run-ci') }}" == "false" ]]; then
+            echo "Missing required label 'run-ci'."
+            exit 1
+          fi
+
+      - name: Enforce rate limit for low-permission actors
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const HOURS = 2;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const eventName = context.eventName;
+            const curRun = await github.rest.actions.getWorkflowRun({
+              owner, repo, run_id: context.runId
+            });
+            const triggeringActor = curRun.data.triggering_actor?.login || context.actor;
+
+            async function hasHighPermission(username) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+                const perm = data.permission || 'none';
+                return perm === 'write' || perm === 'maintain' || perm === 'admin';
+              } catch (e) {
+                if (e.status === 404 || e.status === 403) return false;
+                throw e;
+              }
+            }
+
+            if (await hasHighPermission(triggeringActor)) {
+              core.info(`Triggering user '${triggeringActor}' has high permission. No rate limit applied.`);
+              return;
+            }
+
+            const cutoff = new Date(Date.now() - HOURS * 60 * 60 * 1000);
+            core.info(`Checking for workflow runs since ${cutoff.toISOString()} (last ${HOURS} hours) for event '${eventName}'.`);
+
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 'pr-test.yml',
+              event: eventName,
+              per_page: 100,
+            });
+
+            const runs = data.workflow_runs || [];
+            const recentFound = runs.find((run) => {
+              if (String(run.id) === String(context.runId)) return false;
+              if (new Date(run.created_at) < cutoff) return false;
+              return (run.actor?.login === triggeringActor) || (run.triggering_actor?.login === triggeringActor);
+            });
+
+            if (recentFound) {
+              core.setFailed(
+                `User '${triggeringActor}' already triggered '${context.workflow}' via '${eventName}' at ${recentFound.created_at}. ` +
+                `Please wait ${HOURS} hours before triggering again.`
+              );
+            } else {
+              core.info(`No recent runs detected within the last ${HOURS} hours; proceeding.`);
+            }

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -19,7 +19,7 @@ on:
       - "test/**"
       - "sgl-kernel/**"
       - ".github/workflows/pr-test-amd.yml"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -27,7 +27,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  call-gate:
+    uses: ./.github/workflows/pr-gate.yml
+    secrets: inherit
   check-changes:
+    needs: [call-gate]
     runs-on: ubuntu-latest
     outputs:
       main_package: ${{ steps.filter.outputs.main_package }}
@@ -35,19 +39,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Fail if the PR does not have the 'run-ci' label
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-ci')
-        run: |
-          echo "This pull request does not have the 'run-ci' label. Failing the workflow."
-          exit 1
-
-      - name: Fail if the PR is a draft
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
-        run: |
-          echo "This pull request is a draft. Failing the workflow."
-          exit 1
-
       - name: Detect file changes
         id: filter
         uses: dorny/paths-filter@v3
@@ -416,6 +407,7 @@ jobs:
   pr-test-amd-finish:
     needs:
       [
+        call-gate,
         check-changes,
 
         sgl-kernel-unit-test-amd,

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -17,7 +17,7 @@ on:
       - "scripts/ci/**"
       - "test/**"
       - ".github/workflows/pr-test-npu.yml"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test-pd-router.yml
+++ b/.github/workflows/pr-test-pd-router.yml
@@ -13,7 +13,7 @@ on:
       - 'python/sglang/srt/disaggregation/**'
       - 'scripts/ci/ci_start_disaggregation_servers.sh'
       - 'sgl-router/**'
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -9,7 +9,7 @@ on:
     branches: [ main ]
     paths:
       - "sgl-router/**"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -21,7 +21,7 @@ on:
       - "sgl-kernel/**"
       - ".github/workflows/pr-test-xeon.yml"
       - "docker/xeon.Dockerfile"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -19,7 +19,7 @@ on:
       - "test/**"
       - "sgl-kernel/**"
       - ".github/workflows/pr-test-xpu.yml"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
     inputs:
       version:
@@ -32,14 +32,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Skip if PR triggered by non-'run-ci' label
-        if: github.event_name == 'pull_request' &&
-            github.event.action == 'labeled' &&
-            github.event.label.name != 'run-ci'
-        run: |
-          echo "Skip this run because the PR was triggered by a label other than 'run-ci'."
-          exit 1
 
       - name: Fail if the PR does not have the 'run-ci' label
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-ci')

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -23,104 +23,13 @@ concurrency:
 
 jobs:
   # ============================================== PR gating check ===================================================
-  pr-gate:
-    name: PR gating checks
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Fetch latest PR info
-        id: pr
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            core.setOutput("labels", JSON.stringify(pr.data.labels.map(l => l.name)));
-            core.setOutput("draft", pr.data.draft);
-            core.setOutput("user", pr.data.user.login);
-
-      - name: Block draft PR
-        if: github.event_name == 'pull_request' && fromJson(steps.pr.outputs.draft)
-        run: |
-          echo "PR is draft. Blocking CI."
-          exit 1
-
-      - name: Require run-ci label
-        if: github.event_name == 'pull_request'
-        run: |
-          labels='${{ steps.pr.outputs.labels }}'
-          echo "Labels: $labels"
-          if [[ "${{ contains(fromJson(steps.pr.outputs.labels), 'run-ci') }}" == "false" ]]; then
-            echo "Missing required label 'run-ci'."
-            exit 1
-          fi
-
-      - name: Enforce rate limit for low-permission actors
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const HOURS = 2;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const eventName = context.eventName;
-            const curRun = await github.rest.actions.getWorkflowRun({
-              owner, repo, run_id: context.runId
-            });
-            const triggeringActor = curRun.data.triggering_actor?.login || context.actor;
-
-            async function hasHighPermission(username) {
-              try {
-                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
-                const perm = data.permission || 'none';
-                return perm === 'write' || perm === 'maintain' || perm === 'admin';
-              } catch (e) {
-                if (e.status === 404 || e.status === 403) return false;
-                throw e;
-              }
-            }
-
-            if (await hasHighPermission(triggeringActor)) {
-              core.info(`Triggering user '${triggeringActor}' has high permission. No rate limit applied.`);
-              return;
-            }
-
-            const cutoff = new Date(Date.now() - HOURS * 60 * 60 * 1000);
-            core.info(`Checking for workflow runs since ${cutoff.toISOString()} (last ${HOURS} hours) for event '${eventName}'.`);
-
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner,
-              repo,
-              workflow_id: 'pr-test.yml',
-              event: eventName,
-              per_page: 100,
-            });
-
-            const runs = data.workflow_runs || [];
-            const recentFound = runs.find((run) => {
-              if (String(run.id) === String(context.runId)) return false;
-              if (new Date(run.created_at) < cutoff) return false;
-              return (run.actor?.login === triggeringActor) || (run.triggering_actor?.login === triggeringActor);
-            });
-
-            if (recentFound) {
-              core.setFailed(
-                `User '${triggeringActor}' already triggered '${context.workflow}' via '${eventName}' at ${recentFound.created_at}. ` +
-                `Please wait ${HOURS} hours before triggering again.`
-              );
-            } else {
-              core.info(`No recent runs detected within the last ${HOURS} hours; proceeding.`);
-            }
+  call-gate:
+    uses: ./.github/workflows/pr-gate.yml
+    secrets: inherit
 
   # =============================================== check changes ====================================================
   check-changes:
-    needs: [pr-gate]
+    needs: [call-gate]
     runs-on: ubuntu-latest
     outputs:
       main_package: ${{ steps.filter.outputs.main_package }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Skip if PR triggered by non-'run-ci' label
+        if: github.event_name == 'pull_request' &&
+            github.event.action == 'labeled' &&
+            github.event.label.name != 'run-ci'
+        run: |
+          echo "Skip this run because the PR was triggered by a label other than 'run-ci'."
+          exit 1
+
       - name: Fail if the PR does not have the 'run-ci' label
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-ci')
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -22,35 +22,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # =============================================== check changes ====================================================
-  check-changes:
+  # ============================================== PR gating check ===================================================
+  pr-gate:
+    name: PR gating checks
     runs-on: ubuntu-latest
-    outputs:
-      main_package: ${{ steps.filter.outputs.main_package }}
-      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel }}
-      multimodal_gen: ${{ steps.filter.outputs.multimodal_gen }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
-      - name: Debug PR labels
+    steps:
+      - name: Fetch latest PR info
+        id: pr
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput("labels", JSON.stringify(pr.data.labels.map(l => l.name)));
+            core.setOutput("draft", pr.data.draft);
+            core.setOutput("user", pr.data.user.login);
+
+      - name: Block draft PR
+        if: github.event_name == 'pull_request' && fromJson(steps.pr.outputs.draft)
+        run: |
+          echo "PR is draft. Blocking CI."
+          exit 1
+
+      - name: Require run-ci label
         if: github.event_name == 'pull_request'
         run: |
-          echo '${{ toJson(github.event.pull_request.labels) }}'
-          echo "Label names only:"
-          echo '${{ toJson(github.event.pull_request.labels.*.name) }}'
-
-      - name: Fail if the PR does not have the 'run-ci' label
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-ci')
-        run: |
-          echo "This pull request does not have the 'run-ci' label. Failing the workflow."
-          exit 1
-
-      - name: Fail if the PR is a draft
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
-        run: |
-          echo "This pull request is a draft. Failing the workflow."
-          exit 1
+          labels='${{ steps.pr.outputs.labels }}'
+          echo "Labels: $labels"
+          if [[ "${{ contains(fromJson(steps.pr.outputs.labels), 'run-ci') }}" == "false" ]]; then
+            echo "Missing required label 'run-ci'."
+            exit 1
+          fi
 
       - name: Enforce rate limit for low-permission actors
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -109,6 +117,18 @@ jobs:
             } else {
               core.info(`No recent runs detected within the last ${HOURS} hours; proceeding.`);
             }
+
+  # =============================================== check changes ====================================================
+  check-changes:
+    needs: [pr-gate]
+    runs-on: ubuntu-latest
+    outputs:
+      main_package: ${{ steps.filter.outputs.main_package }}
+      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel }}
+      multimodal_gen: ${{ steps.filter.outputs.multimodal_gen }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Detect file changes
         id: filter

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -22,11 +22,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ============================================== PR gating check ===================================================
   call-gate:
     uses: ./.github/workflows/pr-gate.yml
     secrets: inherit
-
   # =============================================== check changes ====================================================
   check-changes:
     needs: [call-gate]

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -893,6 +893,7 @@ jobs:
   pr-test-finish:
     needs:
       [
+        call-gate,
         check-changes,
 
         sgl-kernel-build-wheels,

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Debug PR labels
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Labels raw:"
+          echo '${{ toJson(github.event.pull_request.labels) }}'
+          echo "Label names only:"
+          echo '${{ toJson(github.event.pull_request.labels.*.name) }}'
+
       - name: Fail if the PR does not have the 'run-ci' label
         if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'run-ci')
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Debug PR labels
         if: github.event_name == 'pull_request'
         run: |
-          echo "Labels raw:"
           echo '${{ toJson(github.event.pull_request.labels) }}'
           echo "Label names only:"
           echo '${{ toJson(github.event.pull_request.labels.*.name) }}'

--- a/.github/workflows/quantization-test.yml
+++ b/.github/workflows/quantization-test.yml
@@ -17,7 +17,7 @@ on:
       - "scripts/ci/**"
       - "test/**"
       - ".github/workflows/quantization-test.yml"
-    types: [synchronize, labeled]
+    types: [synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -24,7 +24,6 @@ The following is the flow of data structures for a batch:
 
 ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 
-
 - ScheduleBatch is managed by `scheduler.py::Scheduler`.
   It contains high-level scheduling data. Most of the data is on the CPU.
 - ModelWorkerBatch is managed by `tp_worker.py::TpModelWorker`.

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -24,6 +24,7 @@ The following is the flow of data structures for a batch:
 
 ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 
+
 - ScheduleBatch is managed by `scheduler.py::Scheduler`.
   It contains high-level scheduling data. Most of the data is on the CPU.
 - ModelWorkerBatch is managed by `tp_worker.py::TpModelWorker`.


### PR DESCRIPTION
### `run-ci` label behavior update

- Existing workflows are only triggered by the `synchronize` event. The `labeled` event no longer triggers CI runs.
- The `run-ci` label is not automatically added to new pull requests.

### How to run CI for a pull request

1. The PR author opens a pull request.
2. An SGLang collaborator with permission `triage` or higher adds the `run-ci` label to the PR.
3. After the label is added, the PR author can:
   - Push new commits, or
   - Use the “re-run” / retrigger button to start the CI workflow.