### PR TITLE
support eplb async d2d

### DIFF
--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -285,6 +285,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--ep-dispatch-algorithm` | The algorithm to choose ranks for redundant experts in expert parallel. | `None` | Type: str |
 | `--init-expert-location` | Initial location of EP experts. | `trivial` | Type: str |
 | `--enable-eplb` | Enable EPLB algorithm | `False` | bool flag (set to enable) |
+| `--enable-eplb-async-d2d` | Enable expert asynchronous transfer when EPLB is active. | `False` | bool flag (set to enable) |
 | `--eplb-algorithm` | Chosen EPLB algorithm | `auto` | Type: str |
 | `--eplb-rebalance-num-iterations` | Number of iterations to automatically trigger a EPLB re-balance. | `1000` | Type: int |
 | `--eplb-rebalance-layers-per-chunk` | Number of layers to rebalance per forward pass. | `None` | Type: int |

--- a/python/sglang/srt/eplb/eplb_manager.py
+++ b/python/sglang/srt/eplb/eplb_manager.py
@@ -53,7 +53,9 @@ class EPLBManager:
     def rebalance(self):
         logger.info("[EPLBManager] rebalance start")
 
-        enable_timing = self._rebalance_layers_per_chunk is None and not self._enable_eplb_async_d2d
+        enable_timing = (
+            self._rebalance_layers_per_chunk is None and not self._enable_eplb_async_d2d
+        )
 
         if enable_timing:
             torch.get_device_module().synchronize()
@@ -79,7 +81,7 @@ class EPLBManager:
         for chunk_index, update_layer_ids in enumerate(update_layer_ids_chunks):
             if len(update_layer_ids_chunks) > 1:
                 yield
-            
+
             yield from self._model_runner.update_expert_location(
                 expert_location_metadata,
                 update_layer_ids=update_layer_ids,

--- a/python/sglang/srt/eplb/expert_location_updater.py
+++ b/python/sglang/srt/eplb/expert_location_updater.py
@@ -164,6 +164,7 @@ def _update_expert_weights_raw(
                 update_layer_ids=[layer_id],
             )
 
+
 def create_temp_buffers(sample_tensors):
     return [torch.empty_like(tensor) for tensor in sample_tensors]
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -891,7 +891,7 @@ class ModelRunner:
                 lambda name: "mlp.experts" in name and "mlp.shared_experts" not in name,
             )
         else:
-            self.expert_location_updater.update(
+            yield from self.expert_location_updater.update(
                 self.model.routed_experts_weights_of_layer,
                 new_expert_location_metadata,
                 update_layer_ids=update_layer_ids,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -432,6 +432,9 @@ class ServerArgs:
     mamba_ssm_dtype: str = "float32"
     mamba_full_memory_ratio: float = 0.9
 
+    # async eplb weight d2d transfer
+    enable_eplb_async_d2d: bool = False
+
     # Hierarchical cache
     enable_hierarchical_cache: bool = False
     hicache_ratio: float = 2.0
@@ -3007,6 +3010,11 @@ class ServerArgs:
             "--enable-eplb",
             action="store_true",
             help="Enable EPLB algorithm",
+        )
+        parser.add_argument(
+            "--enable-eplb-async-d2d",
+            action="store_true",
+            help="Enable EPLB async weight D2D transfer",
         )
         parser.add_argument(
             "--eplb-algorithm",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

We have added asynchronous support for eplb expert transfers, controlled by the parameter `--enable-eplb-async-d2d` to enable or disable it.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

When enabling expert asynchronous transfer, we avoid synchronous waiting by yielding control, allowing inference to proceed without blocking on weight transfers.

```python
if enable_eplb_async_d2d:
    yield
```

<!-- Detail the changes made in this pull request. -->

## Benchmarking and Profiling

Launch sglang server

```sh
python -m sglang.launch_server \
--model-path /data/weights/dsv3 \
--trust-remote-code \
--mem-fraction-static 0.8 \
--attention-backend ascend \
--device npu \
--quantization w8a8_int8 \
--disable-radix-cache \
--disable-cuda-graph \
--host 127.0.0.1 \
--port 8234 \
--tp-size 16 \
--moe-a2a-backend deepep --deepep-mode normal \
--served-model-name dsv3 \
--eplb-rebalance-num-iterations 100 \
--eplb-rebalance-layers-per-chunk 1 \
--enable-eplb \
--enable-eplb-async-d2d
```

benchmark

```sh
python3 -m sglang.bench_serving \
--dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
--dataset-name sharegpt \
--model /data/weights/dsv3 \
--backend sglang \
--host 127.0.0.1 \
--port 8234 \
--max-concurrency 32 \
--random-output-len 1500 \
--random-input-len 3500 \
--num-prompts 64
```

<img width="1238" height="580" alt="image" src="https://github.com/user-attachments/assets/0325a9f4-abde-4d0e-9698-2a1e456e7f86" />

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
