### PR TITLE
Flashinfer TRTLLM-GEN-MoE + Qwen3

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -49,6 +49,7 @@ from sglang.srt.layers.moe import (
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.moe.utils import RoutingMethodType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding, get_rope
@@ -111,6 +112,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             quant_config=quant_config,
             prefix=add_prefix("experts", prefix),
+            routing_method_type=RoutingMethodType.RenormalizeNaive,
         )
 
         self.gate = ReplicatedLinear(

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -112,7 +112,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             quant_config=quant_config,
             prefix=add_prefix("experts", prefix),
-            routing_method_type=RoutingMethodType.RenormalizeNaive,
+            routing_method_type=RoutingMethodType.Renormalize,
         )
 
         self.gate = ReplicatedLinear(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1096,6 +1096,12 @@ class ServerArgs:
                 f"Disabling Radix Cache for {model_arch} as it is not yet supported."
             )
             self.disable_radix_cache = True
+        elif model_arch in ["Qwen3ForCausalLM"]:
+            if self.quantization == "fp8" and self.moe_runner_backend == "auto":
+                self.moe_runner_backend = "flashinfer_trtllm"
+                logger.warning(
+                    "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3ForCausalLM"
+                )
         elif model_arch in ["Qwen3NextForCausalLM"]:
             if not self.disable_radix_cache:
                 logger.warning(
@@ -1103,7 +1109,11 @@ class ServerArgs:
                     "overlap schedule currently, try to use --disable-radix-cache if overlap schedule is necessary"
                 )
                 self.disable_overlap_schedule = True
-
+            if self.quantization == "fp8" and self.moe_runner_backend == "auto":
+                self.moe_runner_backend = "flashinfer_trtllm"
+                logger.warning(
+                    "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
+                )
         if is_deepseek_nsa(hf_config):
             if (
                 self.attention_backend is None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1096,8 +1096,8 @@ class ServerArgs:
                 f"Disabling Radix Cache for {model_arch} as it is not yet supported."
             )
             self.disable_radix_cache = True
-        elif model_arch in ["Qwen3ForCausalLM"]:
-            if is_cuda() and is_sm100_supported():
+        elif model_arch in ["Qwen3MoeForCausalLM"]:
+            if is_sm100_supported():
                 quantization_config = getattr(hf_config, "quantization_config", None)
                 quant_method = (
                     quantization_config.get("quant_method")
@@ -1120,7 +1120,7 @@ class ServerArgs:
                     "overlap schedule currently, try to use --disable-radix-cache if overlap schedule is necessary"
                 )
                 self.disable_overlap_schedule = True
-            if is_cuda() and is_sm100_supported():
+            if is_sm100_supported():
                 quantization_config = getattr(hf_config, "quantization_config", None)
                 quant_method = (
                     quantization_config.get("quant_method")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1097,15 +1097,22 @@ class ServerArgs:
             )
             self.disable_radix_cache = True
         elif model_arch in ["Qwen3ForCausalLM"]:
-            if (
-                is_sm100_supported()
-                and self.quantization == "fp8"
-                and self.moe_runner_backend == "auto"
-            ):
-                self.moe_runner_backend = "flashinfer_trtllm"
-                logger.warning(
-                    "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3ForCausalLM"
+            if is_cuda() and is_sm100_supported():
+                quantization_config = getattr(hf_config, "quantization_config", None)
+                quant_method = (
+                    quantization_config.get("quant_method")
+                    if quantization_config is not None
+                    else None
                 )
+                if (
+                    (self.quantization == "fp8" or quant_method == "fp8")
+                    and self.moe_a2a_backend == "none"
+                    and self.moe_runner_backend == "auto"
+                ):
+                    self.moe_runner_backend = "flashinfer_trtllm"
+                    logger.warning(
+                        "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3ForCausalLM"
+                    )
         elif model_arch in ["Qwen3NextForCausalLM"]:
             if not self.disable_radix_cache:
                 logger.warning(
@@ -1113,15 +1120,22 @@ class ServerArgs:
                     "overlap schedule currently, try to use --disable-radix-cache if overlap schedule is necessary"
                 )
                 self.disable_overlap_schedule = True
-            if (
-                is_sm100_supported()
-                and self.quantization == "fp8"
-                and self.moe_runner_backend == "auto"
-            ):
-                self.moe_runner_backend = "flashinfer_trtllm"
-                logger.warning(
-                    "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
+            if is_cuda() and is_sm100_supported():
+                quantization_config = getattr(hf_config, "quantization_config", None)
+                quant_method = (
+                    quantization_config.get("quant_method")
+                    if quantization_config is not None
+                    else None
                 )
+                if (
+                    (self.quantization == "fp8" or quant_method == "fp8")
+                    and self.moe_a2a_backend == "none"
+                    and self.moe_runner_backend == "auto"
+                ):
+                    self.moe_runner_backend = "flashinfer_trtllm"
+                    logger.warning(
+                        "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
+                    )
         if is_deepseek_nsa(hf_config):
             if (
                 self.attention_backend is None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1097,7 +1097,11 @@ class ServerArgs:
             )
             self.disable_radix_cache = True
         elif model_arch in ["Qwen3ForCausalLM"]:
-            if self.quantization == "fp8" and self.moe_runner_backend == "auto":
+            if (
+                is_sm100_supported()
+                and self.quantization == "fp8"
+                and self.moe_runner_backend == "auto"
+            ):
                 self.moe_runner_backend = "flashinfer_trtllm"
                 logger.warning(
                     "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3ForCausalLM"
@@ -1109,7 +1113,11 @@ class ServerArgs:
                     "overlap schedule currently, try to use --disable-radix-cache if overlap schedule is necessary"
                 )
                 self.disable_overlap_schedule = True
-            if self.quantization == "fp8" and self.moe_runner_backend == "auto":
+            if (
+                is_sm100_supported()
+                and self.quantization == "fp8"
+                and self.moe_runner_backend == "auto"
+            ):
                 self.moe_runner_backend = "flashinfer_trtllm"
                 logger.warning(
                     "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1116,7 +1116,8 @@ class ServerArgs:
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
                     logger.info(
-                        "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3ForCausalLM"
+                        "Use flashinfer_trtllm as MoE runner backend on sm100 for "
+                        f"{model_arch}"
                     )
         elif model_arch in ["Qwen3NextForCausalLM"]:
             if not self.disable_radix_cache:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1104,8 +1104,10 @@ class ServerArgs:
                     if quantization_config is not None
                     else None
                 )
+                if self.quantization is None and quant_method is not None:
+                    self.quantization = quant_method
                 if (
-                    (self.quantization == "fp8" or quant_method == "fp8")
+                    self.quantization == "fp8"
                     and self.moe_a2a_backend == "none"
                     and self.moe_runner_backend == "auto"
                 ):
@@ -1127,8 +1129,10 @@ class ServerArgs:
                     if quantization_config is not None
                     else None
                 )
+                if self.quantization is None and quant_method is not None:
+                    self.quantization = quant_method
                 if (
-                    (self.quantization == "fp8" or quant_method == "fp8")
+                    self.quantization == "fp8"
                     and self.moe_a2a_backend == "none"
                     and self.moe_runner_backend == "auto"
                 ):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1110,7 +1110,7 @@ class ServerArgs:
                     and self.moe_runner_backend == "auto"
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.warning(
+                    logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3ForCausalLM"
                     )
         elif model_arch in ["Qwen3NextForCausalLM"]:
@@ -1133,7 +1133,7 @@ class ServerArgs:
                     and self.moe_runner_backend == "auto"
                 ):
                     self.moe_runner_backend = "flashinfer_trtllm"
-                    logger.warning(
+                    logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
                     )
         if is_deepseek_nsa(hf_config):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1096,7 +1096,10 @@ class ServerArgs:
                 f"Disabling Radix Cache for {model_arch} as it is not yet supported."
             )
             self.disable_radix_cache = True
-        elif model_arch in ["Qwen3MoeForCausalLM"]:
+        elif model_arch in [
+            "Qwen3MoeForCausalLM",
+            "Qwen3VLMoeForConditionalGeneration",
+        ]:
             if is_sm100_supported():
                 quantization_config = getattr(hf_config, "quantization_config", None)
                 quant_method = (


### PR DESCRIPTION
```
SGLANG_ENABLE_JIT_DEEPGEMM=false SGLANG_ENABLE_FLASHINFER_FP8_GEMM=1 python3 -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 --moe-runner-backend flashinfer_trtllm --quantization fp8
```

This cmd needs to work, https://github.com/sgl-project/sglang/pull/12543 only make it work for Qwen2 MoE (qwen3 next)

Also set better default, st:

```
CUDA_VISIBLE_DEVICES=7 SGLANG_ENABLE_JIT_DEEPGEMM=false SGLANG_ENABLE_FLASHINFER_FP8_GEMM=1 python3 -m sglang.launch_server --model-path Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
```

Uses `flashinfer_trtllm` automatically.

Before:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:17<00:00, 77.41it/s]
Accuracy: 0.942
Invalid: 0.000
Latency: 17.105 s
Output throughput: 11338.159 token/s
```

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    2.426    |  512   |   1.000    |     211.07      |
+-------------+--------+------------+-----------------+
```

After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:17<00:00, 77.28it/s]
Accuracy: 0.946
Invalid: 0.000
Latency: 17.137 s
Output throughput: 11381.587 token/s
```

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    1.832    |  512   |   1.000    |     279.47      |
+-------------+--------+------------+-----------------+
```

So around 32%. (Full results in original PR)