### PR TITLE
[PD] Clarify init method docstrings for kvsender and kvreceiver

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -75,7 +75,7 @@ class BaseKVSender(ABC):
     @abstractmethod
     def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
         """
-        Set req's index metadata locally or notify the decoder server about the kv indices and aux index.
+        Set req's index metadata locally or notify the decoder server about the kv indices length and aux index.
         """
         ...
 

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -48,7 +48,7 @@ class KVPoll:
 
 
 class BaseKVManager(ABC):
-    """Base class for managing transfers states"""
+    """Base class for managing transfer states"""
 
     @abstractmethod
     def __init__(
@@ -75,7 +75,7 @@ class BaseKVSender(ABC):
     @abstractmethod
     def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
         """
-        Set req's index metadata locally or notify the decoder server about the kv indices length and aux index
+        Set req's index metadata locally or notify the decoder server about the kv indices and aux index.
         """
         ...
 
@@ -86,21 +86,21 @@ class BaseKVSender(ABC):
         state_indices: Optional[List[int]] = None,
     ):
         """
-        Send the kv cache at the given kv indices and the extra cache/state at the given indices to the decoder server
+        Send the kv cache at the given kv indices and the extra cache/state at the given indices to the decoder server.
         """
         ...
 
     @abstractmethod
     def poll(self) -> KVPoll:
         """
-        Check the status of the kv cache transfer
+        Check the status of the kv cache transfer.
         """
         ...
 
     @abstractmethod
     def failure_exception(self):
         """
-        Raise an exception if the kv cache transfer fails
+        Raise an exception if the kv cache transfer fails.
         """
         ...
 
@@ -123,21 +123,21 @@ class BaseKVReceiver(ABC):
         state_indices: Optional[List[int]] = None,
     ):
         """
-        Set req's index metadata locally or notify the prefill server about the kv indices length and aux index
+        Set req's index metadata locally or notify the prefill server about the kv indices, aux index, and state_indices.
         """
         ...
 
     @abstractmethod
     def poll(self) -> KVPoll:
         """
-        Check the status of the kv cache transfer
+        Check the status of the kv cache transfer.
         """
         ...
 
     @abstractmethod
     def failure_exception(self):
         """
-        Raise an exception if the kv cache transfer fails
+        Raise an exception if the kv cache transfer fails.
         """
         ...
 

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -75,7 +75,7 @@ class BaseKVSender(ABC):
     @abstractmethod
     def init(self, num_kv_indices: int, aux_index: Optional[int] = None):
         """
-        Notify the decoder server about the kv indices length and aux index
+        Set req's index metadata locally or notify the decoder server about the kv indices length and aux index
         """
         ...
 
@@ -123,7 +123,7 @@ class BaseKVReceiver(ABC):
         state_indices: Optional[List[int]] = None,
     ):
         """
-        Notify the prefill server about the kv indices, aux index, and state_indices.
+        Set req's index metadata locally or notify the prefill server about the kv indices length and aux index
         """
         ...
 


### PR DESCRIPTION
## Motivation

Fix https://sgl-fru7574.slack.com/archives/C08AP4WU8P3/p1763396094947009

Different backends can have different implementations based on these based interfaces: `BaseKVSender`, `BaseKVReceiver`, `BaseKVManager`.

For current mooncake/nixl/ascend backends, they both adopted a design of decode node notifying prefill node, so their init interface of KVSender only sets inner index metadata locally.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->


## Modifications
To clarify, this PR replaces the current docstring with a more rigorous docstring.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
No need, merely docstring change.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
No need, merely docstring change.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
