### PR TITLE
[NVIDIA] Add fp8 gemm benchmark on blackwell

### DIFF
--- a/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm_blackwell.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm_blackwell.py
@@ -17,6 +17,7 @@ BLOCK_SIZE = 128
 
 def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2
+    assert BLOCK_SIZE == 128
     m, n = x.shape
     x_padded = torch.zeros(
         (ceil_div(m, 128) * 128, ceil_div(n, 128) * 128), dtype=x.dtype, device=x.device

--- a/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm_blackwell.py
+++ b/benchmark/kernels/deepseek/benchmark_deepgemm_fp8_gemm_blackwell.py
@@ -1,0 +1,328 @@
+from typing import Tuple
+
+import argparse
+import torch
+import triton
+from deep_gemm import ceil_div
+from flashinfer.gemm import gemm_fp8_nt_groupwise
+from sglang.srt.layers.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+    w8a8_block_fp8_matmul_deepgemm,
+)
+from sglang.srt.layers.quantization.fp8_utils import (
+    requant_weight_ue8m0,
+)
+
+BLOCK_SIZE = 128
+
+def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    m, n = x.shape
+    x_padded = torch.zeros(
+        (ceil_div(m, 128) * 128, ceil_div(n, 128) * 128), dtype=x.dtype, device=x.device
+    )
+    x_padded[:m, :n] = x
+    x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
+    x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
+    x_scaled = (x_view * (448.0 / x_amax)).to(torch.float8_e4m3fn)
+    return x_scaled.view_as(x_padded)[:m, :n].contiguous(), (x_amax / 448.0).view(
+        x_view.size(0), x_view.size(2)
+    )
+
+
+def get_weight_shapes(tp_size):
+    # cannot TP
+    total = [
+        (512 + 64, 7168),
+        ((128 + 64) * 128, 7168),
+        (128 * (128 + 128), 512),
+        (7168, 16384),
+        (7168, 18432),
+    ]
+    # N can TP
+    n_tp = [
+        (18432 * 2, 7168),
+        ((128 + 64) * 128, 7168),
+        (128 * (128 + 128), 512),
+        (24576, 1536),
+        (4096, 7168),
+    ]
+    # K can TP
+    k_tp = [(7168, 18432), (7168, 16384), (7168, 2048)]
+
+    weight_shapes = []
+    for t in total:
+        weight_shapes.append(t)
+    for n_t in n_tp:
+        new_t = (n_t[0] // tp_size, n_t[1])
+        weight_shapes.append(new_t)
+    for k_t in k_tp:
+        new_t = (k_t[0], k_t[1] // tp_size)
+        weight_shapes.append(new_t)
+
+    return weight_shapes
+
+
+def create_benchmark_configs(tp_size):
+    configs = []
+    weight_shapes = get_weight_shapes(tp_size)
+    batch_sizes = [8, 16, 32, 64, 128, 256, 1024, 2048, 4096]
+
+    for n, k in weight_shapes:
+        for m in batch_sizes:
+            configs.append((m, n, k, tp_size))
+
+    return configs
+
+
+def fp8_gemm_flashinfer(
+    x_fp8: torch.Tensor,
+    x_scale: torch.Tensor,
+    y_fp8: torch.Tensor,
+    y_scale: torch.Tensor,
+):
+    """Flashinfer implementation of FP8 GEMM"""
+    output = gemm_fp8_nt_groupwise(
+        x_fp8,
+        y_fp8,
+        x_scale,
+        y_scale,
+        out_dtype=torch.bfloat16,
+        backend="trtllm",
+    )
+    return output
+
+
+def fp8_gemm_deepgemm_blackwell(
+    x_fp8: torch.Tensor,
+    x_scale: torch.Tensor,
+    y_fp8: torch.Tensor,
+    y_scale: torch.Tensor,
+):
+    """DeepGEMM implementation of FP8 GEMM"""
+    block_size = [BLOCK_SIZE, BLOCK_SIZE]
+    output = w8a8_block_fp8_matmul_deepgemm(
+        x_fp8, y_fp8, x_scale, y_scale, block_size, output_dtype=torch.bfloat16
+    )
+    return output
+
+
+def check_accuracy(a, b, atol, rtol, percent):
+    """Unified accuracy checking function with detailed error reporting."""
+    if not torch.isfinite(a).all():
+        print("Non-finite values in reference output")
+        return False
+    if not torch.isfinite(b).all():
+        print("Non-finite values in actual output")
+        return False
+    assert a.shape == b.shape, f"Shape mismatch: {a.shape} vs {b.shape}"
+
+    close = torch.isclose(a, b, atol=atol, rtol=rtol)
+    match_ratio = close.float().mean()
+    if match_ratio >= percent:
+        return True
+
+    mismatch_percent = 1.0 - match_ratio.item()
+    if mismatch_percent > 1 - percent:
+        print(
+            f"Mismatch percentage is {mismatch_percent:.4f} for rtol {rtol} "
+            f"(threshold: {1 - percent:.4f})"
+        )
+        return False
+
+
+def calculate_diff(m: int, n: int, k: int):
+    x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    y = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+
+    y_fp8, y_scale = per_block_cast_to_fp8(y)
+    x_fp8, x_scale = sglang_per_token_group_quant_fp8(
+        x, BLOCK_SIZE, column_major_scales=True
+    )
+    out_flashinfer = fp8_gemm_flashinfer(
+        x_fp8,
+        x_scale,
+        y_fp8,
+        y_scale,
+    )
+
+    dg_x_fp8, dg_x_scale = sglang_per_token_group_quant_fp8(
+        x,
+        BLOCK_SIZE,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    # We can directly quantize y here, but to mimic the behavior of the actual
+    # implementations, we requant it here.
+    dg_y_fp8, dg_y_scale = requant_weight_ue8m0(
+        y_fp8,
+        y_scale,
+        [BLOCK_SIZE, BLOCK_SIZE]
+    )
+    out_deepgemm = fp8_gemm_deepgemm_blackwell(
+        dg_x_fp8, dg_x_scale, dg_y_fp8, dg_y_scale
+    )
+
+    print(f"Shape m={m}, n={n}, k={k}:")
+    print(f"Flashinfer output: {out_flashinfer[0, 0:5]}")
+    print(f"DeepGEMM output: {out_deepgemm[0, 0:5]}")
+
+    flashinfer_deepgemm_match = check_accuracy(out_flashinfer, out_deepgemm, 0.1, 0.6, 0.95)
+    print("Correctness check:")
+    print(f"  - Flashinfer vs DeepGEMM: {'✅' if flashinfer_deepgemm_match else '❌'}")
+
+
+def _benchmark(m, n, k, tp_size, provider):
+    print(f"Shape (m={m}, n={n}, k={k}, tp={tp_size}), Provider: {provider}")
+    x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+    y = torch.randn((n, k), device="cuda", dtype=torch.bfloat16)
+
+    # Preprocess data before benchmarking
+    y_fp8, y_scale = per_block_cast_to_fp8(y)
+    x_fp8, x_scale = sglang_per_token_group_quant_fp8(
+        x, BLOCK_SIZE, column_major_scales=True
+    )
+    dg_x_fp8, dg_x_scale = sglang_per_token_group_quant_fp8(
+        x,
+        BLOCK_SIZE,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    dg_y_fp8, dg_y_scale = requant_weight_ue8m0(
+        y_fp8,
+        y_scale,
+        [BLOCK_SIZE, BLOCK_SIZE]
+    )
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if provider == "deepgemm":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: fp8_gemm_deepgemm_blackwell(
+                dg_x_fp8,
+                dg_x_scale,
+                dg_y_fp8,
+                dg_y_scale,
+            ),
+            quantiles=quantiles,
+        )
+    elif provider == "flashinfer":
+        ms, min_ms, max_ms = triton.testing.do_bench(
+            lambda: fp8_gemm_flashinfer(
+                x_fp8,
+                x_scale,
+                y_fp8,
+                y_scale,
+            ),
+            quantiles=quantiles,
+        )
+
+    # Calculate TFLOPS
+    flops = 2 * m * n * k  # multiply-adds
+    tflops = flops / (ms * 1e-3) / 1e12
+
+    # Print shape-specific results with TFLOPS
+    print(f"Time: {ms*1000:.2f} us, TFLOPS: {tflops:.2f}")
+    return ms, max_ms, min_ms
+
+
+def get_benchmark_plot_friendly(tp_size):
+    all_configs = create_benchmark_configs(tp_size)
+    x_vals = list(range(len(all_configs)))
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["cfg_id"],
+            x_vals=x_vals,
+            line_arg="provider",
+            line_vals=["deepgemm", "flashinfer"],
+            line_names=["DeepGEMM", "Flashinfer"],
+            styles=[("blue", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name=f"fp8-gemm-performance-comparison-tp{tp_size}",
+            args={},
+        )
+    )
+    def benchmark(cfg_id, provider):
+        m, n, k, tp_size = all_configs[cfg_id]
+        ms, min_ms, max_ms = _benchmark(m, n, k, tp_size, provider)
+        return ms * 1000, max_ms * 1000, min_ms * 1000  # convert to ms
+
+    return benchmark
+
+
+def get_benchmark(tp_size):
+    all_configs = create_benchmark_configs(tp_size)
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["m", "n", "k", "tp_size"],
+            x_vals=[list(config) for config in all_configs],
+            line_arg="provider",
+            line_vals=["deepgemm", "flashinfer"],
+            line_names=["DeepGEMM", "Flashinfer"],
+            styles=[("blue", "-"), ("red", "-")],
+            ylabel="us",
+            plot_name=f"fp8-gemm-performance-comparison-tp{tp_size}",
+            args={},
+        )
+    )
+    def benchmark(m, n, k, tp_size, provider):
+        ms, min_ms, max_ms = _benchmark(m, n, k, tp_size, provider)
+        return ms * 1000, max_ms * 1000, min_ms * 1000  # convert to ms
+    return benchmark
+
+
+if __name__ == "__main__":
+    if (not torch.cuda.is_available()
+        or torch.cuda.get_device_capability()[0] != 10):
+        print("Skipping benchmark because the device is not supported")
+        exit(0)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--save-path",
+        type=str,
+        default="./configs/benchmark_ops/fp8_gemm/",
+        help="Path to save fp8 gemm benchmark results",
+    )
+    parser.add_argument(
+        "--run-correctness",
+        action="store_true",
+        default=True,
+        help="Whether to run correctness test",
+    )
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=1,
+        help="Tensor parallelism size to benchmark (default: 1)",
+    )
+    parser.add_argument(
+        "--plot-friendly",
+        action="store_true",
+        default=False,
+        help="Plot x axis as the config index instead of the m",
+    )
+    args = parser.parse_args()
+
+    # Set random seed for reproducibility
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    # Run correctness tests on a few examples
+    if args.run_correctness:
+        print("Running correctness tests...")
+        calculate_diff(64, 512, 7168)  # Small test
+        calculate_diff(64, 7168, 16384)  # Medium test
+        calculate_diff(64, 18432, 7168)  # Large test
+
+    # Get the benchmark function with the specified tp_size
+    benchmark = (
+        get_benchmark_plot_friendly(args.tp_size) if args.plot_friendly
+        else get_benchmark(args.tp_size)
+    )
+
+    print(f"Running performance benchmark for TP size = {args.tp_size}...")
+    benchmark.run(print_data=True, save_path=args.save_path)

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -439,7 +439,7 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
     assert isinstance(weight, torch.nn.Parameter)
     assert isinstance(weight_scale_inv, torch.nn.Parameter)
 
-    new_weight, new_weight_scale_inv = _requant_weight_ue8m0(
+    new_weight, new_weight_scale_inv = requant_weight_ue8m0(
         weight.to(weight_scale_inv.device), weight_scale_inv, weight_block_size
     )
 
@@ -447,7 +447,7 @@ def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
     weight_scale_inv.data = new_weight_scale_inv
 
 
-def _requant_weight_ue8m0(
+def requant_weight_ue8m0(
     weight: torch.Tensor,
     weight_scale_inv: torch.Tensor,
     weight_block_size: List[int],


### PR DESCRIPTION
This PR adds a kernel benchmark for fp8 gemms available for Blackwell GPUs. Currently it covers the flashinfer and deepgemm impls. This can guide users which backends should be picked based on the use cases.

# Benchmark
On GB200:
```
> python benchmark_deepgemm_fp8_gemm_blackwell.py --tp-size 4 --plot-friendly
```
<img width="595" height="471" alt="image" src="https://github.com/user-attachments/assets/3af10d62-7d5b-4a7e-8e1f-b99d3b7777da" />


```
# unfortunately, we need to run it again in the normal mode to get a more human readable text with shapes
> python benchmark_deepgemm_fp8_gemm_blackwell.py --tp-size 4
          m        n        k  tp_size    DeepGEMM   Flashinfer
0       8.0    576.0   7168.0      4.0   65.119997    16.640000
1      16.0    576.0   7168.0      4.0   60.640000    16.287999
2      32.0    576.0   7168.0      4.0   61.792001    16.416000
3      64.0    576.0   7168.0      4.0   59.904002    16.352000
4     128.0    576.0   7168.0      4.0   60.160000    16.384000
5     256.0    576.0   7168.0      4.0   58.304001    16.384000
6    1024.0    576.0   7168.0      4.0   60.543999    28.704001
7    2048.0    576.0   7168.0      4.0   61.439998    41.216001
8    4096.0    576.0   7168.0      4.0   62.208001    63.487999
9       8.0  24576.0   7168.0      4.0   72.031997    47.136001
10     16.0  24576.0   7168.0      4.0   70.047997    47.104001
11     32.0  24576.0   7168.0      4.0   70.015997    47.392000
12     64.0  24576.0   7168.0      4.0   71.039997    69.920003
13    128.0  24576.0   7168.0      4.0   69.103997   125.216007
14    256.0  24576.0   7168.0      4.0   71.039997   223.519996
15   1024.0  24576.0   7168.0      4.0  146.031998   826.191992
16   2048.0  24576.0   7168.0      4.0  260.383993  1632.544041
17   4096.0  24576.0   7168.0      4.0  514.335990  3283.008099
18      8.0  32768.0    512.0      4.0   59.967998    11.904000
19     16.0  32768.0    512.0      4.0   58.912002    13.216000
20     32.0  32768.0    512.0      4.0   59.487998    16.352000
21     64.0  32768.0    512.0      4.0   58.095999    20.703999
22    128.0  32768.0    512.0      4.0   58.304001    32.768000
23    256.0  32768.0    512.0      4.0   57.728000    55.264000
24   1024.0  32768.0    512.0      4.0   58.368001   192.736000
25   2048.0  32768.0    512.0      4.0   66.463999   375.039995
26   4096.0  32768.0    512.0      4.0   73.760003   741.375983
27      8.0   7168.0  16384.0      4.0   65.920003    44.608001
28     16.0   7168.0  16384.0      4.0   68.960004    45.056000
29     32.0   7168.0  16384.0      4.0   70.015997    44.608001
30     64.0   7168.0  16384.0      4.0   66.944003    45.311999
31    128.0   7168.0  16384.0      4.0   66.944003    73.728003
32    256.0   7168.0  16384.0      4.0   65.920003   100.351997
33   1024.0   7168.0  16384.0      4.0   89.695998   350.511998
34   2048.0   7168.0  16384.0      4.0  184.640005   700.687975
35   4096.0   7168.0  16384.0      4.0  358.720005  1507.328033
36      8.0   7168.0  18432.0      4.0   64.896002    47.359999
37     16.0   7168.0  18432.0      4.0   64.896002    47.327999
38     32.0   7168.0  18432.0      4.0   65.920003    47.104001
39     64.0   7168.0  18432.0      4.0   65.920003    47.104001
40    128.0   7168.0  18432.0      4.0   63.872002    77.903997
41    256.0   7168.0  18432.0      4.0   63.872002   108.800001
42   1024.0   7168.0  18432.0      4.0  104.720000   393.216014
43   2048.0   7168.0  18432.0      4.0  204.832003   751.616001
44   4096.0   7168.0  18432.0      4.0  395.296007  1559.551954
45      8.0   9216.0   7168.0      4.0   55.744000    24.768000
46     16.0   9216.0   7168.0      4.0   56.704000    24.576001
47     32.0   9216.0   7168.0      4.0   51.344000    24.576001
48     64.0   9216.0   7168.0      4.0   52.191999    26.624000
49    128.0   9216.0   7168.0      4.0   52.223999    39.168000
50    256.0   9216.0   7168.0      4.0   55.328000    61.407998
51   1024.0   9216.0   7168.0      4.0   61.087999   192.543998
52   2048.0   9216.0   7168.0      4.0  112.896003   358.687997
53   4096.0   9216.0   7168.0      4.0  212.576002   692.480028
54      8.0   6144.0   7168.0      4.0   54.655999    20.768000
55     16.0   6144.0   7168.0      4.0   55.679999    20.768000
56     32.0   6144.0   7168.0      4.0   47.711998    20.992000
57     64.0   6144.0   7168.0      4.0   48.160002    22.496000
58    128.0   6144.0   7168.0      4.0   47.904000    33.023998
59    256.0   6144.0   7168.0      4.0   48.160002    45.056000
60   1024.0   6144.0   7168.0      4.0   54.687999   131.104007
61   2048.0   6144.0   7168.0      4.0   66.175997   239.904001
62   4096.0   6144.0   7168.0      4.0  140.864000   459.776014
63      8.0   8192.0    512.0      4.0   45.568001     9.216000
64     16.0   8192.0    512.0      4.0   44.608001     8.864000
65     32.0   8192.0    512.0      4.0   44.064000     9.168000
66     64.0   8192.0    512.0      4.0   44.192001    10.240000
67    128.0   8192.0    512.0      4.0   43.584000    14.784000
68    256.0   8192.0    512.0      4.0   43.935999    22.784000
69   1024.0   8192.0    512.0      4.0   44.160001    71.648002
70   2048.0   8192.0    512.0      4.0   45.024000   133.376002
71   4096.0   8192.0    512.0      4.0   49.120001   260.127991
72      8.0   6144.0   1536.0      4.0   46.335999    10.240000
73     16.0   6144.0   1536.0      4.0   45.472000    10.240000
74     32.0   6144.0   1536.0      4.0   46.592001    10.240000
75     64.0   6144.0   1536.0      4.0   46.224000    14.336000
76    128.0   6144.0   1536.0      4.0   45.855999    18.495999
77    256.0   6144.0   1536.0      4.0   46.624001    28.608000
78   1024.0   6144.0   1536.0      4.0   46.895999    82.496002
79   2048.0   6144.0   1536.0      4.0   47.104001   157.664001
80   4096.0   6144.0   1536.0      4.0   51.584002   307.231992
81      8.0   1024.0   7168.0      4.0   50.207999    16.896000
82     16.0   1024.0   7168.0      4.0   47.136001    16.960001
83     32.0   1024.0   7168.0      4.0   45.311999    17.408000
84     64.0   1024.0   7168.0      4.0   45.056000    16.384000
85    128.0   1024.0   7168.0      4.0   44.224001    16.480001
86    256.0   1024.0   7168.0      4.0   44.831999    17.408000
87   1024.0   1024.0   7168.0      4.0   44.624001    30.208001
88   2048.0   1024.0   7168.0      4.0   46.815999    53.247999
89   4096.0   1024.0   7168.0      4.0   52.607998    87.583996
90      8.0   7168.0   4608.0      4.0   46.112001    16.384000
91     16.0   7168.0   4608.0      4.0   47.104001    16.384000
92     32.0   7168.0   4608.0      4.0   43.807998    16.384000
93     64.0   7168.0   4608.0      4.0   44.576000    16.640000
94    128.0   7168.0   4608.0      4.0   44.128001    24.576001
95    256.0   7168.0   4608.0      4.0   44.351999    34.784000
96   1024.0   7168.0   4608.0      4.0   49.536001   104.447998
97   2048.0   7168.0   4608.0      4.0   51.775999   194.848001
98   4096.0   7168.0   4608.0      4.0  104.768001   376.832008
99      8.0   7168.0   4096.0      4.0   46.112001    15.904000
100    16.0   7168.0   4096.0      4.0   44.256002    15.904000
101    32.0   7168.0   4096.0      4.0   42.975999    15.904000
102    64.0   7168.0   4096.0      4.0   43.887999    16.352000
103   128.0   7168.0   4096.0      4.0   44.128001    22.528000
104   256.0   7168.0   4096.0      4.0   43.136001    30.688001
105  1024.0   7168.0   4096.0      4.0   50.528001    96.256003
106  2048.0   7168.0   4096.0      4.0   49.152002   178.207994
107  4096.0   7168.0   4096.0      4.0   93.759999   344.352007
108     8.0   7168.0    512.0      4.0   46.464000     8.864000
109    16.0   7168.0    512.0      4.0   43.968000     8.192000
110    32.0   7168.0    512.0      4.0   44.447999     9.184000
111    64.0   7168.0    512.0      4.0   43.648001    10.240000
112   128.0   7168.0    512.0      4.0   43.552000    14.304000
113   256.0   7168.0    512.0      4.0   42.688001    20.736000
114  1024.0   7168.0    512.0      4.0   44.767998    63.744001
115  2048.0   7168.0    512.0      4.0   43.680001   118.784003
116  4096.0   7168.0    512.0      4.0   46.080001   231.040001
```


# Accuracy

The test contains correctness check:
```
Running correctness tests...                                                                                                                                                                                                               
[2025-11-18 18:04:02] WARNING compile_utils.py:94: Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_
gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`     
[2025-11-18 18:04:02] INFO compile_utils.py:104: Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=512, K=7168, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep_g
emm`.                                                                                                                                                                                                                                      
DeepGEMM warmup: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16384/16384 [00:02<00:00, 8031.39it/s]
Shape m=64, n=512, k=7168:                                                                                                                                                                                                                 
Flashinfer output: tensor([-26.2500,  40.5000, -15.4375, -61.0000, -68.5000], device='cuda:0',                                                                                                                                             
       dtype=torch.bfloat16)                                                                                                                                                                                                               
DeepGEMM output: tensor([-17.5000,  39.0000, -11.8125, -58.7500, -66.5000], device='cuda:0',                                                                                                                                               
       dtype=torch.bfloat16)                                                                                                                                                                                                               
Correctness check:                                                                                                                                                                                                                         
  - Flashinfer vs DeepGEMM: ✅                                                                                                                                                                                                             
[2025-11-18 18:04:04] WARNING compile_utils.py:94: Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_
gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`     
[2025-11-18 18:04:04] INFO compile_utils.py:104: Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=7168, K=16384, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep
_gemm`.                                                                                                                                                                                                                                    
DeepGEMM warmup: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16384/16384 [00:02<00:00, 8106.33it/s]
Shape m=64, n=7168, k=16384:                                                                                                                                                                                                               
Flashinfer output: tensor([ 51.5000, 137.0000, -87.5000, -53.7500, 111.0000], device='cuda:0',                       
       dtype=torch.bfloat16)                                                                                                                                                                                                               
DeepGEMM output: tensor([ 50.2500, 138.0000, -95.0000, -61.7500, 114.0000], device='cuda:0',                         
       dtype=torch.bfloat16)                                                                                         
Correctness check:                                                                                                   
  - Flashinfer vs DeepGEMM: ✅                                                                                       
[2025-11-18 18:04:06] WARNING compile_utils.py:94: Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_
gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`     
[2025-11-18 18:04:06] INFO compile_utils.py:104: Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=18432, K=7168, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep
_gemm`.                                                                                                                                                                                                                                    
DeepGEMM warmup: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16384/16384 [00:02<00:00, 8110.53it/s]
Shape m=64, n=18432, k=7168:                                                                                         
Flashinfer output: tensor([-41.0000,  29.7500, 117.5000,  78.0000,  28.8750], device='cuda:0',                                                                                                                                             
       dtype=torch.bfloat16)                                                                                         
DeepGEMM output: tensor([-35.2500,  33.7500, 120.0000,  75.0000,  26.2500], device='cuda:0',
       dtype=torch.bfloat16)                                                                                         
Correctness check:                                                                                                   
  - Flashinfer vs DeepGEMM: ✅  
```