### PR TITLE
Fix: `get_stats` blocks main thread on storage failure

### DIFF
--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional
 
 import torch
 
+from python.sglang.srt.metrics.collector import StorageMetrics
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
 
 logger = logging.getLogger(__name__)
@@ -162,7 +163,7 @@ class HiCacheStorage(ABC):
     def clear(self) -> None:
         pass
 
-    def get_stats(self):
+    def get_stats(self) -> Optional[StorageMetrics]:
         return None
 
 


### PR DESCRIPTION
Hi from [novita.ai](https://novita.ai/) team 👋

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
When using HiCache with 3fs backend, the main scheduler thread could become blocked when collecting storage metrics via get_stats(). This issue occurs due to lock contention between multiple threads:

Backup thread: Holds the lock during long-running filesystem I/O operations in _batch_set() (decorated with `@synchronized()`)
Main thread: Periodically calls get_stats() (also decorated with `@synchronized()`) to collect storage metrics for monitoring

When storage is slow or down, the backup thread holds the lock for extended periods, causing the main thread to block when trying to acquire the same lock.

## Modifications
Changed get_stats() to use non-blocking lock acquisition: uses self.lock.acquire(blocking=False) instead of the `@synchronized()` decorator.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
