### PR TITLE
[CI] fix lint yml (syntax error)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name)
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
We remove the `run-ci` requirement for lint tasks.