### PR TITLE
[WIP] Fix piecewise cuda graph recompile

### DIFF
--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -300,20 +300,24 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
                     runtime_shape=None,
                 )
             )
+            if target not in self.module.__dict__:
+                self.module.__dict__[target] = CUDAPiecewiseBackend(
+                    submod,
+                    self.compile_config,
+                    self.inductor_config,
+                    self.graph_pool,
+                    index,
+                    len(self.compile_submod_names),
+                    sym_shape_indices,
+                    compiled_graph_for_dynamic_shape,
+                    self.sglang_backend,
+                )
+                # print(f"[DEBUG] Created CUDAPiecewiseBackend for submodule {target}, index {index}, backend_id={id(self.module.__dict__[target])}")
 
-            self.module.__dict__[target] = CUDAPiecewiseBackend(
-                submod,
-                self.compile_config,
-                self.inductor_config,
-                self.graph_pool,
-                index,
-                len(self.compile_submod_names),
-                sym_shape_indices,
-                compiled_graph_for_dynamic_shape,
-                self.sglang_backend,
-            )
-
-            compilation_counter.num_piecewise_capturable_graphs_seen += 1
+                compilation_counter.num_piecewise_capturable_graphs_seen += 1
+            else:
+                # print(f"[DEBUG] Reusing existing CUDAPiecewiseBackend for submodule {target}, index {index}, backend_id={id(self.module.__dict__[target])}")
+                pass
 
         return output
 
@@ -396,7 +400,16 @@ class SGLangBackend:
         )
         compilation_counter.num_graphs_seen += 1
 
-        assert not self._called, "SGLangBackend can only be called once"
+        # assert not self._called, "SGLangBackend can only be called once"
+        if (self._called):
+            return self.split_gm
+        
+        # Print call stack trace
+        # import traceback
+        # print(f"[DEBUG] SGLangBackend __call__ invoked, backend_id={id(self)}")
+        # print("[DEBUG] Call stack:")
+        # for line in traceback.format_stack()[:-1]:  # Exclude current frame
+        #     print(line.rstrip())
 
         self.graph = graph
         self.configure_post_pass()

--- a/python/sglang/srt/compilation/backend.py
+++ b/python/sglang/srt/compilation/backend.py
@@ -300,24 +300,19 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
                     runtime_shape=None,
                 )
             )
-            if target not in self.module.__dict__:
-                self.module.__dict__[target] = CUDAPiecewiseBackend(
-                    submod,
-                    self.compile_config,
-                    self.inductor_config,
-                    self.graph_pool,
-                    index,
-                    len(self.compile_submod_names),
-                    sym_shape_indices,
-                    compiled_graph_for_dynamic_shape,
-                    self.sglang_backend,
-                )
-                # print(f"[DEBUG] Created CUDAPiecewiseBackend for submodule {target}, index {index}, backend_id={id(self.module.__dict__[target])}")
+            self.module.__dict__[target] = CUDAPiecewiseBackend(
+                submod,
+                self.compile_config,
+                self.inductor_config,
+                self.graph_pool,
+                index,
+                len(self.compile_submod_names),
+                sym_shape_indices,
+                compiled_graph_for_dynamic_shape,
+                self.sglang_backend,
+            )
 
-                compilation_counter.num_piecewise_capturable_graphs_seen += 1
-            else:
-                # print(f"[DEBUG] Reusing existing CUDAPiecewiseBackend for submodule {target}, index {index}, backend_id={id(self.module.__dict__[target])}")
-                pass
+            compilation_counter.num_piecewise_capturable_graphs_seen += 1
 
         return output
 
@@ -399,10 +394,6 @@ class SGLangBackend:
             local_cache_dir, disable_cache=False, prefix=""
         )
         compilation_counter.num_graphs_seen += 1
-
-        # assert not self._called, "SGLangBackend can only be called once"
-        if (self._called):
-            return self.split_gm
         
         # Print call stack trace
         # import traceback
@@ -410,6 +401,10 @@ class SGLangBackend:
         # print("[DEBUG] Call stack:")
         # for line in traceback.format_stack()[:-1]:  # Exclude current frame
         #     print(line.rstrip())
+
+        # assert not self._called, "SGLangBackend can only be called once"
+        if (self._called):
+            return self.split_gm
 
         self.graph = graph
         self.configure_post_pass()

--- a/python/sglang/srt/compilation/compile.py
+++ b/python/sglang/srt/compilation/compile.py
@@ -136,12 +136,13 @@ def install_torch_compiled(
 
     dyn_map = dynamic_arg_dims or _infer_dynamic_arg_dims_from_annotations(unbound_fwd)
 
+    # Create the backend instance once and reuse it
+    backend_instance = None
     if backend_factory is None:
         from sglang.srt.compilation.backend import SGLangBackend
 
-        backend_factory = lambda gm, ex: SGLangBackend(compile_config, graph_pool)(
-            gm, ex
-        )
+        backend_instance = SGLangBackend(compile_config, graph_pool)
+        backend_factory = lambda gm, ex: backend_instance(gm, ex)
 
     compiled_codes: list[type(original_code)] = []
     state = {"compiled": False, "compiled_callable": None}

--- a/python/sglang/srt/compilation/cuda_piecewise_backend.py
+++ b/python/sglang/srt/compilation/cuda_piecewise_backend.py
@@ -141,6 +141,7 @@ class CUDAPiecewiseBackend:
             return self.compiled_graph_for_general_shape(*args)
 
         entry = self.concrete_size_entries[runtime_shape]
+        # print(f"[DEBUG] __call__ graph {self.piecewise_compile_index}, shape={runtime_shape}, backend_id={id(self)}, entry_id={id(entry)}, warmup={entry.num_finished_warmup}, has_cudagraph={entry.cudagraph is not None}")
 
         if entry.runnable is None:
             entry.runnable = self.compiled_graph_for_general_shape
@@ -169,7 +170,7 @@ class CUDAPiecewiseBackend:
         #     return entry.runnable(*args)
 
         if entry.cudagraph is None:
-            if entry.num_finished_warmup < 1:  # noqa
+            if entry.num_finished_warmup < 2:  # noqa
                 entry.num_finished_warmup += 1
                 return entry.runnable(*args)
 

--- a/python/sglang/srt/compilation/cuda_piecewise_backend.py
+++ b/python/sglang/srt/compilation/cuda_piecewise_backend.py
@@ -170,7 +170,7 @@ class CUDAPiecewiseBackend:
         #     return entry.runnable(*args)
 
         if entry.cudagraph is None:
-            if entry.num_finished_warmup < 2:  # noqa
+            if entry.num_finished_warmup < 1:  # noqa
                 entry.num_finished_warmup += 1
                 return entry.runnable(*args)
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -357,6 +357,7 @@ class ModelRunner:
                 )
                 self.piecewise_cuda_graph_runner = None
             else:
+                print(f"[DEBUG] Initializing PiecewiseCudaGraphRunner")
                 self.piecewise_cuda_graph_runner = PiecewiseCudaGraphRunner(self)
         else:
             self.piecewise_cuda_graph_runner = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -357,7 +357,6 @@ class ModelRunner:
                 )
                 self.piecewise_cuda_graph_runner = None
             else:
-                print(f"[DEBUG] Initializing PiecewiseCudaGraphRunner")
                 self.piecewise_cuda_graph_runner = PiecewiseCudaGraphRunner(self)
         else:
             self.piecewise_cuda_graph_runner = None

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -197,9 +197,6 @@ class PiecewiseCudaGraphRunner:
                     graph_pool=get_global_graph_memory_pool(),
                 )
 
-                # with set_compiled(True):
-                #     self.warmup_and_capture()
-
                 # Capture
                 try:
                     self.capture()

--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -197,8 +197,8 @@ class PiecewiseCudaGraphRunner:
                     graph_pool=get_global_graph_memory_pool(),
                 )
 
-                with set_compiled(True):
-                    self.warmup_and_capture()
+                # with set_compiled(True):
+                #     self.warmup_and_capture()
 
                 # Capture
                 try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Closes https://github.com/sgl-project/sglang/issues/13469

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Without piecewise cuda graph:
```
python3 -m sglang.launch_server --model /shared/public/elr-models/xai-org/grok-2/ --tokenizer-path /shared/public/elr-models/xai-org/grok-2/tokenizer.tok.json --tp 8 --quantization fp8 --attention-backend triton --disable-radix-cache

python benchmark/gsm8k/bench_sglang.py --data-path /shared/public/data/gsm8k/test.jsonl --num-questions 1319
Accuracy: 0.929
Invalid: 0.000
Latency: 133.680 s
Output throughput: 1111.674 token/s

python3 -m sglang.bench_serving --backend sglang --dataset-name random-ids --num-prompts 1 --random-input-len 10
24 --random-output-len 1 --random-range-ratio 1 --tokenizer /shared/public/elr-models/xai-org/grok-2/tokenizer.tok.json
---------------Time to First Token----------------
Mean TTFT (ms):                          104.61    
Median TTFT (ms):                        104.61    
P99 TTFT (ms):                           104.61    
```

With piecewise cuda graph:
```
python3 -m sglang.launch_server --model /shared/public/elr-models/xai-org/grok-2/ --tokenizer-path /shared/public/elr-models/xai-org/grok-2/tokenizer.tok.json --tp 8 --quantization fp8 --attention-backend triton --enable-piecewise-cuda-graph --disable-radix-cache

python3 -m sglang.bench_serving --backend sglang --dataset-name random-ids --num-prompts 1 --random-input-len 1024 --random-output-len 1 --random-range-ratio 1 --tokenizer /shared/public/elr-models/xai-org/grok-2/tokenizer.tok.json

python benchmark/gsm8k/bench_sglang.py --data-path /shared/public/data/gsm8k/test.jsonl --num-questions 1319
Accuracy: 0.934
Invalid: 0.001
Latency: 121.737 s
Output throughput: 1219.835 token/s

python3 -m sglang.bench_serving --backend sglang --dataset-name random-ids --num-prompts 1 --random-input-len 10
24 --random-output-len 1 --random-range-ratio 1 --tokenizer /shared/public/elr-models/xai-org/grok-2/tokenizer.tok.json
---------------Time to First Token----------------
Mean TTFT (ms):                          79.50     
Median TTFT (ms):                        79.50     
P99 TTFT (ms):                           79.50    
```
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
