### PR TITLE
Integration with elasticmem

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1030,6 +1030,8 @@ def is_hybrid_model(
         and context_length > attention_chunk_size
     ):
         return hybrid_kvcache_ratio
+    elif hybrid_kvcache_ratio > 0 and model_architectures[0] == "GptOssForCausalLM":
+        return hybrid_kvcache_ratio
     else:
         return None
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -153,9 +153,7 @@ from sglang.srt.managers.session_controller import Session
 from sglang.srt.managers.utils import GenerationBatchResult, validate_input_length
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.common import release_kv_cache
-from sglang.srt.mem_cache.elastic.elasticmem_orchestrator import (
-    use_elasticmem,
-)
+from sglang.srt.mem_cache.elastic.elasticmem_orchestrator import use_elasticmem
 from sglang.srt.mem_cache.radix_cache import RadixCache
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin

--- a/python/sglang/srt/mem_cache/allocator.py
+++ b/python/sglang/srt/mem_cache/allocator.py
@@ -188,28 +188,31 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert isinstance(kvcache, SWAKVPool)
         self._size_full = size
         self._size_swa = size_swa
-        self.full_attn_allocator = TokenToKVPoolAllocator(
-            size,
-            dtype,
-            device,
-            kvcache.full_kv_pool,
-            need_sort,
-        )
-        self.swa_attn_allocator = TokenToKVPoolAllocator(
-            size_swa,
-            dtype,
-            device,
-            kvcache.swa_kv_pool,
-            need_sort,
-        )
-        self.full_to_swa_index_mapping = torch.empty(
-            size + size_swa + 1,
-            dtype=torch.int64,
-            device=device,
-        )
+        self._create_allocator()
         self.clear()
 
         self._kvcache.full_to_swa_index_mapping = self.full_to_swa_index_mapping
+
+    def _create_allocator(self):
+        self.full_attn_allocator = TokenToKVPoolAllocator(
+            self._size_full,
+            self.dtype,
+            self.device,
+            self._kvcache.full_kv_pool,
+            self.need_sort,
+        )
+        self.swa_attn_allocator = TokenToKVPoolAllocator(
+            self._size_swa,
+            self.dtype,
+            self.device,
+            self._kvcache.swa_kv_pool,
+            self.need_sort,
+        )
+        self.full_to_swa_index_mapping = torch.empty(
+            self._size_full + self._size_swa + 1,
+            dtype=torch.int64,
+            device=self.device,
+        )
 
     def available_size(self):
         raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/elastic/elastic_allocator.py
+++ b/python/sglang/srt/mem_cache/elastic/elastic_allocator.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+"""
+Copyright 2025 SGLang Team
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+from typing import TYPE_CHECKING, override
+
+import torch
+
+from sglang.srt.mem_cache.allocator import (
+    SWATokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.elastic.elasticmem_orchestrator import (
+    ElasticAllocator,
+    cu_page_size,
+)
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticTokenToKVPoolAllocator(TokenToKVPoolAllocator, ElasticAllocator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.need_sort = True
+        logger.debug(
+            f"ElasticTokenToKVPoolAllocator {self._kvcache.pool_name} initialized"
+        )
+
+    @override
+    def merge_and_sort_free(self):
+        if len(self.release_pages) > 0:
+            super().merge_and_sort_free()
+        else:
+            self.free_pages, _ = torch.sort(self.free_pages)
+
+    # TODO: a more efficient way
+    @override
+    def alloc(self, need_size: int):
+        self.merge_and_sort_free()
+        return super().alloc(need_size)
+
+    @override
+    def can_unmap(self) -> bool:
+        if self.token_usage() > 0.9:
+            return False
+
+        self.evict(self.evictable_size())
+        self.merge_and_sort_free()
+        cu_page_token = (cu_page_size // self._kvcache.state_memsize + 1) * 2
+        return (
+            len(self.free_pages) >= cu_page_token
+            and self.free_pages[-cu_page_token] == self.size - cu_page_token + 1
+        )
+
+    @override
+    def can_map(self) -> bool:
+        return self.token_usage() > 0.9
+
+    @override
+    def reduce(self) -> int:
+        self.merge_and_sort_free()
+        low, mid, high = 0, 0, len(self.free_pages)
+        tail_consecutive_size = -1
+        while low < high:
+            mid = (low + high) // 2
+            if self.free_pages[mid] == self.size - (len(self.free_pages) - mid) + 1:
+                tail_consecutive_size = len(self.free_pages) - mid
+                high = mid
+            elif self.free_pages[mid] < self.size - (len(self.free_pages) - mid) + 1:
+                low = mid + 1
+            else:
+                assert False
+
+        reduce_size = tail_consecutive_size // 2
+        reduce_size = reduce_size // self.page_size * self.page_size
+        if reduce_size <= 0:
+            return 0
+
+        new_size = self.size - reduce_size
+        self.free_pages = self.free_pages[:-reduce_size]
+        unmap_num, cur_size = self._kvcache.reduce(new_size)
+        logger.debug(f"{(unmap_num, cur_size)=}")
+        assert cur_size == self.free_pages[-1]
+        self.size = cur_size
+
+        return unmap_num
+
+    @override
+    def expand(self, expand_size: int) -> int:
+        if expand_size <= 0:
+            return 0
+
+        assert expand_size % self.page_size == 0
+
+        new_size = self.size + expand_size
+        map_num, cur_size = self._kvcache.expand(new_size)
+        logger.debug(f"{(map_num, cur_size)=}")
+
+        self.release_pages = torch.cat(
+            (
+                self.release_pages,
+                torch.tensor(
+                    range(self.size + 1, cur_size + 1),
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+            )
+        )
+
+        self.size = cur_size
+
+        return map_num
+
+    @override
+    def cu_page_to_token(self, cu_page_num: int) -> int:
+        return self._kvcache.cu_page_to_token(cu_page_num)
+
+    @override
+    def register_evict_func(self, func_evictable_size, func_evict) -> None:
+        self.func_evictable_size = func_evictable_size
+        self.func_evict = func_evict
+
+    @override
+    def token_usage(self) -> float:
+        num_used = self.size - (self.available_size() + self.evictable_size())
+        return num_used / self.size
+
+    @override
+    def evictable_size(self) -> int:
+        return self.func_evictable_size()
+
+    @override
+    def evict(self, evictable_size: int) -> None:
+        self.func_evict(evictable_size)
+
+    @override
+    def update_size(self):
+        # size is updated in enable()/disable()
+        assert self.size == self._kvcache.size
+
+
+class ElasticSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator, ElasticAllocator):
+    def __init__(self, *args, emem_orch, **kwargs):
+        self.emem_orch = emem_orch
+
+        super().__init__(*args, **kwargs)
+        logger.debug(f"ElasticSWATokenToKVPoolAllocator initialized")
+
+        self.emem_orch.register_allocator(self)
+        self.emem_orch.register_allocator(self.full_attn_allocator)
+        self.emem_orch.register_allocator(self.swa_attn_allocator)
+        logger.debug(f"ElasticSWATokenToKVPoolAllocator register_allocator")
+
+    def _create_allocator(self):
+        self.full_attn_allocator = ElasticTokenToKVPoolAllocator(
+            self._size_full,
+            self.dtype,
+            self.device,
+            self._kvcache.full_kv_pool,
+            self.need_sort,
+        )
+        self.swa_attn_allocator = ElasticTokenToKVPoolAllocator(
+            self._size_swa,
+            self.dtype,
+            self.device,
+            self._kvcache.swa_kv_pool,
+            self.need_sort,
+        )
+        # oversubscribe as full pool may expand
+        self.full_to_swa_index_mapping = torch.empty(
+            (self._size_full + self._size_swa + 1) * 3,
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+    @override
+    def register_scheduler(self, scheduler) -> None:
+        self.scheduler = scheduler
+        self.full_attn_allocator.register_evict_func(
+            func_evictable_size=self.scheduler.tree_cache.full_evictable_size,
+            func_evict=lambda evictable_size: self.scheduler.tree_cache.evict(
+                evictable_size, 0
+            ),
+        )
+        self.swa_attn_allocator.register_evict_func(
+            func_evictable_size=self.scheduler.tree_cache.swa_evictable_size,
+            func_evict=lambda evictable_size: self.scheduler.tree_cache.evict(
+                0, evictable_size
+            ),
+        )
+
+    @override
+    def can_unmap(self) -> bool:
+        return False
+
+    @override
+    def can_map(self) -> bool:
+        return False
+
+    @override
+    def reduce(self) -> int:
+        raise NotImplementedError()
+
+    @override
+    def expand(self, expand_size: int) -> int:
+        raise NotImplementedError()
+
+    @override
+    def cu_page_to_token(self, cu_page_num: int) -> int:
+        raise NotImplementedError()
+
+    @override
+    def register_evict_func(self, func_evictable_size, func_evict) -> None:
+        raise NotImplementedError()
+
+    @override
+    def token_usage(self) -> float:
+        return 1
+
+    @override
+    def evictable_size(self) -> int:
+        raise NotImplementedError()
+
+    @override
+    def evict(self, evictable_size: int) -> None:
+        raise NotImplementedError()
+
+    @override
+    def update_size(self):
+        self._kvcache.size = self.full_attn_allocator.size
+        self._kvcache.size_swa = self.swa_attn_allocator.size
+        self._size_swa = self.swa_attn_allocator.size
+        self._size_full = self.full_attn_allocator.size
+        self.scheduler.swa_tokens_per_layer = self._size_swa
+        self.scheduler.full_tokens_per_layer = self._size_full
+        logger.info(
+            "ElasticSWATokenToKVPoolAllocator update_size: "
+            f"{(self._size_swa, self._size_full)=}, "
+            f"{(self.scheduler.swa_tokens_per_layer, self.scheduler.full_tokens_per_layer)=}"
+        )

--- a/python/sglang/srt/mem_cache/elastic/elastic_allocator.py
+++ b/python/sglang/srt/mem_cache/elastic/elastic_allocator.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 import logging
+import time
 from typing import TYPE_CHECKING, override
 
 import torch
@@ -26,6 +27,8 @@ from sglang.srt.mem_cache.allocator import (
 )
 from sglang.srt.mem_cache.elastic.elasticmem_orchestrator import (
     ElasticAllocator,
+    can_map_threshold,
+    can_unmap_threshold,
     cu_page_size,
 )
 
@@ -35,75 +38,305 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+from torch.utils.cpp_extension import load_inline
+
+source_get_tail_consecutive_start = """
+int64_t get_tail_consecutive_start(at::Tensor unused_pages) {
+    int64_t n = unused_pages.numel();
+    if (n == 0) return 0;
+
+    auto acc = unused_pages.accessor<bool, 1>();
+    int64_t i;
+    for (i = n - 1; i >= 0 && acc[i]; i--);
+
+    return i + 1;
+}
+"""
+
+elasticmem_utils = load_inline(
+    name="elasticmem_utils",
+    cpp_sources=[source_get_tail_consecutive_start],
+    functions=["get_tail_consecutive_start"],
+)
+
+
 class ElasticTokenToKVPoolAllocator(TokenToKVPoolAllocator, ElasticAllocator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.need_sort = True
+        self.cu_page_token_num = cu_page_size // self._kvcache.state_memsize + 1
         logger.debug(
-            f"ElasticTokenToKVPoolAllocator {self._kvcache.pool_name} initialized"
+            f"ElasticTokenToKVPoolAllocator {self._kvcache.pool_name} initialized, "
+            f"{self.cu_page_token_num=}"
         )
 
     @override
-    def merge_and_sort_free(self):
-        if len(self.release_pages) > 0:
-            super().merge_and_sort_free()
-        else:
-            self.free_pages, _ = torch.sort(self.free_pages)
+    def clear(self):
+        super().clear()
+        self.unused_pages = torch.ones((self.size + 1,), dtype=torch.bool)
+        self.candidate_size = self.size
+        self.candidate_unmap_pages = torch.empty(
+            (0,), dtype=torch.int64, device=self.device
+        )
 
-    # TODO: a more efficient way
+    def available_size(self):
+        return (
+            len(self.free_pages)
+            + len(self.release_pages)
+            + len(self.candidate_unmap_pages)
+        )
+
+    def _check_unused_pages(self):
+        self_unused_pages = self.unused_pages[1:]
+        self_unused_pages = self_unused_pages[self_unused_pages == True]
+        assert (self.available_size() + self.evictable_size()) == len(
+            self_unused_pages
+        ), (
+            f"{len(self.free_pages)=}, {len(self.release_pages)=}, {len(self.candidate_unmap_pages)=}, "
+            f"{self.available_size()=} + {self.evictable_size()=} = {self.available_size() + self.evictable_size()}; "
+            f"{len(self_unused_pages)=}, {len(self.unused_pages)=}"
+        )
+
+    def _unmap_candidate_pre_alloc(self, need_size: int):
+        if self.candidate_size == self.size:
+            return
+
+        available_size = len(self.free_pages) + len(self.release_pages)
+        if need_size <= available_size:
+            return
+
+        self._evict_tail()
+        evict_size = min(self.evictable_size(), need_size)
+        self.evict(evict_size)
+
+        available_size = len(self.free_pages) + len(self.release_pages)
+        if need_size <= available_size:
+            return
+
+        extra_need_size = need_size - available_size
+        logger.debug(
+            f"{extra_need_size=} {available_size=} {self.evictable_size()=} {len(self.candidate_unmap_pages)=}"
+        )
+
+        if self.need_sort:
+            self.release_pages = torch.cat(
+                (
+                    self.release_pages,
+                    self.candidate_unmap_pages[:extra_need_size],
+                )
+            )
+        else:
+            self.free_pages = torch.cat(
+                (
+                    self.free_pages,
+                    self.candidate_unmap_pages[:extra_need_size],
+                )
+            )
+
+        self.candidate_unmap_pages = self.candidate_unmap_pages[extra_need_size:]
+
+        # DEBUG
+        self_candidate_unmap_pages = self.candidate_unmap_pages.tolist()
+        assert len(set(self_candidate_unmap_pages)) == len(self_candidate_unmap_pages)
+
     @override
     def alloc(self, need_size: int):
-        self.merge_and_sort_free()
-        return super().alloc(need_size)
+        self._check_unused_pages()
+        self._unmap_candidate_pre_alloc(need_size)
+        self._check_unused_pages()
+
+        select_index = super().alloc(need_size)
+        self.unused_pages[select_index.cpu()] = False
+
+        self._check_unused_pages()
+
+        return select_index
+
+    def _unmap_candidate_post_free(self, free_index: torch.Tensor):
+        if self.candidate_size == self.size:
+            return
+
+        if not (free_index > self.candidate_size).any():
+            return
+
+        if self.need_sort:
+            unmap_candidate_mask = self.release_pages > self.candidate_size
+            self.candidate_unmap_pages = torch.cat(
+                (self.candidate_unmap_pages, self.release_pages[unmap_candidate_mask])
+            )
+            self.release_pages = self.release_pages[~unmap_candidate_mask]
+        else:
+            unmap_candidate_mask = self.free_pages > self.candidate_size
+            self.candidate_unmap_pages = torch.cat(
+                (self.candidate_unmap_pages, self.free_pages[unmap_candidate_mask])
+            )
+            self.free_pages = self.free_pages[~unmap_candidate_mask]
+
+        # DEBUG
+        self_free_pages = self.free_pages.tolist()
+        self_candidate_unmap_pages = self.candidate_unmap_pages.tolist()
+        assert len(set(self_free_pages)) == len(self_free_pages)
+        assert len(set(self_candidate_unmap_pages)) == len(self_candidate_unmap_pages)
+        assert len(set(self_free_pages) & set(self_candidate_unmap_pages)) == 0
+
+    @override
+    def free(self, free_index: torch.Tensor):
+        super().free(free_index)
+
+        if not self.is_not_in_free_group:
+            return
+
+        # Free first, then delete_leaf updates evictable_size - may temporarily exceed len(self_unused_pages), skip self._check_unused_pages().
+        self.unused_pages[free_index.cpu()] = True
+
+        self._unmap_candidate_post_free(free_index)
+
+    def add_unused(self, indices: torch.Tensor):
+        self.unused_pages[indices.cpu()] = True
+        self._check_unused_pages()
+
+    def rm_unused(self, indices: torch.Tensor):
+        self.unused_pages[indices.cpu()] = False
+        self._check_unused_pages()
+
+    @override
+    def can_be_candidate(self) -> bool:
+        return True
+
+    def _evict_tail(self):
+        start_time = time.perf_counter()
+        assert all(self.free_pages <= self.candidate_size)
+        assert all(self.release_pages <= self.candidate_size)
+        evict_indices = self.unused_pages.nonzero(as_tuple=True)[0]
+        evict_indices = evict_indices[evict_indices > self.candidate_size]
+
+        if self.candidate_unmap_pages.numel() == evict_indices.numel():
+            return
+
+        if self.candidate_unmap_pages.numel() > 0:
+            evict_indices = evict_indices[
+                ~torch.isin(evict_indices, self.candidate_unmap_pages.cpu())
+            ]
+        logger.debug(
+            f"emem evict_tail prepare took {(time.perf_counter() - start_time) * 1000} ms"
+        )
+
+        while (self.evictable_size() >= len(evict_indices)) and (
+            len(evict_indices) > 0
+        ):
+            self.evict(len(evict_indices))
+            evict_indices = evict_indices[
+                ~torch.isin(evict_indices, self.candidate_unmap_pages.cpu())
+            ]
+
+        logger.info(
+            f"emem evict_tail took {(time.perf_counter() - start_time) * 1000} ms"
+        )
+
+    @override
+    def mark_unmap_candidate(self, is_candidate: bool) -> ElasticAllocator:
+        # is_candidate == False
+        if not is_candidate:
+            assert self.candidate_size <= self.size
+            if self.candidate_size < self.size:
+                self.candidate_size = self.size
+                if self.need_sort:
+                    self.release_pages = torch.cat(
+                        (self.release_pages, self.candidate_unmap_pages)
+                    )
+                else:
+                    self.free_pages = torch.cat(
+                        (self.free_pages, self.candidate_unmap_pages)
+                    )
+
+                self.candidate_unmap_pages = torch.empty(
+                    (0,), dtype=torch.int64, device=self.device
+                )
+            assert len(self.candidate_unmap_pages) == 0
+            logger.info(
+                f"mark_unmap_candidate: {self._kvcache.pool_name=}, {is_candidate=}, {self.size=}, {self.candidate_size=}"
+            )
+            return None
+
+        # is_candidate == True
+        assert (
+            self.candidate_size == self.size and len(self.candidate_unmap_pages) == 0
+        ), f"{self.candidate_size=}, {self.size=}, {len(self.candidate_unmap_pages)=}"
+        token_usage = self.token_usage()
+        new_size = int((token_usage + 1) / 2 * self.size)
+
+        if self.size - new_size < 2 * self.cu_page_token_num:
+            logger.info(
+                f"mark_unmap_candidate: {self._kvcache.pool_name=}, {is_candidate=}, {self.size=}, {self.candidate_size=}"
+            )
+            return None
+
+        self.candidate_size = new_size
+
+        unmap_candidate_mask = self.release_pages > self.candidate_size
+        self.candidate_unmap_pages = torch.cat(
+            (self.candidate_unmap_pages, self.release_pages[unmap_candidate_mask])
+        )
+        self.release_pages = self.release_pages[~unmap_candidate_mask]
+        unmap_candidate_mask = self.free_pages > self.candidate_size
+        self.candidate_unmap_pages = torch.cat(
+            (self.candidate_unmap_pages, self.free_pages[unmap_candidate_mask])
+        )
+        self.free_pages = self.free_pages[~unmap_candidate_mask]
+
+        logger.info(
+            f"mark_unmap_candidate: {self._kvcache.pool_name=}, {self.size=}, {self.candidate_size=}"
+        )
+        return self
 
     @override
     def can_unmap(self) -> bool:
-        if self.token_usage() > 0.9:
-            return False
+        return self.token_usage() < can_unmap_threshold
 
-        self.evict(self.evictable_size())
-        self.merge_and_sort_free()
-        cu_page_token = (cu_page_size // self._kvcache.state_memsize + 1) * 2
-        return (
-            len(self.free_pages) >= cu_page_token
-            and self.free_pages[-cu_page_token] == self.size - cu_page_token + 1
+    @override
+    def can_do_unmap(self) -> bool:
+        tail_consecutive_start = elasticmem_utils.get_tail_consecutive_start(
+            self.unused_pages
         )
+        return tail_consecutive_start <= self.candidate_size + 1
 
     @override
     def can_map(self) -> bool:
-        return self.token_usage() > 0.9
+        return self.token_usage() > can_map_threshold
 
     @override
     def reduce(self) -> int:
-        self.merge_and_sort_free()
-        low, mid, high = 0, 0, len(self.free_pages)
-        tail_consecutive_size = -1
-        while low < high:
-            mid = (low + high) // 2
-            if self.free_pages[mid] == self.size - (len(self.free_pages) - mid) + 1:
-                tail_consecutive_size = len(self.free_pages) - mid
-                high = mid
-            elif self.free_pages[mid] < self.size - (len(self.free_pages) - mid) + 1:
-                low = mid + 1
-            else:
-                assert False
+        start_time = time.perf_counter()
 
-        reduce_size = tail_consecutive_size // 2
-        reduce_size = reduce_size // self.page_size * self.page_size
-        if reduce_size <= 0:
-            return 0
+        self._evict_tail()
 
-        new_size = self.size - reduce_size
-        self.free_pages = self.free_pages[:-reduce_size]
-        unmap_num, cur_size = self._kvcache.reduce(new_size)
-        logger.debug(f"{(unmap_num, cur_size)=}")
-        assert cur_size == self.free_pages[-1]
+        # DEBUG
+        self_candidate_unmap_pages = self.candidate_unmap_pages.tolist()
+        assert len(set(self_candidate_unmap_pages)) == len(
+            self_candidate_unmap_pages
+        ), f"{(len(self.candidate_unmap_pages), min(self.candidate_unmap_pages), max(self.candidate_unmap_pages), self.size, self.candidate_size)=}"
+
+        assert (
+            len(self.candidate_unmap_pages) == self.size - self.candidate_size
+        ), f"{(len(self.candidate_unmap_pages), min(self.candidate_unmap_pages), max(self.candidate_unmap_pages), self.size, self.candidate_size)=}"
+
+        new_size = self.candidate_size
+        self.candidate_unmap_pages = torch.empty(
+            (0,), dtype=torch.int64, device=self.device
+        )
+        self.unused_pages = self.unused_pages[: new_size + 1]
+        unmap_num, cur_size = self._kvcache.reduce(self.candidate_size)
+        logger.debug(f"{(self.size, self.candidate_size, unmap_num, cur_size)=}")
         self.size = cur_size
 
+        logger.info(f"reduce took {(time.perf_counter() - start_time) * 1000} ms")
         return unmap_num
 
     @override
     def expand(self, expand_size: int) -> int:
+        start_time = time.perf_counter()
+
+        assert self.candidate_size == self.size and len(self.candidate_unmap_pages) == 0
+
         if expand_size <= 0:
             return 0
 
@@ -111,11 +344,11 @@ class ElasticTokenToKVPoolAllocator(TokenToKVPoolAllocator, ElasticAllocator):
 
         new_size = self.size + expand_size
         map_num, cur_size = self._kvcache.expand(new_size)
-        logger.debug(f"{(map_num, cur_size)=}")
+        logger.debug(f"{expand_size=}, {(map_num, cur_size)=}")
 
-        self.release_pages = torch.cat(
+        self.free_pages = torch.cat(
             (
-                self.release_pages,
+                self.free_pages,
                 torch.tensor(
                     range(self.size + 1, cur_size + 1),
                     dtype=torch.int64,
@@ -123,9 +356,17 @@ class ElasticTokenToKVPoolAllocator(TokenToKVPoolAllocator, ElasticAllocator):
                 ),
             )
         )
+        self.unused_pages = torch.cat(
+            (
+                self.unused_pages,
+                torch.ones((cur_size - self.size,), dtype=torch.bool),
+            )
+        )
 
         self.size = cur_size
+        self.candidate_size = self.size
 
+        logger.info(f"expand took {(time.perf_counter() - start_time) * 1000} ms")
         return map_num
 
     @override
@@ -184,11 +425,42 @@ class ElasticSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator, ElasticAllocat
             self.need_sort,
         )
         # oversubscribe as full pool may expand
+        total_tokens = (
+            self._size_full * self._kvcache.full_kv_pool.layer_num
+            + self._size_swa * self._kvcache.swa_kv_pool.layer_num
+        )
+        oversubscribe_tokens = (
+            max(
+                total_tokens // self._kvcache.full_kv_pool.layer_num,
+                total_tokens // self._kvcache.swa_kv_pool.layer_num,
+            )
+            * 2
+        )
         self.full_to_swa_index_mapping = torch.empty(
-            (self._size_full + self._size_swa + 1) * 3,
+            oversubscribe_tokens,
             dtype=torch.int64,
             device=self.device,
         )
+        logger.debug(
+            f"{(self.full_to_swa_index_mapping.numel() * self.full_to_swa_index_mapping.dtype.itemsize // (1<<20))=}"
+        )
+
+    def add_unused(self, indices: torch.Tensor):
+        self.full_attn_allocator.add_unused(indices)
+
+    def rm_unused(self, indices: torch.Tensor):
+        self.full_attn_allocator.rm_unused(indices)
+
+    def full_indices_to_swa_indices(self, full_index: torch.Tensor):
+        swa_indices = self.full_to_swa_index_mapping[full_index]
+        swa_indices = swa_indices[swa_indices > 0]
+        return swa_indices
+
+    def add_unused_swa(self, indices: torch.Tensor):
+        self.swa_attn_allocator.add_unused(self.full_indices_to_swa_indices(indices))
+
+    def rm_unused_swa(self, indices: torch.Tensor):
+        self.swa_attn_allocator.rm_unused(self.full_indices_to_swa_indices(indices))
 
     @override
     def register_scheduler(self, scheduler) -> None:
@@ -244,14 +516,25 @@ class ElasticSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator, ElasticAllocat
 
     @override
     def update_size(self):
-        self._kvcache.size = self.full_attn_allocator.size
-        self._kvcache.size_swa = self.swa_attn_allocator.size
+        self._kvcache.size == self.full_attn_allocator.size
+        self._kvcache.size_swa == self.swa_attn_allocator.size
         self._size_swa = self.swa_attn_allocator.size
+        assert all(
+            self.full_to_swa_index_mapping[
+                self._size_full + 1 : self.full_attn_allocator.size + 1
+            ]
+            == 0
+        )
         self._size_full = self.full_attn_allocator.size
         self.scheduler.swa_tokens_per_layer = self._size_swa
         self.scheduler.full_tokens_per_layer = self._size_full
+        self.full_to_swa_index_mapping[self._size_full + 1 :] = 0
         logger.info(
             "ElasticSWATokenToKVPoolAllocator update_size: "
             f"{(self._size_swa, self._size_full)=}, "
             f"{(self.scheduler.swa_tokens_per_layer, self.scheduler.full_tokens_per_layer)=}"
         )
+
+    @override
+    def defragmentation(self) -> bool:
+        raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/elastic/elastic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/elastic/elastic_memory_pool.py
@@ -1,0 +1,172 @@
+"""
+Copyright 2025 SGLang Team
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple, override
+
+import torch
+
+from sglang.srt.mem_cache.elastic.elasticmem_orchestrator import (
+    ElasticMempool,
+    cu_page_size,
+    use_elasticmem,
+)
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, SWAKVPool
+
+if use_elasticmem:
+    from kvcached.etensor import ETensor
+
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticMHATokenToKVPool(MHATokenToKVPool, ElasticMempool):
+    def __init__(
+        self,
+        *args,
+        pool_name: Optional[str] = None,
+        **kwargs,
+    ):
+        assert use_elasticmem
+        assert pool_name is not None
+        self.pool_name = pool_name
+        super().__init__(*args, **kwargs)
+        logger.info(f"{self.pool_name=} initialized")
+
+    def _create_buffers(self):
+        self.create_elastic_buffers()
+
+    def _size_to_esize(self, size: int):
+        return size + self.page_size
+
+    def _esize_to_size(self, esize: int):
+        return esize - self.page_size
+
+    @override
+    def create_elastic_buffers(self):
+        current_device_id = f"cuda:{torch.cuda.current_device()}"
+
+        free_memory, total_memory = torch.cuda.mem_get_info()
+
+        self.esize = self._size_to_esize(self.size)
+        page_size = self.page_size
+        state_shape = (self.head_num, self.head_dim)
+        dtype = self.store_dtype
+        self.ek_buffer = [
+            ETensor(
+                f"{self.pool_name}-k-{i}",
+                self.esize,
+                page_size,
+                state_shape,
+                dtype,
+                current_device_id,
+                free_memory,
+            )
+            for i in range(self.layer_num)
+        ]
+        self.ev_buffer = [
+            ETensor(
+                f"{self.pool_name}-v-{i}",
+                self.esize,
+                page_size,
+                state_shape,
+                dtype,
+                current_device_id,
+                free_memory,
+            )
+            for i in range(self.layer_num)
+        ]
+        self.k_buffer = [etensor.etensor for etensor in self.ek_buffer]
+        self.v_buffer = [etensor.etensor for etensor in self.ev_buffer]
+        self.state_memsize = self.ek_buffer[0].state_memsize
+        logger.debug(f"{self.esize=}, {self.k_buffer[0].shape=}, {self.state_memsize=}")
+
+    # TODO: exception handler, consistency in mempool size for each kv layer
+    @override
+    def reduce(self, new_size: int) -> Tuple[int, int]:
+        new_esize = self._size_to_esize(new_size)
+        total_unmap_num = 0
+        for ek, ev in zip(self.ek_buffer, self.ev_buffer):
+            unmap_num, self.esize = ek.reduce(new_esize)
+            total_unmap_num += unmap_num
+            unmap_num, self.esize = ev.reduce(new_esize)
+            total_unmap_num += unmap_num
+        self.size = self._esize_to_size(self.esize)
+        return total_unmap_num, self.size
+
+    @override
+    def expand(self, new_size: int) -> Tuple[int, int]:
+        new_esize = self._size_to_esize(new_size)
+        total_map_num = 0
+        for ek, ev in zip(self.ek_buffer, self.ev_buffer):
+            map_num, self.esize = ek.expand(new_esize)
+            total_map_num += map_num
+            map_num, self.esize = ev.expand(new_esize)
+            total_map_num += map_num
+        self.size = self._esize_to_size(self.esize)
+        return total_map_num, self.size
+
+    @override
+    def cu_page_to_token(self, cu_page_num: int) -> int:
+        cu_page_num_per_kv_layer = cu_page_num // (2 * self.layer_num)
+        cu_mem_per_kv_layer = cu_page_num_per_kv_layer * cu_page_size
+        token_num = cu_mem_per_kv_layer // self.state_memsize
+        token_num = token_num // self.page_size * self.page_size
+        return token_num
+
+
+class ElasticSWAKVPool(SWAKVPool):
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        logger.info(f"ElasticSWAKVPool initialized")
+
+    def _create_buffers(self, token_to_kv_pool_class, **kwargs):
+        self.create_elastic_buffers(token_to_kv_pool_class, **kwargs)
+
+    @override
+    def create_elastic_buffers(self, token_to_kv_pool_class, **kwargs):
+        token_to_kv_pool_class = ElasticMHATokenToKVPool
+        self.swa_kv_pool = token_to_kv_pool_class(
+            size=self.size_swa,
+            dtype=self.dtype,
+            layer_num=self.swa_layer_nums,
+            pool_name="swa",
+            **kwargs,
+        )
+        self.full_kv_pool = token_to_kv_pool_class(
+            size=self.size,
+            dtype=self.dtype,
+            layer_num=self.full_layer_nums,
+            pool_name="full",
+            **kwargs,
+        )
+
+    @override
+    def reduce(self, new_size: int) -> Tuple[int, int]:
+        raise NotImplementedError()
+
+    @override
+    def expand(self, new_size: int) -> Tuple[int, int]:
+        raise NotImplementedError()
+
+    @override
+    def cu_page_to_token(self, cu_page_num: int) -> int:
+        raise NotImplementedError()

--- a/python/sglang/srt/mem_cache/elastic/elasticmem_orchestrator.py
+++ b/python/sglang/srt/mem_cache/elastic/elasticmem_orchestrator.py
@@ -1,0 +1,233 @@
+"""
+Copyright 2025 SGLang Team
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import atexit
+import logging
+import signal
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+import torch
+
+from sglang.srt.utils import get_bool_env_var, get_int_env_var
+
+logger = logging.getLogger(__name__)
+
+use_elasticmem = get_bool_env_var("SGLANG_ELASTIC_MEM_POOL", "false")
+# page size of device memory, default 2MB
+cu_page_size = get_int_env_var("SGLANG_CU_PAGE_SIZE", 2 << 20)
+
+if use_elasticmem:
+    import kvcached.vmm_ops as vmm_ops
+
+
+class ElasticMempool(ABC):
+    @abstractmethod
+    def create_elastic_buffers(self):
+        pass
+
+    @abstractmethod
+    def reduce(self, new_size: int) -> Tuple[int, int]:
+        """Reduce the memory pool to a new size.
+
+        Args:
+            new_size: Target size for the memory pool.
+
+        Returns:
+            A tuple containing (released_cu_pages, mempool_size_after_reduce).
+        """
+        pass
+
+    @abstractmethod
+    def expand(self, new_size: int) -> Tuple[int, int]:
+        """Expand the memory pool to a new size.
+
+        Args:
+            new_size: Target size for the memory pool.
+
+        Returns:
+            A tuple containing (allocated_cu_pages, mempool_size_after_expand).
+        """
+        pass
+
+    @abstractmethod
+    def cu_page_to_token(self, cu_page_num: int) -> int:
+        # The approximate number of tokens that can be expanded by mapping cu_page_num cu_pages.
+        pass
+
+
+class ElasticAllocator(ABC):
+    def register_scheduler(self, scheduler) -> None:
+        self.scheduler = scheduler
+
+    def register_emem_orch(self, emem_orch):
+        self.emem_orch = emem_orch
+
+    @abstractmethod
+    def can_unmap(self) -> bool:
+        pass
+
+    @abstractmethod
+    def can_map(self) -> bool:
+        pass
+
+    @abstractmethod
+    def reduce(self) -> int:
+        """Reduce the allocated memory.
+
+        Returns:
+            Number of cu_page unmapped.
+        """
+        pass
+
+    @abstractmethod
+    def expand(self, expand_size: int) -> int:
+        """Expand the allocated memory.
+
+        Args:
+            need_size: Required additional size.
+
+        Returns:
+            Number of cu_page mapped.
+        """
+        pass
+
+    @abstractmethod
+    def cu_page_to_token(self, cu_page_num: int) -> int:
+        # The approximate number of tokens that can be expanded by mapping cu_page_num cu_pages.
+        pass
+
+    @abstractmethod
+    def register_evict_func(self, func_evictable_size, func_evict) -> None:
+        pass
+
+    @abstractmethod
+    def token_usage(self) -> float:
+        pass
+
+    @abstractmethod
+    def evictable_size(self) -> int:
+        pass
+
+    @abstractmethod
+    def evict(self, evictable_size: int) -> None:
+        pass
+
+    @abstractmethod
+    def update_size(self) -> None:
+        """Update the internal size tracking."""
+        pass
+
+    def free_all(self) -> None:
+        self.evict(self.evictable_size())
+
+
+class ElasticMempoolOrchestrator:
+    """Orchestrator for managing elastic memory pools.
+    Coordinates between different allocators to dynamically resize memory pools
+    based on demand.
+    """
+
+    def __init__(self):
+        assert use_elasticmem
+        atexit.register(vmm_ops.shutdown_emem)
+        signal.signal(signal.SIGINT, lambda sig, frame: vmm_ops.shutdown_emem())
+        signal.signal(signal.SIGTERM, lambda sig, frame: vmm_ops.shutdown_emem())
+        signal.signal(signal.SIGQUIT, lambda sig, frame: vmm_ops.shutdown_emem())
+
+        current_device_id = f"cuda:{torch.cuda.current_device()}"
+        vmm_ops.init_emem(current_device_id, cu_page_size)
+
+        self.allocators = []
+        self.free_all = False
+        self.free_all_allocator = None
+
+        self.remaining_page = 0
+
+    def register_allocator(self, allocator: ElasticAllocator):
+        allocator.register_emem_orch(self)
+        self.allocators.append(allocator)
+
+    def try_resize(self) -> None:
+        map_candidate = None
+        unmap_candidate = None
+        for allocator in self.allocators:
+            if allocator.can_map() and (
+                (map_candidate is None)
+                or (allocator.token_usage() > map_candidate.token_usage())
+            ):
+                map_candidate = allocator
+
+        if map_candidate is None:
+            if self.free_all and self.free_all_allocator.token_usage() < 0.1:
+                self.free_all_allocator.free_all()
+                self.free_all = False
+                self.free_all_allocator = None
+            return
+
+        min_token_usage = 1
+        min_token_usage_allocator = None
+        for allocator in self.allocators:
+            if allocator.token_usage() < min_token_usage:
+                min_token_usage = allocator.token_usage()
+                min_token_usage_allocator = allocator
+
+            if allocator.can_unmap() and (
+                (unmap_candidate is None)
+                or (allocator.token_usage() < unmap_candidate.token_usage())
+            ):
+                unmap_candidate = allocator
+
+        if unmap_candidate is None and min_token_usage < 0.9:
+            self.free_all = True
+            self.free_all_allocator = min_token_usage_allocator
+
+        if (
+            map_candidate is not None
+            and unmap_candidate is not None
+            and map_candidate != unmap_candidate
+        ):
+            logger.info(
+                "ElasticMempoolOrchestrator try_resize "
+                f"{map_candidate.token_usage()=}, "
+                f"{unmap_candidate.token_usage()=}"
+            )
+            self.do_resize(map_candidate, unmap_candidate)
+
+    def do_resize(
+        self, map_allocator: ElasticAllocator, unmap_allocator: ElasticAllocator
+    ) -> None:
+        torch.cuda.synchronize()
+        logger.info("ElasticMempoolOrchestrator do_resize")
+        unmap_page = 0
+        unmap_allocator.evict(unmap_allocator.evictable_size())
+        unmap_page = unmap_allocator.reduce()
+        logger.info(
+            f"{unmap_allocator._kvcache.pool_name} unmap {unmap_page}, remain {self.remaining_page} cu_page"
+        )
+
+        # The approximate number of tokens that can be expanded by mapping cu_page_num cu_pages.
+        to_map_page = unmap_page + self.remaining_page
+        map_token = map_allocator.cu_page_to_token(to_map_page)
+        map_page = 0
+        if map_token > 0:
+            map_page = map_allocator.expand(map_token)
+        self.remaining_page = to_map_page - map_page
+        logger.info(
+            f"{map_allocator._kvcache.pool_name} map {map_page}, remain {self.remaining_page} cu_page"
+        )
+
+        for _allocator in self.allocators:
+            _allocator.update_size()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2022,6 +2022,7 @@ class ModelRunner:
                         if use_elasticmem:
                             swa_allocator_class = ElasticSWATokenToKVPoolAllocator
                             swa_kwargs["emem_orch"] = self.emem_orch
+                            swa_kwargs["sliding_window_size"] = self.sliding_window_size
                         self.token_to_kv_pool_allocator = swa_allocator_class(
                             self.full_max_total_num_tokens,
                             self.swa_max_total_num_tokens,

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -18,6 +18,7 @@ import numpy as np
 import torch
 
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_cuda
 
@@ -34,6 +35,7 @@ def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
         _is_cuda
         and hasattr(forward_batch.token_to_kv_pool, "dtype")
         and forward_batch.token_to_kv_pool.dtype == torch.bfloat16
+        and not isinstance(forward_batch.token_to_kv_pool, SWAKVPool)
     )
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -679,6 +679,9 @@ class ServerArgs:
         # Handle elastic expert parallelism.
         self._handle_elastic_ep()
 
+        # Handle elastic memory.
+        self._handle_emem()
+
     def _handle_deprecated_args(self):
         # handle deprecated tool call parsers
         deprecated_tool_call_parsers = {"qwen25": "qwen", "glm45": "glm"}
@@ -2040,6 +2043,14 @@ class ServerArgs:
             )
             self.disable_cuda_graph = True
             self.skip_server_warmup = True
+
+    def _handle_emem(self):
+        if self.enable_memory_saver:
+            if get_bool_env_var("SGLANG_ELASTIC_MEM_POOL", "false"):
+                logger.warning(
+                    "Currently, elasticmem is not compatible with memory_saver"
+                )
+                os.environ["SGLANG_ELASTIC_MEM_POOL"] = "false"
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):

--- a/scripts/emem/dev.sh
+++ b/scripts/emem/dev.sh
@@ -1,0 +1,163 @@
+####################################################################################################
+# A10 dev
+
+sudo docker run -d -it \
+    --ulimit memlock=-1  --ulimit stack=67108864  --ulimit core=-1 \
+    --ipc=host --network=host --privileged \
+    --shm-size=64g --gpus all \
+    -v /mnt/vdb1:/data-mnt \
+    --name sglang-elasticmem \
+    mirrors-ssl.aliyuncs.com/lmsysorg/sglang:v0.5.5.post1 bash
+
+# sglang
+pip install vllm==0.11.0
+
+# elasticmem
+git clone https://github.com/sglang-bot/elasticmem && cd elasticmem
+pip install -e . --no-build-isolation
+python3 test/test_elastic.py
+
+##############################
+# tiny-random-llama-4-8E
+##############################
+# diff --git a/config.json b/config.json
+# index ce581b5..42d45c9 100644
+# --- a/config.json
+# +++ b/config.json
+# @@ -52,13 +52,13 @@
+#      "rope_theta": 500000.0,
+#      "router_aux_loss_coef": 0.001,
+#      "router_jitter_noise": 0.0,
+# -    "torch_dtype": "float32",
+# +    "torch_dtype": "bfloat16",
+#      "use_cache": true,
+#      "use_qk_norm": true,
+#      "vocab_size": 202048
+#    },
+#    "tie_word_embeddings": false,
+# -  "torch_dtype": "float32",
+# +  "torch_dtype": "bfloat16",
+#    "transformers_version": "4.51.3",
+#    "vision_config": {
+#      "_attn_implementation_autoset": true,
+
+for _ in {1..2}; do
+  ps aux | grep "sglang.launch_server" | grep -v grep | awk '{print $2}' | xargs kill -9
+  ps aux | grep "sglang::" | grep -v grep | awk '{print $2}' | xargs kill -9
+  sleep 1
+done
+
+export CUDA_LAUNCH_BLOCKING=1
+export TORCH_USE_CUDA_DSA=1
+export CUDA_ENABLE_COREDUMP_ON_EXCEPTION=1
+export CUDA_COREDUMP_SHOW_PROGRESS=1
+export CUDA_COREDUMP_GENERATION_FLAGS='skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory'
+export CUDA_COREDUMP_FILE="/tmp/cuda_coredump_%h.%p.%t"
+export SGLANG_ELASTIC_MEM_POOL=true
+export SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1
+rm -rf nohup.out
+nohup python3 -m sglang.launch_server \
+  --log-level debug \
+  --model /data-mnt/tiny-random-llama-4-8E/ \
+  --attention-backend fa3 \
+  --cuda-graph-max-bs 256 \
+  --mem-fraction-static 0.3 \
+  --hybrid-kvcache-ratio 1.0 \
+  --context-length 65536 &
+
+sleep 3
+
+tail -f nohup.out
+
+python3 -m sglang.bench_serving --backend sglang \
+  --dataset-name random --dataset-path /data-mnt/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 2048 --random-input 24576 --random-output 1024 --random-range-ratio 0.5 \
+  --max-concurrency 800
+
+python3 -m sglang.bench_serving --backend sglang \
+  --dataset-name random --dataset-path /data-mnt/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 8192 --random-input 8192 --random-output 8192 --random-range-ratio 0.5 \
+  --max-concurrency 1024
+
+nohup python3 -m sglang.bench_serving --backend sglang \
+  --dataset-name random --dataset-path /data-mnt/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 8192 --random-input 8192 --random-output 8192 --random-range-ratio 0.5 \
+  --max-concurrency 24 > bench.out &
+
+curl -L -X POST 'http://127.0.0.1:30000/v1/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+--data-raw '{
+  "messages": [
+    {
+      "content": "Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, “and what is the use of a book,” thought Alice “without pictures or conversations?”",
+      "role": "user"
+    }
+  ],
+  "model": "xxx",
+  "max_tokens": 64,
+  "stream": false
+}'
+
+curl -X POST 127.0.0.1:30000/start_profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "output_dir": "/tmp/profiles",
+    "activities": ["CPU", "GPU"]
+  }'
+
+curl -X POST 127.0.0.1:30000/stop_profile
+
+####################################################################################################
+# h20 dev
+
+for _ in {1..2}; do
+  ps aux | grep "sglang.launch_server" | grep -v grep | awk '{print $2}' | xargs kill -9
+  ps aux | grep "sglang::" | grep -v grep | awk '{print $2}' | xargs kill -9
+  sleep 1
+done
+
+export SGLANG_ELASTIC_MEM_POOL=true
+export SGLANG_RATIO=0.5
+export PORT=30000
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+
+export SGLANG_ELASTIC_MEM_POOL=false
+export SGLANG_RATIO=0.5
+export PORT=30001
+CUDA_VISIBLE_DEVICES=4,5,6,7 \
+
+nohup python3 -m sglang.launch_server \
+  --log-level debug \
+  --model /home/t4/models/lvm-data/Llama-4-Scout-17B-16E-Instruct \
+  --tp 4 \
+  --schedule-conservativeness 100 \
+  --attention-backend fa3 \
+  --hybrid-kvcache-ratio ${SGLANG_RATIO} \
+  --context-length 200000 \
+  --port ${PORT} \
+  > nohup.emem.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.port.${PORT}.out 2>&1 \
+  &
+
+echo "" > nohup.bench.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.port.${PORT}.out
+
+python3 -m sglang.bench_serving --backend sglang \
+  --dataset-name random --dataset-path /home/t4/models/lvm-data/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 1024 --random-input 1024 --random-output 7168 --random-range-ratio 1 \
+  --max-concurrency 384 --seed 0 \
+  --port ${PORT} \
+  >> nohup.bench.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.port.${PORT}.out 2>&1
+
+python3 -m sglang.bench_serving --backend sglang \
+  --dataset-name random --dataset-path /home/t4/models/lvm-data/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 192 --random-input 8192 --random-output 65536 --random-range-ratio 1 \
+  --max-concurrency 64 --seed 1 \
+  --port ${PORT} \
+  >> nohup.bench.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.port.${PORT}.out 2>&1
+
+python3 -m sglang.bench_serving --backend sglang \
+  --dataset-name random --dataset-path /home/t4/models/lvm-data/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 1024 --random-input 1024 --random-output 7168 --random-range-ratio 1 \
+  --max-concurrency 384 --seed 2 \
+  --port ${PORT} \
+  >> nohup.bench.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.port.${PORT}.out 2>&1

--- a/scripts/emem/dev.sh
+++ b/scripts/emem/dev.sh
@@ -55,12 +55,13 @@ export CUDA_COREDUMP_GENERATION_FLAGS='skip_nonrelocated_elf_images,skip_global_
 export CUDA_COREDUMP_FILE="/tmp/cuda_coredump_%h.%p.%t"
 export SGLANG_ELASTIC_MEM_POOL=true
 export SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1
+export SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK=1
 rm -rf nohup.out
 nohup python3 -m sglang.launch_server \
   --log-level debug \
   --model /data-mnt/tiny-random-llama-4-8E/ \
   --attention-backend fa3 \
-  --cuda-graph-max-bs 256 \
+  --cuda-graph-max-bs 1024 \
   --mem-fraction-static 0.3 \
   --hybrid-kvcache-ratio 1.0 \
   --context-length 65536 &

--- a/scripts/emem/plot/main.py
+++ b/scripts/emem/plot/main.py
@@ -1,0 +1,296 @@
+import os
+import re
+
+import matplotlib.pyplot as plt
+
+
+def parse_log_file(file_path, label_prefix):
+    """Parse log file and extract full token usage, swa token usage, running requests, and generation throughput data"""
+    full_token_usage = []
+    swa_token_usage = []
+    running_req = []
+    gen_throughput = []  # New data for generation throughput
+    timestamps = []
+
+    with open(file_path, "r") as f:
+        for line in f:
+            # Look for prefill or decode batch lines
+            if "Prefill batch" in line or "Decode batch" in line:
+                # Extract full token usage and swa token usage
+                full_match = re.search(r"full token usage: ([0-9.]+)", line)
+                swa_match = re.search(r"swa token usage: ([0-9.]+)", line)
+                req_match = re.search(r"#running-req: ([0-9]+)", line)
+
+                # Extract generation throughput for decode batches
+                gen_throughput_match = re.search(
+                    r"gen throughput \(token/s\): ([0-9.]+)", line
+                )
+
+                if full_match and swa_match and req_match:
+                    full_token_usage.append(float(full_match.group(1)))
+                    swa_token_usage.append(float(swa_match.group(1)))
+                    running_req.append(int(req_match.group(1)))
+
+                    # Add generation throughput if available, otherwise 0
+                    if gen_throughput_match:
+                        gen_throughput.append(float(gen_throughput_match.group(1)))
+                    else:
+                        gen_throughput.append(0.0)
+
+                    timestamps.append(len(timestamps))
+
+    return timestamps, full_token_usage, swa_token_usage, running_req, gen_throughput
+
+
+def plot_token_usage():
+    """Plot token usage from log files"""
+    # File paths
+    file_false_06 = "nohup.emem.false.ratio.0.6.out"
+    file_false_10 = "nohup.emem.false.ratio.1.0.out"
+    file_true_10 = "nohup.emem.true.ratio.1.0.v4.out"
+
+    # Create figure with subplots (2 columns x 3 rows)
+    fig, axes = plt.subplots(3, 2, figsize=(16, 15))
+    fig.suptitle("Token Usage and Performance Analysis", fontsize=16)
+
+    # Collect all data for consistent y-axis scaling
+    all_full_data = []
+    all_swa_data = []
+    all_req_data = []
+    all_gen_throughput_data = []
+
+    # Plot for emem=false, ratio=0.6
+    if os.path.exists(file_false_06):
+        timestamps1, full1, swa1, req1, gen_throughput1 = parse_log_file(
+            file_false_06, "emem=false,ratio=0.6"
+        )
+        all_full_data.extend(full1)
+        all_swa_data.extend(swa1)
+        all_req_data.extend(req1)
+        all_gen_throughput_data.extend(gen_throughput1)
+
+    # Plot for emem=false, ratio=1.0
+    if os.path.exists(file_false_10):
+        timestamps2, full2, swa2, req2, gen_throughput2 = parse_log_file(
+            file_false_10, "emem=false,ratio=1.0"
+        )
+        all_full_data.extend(full2)
+        all_swa_data.extend(swa2)
+        all_req_data.extend(req2)
+        all_gen_throughput_data.extend(gen_throughput2)
+
+    # Plot for emem=true, ratio=1.0
+    if os.path.exists(file_true_10):
+        timestamps3, full3, swa3, req3, gen_throughput3 = parse_log_file(
+            file_true_10, "emem=true,ratio=1.0"
+        )
+        all_full_data.extend(full3)
+        all_swa_data.extend(swa3)
+        all_req_data.extend(req3)
+        all_gen_throughput_data.extend(gen_throughput3)
+
+    # Determine shared y-axis limits
+    token_min = (
+        min(min(all_full_data), min(all_swa_data))
+        if all_full_data and all_swa_data
+        else 0
+    )
+    token_max = (
+        max(max(all_full_data), max(all_swa_data))
+        if all_full_data and all_swa_data
+        else 1
+    )
+    req_min = min(all_req_data) if all_req_data else 0
+    req_max = max(all_req_data) if all_req_data else 1
+    gen_throughput_min = min(all_gen_throughput_data) if all_gen_throughput_data else 0
+    gen_throughput_max = max(all_gen_throughput_data) if all_gen_throughput_data else 1
+
+    # Add some padding
+    token_padding = (token_max - token_min) * 0.1
+    req_padding = (req_max - req_min) * 0.1
+    gen_throughput_padding = (gen_throughput_max - gen_throughput_min) * 0.1
+
+    # Plot for emem=false, ratio=0.6
+    if os.path.exists(file_false_06):
+        timestamps1, full1, swa1, req1, gen_throughput1 = parse_log_file(
+            file_false_06, "emem=false,ratio=0.6"
+        )
+
+        # Left column - Token usage
+        ax1_left = axes[0, 0]
+        ax1_left.plot(
+            timestamps1, full1, label="Full Token Usage", marker="o", markersize=3
+        )
+        ax1_left.plot(
+            timestamps1, swa1, label="SWA Token Usage", marker="s", markersize=3
+        )
+        ax1_left.set_title("emem=false, ratio=0.6 - Token Usage")
+        ax1_left.set_ylabel("Token Usage")
+        ax1_left.grid(True)
+        ax1_left.set_ylim(token_min - token_padding, token_max + token_padding)
+        ax1_left.legend(loc="upper left")
+
+        # Right column - Running requests and generation throughput
+        ax1_right = axes[0, 1]
+        ax1_right.plot(
+            timestamps1,
+            req1,
+            label="#Running Requests",
+            color="red",
+            marker="^",
+            markersize=3,
+            zorder=2,
+        )
+        ax1_right_twin = ax1_right.twinx()
+        ax1_right_twin.fill_between(
+            timestamps1,
+            gen_throughput1,
+            alpha=0.3,
+            label="Gen Throughput (token/s)",
+            color="olive",
+            zorder=1,
+        )
+        ax1_right.set_title("emem=false, ratio=0.6 - Performance Metrics")
+        ax1_right.set_ylabel("#Running Requests", color="red")
+        ax1_right.tick_params(axis="y", labelcolor="red")
+        ax1_right_twin.set_ylabel("Gen Throughput (token/s)", color="olive")
+        ax1_right_twin.tick_params(axis="y", labelcolor="olive")
+        ax1_right.set_ylim(req_min - req_padding, req_max + req_padding)
+        ax1_right_twin.set_ylim(
+            gen_throughput_min - gen_throughput_padding,
+            gen_throughput_max + gen_throughput_padding,
+        )
+        ax1_right.grid(True)
+        ax1_right_twin.grid(True)
+
+        # Combined legend
+        lines1, labels1 = ax1_right.get_legend_handles_labels()
+        lines2, labels2 = ax1_right_twin.get_legend_handles_labels()
+        ax1_right.legend(lines1 + lines2, labels1 + labels2, loc="upper left")
+
+    # Plot for emem=false, ratio=1.0
+    if os.path.exists(file_false_10):
+        timestamps2, full2, swa2, req2, gen_throughput2 = parse_log_file(
+            file_false_10, "emem=false,ratio=1.0"
+        )
+
+        # Left column - Token usage
+        ax2_left = axes[1, 0]
+        ax2_left.plot(
+            timestamps2, full2, label="Full Token Usage", marker="o", markersize=3
+        )
+        ax2_left.plot(
+            timestamps2, swa2, label="SWA Token Usage", marker="s", markersize=3
+        )
+        ax2_left.set_title("emem=false, ratio=1.0 - Token Usage")
+        ax2_left.set_ylabel("Token Usage")
+        ax2_left.grid(True)
+        ax2_left.set_ylim(token_min - token_padding, token_max + token_padding)
+        ax2_left.legend(loc="upper left")
+
+        # Right column - Running requests and generation throughput
+        ax2_right = axes[1, 1]
+        ax2_right.plot(
+            timestamps2,
+            req2,
+            label="#Running Requests",
+            color="red",
+            marker="^",
+            markersize=3,
+            zorder=2,
+        )
+        ax2_right_twin = ax2_right.twinx()
+        ax2_right_twin.fill_between(
+            timestamps2,
+            gen_throughput2,
+            alpha=0.3,
+            label="Gen Throughput (token/s)",
+            color="olive",
+            zorder=1,
+        )
+        ax2_right.set_title("emem=false, ratio=1.0 - Performance Metrics")
+        ax2_right.set_ylabel("#Running Requests", color="red")
+        ax2_right.tick_params(axis="y", labelcolor="red")
+        ax2_right_twin.set_ylabel("Gen Throughput (token/s)", color="olive")
+        ax2_right_twin.tick_params(axis="y", labelcolor="olive")
+        ax2_right.set_ylim(req_min - req_padding, req_max + req_padding)
+        ax2_right_twin.set_ylim(
+            gen_throughput_min - gen_throughput_padding,
+            gen_throughput_max + gen_throughput_padding,
+        )
+        ax2_right.grid(True)
+        ax2_right_twin.grid(True)
+
+        # Combined legend
+        lines1, labels1 = ax2_right.get_legend_handles_labels()
+        lines2, labels2 = ax2_right_twin.get_legend_handles_labels()
+        ax2_right.legend(lines1 + lines2, labels1 + labels2, loc="upper left")
+
+    # Plot for emem=true, ratio=1.0
+    if os.path.exists(file_true_10):
+        timestamps3, full3, swa3, req3, gen_throughput3 = parse_log_file(
+            file_true_10, "emem=true,ratio=1.0"
+        )
+
+        # Left column - Token usage
+        ax3_left = axes[2, 0]
+        ax3_left.plot(
+            timestamps3, full3, label="Full Token Usage", marker="o", markersize=3
+        )
+        ax3_left.plot(
+            timestamps3, swa3, label="SWA Token Usage", marker="s", markersize=3
+        )
+        ax3_left.set_title("emem=true, ratio=1.0 - Token Usage")
+        ax3_left.set_ylabel("Token Usage")
+        ax3_left.set_xlabel("Time Steps")
+        ax3_left.grid(True)
+        ax3_left.set_ylim(token_min - token_padding, token_max + token_padding)
+        ax3_left.legend(loc="upper left")
+
+        # Right column - Running requests and generation throughput
+        ax3_right = axes[2, 1]
+        ax3_right.plot(
+            timestamps3,
+            req3,
+            label="#Running Requests",
+            color="red",
+            marker="^",
+            markersize=3,
+            zorder=2,
+        )
+        ax3_right_twin = ax3_right.twinx()
+        ax3_right_twin.fill_between(
+            timestamps3,
+            gen_throughput3,
+            alpha=0.3,
+            label="Gen Throughput (token/s)",
+            color="olive",
+            zorder=1,
+        )
+        ax3_right.set_title("emem=true, ratio=1.0 - Performance Metrics")
+        ax3_right.set_ylabel("#Running Requests", color="red")
+        ax3_right.tick_params(axis="y", labelcolor="red")
+        ax3_right_twin.set_ylabel("Gen Throughput (token/s)", color="olive")
+        ax3_right_twin.tick_params(axis="y", labelcolor="olive")
+        ax3_right.set_xlabel("Time Steps")
+        ax3_right.set_ylim(req_min - req_padding, req_max + req_padding)
+        ax3_right_twin.set_ylim(
+            gen_throughput_min - gen_throughput_padding,
+            gen_throughput_max + gen_throughput_padding,
+        )
+        ax3_right.grid(True)
+        ax3_right_twin.grid(True)
+
+        # Combined legend
+        lines1, labels1 = ax3_right.get_legend_handles_labels()
+        lines2, labels2 = ax3_right_twin.get_legend_handles_labels()
+        ax3_right.legend(lines1 + lines2, labels1 + labels2, loc="upper left")
+
+    # Adjust layout and save
+    plt.tight_layout()
+    plt.savefig("token_usage_analysis.png", dpi=300, bbox_inches="tight")
+    plt.show()
+
+
+if __name__ == "__main__":
+    plot_token_usage()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR implements dynamic scaling between different attention-type pools within the hybrid model in sglang, based on elasticmem.

<img width="2754" height="2091" alt="______________________________________________________________________a-Flowchart (10)" src="https://github.com/user-attachments/assets/751cc72f-ab10-4775-a3df-14b3562b2898" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

```bash

export SGLANG_ELASTIC_MEM_POOL=true
export SGLANG_RATIO=1.0
nohup python3 -m sglang.launch_server \
  --log-level debug \
  --model /home/t4/models/lvm-data/Llama-4-Scout-17B-16E-Instruct \
  --tp 2 \
  --attention-backend fa3 \
  --hybrid-kvcache-ratio ${SGLANG_RATIO} \
  --context-length 200000 \
  > nohup.emem.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.out 2>&1 \
  &

export SGLANG_ELASTIC_MEM_POOL=true
export SGLANG_RATIO=1.0
nohup python3 -m sglang.bench_serving --backend sglang \
  --dataset-name random --dataset-path /home/t4/models/lvm-data/ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 1024 --random-input 1024 --random-output 1024 --random-range-ratio 1 \
  --max-concurrency 128 \
  > nohup.bench.${SGLANG_ELASTIC_MEM_POOL}.ratio.${SGLANG_RATIO}.out 2>&1 \
  &
```

<img width="4770" height="4425" alt="image" src="https://github.com/user-attachments/assets/2b47ce29-ce39-43ac-b0d3-ea3ff6ff1bee" />

- Horizontal axis: Each time step represents a log entry for Prefill/Decode.
- Vertical axis: As shown in the figure, it represents:
  - Token usage for different pools,
  - Real-time running requests,
  - Generation throughput during decoding (set to 0 during prefill).
- First row: Current static pool configuration with --hybrid-kvcache-ratio=0.6 (relatively balanced allocation between the full and swa pools).
- Second row: Current static pool configuration with --hybrid-kvcache-ratio=1.0 (most GPU memory allocated to the full pool).
- Third row: Elastic pool configuration with --hybrid-kvcache-ratio=1.0 (initial allocation favors the full pool but supports dynamic runtime adjustments).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
