### PR TITLE
[model-gateway] limit opened files in docker build to fix edge case

### DIFF
--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -59,7 +59,7 @@ RUN uv pip install maturin \
     && cargo clean \
     && rm -rf bindings/python/dist/ \
     && cd bindings/python \
-    && maturin build --release --features vendored-openssl --out dist \
+    && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
     && rm -rf /root/.cache
 
 ######################### ROUTER IMAGE #########################


### PR DESCRIPTION
this can happen in some OS with too many opened files

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
