### PR TITLE
Fix bugs for Sglang-diffusion by GMIcloud

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipelines/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipelines/wan.py
@@ -103,6 +103,7 @@ class WanT2V720PConfig(WanT2V480PConfig):
 class WanI2V480PConfig(WanT2V480PConfig, WanI2VCommonConfig):
     """Base configuration for Wan I2V 14B 480P pipeline architecture."""
 
+    max_area: int = 480 * 832
     # WanConfig-specific parameters with defaults
     task_type: ModelTaskType = ModelTaskType.I2V
     # Precision for each component
@@ -127,6 +128,7 @@ class WanI2V480PConfig(WanT2V480PConfig, WanI2VCommonConfig):
 class WanI2V720PConfig(WanI2V480PConfig):
     """Base configuration for Wan I2V 14B 720P pipeline architecture."""
 
+    max_area: int = 720 * 1280
     # WanConfig-specific parameters with defaults
 
     # Denoising stage

--- a/python/sglang/multimodal_gen/configs/sample/base.py
+++ b/python/sglang/multimodal_gen/configs/sample/base.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import align_to
+from sglang.multimodal_gen.utils import align_to, StoreBoolean
 
 logger = init_logger(__name__)
 
@@ -135,6 +135,10 @@ class SamplingParams:
     return_frames: bool = False
     return_trajectory_latents: bool = False  # returns all latents for each timestep
     return_trajectory_decoded: bool = False  # returns decoded latents for each timestep
+    # If True, allow user params to override subclass-defined protected fields
+    override_protected_fields: bool = False
+    # Whether to adjust num_frames for multi-GPU friendly splitting (default: True)
+    adjust_frames: bool = True
 
     def set_output_file_ext(self):
         # add extension if needed
@@ -388,6 +392,25 @@ class SamplingParams:
             default=SamplingParams.return_trajectory_decoded,
             help="Whether to return the decoded trajectory",
         )
+        parser.add_argument(
+            "--override-protected-fields",
+            action="store_true",
+            default=SamplingParams.override_protected_fields,
+            help=(
+                "If set, allow user params to override fields defined in subclasses "
+                "(protected by default)."
+            ),
+        )
+        parser.add_argument(
+            "--adjust-frames",
+            action=StoreBoolean,
+            default=SamplingParams.adjust_frames,
+            help=(
+                "Enable/disable adjusting num_frames to evenly split latent frames across GPUs "
+                "and satisfy model temporal constraints. Default: true. "
+                "Examples: --adjust-frames, --adjust-frames true, --adjust-frames false."
+            ),
+        )
         return parser
 
     @classmethod
@@ -416,6 +439,12 @@ class SamplingParams:
         # Get fields defined directly in the subclass (not inherited)
         subclass_defined_fields = set(type(self).__annotations__.keys())
 
+        # Global switch: if True, allow overriding protected fields
+        allow_override_protected = bool(
+            getattr(user_params, "override_protected_fields", False)
+            or getattr(self, "override_protected_fields", False)
+        )
+
         # Compare against current instance to avoid constructing a default instance
         default_params = SamplingParams()
 
@@ -432,7 +461,7 @@ class SamplingParams:
                 if field_name != "output_file_name"
                 else user_params.output_file_path is not None
             )
-            if is_user_modified and field_name not in subclass_defined_fields:
+            if is_user_modified and (allow_override_protected or field_name not in subclass_defined_fields):
                 if hasattr(self, field_name):
                     setattr(self, field_name, user_value)
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/utils.py
@@ -55,7 +55,7 @@ def prepare_sampling_params(
         logger.debug(f"Setting num_frames to 1 because this is a image-gen model")
         sampling_params.num_frames = 1
         sampling_params.data_type = DataType.IMAGE
-    else:
+    elif sampling_params.adjust_frames:
         # Adjust number of frames based on number of GPUs for video task
         use_temporal_scaling_frames = (
             pipeline_config.vae_config.use_temporal_scaling_frames
@@ -107,6 +107,9 @@ def prepare_sampling_params(
         sampling_params.num_frames = server_args.pipeline_config.adjust_num_frames(
             sampling_params.num_frames
         )
+    else:
+        logger.info(
+            "Not adjusting number of frames because adjust_frames is False")
 
     sampling_params.set_output_file_ext()
     sampling_params.log(server_args=server_args)

--- a/python/sglang/multimodal_gen/runtime/pipelines/stages/input_validation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/stages/input_validation.py
@@ -164,7 +164,7 @@ class InputValidationStage(PipelineStage):
         if isinstance(server_args.pipeline_config, WanI2V480PConfig):
             # TODO: could we merge with above?
             # resize image only, Wan2.1 I2V
-            max_area = 720 * 1280
+            max_area = server_args.pipeline_config.max_area
             aspect_ratio = image.height / image.width
             mod_value = (
                 server_args.pipeline_config.vae_config.arch_config.scale_factor_spatial


### PR DESCRIPTION
Hi Sglang-Diffusion Team,
We made the following updates:
1) Change the max area from hard-coded 1280 * 720 to the variable "max_area" defined in different WanI2VConfigs, so that 480P can not generate videos larger than 480P
2) Add additional Args named “--override-protected-fields” in SamplingParams so that users can override parameters such as num_frames and denoising steps in the inference stage.
3) Add additional Args names "--adjust-frames" in SamplingParams to allow users to turn off the automatic frame adjustment so that they can generate videos with the exact number of frames they want.

Best,
GMIcloud Team
