### PR TITLE
enable csgmv automatically on cuda

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -113,7 +113,7 @@ SGLang supports various environment variables that can be used to configure its 
 | --- | --- | --- |
 | `SGLANG_WAIT_WEIGHTS_READY_TIMEOUT` | Timeout period for waiting on weights | `120` |
 | `SGLANG_DISABLE_OUTLINES_DISK_CACHE` | Disable Outlines disk cache | `true` |
-| `SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE` | Use SGLang's custom Triton kernel cache implementation for lower overheads (automatically enabled on CUDA + Triton 3.4 when compatible) | `false` |
+| `SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE` | Use SGLang's custom Triton kernel cache implementation for lower overheads (automatically enabled on CUDA) | `false` |
 
 ## Function Calling / Tool Use
 

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -113,6 +113,7 @@ SGLang supports various environment variables that can be used to configure its 
 | --- | --- | --- |
 | `SGLANG_WAIT_WEIGHTS_READY_TIMEOUT` | Timeout period for waiting on weights | `120` |
 | `SGLANG_DISABLE_OUTLINES_DISK_CACHE` | Disable Outlines disk cache | `true` |
+| `SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE` | Use SGLang's custom Triton kernel cache implementation for lower overheads (automatically enabled on CUDA + Triton 3.4 when compatible) | `false` |
 
 ## Function Calling / Tool Use
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1434,15 +1434,6 @@ def is_triton_3():
     return triton.__version__.startswith("3.")
 
 
-def is_triton_34() -> bool:
-    """
-    Returns True when running on a CUDA backend with Triton 3.4.x.
-    Currently, this is used to gate CSGMV Triton cache, as
-    we currently use a private API for the cache.
-    """
-    return triton.__version__.startswith("3.4.")
-
-
 def maybe_torch_compile(*args, **kwargs):
     """
     torch.compile does not work for triton 2.2.0, which is needed in xlm1's jax.
@@ -3627,17 +3618,10 @@ def cached_triton_kernel(key_fn=None):
     """
 
     def decorator(fn):
-        # Auto-enable the custom kernel cache for CUDA + Triton 3.4, where it is
+        # Auto-enable the custom kernel cache for CUDA, where it is
         # known to be compatible.
-        # TODO(brayden): expand this for other versions as well.
-        if (
-            is_triton_34()
-            and is_cuda()
-            and not envs.SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE.get()
-        ):
-            logger.debug(
-                "Detected CUDA + Triton 3.4.x; using custom triton kernel cache."
-            )
+        if is_cuda() and not envs.SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE.get():
+            logger.debug("Detected platform CUDA, using custom triton kernel cache.")
             return CachedKernel(fn, key_fn)
 
         if envs.SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE.get():

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3620,7 +3620,7 @@ def cached_triton_kernel(key_fn=None):
     def decorator(fn):
         # Auto-enable the custom kernel cache for CUDA, where it is
         # known to be compatible.
-        if is_cuda() and not envs.SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE.get():
+        if is_cuda() and not envs.SGLANG_USE_CUSTOM_TRITON_KERNEL_CACHE.is_set():
             logger.debug("Detected platform CUDA, using custom triton kernel cache.")
             return CachedKernel(fn, key_fn)
 


### PR DESCRIPTION
It's fine on CUDA platform, so we can auto enable it there, it may also work for ROCm, but it should be tested first.

In Docker image with CUDA 13 + Triton 3.5.1, it also seems to work (and the accuracy is fine):

<img width="802" height="245" alt="Screenshot 2025-11-19 at 1 06 26 PM" src="https://github.com/user-attachments/assets/d2cfa93f-afd5-4e7b-89cd-690f98c04008" />