### PR TITLE
diffusion: fix user provided params was overriding

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/base.py
+++ b/python/sglang/multimodal_gen/configs/sample/base.py
@@ -404,17 +404,12 @@ class SamplingParams:
         """
         Merges parameters from a user-provided SamplingParams object.
 
-        This method updates the current object with values from `user_params`,
-        but skips any fields that are explicitly defined in the current object's
-        subclass. This is to preserve model-specific optimal parameters.
+        This method updates the current object with values from `user_params`.
         It also skips fields that the user has not changed from the default
         in `user_params`.
         """
         if user_params is None:
             return
-
-        # Get fields defined directly in the subclass (not inherited)
-        subclass_defined_fields = set(type(self).__annotations__.keys())
 
         # Compare against current instance to avoid constructing a default instance
         default_params = SamplingParams()
@@ -432,7 +427,7 @@ class SamplingParams:
                 if field_name != "output_file_name"
                 else user_params.output_file_path is not None
             )
-            if is_user_modified and field_name not in subclass_defined_fields:
+            if is_user_modified:
                 if hasattr(self, field_name):
                     setattr(self, field_name, user_value)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
User provided parameters will be ignored due to the sampling params merge logic. If we want to generate a 832x480 video using model Wan2.1-T2V-14B-Diffusers, it will instead produce a 1280×720 video, which is not what we intended.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Fix this issue by overriding the subclass default parameters whenever the user provides their own values.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
