### PR TITLE
[NVIDIA] Enable trtllm fp4 moe for qwen

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1095,7 +1095,7 @@ class FlashInferFP4MoE(FusedMoE):
             symm_output = torch.empty(
                 num_tokens, hidden_size, dtype=torch.bfloat16, device=hs_fp4.device
             )
-        
+
         # Some dtype or value requirements for the flashinfer trtllm kernels.
         router_logits = (
             router_logits.to(torch.float32)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Inspired by https://github.com/sgl-project/sglang/pull/13489, this PR enables the NVFP4 FlashInfer TRT-LLM MoE backend. With this change, users can now set `--moe-runner-backend flashinfer_trtllm` when using NVFP4 checkpoints such as `nvidia/Qwen3-30B-A3B-NVFP4`.

In our tests, accuracy remains unchanged while performance improves by roughly 8% compared to the Cutlass FP4 MoE backend.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests


```
# Before (with cutlass fp4 moe):
+ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8 --port 30000            
100%|███████████████████████████████████████████████████████████████████████████| 1319/1319 [02:58<00:00,  7.39it/s] 
Accuracy: 0.907                                           
Invalid: 0.000                                            
Latency: 178.658 s                                        
Output throughput: 958.693 token/s

# After (with flashinfer trtllm fp4 moe):
+ python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 2000 --num-shots 8 --port 30000            
100%|███████████████████████████████████████████████████████████████████████████| 1319/1319 [02:42<00:00,  8.11it/s] 
Accuracy: 0.900                                           
Invalid: 0.000                                            
Latency: 162.700 s                                        
Output throughput: 1035.904 token/s
```

```
model_str=nvidia/Qwen3-30B-A3B-NVFP4

if [[ "$1" == "server0" ]]; then
python3 -m sglang.launch_server \
  --model-path $model_str \
  --trust-remote-code \
  --disable-radix-cache \
  --max-running-requests 256 \
  --chunked-prefill-size 1024 \
  --mem-fraction-static 0.89 \
  --max-prefill-tokens 16384 \
  --quantization modelopt_fp4
fi

if [[ "$1" == "server1" ]]; then
python3 -m sglang.launch_server \
  --model-path $model_str \
  --trust-remote-code \
  --disable-radix-cache \
  --max-running-requests 256 \
  --chunked-prefill-size 1024 \
  --mem-fraction-static 0.89 \
  --max-prefill-tokens 16384 \
  --quantization modelopt_fp4 \
  --moe-runner-backend flashinfer_trtllm

fi

if [[ "$1" == "bench" ]]; then
  curl -X POST "http://127.0.0.1:30000/flush_cache"
  cd /scratch/repo/sglang
  python3 benchmark/gsm8k/bench_sglang.py \
      --num-questions 2000 \
      --parallel 2000 \
      --num-shots 8 \
      --port 30000
fi
```

## Benchmarking and Profiling


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
