### PR TITLE
Enable RadixCache for Mamba2 models

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -362,9 +362,7 @@ class PrefillAdder:
         self.is_hybrid_swa = isinstance(
             self.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator
         )
-        self.is_hybrid_gdn_or_mamba2_cache = isinstance(
-            self.tree_cache, MambaRadixCache
-        )
+        self.is_ssm_radix_cache = isinstance(self.tree_cache, MambaRadixCache)
 
         self.priority_scheduling_preemption_threshold = (
             priority_scheduling_preemption_threshold
@@ -389,7 +387,7 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.swa_available_size()
                 + self.tree_cache.swa_evictable_size(),
             )
-        elif self.is_hybrid_gdn_or_mamba2_cache:
+        elif self.is_ssm_radix_cache:
             available_and_evictable = (
                 self.token_to_kv_pool_allocator.available_size()
                 + self.tree_cache.full_evictable_size()
@@ -411,7 +409,7 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.swa_available_size()
                 + self.tree_cache.swa_evictable_size(),
             )
-        elif self.is_hybrid_gdn_or_mamba2_cache:
+        elif self.is_ssm_radix_cache:
             available_and_evictable = (
                 self.token_to_kv_pool_allocator.available_size()
                 + self.tree_cache.full_evictable_size()

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -362,7 +362,9 @@ class PrefillAdder:
         self.is_hybrid_swa = isinstance(
             self.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator
         )
-        self.is_hybrid_gdn_cache = isinstance(self.tree_cache, MambaRadixCache)
+        self.is_hybrid_gdn_or_mamba2_cache = isinstance(
+            self.tree_cache, MambaRadixCache
+        )
 
         self.priority_scheduling_preemption_threshold = (
             priority_scheduling_preemption_threshold
@@ -387,7 +389,7 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.swa_available_size()
                 + self.tree_cache.swa_evictable_size(),
             )
-        elif self.is_hybrid_gdn_cache:
+        elif self.is_hybrid_gdn_or_mamba2_cache:
             available_and_evictable = (
                 self.token_to_kv_pool_allocator.available_size()
                 + self.tree_cache.full_evictable_size()
@@ -409,7 +411,7 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.swa_available_size()
                 + self.tree_cache.swa_evictable_size(),
             )
-        elif self.is_hybrid_gdn_cache:
+        elif self.is_hybrid_gdn_or_mamba2_cache:
             available_and_evictable = (
                 self.token_to_kv_pool_allocator.available_size()
                 + self.tree_cache.full_evictable_size()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -398,7 +398,7 @@ class Scheduler(
 
         # Hybrid memory pool
         self.is_hybrid_swa = self.tp_worker.is_hybrid_swa
-        self.is_hybrid_gdn_or_mamba2 = (
+        self.is_ssm_model = (
             self.tp_worker.model_runner.hybrid_gdn_config is not None
             or self.tp_worker.model_runner.mamba2_config is not None
         )
@@ -765,7 +765,7 @@ class Scheduler(
                 self.tree_cache = SWARadixCache(
                     params=params, sliding_window_size=self.sliding_window_size
                 )
-            elif self.is_hybrid_gdn_or_mamba2:
+            elif self.is_ssm_model:
                 from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 
                 self.tree_cache = MambaRadixCache(params)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -398,7 +398,10 @@ class Scheduler(
 
         # Hybrid memory pool
         self.is_hybrid_swa = self.tp_worker.is_hybrid_swa
-        self.is_hybrid_gdn = self.tp_worker.model_runner.hybrid_gdn_config is not None
+        self.is_hybrid_gdn_or_mamba2 = (
+            self.tp_worker.model_runner.hybrid_gdn_config is not None
+            or self.tp_worker.model_runner.mamba2_config is not None
+        )
 
         if self.is_hybrid_swa:
             self.sliding_window_size = self.tp_worker.sliding_window_size
@@ -762,7 +765,7 @@ class Scheduler(
                 self.tree_cache = SWARadixCache(
                     params=params, sliding_window_size=self.sliding_window_size
                 )
-            elif self.is_hybrid_gdn:
+            elif self.is_hybrid_gdn_or_mamba2:
                 from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
 
                 self.tree_cache = MambaRadixCache(params)

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -112,7 +112,7 @@ class SchedulerMetricsMixin:
                 f"full token usage: {full_token_usage:.2f}, "
                 f"swa token usage: {swa_token_usage:.2f}, "
             )
-        elif self.is_hybrid_gdn_or_mamba2:
+        elif self.is_ssm_model:
             (
                 full_num_used,
                 _,
@@ -166,7 +166,7 @@ class SchedulerMetricsMixin:
             self.stats.token_usage = token_usage
             if self.is_hybrid_swa:
                 self.stats.swa_token_usage = swa_token_usage
-            if self.is_hybrid_gdn_or_mamba2:
+            if self.is_ssm_model:
                 self.stats.mamba_usage = mamba_usage
             self.stats.num_queue_reqs = len(self.waiting_queue)
             self.stats.num_grammar_queue_reqs = len(self.grammar_queue)
@@ -238,7 +238,7 @@ class SchedulerMetricsMixin:
                 f"#swa token: {swa_num_used}, "
                 f"swa token usage: {swa_token_usage:.2f}, "
             )
-        elif self.is_hybrid_gdn_or_mamba2:
+        elif self.is_ssm_model:
             (
                 full_num_used,
                 mamba_used,
@@ -315,7 +315,7 @@ class SchedulerMetricsMixin:
             self.stats.token_usage = token_usage
             if self.is_hybrid_swa:
                 self.stats.swa_token_usage = swa_token_usage
-            if self.is_hybrid_gdn_or_mamba2:
+            if self.is_ssm_model:
                 self.stats.mamba_usage = mamba_usage
             self.stats.gen_throughput = self.last_gen_throughput
             self.stats.num_queue_reqs = len(self.waiting_queue)

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -112,7 +112,7 @@ class SchedulerMetricsMixin:
                 f"full token usage: {full_token_usage:.2f}, "
                 f"swa token usage: {swa_token_usage:.2f}, "
             )
-        elif self.is_hybrid_gdn:
+        elif self.is_hybrid_gdn_or_mamba2:
             (
                 full_num_used,
                 _,
@@ -166,7 +166,7 @@ class SchedulerMetricsMixin:
             self.stats.token_usage = token_usage
             if self.is_hybrid_swa:
                 self.stats.swa_token_usage = swa_token_usage
-            if self.is_hybrid_gdn:
+            if self.is_hybrid_gdn_or_mamba2:
                 self.stats.mamba_usage = mamba_usage
             self.stats.num_queue_reqs = len(self.waiting_queue)
             self.stats.num_grammar_queue_reqs = len(self.grammar_queue)
@@ -238,7 +238,7 @@ class SchedulerMetricsMixin:
                 f"#swa token: {swa_num_used}, "
                 f"swa token usage: {swa_token_usage:.2f}, "
             )
-        elif self.is_hybrid_gdn:
+        elif self.is_hybrid_gdn_or_mamba2:
             (
                 full_num_used,
                 mamba_used,
@@ -315,7 +315,7 @@ class SchedulerMetricsMixin:
             self.stats.token_usage = token_usage
             if self.is_hybrid_swa:
                 self.stats.swa_token_usage = swa_token_usage
-            if self.is_hybrid_gdn:
+            if self.is_hybrid_gdn_or_mamba2:
                 self.stats.mamba_usage = mamba_usage
             self.stats.gen_throughput = self.last_gen_throughput
             self.stats.num_queue_reqs = len(self.waiting_queue)

--- a/python/sglang/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/managers/scheduler_metrics_mixin.py
@@ -401,7 +401,7 @@ class SchedulerMetricsMixin:
         if self.is_hybrid_swa:
             full_num_used, swa_num_used, *_ = self._get_swa_token_info()
             num_tokens = max(full_num_used, swa_num_used)
-        elif self.is_hybrid_gdn:
+        elif self.is_ssm_model:
             num_tokens = self._get_mamba_token_info()[0]
         else:
             num_tokens = self._get_token_info()[0]

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -204,9 +204,7 @@ class SchedulerRuntimeCheckerMixin:
     def check_memory(self: Scheduler):
         if self.is_hybrid_swa:
             memory_leak, token_msg = self._check_hybrid_memory()
-        elif self.is_hybrid_gdn_or_mamba2 and isinstance(
-            self.tree_cache, MambaRadixCache
-        ):
+        elif self.is_ssm_model and isinstance(self.tree_cache, MambaRadixCache):
             memory_leak, token_msg = self._check_mamba_memory()
         else:
             memory_leak, token_msg = self._check_radix_cache_memory()
@@ -241,7 +239,7 @@ class SchedulerRuntimeCheckerMixin:
                 ) = self._get_swa_token_info()
                 num_used = max(full_num_used, swa_num_used)
                 token_usage = max(full_token_usage, swa_token_usage)
-            elif self.is_hybrid_gdn_or_mamba2:
+            elif self.is_ssm_model:
                 (
                     num_used,
                     _,
@@ -280,8 +278,7 @@ class SchedulerRuntimeCheckerMixin:
 
     def check_tree_cache(self: Scheduler):
         if (self.is_hybrid_swa and isinstance(self.tree_cache, SWARadixCache)) or (
-            self.is_hybrid_gdn_or_mamba2
-            and isinstance(self.tree_cache, MambaRadixCache)
+            self.is_ssm_model and isinstance(self.tree_cache, MambaRadixCache)
         ):
             self.tree_cache.sanity_check()
 
@@ -325,9 +322,7 @@ class SchedulerRuntimeCheckerMixin:
             # Print batch size and memory pool info to check whether there are de-sync issues.
             if self.is_hybrid_swa:
                 _, info_msg = self._check_hybrid_memory()
-            elif self.is_hybrid_gdn_or_mamba2 and isinstance(
-                self.tree_cache, MambaRadixCache
-            ):
+            elif self.is_ssm_model and isinstance(self.tree_cache, MambaRadixCache):
                 _, info_msg = self._check_mamba_memory()
             else:
                 _, info_msg = self._check_radix_cache_memory()

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -204,7 +204,9 @@ class SchedulerRuntimeCheckerMixin:
     def check_memory(self: Scheduler):
         if self.is_hybrid_swa:
             memory_leak, token_msg = self._check_hybrid_memory()
-        elif self.is_hybrid_gdn and isinstance(self.tree_cache, MambaRadixCache):
+        elif self.is_hybrid_gdn_or_mamba2 and isinstance(
+            self.tree_cache, MambaRadixCache
+        ):
             memory_leak, token_msg = self._check_mamba_memory()
         else:
             memory_leak, token_msg = self._check_radix_cache_memory()
@@ -239,7 +241,7 @@ class SchedulerRuntimeCheckerMixin:
                 ) = self._get_swa_token_info()
                 num_used = max(full_num_used, swa_num_used)
                 token_usage = max(full_token_usage, swa_token_usage)
-            elif self.is_hybrid_gdn:
+            elif self.is_hybrid_gdn_or_mamba2:
                 (
                     num_used,
                     _,
@@ -278,7 +280,8 @@ class SchedulerRuntimeCheckerMixin:
 
     def check_tree_cache(self: Scheduler):
         if (self.is_hybrid_swa and isinstance(self.tree_cache, SWARadixCache)) or (
-            self.is_hybrid_gdn and isinstance(self.tree_cache, MambaRadixCache)
+            self.is_hybrid_gdn_or_mamba2
+            and isinstance(self.tree_cache, MambaRadixCache)
         ):
             self.tree_cache.sanity_check()
 
@@ -322,7 +325,9 @@ class SchedulerRuntimeCheckerMixin:
             # Print batch size and memory pool info to check whether there are de-sync issues.
             if self.is_hybrid_swa:
                 _, info_msg = self._check_hybrid_memory()
-            elif self.is_hybrid_gdn and isinstance(self.tree_cache, MambaRadixCache):
+            elif self.is_hybrid_gdn_or_mamba2 and isinstance(
+                self.tree_cache, MambaRadixCache
+            ):
                 _, info_msg = self._check_mamba_memory()
             else:
                 _, info_msg = self._check_radix_cache_memory()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -441,11 +441,6 @@ class ModelRunner:
             if architectures and not any("Llama4" in arch for arch in architectures):
                 self.is_hybrid_swa = self.model_config.is_hybrid_swa = True
 
-        if config := self.mamba2_config:
-            class_name = config.__class__.__name__
-            logger.warning(f"{class_name} model detected, disable radix cache")
-            self.server_args.disable_radix_cache = True
-
         # For MTP models like DeepSeek-V3 or GLM-4.5, the MTP layer(s) are used separately as draft
         # models for speculative decoding. In those cases, `num_nextn_predict_layers` is used to
         # determine the number of layers.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1268,6 +1268,18 @@ class ServerArgs:
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
                     )
+        elif model_arch in [
+            "NemotronHForCausalLM",
+            "FalconH1ForCausalLM",
+            "JetNemotronForCausalLM",
+            "JetVLMForConditionalGeneration",
+        ]:
+            if not self.disable_radix_cache:
+                logger.warning(
+                    "Disabling overlap schedule since MambaRadixCache is not compatible with "
+                    "overlap schedule currently, try to use --disable-radix-cache if overlap schedule is necessary"
+                )
+                self.disable_overlap_schedule = True
 
     def _handle_sampling_backend(self):
         if self.sampling_backend is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR picks up off of https://github.com/sgl-project/sglang/pull/11214, enabling RadixCache for Mamba2-based models as well.

## Modifications

<!-- Detail the changes made in this pull request. -->
In the scheduler (and related mixins), changed all of the places that accept GDN-based models to also accept Mamba2-based models.
In the model runner, remove section that forcefully disabled radix caching for Mamba2-based models.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Running the server with 
```
python -m sglang.launch_server --model-path nvidia/NVIDIA-Nemotron-Nano-9B-v2 --max-running-requests 16 --chunked-prefill-size 64
```

And running evaluation with
```
python3 benchmark/gsm8k/bench_sglang.py --num-question 1000
```

The results are:
```
Accuracy: 0.878
Invalid: 0.002
Latency: 98.529 s
Output throughput: 1212.953 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Benchmarked both scenarios by running:
```
python3 -m sglang.bench_serving --backend sglang --dataset-name generated-shared-prefix --gsp-num-groups 50 --gsp-prompts-per-group 10 --gsp-system-prompt-len 10240 --gsp-question-len 256 --gsp-output-len 128 --max-concurrency 5  --port 30000
```

With Radix Cache disabled:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 5         
Successful requests:                     500       
Benchmark duration (s):                  399.85    
Total input tokens:                      5417013   
Total input text tokens:                 5417013   
Total input vision tokens:               0         
Total generated tokens:                  64000     
Total generated tokens (retokenized):    63988     
Request throughput (req/s):              1.25      
Input token throughput (tok/s):          13547.53  
Output token throughput (tok/s):         160.06    
Total token throughput (tok/s):          13707.58  
Concurrency:                             5.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3997.15   
Median E2E Latency (ms):                 3997.09   
---------------Time to First Token----------------
Mean TTFT (ms):                          1935.20   
Median TTFT (ms):                        1787.74   
P99 TTFT (ms):                           2921.15   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.24     
Median TPOT (ms):                        17.39     
P99 TPOT (ms):                           24.45     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           16.24     
Median ITL (ms):                         8.51      
P95 ITL (ms):                            8.64      
P99 ITL (ms):                            11.20     
Max ITL (ms):                            2288.25   
==================================================
```

With Radix Cache Enabled:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 5         
Successful requests:                     500       
Benchmark duration (s):                  275.80    
Total input tokens:                      5417013   
Total input text tokens:                 5417013   
Total input vision tokens:               0         
Total generated tokens:                  64000     
Total generated tokens (retokenized):    62790     
Request throughput (req/s):              1.81      
Input token throughput (tok/s):          19641.07  
Output token throughput (tok/s):         232.05    
Total token throughput (tok/s):          19873.12  
Concurrency:                             5.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2756.64   
Median E2E Latency (ms):                 2667.39   
---------------Time to First Token----------------
Mean TTFT (ms):                          1167.32   
Median TTFT (ms):                        1210.72   
P99 TTFT (ms):                           2570.21   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.51     
Median TPOT (ms):                        11.50     
P99 TPOT (ms):                           23.07     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           12.52     
Median ITL (ms):                         8.50      
P95 ITL (ms):                            8.63      
P99 ITL (ms):                            11.54     
Max ITL (ms):                            3126.91   
==================================================
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
