### PR TITLE
[Bad idea] Use secrets.GITHUB_TOKEN for ci monitor

### DIFF
--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run Failure Analysis
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: 1
           PYTHONIOENCODING: utf-8
         run: |

--- a/.github/workflows/ci-monitor.yml
+++ b/.github/workflows/ci-monitor.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run CI Analysis
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: 1
           PYTHONIOENCODING: utf-8
         run: |
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run Performance Analysis
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: 1
           PYTHONIOENCODING: utf-8
         run: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run Test Balance Analysis
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: 1
           PYTHONIOENCODING: utf-8
         run: |


### PR DESCRIPTION
We can use the built-in token to run most queries. It should have better rate limit and it does not expire.

test run: https://github.com/sgl-project/sglang/actions/runs/19461084334