### PR TITLE
remove unnecessary starvation check

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -129,16 +129,6 @@ class LoRAManager:
             lora_ref.lora_id not in self.loras
         ), f"LoRA adapter with ID {lora_ref.lora_id} is already loaded. This should have been verified before request is sent to the backend."
 
-        if lora_ref.pinned and self.num_pinned_loras >= self.max_loras_per_batch - 1:
-            return self.create_lora_update_result(
-                success=False,
-                error_message=(
-                    f"Already have {self.num_pinned_loras} pinned adapters, "
-                    f"max allowed is {self.max_loras_per_batch - 1} (reserving 1 slot for dynamic use). "
-                    f"Please unpin some adapters or increase max_loras_per_batch."
-                ),
-            )
-
         try:
             # load configs
             new_adapter = LoRAConfig(lora_ref.lora_path)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

- This check is duplicated in `validate_new_adapter`.
- Currently, `test/srt/lora/test_lora_update.py` fails because it is hitting the first check, which doesn't have the correct error message.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
