### PR TITLE
Improve Qwen3CoderDetector with schema-aware parameter type conversion

### DIFF
--- a/test/per_commit/function_call/test_function_call_parser.py
+++ b/test/per_commit/function_call/test_function_call_parser.py
@@ -1422,6 +1422,10 @@ TX
                         "bool_param": {"type": "boolean"},
                         "str_param": {"type": "string"},
                         "obj_param": {"type": "object"},
+                        "str_param_int_content": {"type": "string"},
+                        "str_param_float_content": {"type": "string"},
+                        "str_param_bool_content": {"type": "string"},
+                        "str_param_obj_content": {"type": "string"},
                     },
                 },
             ),
@@ -1444,6 +1448,18 @@ hello world
 <parameter=obj_param>
 {"key": "value"}
 </parameter>
+<parameter=str_param_int_content>
+42
+</parameter>
+<parameter=str_param_float_content>
+3.14
+</parameter>
+<parameter=str_param_bool_content>
+true
+</parameter>
+<parameter=str_param_obj_content>
+{"key": "value"}
+</parameter>
 </function>
 </tool_call>"""
 
@@ -1456,6 +1472,10 @@ hello world
         self.assertEqual(params["bool_param"], True)
         self.assertEqual(params["str_param"], "hello world")
         self.assertEqual(params["obj_param"], {"key": "value"})
+        self.assertEqual(params["str_param_int_content"], "42")
+        self.assertEqual(params["str_param_float_content"], "3.14")
+        self.assertEqual(params["str_param_bool_content"], "true")
+        self.assertEqual(params["str_param_obj_content"], '{"key": "value"}')
 
     def test_parse_streaming_incremental(self):
         """Test that streaming is truly incremental with very small chunks."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

In the original implementation of Qwen3CoderDetector, there is a function called `_safe_val` to help convert the parameter type of function calls:

```python
def _safe_val(raw: str) -> Any:
    raw = html.unescape(raw.strip())
    try:
        return json.loads(raw)
    except Exception:
        try:
            return ast.literal_eval(raw)
        except Exception:
            return raw
```

However, due to the unique structure of Qwen3-Coder’s function call format, it is challenging to accurately infer a parameter’s type without introducing explicit tool schemas:

```plaintext
<tool_call>
<function=Personal_Information_Registration>
<parameter=name>
Cooper Freeman     # definitely a string
</parameter>
<parameter=age>
32                 # definitely an integer
</parameter>
<parameter=zip_code>
03106              # a string, or an integer?
</parameter>
</function>
</tool_call>
```

This imposes an additional burden on tool design: although the parameter types are correctly defined, the inference engine often produces completely incorrect type outputs.

## Modifications

<!-- Detail the changes made in this pull request. -->

Therefore, I used `_convert_param_value` (adapted from vllm-project/vllm) instead of the simplistic `_safe_val`, introducing a utility schema that enables more precise parameter type conversion:

```python
def _convert_param_value(
    param_value: str, param_name: str, param_config: dict, func_name: str
) -> Any:
    ...
```

As you can see, besides the `param_value` argument (the raw input used in `_safe_val`), the function now also accepts `param_config` to determine the parameter type. To make this work, I added a `_tool_parameter_configs` variable in two parts of the code — a dictionary mapping each tool name to its parameter schema.

```python
_tool_parameter_configs = {
    "tool_name": {
        "param1": {
            "type": "string",
            ...
        },
        "param2": {
            "type": "int",
            ...
        }
    }
}
```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

No changes to models outputs

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

No impacts on inference speed

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
