### PR TITLE
[CI fix] Fix image download failures in VLM CI tests

### DIFF
--- a/test/srt/test_skip_tokenizer_init.py
+++ b/test/srt/test_skip_tokenizer_init.py
@@ -5,10 +5,8 @@ python3 -m unittest test_skip_tokenizer_init.TestSkipTokenizerInit.run_decode_st
 
 import json
 import unittest
-from io import BytesIO
 
 import requests
-from PIL import Image
 from transformers import AutoProcessor, AutoTokenizer
 
 from sglang.lang.chat_template import get_chat_template_by_model_path
@@ -20,6 +18,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    download_image_with_retry,
     popen_launch_server,
 )
 
@@ -204,8 +203,7 @@ class TestSkipTokenizerInitVLM(TestSkipTokenizerInit):
     @classmethod
     def setUpClass(cls):
         cls.image_url = DEFAULT_IMAGE_URL
-        response = requests.get(cls.image_url)
-        cls.image = Image.open(BytesIO(response.content))
+        cls.image = download_image_with_retry(cls.image_url)
         cls.model = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
         cls.tokenizer = AutoTokenizer.from_pretrained(cls.model, use_fast=False)
         cls.processor = AutoProcessor.from_pretrained(cls.model, trust_remote_code=True)

--- a/test/srt/test_vlm_accuracy.py
+++ b/test/srt/test_vlm_accuracy.py
@@ -2,14 +2,11 @@
 """
 
 import unittest
-from io import BytesIO
 from typing import List, Optional
 
 import numpy as np
-import requests
 import torch
 import torch.nn.functional as F
-from PIL import Image
 from transformers import AutoModel, AutoProcessor, AutoTokenizer
 
 from sglang.srt.configs.model_config import ModelConfig
@@ -24,6 +21,7 @@ from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import download_image_with_retry
 
 
 # Test the logits output between HF and SGLang
@@ -35,8 +33,7 @@ class VisionLLMLogitsBase(unittest.IsolatedAsyncioTestCase):
         cls.model_path = ""
         cls.chat_template = ""
         cls.processor = ""
-        response = requests.get(cls.image_url)
-        cls.main_image = Image.open(BytesIO(response.content))
+        cls.main_image = download_image_with_retry(cls.image_url)
 
     def compare_outputs(self, sglang_output: torch.Tensor, hf_output: torch.Tensor):
         # Convert to float32 for numerical stability if needed

--- a/test/srt/test_vlm_input_format.py
+++ b/test/srt/test_vlm_input_format.py
@@ -1,11 +1,8 @@
 import json
 import unittest
-from io import BytesIO
 from typing import Optional
 
-import requests
 import torch
-from PIL import Image
 from transformers import (
     AutoProcessor,
     Gemma3ForConditionalGeneration,
@@ -15,6 +12,7 @@ from transformers import (
 from sglang import Engine
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.parser.conversation import generate_chat_conv
+from sglang.test.test_utils import download_image_with_retry
 
 TEST_IMAGE_URL = "https://github.com/sgl-project/sglang/blob/main/examples/assets/example_image.png?raw=true"
 
@@ -31,8 +29,7 @@ class VLMInputTestBase:
         assert cls.chat_template is not None, "Set chat_template in subclass"
         cls.image_url = TEST_IMAGE_URL
         cls.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        response = requests.get(cls.image_url)
-        cls.main_image = Image.open(BytesIO(response.content))
+        cls.main_image = download_image_with_retry(cls.image_url)
         cls.processor = AutoProcessor.from_pretrained(
             cls.model_path, trust_remote_code=True, use_fast=True
         )


### PR DESCRIPTION

## Motivation

VLM tests frequently fail in CI with `PIL.UnidentifiedImageError: cannot identify image file` due to network issues when downloading test images. Such as https://github.com/sgl-project/sglang/actions/runs/19505654565/job/55843358846

## Fix
- Added `download_image_with_retry()` helper function in `test_utils.py`
- Implements retry mechanism with exponential backoff (max 3 retries)
- Updated all VLM test files to use the new helper function

