### PR TITLE
[Bug] Fixes accuracy issues caused by incorrect use of rope

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -168,7 +168,7 @@ class Indexer(CustomOp):
             max_position=max_position_embeddings,
             base=rope_theta,  # type: ignore
             rope_scaling=rope_scaling,
-            is_neox_style=False,
+            is_neox_style=True,
             device=get_global_server_args().device,
         )
         self.block_size = block_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

During our Ruler testing, we noticed a significant drop in the score of dsv3.2_exp compared to dsv3.1-terminus. We then conducted targeted testing on niah_multikey_3 and found that these cases were almost 100% correct on the DeepSeek official API, but scored low with sglang + dsv3.2.

To address this issue, we followed DeepSeek's advice and ran their inference demo released with the model, but the problem persisted.

After they modified the inference demo, the bad cases passed; https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp/commit/1938e9df3dea7218cb36c21fe8287384b99acd96

We referenced their modifications and specifically changed the rope-related code in sglang nsa_indexer.py, and the bad cases also passed.

### before
| dataset_version                   | metric | mode | opencompass.models.OpenAISDK_opencompass_Deepseek_V32_EXP |
|-----------------------------------|--------|------|-----------------------------------------------------------|
| ruler_niah_multikey_3_4k          | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_8k          | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_16k         | score  | gen  | 87.50                                                     |
| ruler_niah_multikey_3_32k         | score  | gen  | 62.50                                                     |
| ruler_niah_multikey_3_64k         | score  | gen  | 25.00                                                     |
| ruler_niah_multikey_3_96k         | score  | gen  | 43.75                                                     |
| ruler_niah_multikey_3_128k        | score  | gen  | 0.00                                                      |

### after
| dataset_version                | metric | mode | opencompass.models.OpenAISDK_opencompass_Deepseek_V32_EXP |
|--------------------------------|--------|------|-----------------------------------------------------------|
| ruler_niah_multikey_3_4k       | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_8k       | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_16k      | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_32k      | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_64k      | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_96k      | score  | gen  | 100.00                                                    |
| ruler_niah_multikey_3_128k     | score  | gen  | 100.00                                                    |

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
