### PR TITLE
[Router bugfix] Fix router_manager selecting the wrong router when enable-igw.

### DIFF
--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -269,6 +269,12 @@ impl RouterManager {
         let mut best_router = None;
         let mut best_score = 0.0;
 
+        let num_regular_workers = self.worker_registry.get_all()
+            .iter()
+            .filter(|w| matches!(w.worker_type(), WorkerType::Regular))
+            .count();
+        let num_pd_workers = self.worker_registry.get_all().iter().count() - num_regular_workers;
+
         for router in candidate_routers {
             let mut score = 1.0;
 
@@ -284,7 +290,8 @@ impl RouterManager {
             // - Average worker cost vs max_cost
             // - Current load and health status
 
-            if score > best_score {
+            let valid_router = (router.is_pd_mode() && num_pd_workers > 0) || (!router.is_pd_mode() && num_regular_workers > 0);
+            if score > best_score && valid_router {
                 best_score = score;
                 best_router = Some(router);
             }

--- a/sgl-router/src/routers/router_manager.rs
+++ b/sgl-router/src/routers/router_manager.rs
@@ -269,11 +269,13 @@ impl RouterManager {
         let mut best_router = None;
         let mut best_score = 0.0;
 
-        let num_regular_workers = self.worker_registry.get_all()
+        let num_regular_workers = self
+            .worker_registry
+            .get_all()
             .iter()
             .filter(|w| matches!(w.worker_type(), WorkerType::Regular))
             .count();
-        let num_pd_workers = self.worker_registry.get_all().iter().count() - num_regular_workers;
+        let num_pd_workers = self.worker_registry.get_all().len() - num_regular_workers;
 
         for router in candidate_routers {
             let mut score = 1.0;
@@ -290,7 +292,8 @@ impl RouterManager {
             // - Average worker cost vs max_cost
             // - Current load and health status
 
-            let valid_router = (router.is_pd_mode() && num_pd_workers > 0) || (!router.is_pd_mode() && num_regular_workers > 0);
+            let valid_router = (router.is_pd_mode() && num_pd_workers > 0)
+                || (!router.is_pd_mode() && num_regular_workers > 0);
             if score > best_score && valid_router {
                 best_score = score;
                 best_router = Some(router);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When multi-model gateway is enabled using --enable-igw and only pd workers are registered, the request can't be routed correctly. The reason is that both regular and pd routers are created in router_manager if enable-igw, and the router selection algorithm (shown below) doesn't check if the router with higher score really has workers.
<img width="1630" height="1402" alt="PixPin_2025-11-19_17-48-34" src="https://github.com/user-attachments/assets/65cbec1a-16e8-4440-b65b-97dbdf01ea99" />

## Reproduction
launch pd server
```
CUDA_VISIBLE_DEVICES=0 python3 -m sglang.launch_server --model-path /upfs/models/Qwen/Qwen3-8B --disaggregation-mode prefill --disaggregation-ib-device mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7 --tp-size 1 --dp-size 1 --host 127.0.0.1 --port 10250 --trust-remote-code --mem-fraction-static 0.4 --max-running-requests 512
CUDA_VISIBLE_DEVICES=1 python3 -m sglang.launch_server --model-path /upfs/models/Qwen/Qwen3-8B --disaggregation-mode decode --disaggregation-transfer-backend mooncake --tp-size 1 --dp-size 1 --host 127.0.0.1 --port 40250 --trust-remote-code --disaggregation-mode decode --mem-fraction-static 0.4 --max-running-requests 512
```
launch router and register worker
```
python3 -m sglang_router.launch_router --host 127.0.0.1 --port 30000 --policy cache_aware --enable-igw

curl -X POST http://localhost:30000/workers -H "Content-Type: application/json" -d '{
	"url": "http://127.0.0.1:10250",
	"worker_type":"prefill",
	"model_id": "qwen3-8b"
}'
curl -X POST http://localhost:30000/workers -H "Content-Type: application/json" -d '{
	"url": "http://127.0.0.1:40250",
	"worker_type":"decode",
	"model_id": "qwen3-8b"
}'
```
Finally, send a normal request without 'x-prefer-pd' in the request header.
```
curl http://127.0.0.1:30000/generate -H "Content-Type: application/json" -d '{
    "text": "Who are you",
    "sampling_params": {"temperature": 0, "max_new_tokens": 64}
}'
```

Then the bug can be reproduced.
<img width="2560" height="488" alt="PixPin_2025-11-19_18-02-11" src="https://github.com/user-attachments/assets/85f07434-9b02-47fe-81ed-eebae77c556b" />


## Modifications

Modify the router selection algorithm to check if preferred router has workers before select it.

## Accuracy Tests
Only pd workers are registered. The request without x-prefer-pd can route correctly.
<img width="2648" height="354" alt="PixPin_2025-11-19_17-21-12" src="https://github.com/user-attachments/assets/515de825-b91a-4849-9205-d3578c6aacce" />

PD and regular workers are both registered. The routing behaves correctly.
<img width="1594" height="930" alt="PixPin_2025-11-19_17-25-43" src="https://github.com/user-attachments/assets/b66de753-8ea3-4f8f-a0e8-437b6cdaf3a2" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
