### PR TITLE
fix MambaPool clear method after refactoring

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -273,11 +273,8 @@ class MambaPool:
     def clear(self):
         # Zero the entire mamba cache before resetting free_slots
         # This ensures that when slots are reallocated, they start with clean state
-        if self.is_kda_cache:
-            for i in range(len(self.mamba_cache.conv)):
-                self.mamba_cache.conv[i].zero_()
-        else:
-            self.mamba_cache.conv.zero_()
+        for i in range(len(self.mamba_cache.conv)):
+            self.mamba_cache.conv[i].zero_()
         self.mamba_cache.temporal.zero_()
 
         self.free_slots = torch.arange(self.size, dtype=torch.int64, device=self.device)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
After this linear attn [refactoring](https://github.com/sgl-project/sglang/pull/13004), we unified kda/gdn/mamba2 logics. We need to update the `clear` method as well, otherwise it complains:
```
  File "/home/jobuser/zminglei/sglang/python/sglang/utils.py", line 507, in __call__
    return fn(obj)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/scheduler.py", line 2224, in flush_cache_wrapped
    success = self.flush_cache()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/managers/scheduler.py", line 2266, in flush_cache
    self.req_to_token_pool.clear()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 422, in clear
    self.mamba_pool.clear()
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 276, in clear
    if self.is_kda_cache:
AttributeError: 'MambaPool' object has no attribute 'is_kda_cache'
```
With this fix, it runs well

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

```
python3 -m sglang.launch_server --model-path /shared/public/elr-models/Qwen/Qwen3-Next-80B-A3B-Instruct/ --tp 4 --context-length 262144 --mem-fraction-static 0.8 --enable-deterministic-inference

python benchmark/gsm8k/bench_sglang.py --data-path /shared/public/data/gsm8k/test.jsonl
Accuracy: 0.940
Invalid: 0.000
Latency: 24.543 s
Output throughput: 1347.818 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
