### PR TITLE
[SPEC_V2] Optimize _draft_extend_for_prefill by Replacing Python Copy Loop with Triton Kernel

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -52,6 +52,7 @@ try:
         shift_append_input_ids_triton,
         warmup_eagle_triton_kernels,
     )
+
     _triton_available = True
 except ImportError:
     _triton_available = False
@@ -151,7 +152,7 @@ class EagleDraftWorker(BaseDraftWorker):
         self.tree_mask_mode = TreeMaskMode.FULL_MASK
 
         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)
-        
+
         # Warmup Triton kernels to avoid JIT compilation overhead
         self._warmup_triton_kernels()
 
@@ -467,7 +468,7 @@ class EagleDraftWorker(BaseDraftWorker):
         # Create ForwardBatch first to reuse extend_seq_lens
         forward_batch = ForwardBatch.init_new(batch, self.draft_runner)
 
-        # Construct input_ids (in-place modification)
+        # Construct input_ids (in-place)
         if not batch.forward_mode.is_idle():
             if _triton_available and self.device == "cuda" and not _is_npu:
                 shift_append_input_ids_triton(

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -84,10 +84,7 @@ def shift_append_input_ids_triton(
     assert input_ids.is_contiguous()
 
     bs = extend_seq_lens.shape[0]
-    if extend_seq_lens.dtype != torch.int32:
-        lens_i32 = extend_seq_lens.to(dtype=torch.int32)
-    else:
-        lens_i32 = extend_seq_lens
+    lens_i32 = extend_seq_lens.to(dtype=torch.int32)
     offsets = torch.cumsum(lens_i32, dim=0) - lens_i32
 
     shift_append_input_ids_kernel[(bs,)](

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -40,6 +40,70 @@ else:
 logger = logging.getLogger(__name__)
 
 
+@triton.jit
+def shift_append_input_ids_kernel(
+    input_ids_ptr,
+    next_ids_ptr,
+    offsets_ptr,
+    lens_ptr,
+    n_seq,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if pid >= n_seq:
+        return
+
+    offset = tl.load(offsets_ptr + pid)
+    length = tl.load(lens_ptr + pid)
+    n = tl.maximum(length - 1, 0)
+
+    base_src = input_ids_ptr + offset + 1
+    base_dst = input_ids_ptr + offset
+
+    start = 0
+    while start < n:
+        idx = start + tl.arange(0, BLOCK)
+        mask = idx < n
+        src = tl.load(base_src + idx, mask=mask, other=0)
+        tl.store(base_dst + idx, src, mask=mask)
+        start += BLOCK
+
+    if length > 0:
+        last_pos = offset + length - 1
+        last_val = tl.load(next_ids_ptr + pid)
+        tl.store(input_ids_ptr + last_pos, last_val)
+
+
+def shift_append_input_ids_triton(
+    input_ids: torch.Tensor,
+    extend_seq_lens: torch.Tensor,
+    next_token_ids: torch.Tensor,
+):
+    if input_ids.numel() == 0:
+        return
+    assert input_ids.is_contiguous()
+
+    bs = extend_seq_lens.shape[0]
+    if extend_seq_lens.dtype != torch.int32:
+        lens_i32 = extend_seq_lens.to(dtype=torch.int32)
+    else:
+        lens_i32 = extend_seq_lens
+    offsets = torch.cumsum(lens_i32, dim=0) - lens_i32
+
+    shift_append_input_ids_kernel[(bs,)](
+        input_ids, next_token_ids, offsets, lens_i32, bs, BLOCK=128
+    )
+
+
+def warmup_eagle_triton_kernels(device: torch.device):
+    B, L = 4, 8
+    dummy_input_ids = torch.zeros(B * L, dtype=torch.int64, device=device)
+    dummy_lens = torch.full((B,), L, dtype=torch.int64, device=device)
+    dummy_next_ids = torch.zeros(B, dtype=torch.int64, device=device)
+    shift_append_input_ids_triton(dummy_input_ids, dummy_lens, dummy_next_ids)
+    torch.cuda.synchronize(device)
+
+
 # Simulate acceptance length for benchmarking purposes
 SIMULATE_ACC_LEN = envs.SGLANG_SIMULATE_ACC_LEN.get()  # turn off if < 0
 SIMULATE_ACC_METHOD = envs.SGLANG_SIMULATE_ACC_METHOD.get()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

 EAGLE V2 speculative path spends a noticeable amount of time in `_draft_extend_for_prefill`, where `batch.input_ids` is updated via a Python for-loop and repeated `aten::copy_` calls.  

For large-batch workloads (e.g., `bs>=64`), profiling shows:

-  Python for-loop and repeated `aten::copy_` calls are taking **～3-5 ms per iteration**.
<img width="2064" height="692" alt="image" src="https://github.com/user-attachments/assets/070d9f33-e1eb-4c2f-9401-1a371da095c2" />

- On the CUDA stream, this appears as **~1 ms** of back-to-back tiny copy kernels.
<img width="2048" height="569" alt="image" src="https://github.com/user-attachments/assets/7461b9dc-5a79-4003-be84-a0a7ba5d2b77" />

This cost is incurred every decode step and becomes a bottleneck when running high-throughput speculative decoding.

The goal of this PR is to eliminate this overhead by replacing the Python copy loop with a fused Triton kernel while preserving correctness.

## Modifications

- Added a Triton kernel `shift_append_input_ids_kernel` that, for each sequence, performs:
  - `input_ids[offset : offset + L - 1] = input_ids[offset + 1 : offset + L]`
  - `input_ids[offset + L - 1] = next_token_ids[i]`
  in a single kernel launch using per-sequence lengths and offsets.
- Introduced a small wrapper `shift_append_input_ids_triton` that:
  - Takes `input_ids`, `extend_seq_lens`, and `next_token_ids`.
  - Computes per-sequence offsets via `cumsum`.
  - Launches the Triton kernel.
- Updated `_draft_extend_for_prefill` in `EAGLEWorkerV2` to:
  - Use the Triton path on CUDA when Triton is available.
  - Fall back to the original Python loop on non-CUDA / NPU / Triton-unavailable paths.
- No changes were made to sampling logic, KV-cache layout, or verify logic; only the way `input_ids` are shifted is optimized.

## Accuracy Tests

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319 --port 40020
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
/tmp/test.jsonl: 732kB [00:00, 33.5MB/s]                                                           
100%|██████████████████████████████████████████████████████████| 1319/1319 [00:32<00:00, 41.10it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 32.755 s
Output throughput: 4485.875 token/s
```
## Benchmarking and Profiling

Environment: CUDA backend with speculative decoding enabled.

### Before (Python for-loop)

Workload: `bs=512`, extend seq len ≈ 256.

- `_draft_extend_for_prefill` on calling stack: **~25–30 ms**.

-  Python for-loop and repeated `aten::copy_` calls on caliing stack: **~5 ms**.
<img width="1738" height="388" alt="image" src="https://github.com/user-attachments/assets/ea844fb7-364a-4e59-b3a4-ac62725cc67e" />

- On the CUDA stream:
  - >1 ms of continuous tiny kernels (`aten::copy_`, elementwise copies) per iteration.
<img width="2306" height="548" alt="image" src="https://github.com/user-attachments/assets/207648a6-b50d-4aa1-8e34-1017cc8e4521" />


### After (with `shift_append_input_ids_kernel`)

Same workload (`bs=512`, extend seq len ≈ 256):

- `_draft_extend_for_prefill` on CPU stack: 20-22 ms
  - `shift_append_input_ids_triton` appears as **~100–130 μs**.
 
<img width="1746" height="166" alt="image" src="https://github.com/user-attachments/assets/3ff5c5e2-ff01-4004-98ef-07f2e9e09ce1" />


- On the CUDA stream:
  - Only ~5 small kernels remain (dtype cast, `cumsum`, Triton kernel).
  - `shift_append_input_ids_kernel` itself is **~2–3 μs**.
  - Total GPU time for the shift+append step is **≈20 μs**.
<img width="1458" height="674" alt="image" src="https://github.com/user-attachments/assets/158e533a-b3bc-464f-adf8-5f052f91b6fb" />

Overall effect:

- Per-iteration cost of `_draft_extend_for_prefill` reduced by **~5–10 ms** for `bs=512` workloads.
- The heavy band of copy kernels on the CUDA stream is replaced by a single short Triton kernel burst, improving overall decode throughput for large-batch speculative runs.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
