### PR TITLE
add speculative args checking

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1612,6 +1612,14 @@ class ServerArgs:
                 self.speculative_num_draft_tokens = self.speculative_num_steps + 1
 
             if (
+                self.speculative_num_draft_tokens is not None
+                and self.speculative_num_draft_tokens < self.speculative_num_steps + 1
+            ):
+                raise ValueError(
+                    "speculative_num_draft_tokens should >= speculative_num_steps + 1 to avoid useless draft token computing."
+                )
+
+            if (
                 self.speculative_eagle_topk > 1
                 and self.page_size > 1
                 and self.attention_backend != "flashinfer"

--- a/scripts/playground/bench_speculative.py
+++ b/scripts/playground/bench_speculative.py
@@ -141,6 +141,9 @@ def main(args, server_args):
                     if steps * topk + 1 < num_draft_tokens:
                         continue
 
+                    if num_draft_tokens < steps + 1:
+                        continue
+
                     if (steps == 0 or topk == 0 or num_draft_tokens == 0) and (
                         steps + topk + num_draft_tokens != 0
                     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Add args checking to speculative decoding to avoid improper settings.
In speculative decoding, speculative_num_draft_tokens should at least be speculative_num_steps + 1 to avoid useless draft token computing.
This PR add this check to the bench_speculative.py and the server args validation.