### PR TITLE
[Ci tiny fix] Lower score threshold in evaluation test

### DIFF
--- a/test/srt/quant/test_awq.py
+++ b/test/srt/quant/test_awq.py
@@ -71,7 +71,7 @@ class TestAWQMarlinBfloat16(CustomTestCase):
         )
 
         metrics = run_eval(args)
-        self.assertGreater(metrics["score"], 0.87)
+        self.assertGreater(metrics["score"], 0.85)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
According to the CI monitor (https://github.com/sgl-project/sglang/actions/runs/19429184963), I noticed that `sglang/test/srt/quant/test_awq.py` often fails, for example: https://github.com/sgl-project/sglang/actions/runs/19418164197/job/55550523397

<img width="625" height="195" alt="图片" src="https://github.com/user-attachments/assets/708e0082-5431-4bde-b905-850b6e4ced73" />

<img width="1395" height="501" alt="图片" src="https://github.com/user-attachments/assets/a05e9099-0f10-4d30-921f-680275cea119" />


I ran `sglang/test/srt/quant/test_awq.py`  six times locally, I get follow results:

```shell
0.875
0.859375
0.891
0.84375 
0.906
0.859375
```

So the pr relax the  score threshold from 0.87->0.85.