### PR TITLE
CI Failure Monitor Improvements

### DIFF
--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -1080,7 +1080,7 @@ class SGLangFailuresAnalyzer:
                 print("## ALERTS: Runners with Issues")
                 print("=" * 100)
                 print(
-                    "\nNothing to display (no runners with consecutive failure streak >= 2)"
+                    "\nNothing to display (no runners with consecutive failure streak > 2)"
                 )
 
         # Section 1: Currently Broken Jobs (streak >= 2)
@@ -1483,7 +1483,7 @@ class SGLangFailuresAnalyzer:
                     summary_lines.append("## ALERTS: Runners with Issues")
                     summary_lines.append("")
                     summary_lines.append(
-                        "Nothing to display (no runners with consecutive failure streak >= 2)"
+                        "Nothing to display (no runners with consecutive failure streak > 2)"
                     )
                     summary_lines.append("")
                     summary_lines.append("")

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -55,6 +55,8 @@ class SGLangFailuresAnalyzer:
             "check-changes",
             "pr-test-finish",  # Nvidia workflow teardown
             "pr-test-amd-finish",  # AMD workflow teardown
+            "call-gate",
+            "pr-gate",
         ]
 
     def get_recent_runs(self, limit: int = 500) -> List[Dict]:
@@ -639,6 +641,8 @@ class SGLangFailuresAnalyzer:
                         job_first_failure_in_streak[job_name] = {
                             **run_info,
                             "job_name": job_name,
+                            "job_id": job.get("id"),
+                            "job_url": job.get("html_url", run_info["url"]),
                             "conclusion": conclusion,
                         }
 
@@ -646,6 +650,8 @@ class SGLangFailuresAnalyzer:
                     job_last_failure_in_streak[job_name] = {
                         **run_info,
                         "job_name": job_name,
+                        "job_id": job.get("id"),
+                        "job_url": job.get("html_url", run_info["url"]),
                         "conclusion": conclusion,
                     }
 
@@ -1321,13 +1327,13 @@ class SGLangFailuresAnalyzer:
 
                         first_failure = alert.get("first_failure")
                         if first_failure:
-                            first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure['url']})"
+                            first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure.get('job_url', first_failure['url'])})"
                         else:
                             first_failure_str = "N/A"
 
                         last_failure = alert.get("last_failure")
                         if last_failure:
-                            last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure['url']})"
+                            last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure.get('job_url', last_failure['url'])})"
                         else:
                             last_failure_str = "N/A"
 
@@ -1472,13 +1478,13 @@ class SGLangFailuresAnalyzer:
                     # Get first and last failure info
                     first_failure = data.get("first_failure_in_streak")
                     if first_failure:
-                        first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure['url']})"
+                        first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure.get('job_url', first_failure['url'])})"
                     else:
                         first_failure_str = "N/A"
 
                     last_failure = data.get("last_failure_in_streak")
                     if last_failure:
-                        last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure['url']})"
+                        last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure.get('job_url', last_failure['url'])})"
                     else:
                         last_failure_str = "N/A"
 

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -908,13 +908,13 @@ class SGLangFailuresAnalyzer:
             filtered_job_alerts = [a for a in job_alerts if a["current_streak"] >= 2]
 
             if filtered_job_alerts:
-                print("\n" + "=" * 200)
+                print("\n" + "=" * 150)
                 print("## ALERTS: Critical Consecutive Job Failures")
-                print("=" * 200)
+                print("=" * 150)
                 print(
-                    f"\n{'Job Name':<40} {'Streak':<8} {'Max':<6} {'First Failure':<16} {'Last Failure':<16} {'Top Errors':<60} {'First Link':<50}"
+                    f"\n{'Job Name':<40} {'Streak':<8} {'Max':<6} {'First Failure':<16} {'Last Failure':<16} {'Top Errors':<60}"
                 )
-                print("-" * 200)
+                print("-" * 150)
 
                 for alert in sorted(
                     filtered_job_alerts, key=lambda x: x["current_streak"], reverse=True
@@ -930,29 +930,23 @@ class SGLangFailuresAnalyzer:
                         if first_failure
                         else "N/A"
                     )
-                    first_failure_link = first_failure["url"] if first_failure else ""
 
                     last_failure = alert.get("last_failure")
                     last_failure_str = (
                         f"Run #{last_failure['run_number']}" if last_failure else "N/A"
                     )
 
-                    # Format top errors
+                    # Format top errors - don't truncate
                     top_errors = alert.get("top_error_signatures", [])
                     if top_errors:
-                        error_str = ", ".join(
-                            [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
-                        )
-                        error_display = (
-                            error_str
-                            if len(error_str) <= 58
-                            else error_str[:55] + "..."
+                        error_display = ", ".join(
+                            [f"{err[0]} ({err[1]})" for err in top_errors]
                         )
                     else:
                         error_display = "N/A"
 
                     print(
-                        f"{display_name:<40} {alert['current_streak']:<8} {alert['max_streak']:<6} {first_failure_str:<16} {last_failure_str:<16} {error_display:<60} {first_failure_link:<50}"
+                        f"{display_name:<40} {alert['current_streak']:<8} {alert['max_streak']:<6} {first_failure_str:<16} {last_failure_str:<16} {error_display:<60}"
                     )
             else:
                 print("\n" + "=" * 100)
@@ -973,14 +967,14 @@ class SGLangFailuresAnalyzer:
             ]
 
             if instance_alerts:
-                print("\n" + "=" * 220)
+                print("\n" + "=" * 170)
                 print("## ALERTS: Runners with Issues")
-                print("=" * 220)
+                print("=" * 170)
                 print("\n### Runner Consecutive Failures")
                 print(
-                    f"\n{'Runner':<30} {'Str':<5} {'Max':<5} {'Fail%':<7} {'AvgQ':<7} {'First':<13} {'Last':<13} {'Top Errors':<45} {'Jobs Failed':<40} {'Link':<50}"
+                    f"\n{'Runner':<30} {'Str':<5} {'Max':<5} {'Fail%':<7} {'AvgQ':<7} {'First':<13} {'Last':<13} {'Top Errors':<45} {'Jobs Failed':<40}"
                 )
-                print("-" * 220)
+                print("-" * 170)
 
                 for alert in sorted(
                     instance_alerts,
@@ -995,18 +989,15 @@ class SGLangFailuresAnalyzer:
                         else runner_name[:25] + "..."
                     )
 
-                    # Get top 3 failed jobs
+                    # Get all failed jobs - don't truncate
                     jobs_failed = alert.get("jobs_failed", {})
                     top_jobs = sorted(
                         jobs_failed.items(), key=lambda x: x[1], reverse=True
-                    )[:3]
-                    jobs_str = (
+                    )
+                    jobs_display = (
                         ", ".join([f"{job} ({count})" for job, count in top_jobs])
                         if top_jobs
                         else "N/A"
-                    )
-                    jobs_display = (
-                        jobs_str if len(jobs_str) <= 38 else jobs_str[:35] + "..."
                     )
 
                     # Format queue time
@@ -1019,29 +1010,23 @@ class SGLangFailuresAnalyzer:
                         if first_failure
                         else "N/A"
                     )
-                    first_failure_link = first_failure["url"] if first_failure else ""
 
                     last_failure = alert.get("last_failure")
                     last_failure_str = (
                         f"Run #{last_failure['run_number']}" if last_failure else "N/A"
                     )
 
-                    # Format top errors
+                    # Format top errors - don't truncate
                     top_errors = alert.get("top_error_signatures", [])
                     if top_errors:
-                        error_str = ", ".join(
-                            [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
-                        )
-                        error_display = (
-                            error_str
-                            if len(error_str) <= 43
-                            else error_str[:40] + "..."
+                        error_display = ", ".join(
+                            [f"{err[0]} ({err[1]})" for err in top_errors]
                         )
                     else:
                         error_display = "N/A"
 
                     print(
-                        f"{display_name:<30} {alert['current_streak']:<5} {alert['max_streak']:<5} {alert['failure_rate']:>5.1f}% {avg_queue_str:<7} {first_failure_str:<13} {last_failure_str:<13} {error_display:<45} {jobs_display:<40} {first_failure_link:<50}"
+                        f"{display_name:<30} {alert['current_streak']:<5} {alert['max_streak']:<5} {alert['failure_rate']:>5.1f}% {avg_queue_str:<7} {first_failure_str:<13} {last_failure_str:<13} {error_display:<45} {jobs_display:<40}"
                     )
             else:
                 print("\n" + "=" * 100)
@@ -1057,13 +1042,13 @@ class SGLangFailuresAnalyzer:
         ]
 
         if broken_jobs:
-            print("\n" + "=" * 200)
+            print("\n" + "=" * 150)
             print("## Section 1: Top 15 Consecutively Failing Jobs")
-            print("=" * 200)
+            print("=" * 150)
             print(
-                f"\n{'Rank':<6} {'Job Name':<40} {'Streak':<8} {'Max':<6} {'First':<13} {'Last':<13} {'Top Errors':<50} {'First Link':<50}"
+                f"\n{'Rank':<6} {'Job Name':<40} {'Streak':<8} {'Max':<6} {'First':<13} {'Last':<13} {'Top Errors':<50}"
             )
-            print("-" * 200)
+            print("-" * 150)
             for i, (job_name, data) in enumerate(broken_jobs[:20], 1):
                 display_name = (
                     job_name if len(job_name) <= 38 else job_name[:35] + "..."
@@ -1074,27 +1059,23 @@ class SGLangFailuresAnalyzer:
                 first_failure_str = (
                     f"Run #{first_failure['run_number']}" if first_failure else "N/A"
                 )
-                first_failure_link = first_failure["url"] if first_failure else ""
 
                 last_failure = data.get("last_failure_in_streak")
                 last_failure_str = (
                     f"Run #{last_failure['run_number']}" if last_failure else "N/A"
                 )
 
-                # Format top errors
+                # Format top errors - don't truncate
                 top_errors = data.get("top_error_signatures", [])
                 if top_errors:
-                    error_str = ", ".join(
-                        [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
-                    )
-                    error_display = (
-                        error_str if len(error_str) <= 48 else error_str[:45] + "..."
+                    error_display = ", ".join(
+                        [f"{err[0]} ({err[1]})" for err in top_errors]
                     )
                 else:
                     error_display = "N/A"
 
                 print(
-                    f"{i:<6} {display_name:<40} {data['current_streak']:<8} {data['max_streak']:<6} {first_failure_str:<13} {last_failure_str:<13} {error_display:<50} {first_failure_link:<50}"
+                    f"{i:<6} {display_name:<40} {data['current_streak']:<8} {data['max_streak']:<6} {first_failure_str:<13} {last_failure_str:<13} {error_display:<50}"
                 )
 
         # Section 2: Runner Health Analysis - Use machine names from runner instances (streak >= 2)
@@ -1136,13 +1117,13 @@ class SGLangFailuresAnalyzer:
             ]
 
             if runners_with_issues:
-                print("\n" + "=" * 220)
+                print("\n" + "=" * 170)
                 print("## Section 2: Top 15 Workers by Consecutive Failures")
-                print("=" * 220)
+                print("=" * 170)
                 print(
-                    f"\n{'Rank':<6} {'Machine Name':<30} {'Str':<5} {'Max':<5} {'Fail%':<7} {'AvgQ':<7} {'First':<13} {'Last':<13} {'Top Errors':<45} {'Total':<7} {'Unique':<8} {'Link':<50}"
+                    f"\n{'Rank':<6} {'Machine Name':<30} {'Str':<5} {'Max':<5} {'Fail%':<7} {'AvgQ':<7} {'First':<13} {'Last':<13} {'Top Errors':<45} {'Total Jobs':<11} {'Unique Jobs':<12}"
                 )
-                print("-" * 220)
+                print("-" * 170)
 
                 for i, runner_data in enumerate(runners_with_issues[:15], 1):
                     # Truncate machine name if too long for display
@@ -1170,29 +1151,23 @@ class SGLangFailuresAnalyzer:
                         if first_failure
                         else "N/A"
                     )
-                    first_failure_link = first_failure["url"] if first_failure else ""
 
                     last_failure = runner_data.get("last_failure")
                     last_failure_str = (
                         f"Run #{last_failure['run_number']}" if last_failure else "N/A"
                     )
 
-                    # Format top errors
+                    # Format top errors - don't truncate
                     top_errors = runner_data.get("top_error_signatures", [])
                     if top_errors:
-                        error_str = ", ".join(
-                            [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
-                        )
-                        error_display = (
-                            error_str
-                            if len(error_str) <= 43
-                            else error_str[:40] + "..."
+                        error_display = ", ".join(
+                            [f"{err[0]} ({err[1]})" for err in top_errors]
                         )
                     else:
                         error_display = "N/A"
 
                     print(
-                        f"{i:<6} {display_name:<30} {streak_str:<5} {max_str:<5} {runner_data['failure_rate']:>5.1f}% {avg_queue_str:<7} {first_failure_str:<13} {last_failure_str:<13} {error_display:<45} {runner_data['total_jobs']:<7} {runner_data['unique_jobs']:<8} {first_failure_link:<50}"
+                        f"{i:<6} {display_name:<30} {streak_str:<5} {max_str:<5} {runner_data['failure_rate']:>5.1f}% {avg_queue_str:<7} {first_failure_str:<13} {last_failure_str:<13} {error_display:<45} {runner_data['total_jobs']:<11} {runner_data['unique_jobs']:<12}"
                     )
 
         # Build report data (always needed for GitHub summary)
@@ -1329,10 +1304,10 @@ class SGLangFailuresAnalyzer:
                     summary_lines.append("## ALERTS: Critical Consecutive Job Failures")
                     summary_lines.append("")
                     summary_lines.append(
-                        "| Job Name | Streak | Max | First Failure | Last Failure | Top Errors | First Link | Last Link |"
+                        "| Job Name | Streak | Max | First Failure | Last Failure | Top Errors |"
                     )
                     summary_lines.append(
-                        "|----------|--------|-----|---------------|--------------|------------|------------|-----------|"
+                        "|----------|--------|-----|---------------|--------------|------------|"
                     )
 
                     for alert in sorted(
@@ -1345,37 +1320,29 @@ class SGLangFailuresAnalyzer:
                             job_name = job_name[:32] + "..."
 
                         first_failure = alert.get("first_failure")
-                        first_failure_str = (
-                            f"Run #{first_failure['run_number']}"
-                            if first_failure
-                            else "N/A"
-                        )
-                        first_failure_link = (
-                            first_failure["url"] if first_failure else ""
-                        )
+                        if first_failure:
+                            first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure['url']})"
+                        else:
+                            first_failure_str = "N/A"
 
                         last_failure = alert.get("last_failure")
-                        last_failure_str = (
-                            f"Run #{last_failure['run_number']}"
-                            if last_failure
-                            else "N/A"
-                        )
-                        last_failure_link = last_failure["url"] if last_failure else ""
+                        if last_failure:
+                            last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure['url']})"
+                        else:
+                            last_failure_str = "N/A"
 
-                        # Format top errors
+                        # Format top errors - don't truncate
                         top_errors = alert.get("top_error_signatures", [])
                         if top_errors:
                             error_str = ", ".join(
-                                [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
+                                [f"{err[0]} ({err[1]})" for err in top_errors]
                             )
-                            if len(error_str) > 40:
-                                error_str = error_str[:37] + "..."
                         else:
                             error_str = "N/A"
 
                         summary_lines.append(
                             f"| `{job_name}` | {alert['current_streak']} | {alert['max_streak']} | "
-                            f"{first_failure_str} | {last_failure_str} | {error_str} | [View]({first_failure_link}) | [View]({last_failure_link}) |"
+                            f"{first_failure_str} | {last_failure_str} | {error_str} |"
                         )
 
                     summary_lines.append("")
@@ -1401,10 +1368,10 @@ class SGLangFailuresAnalyzer:
                     summary_lines.append("## ALERTS: Workers with Issues")
                     summary_lines.append("")
                     summary_lines.append(
-                        "| Runner | Streak | Max | Fail Rate | Avg Queue | First Failure | Last Failure | Top Errors | Jobs Failed | First Link | Last Link |"
+                        "| Runner | Streak | Max | Fail Rate | Avg Queue | First Failure | Last Failure | Top Errors | Jobs Failed |"
                     )
                     summary_lines.append(
-                        "|--------|--------|-----|-----------|-----------|---------------|--------------|------------|-------------|------------|-----------|"
+                        "|--------|--------|-----|-----------|-----------|---------------|--------------|------------|-------------|"
                     )
 
                     for alert in sorted(
@@ -1417,18 +1384,16 @@ class SGLangFailuresAnalyzer:
                         if len(runner_name) > 28:
                             runner_name = runner_name[:25] + "..."
 
-                        # Get top 3 failed jobs
+                        # Get all failed jobs - don't truncate
                         jobs_failed = alert.get("jobs_failed", {})
                         top_jobs = sorted(
                             jobs_failed.items(), key=lambda x: x[1], reverse=True
-                        )[:3]
+                        )
                         jobs_str = (
                             ", ".join([f"{job} ({count})" for job, count in top_jobs])
                             if top_jobs
                             else "N/A"
                         )
-                        if len(jobs_str) > 35:
-                            jobs_str = jobs_str[:32] + "..."
 
                         # Format queue time
                         avg_queue = alert.get("avg_queue_time_seconds", 0)
@@ -1437,38 +1402,30 @@ class SGLangFailuresAnalyzer:
                         )
 
                         first_failure = alert.get("first_failure")
-                        first_failure_str = (
-                            f"Run #{first_failure['run_number']}"
-                            if first_failure
-                            else "N/A"
-                        )
-                        first_failure_link = (
-                            first_failure["url"] if first_failure else ""
-                        )
+                        if first_failure:
+                            first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure['url']})"
+                        else:
+                            first_failure_str = "N/A"
 
                         last_failure = alert.get("last_failure")
-                        last_failure_str = (
-                            f"Run #{last_failure['run_number']}"
-                            if last_failure
-                            else "N/A"
-                        )
-                        last_failure_link = last_failure["url"] if last_failure else ""
+                        if last_failure:
+                            last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure['url']})"
+                        else:
+                            last_failure_str = "N/A"
 
-                        # Format top errors
+                        # Format top errors - don't truncate
                         top_errors = alert.get("top_error_signatures", [])
                         if top_errors:
                             error_str = ", ".join(
-                                [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
+                                [f"{err[0]} ({err[1]})" for err in top_errors]
                             )
-                            if len(error_str) > 35:
-                                error_str = error_str[:32] + "..."
                         else:
                             error_str = "N/A"
 
                         summary_lines.append(
                             f"| `{runner_name}` | {alert['current_streak']} | {alert['max_streak']} | "
                             f"{alert['failure_rate']:.1f}% | {avg_queue_str} | {first_failure_str} | {last_failure_str} | "
-                            f"{error_str} | {jobs_str} | [View]({first_failure_link}) | [View]({last_failure_link}) |"
+                            f"{error_str} | {jobs_str} |"
                         )
 
                     summary_lines.append("")
@@ -1500,10 +1457,10 @@ class SGLangFailuresAnalyzer:
                 summary_lines.append("## Section 1: Top 15 Consecutively Failing Jobs")
                 summary_lines.append("")
                 summary_lines.append(
-                    "| Rank | Job Name | Streak | Max | First Failure | Last Failure | Top Errors | First Link | Last Link |"
+                    "| Rank | Job Name | Streak | Max | First Failure | Last Failure | Top Errors |"
                 )
                 summary_lines.append(
-                    "|------|----------|--------|-----|---------------|--------------|------------|------------|-----------|"
+                    "|------|----------|--------|-----|---------------|--------------|------------|"
                 )
                 for i, (job_name, data) in enumerate(broken_jobs[:20], 1):
                     display_name = (
@@ -1512,33 +1469,29 @@ class SGLangFailuresAnalyzer:
 
                     # Get first and last failure info
                     first_failure = data.get("first_failure_in_streak")
-                    first_failure_str = (
-                        f"Run #{first_failure['run_number']}"
-                        if first_failure
-                        else "N/A"
-                    )
-                    first_failure_link = first_failure["url"] if first_failure else ""
+                    if first_failure:
+                        first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure['url']})"
+                    else:
+                        first_failure_str = "N/A"
 
                     last_failure = data.get("last_failure_in_streak")
-                    last_failure_str = (
-                        f"Run #{last_failure['run_number']}" if last_failure else "N/A"
-                    )
-                    last_failure_link = last_failure["url"] if last_failure else ""
+                    if last_failure:
+                        last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure['url']})"
+                    else:
+                        last_failure_str = "N/A"
 
-                    # Format top errors
+                    # Format top errors - don't truncate
                     top_errors = data.get("top_error_signatures", [])
                     if top_errors:
                         error_str = ", ".join(
-                            [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
+                            [f"{err[0]} ({err[1]})" for err in top_errors]
                         )
-                        if len(error_str) > 35:
-                            error_str = error_str[:32] + "..."
                     else:
                         error_str = "N/A"
 
                     summary_lines.append(
                         f"| {i} | `{display_name}` | {data['current_streak']} | {data['max_streak']} | "
-                        f"{first_failure_str} | {last_failure_str} | {error_str} | [View]({first_failure_link}) | [View]({last_failure_link}) |"
+                        f"{first_failure_str} | {last_failure_str} | {error_str} |"
                     )
 
                 summary_lines.append("")
@@ -1595,10 +1548,10 @@ class SGLangFailuresAnalyzer:
                     )
                     summary_lines.append("")
                     summary_lines.append(
-                        "| Rank | Machine Name | Streak | Max | Fail Rate | Avg Queue | First Failure | Last Failure | Top Errors | Total | Unique | First Link | Last Link |"
+                        "| Rank | Machine Name | Streak | Max | Fail Rate | Avg Queue | First Failure | Last Failure | Top Errors | Total Jobs | Unique Jobs |"
                     )
                     summary_lines.append(
-                        "|------|--------------|--------|-----|-----------|-----------|---------------|--------------|------------|-------|--------|------------|-----------|"
+                        "|------|--------------|--------|-----|-----------|-----------|---------------|--------------|------------|------------|-------------|"
                     )
 
                     for i, runner_data in enumerate(runners_with_issues[:15], 1):
@@ -1621,38 +1574,30 @@ class SGLangFailuresAnalyzer:
 
                         # Get first and last failure info
                         first_failure = runner_data.get("first_failure")
-                        first_failure_str = (
-                            f"Run #{first_failure['run_number']}"
-                            if first_failure
-                            else "N/A"
-                        )
-                        first_failure_link = (
-                            first_failure["url"] if first_failure else ""
-                        )
+                        if first_failure:
+                            first_failure_str = f"[Run #{first_failure['run_number']}]({first_failure['url']})"
+                        else:
+                            first_failure_str = "N/A"
 
                         last_failure = runner_data.get("last_failure")
-                        last_failure_str = (
-                            f"Run #{last_failure['run_number']}"
-                            if last_failure
-                            else "N/A"
-                        )
-                        last_failure_link = last_failure["url"] if last_failure else ""
+                        if last_failure:
+                            last_failure_str = f"[Run #{last_failure['run_number']}]({last_failure['url']})"
+                        else:
+                            last_failure_str = "N/A"
 
-                        # Format top errors
+                        # Format top errors - don't truncate
                         top_errors = runner_data.get("top_error_signatures", [])
                         if top_errors:
                             error_str = ", ".join(
-                                [f"{err[0]} ({err[1]})" for err in top_errors[:2]]
+                                [f"{err[0]} ({err[1]})" for err in top_errors]
                             )
-                            if len(error_str) > 30:
-                                error_str = error_str[:27] + "..."
                         else:
                             error_str = "N/A"
 
                         summary_lines.append(
                             f"| {i} | `{display_name}` | {streak_str} | {max_str} | {runner_data['failure_rate']:.1f}% | "
                             f"{avg_queue_str} | {first_failure_str} | {last_failure_str} | {error_str} | "
-                            f"{runner_data['total_jobs']} | {runner_data['unique_jobs']} | [View]({first_failure_link}) | [View]({last_failure_link}) |"
+                            f"{runner_data['total_jobs']} | {runner_data['unique_jobs']} |"
                         )
 
                     summary_lines.append("")

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -326,26 +326,19 @@ class SGLangFailuresAnalyzer:
             ):
                 if runner_had_failure[runner_key]:
                     runner_current_streak[runner_key] += 1
-
-                    # Track if this is the first failure in a new streak
-                    if runner_current_streak[runner_key] == 1:
-                        failure_info = {
-                            **run_info,
-                            "runner_key": runner_key,
-                        }
-                        # Include job URL if we have it
-                        if runner_key in runner_first_failed_job:
-                            failure_info.update(runner_first_failed_job[runner_key])
-                        runner_first_failure_in_streak[runner_key] = failure_info
-
-                    # Always update last failure to the most recent one
                     failure_info = {
                         **run_info,
                         "runner_key": runner_key,
                     }
+
                     # Include job URL if we have it
                     if runner_key in runner_first_failed_job:
                         failure_info.update(runner_first_failed_job[runner_key])
+
+                    # Track if this is the first failure in a new streak
+                    if runner_current_streak[runner_key] == 1:
+                        runner_first_failure_in_streak[runner_key] = failure_info
+                    # Always update last failure to the most recent one
                     runner_last_failure_in_streak[runner_key] = failure_info
 
                     # Update max streak
@@ -576,11 +569,11 @@ class SGLangFailuresAnalyzer:
             runner_instance_streak_data,
         )
 
-    def _extract_error_signature(self, job: Dict) -> Optional[str]:
+    def _extract_error_signature(self, job: Dict) -> str:
         """
         Extract error signature from a failed job.
 
-        Returns a simplified error type string, or None if unable to extract.
+        Returns a simplified error type string.
         """
         # Check if job has steps with failures
         steps = job.get("steps", [])

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -1042,14 +1042,14 @@ class SGLangFailuresAnalyzer:
         ]
 
         if broken_jobs:
-            print("\n" + "=" * 150)
+            print("\n" + "=" * 140)
             print("## Section 1: Top 15 Consecutively Failing Jobs")
-            print("=" * 150)
+            print("=" * 140)
             print(
-                f"\n{'Rank':<6} {'Job Name':<40} {'Streak':<8} {'Max':<6} {'First':<13} {'Last':<13} {'Top Errors':<50}"
+                f"\n{'Job Name':<40} {'Streak':<8} {'Max':<6} {'First':<13} {'Last':<13} {'Top Errors':<50}"
             )
-            print("-" * 150)
-            for i, (job_name, data) in enumerate(broken_jobs[:20], 1):
+            print("-" * 140)
+            for job_name, data in broken_jobs[:20]:
                 display_name = (
                     job_name if len(job_name) <= 38 else job_name[:35] + "..."
                 )
@@ -1075,7 +1075,7 @@ class SGLangFailuresAnalyzer:
                     error_display = "N/A"
 
                 print(
-                    f"{i:<6} {display_name:<40} {data['current_streak']:<8} {data['max_streak']:<6} {first_failure_str:<13} {last_failure_str:<13} {error_display:<50}"
+                    f"{display_name:<40} {data['current_streak']:<8} {data['max_streak']:<6} {first_failure_str:<13} {last_failure_str:<13} {error_display:<50}"
                 )
 
         # Section 2: Runner Health Analysis - Use machine names from runner instances (streak >= 2)
@@ -1117,15 +1117,15 @@ class SGLangFailuresAnalyzer:
             ]
 
             if runners_with_issues:
-                print("\n" + "=" * 170)
+                print("\n" + "=" * 160)
                 print("## Section 2: Top 15 Workers by Consecutive Failures")
-                print("=" * 170)
+                print("=" * 160)
                 print(
-                    f"\n{'Rank':<6} {'Machine Name':<30} {'Str':<5} {'Max':<5} {'Fail%':<7} {'AvgQ':<7} {'First':<13} {'Last':<13} {'Top Errors':<45} {'Total Jobs':<11} {'Unique Jobs':<12}"
+                    f"\n{'Machine Name':<30} {'Str':<5} {'Max':<5} {'Fail%':<7} {'AvgQ':<7} {'First':<13} {'Last':<13} {'Top Errors':<45} {'Total Jobs':<11} {'Unique Jobs':<12}"
                 )
-                print("-" * 170)
+                print("-" * 160)
 
-                for i, runner_data in enumerate(runners_with_issues[:15], 1):
+                for runner_data in runners_with_issues[:15]:
                     # Truncate machine name if too long for display
                     display_name = (
                         runner_data["runner_name"]
@@ -1167,7 +1167,7 @@ class SGLangFailuresAnalyzer:
                         error_display = "N/A"
 
                     print(
-                        f"{i:<6} {display_name:<30} {streak_str:<5} {max_str:<5} {runner_data['failure_rate']:>5.1f}% {avg_queue_str:<7} {first_failure_str:<13} {last_failure_str:<13} {error_display:<45} {runner_data['total_jobs']:<11} {runner_data['unique_jobs']:<12}"
+                        f"{display_name:<30} {streak_str:<5} {max_str:<5} {runner_data['failure_rate']:>5.1f}% {avg_queue_str:<7} {first_failure_str:<13} {last_failure_str:<13} {error_display:<45} {runner_data['total_jobs']:<11} {runner_data['unique_jobs']:<12}"
                     )
 
         # Build report data (always needed for GitHub summary)
@@ -1457,12 +1457,12 @@ class SGLangFailuresAnalyzer:
                 summary_lines.append("## Section 1: Top 15 Consecutively Failing Jobs")
                 summary_lines.append("")
                 summary_lines.append(
-                    "| Rank | Job Name | Streak | Max | First Failure | Last Failure | Top Errors |"
+                    "| Job Name | Streak | Max | First Failure | Last Failure | Top Errors |"
                 )
                 summary_lines.append(
-                    "|------|----------|--------|-----|---------------|--------------|------------|"
+                    "|----------|--------|-----|---------------|--------------|------------|"
                 )
-                for i, (job_name, data) in enumerate(broken_jobs[:20], 1):
+                for job_name, data in broken_jobs[:20]:
                     display_name = (
                         job_name if len(job_name) <= 35 else job_name[:32] + "..."
                     )
@@ -1480,17 +1480,17 @@ class SGLangFailuresAnalyzer:
                     else:
                         last_failure_str = "N/A"
 
-                    # Format top errors - don't truncate
+                    # Format top errors as bullet list
                     top_errors = data.get("top_error_signatures", [])
                     if top_errors:
-                        error_str = ", ".join(
-                            [f"{err[0]} ({err[1]})" for err in top_errors]
+                        error_str = "<br>".join(
+                            [f"• {err[0]} ({err[1]})" for err in top_errors]
                         )
                     else:
                         error_str = "N/A"
 
                     summary_lines.append(
-                        f"| {i} | `{display_name}` | {data['current_streak']} | {data['max_streak']} | "
+                        f"| `{display_name}` | {data['current_streak']} | {data['max_streak']} | "
                         f"{first_failure_str} | {last_failure_str} | {error_str} |"
                     )
 
@@ -1548,13 +1548,13 @@ class SGLangFailuresAnalyzer:
                     )
                     summary_lines.append("")
                     summary_lines.append(
-                        "| Rank | Machine Name | Streak | Max | Fail Rate | Avg Queue | First Failure | Last Failure | Top Errors | Total Jobs | Unique Jobs |"
+                        "| Machine Name | Streak | Max | Fail Rate | Avg Queue | First Failure | Last Failure | Top Errors | Total Jobs | Unique Jobs |"
                     )
                     summary_lines.append(
-                        "|------|--------------|--------|-----|-----------|-----------|---------------|--------------|------------|------------|-------------|"
+                        "|--------------|--------|-----|-----------|-----------|---------------|--------------|------------|------------|-------------|"
                     )
 
-                    for i, runner_data in enumerate(runners_with_issues[:15], 1):
+                    for runner_data in runners_with_issues[:15]:
                         display_name = (
                             runner_data["runner_name"]
                             if len(runner_data["runner_name"]) <= 28
@@ -1585,17 +1585,17 @@ class SGLangFailuresAnalyzer:
                         else:
                             last_failure_str = "N/A"
 
-                        # Format top errors - don't truncate
+                        # Format top errors as bullet list
                         top_errors = runner_data.get("top_error_signatures", [])
                         if top_errors:
-                            error_str = ", ".join(
-                                [f"{err[0]} ({err[1]})" for err in top_errors]
+                            error_str = "<br>".join(
+                                [f"• {err[0]} ({err[1]})" for err in top_errors]
                             )
                         else:
                             error_str = "N/A"
 
                         summary_lines.append(
-                            f"| {i} | `{display_name}` | {streak_str} | {max_str} | {runner_data['failure_rate']:.1f}% | "
+                            f"| `{display_name}` | {streak_str} | {max_str} | {runner_data['failure_rate']:.1f}% | "
                             f"{avg_queue_str} | {first_failure_str} | {last_failure_str} | {error_str} | "
                             f"{runner_data['total_jobs']} | {runner_data['unique_jobs']} |"
                         )

--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -1331,11 +1331,11 @@ class SGLangFailuresAnalyzer:
                         else:
                             last_failure_str = "N/A"
 
-                        # Format top errors - don't truncate
+                        # Format top errors as bullet list
                         top_errors = alert.get("top_error_signatures", [])
                         if top_errors:
-                            error_str = ", ".join(
-                                [f"{err[0]} ({err[1]})" for err in top_errors]
+                            error_str = "<br>".join(
+                                [f"• {err[0]} ({err[1]})" for err in top_errors]
                             )
                         else:
                             error_str = "N/A"
@@ -1384,13 +1384,15 @@ class SGLangFailuresAnalyzer:
                         if len(runner_name) > 28:
                             runner_name = runner_name[:25] + "..."
 
-                        # Get all failed jobs - don't truncate
+                        # Get all failed jobs as bullet list
                         jobs_failed = alert.get("jobs_failed", {})
                         top_jobs = sorted(
                             jobs_failed.items(), key=lambda x: x[1], reverse=True
                         )
                         jobs_str = (
-                            ", ".join([f"{job} ({count})" for job, count in top_jobs])
+                            "<br>".join(
+                                [f"• {job} ({count})" for job, count in top_jobs]
+                            )
                             if top_jobs
                             else "N/A"
                         )
@@ -1413,11 +1415,11 @@ class SGLangFailuresAnalyzer:
                         else:
                             last_failure_str = "N/A"
 
-                        # Format top errors - don't truncate
+                        # Format top errors as bullet list
                         top_errors = alert.get("top_error_signatures", [])
                         if top_errors:
-                            error_str = ", ".join(
-                                [f"{err[0]} ({err[1]})" for err in top_errors]
+                            error_str = "<br>".join(
+                                [f"• {err[0]} ({err[1]})" for err in top_errors]
                             )
                         else:
                             error_str = "N/A"


### PR DESCRIPTION
## Motivation

Currently, the ci-failure-monitor doesn't correctly display machine names. We also want more information on error codes and links to the failures to assist with more efficient triaging.

## Modifications

Added the following improvements:
- Runner alerts now show machine name instead of runner label.
- All rows now include first and last failures, hyperlinking to the specific job failure.
- All rows now also include a breakdown of error codes encountered in the failing jobs, with detailed failure parsing heuristics to surface common errors quickly.
- Removed display of workers and jobs with failure streaks of > 2.

## Accuracy Tests

N/A.

## Benchmarking and Profiling

N/A.

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [N/A] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [N/A ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
