### PR TITLE
fix lora test

### DIFF
--- a/test/srt/lora/test_multi_lora_backend.py
+++ b/test/srt/lora/test_multi_lora_backend.py
@@ -24,6 +24,7 @@ from utils import (
     TORCH_DTYPES,
     LoRAModelCase,
     run_lora_test_one_by_one,
+    run_lora_multiple_batch_on_model_cases,
 )
 
 from sglang.test.test_utils import CustomTestCase, is_in_ci
@@ -44,28 +45,8 @@ PROMPTS = [
 
 
 class TestMultiLoRABackend(CustomTestCase):
-
-    def _run_multi_lora_test_on_model_cases(self, model_cases: List[LoRAModelCase]):
-        for model_case in model_cases:
-            # If skip_long_prompt is True, filter out prompts longer than 1000 characters.
-            batch_prompts = (
-                PROMPTS
-                if not model_case.skip_long_prompt
-                else [p for p in PROMPTS if len(p) < 1000]
-            )
-            for torch_dtype in TORCH_DTYPES:
-                for backend in BACKENDS:
-                    run_lora_test_one_by_one(
-                        batch_prompts,
-                        model_case,
-                        torch_dtype,
-                        max_new_tokens=32,
-                        backend=backend,
-                        test_tag="multi-lora-backend",
-                    )
-
     def test_ci_lora_models(self):
-        self._run_multi_lora_test_on_model_cases(CI_MULTI_LORA_MODELS)
+        run_lora_multiple_batch_on_model_cases(CI_MULTI_LORA_MODELS)
 
     def test_all_lora_models(self):
         if is_in_ci():
@@ -78,7 +59,7 @@ class TestMultiLoRABackend(CustomTestCase):
                 continue
             filtered_models.append(model_case)
 
-        self._run_multi_lora_test_on_model_cases(filtered_models)
+        run_lora_multiple_batch_on_model_cases(filtered_models)
 
 
 if __name__ == "__main__":

--- a/test/srt/lora/test_multi_lora_backend.py
+++ b/test/srt/lora/test_multi_lora_backend.py
@@ -15,15 +15,10 @@
 import multiprocessing as mp
 import os
 import unittest
-from typing import List
 
 from utils import (
     ALL_OTHER_MULTI_LORA_MODELS,
-    BACKENDS,
     CI_MULTI_LORA_MODELS,
-    TORCH_DTYPES,
-    LoRAModelCase,
-    run_lora_test_one_by_one,
     run_lora_multiple_batch_on_model_cases,
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
currently the test failed with following callstack:

```
capturing batches (bs=1 avail_mem=9.11 GB): 100%|█████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 13.78it/s]
`torch_dtype` is deprecated! Use `dtype` instead!
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 94.44it/s]
/usr/local/lib/python3.10/dist-packages/peft/tuners/tuners_utils.py:282: UserWarning: Already found a `peft_config` attribute in the model. This will lead to having multiple adapters in the model. Make sure to know what you are doing!
  warnings.warn(
Max prefill diff (HF vs SRT): tensor(0.0147)
Max decode diff (HF vs SRT): tensor(0.0622)
ROUGE-L score: 1.0
SRT output: building smart machines capable of performing tasks that typically require human intelligence.
AI is a field of computer science focused on building smart machines capable of performing tasks that typically
HF output: building smart machines capable of performing tasks that typically require human intelligence.
AI is a field of computer science focused on building smart machines capable of performing tasks that typically
Max diff (SRT base vs SRT LoRA prefill): tensor(0.0526)
Max diff (HF base vs HF LoRA prefill): tensor(0.0625)
Max prefill diff (HF vs SRT): tensor(0.0845)
Max decode diff (HF vs SRT): tensor(5.4785)
ROUGE-L score: 1.0
SRT output: 1. Llamas are large, long-necked animals with a woolly coat.
    2. They have two toes on each
HF output: 1. Llamas are large, long-necked animals with a woolly coat.
    2. They have two toes on each
Max diff (SRT base vs SRT LoRA prefill): tensor(7.5725)
Max diff (HF base vs HF LoRA prefill): tensor(7.5832)
Traceback (most recent call last):
  File "/home/weigong/workspace/tmp/sglang/python/sglang/srt/utils/common.py", line 2496, in retry
    return fn()
  File "/home/weigong/workspace/tmp/sglang/python/sglang/test/test_utils.py", line 1683, in <lambda>
    lambda: super(CustomTestCase, self)._callTestMethod(method),
  File "/usr/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/home/weigong/workspace/tmp/sglang/test/srt/lora/test_multi_lora_backend.py", line 68, in test_ci_lora_models
    self._run_multi_lora_test_on_model_cases(CI_MULTI_LORA_MODELS)
  File "/home/weigong/workspace/tmp/sglang/test/srt/lora/test_multi_lora_backend.py", line 58, in _run_multi_lora_test_on_model_cases
    run_lora_test_one_by_one(
  File "/home/weigong/workspace/tmp/sglang/test/srt/lora/utils.py", line 269, in run_lora_test_one_by_one
    assert torch.all(torch.abs(hf_decode - srt_decode) < decode_tol), (
AssertionError: Decode logprobs mismatch for base 'meta-llama/Llama-2-7b-hf', adaptor '['winddude/wizardLM-LlaMA-LoRA-7B', 'RuterNorway/Llama-2-7b-chat-norwegian-LoRa']', backend 'triton', prompt: 'AI is a field of computer science focused on...'
E
======================================================================
ERROR: test_ci_lora_models (__main__.TestMultiLoRABackend)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/weigong/workspace/tmp/sglang/python/sglang/srt/utils/common.py", line 2496, in retry
    return fn()
  File "/home/weigong/workspace/tmp/sglang/python/sglang/test/test_utils.py", line 1683, in <lambda>
    lambda: super(CustomTestCase, self)._callTestMethod(method),
AssertionError: Decode logprobs mismatch for base 'meta-llama/Llama-2-7b-hf', adaptor '['winddude/wizardLM-LlaMA-LoRA-7B', 'RuterNorway/Llama-2-7b-chat-norwegian-LoRa']', backend 'triton', prompt: 'AI is a field of computer science focused on...'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/weigong/workspace/tmp/sglang/python/sglang/test/test_utils.py", line 1682, in _callTestMethod
    retry(
  File "/home/weigong/workspace/tmp/sglang/python/sglang/srt/utils/common.py", line 2501, in retry
    raise Exception(f"retry() exceed maximum number of retries.")
Exception: retry() exceed maximum number of retries.
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
