### PR TITLE
feat: support execute customized tasks in model workers for second-level  weight synchronization  in RL systems

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -27,7 +27,7 @@ import random
 import signal
 import threading
 import time
-from typing import AsyncIterator, Dict, Iterator, List, Optional, Tuple, Union
+from typing import AsyncIterator, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import zmq
 
@@ -425,6 +425,21 @@ class Engine(EngineBase):
             "internal_states": internal_states,
             "version": __version__,
         }
+
+    async def async_execute_task_in_model_worker(
+        self, task_func: Callable, **kwargs
+    ) -> List:
+        """Execute a task on every model worker subprocess"""
+        return await self.tokenizer_manager.execute_task_in_model_worker(
+            task_func, **kwargs
+        )
+
+    def execute_task_in_model_worker(self, task_func: Callable, **kwargs) -> List:
+        """Execute a task on every model worker subprocess"""
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(
+            self.tokenizer_manager.execute_task_in_model_worker(task_func, **kwargs)
+        )
 
     def init_weights_update_group(
         self,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -21,7 +21,7 @@ import uuid
 from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import BaseFinishReason
@@ -1344,6 +1344,17 @@ class AbortReq(BaseReq):
         # FIXME: This is a hack to keep the same with the old code
         if self.rid is None:
             self.rid = ""
+
+
+@dataclass
+class ModelWorkerTask:
+    task_func: Callable
+    kwargs: Dict[str, Any]
+
+
+@dataclass
+class ModelWorkerTaskOutput:
+    result: Any
 
 
 @dataclass

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -93,6 +93,8 @@ from sglang.srt.managers.io_struct import (
     InitWeightsUpdateGroupReqInput,
     LoadLoRAAdapterReqInput,
     LoadLoRAAdapterReqOutput,
+    ModelWorkerTask,
+    ModelWorkerTaskOutput,
     OpenSessionReqInput,
     OpenSessionReqOutput,
     PauseGenerationReqInput,
@@ -541,6 +543,7 @@ class Scheduler(
         # Init request dispatcher
         self._request_dispatcher = TypeBasedDispatcher(
             [
+                (ModelWorkerTask, self.execute_task_in_model_worker),
                 (TokenizedGenerateReqInput, self.handle_generate_request),
                 (TokenizedEmbeddingReqInput, self.handle_embedding_request),
                 (BatchTokenizedGenerateReqInput, self.handle_batch_generate_request),
@@ -2448,6 +2451,39 @@ class Scheduler(
 
     def continue_generation(self, recv_req: ContinueGenerationReqInput):
         self._engine_paused = False
+
+    def execute_task_in_model_worker(self, task_spec: ModelWorkerTask):
+        """Execute a task on all tp workers"""
+        # need gather from all tp workers since only scheduler with
+        # `self.pp_rank == 0 and self.attn_tp_rank == 0` send result back to TokenizerManager.
+        # need to use all gather to be compatible with dp attention.
+        import torch.distributed as dist
+
+        model_context = dict(
+            tp_rank=self.tp_rank,
+            pp_rank=self.pp_rank,
+            tp_size=self.tp_size,
+            pp_size=self.pp_size,
+            dp_size=self.dp_size,
+            attn_tp_rank=self.attn_tp_rank,
+            attn_tp_size=self.attn_tp_size,
+            attn_dp_rank=self.attn_dp_rank,
+            world_size=self.world_group.world_size,
+            global_rank=self.world_group.rank,
+            local_rank=self.world_group.local_rank,
+            nnodes=self.server_args.nnodes,
+            server_args=self.server_args,
+            scheduler=self,
+        )
+        task_spec.kwargs["model_context"] = model_context
+        result = self.model_worker.execute_task_in_model_worker(task_spec)
+        results = [None] * self.tp_size
+        dist.all_gather_object(
+            results,
+            result,
+            group=self.tp_cpu_group,
+        )
+        return ModelWorkerTaskOutput(result=results)
 
     def load_lora_adapter(
         self, recv_req: LoadLoRAAdapterReqInput

--- a/python/sglang/srt/managers/tokenizer_communicator_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_communicator_mixin.py
@@ -9,6 +9,7 @@ from collections import deque
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Deque,
     Dict,
     Generic,
@@ -47,6 +48,8 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     LoadLoRAAdapterReqOutput,
     LoRAUpdateOutput,
+    ModelWorkerTask,
+    ModelWorkerTaskOutput,
     OpenSessionReqInput,
     ProfileReq,
     ProfileReqOutput,
@@ -155,6 +158,9 @@ class TokenizerCommunicatorMixin:
 
     def init_communicators(self: TokenizerManager, server_args: ServerArgs):
         # Communicators
+        self.model_worker_execute_task_group_communicator = _Communicator(
+            self.send_to_scheduler, server_args.dp_size
+        )
         self.init_weights_update_group_communicator = _Communicator(
             self.send_to_scheduler, server_args.dp_size
         )
@@ -221,6 +227,10 @@ class TokenizerCommunicatorMixin:
     def _get_communicator_dispatcher(self: TokenizerManager):
         return TypeBasedDispatcher(
             [
+                (
+                    ModelWorkerTaskOutput,
+                    self.model_worker_execute_task_group_communicator.handle_recv,
+                ),
                 (
                     InitWeightsUpdateGroupReqOutput,
                     self.init_weights_update_group_communicator.handle_recv,
@@ -664,6 +674,13 @@ class TokenizerCommunicatorMixin:
             return all_parameters[0]
         else:
             return all_parameters
+
+    async def execute_task_in_model_worker(self, task_func: Callable, **kwargs) -> List:
+        """Execute a task on every model worker subprocess"""
+        self.auto_create_handle_loop()
+        task = ModelWorkerTask(task_func=task_func, kwargs=kwargs)
+        results = await self.model_worker_execute_task_group_communicator(task)
+        return results[0].result
 
     async def release_memory_occupation(
         self: TokenizerManager,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -29,6 +29,7 @@ from sglang.srt.managers.io_struct import (
     InitWeightsSendGroupForRemoteInstanceReqInput,
     InitWeightsUpdateGroupReqInput,
     LoadLoRAAdapterReqInput,
+    ModelWorkerTask,
     SendWeightsToRemoteInstanceReqInput,
     UnloadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
@@ -98,6 +99,10 @@ class BaseTpWorker(ABC):
             self.model_runner.req_to_token_pool,
             self.model_runner.token_to_kv_pool_allocator,
         )
+
+    def execute_task_in_model_worker(self, task_spec: ModelWorkerTask, models=None):
+        """Execute a task on every model worker subprocess"""
+        return self.model_runner.execute_task_in_model_worker(task_spec, models=models)
 
     def update_weights_from_disk(self, recv_req: UpdateWeightFromDiskReqInput):
         success, message = self.model_runner.update_weights_from_disk(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -922,6 +922,14 @@ class ModelRunner:
                 rank=self.tp_rank,
             )
 
+    def execute_task_in_model_worker(self, task_spec, models=None):
+        """Execute a task on every model worker subprocess"""
+        task_func = task_spec.task_func
+        kwargs = task_spec.kwargs or {}
+        kwargs["model"] = models or self.model
+        kwargs["model_runner"] = self
+        return task_func(**kwargs)
+
     def update_weights_from_disk(
         self,
         model_path: str,

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -1028,6 +1028,11 @@ class EAGLEWorker(TpModelWorker):
         )
         return success, message
 
+    def execute_task_in_model_worker(self, task_spec):
+        """Execute a task on model shard"""
+        models = [self.target_worker.model_runner.model, self.draft_model_runner.model]
+        return self.target_worker.execute_task_in_model_worker(task_spec, models=models)
+
 
 @torch.compile(dynamic=True, disable=_is_npu)
 def get_last_loc_large_page_size_top_k_1(

--- a/test/srt/test_execute_task_in_model_worker.py
+++ b/test/srt/test_execute_task_in_model_worker.py
@@ -1,0 +1,128 @@
+import unittest
+from dataclasses import dataclass
+
+import torch
+
+from sglang.srt.entrypoints.engine import Engine
+from sglang.test.test_utils import CustomTestCase
+
+
+def simple_task_func(**kwargs):
+    # This function will be run on all model workers
+    return 12345
+
+
+def get_model_param_info(**kwargs):
+    # kwargs will contain 'model' and 'model_runner'
+    model = kwargs["model"]
+    param_info = []
+    for name, param in model.named_parameters():
+        param_info.append(
+            {
+                "name": name,
+                "numel": param.numel(),
+                "shape": tuple(param.shape),
+                "dtype": str(param.dtype),
+            }
+        )
+    return param_info
+
+
+@dataclass
+class ParamInfo:
+    name: str
+    shape: tuple
+    numel: int
+    dtype: torch.dtype
+
+
+def get_model_param_info_struct(**kwargs):
+    # kwargs will contain 'model' and 'model_runner'
+    model = kwargs["model"]
+    param_info = []
+    for name, param in model.named_parameters():
+        param_info.append(
+            ParamInfo(
+                name=name,
+                shape=tuple(param.shape),
+                numel=param.numel(),
+                dtype=param.dtype,
+            )
+        )
+    return param_info
+
+
+class TestExecuteTaskInModelWorker(CustomTestCase):
+
+    def _run_test(self, tp_size, dp_size, enable_dp_attention, expected_len):
+        model_path = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+        engine = Engine(
+            model_path=model_path,
+            served_model_name=model_path,
+            attention_backend="torch_native",
+            tp_size=tp_size,
+            trust_remote_code=True,
+            dp_size=dp_size,
+            enable_dp_attention=enable_dp_attention,
+            log_level="error",
+            stream_output=False,
+        )
+
+        try:
+            # Test simple_task_func
+            results = engine.execute_task_in_model_worker(simple_task_func)
+            self.assertIsInstance(results, list)
+            self.assertEqual(len(results), expected_len)
+            for r in results:
+                self.assertEqual(r, 12345)
+
+            # Test get_model_param_info
+            param_info_results = engine.execute_task_in_model_worker(
+                get_model_param_info
+            )
+            self.assertIsInstance(param_info_results, list)
+            self.assertEqual(len(param_info_results), expected_len)
+            for param_info in param_info_results:
+                self.assertIsInstance(param_info, list)
+                for param in param_info:
+                    self.assertIn("name", param)
+                    self.assertIn("numel", param)
+                    self.assertIn("shape", param)
+                    self.assertIn("dtype", param)
+
+            all_weight_names = [
+                param["name"]
+                for param_info in param_info_results
+                for param in param_info
+            ]
+            self.assertIn("model.embed_tokens.weight", all_weight_names)
+            self.assertIn("model.layers.0.self_attn.qkv_proj.weight", all_weight_names)
+            self.assertIn("model.layers.0.mlp.gate_up_proj.weight", all_weight_names)
+            self.assertIn("model.layers.1.input_layernorm.weight", all_weight_names)
+
+            # Test struct serialization
+            param_info_results = engine.execute_task_in_model_worker(
+                get_model_param_info_struct
+            )
+            for param_info in param_info_results:
+                self.assertIsInstance(param_info, list)
+                for param in param_info:
+                    self.assertTrue(param.name)
+                    self.assertGreater(param.numel, 0)
+                    self.assertGreaterEqual(len(param.shape), 1)
+                    self.assertIsInstance(param.dtype, torch.dtype)
+        finally:
+            engine.shutdown()
+
+    def test_tp1_dp1(self):
+        self._run_test(tp_size=1, dp_size=1, enable_dp_attention=False, expected_len=1)
+
+    def test_tp4_dp1(self):
+        self._run_test(tp_size=4, dp_size=1, enable_dp_attention=False, expected_len=4)
+
+    def test_tp4_dp2_attention(self):
+        self._run_test(tp_size=4, dp_size=2, enable_dp_attention=True, expected_len=8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

[Awex](https://github.com/inclusionAI/asystem-awex)  is a high-performance RL training-inference **weight synchronization framework**, designed to enable **second-level parameter updates** for **Trillion-parameter models** from training to inference in RL workflows. It minimizes iteration latency, ensuring rollout phases consistently use the latest model.

Here are some performance result for reference:
| Weight Parameter Scale | Weight Data Size | Awex NCCL Transmission Time | Awex RDMA Transmission Time |
| --- | --- |  --- | --- |
| 10B | 31GB | 0.8S | 0.5S |
| 100B | 191GB |9S | 3.2S |
| 1000B | 1000GB (FP8) | 20S | 6S |


Awex support megatron and sglang. But sglang support requires the ability to **execute initialization and weight‑update functions directly inside all SGLang model workers**. To support this, Awex integrates with SGLang by calling a distributed RPC‑style API that runs a **user‑defined function on every model worker process** with provided model context.

SGLang currently does not expose a public API for executing custom code inside all model workers. `collective_rpc` are close, but lacks of model context, and don't return result from all model workers.
So this PR introduces a new API `execute_task_in_model_worker`, enabling users and downstream systems (such as Awex) to run customized Python functions within SGLang’s model worker processes in a safe and controlled manner.

This API unblocks Awex integration and enables broader use cases such as:
- distributed weight updates  
- custom in‑worker initialization logic  
- advanced model‑side instrumentation  
- system‑level RL workflows requiring synchronized model‑side execution  

<!-- Describe the purpose and goals of this pull request. -->

## Modifications


This PR adds a new method:

```python
def execute_task_in_model_worker(self, fn, **kwargs):
    if not self._initialized:
        raise RuntimeError("Engine not initialized. Call `initialize` first.")
    if self.node_rank != 0:
        raise RuntimeError(
            f"Non-zero rank node {self.rank_coordinate} is not allowed to "
            f"execute task in model workers"
        )
    return self._sgl_engine.execute_task_in_model_worker(fn, **kwargs)
```

Key modifications:

- Added the execute_task_in_model_worker API to the engine wrapper.
- Ensures it can only be invoked after initialization and only from node rank 0.
- Delegates execution to the underlying SGLang engine, which broadcasts the function to all model workers.
- Enables custom function execution across workers without modifying the core scheduling mechanism.
- No existing SGLang behavior is changed; this PR only adds capability.

## Accuracy Tests

This change does not affect model outputs or inference logic.
No changes to kernel or forward pass behavior.

To verify correctness:

- Confirmed that user-defined functions run correctly on all model workers.
- Verified that weight‑update functions produce consistent results across workers.

## Benchmarking and Profiling

This feature does not modify inference kernels, batching logic, or scheduling.
No performance regressions observed.

The overhead of executing a function across workers is negligible and only occurs when explicitly invoked by the user.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
