### PR TITLE
[CI] remove auto-labeling `run-ci` label.

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,27 +19,3 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml
           sync-labels: false
-
-      # Step 2: Add run-ci label for authorized users (only on opened/reopened)
-      - name: Check user permission
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
-        id: checkAccess
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Add run-ci label
-        if: (github.event.action == 'opened' || github.event.action == 'reopened') && steps.checkAccess.outputs.require-result == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
-          script: |
-            github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['run-ci']
-            })

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      # Step 1: Add category labels based on file changes
       - name: Auto-label by file changes
         uses: actions/labeler@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'run-ci')
+    if: contains(github.event.pull_request.labels.*.name)
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -69,11 +69,18 @@ You will need to work with the Merge Oncall, Codeowner, and other reviewers to g
 Then your PR can be merged.
 
 ## How to trigger CI
+
 To trigger CI, the pull request must have the "run-ci" label.
 
-- If you have write access to sgl-project/sglang, your pull request will be automatically tagged by @sglang-bot.
-- If you have triage access to sgl-project/sglang, you can manually add the label by clicking "Labels" on the right side of your pull request page.
-- If you do not have the above access, please request a review and ask other maintainers to add the label for you.
+- The "run-ci" label is not added automatically to new pull requests.
+- Only collaborators with triage or higher permission can add the "run-ci" label.
+- If you have triage/write/maintain/admin access, you can manually add the label by clicking "Labels" on the right side of the pull request.
+- If you do not have triage or higher permission, please request a review and ask a collaborator to add the label for you.
+
+After the "run-ci" label is added, the PR author can trigger CI by:
+
+1. Pushing new commits, or
+2. Clicking "Re-run" / retrigger on the workflow page.
 
 ## General code style
 - Avoid code duplication. If the same code snippet (more than five lines) appears multiple times, extract it into a shared function.


### PR DESCRIPTION
For avoiding CI abuse. Now we have to manually add a run-ci label and retrigger it (or push new commits to trigger the synchronize event)