### PR TITLE
[Piecewise Cuda Graph] Support EP piecewise cuda graph

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -103,8 +103,9 @@ class StandardDispatcher(BaseDispatcher):
 
         if self.local_expert_mapping is not None and not _use_aiter:
             if TopKOutputChecker.format_is_standard(topk_output):
-                topk_output = topk_output._replace(
-                    topk_ids=self.local_expert_mapping[topk_output.topk_ids]
+                # Note: "topk_output = topk_output._replace(topk_ids=self.local_expert_mapping[topk_output.topk_ids])" is incompatible with piecewise cuda graph
+                topk_output.topk_ids.copy_(
+                    self.local_expert_mapping[topk_output.topk_ids]
                 )
             elif TopKOutputChecker.format_is_triton_kernels(topk_output):
                 raise NotImplementedError()

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from enum import Enum, auto
+from enum import IntEnum, auto
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -111,42 +111,30 @@ class TopKOutputChecker:
 
     @staticmethod
     def format_is_standard(topk_output: TopKOutput) -> TypeGuard[StandardTopKOutput]:
-        return topk_output.format.is_standard()
+        return isinstance(topk_output, StandardTopKOutput)
 
     @staticmethod
     def format_is_triton_kernels(
         topk_output: TopKOutput,
     ) -> TypeGuard[TritonKernelTopKOutput]:
-        return topk_output.format.is_triton_kernels()
+        return isinstance(topk_output, TritonKernelTopKOutput)
 
     @staticmethod
     def format_is_bypassed(topk_output: TopKOutput) -> TypeGuard[BypassedTopKOutput]:
-        return topk_output.format.is_bypassed()
+        return isinstance(topk_output, BypassedTopKOutput)
 
 
-class TopKOutputFormat(Enum):
+class TopKOutputFormat(IntEnum):
     STANDARD = auto()
     TRITON_KERNEL = auto()
     BYPASSED = auto()
-
-    def is_standard(self) -> bool:
-        return self == TopKOutputFormat.STANDARD
-
-    def is_triton_kernels(self) -> bool:
-        return self == TopKOutputFormat.TRITON_KERNEL
-
-    def is_bypassed(self) -> bool:
-        return self == TopKOutputFormat.BYPASSED
 
 
 @runtime_checkable
 class TopKOutput(Protocol):
     """Protocol for top-k outputs in different formats."""
 
-    @property
-    def format(self) -> TopKOutputFormat:
-        """The format of the output."""
-        ...
+    ...
 
 
 class StandardTopKOutput(NamedTuple):
@@ -156,10 +144,6 @@ class StandardTopKOutput(NamedTuple):
     topk_ids: torch.Tensor
     router_logits: torch.Tensor
 
-    @property
-    def format(self) -> TopKOutputFormat:
-        return TopKOutputFormat.STANDARD
-
 
 class TritonKernelTopKOutput(NamedTuple):
     """Triton kernel top-k output format."""
@@ -167,10 +151,6 @@ class TritonKernelTopKOutput(NamedTuple):
     routing_data: RoutingData
     gather_indx: GatherIndx
     scatter_indx: ScatterIndx
-
-    @property
-    def format(self) -> TopKOutputFormat:
-        return TopKOutputFormat.TRITON_KERNEL
 
 
 class BypassedTopKOutput(NamedTuple):
@@ -181,10 +161,6 @@ class BypassedTopKOutput(NamedTuple):
     topk_config: TopKConfig
     num_token_non_padded: Optional[torch.Tensor] = None
     expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None
-
-    @property
-    def format(self) -> TopKOutputFormat:
-        return TopKOutputFormat.BYPASSED
 
 
 # -------------------------------- TopK ---------------------------------------

--- a/test/srt/test_piecewise_cuda_graph.py
+++ b/test/srt/test_piecewise_cuda_graph.py
@@ -94,7 +94,7 @@ class TestPiecewiseCudaGraphLlama31FP4(CustomTestCase):
 
 
 class TestPiecewiseCudaGraphQwen3MoE(CustomTestCase):
-    """Test piecewise CUDA graph with Qwen3-Coder-30B-A3B-Instruct MoE model"""
+    """Test piecewise CUDA graph with Qwen3-Coder-30B-A3B-Instruct MoE model with TP & EP"""
 
     @classmethod
     def setUpClass(cls):
@@ -108,6 +108,10 @@ class TestPiecewiseCudaGraphQwen3MoE(CustomTestCase):
                 "--enable-piecewise-cuda-graph",
                 "--piecewise-cuda-graph-compiler",
                 "eager",
+                "--ep",
+                "2",
+                "--tp",
+                "2",
             ],
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

https://github.com/sgl-project/sglang/issues/11490

### @property & Enum issue in torch compile
Python @property & Enum is not well supported in torch compile. Some modifications are required 

#### @property: it leads to torch compile unable to recognize the variable type
```
 Explanation: Dynamo does not know how to trace method `is_standard` of class `<unknown type>`
  Hint: Avoid calling `<unknown type>.is_standard` in your code.
  Hint: Please report an issue to PyTorch.

  Developer debug context: call_method GetAttrVariable(NamedTupleVariable(length=3), format) is_standard [] {}
```

#### enum: enum_obj == enum_value is not supported by torch compile
```
torch._dynamo.exc.Unsupported: Builtin `operator.*` comparison with constant `self` failed
  Explanation: Failed to compare GetAttrVariable(NamedTupleVariable(length=3), format) with EnumVariable(<enum 'TopKOutputFormat'>), because EnumVariable(<enum 'TopKOutputFormat'>) is not a Python constant or its mutation check fails.


  Developer debug context: call_method GetAttrVariable(NamedTupleVariable(length=3), format) __eq__ [EnumVariable(<enum 'TopKOutputFormat'>)] {}
```

### _replace -> copy_

_replace is not supported in torch compile instead we should use copy_() to update the tensor content

```
torch._dynamo.exc.Unsupported: Attempted to inline function marked as skipped
  Explanation: Dynamo developers have intentionally marked that the function `StandardTopKOutput._replace` should not be traced.
  Hint: Avoid calling the function `StandardTopKOutput._replace`.
  Hint: Apply `@torch._dynamo.dont_skip_tracing` to the function `StandardTopKOutput._replace` to force tracing into the function. More graph breaks may occur as a result of attempting to trace into the function.
  Hint: Please file an issue to PyTorch.

  Developer debug context: qualname: StandardTopKOutput._replace, name: _replace, filename: `/usr/lib/python3.10/collections/__init__.py`, skip reason: skipped according trace_rules.lookup SKIP_DIRS
``` 
## Next Steps
Test all other combinations of EP such as deepep, different moe runner and etc. Test other MOE models

## Accuracy Tests

```
(venv) jobuser@ankc4t7ljfn8mffqv69d-n0-0-master-0:~/sglang$ python3 benchmark/gsm8k/bench_sglang.py 
/home/jobuser/sglang/venv/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:10<00:00, 18.86it/s]
Accuracy: 0.960
Invalid: 0.000
Latency: 10.671 s
Output throughput: 2825.825 token/s
```

## Benchmarking and Profiling
```
from sglang.srt.entrypoints.http_server import launch_server
from sglang.srt.server_args import prepare_server_args
import torch
torch._dynamo.config.reorderable_logging_functions.add(print)
if __name__ == "__main__":
    # Simulate CLI arguments (excluding the script name)
    args = [
        "--model-path",
        "/shared/public/elr-models/Qwen/Qwen3-30B-A3B-Instruct-2507/61082d4deaa4785f64943b443cbc2b5de7524fad/",
        "--tp",
        "2",
        "--ep",
        "2",        
        "--attention-backend",
        "fa3",
        "--enable-piecewise-cuda-graph"
    ]
    server_args = prepare_server_args(args)
    launch_server(server_args)
```

```
python3 -m sglang.bench_one_batch_server --model-path /shared/public/elr-models/Qwen/Qwen3-30B-A3B-Instruct-2507/61082d4deaa4785f64943b443cbc2b5de7524fad/ --host 127.0.0.1 --port 30000 --batch 1 --input-len 16 32 64 128 256 512 1024 --output-len 1 
```

| Input Tokens | Input Throughput Before (tok/s) | Input Throughput After (tok/s) | Speedup (%) |
|--------------|-------------------------------|------------------------------|------------|
| 16           | 257.00                        | 379.61                       | 47.7       |
| 32           | 541.06                        | 1070.66                      | 97.9       |
| 64           | 1142.67                       | 2103.46                      | 84.1       |
| 128          | 2286.17                       | 4001.13                      | 75.0       |
| 256          | 4322.51                       | 7278.06                      | 68.4       |
| 512          | 7749.29                       | 12179.85                     | 57.2       |
| 1024         | 16091.64                      | 20440.95                     | 27.0       |
| 2048         | 26269.28                      | 30152.25                     | 14.8       |
| 4096         | 40663.30                      | 43808.07                     | 7.7        |
| 8192         | 45929.90                      | 47956.66                     | 4.4        |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
