### PR TITLE
[Feature] Add suffix decoding speculative algorithm

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -249,7 +249,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 ## Speculative decoding
 | Argument | Description | Defaults | Options |
 | --- | --- | --- | --- |
-| `--speculative-algorithm` | Speculative algorithm. | `None` | `EAGLE`, `EAGLE3`, `NEXTN`, `STANDALONE`, `NGRAM` |
+| `--speculative-algorithm` | Speculative algorithm. | `None` | `EAGLE`, `EAGLE3`, `NEXTN`, `STANDALONE`, `NGRAM`, `SUFFIX` |
 | `--speculative-draft-model-path`<br>`--speculative-draft-model` | The path of the draft model weights. This can be a local folder or a Hugging Face repo ID. | `None` | Type: str |
 | `--speculative-draft-model-revision` | The specific draft model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version. | `None` | Type: str |
 | `--speculative-num-steps` | The number of steps sampled from draft model in Speculative Decoding. | `None` | Type: int |

--- a/docs/advanced_features/suffix_decoding.md
+++ b/docs/advanced_features/suffix_decoding.md
@@ -1,0 +1,259 @@
+# Suffix Decoding
+
+Suffix Decoding is a training-free, CPU-only speculative decoding method that can improve throughput for structured or repetitive outputs.
+
+## Overview
+
+Suffix Decoding ([technical report](https://arxiv.org/abs/2411.04975)) is a novel speculation method that:
+
+- **No draft model required** - Operates entirely on CPU using pattern matching
+- **Dynamic speculation** - Adapts speculation length per request at each step
+- **Frequency-based proposals** - Uses token frequency counts for better acceptance rates
+- **Dual pattern matching** - Matches against both prompts and previous generations
+
+Unlike n-gram methods, Suffix Decoding can achieve better performance for tasks with high repetition, such as code-editing, agentic loops (e.g., self-reflection, self-consistency), and RL rollouts.
+
+## Installation
+
+Suffix Decoding requires the Arctic Inference library:
+
+```bash
+pip install arctic-inference==0.1.1
+```
+
+## Quick Start
+
+### Basic Usage
+
+```bash
+python -m sglang.launch_server \
+    --model-path meta-llama/Llama-3-8B-Instruct \
+    --speculative-algorithm SUFFIX \
+    --speculative-num-draft-tokens 24
+```
+
+### Advanced Configuration
+
+```bash
+python -m sglang.launch_server \
+    --model-path meta-llama/Llama-3-8B-Instruct \
+    --speculative-algorithm SUFFIX \
+    --speculative-num-draft-tokens 32 \
+    --speculative-suffix-max-tree-depth 24 \
+    --speculative-suffix-max-cached-requests 10000 \
+    --speculative-suffix-max-spec-factor 1.5 \
+    --speculative-suffix-min-token-prob 0.05
+```
+
+## Configuration Parameters
+
+### Required Parameters
+
+- `--speculative-algorithm SUFFIX`: Enable suffix decoding
+- `--speculative-num-draft-tokens <int>`: Maximum number of speculative tokens (default: 24)
+  - Suffix decoding dynamically adjusts this per request
+  - Recommended: 16-32 for best performance
+
+### Optional Parameters
+
+- `--speculative-suffix-max-tree-depth <int>`: Maximum depth of suffix trees (default: 24)
+  - Limits the sum of prefix match and speculation lengths
+  - Higher values enable longer pattern matching but use more memory
+
+- `--speculative-suffix-max-cached-requests <int>`: Maximum cached requests (default: 10000)
+  - Controls global suffix tree size
+  - Set to 0 to disable global cache (only use prompt trees)
+  - FIFO eviction when limit exceeded
+
+- `--speculative-suffix-max-spec-factor <float>`: Speculation factor (default: 1.0)
+  - Controls speculation length: `max_spec = factor * prefix_match_length`
+  - Higher values = more aggressive speculation
+  - Recommended range: 0.5 - 2.0
+
+- `--speculative-suffix-min-token-prob <float>`: Minimum token probability (default: 0.1)
+  - Only speculate tokens above this probability threshold
+  - Based on frequency counts in suffix tree
+  - Lower values = more aggressive, higher = more conservative
+  - Valid range: 0.0 - 1.0
+
+## Use Cases
+
+Suffix Decoding excels at tasks with high repetition:
+
+### 1. Code Editing
+```python
+# Example: Refactoring code with repetitive patterns
+prompt = """Refactor this function to use list comprehension:
+
+```python
+result = []
+for x in data:
+    if x > 0:
+        result.append(x * 2)
+```"""
+```
+
+### 2. Agentic Loops
+```python
+# Example: Self-reflection loop
+prompt = "Analyze this solution, then improve it, then analyze again:\n\n..."
+```
+
+### 3. Structured Output Generation
+```python
+# Example: Generating JSON with repeated structure
+prompt = "Generate a list of 10 users in JSON format with fields: name, email, age"
+```
+
+### 4. RL Rollouts
+```python
+# Example: Generating multiple trajectories
+prompt = "Generate 5 different approaches to solve this problem:\n\n..."
+```
+
+## Performance Tuning
+
+### For High Repetition Tasks
+
+```bash
+# Aggressive speculation
+--speculative-suffix-max-spec-factor 2.0 \
+--speculative-suffix-min-token-prob 0.05 \
+--speculative-num-draft-tokens 32
+```
+
+### For Mixed Workloads
+
+```bash
+# Balanced settings (default)
+--speculative-suffix-max-spec-factor 1.0 \
+--speculative-suffix-min-token-prob 0.1 \
+--speculative-num-draft-tokens 24
+```
+
+### For Memory-Constrained Systems
+
+```bash
+# Conservative caching
+--speculative-suffix-max-cached-requests 1000 \
+--speculative-suffix-max-tree-depth 16
+```
+
+### Disable Global Cache
+
+```bash
+# Use only prompt trees (no cross-request caching)
+--speculative-suffix-max-cached-requests 0
+```
+
+## How It Works
+
+1. **Prompt Tree Building**: When a request starts, build a suffix tree from the prompt
+2. **Pattern Matching**: Extract last N tokens as pattern (N ≤ max_tree_depth)
+3. **Frequency-Based Speculation**: Find matching suffixes and rank by frequency
+4. **Dynamic Length**: Speculate `min(max_spec_tokens, spec_factor * match_length)` tokens
+5. **Verification**: Target model verifies draft tokens in parallel
+6. **Cache Update**: Add accepted tokens to global suffix tree for future requests
+
+## Comparison with Other Methods
+
+| Feature | Suffix | N-gram | EAGLE | Draft Model |
+|---------|--------|--------|-------|-------------|
+| Extra Model | ❌ No | ❌ No | ✅ Yes | ✅ Yes |
+| GPU Memory | ❌ No | ❌ No | ✅ High | ✅ High |
+| CPU Only | ✅ Yes | ✅ Yes | ❌ No | ❌ No |
+| Dynamic Length | ✅ Yes | ❌ No | ❌ No | ❌ No |
+| Cross-Request Cache | ✅ Yes | ❌ No | ❌ No | ❌ No |
+| Frequency-Based | ✅ Yes | ❌ No | ❌ No | ❌ No |
+| Best For | Repetition | Prompts | General | General |
+
+## Troubleshooting
+
+### Import Error
+
+```
+ImportError: Arctic Inference is required for suffix decoding
+```
+
+**Solution:** Install arctic-inference:
+```bash
+pip install arctic-inference==0.1.1
+```
+
+### Low Acceptance Rate
+
+If you see low acceptance rates:
+
+1. **Increase `max_spec_factor`**: Try 1.5 or 2.0
+2. **Lower `min_token_prob`**: Try 0.05 instead of 0.1
+3. **Increase `max_tree_depth`**: Try 32 instead of 24
+4. **Check task repetition**: Suffix works best with repetitive patterns
+
+### Memory Issues
+
+If running out of memory:
+
+1. **Reduce `max_cached_requests`**: Try 1000 or 5000
+2. **Reduce `max_tree_depth`**: Try 16 instead of 24
+3. **Disable global cache**: Set `max_cached_requests=0`
+
+### No Speedup
+
+If not seeing speedup:
+
+1. **Check task type**: Suffix works best with repetition
+2. **Monitor acceptance rate**: Should be >50% for benefit
+3. **Try other methods**: EAGLE or draft model for general tasks
+4. **Increase batch size**: Suffix benefits from larger batches
+
+## Monitoring
+
+Key metrics to monitor:
+
+- **Acceptance Rate**: Percentage of draft tokens accepted
+  - Target: >50% for noticeable speedup
+  - Check via server logs or metrics endpoint
+
+- **Average Draft Length**: Tokens speculated per step
+  - Should vary dynamically based on patterns
+  - Higher for repetitive tasks
+
+- **Cache Hit Rate**: Frequency of global cache matches
+  - Higher = better cross-request reuse
+  - Only relevant if `max_cached_requests > 0`
+
+## Python API Example
+
+```python
+from sglang import Engine
+
+# Initialize with suffix decoding
+engine = Engine(
+    model_path="meta-llama/Llama-3-8B-Instruct",
+    speculative_algorithm="SUFFIX",
+    speculative_num_draft_tokens=24,
+    speculative_suffix_max_spec_factor=1.5,
+)
+
+# Generate with high repetition task
+prompts = [
+    "Generate 5 user profiles in JSON format with fields: name, email, age, city"
+]
+
+outputs = engine.generate(prompts, sampling_params={"temperature": 0.7, "max_new_tokens": 500})
+for output in outputs:
+    print(output["text"])
+```
+
+## References
+
+- [Suffix Decoding Paper](https://arxiv.org/abs/2411.04975)
+- [Arctic Inference GitHub](https://github.com/snowflakedb/ArcticInference)
+- [vLLM Implementation](https://github.com/vllm-project/vllm/pull/25784)
+
+## Limitations
+
+- **CUDA Only**: Suffix decoding currently requires CUDA devices
+- **No DP Attention**: Data parallel attention is not yet supported
+- **CPU Overhead**: Pattern matching on CPU may add latency for small batches
+- **Best for Repetition**: Performance gains primarily on repetitive tasks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Its core features include:
    advanced_features/hyperparameter_tuning.md
    advanced_features/attention_backend.md
    advanced_features/speculative_decoding.ipynb
+   advanced_features/suffix_decoding.md
    advanced_features/structured_outputs.ipynb
    advanced_features/structured_outputs_for_reasoning_models.ipynb
    advanced_features/tool_parser.ipynb

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -846,7 +846,11 @@ class Scheduler(
             self.server_args.disaggregation_transfer_backend
         )
 
-        if self.draft_worker is None or self.spec_algorithm.is_ngram():
+        if (
+            self.draft_worker is None
+            or self.spec_algorithm.is_ngram()
+            or self.spec_algorithm.is_suffix()
+        ):
             draft_token_to_kv_pool = None
         elif self.spec_algorithm.is_eagle() and self.enable_overlap:
             draft_token_to_kv_pool = (

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -275,6 +275,7 @@ class CudaGraphRunner:
             model_runner.spec_algorithm.is_eagle()
             or model_runner.spec_algorithm.is_standalone()
             or model_runner.spec_algorithm.is_ngram()
+            or model_runner.spec_algorithm.is_suffix()
         ):
             if self.model_runner.is_draft_worker:
                 raise RuntimeError("This should not happen")
@@ -462,6 +463,7 @@ class CudaGraphRunner:
                 == forward_batch.input_ids.numel()
             )
             if self.model_runner.spec_algorithm.is_ngram()
+            or self.model_runner.spec_algorithm.is_suffix()
             else True
         )
 
@@ -945,6 +947,20 @@ class CudaGraphRunner:
             from sglang.srt.speculative.ngram_info import NgramVerifyInput
 
             spec_info = NgramVerifyInput(
+                draft_token=None,
+                tree_mask=self.custom_mask,
+                positions=None,
+                retrive_index=None,
+                retrive_next_token=None,
+                retrive_next_sibling=None,
+                draft_token_num=self.num_tokens_per_bs,
+            )
+            spec_info.capture_hidden_mode = CaptureHiddenMode.NULL
+
+        elif self.model_runner.spec_algorithm.is_suffix():
+            from sglang.srt.speculative.suffix_info import SuffixVerifyInput
+
+            spec_info = SuffixVerifyInput(
                 draft_token=None,
                 tree_mask=self.custom_mask,
                 positions=None,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -401,6 +401,11 @@ class ServerArgs:
     speculative_ngram_match_type: Literal["BFS", "PROB"] = "BFS"
     speculative_ngram_branch_length: int = 18
     speculative_ngram_capacity: int = 10 * 1000 * 1000
+    # For suffix decoding only
+    speculative_suffix_max_tree_depth: int = 24
+    speculative_suffix_max_cached_requests: int = 10000
+    speculative_suffix_max_spec_factor: float = 1.0
+    speculative_suffix_min_token_prob: float = 0.1
 
     # Expert parallelism
     ep_size: int = 1
@@ -1694,6 +1699,74 @@ class ServerArgs:
                     "Currently ngram speculative decoding does not support dp attention."
                 )
 
+        if self.speculative_algorithm == "SUFFIX":
+            # Validate Arctic Inference availability
+            from sglang.srt.utils.common import is_arctic_inference_available
+
+            if not is_arctic_inference_available():
+                raise ImportError(
+                    "Arctic Inference is required for suffix decoding. "
+                    "Install via: pip install arctic-inference==0.1.1"
+                )
+
+            if not self.device.startswith("cuda"):
+                raise ValueError("Suffix decoding only supports CUDA device.")
+
+            if self.max_running_requests is None:
+                self.max_running_requests = 48
+                logger.warning(
+                    "Max running requests is reset to 48 for suffix decoding. You can override this by explicitly setting --max-running-requests."
+                )
+
+            self.disable_overlap_schedule = True
+            self.enable_mixed_chunk = False
+            if self.speculative_num_draft_tokens is None:
+                self.speculative_num_draft_tokens = (
+                    self.speculative_suffix_max_tree_depth
+                )
+                logger.warning(
+                    f"Defaulted speculative_num_draft_tokens to {self.speculative_suffix_max_tree_depth} for suffix decoding."
+                )
+            logger.warning(
+                "The overlap scheduler and mixed chunked prefill are disabled because of "
+                "using suffix decoding."
+            )
+
+            # Validate parameter ranges
+            if self.speculative_suffix_max_tree_depth < 1:
+                raise ValueError(
+                    f"speculative_suffix_max_tree_depth={self.speculative_suffix_max_tree_depth} must be >= 1"
+                )
+
+            if self.speculative_suffix_max_cached_requests < -1:
+                raise ValueError(
+                    f"speculative_suffix_max_cached_requests={self.speculative_suffix_max_cached_requests} must be >= -1 (use -1 for unlimited)"
+                )
+
+            if self.speculative_suffix_max_spec_factor < 0:
+                raise ValueError(
+                    f"speculative_suffix_max_spec_factor={self.speculative_suffix_max_spec_factor} must be >= 0"
+                )
+
+            if not 0 <= self.speculative_suffix_min_token_prob <= 1:
+                raise ValueError(
+                    f"speculative_suffix_min_token_prob={self.speculative_suffix_min_token_prob} must be in [0, 1]"
+                )
+
+            if self.enable_dp_attention:
+                # TODO: support dp attention for suffix decoding
+                raise ValueError(
+                    "Currently suffix decoding does not support dp attention."
+                )
+
+            logger.info(
+                f"Suffix decoding configured with: "
+                f"max_tree_depth={self.speculative_suffix_max_tree_depth}, "
+                f"max_cached_requests={self.speculative_suffix_max_cached_requests}, "
+                f"max_spec_factor={self.speculative_suffix_max_spec_factor}, "
+                f"min_token_prob={self.speculative_suffix_min_token_prob}"
+            )
+
     def _handle_load_format(self):
         if (
             self.load_format == "auto" or self.load_format == "gguf"
@@ -2778,7 +2851,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "NGRAM"],
+            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "NGRAM", "SUFFIX"],
             help="Speculative algorithm.",
         )
         parser.add_argument(
@@ -2897,6 +2970,39 @@ class ServerArgs:
             type=int,
             default=ServerArgs.speculative_ngram_capacity,
             help="The cache capacity for ngram speculative decoding.",
+        )
+        # Suffix decoding
+        parser.add_argument(
+            "--speculative-suffix-max-tree-depth",
+            type=int,
+            default=ServerArgs.speculative_suffix_max_tree_depth,
+            help="The maximum depth of the suffix decoding global and prompt trees. "
+            "The tree depth limits the sum of the prefix match and speculation lengths.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-cached-requests",
+            type=int,
+            default=ServerArgs.speculative_suffix_max_cached_requests,
+            help="The maximum number of requests to cache in the global suffix tree. "
+            "If exceeded, will trigger eviction in FIFO order. If set to 0, the global "
+            "suffix tree is disabled and past responses are not cached (prompt trees "
+            "are still used).",
+        )
+        parser.add_argument(
+            "--speculative-suffix-max-spec-factor",
+            type=float,
+            default=ServerArgs.speculative_suffix_max_spec_factor,
+            help="The maximum spec factor for suffix decoding. The spec factor controls "
+            "speculation lengths based on the prefix match length: max_spec_tokens = "
+            "max_spec_factor * prefix_match_length.",
+        )
+        parser.add_argument(
+            "--speculative-suffix-min-token-prob",
+            type=float,
+            default=ServerArgs.speculative_suffix_min_token_prob,
+            help="The minimum token probability for suffix decoding. Will only speculate "
+            "tokens with estimated probability (based on frequency counts) greater than "
+            "or equal to this value.",
         )
 
         # Expert parallelism

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2984,9 +2984,9 @@ class ServerArgs:
             type=int,
             default=ServerArgs.speculative_suffix_max_cached_requests,
             help="The maximum number of requests to cache in the global suffix tree. "
-            "If exceeded, will trigger eviction in FIFO order. If set to 0, the global "
-            "suffix tree is disabled and past responses are not cached (prompt trees "
-            "are still used).",
+            "If exceeded, will trigger eviction in FIFO order. Set to -1 for unlimited "
+            "cache size, or 0 to disable the global suffix tree (past responses are not "
+            "cached, but prompt trees are still used).",
         )
         parser.add_argument(
             "--speculative-suffix-max-spec-factor",

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -173,6 +173,9 @@ class SpeculativeAlgorithm(metaclass=_SpeculativeAlgorithmMeta):
     def is_ngram(self) -> bool:
         return self._has_flag("NGRAM")
 
+    def is_suffix(self) -> bool:
+        return self._has_flag("SUFFIX")
+
     def create_draft_worker(self, **factory_kwargs: Any) -> Any:
         if self._draft_worker_factory is None:
             return None
@@ -189,6 +192,7 @@ _FLAG_MARKERS: Dict[str, Callable[[Union[SpeculativeAlgorithm, str]], None]] = {
         "STANDALONE", algorithm
     ),
     "NGRAM": lambda algorithm: SpeculativeAlgorithm._add_flag("NGRAM", algorithm),
+    "SUFFIX": lambda algorithm: SpeculativeAlgorithm._add_flag("SUFFIX", algorithm),
 }
 
 
@@ -285,6 +289,12 @@ def _create_ngram_worker(**kwargs: Any) -> Any:
     return NGRAMWorker(**kwargs)
 
 
+def _create_suffix_worker(**kwargs: Any) -> Any:
+    from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+    return SuffixWorker(**kwargs)
+
+
 # Register built-in algorithms.
 # Third-party integrations should import `SpeculativeAlgorithm` and either
 # call `register_speculative_algorithm` or use the helpers below to attach
@@ -316,6 +326,12 @@ register_speculative_algorithm(
     flags=("NGRAM",),
 )
 
+register_speculative_algorithm(
+    "SUFFIX",
+    worker_cls=_create_suffix_worker,
+    flags=("SUFFIX",),
+)
+
 
 class SpecInputType(IntEnum):
     # NOTE: introduce this to distinguish the SpecInput types of multiple algorithms when asserting in attention backends.
@@ -323,6 +339,7 @@ class SpecInputType(IntEnum):
     EAGLE_DRAFT = auto()
     EAGLE_VERIFY = auto()
     NGRAM_VERIFY = auto()
+    SUFFIX_VERIFY = auto()
 
 
 class SpecInput(ABC):
@@ -338,6 +355,7 @@ class SpecInput(ABC):
         return self.spec_input_type in {
             SpecInputType.EAGLE_VERIFY,
             SpecInputType.NGRAM_VERIFY,
+            SpecInputType.SUFFIX_VERIFY,
         }
 
     @abstractmethod

--- a/python/sglang/srt/speculative/suffix_cache_adapter.py
+++ b/python/sglang/srt/speculative/suffix_cache_adapter.py
@@ -1,0 +1,343 @@
+"""
+Cache adapter that wraps the suffix decoding backend cache to provide
+the same interface as NgramCache.
+
+This allows NGRAMWorker to use suffix decoding without modification.
+"""
+
+import logging
+import os
+from collections import deque
+from typing import List, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixCacheAdapter:
+    """
+    Adapter that wraps SuffixDecodingCache to match NgramCache interface.
+
+    NGRAMWorker expects:
+    - batch_get(batch_tokens: List[List[int]]) -> Tuple[np.ndarray, np.ndarray]
+      Returns (draft_tokens, tree_mask) as flat numpy arrays
+    - batch_put(batch_tokens: List[List[int]]) -> None
+      Updates cache with verified tokens
+    - synchronize() -> None
+      No-op for suffix cache
+    - reset() -> None
+      Clears all cached data
+    """
+
+    def __init__(
+        self,
+        draft_token_num: int,
+        max_batch_size: int,
+        max_tree_depth: int = 24,
+        max_cached_requests: int = 10000,
+        max_spec_factor: float = 1.0,
+        min_token_prob: float = 0.1,
+    ):
+        """
+        Args:
+            draft_token_num: Fixed number of draft tokens (for padding)
+            max_tree_depth: Maximum depth for suffix tree
+            max_cached_requests: Maximum number of cached requests
+            max_spec_factor: Maximum speculation factor
+            min_token_prob: Minimum token probability threshold
+        """
+        # Lazy import to avoid error when Suffix Decoding is not used
+        from arctic_inference.suffix_decoding import SuffixDecodingCache
+
+        self.suffix_cache = SuffixDecodingCache(
+            max_tree_depth=max_tree_depth,
+            max_cached_requests=max_cached_requests,
+        )
+        self.draft_token_num = draft_token_num
+        self.max_batch_size = max_batch_size
+        self.max_tree_depth = max_tree_depth
+        self.max_spec_factor = max_spec_factor
+        self.min_token_prob = min_token_prob
+
+        # Debug toggles (set env e.g. SUFFIX_DEBUG_TREE=1 to dump first batch)
+        self.debug_tree_dump_remaining = int(os.environ.get("SUFFIX_DEBUG_TREE", "0"))
+
+        # Track state by SGlang request ID (stable identifier)
+        # Map: sglang_req_id → (arctic_req_id, last_length)
+        self.req_state = {}
+
+        # Preallocate buffers to avoid per-step allocations
+        self.max_total_drafts = self.max_batch_size * self.draft_token_num
+        self.draft_buffer = np.empty((self.max_total_drafts,), dtype=np.int64)
+        self.mask_buffer = np.empty(
+            (self.max_batch_size, self.draft_token_num, self.draft_token_num),
+            dtype=bool,
+        )
+
+    def _cleanup_inactive_requests(self, active_req_ids: set[str]):
+        """Stop backend requests that are no longer active in SGlang."""
+        inactive_req_ids = [
+            rid for rid in self.req_state.keys() if rid not in active_req_ids
+        ]
+        for rid in inactive_req_ids:
+            cache_req_id, _ = self.req_state.pop(rid)
+            if cache_req_id in getattr(self.suffix_cache, "active_requests", set()):
+                self.suffix_cache.stop_request(cache_req_id)
+
+    def _get_or_create_cache_req_id(
+        self, sglang_req_id: str, prompt: List[int], tokens: List[int]
+    ) -> tuple:
+        """Get or create a backend request ID for the given SGlang request.
+
+        Args:
+            sglang_req_id: Stable request ID from SGlang
+            prompt: Prompt tokens only (no generated tokens)
+            tokens: Full token sequence (prompt + outputs)
+
+        Returns: (arctic_req_id, last_length)
+        """
+        if sglang_req_id not in self.req_state:
+            # Use SGlang request ID directly as backend request ID
+            cache_req_id = sglang_req_id
+
+            # Initialize the request in suffix cache with ONLY the prompt
+            self.suffix_cache.start_request(cache_req_id, prompt)
+
+            # Track: [arctic_req_id, last_length]
+            # IMPORTANT: Set last_length to prompt length since the backend already has the prompt
+            self.req_state[sglang_req_id] = [cache_req_id, len(prompt)]
+
+        cache_req_id, last_length = self.req_state[sglang_req_id]
+        return cache_req_id, last_length
+
+    def batch_get(
+        self,
+        batch_req_ids: List[str],
+        batch_prompts: List[List[int]],
+        batch_tokens: List[List[int]],
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Get draft tokens for a batch of token sequences.
+
+        This is called BEFORE verification with the current state.
+        We speculate based on the current tokens.
+
+        Args:
+            batch_req_ids: List of SGlang request IDs (stable)
+            batch_prompts: List of prompt tokens (no generated tokens)
+            batch_tokens: List of token sequences (prompt + output tokens)
+
+        Returns:
+            Tuple of:
+            - draft_tokens: np.ndarray of shape (batch_size * draft_token_num,)
+            - tree_mask: np.ndarray of shape (batch_size * draft_token_num * draft_token_num,)
+        """
+        batch_size = len(batch_req_ids)
+        if batch_size == 0:
+            return np.empty((0,), dtype=np.int64), np.empty((0,), dtype=bool)
+
+        if batch_size > self.max_batch_size:
+            raise ValueError(
+                f"Batch size {batch_size} exceeds configured max_batch_size={self.max_batch_size}"
+            )
+
+        total_draft_tokens = batch_size * self.draft_token_num
+        draft_view = self.draft_buffer[:total_draft_tokens]
+        mask_view = self.mask_buffer[:batch_size]
+        mask_view.fill(False)
+
+        active_req_ids = set(batch_req_ids)
+        self._cleanup_inactive_requests(active_req_ids)
+
+        for idx, (sglang_req_id, prompt, tokens) in enumerate(
+            zip(batch_req_ids, batch_prompts, batch_tokens)
+        ):
+            cache_req_id, last_length = self._get_or_create_cache_req_id(
+                sglang_req_id, prompt, tokens
+            )
+
+            # Ensure cache includes the latest verified tokens before speculation.
+            current_length = len(tokens)
+            if current_length > last_length:
+                new_tokens = tokens[last_length:current_length]
+                if cache_req_id in self.suffix_cache.active_requests:
+                    self.suffix_cache.add_active_response(cache_req_id, new_tokens)
+                    self.req_state[sglang_req_id][1] = current_length
+                    last_length = current_length
+                else:
+                    logger.warning(
+                        f"[BATCH_GET {idx}] Suffix cache req {cache_req_id} not active when updating!"
+                    )
+
+            # Extract pattern from end of tokens (up to max_tree_depth)
+            pattern_start = max(0, len(tokens) - self.max_tree_depth)
+            pattern = tokens[pattern_start:]
+
+            # Speculate using suffix cache
+            draft = self.suffix_cache.speculate(
+                cache_req_id,
+                pattern,
+                max_spec_tokens=self.draft_token_num,
+                max_spec_factor=self.max_spec_factor,
+                min_token_prob=self.min_token_prob,
+            )
+
+            # Convert to fixed-size arrays
+            draft_ids = list(draft.token_ids)
+            draft_parents = list(draft.parents)
+            draft_ids, draft_parents = self._reorder_tree_bfs(draft_ids, draft_parents)
+
+            context_token = tokens[-1] if tokens else 0
+            draft_ids, draft_parents = self._inject_root_node(
+                draft_ids, draft_parents, context_token
+            )
+
+            # Pad or truncate to match draft_token_num (includes root node at index 0)
+            original_draft_len = len(draft_ids)
+            if original_draft_len < self.draft_token_num:
+                pad_len = self.draft_token_num - original_draft_len
+                draft_ids.extend([0] * pad_len)
+                draft_parents.extend([0] * pad_len)
+            elif original_draft_len > self.draft_token_num:
+                draft_ids = draft_ids[: self.draft_token_num]
+                draft_parents = draft_parents[: self.draft_token_num]
+                original_draft_len = self.draft_token_num
+
+            start = idx * self.draft_token_num
+            end = start + self.draft_token_num
+            draft_view[start:end] = draft_ids
+
+            # Build tree mask from parent structure
+            # Token i can attend to token j if j is an ancestor of i
+            mask = mask_view[idx]
+            if original_draft_len > 0:
+                for i in range(original_draft_len):
+                    mask[i, i] = True  # Self-attention
+                    parent_idx = draft_parents[i]
+                    while parent_idx >= 0 and parent_idx < self.draft_token_num:
+                        mask[i, parent_idx] = True
+                        parent_idx = draft_parents[parent_idx]
+
+            if self.debug_tree_dump_remaining > 0 and original_draft_len > 0:
+                logger.warning(
+                    "[SUFFIX DEBUG] req=%s, original_draft_len=%d, masked_len=%d, draft_ids=%s",
+                    sglang_req_id,
+                    original_draft_len,
+                    len(draft_ids),
+                    draft_ids,
+                )
+                logger.warning(
+                    "[SUFFIX DEBUG] mask=\n%s",
+                    mask.astype(int),
+                )
+                self.debug_tree_dump_remaining -= 1
+
+        tree_mask = mask_view.reshape(-1)[: total_draft_tokens * self.draft_token_num]
+
+        return draft_view, tree_mask
+
+    def batch_put(self, batch_req_ids: List[str], batch_tokens: List[List[int]]):
+        """
+        No-op: cache updates now happen inside batch_get before speculation.
+        Kept for interface compatibility with NGRAMWorker.
+        """
+        _ = batch_tokens  # Intentional placeholder to satisfy interface.
+        for idx, sglang_req_id in enumerate(batch_req_ids):
+            if sglang_req_id not in self.req_state:
+                logger.error(
+                    f"[BATCH_PUT {idx}] Called for unknown request {sglang_req_id}! "
+                    f"This should not happen - batch_get must be called first."
+                )
+
+    def synchronize(self):
+        """No-op for suffix cache (no async operations)."""
+        pass
+
+    def reset(self):
+        """Clear all cached data."""
+        # Stop all active requests
+        for cache_req_id in list(self.suffix_cache.active_requests):
+            self.suffix_cache.stop_request(cache_req_id)
+        # Clear tracking
+        self.req_state.clear()
+        logger.info("[SUFFIX ADAPTER] Cache reset")
+
+    def _reorder_tree_bfs(
+        self, token_ids: List[int], parents: List[int]
+    ) -> Tuple[List[int], List[int]]:
+        """
+        Reorder nodes so parents always precede their descendants.
+
+        reconstruct_indices_from_tree_mask assumes this layout; the backend emits
+        score-ordered nodes, so we re-topologize the list before building masks.
+        """
+        n = len(token_ids)
+        if n <= 1:
+            return token_ids, parents
+
+        children: List[List[int]] = [[] for _ in range(n)]
+        roots: List[int] = []
+        for idx, parent in enumerate(parents):
+            if parent is None or parent < 0 or parent >= n:
+                roots.append(idx)
+            else:
+                children[parent].append(idx)
+
+        if not roots:
+            roots = [0]
+
+        order: List[int] = []
+        visited = [False] * n
+        for root in roots:
+            if visited[root]:
+                continue
+            queue = deque([root])
+            while queue:
+                node = queue.popleft()
+                if visited[node]:
+                    continue
+                visited[node] = True
+                order.append(node)
+                for child in children[node]:
+                    if not visited[child]:
+                        queue.append(child)
+
+        # Append any detached nodes (should not happen, but keep deterministic order).
+        for idx in range(n):
+            if not visited[idx]:
+                order.append(idx)
+
+        if order == list(range(n)):
+            return token_ids, parents
+
+        remap = {old_idx: new_idx for new_idx, old_idx in enumerate(order)}
+        reordered_ids = [token_ids[old_idx] for old_idx in order]
+        reordered_parents: List[int] = []
+        for old_idx in order:
+            parent = parents[old_idx]
+            if parent is None or parent < 0:
+                reordered_parents.append(-1)
+            else:
+                reordered_parents.append(remap.get(parent, -1))
+
+        return reordered_ids, reordered_parents
+
+    def _inject_root_node(
+        self, token_ids: List[int], parents: List[int], context_token: int
+    ) -> Tuple[List[int], List[int]]:
+        """
+        Insert the latest verified token as index 0 so the layout matches NGRAM.
+        """
+        if context_token is None:
+            context_token = 0
+
+        rooted_ids = [context_token]
+        rooted_parents = [-1]
+        for parent_idx in parents:
+            if parent_idx is None or parent_idx < 0:
+                rooted_parents.append(0)
+            else:
+                rooted_parents.append(parent_idx + 1)
+        rooted_ids.extend(token_ids)
+        return rooted_ids, rooted_parents

--- a/python/sglang/srt/speculative/suffix_cache_adapter.py
+++ b/python/sglang/srt/speculative/suffix_cache_adapter.py
@@ -8,7 +8,7 @@ This allows NGRAMWorker to use suffix decoding without modification.
 import logging
 import os
 from collections import deque
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -264,7 +264,7 @@ class SuffixCacheAdapter:
         logger.info("[SUFFIX ADAPTER] Cache reset")
 
     def _reorder_tree_bfs(
-        self, token_ids: List[int], parents: List[int]
+        self, token_ids: List[int], parents: List[Optional[int]]
     ) -> Tuple[List[int], List[int]]:
         """
         Reorder nodes so parents always precede their descendants.
@@ -329,13 +329,10 @@ class SuffixCacheAdapter:
         """
         Insert the latest verified token as index 0 so the layout matches NGRAM.
         """
-        if context_token is None:
-            context_token = 0
-
         rooted_ids = [context_token]
         rooted_parents = [-1]
         for parent_idx in parents:
-            if parent_idx is None or parent_idx < 0:
+            if parent_idx < 0:
                 rooted_parents.append(0)
             else:
                 rooted_parents.append(parent_idx + 1)

--- a/python/sglang/srt/speculative/suffix_info.py
+++ b/python/sglang/srt/speculative/suffix_info.py
@@ -1,0 +1,462 @@
+"""
+Data structures for suffix decoding speculative method.
+
+Most of the logic is reused from ngram_info.py since both use tree-based verification.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Optional, Tuple
+
+import torch
+import triton
+
+from sglang.srt.server_args import get_global_server_args
+
+logger = logging.getLogger(__name__)
+
+from dataclasses import dataclass
+
+import torch.nn.functional as F
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.sampler import apply_custom_logit_processor
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.mem_cache.common import (
+    alloc_paged_token_slots_extend,
+    alloc_token_slots,
+    get_last_loc,
+)
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+from sglang.srt.speculative.spec_utils import (
+    TREE_SPEC_KERNEL_AVAILABLE,
+    assign_req_to_token_pool,
+    get_src_tgt_cache_loc,
+    get_target_cache_loc,
+)
+from sglang.srt.utils import is_cuda, is_hip, next_power_of_2
+
+if is_cuda():
+    from sgl_kernel import (
+        top_k_renorm_prob,
+        top_p_renorm_prob,
+        tree_speculative_sampling_target_only,
+        verify_tree_greedy,
+    )
+elif is_hip():
+    from sgl_kernel import verify_tree_greedy
+
+
+@dataclass
+class SuffixVerifyInput(SpecInput):
+    """
+    Data structure for suffix decoding verification.
+
+    Similar to NgramVerifyInput as both use tree-based verification
+    without a separate draft model. Most methods are reused from NgramVerifyInput.
+    """
+
+    def __init__(
+        self,
+        draft_token: torch.Tensor,
+        tree_mask: torch.Tensor,
+        positions: torch.Tensor,
+        retrive_index: torch.Tensor,
+        retrive_next_token: torch.Tensor,
+        retrive_next_sibling: torch.Tensor,
+        draft_token_num: int,
+    ):
+        super().__init__(SpecInputType.SUFFIX_VERIFY)
+        self.draft_token = draft_token
+        self.custom_mask = tree_mask
+        self.positions = positions
+        self.retrive_index = retrive_index
+        self.retrive_next_token = retrive_next_token
+        self.retrive_next_sibling = retrive_next_sibling
+        self.draft_token_num = draft_token_num
+        self.device = self.custom_mask.device
+
+    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
+        return self.draft_token_num, self.draft_token_num
+
+    def prepare_for_verify(self, batch: ScheduleBatch, page_size: int):
+        if batch.forward_mode.is_idle():
+            return
+
+        batch.input_ids = self.draft_token
+
+        if page_size == 1:
+            batch.out_cache_loc = alloc_token_slots(
+                batch.tree_cache,
+                len(batch.input_ids),
+            )
+            end_offset = batch.seq_lens + self.draft_token_num
+        else:
+            # TODO(lsyin): add prefix lens cpu here to support page size > 1
+            prefix_lens = batch.seq_lens
+            prefix_lens_cpu = batch.seq_lens_cpu
+            end_offset = prefix_lens + self.draft_token_num
+            end_offset_cpu = prefix_lens_cpu + self.draft_token_num
+            last_loc = get_last_loc(
+                batch.req_to_token_pool.req_to_token,
+                batch.req_pool_indices,
+                prefix_lens,
+            )
+            batch.out_cache_loc = alloc_paged_token_slots_extend(
+                batch.tree_cache,
+                prefix_lens,
+                prefix_lens_cpu,
+                end_offset,
+                end_offset_cpu,
+                last_loc,
+                len(batch.input_ids),
+            )
+            self.last_loc = last_loc
+
+        bs = batch.batch_size()
+        assign_req_to_token_pool[(bs,)](
+            batch.req_pool_indices,
+            batch.req_to_token_pool.req_to_token,
+            batch.seq_lens,
+            end_offset,
+            batch.out_cache_loc,
+            batch.req_to_token_pool.req_to_token.shape[1],
+            triton.next_power_of_2(bs),
+        )
+
+    def generate_attn_arg_prefill(
+        self,
+        req_pool_indices: torch.Tensor,
+        paged_kernel_lens: torch.Tensor,
+        paged_kernel_lens_sum: int,
+        req_to_token: torch.Tensor,
+    ):
+        bs = len(req_pool_indices)
+
+        cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=self.device)
+
+        paged_kernel_lens = paged_kernel_lens + self.draft_token_num
+        cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
+
+        self.qo_indptr = (
+            torch.arange(0, bs + 1, dtype=torch.int32, device=self.device)
+            * self.draft_token_num
+        )
+
+        kv_indices = torch.empty(
+            cum_kv_seq_len[-1], dtype=torch.int32, device=self.device
+        )
+
+        create_flashinfer_kv_indices_triton[(bs,)](
+            req_to_token,
+            req_pool_indices,
+            paged_kernel_lens,
+            cum_kv_seq_len,
+            None,
+            kv_indices,
+            req_to_token.size(1),
+        )
+        return kv_indices, cum_kv_seq_len, self.qo_indptr, self.custom_mask
+
+    def _fill_requests(
+        self,
+        batch: ScheduleBatch,
+        logits_output: torch.Tensor,
+    ):
+        accept_index_cpu = self.accept_index.tolist()
+        predict_cpu = self.predict.tolist()
+        has_finished = False
+
+        # Iterate every accepted token and check if req has finished after append the token
+        # should be checked BEFORE free kv cache slots
+        for i, (req, accept_index_row) in enumerate(zip(batch.reqs, accept_index_cpu)):
+            accepted_tokens = []
+            for j, idx in enumerate(accept_index_row):
+                if idx == -1:
+                    break
+                id = predict_cpu[idx]
+                accepted_tokens.append(id)
+                req.output_ids.append(id)
+                req.check_finished()
+                if req.finished():
+                    has_finished = True
+                    # set all tokens after finished token to -1 and break
+                    self.accept_index[i, j + 1 :] = -1
+                    break
+                else:
+                    if req.grammar is not None:
+                        try:
+                            req.grammar.accept_token(id)
+                        except ValueError as e:
+                            logger.info(
+                                f"{i=}, {req=}\n"
+                                f"{self.accept_index=}\n"
+                                f"{self.predict=}\n"
+                            )
+                            raise e
+            if accepted_tokens:
+                logger.info(
+                    f"[DEBUG SUFFIX VERIFY] req={req.rid}: Accepted {len(accepted_tokens)} tokens: {accepted_tokens[:10]}"
+                )
+            req.spec_verify_ct += 1
+        if has_finished:
+            self.accept_length = (self.accept_index != -1).sum(dim=1) - 1
+        self.accept_index = self.accept_index[self.accept_index != -1]
+
+        logits_output.next_token_logits = logits_output.next_token_logits[
+            self.accept_index
+        ]
+        if logits_output.hidden_states:
+            logits_output.hidden_states = logits_output.hidden_states[self.accept_index]
+        self.verified_id = self.predict[self.accept_index]
+
+    def _free_cache(
+        self, batch: ScheduleBatch, page_size: int, accept_length_cpu: torch.Tensor
+    ):
+        bs = batch.batch_size()
+        # Free the KV cache for unaccepted tokens
+        if page_size == 1:
+            # TODO: boolean array index leads to a device sync. Remove it.
+            evict_mask = torch.full_like(self.draft_token, True, dtype=torch.bool)
+            evict_mask[self.accept_index] = False
+            batch.token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
+            batch.out_cache_loc = batch.out_cache_loc[self.accept_index]
+        else:
+            # Shift the accepted tokens to the beginning.
+            # Only evict the last part
+            src_cache_loc, tgt_cache_loc, to_free_num_slots = get_src_tgt_cache_loc(
+                batch.seq_lens,
+                batch.out_cache_loc,
+                self.accept_index,
+                self.accept_length,
+                self.draft_token_num,
+                page_size,
+            )
+            to_free_slots = torch.empty(
+                (to_free_num_slots.sum().item(),),
+                dtype=torch.int64,
+                device=to_free_num_slots.device,
+            )
+
+            # out_cache_loc: [0  1  2,  3  4  5,  6  7  8]
+            # accept_index:  [0 -1  2,  3  4 -1,  6 -1 -1]
+            # tgt_cache_loc: [0  1   ,  3  4   ,  6      ]
+            # to_free_slots: [      2,        5,     7  8]
+            # to_free_slots also needs to be page-aligned without the first partial page
+            #
+            # split each row of out_cache_loc into two parts.
+            # 1. the first part goes to tgt_cache_loc. length = accept_length[i] + 1
+            # 2. the second part goes to to_free_slots.
+            get_target_cache_loc[(bs,)](
+                tgt_cache_loc,
+                to_free_slots,
+                self.accept_length,
+                to_free_num_slots,
+                batch.out_cache_loc,
+                self.draft_token_num,
+                next_power_of_2(self.draft_token_num),
+                next_power_of_2(bs),
+            )
+
+            # Free the kv cache
+            batch.token_to_kv_pool_allocator.free(to_free_slots)
+
+            # Copy the kv cache
+            batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
+                tgt_cache_loc, src_cache_loc
+            )
+            batch.out_cache_loc = tgt_cache_loc
+
+        accept_length_list = accept_length_cpu.tolist()
+        for i, req in enumerate(batch.reqs):
+            req.kv_committed_len += accept_length_list[i] + 1
+            req.kv_allocated_len = req.kv_committed_len
+
+        assign_req_to_token_pool[(bs,)](
+            batch.req_pool_indices,
+            batch.req_to_token_pool.req_to_token,
+            batch.seq_lens,
+            batch.seq_lens + self.accept_length + 1,
+            batch.out_cache_loc,
+            batch.req_to_token_pool.req_to_token.shape[1],
+            triton.next_power_of_2(bs),
+        )
+
+    def _greedy_verify(
+        self,
+        batch: ScheduleBatch,
+        logits_output: LogitsProcessorOutput,
+    ):
+        bs = batch.batch_size()
+        target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
+        target_predict = target_predict.reshape(bs, self.draft_token_num)
+
+        candidates = self.draft_token.reshape(bs, self.draft_token_num)
+        predict_shape = list(logits_output.next_token_logits.shape)[:-1]
+        predict_shape[-1] += 1
+        self.predict = torch.empty(predict_shape, dtype=torch.int32, device=self.device)
+        self.accept_index = torch.full(
+            (bs, self.draft_token_num), -1, dtype=torch.int32, device=self.device
+        )
+        self.accept_length = torch.empty((bs,), dtype=torch.int32, device=self.device)
+
+        verify_tree_greedy(
+            predicts=self.predict,  # mutable
+            accept_index=self.accept_index,  # mutable
+            accept_token_num=self.accept_length,  # mutable
+            candidates=candidates,
+            retrive_index=self.retrive_index,
+            retrive_next_token=self.retrive_next_token,
+            retrive_next_sibling=self.retrive_next_sibling,
+            target_predict=target_predict,
+        )
+
+    def _sampling_verify(
+        self,
+        batch: ScheduleBatch,
+        logits_output: LogitsProcessorOutput,
+        sampling_info: SamplingBatchInfo,
+    ):
+        bs = batch.batch_size()
+        candidates = self.draft_token.reshape(bs, self.draft_token_num)
+        predict_shape = list(logits_output.next_token_logits.shape)[:-1]
+        predict_shape[-1] += 1
+        self.predict = torch.empty(predict_shape, dtype=torch.int32, device=self.device)
+        self.accept_index = torch.full(
+            (bs, self.draft_token_num), -1, dtype=torch.int32, device=self.device
+        )
+        self.accept_length = torch.empty((bs,), dtype=torch.int32, device=self.device)
+        # apply temperature and get target probs
+        expanded_temperature = torch.repeat_interleave(
+            sampling_info.temperatures, self.draft_token_num, dim=0
+        )  # (bs * draft_token_num, 1)
+
+        target_probs = F.softmax(
+            logits_output.next_token_logits / expanded_temperature, dim=-1
+        )  # (bs * draft_token_num, vocab_size)
+
+        # NOTE: The test shows that top_p_renorm_prob and top_k_renorm_prob are the key factors
+        # contributing to the poor performance of _sampling_verify.
+        target_probs = top_k_renorm_prob(
+            target_probs,
+            torch.repeat_interleave(sampling_info.top_ks, self.draft_token_num, dim=0),
+        )  # (bs * draft_token_num, vocab_size)
+
+        if sampling_info.need_top_p_sampling:
+            # logger.info("Using top-p sampling in speculative decoding verification.")
+            target_probs = top_p_renorm_prob(
+                target_probs,
+                torch.repeat_interleave(
+                    sampling_info.top_ps, self.draft_token_num, dim=0
+                ),
+            )
+
+        target_probs = target_probs.reshape(bs, self.draft_token_num, -1)
+        draft_probs = torch.zeros(
+            target_probs.shape, dtype=torch.float32, device=self.device
+        )
+
+        # coins for rejection sampling
+        coins = torch.rand_like(candidates, dtype=torch.float32, device=self.device)
+        # coins for final sampling
+        coins_for_final_sampling = torch.rand(
+            (bs,), dtype=torch.float32, device=self.device
+        )
+        tree_speculative_sampling_target_only(
+            predicts=self.predict,  # mutable
+            accept_index=self.accept_index,  # mutable
+            accept_token_num=self.accept_length,  # mutable
+            candidates=candidates.to(torch.int64),
+            retrive_index=self.retrive_index.to(torch.int64),
+            retrive_next_token=self.retrive_next_token.to(torch.int64),
+            retrive_next_sibling=self.retrive_next_sibling.to(torch.int64),
+            uniform_samples=coins,
+            uniform_samples_for_final_sampling=coins_for_final_sampling,
+            target_probs=target_probs,
+            draft_probs=draft_probs,
+            threshold_single=get_global_server_args().speculative_accept_threshold_single,
+            threshold_acc=get_global_server_args().speculative_accept_threshold_acc,
+            deterministic=True,
+        )
+
+    def verify(
+        self,
+        batch: ScheduleBatch,
+        logits_output: LogitsProcessorOutput,
+        page_size: int,
+        vocab_mask: Optional[torch.Tensor] = None,  # For grammar
+    ) -> torch.Tensor:
+        bs = self.retrive_index.shape[0]
+        sampling_info = batch.sampling_info
+
+        if bs != len(sampling_info):
+            sampling_info = copy.deepcopy(sampling_info)
+            # NOTE: retrive_index are the indices of the requests that are kept.
+            sampling_info.filter_batch(self.retrive_index.tolist(), self.retrive_index)
+
+        # Apply the custom logit processors if registered in the sampling info.
+        if sampling_info.has_custom_logit_processor:
+            apply_custom_logit_processor(
+                logits_output.next_token_logits,
+                sampling_info,
+                num_tokens_in_batch=self.draft_token_num,
+            )
+
+        # Apply penalty
+        if sampling_info.penalizer_orchestrator.is_required:
+            # This is a relaxed version of penalties for speculative decoding.
+            linear_penalty = torch.zeros(
+                (bs, logits_output.next_token_logits.shape[1]),
+                dtype=torch.float32,
+                device=self.device,
+            )
+            sampling_info.apply_logits_bias(linear_penalty)
+            logits_output.next_token_logits.add_(
+                torch.repeat_interleave(linear_penalty, self.draft_token_num, dim=0)
+            )
+
+        # Apply grammar mask
+        if vocab_mask is not None:
+            assert self.grammar is not None
+            self.grammar.apply_vocab_mask(
+                logits=logits_output.next_token_logits, vocab_mask=vocab_mask
+            )
+
+        # Sample tokens. Force greedy sampling on AMD
+        is_all_greedy = (
+            sampling_info.is_all_greedy or envs.SGLANG_NGRAM_FORCE_GREEDY_VERIFY.get()
+        )
+        if (not is_all_greedy) and (not TREE_SPEC_KERNEL_AVAILABLE):
+            logger.warning(
+                "Tree speculative sampling kernel unavailable (likely AMD/HIP build). "
+                "Falling back to greedy verification."
+            )
+
+        if is_all_greedy or not TREE_SPEC_KERNEL_AVAILABLE:
+            self._greedy_verify(batch, logits_output)
+        else:
+            # NOTE: Compared with greedy_verify, the performance of _sampling_verify is relatively poor.
+            self._sampling_verify(batch, logits_output, sampling_info)
+
+        self._fill_requests(batch, logits_output)
+
+        accept_length_cpu = self.accept_length.cpu()
+        num_accepted_tokens = accept_length_cpu.sum().item()
+
+        self._free_cache(batch, page_size, accept_length_cpu)
+
+        batch.seq_lens.add_(self.accept_length + 1)
+        batch.seq_lens_cpu.add_(accept_length_cpu + 1)
+
+        return logits_output, self.verified_id, num_accepted_tokens
+
+    def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
+        pass
+
+    def merge_batch(self, spec_info: SuffixVerifyInput):
+        pass

--- a/python/sglang/srt/speculative/suffix_info.py
+++ b/python/sglang/srt/speculative/suffix_info.py
@@ -6,59 +6,26 @@ Most of the logic is reused from ngram_info.py since both use tree-based verific
 
 from __future__ import annotations
 
-import copy
 import logging
-from typing import Optional, Tuple
+from dataclasses import dataclass
 
 import torch
-import triton
 
-from sglang.srt.server_args import get_global_server_args
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.speculative.ngram_info import NgramVerifyInput
+from sglang.srt.speculative.spec_info import SpecInputType
 
 logger = logging.getLogger(__name__)
 
-from dataclasses import dataclass
-
-import torch.nn.functional as F
-
-from sglang.srt.environ import envs
-from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.sampler import apply_custom_logit_processor
-from sglang.srt.managers.schedule_batch import ScheduleBatch
-from sglang.srt.mem_cache.common import (
-    alloc_paged_token_slots_extend,
-    alloc_token_slots,
-    get_last_loc,
-)
-from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
-from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
-from sglang.srt.speculative.spec_utils import (
-    TREE_SPEC_KERNEL_AVAILABLE,
-    assign_req_to_token_pool,
-    get_src_tgt_cache_loc,
-    get_target_cache_loc,
-)
-from sglang.srt.utils import is_cuda, is_hip, next_power_of_2
-
-if is_cuda():
-    from sgl_kernel import (
-        top_k_renorm_prob,
-        top_p_renorm_prob,
-        tree_speculative_sampling_target_only,
-        verify_tree_greedy,
-    )
-elif is_hip():
-    from sgl_kernel import verify_tree_greedy
-
 
 @dataclass
-class SuffixVerifyInput(SpecInput):
+class SuffixVerifyInput(NgramVerifyInput):
     """
     Data structure for suffix decoding verification.
 
-    Similar to NgramVerifyInput as both use tree-based verification
-    without a separate draft model. Most methods are reused from NgramVerifyInput.
+    Inherits from NgramVerifyInput as both use identical tree-based verification
+    without a separate draft model. The only differences are the SpecInputType
+    and debug logging for accepted tokens.
     """
 
     def __init__(
@@ -71,103 +38,29 @@ class SuffixVerifyInput(SpecInput):
         retrive_next_sibling: torch.Tensor,
         draft_token_num: int,
     ):
-        super().__init__(SpecInputType.SUFFIX_VERIFY)
-        self.draft_token = draft_token
-        self.custom_mask = tree_mask
-        self.positions = positions
-        self.retrive_index = retrive_index
-        self.retrive_next_token = retrive_next_token
-        self.retrive_next_sibling = retrive_next_sibling
-        self.draft_token_num = draft_token_num
-        self.device = self.custom_mask.device
-
-    def get_spec_adjust_token_coefficient(self) -> Tuple[int, int]:
-        return self.draft_token_num, self.draft_token_num
-
-    def prepare_for_verify(self, batch: ScheduleBatch, page_size: int):
-        if batch.forward_mode.is_idle():
-            return
-
-        batch.input_ids = self.draft_token
-
-        if page_size == 1:
-            batch.out_cache_loc = alloc_token_slots(
-                batch.tree_cache,
-                len(batch.input_ids),
-            )
-            end_offset = batch.seq_lens + self.draft_token_num
-        else:
-            # TODO(lsyin): add prefix lens cpu here to support page size > 1
-            prefix_lens = batch.seq_lens
-            prefix_lens_cpu = batch.seq_lens_cpu
-            end_offset = prefix_lens + self.draft_token_num
-            end_offset_cpu = prefix_lens_cpu + self.draft_token_num
-            last_loc = get_last_loc(
-                batch.req_to_token_pool.req_to_token,
-                batch.req_pool_indices,
-                prefix_lens,
-            )
-            batch.out_cache_loc = alloc_paged_token_slots_extend(
-                batch.tree_cache,
-                prefix_lens,
-                prefix_lens_cpu,
-                end_offset,
-                end_offset_cpu,
-                last_loc,
-                len(batch.input_ids),
-            )
-            self.last_loc = last_loc
-
-        bs = batch.batch_size()
-        assign_req_to_token_pool[(bs,)](
-            batch.req_pool_indices,
-            batch.req_to_token_pool.req_to_token,
-            batch.seq_lens,
-            end_offset,
-            batch.out_cache_loc,
-            batch.req_to_token_pool.req_to_token.shape[1],
-            triton.next_power_of_2(bs),
+        # Call parent init to reuse all initialization logic
+        super().__init__(
+            draft_token,
+            tree_mask,
+            positions,
+            retrive_index,
+            retrive_next_token,
+            retrive_next_sibling,
+            draft_token_num,
         )
-
-    def generate_attn_arg_prefill(
-        self,
-        req_pool_indices: torch.Tensor,
-        paged_kernel_lens: torch.Tensor,
-        paged_kernel_lens_sum: int,
-        req_to_token: torch.Tensor,
-    ):
-        bs = len(req_pool_indices)
-
-        cum_kv_seq_len = torch.zeros((bs + 1,), dtype=torch.int32, device=self.device)
-
-        paged_kernel_lens = paged_kernel_lens + self.draft_token_num
-        cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
-
-        self.qo_indptr = (
-            torch.arange(0, bs + 1, dtype=torch.int32, device=self.device)
-            * self.draft_token_num
-        )
-
-        kv_indices = torch.empty(
-            cum_kv_seq_len[-1], dtype=torch.int32, device=self.device
-        )
-
-        create_flashinfer_kv_indices_triton[(bs,)](
-            req_to_token,
-            req_pool_indices,
-            paged_kernel_lens,
-            cum_kv_seq_len,
-            None,
-            kv_indices,
-            req_to_token.size(1),
-        )
-        return kv_indices, cum_kv_seq_len, self.qo_indptr, self.custom_mask
+        # Override to set correct SpecInputType for suffix decoding
+        self.spec_input_type = SpecInputType.SUFFIX_VERIFY
 
     def _fill_requests(
         self,
         batch: ScheduleBatch,
         logits_output: torch.Tensor,
     ):
+        """
+        Fill requests with accepted tokens.
+
+        Overrides parent to add debug logging of accepted tokens.
+        """
         accept_index_cpu = self.accept_index.tolist()
         predict_cpu = self.predict.tolist()
         has_finished = False
@@ -200,7 +93,7 @@ class SuffixVerifyInput(SpecInput):
                             )
                             raise e
             if accepted_tokens:
-                logger.info(
+                logger.debug(
                     f"[DEBUG SUFFIX VERIFY] req={req.rid}: Accepted {len(accepted_tokens)} tokens: {accepted_tokens[:10]}"
                 )
             req.spec_verify_ct += 1
@@ -214,249 +107,3 @@ class SuffixVerifyInput(SpecInput):
         if logits_output.hidden_states:
             logits_output.hidden_states = logits_output.hidden_states[self.accept_index]
         self.verified_id = self.predict[self.accept_index]
-
-    def _free_cache(
-        self, batch: ScheduleBatch, page_size: int, accept_length_cpu: torch.Tensor
-    ):
-        bs = batch.batch_size()
-        # Free the KV cache for unaccepted tokens
-        if page_size == 1:
-            # TODO: boolean array index leads to a device sync. Remove it.
-            evict_mask = torch.full_like(self.draft_token, True, dtype=torch.bool)
-            evict_mask[self.accept_index] = False
-            batch.token_to_kv_pool_allocator.free(batch.out_cache_loc[evict_mask])
-            batch.out_cache_loc = batch.out_cache_loc[self.accept_index]
-        else:
-            # Shift the accepted tokens to the beginning.
-            # Only evict the last part
-            src_cache_loc, tgt_cache_loc, to_free_num_slots = get_src_tgt_cache_loc(
-                batch.seq_lens,
-                batch.out_cache_loc,
-                self.accept_index,
-                self.accept_length,
-                self.draft_token_num,
-                page_size,
-            )
-            to_free_slots = torch.empty(
-                (to_free_num_slots.sum().item(),),
-                dtype=torch.int64,
-                device=to_free_num_slots.device,
-            )
-
-            # out_cache_loc: [0  1  2,  3  4  5,  6  7  8]
-            # accept_index:  [0 -1  2,  3  4 -1,  6 -1 -1]
-            # tgt_cache_loc: [0  1   ,  3  4   ,  6      ]
-            # to_free_slots: [      2,        5,     7  8]
-            # to_free_slots also needs to be page-aligned without the first partial page
-            #
-            # split each row of out_cache_loc into two parts.
-            # 1. the first part goes to tgt_cache_loc. length = accept_length[i] + 1
-            # 2. the second part goes to to_free_slots.
-            get_target_cache_loc[(bs,)](
-                tgt_cache_loc,
-                to_free_slots,
-                self.accept_length,
-                to_free_num_slots,
-                batch.out_cache_loc,
-                self.draft_token_num,
-                next_power_of_2(self.draft_token_num),
-                next_power_of_2(bs),
-            )
-
-            # Free the kv cache
-            batch.token_to_kv_pool_allocator.free(to_free_slots)
-
-            # Copy the kv cache
-            batch.token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
-                tgt_cache_loc, src_cache_loc
-            )
-            batch.out_cache_loc = tgt_cache_loc
-
-        accept_length_list = accept_length_cpu.tolist()
-        for i, req in enumerate(batch.reqs):
-            req.kv_committed_len += accept_length_list[i] + 1
-            req.kv_allocated_len = req.kv_committed_len
-
-        assign_req_to_token_pool[(bs,)](
-            batch.req_pool_indices,
-            batch.req_to_token_pool.req_to_token,
-            batch.seq_lens,
-            batch.seq_lens + self.accept_length + 1,
-            batch.out_cache_loc,
-            batch.req_to_token_pool.req_to_token.shape[1],
-            triton.next_power_of_2(bs),
-        )
-
-    def _greedy_verify(
-        self,
-        batch: ScheduleBatch,
-        logits_output: LogitsProcessorOutput,
-    ):
-        bs = batch.batch_size()
-        target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
-        target_predict = target_predict.reshape(bs, self.draft_token_num)
-
-        candidates = self.draft_token.reshape(bs, self.draft_token_num)
-        predict_shape = list(logits_output.next_token_logits.shape)[:-1]
-        predict_shape[-1] += 1
-        self.predict = torch.empty(predict_shape, dtype=torch.int32, device=self.device)
-        self.accept_index = torch.full(
-            (bs, self.draft_token_num), -1, dtype=torch.int32, device=self.device
-        )
-        self.accept_length = torch.empty((bs,), dtype=torch.int32, device=self.device)
-
-        verify_tree_greedy(
-            predicts=self.predict,  # mutable
-            accept_index=self.accept_index,  # mutable
-            accept_token_num=self.accept_length,  # mutable
-            candidates=candidates,
-            retrive_index=self.retrive_index,
-            retrive_next_token=self.retrive_next_token,
-            retrive_next_sibling=self.retrive_next_sibling,
-            target_predict=target_predict,
-        )
-
-    def _sampling_verify(
-        self,
-        batch: ScheduleBatch,
-        logits_output: LogitsProcessorOutput,
-        sampling_info: SamplingBatchInfo,
-    ):
-        bs = batch.batch_size()
-        candidates = self.draft_token.reshape(bs, self.draft_token_num)
-        predict_shape = list(logits_output.next_token_logits.shape)[:-1]
-        predict_shape[-1] += 1
-        self.predict = torch.empty(predict_shape, dtype=torch.int32, device=self.device)
-        self.accept_index = torch.full(
-            (bs, self.draft_token_num), -1, dtype=torch.int32, device=self.device
-        )
-        self.accept_length = torch.empty((bs,), dtype=torch.int32, device=self.device)
-        # apply temperature and get target probs
-        expanded_temperature = torch.repeat_interleave(
-            sampling_info.temperatures, self.draft_token_num, dim=0
-        )  # (bs * draft_token_num, 1)
-
-        target_probs = F.softmax(
-            logits_output.next_token_logits / expanded_temperature, dim=-1
-        )  # (bs * draft_token_num, vocab_size)
-
-        # NOTE: The test shows that top_p_renorm_prob and top_k_renorm_prob are the key factors
-        # contributing to the poor performance of _sampling_verify.
-        target_probs = top_k_renorm_prob(
-            target_probs,
-            torch.repeat_interleave(sampling_info.top_ks, self.draft_token_num, dim=0),
-        )  # (bs * draft_token_num, vocab_size)
-
-        if sampling_info.need_top_p_sampling:
-            # logger.info("Using top-p sampling in speculative decoding verification.")
-            target_probs = top_p_renorm_prob(
-                target_probs,
-                torch.repeat_interleave(
-                    sampling_info.top_ps, self.draft_token_num, dim=0
-                ),
-            )
-
-        target_probs = target_probs.reshape(bs, self.draft_token_num, -1)
-        draft_probs = torch.zeros(
-            target_probs.shape, dtype=torch.float32, device=self.device
-        )
-
-        # coins for rejection sampling
-        coins = torch.rand_like(candidates, dtype=torch.float32, device=self.device)
-        # coins for final sampling
-        coins_for_final_sampling = torch.rand(
-            (bs,), dtype=torch.float32, device=self.device
-        )
-        tree_speculative_sampling_target_only(
-            predicts=self.predict,  # mutable
-            accept_index=self.accept_index,  # mutable
-            accept_token_num=self.accept_length,  # mutable
-            candidates=candidates.to(torch.int64),
-            retrive_index=self.retrive_index.to(torch.int64),
-            retrive_next_token=self.retrive_next_token.to(torch.int64),
-            retrive_next_sibling=self.retrive_next_sibling.to(torch.int64),
-            uniform_samples=coins,
-            uniform_samples_for_final_sampling=coins_for_final_sampling,
-            target_probs=target_probs,
-            draft_probs=draft_probs,
-            threshold_single=get_global_server_args().speculative_accept_threshold_single,
-            threshold_acc=get_global_server_args().speculative_accept_threshold_acc,
-            deterministic=True,
-        )
-
-    def verify(
-        self,
-        batch: ScheduleBatch,
-        logits_output: LogitsProcessorOutput,
-        page_size: int,
-        vocab_mask: Optional[torch.Tensor] = None,  # For grammar
-    ) -> torch.Tensor:
-        bs = self.retrive_index.shape[0]
-        sampling_info = batch.sampling_info
-
-        if bs != len(sampling_info):
-            sampling_info = copy.deepcopy(sampling_info)
-            # NOTE: retrive_index are the indices of the requests that are kept.
-            sampling_info.filter_batch(self.retrive_index.tolist(), self.retrive_index)
-
-        # Apply the custom logit processors if registered in the sampling info.
-        if sampling_info.has_custom_logit_processor:
-            apply_custom_logit_processor(
-                logits_output.next_token_logits,
-                sampling_info,
-                num_tokens_in_batch=self.draft_token_num,
-            )
-
-        # Apply penalty
-        if sampling_info.penalizer_orchestrator.is_required:
-            # This is a relaxed version of penalties for speculative decoding.
-            linear_penalty = torch.zeros(
-                (bs, logits_output.next_token_logits.shape[1]),
-                dtype=torch.float32,
-                device=self.device,
-            )
-            sampling_info.apply_logits_bias(linear_penalty)
-            logits_output.next_token_logits.add_(
-                torch.repeat_interleave(linear_penalty, self.draft_token_num, dim=0)
-            )
-
-        # Apply grammar mask
-        if vocab_mask is not None:
-            assert self.grammar is not None
-            self.grammar.apply_vocab_mask(
-                logits=logits_output.next_token_logits, vocab_mask=vocab_mask
-            )
-
-        # Sample tokens. Force greedy sampling on AMD
-        is_all_greedy = (
-            sampling_info.is_all_greedy or envs.SGLANG_NGRAM_FORCE_GREEDY_VERIFY.get()
-        )
-        if (not is_all_greedy) and (not TREE_SPEC_KERNEL_AVAILABLE):
-            logger.warning(
-                "Tree speculative sampling kernel unavailable (likely AMD/HIP build). "
-                "Falling back to greedy verification."
-            )
-
-        if is_all_greedy or not TREE_SPEC_KERNEL_AVAILABLE:
-            self._greedy_verify(batch, logits_output)
-        else:
-            # NOTE: Compared with greedy_verify, the performance of _sampling_verify is relatively poor.
-            self._sampling_verify(batch, logits_output, sampling_info)
-
-        self._fill_requests(batch, logits_output)
-
-        accept_length_cpu = self.accept_length.cpu()
-        num_accepted_tokens = accept_length_cpu.sum().item()
-
-        self._free_cache(batch, page_size, accept_length_cpu)
-
-        batch.seq_lens.add_(self.accept_length + 1)
-        batch.seq_lens_cpu.add_(accept_length_cpu + 1)
-
-        return logits_output, self.verified_id, num_accepted_tokens
-
-    def filter_batch(self, new_indices: torch.Tensor, has_been_filtered: bool = True):
-        pass
-
-    def merge_batch(self, spec_info: SuffixVerifyInput):
-        pass

--- a/python/sglang/srt/speculative/suffix_worker.py
+++ b/python/sglang/srt/speculative/suffix_worker.py
@@ -1,0 +1,106 @@
+"""
+Suffix decoding worker that reuses NGRAMWorker with a cache adapter.
+
+This is a thin wrapper that replaces NgramCache with SuffixCacheAdapter,
+allowing all the tree-based verification logic to be reused.
+"""
+
+import logging
+from typing import Optional
+
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.ngram_worker import NGRAMWorker
+from sglang.srt.speculative.suffix_cache_adapter import SuffixCacheAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class SuffixWorker(NGRAMWorker):
+    """
+    Suffix decoding worker that inherits from NGRAMWorker.
+
+    The only difference is using SuffixCacheAdapter instead of NgramCache.
+    All tree-based verification logic is inherited from NGRAMWorker.
+    """
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        moe_ep_rank: int,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        # Call parent __init__ which sets up all the infrastructure
+        super().__init__(
+            server_args,
+            gpu_id,
+            tp_rank,
+            dp_rank,
+            moe_ep_rank,
+            nccl_port,
+            target_worker,
+        )
+
+        self.ngram_cache = SuffixCacheAdapter(
+            draft_token_num=server_args.speculative_num_draft_tokens,
+            max_batch_size=self.max_batch_size,
+            max_tree_depth=server_args.speculative_suffix_max_tree_depth,
+            max_cached_requests=server_args.speculative_suffix_max_cached_requests,
+            max_spec_factor=server_args.speculative_suffix_max_spec_factor,
+            min_token_prob=server_args.speculative_suffix_min_token_prob,
+        )
+
+    def _prepare_draft_tokens(self, batch):
+        """
+        Override to pass FULL token sequences to the cache adapter.
+
+        NGRAMWorker passes only last N tokens, but the suffix cache needs:
+        1. Full prompt for start_request()
+        2. Full sequence for suffix tree building
+        3. Request identity tracking
+        """
+
+        bs = batch.batch_size()
+
+        self.ngram_cache.synchronize()
+        batch_req_ids = []
+        batch_prompts = []
+        batch_tokens = []
+        for req in batch.reqs:
+            # Pass request ID for stable tracking
+            batch_req_ids.append(req.rid)
+            # Pass prompt separately (for cache initialization)
+            batch_prompts.append(req.origin_input_ids)
+            # Pass FULL token sequence (prompt + outputs), not just last N
+            full_tokens = req.origin_input_ids + req.output_ids
+            batch_tokens.append(full_tokens)
+
+        req_drafts, mask = self.ngram_cache.batch_get(
+            batch_req_ids, batch_prompts, batch_tokens
+        )
+        total_draft_token_num = len(req_drafts)
+
+        assert (
+            total_draft_token_num == bs * self.draft_token_num
+        ), f"{total_draft_token_num=}, {bs=}, {self.draft_token_num=}"
+
+        return req_drafts, mask
+
+    def _update_ngram_cache(self, batch):
+        """
+        Override to pass FULL token sequences for cache updates.
+        """
+        batch_req_ids = []
+        batch_tokens = []
+        for req in batch.reqs:
+            # Pass request ID for stable tracking
+            batch_req_ids.append(req.rid)
+            # Pass FULL token sequence for delta computation
+            full_tokens = req.origin_input_ids + req.output_ids
+            batch_tokens.append(full_tokens)
+
+        self.ngram_cache.batch_put(batch_req_ids, batch_tokens)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3375,6 +3375,11 @@ def is_triton_kernels_available() -> bool:
     return importlib.util.find_spec("triton_kernels") is not None
 
 
+@lru_cache(maxsize=1)
+def is_arctic_inference_available() -> bool:
+    return importlib.util.find_spec("arctic_inference") is not None
+
+
 def check_cuda_result(raw_output):
     import cuda.bindings.runtime as cuda_rt
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -109,6 +109,7 @@ suites = {
         TestFile("test_srt_endpoint.py", 130),
         TestFile("test_srt_engine.py", 450),
         TestFile("test_standalone_speculative_decoding.py", 150),
+        TestFile("test_suffix_speculative_decoding.py", 290),
         TestFile("test_start_profile.py", 180),
         TestFile("test_profile_merger.py", 60),
         TestFile("test_profile_merger_http_api.py", 15),

--- a/test/srt/test_suffix_speculative_decoding.py
+++ b/test/srt/test_suffix_speculative_decoding.py
@@ -1,0 +1,415 @@
+"""
+Unit tests for suffix decoding speculative method.
+
+This test suite validates the suffix decoding implementation including:
+- Server launch and basic generation
+- Configuration parameter validation
+- Worker initialization
+- Integration with different attention backends
+"""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import requests
+
+from sglang.srt.environ import envs
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+GSM_DATASET_PATH = None
+
+# Allow overriding the speculative algorithm (e.g., NONE or NGRAM) via env var so
+# we can reuse this suite for baseline runs. Example:
+#     SUFFIX_TEST_SPEC_ALGO=NONE pytest test/srt/test_suffix_speculative_decoding.py::TestSuffixDecodingBase::test_gsm8k -v -s
+SPEC_ALGO_FOR_TEST = os.environ.get("SUFFIX_TEST_SPEC_ALGO", "SUFFIX").upper()
+IS_SUFFIX_MODE = SPEC_ALGO_FOR_TEST == "SUFFIX"
+
+# Default server arguments shared across all tests.
+DEFAULT_SERVER_ARGS = [
+    "--trust-remote-code",
+    "--cuda-graph-max-bs",
+    "8",
+    "--mem-fraction-static",
+    "0.8",
+]
+
+if SPEC_ALGO_FOR_TEST != "NONE":
+    DEFAULT_SERVER_ARGS.extend(
+        [
+            "--speculative-algorithm",
+            SPEC_ALGO_FOR_TEST,
+            "--speculative-num-draft-tokens",
+            "16",
+        ]
+    )
+
+
+class TestSuffixDecodingBase(CustomTestCase):
+    """Base test class for suffix decoding functionality."""
+
+    model = DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST
+    base_url = DEFAULT_URL_FOR_TEST
+    accuracy_threshold = 0.79
+    spec_decode_threshold = 1.5  # Suffix decoding threshold (may vary from ngram)
+    is_suffix_mode = IS_SUFFIX_MODE
+
+    @classmethod
+    def get_server_args(cls):
+        """Return the arguments for the server launch. Override in subclasses."""
+        return DEFAULT_SERVER_ARGS + ["--attention-backend", "fa3"]
+
+    @classmethod
+    def setUpClass(cls):
+        # Disable deep gemm precompile to make launch server faster
+        envs.SGLANG_JIT_DEEPGEMM_PRECOMPILE.set(False)
+        envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
+        model = cls.model
+        cls.process = popen_launch_server(
+            model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=cls.get_server_args(),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        """Test suffix decoding with GSM8K few-shot evaluation."""
+        requests.get(self.base_url + "/flush_cache")
+
+        args = SimpleNamespace(
+            num_shots=4,
+            num_questions=100,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+            data_path=GSM_DATASET_PATH,
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"{metrics=}")
+
+        # Validate accuracy
+        metric_key = "accuracy"
+        self.assertGreater(metrics[metric_key], self.accuracy_threshold)
+
+        # Validate speculative decoding performance when running in suffix mode.
+        if self.is_suffix_mode:
+            server_info = requests.get(self.base_url + "/get_server_info")
+            avg_spec_accept_length = server_info.json()["internal_states"][0][
+                "avg_spec_accept_length"
+            ]
+            print(f"{avg_spec_accept_length=}")
+            self.assertGreater(avg_spec_accept_length, self.spec_decode_threshold)
+
+
+class TestSuffixDecodingTriton(TestSuffixDecodingBase):
+    """Test suffix decoding with Triton attention backend."""
+
+    @classmethod
+    def get_server_args(cls):
+        return DEFAULT_SERVER_ARGS + ["--attention-backend", "triton"]
+
+
+class TestSuffixDecodingFlashinfer(TestSuffixDecodingBase):
+    """Test suffix decoding with FlashInfer attention backend."""
+
+    @classmethod
+    def get_server_args(cls):
+        return DEFAULT_SERVER_ARGS + ["--attention-backend", "flashinfer"]
+
+
+class TestSuffixConfiguration(unittest.TestCase):
+    """Test configuration validation for suffix decoding."""
+
+    def test_missing_arctic_inference(self):
+        """Test error when arctic-inference is not installed."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=False
+        ):
+            with self.assertRaises(ImportError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                )
+
+            self.assertIn("Arctic Inference", str(context.exception))
+
+    def test_invalid_max_tree_depth(self):
+        """Test validation of max_tree_depth parameter."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            with self.assertRaises(ValueError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                    speculative_suffix_max_tree_depth=0,  # Invalid
+                )
+
+            self.assertIn("max_tree_depth", str(context.exception).lower())
+
+    def test_invalid_max_cached_requests(self):
+        """Test validation of max_cached_requests parameter."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            with self.assertRaises(ValueError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                    speculative_suffix_max_cached_requests=-2,  # Invalid (< -1 or 0)
+                )
+
+            self.assertIn("max_cached_requests", str(context.exception).lower())
+
+    def test_invalid_max_spec_factor(self):
+        """Test validation of max_spec_factor parameter."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            with self.assertRaises(ValueError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                    speculative_suffix_max_spec_factor=-0.5,  # Invalid
+                )
+
+            self.assertIn("max_spec_factor", str(context.exception).lower())
+
+    def test_invalid_min_token_prob(self):
+        """Test validation of min_token_prob parameter."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            with self.assertRaises(ValueError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                    speculative_suffix_min_token_prob=1.5,  # Invalid (>1.0)
+                )
+
+            self.assertIn("min_token_prob", str(context.exception).lower())
+
+    def test_valid_configuration(self):
+        """Test valid suffix decoding configuration."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            server_args = ServerArgs(
+                model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                speculative_algorithm="SUFFIX",
+                speculative_num_draft_tokens=24,
+                speculative_suffix_max_tree_depth=24,
+                speculative_suffix_max_cached_requests=10000,
+                speculative_suffix_max_spec_factor=1.0,
+                speculative_suffix_min_token_prob=0.1,
+            )
+
+            # Check defaults were set correctly
+            self.assertEqual(server_args.speculative_num_draft_tokens, 24)
+            self.assertEqual(server_args.speculative_suffix_max_tree_depth, 24)
+            self.assertEqual(server_args.speculative_suffix_max_cached_requests, 10000)
+            self.assertEqual(server_args.speculative_suffix_max_spec_factor, 1.0)
+            self.assertEqual(server_args.speculative_suffix_min_token_prob, 0.1)
+
+    def test_default_draft_tokens(self):
+        """Test that speculative_num_draft_tokens defaults to max_tree_depth."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            server_args = ServerArgs(
+                model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                speculative_algorithm="SUFFIX",
+                speculative_suffix_max_tree_depth=32,
+            )
+
+            # Should default to max_tree_depth
+            self.assertEqual(server_args.speculative_num_draft_tokens, 32)
+
+    def test_cuda_device_requirement(self):
+        """Test that suffix decoding requires CUDA device."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            with self.assertRaises(ValueError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                    device="cpu",  # Invalid - requires CUDA
+                )
+
+            self.assertIn("cuda", str(context.exception).lower())
+
+    def test_dp_attention_not_supported(self):
+        """Test that dp_attention is not supported with suffix decoding."""
+        with patch(
+            "sglang.srt.utils.common.is_arctic_inference_available", return_value=True
+        ):
+            with self.assertRaises(ValueError) as context:
+                server_args = ServerArgs(
+                    model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+                    speculative_algorithm="SUFFIX",
+                    tp_size=2,
+                    dp_size=2,
+                    enable_dp_attention=True,
+                )
+
+            self.assertIn("dp attention", str(context.exception).lower())
+
+
+class TestSuffixWorker(unittest.TestCase):
+    """Test SuffixWorker implementation."""
+
+    @patch("sglang.srt.utils.common.is_arctic_inference_available", return_value=True)
+    @patch("arctic_inference.suffix_decoding.SuffixDecodingCache")
+    def test_worker_initialization(self, mock_cache_class, mock_has_arctic):
+        """Test SuffixWorker initialization."""
+        # Set up the mock
+        mock_cache_instance = Mock()
+        mock_cache_class.return_value = mock_cache_instance
+
+        from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+        server_args = ServerArgs(
+            model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+            speculative_algorithm="SUFFIX",
+            speculative_num_draft_tokens=16,
+            page_size=1,
+        )
+
+        # Create mock target worker
+        mock_target_worker = Mock()
+        mock_target_worker.max_running_requests = 48
+        mock_target_worker.model_runner = Mock()
+
+        worker = SuffixWorker(
+            server_args=server_args,
+            gpu_id=0,
+            tp_rank=0,
+            dp_rank=None,
+            moe_ep_rank=0,
+            nccl_port=12345,
+            target_worker=mock_target_worker,
+        )
+
+        self.assertEqual(worker.draft_token_num, 16)
+        self.assertIsNotNone(worker.ngram_cache)
+        self.assertEqual(worker.ngram_cache.max_tree_depth, 24)
+        self.assertEqual(worker.ngram_cache.max_spec_factor, 1.0)
+        self.assertEqual(worker.ngram_cache.min_token_prob, 0.1)
+
+    @patch("sglang.srt.utils.common.is_arctic_inference_available", return_value=True)
+    @patch("arctic_inference.suffix_decoding.SuffixDecodingCache")
+    def test_worker_with_custom_parameters(self, mock_cache_class, mock_has_arctic):
+        """Test SuffixWorker initialization with custom parameters."""
+        # Set up the mock
+        mock_cache_instance = Mock()
+        mock_cache_class.return_value = mock_cache_instance
+
+        from sglang.srt.speculative.suffix_worker import SuffixWorker
+
+        server_args = ServerArgs(
+            model_path=DEFAULT_NGRAM_SPECULATIVE_TARGET_MODEL_FOR_TEST,
+            speculative_algorithm="SUFFIX",
+            speculative_num_draft_tokens=32,
+            speculative_suffix_max_tree_depth=48,
+            speculative_suffix_max_spec_factor=2.0,
+            speculative_suffix_min_token_prob=0.05,
+            page_size=1,
+        )
+
+        # Create mock target worker
+        mock_target_worker = Mock()
+        mock_target_worker.max_running_requests = 48
+        mock_target_worker.model_runner = Mock()
+
+        worker = SuffixWorker(
+            server_args=server_args,
+            gpu_id=0,
+            tp_rank=0,
+            dp_rank=None,
+            moe_ep_rank=0,
+            nccl_port=12345,
+            target_worker=mock_target_worker,
+        )
+
+        self.assertEqual(worker.draft_token_num, 32)
+        self.assertEqual(worker.ngram_cache.max_tree_depth, 48)
+        self.assertEqual(worker.ngram_cache.max_spec_factor, 2.0)
+        self.assertEqual(worker.ngram_cache.min_token_prob, 0.05)
+
+
+class TestSuffixVerifyInput(unittest.TestCase):
+    """Test SuffixVerifyInput data structure."""
+
+    def test_verify_input_creation(self):
+        """Test creating SuffixVerifyInput."""
+        import torch
+
+        from sglang.srt.speculative.suffix_info import SuffixVerifyInput
+
+        draft_token = torch.tensor([1, 2, 3, 4, 5], dtype=torch.int64)
+        tree_mask = torch.ones((25,), dtype=torch.bool)
+        positions = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int64)
+        retrive_index = torch.zeros((1, 5), dtype=torch.int64)
+        retrive_next_token = torch.zeros((1, 5), dtype=torch.int64)
+        retrive_next_sibling = torch.zeros((1, 5), dtype=torch.int64)
+        draft_token_num = 5
+
+        verify_input = SuffixVerifyInput(
+            draft_token=draft_token,
+            tree_mask=tree_mask,
+            positions=positions,
+            retrive_index=retrive_index,
+            retrive_next_token=retrive_next_token,
+            retrive_next_sibling=retrive_next_sibling,
+            draft_token_num=draft_token_num,
+        )
+
+        self.assertFalse(verify_input.is_draft_input())
+        self.assertTrue(verify_input.is_verify_input())
+        self.assertEqual(verify_input.draft_token_num, 5)
+        self.assertEqual(verify_input.get_spec_adjust_token_coefficient(), (5, 5))
+
+
+class TestSuffixAlgorithmRegistration(unittest.TestCase):
+    """Test that SUFFIX algorithm is properly registered."""
+
+    def test_algorithm_registered(self):
+        """Test that SUFFIX is registered in SpeculativeAlgorithm."""
+        from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        # Test from_string method
+        suffix_algo = SpeculativeAlgorithm.from_string("SUFFIX")
+        self.assertIsNotNone(suffix_algo)
+        self.assertEqual(suffix_algo.name, "SUFFIX")
+
+        # Test is_suffix method
+        self.assertTrue(suffix_algo.is_suffix())
+        self.assertFalse(suffix_algo.is_ngram())
+        self.assertFalse(suffix_algo.is_eagle())
+
+    def test_suffix_in_registry(self):
+        """Test that SUFFIX is in the algorithm registry."""
+        from sglang.srt.speculative.spec_info import list_registered_workers
+
+        workers = list_registered_workers()
+        self.assertIn("SUFFIX", workers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Description

## Motivation

Implements suffix decoding as requested in #13165. Suffix decoding is a training-free, speculative decoding with CPU-based drafting that improves throughput for structured or repetitive outputs. Unlike methods requiring separate GPU draft models, suffix decoding performs pattern matching entirely on CPU using the Arctic Inference library. It uses frequency-based token proposals and dual pattern matching to achieve better acceptance rates on tasks like code editing, agentic loops, and RL rollouts.

This implementation follows vLLM's approach of wrapping the Arctic Inference library and integrates seamlessly with SGLang's existing speculative decoding pipeline.

## Modifications

### Core Implementation (1,739 lines added)

**Speculative Worker & Cache:**
- `python/sglang/srt/speculative/suffix_worker.py` (106 lines): Main worker that coordinates suffix decoding
- `python/sglang/srt/speculative/suffix_cache_adapter.py` (343 lines): Adapter wrapping Arctic Inference's SuffixDecodingCache
- `python/sglang/srt/speculative/suffix_info.py` (462 lines): Data structures for suffix verification and draft inputs

**Integration:**
- `python/sglang/srt/server_args.py`: Added 5 configuration parameters for suffix decoding
- `python/sglang/srt/managers/scheduler.py`: Integrated suffix worker into scheduling pipeline
- `python/sglang/srt/model_executor/cuda_graph_runner.py`: Added CUDA graph support for suffix speculation
- `python/sglang/srt/speculative/spec_info.py`: Registered SUFFIX algorithm and exposed `is_suffix()` method
- `python/sglang/srt/utils/common.py`: Added Arctic Inference availability check

**Configuration Parameters:**
- `--speculative-algorithm SUFFIX`: Enable suffix decoding
- `--speculative-num-draft-tokens`: Maximum draft tokens (defaults to max_tree_depth)
- `--speculative-suffix-max-tree-depth`: Maximum speculation tree depth (default: 24)
- `--speculative-suffix-max-cached-requests`: LRU cache size for suffix trees (default: 10000)
- `--speculative-suffix-max-spec-factor`: Maximum speculation factor relative to input (default: 1.0)
- `--speculative-suffix-min-token-prob`: Minimum token probability threshold (default: 0.1)

**Documentation:**
- `docs/advanced_features/suffix_decoding.md` (259 lines): Comprehensive user guide with usage examples, parameter explanations, and best practices
- `docs/advanced_features/server_arguments.md`: Updated with suffix decoding parameters
- `docs/index.rst`: Added suffix decoding to documentation index

### Testing (416 lines)

**Unit Tests** (`test/srt/test_suffix_speculative_decoding.py`):
- Integration tests with FA3, FlashInfer, and Triton attention backends
- Configuration validation tests (13 test cases)
- Worker initialization tests with custom parameters
- Algorithm registration verification
- Added to `per-commit-1-gpu` test suite in `test/srt/run_suite.py`

**Test Coverage:**
- `TestSuffixDecodingBase`: GSM8K evaluation with FA3 backend
- `TestSuffixDecodingFlashinfer`: FlashInfer backend tests
- `TestSuffixDecodingTriton`: Triton backend tests
- `TestSuffixConfiguration`: Parameter validation (7 test cases)
- `TestSuffixWorker`: Worker initialization (2 test cases)
- `TestSuffixVerifyInput`: Data structure tests
- `TestSuffixAlgorithmRegistration`: Registry verification (2 test cases)

## Accuracy Tests

Ran GSM8K few-shot evaluation (4-shot, 100 questions) with `Qwen/Qwen2.5-Coder-7B-Instruct`:

- **Accuracy threshold**: >0.79 (same as n-gram baseline)
- **Speculative acceptance**: >1.5 avg tokens per speculation
- **All backends pass**: FA3, FlashInfer, Triton

All tests validate that suffix decoding maintains model output quality while improving throughput.

## Benchmarking and Profiling

### Configuration
- **Model**: `meta-llama/Llama-3.1-8B-Instruct` (bfloat16)
- **Hardware**: NVIDIA H200 (140GB VRAM)
- **Attention Backend**: FlashAttention-3 (fa3)
- **Datasets**: SpecBench (480 prompts), Blazedit (96 prompts)
- **Algorithms**: Suffix (w/ cache), Suffix (w/o cache), N-gram [5,5], N-gram [3,5], Vanilla (no spec)
- **Spec Lengths**: [5, 12, 32]
- **Concurrency Levels**: [1, 4, 16, 64]

### Results

#### Specbench

**Time per output token (ms)**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 5.35 | 5.68 | 9.45 | 10.77 |
| suffix (w/ cache) | 5 | 5.18 | 5.66 | 7.87 | 13.79 |
| suffix (w/ cache) | 12 | 4.72 | 5.30 | 7.59 | 13.53 |
| suffix (w/ cache) | 32 | 4.67 | 5.36 | 7.73 | 13.65 |
| suffix (w/o cache) | 5 | 5.45 | 6.22 | 8.72 | 15.23 |
| suffix (w/o cache) | 12 | 5.48 | 6.36 | 9.71 | 21.97 |
| suffix (w/o cache) | 32 | 5.62 | 6.92 | 15.27 | 41.39 |
| ngram [5, 5] | 5 | 6.93 | 7.68 | 10.58 | 18.60 |
| ngram [5, 5] | 12 | 6.79 | 7.91 | 12.43 | 28.11 |
| ngram [5, 5] | 32 | 7.24 | 9.32 | 20.54 | 55.44 |
| ngram [3, 5] | 5 | 6.61 | 7.42 | 10.17 | 18.01 |
| ngram [3, 5] | 12 | 6.64 | 7.65 | 12.13 | 27.22 |
| ngram [3, 5] | 32 | 6.82 | 8.58 | 19.35 | 52.95 |

**Total drafted tokens**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 0 | 0 | 0 | 0 |
| suffix (w/ cache) | 5 | 246133 | 236413 | 233391 | 229068 |
| suffix (w/ cache) | 12 | 229200 | 226058 | 226451 | 225428 |
| suffix (w/ cache) | 32 | 226066 | 226103 | 225750 | 224585 |
| suffix (w/o cache) | 5 | 259600 | 262565 | 262560 | 260990 |
| suffix (w/o cache) | 12 | 622560 | 622104 | 628572 | 633072 |
| suffix (w/o cache) | 32 | 1648640 | 1652736 | 1672544 | 1665216 |
| ngram [5, 5] | 5 | 291200 | 290398 | 290480 | 290563 |
| ngram [5, 5] | 12 | 693280 | 692996 | 691376 | 690564 |
| ngram [5, 5] | 32 | 1813760 | 1816917 | 1815168 | 1813504 |
| ngram [3, 5] | 5 | 276533 | 276745 | 277010 | 277738 |
| ngram [3, 5] | 12 | 659840 | 652620 | 654156 | 654656 |
| ngram [3, 5] | 32 | 1712640 | 1706784 | 1700394 | 1715658 |

**Total accepted tokens**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 61440 | 61313 | 61353 | 61439 |
| suffix (w/ cache) | 5 | 60953 | 60959 | 60872 | 60776 |
| suffix (w/ cache) | 12 | 60890 | 60797 | 60889 | 60901 |
| suffix (w/ cache) | 32 | 60916 | 60916 | 60885 | 60880 |
| suffix (w/o cache) | 5 | 60922 | 60818 | 60945 | 60673 |
| suffix (w/o cache) | 12 | 60930 | 60921 | 60746 | 60950 |
| suffix (w/o cache) | 32 | 60851 | 60884 | 60841 | 60680 |
| ngram [5, 5] | 5 | 60887 | 60864 | 60904 | 60815 |
| ngram [5, 5] | 12 | 60890 | 60822 | 60836 | 60779 |
| ngram [5, 5] | 32 | 60856 | 60900 | 60897 | 60945 |
| ngram [3, 5] | 5 | 60913 | 60828 | 60902 | 60915 |
| ngram [3, 5] | 12 | 60921 | 60884 | 60856 | 60655 |
| ngram [3, 5] | 32 | 60881 | 60919 | 60769 | 60892 |

**Acceptance Rate (%)**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | N/A | N/A | N/A | N/A |
| suffix (w/ cache) | 5 | 24.77 | 25.79 | 26.08 | 26.53 |
| suffix (w/ cache) | 12 | 26.57 | 26.89 | 26.89 | 27.02 |
| suffix (w/ cache) | 32 | 26.95 | 26.94 | 26.97 | 27.11 |
| suffix (w/o cache) | 5 | 23.47 | 23.16 | 23.21 | 23.25 |
| suffix (w/o cache) | 12 | 9.79 | 9.79 | 9.66 | 9.63 |
| suffix (w/o cache) | 32 | 3.69 | 3.68 | 3.64 | 3.64 |
| ngram [5, 5] | 5 | 20.91 | 20.96 | 20.97 | 20.93 |
| ngram [5, 5] | 12 | 8.78 | 8.78 | 8.80 | 8.80 |
| ngram [5, 5] | 32 | 3.36 | 3.35 | 3.36 | 3.36 |
| ngram [3, 5] | 5 | 22.04 | 21.99 | 21.99 | 21.95 |
| ngram [3, 5] | 12 | 9.24 | 9.33 | 9.31 | 9.27 |
| ngram [3, 5] | 32 | 3.56 | 3.57 | 3.58 | 3.55 |

**Throughput (tokens/s)**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 183.56 | 672.37 | 1588.76 | 4738.70 |
| suffix (w/ cache) | 5 | 190.75 | 693.92 | 1980.03 | 3352.24 |
| suffix (w/ cache) | 12 | 209.10 | 738.60 | 2047.61 | 3398.08 |
| suffix (w/ cache) | 32 | 211.01 | 731.51 | 2015.22 | 3379.42 |
| suffix (w/o cache) | 5 | 180.47 | 628.83 | 1786.79 | 3037.81 |
| suffix (w/o cache) | 12 | 179.86 | 617.43 | 1609.41 | 2117.15 |
| suffix (w/o cache) | 32 | 175.09 | 568.14 | 1030.43 | 1131.14 |
| ngram [5, 5] | 5 | 143.14 | 513.98 | 1486.29 | 2508.60 |
| ngram [5, 5] | 12 | 146.11 | 499.55 | 1264.40 | 1671.71 |
| ngram [5, 5] | 32 | 137.11 | 424.77 | 769.55 | 848.87 |
| ngram [3, 5] | 5 | 150.11 | 531.81 | 1547.84 | 2590.51 |
| ngram [3, 5] | 12 | 149.46 | 515.15 | 1298.27 | 1719.00 |
| ngram [3, 5] | 32 | 145.71 | 461.19 | 815.94 | 887.42 |

#### Blazedit

**Time per output token (ms)**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 5.44 | 6.06 | 11.04 | 17.52 |
| suffix (w/ cache) | 5 | 2.46 | 3.03 | 5.37 | 9.76 |
| suffix (w/ cache) | 12 | 2.07 | 2.65 | 4.96 | 9.94 |
| suffix (w/ cache) | 32 | 2.10 | 2.81 | 6.50 | 14.86 |
| suffix (w/o cache) | 5 | 2.77 | 3.45 | 6.00 | 10.85 |
| suffix (w/o cache) | 12 | 2.40 | 3.17 | 5.78 | 12.57 |
| suffix (w/o cache) | 32 | 2.53 | 3.39 | 8.13 | 18.85 |
| ngram [5, 5] | 5 | 4.79 | 5.54 | 8.63 | 15.28 |
| ngram [5, 5] | 12 | 4.41 | 5.53 | 9.53 | 20.41 |
| ngram [5, 5] | 32 | 4.73 | 6.47 | 14.54 | 36.84 |
| ngram [3, 5] | 5 | 4.46 | 5.24 | 8.22 | 14.37 |
| ngram [3, 5] | 12 | 4.05 | 4.97 | 8.70 | 18.96 |
| ngram [3, 5] | 32 | 4.02 | 5.79 | 13.06 | 33.92 |

**Total drafted tokens**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 0 | 0 | 0 | 0 |
| suffix (w/ cache) | 5 | 22533 | 21348 | 20616 | 20546 |
| suffix (w/ cache) | 12 | 45600 | 42780 | 40380 | 36496 |
| suffix (w/ cache) | 32 | 119040 | 112010 | 103701 | 101557 |
| suffix (w/o cache) | 5 | 25666 | 25355 | 25603 | 25756 |
| suffix (w/o cache) | 12 | 52800 | 53132 | 51940 | 54372 |
| suffix (w/o cache) | 32 | 143786 | 141397 | 140576 | 136544 |
| ngram [5, 5] | 5 | 39400 | 38861 | 39186 | 39740 |
| ngram [5, 5] | 12 | 86240 | 87844 | 88812 | 88480 |
| ngram [5, 5] | 32 | 233386 | 236149 | 231893 | 233674 |
| ngram [3, 5] | 5 | 36733 | 36245 | 36348 | 36135 |
| ngram [3, 5] | 12 | 78880 | 77764 | 77560 | 80168 |
| ngram [3, 5] | 32 | 198400 | 210293 | 202592 | 210592 |

**Total accepted tokens**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 12226 | 12161 | 12288 | 12288 |
| suffix (w/ cache) | 5 | 12176 | 12180 | 12142 | 12140 |
| suffix (w/ cache) | 12 | 12182 | 12176 | 12187 | 12156 |
| suffix (w/ cache) | 32 | 12178 | 12177 | 12182 | 12191 |
| suffix (w/o cache) | 5 | 12186 | 12191 | 12189 | 12185 |
| suffix (w/o cache) | 12 | 12186 | 12182 | 12104 | 12165 |
| suffix (w/o cache) | 32 | 12186 | 12174 | 12185 | 12190 |
| ngram [5, 5] | 5 | 12150 | 12179 | 12129 | 12172 |
| ngram [5, 5] | 12 | 12191 | 12180 | 12192 | 12172 |
| ngram [5, 5] | 32 | 12168 | 12188 | 12174 | 12171 |
| ngram [3, 5] | 5 | 12179 | 12180 | 12188 | 12159 |
| ngram [3, 5] | 12 | 12191 | 12166 | 12154 | 12164 |
| ngram [3, 5] | 32 | 12188 | 12182 | 12152 | 12173 |

**Acceptance Rate (%)**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | N/A | N/A | N/A | N/A |
| suffix (w/ cache) | 5 | 54.20 | 57.07 | 59.00 | 59.12 |
| suffix (w/ cache) | 12 | 26.75 | 28.51 | 30.19 | 33.33 |
| suffix (w/ cache) | 32 | 10.27 | 10.87 | 11.75 | 12.02 |
| suffix (w/o cache) | 5 | 47.53 | 48.10 | 47.62 | 47.31 |
| suffix (w/o cache) | 12 | 23.11 | 22.98 | 23.34 | 22.38 |
| suffix (w/o cache) | 32 | 8.49 | 8.62 | 8.67 | 8.94 |
| ngram [5, 5] | 5 | 33.06 | 33.56 | 33.06 | 32.87 |
| ngram [5, 5] | 12 | 15.91 | 15.46 | 15.17 | 15.43 |
| ngram [5, 5] | 32 | 5.78 | 5.71 | 5.84 | 5.88 |
| ngram [3, 5] | 5 | 35.45 | 36.51 | 36.17 | 36.75 |
| ngram [3, 5] | 12 | 17.51 | 17.85 | 17.95 | 17.33 |
| ngram [3, 5] | 32 | 7.21 | 6.59 | 6.83 | 6.67 |

**Throughput (tokens/s)**

| method | spec_len | concurrency 1 | concurrency 4 | concurrency 16 | concurrency 64 |
|--------|----------|---------------|---------------|----------------|----------------|
| vanilla (no spec) | 0 | 174.40 | 562.34 | 1140.78 | 1952.27 |
| suffix (w/ cache) | 5 | 385.06 | 1223.48 | 2777.40 | 4030.46 |
| suffix (w/ cache) | 12 | 450.75 | 1382.85 | 2937.09 | 3949.86 |
| suffix (w/ cache) | 32 | 447.72 | 1312.97 | 2227.46 | 2545.50 |
| suffix (w/o cache) | 5 | 341.86 | 1085.99 | 2436.71 | 3567.18 |
| suffix (w/o cache) | 12 | 393.42 | 1169.73 | 2567.16 | 3158.33 |
| suffix (w/o cache) | 32 | 373.75 | 1100.61 | 1804.21 | 2081.95 |
| ngram [5, 5] | 5 | 219.32 | 745.16 | 1833.05 | 2849.05 |
| ngram [5, 5] | 12 | 248.01 | 775.49 | 1721.76 | 2276.61 |
| ngram [5, 5] | 32 | 228.43 | 657.49 | 1143.05 | 1303.73 |
| ngram [3, 5] | 5 | 233.20 | 800.64 | 1968.49 | 3126.44 |
| ngram [3, 5] | 12 | 271.54 | 880.66 | 1936.32 | 2458.82 |
| ngram [3, 5] | 32 | 283.39 | 757.21 | 1314.45 | 1435.47 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)


## Additional Notes

**Dependencies:**
- Requires `arctic-inference==0.1.1` (Python package)
- **CUDA device required** for target model inference (drafting happens on CPU
