### PR TITLE
Temporarily disable model hooks CI

### DIFF
--- a/test/srt/test_model_hooks.py
+++ b/test/srt/test_model_hooks.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import unittest
 
 import torch
 import torch.nn as nn
@@ -149,4 +148,5 @@ class TestAttachHooks(CustomTestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pass
+    # unittest.main()


### PR DESCRIPTION
Due to #13217.

@Carlomus, please fix the CI. The test you added will fail.