### PR TITLE
Trigger CI retry with edit

### DIFF
--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -2,7 +2,7 @@ name: Slash Command Handler
 
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 permissions:
   contents: read

--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -80,8 +80,9 @@ For CI to run on a pull request, it must have the **run-ci** label. Authorized u
 - `/tag-run-ci-label`: Tag the "run-ci" label. Every future commits will trigger CI.
 - `/rerun-failed-ci`: Rerun the failed/flaky tests of the last commit.
 
-If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash_command_handler.yml) will execute your command and react with a 👍 on your comment. It may take up to several minutes to react. Here is a usage [example](https://github.com/sgl-project/sglang/pull/13498#issuecomment-3547552157).
-To avoid too many `rerun-failed-ci` comments in a PR, you can also trigger a command by editing an existing comment by appending any suffix (e.g., `/rerun-failed-ci try again`)
+If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash_command_handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/13498#issuecomment-3547552157).
+
+To avoid spamming a PR with too many `/rerun-failed-ci` comments, you can also trigger the command by editing an existing comment and adding any suffix (e.g., `/rerun-failed-ci try again`).
 
 If you don’t have permission, please ask maintainers to trigger CI for you.
 

--- a/docs/developer_guide/contribution_guide.md
+++ b/docs/developer_guide/contribution_guide.md
@@ -81,6 +81,7 @@ For CI to run on a pull request, it must have the **run-ci** label. Authorized u
 - `/rerun-failed-ci`: Rerun the failed/flaky tests of the last commit.
 
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash_command_handler.yml) will execute your command and react with a 👍 on your comment. It may take up to several minutes to react. Here is a usage [example](https://github.com/sgl-project/sglang/pull/13498#issuecomment-3547552157).
+To avoid too many `rerun-failed-ci` comments in a PR, you can also trigger a command by editing an existing comment by appending any suffix (e.g., `/rerun-failed-ci try again`)
 
 If you don’t have permission, please ask maintainers to trigger CI for you.
 


### PR DESCRIPTION
To avoid spamming a PR with too many `/rerun-failed-ci` comments, you can also trigger the command by editing an existing comment and adding any suffix (e.g., `/rerun-failed-ci try again`).
