### PR TITLE
Temporarily comment out multimodal gen test to recover runners

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -308,23 +308,23 @@ jobs:
           echo "All benchmark tests completed!"
 
   # =============================================== multimodal_gen ====================================================
-  multimodal-gen-test:
-    needs: [check-changes]
-    if: needs.check-changes.outputs.multimodal_gen == 'true'
-    runs-on: 1-gpu-runner
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # multimodal-gen-test:
+  #   needs: [check-changes]
+  #   if: needs.check-changes.outputs.multimodal_gen == 'true'
+  #   runs-on: 1-gpu-runner
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/ci_install_dependency.sh diffusion
+  #     - name: Install dependencies
+  #       run: |
+  #         CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} bash scripts/ci/ci_install_dependency.sh diffusion
 
-      - name: Run diffusion server tests
-        timeout-minutes: 60
-        run: |
-          cd python
-          pytest -s -v --log-cli-level=INFO sglang/multimodal_gen/test/server/test_server_performance.py
+  #     - name: Run diffusion server tests
+  #       timeout-minutes: 60
+  #       run: |
+  #         cd python
+  #         pytest -s -v --log-cli-level=INFO sglang/multimodal_gen/test/server/test_server_performance.py
 
   # Adding a single CUDA13 smoke test to verify that the kernel builds and runs
   # TODO: Add back this test when it can pass on CI


### PR DESCRIPTION
The logs directory below is created in python/sglang/multimodal_gen/runtime/utils/performance_logger.py, commenting out the test to make sure the test is not executed to cause further issues.

File was unable to be removed Error: EBUSY: resource busy or locked, unlink '/public_sglang_ci/runner-l1b-gpu-23/_work/sglang/sglang/python/sglang/logs/.nfsa3ccd677b154c8f400000171'