### PR TITLE
Adding nightly tests as release guard for bot bump workflows

### DIFF
--- a/.github/workflows/bot-bump-kernel-version-to-sglang.yml
+++ b/.github/workflows/bot-bump-kernel-version-to-sglang.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   bump-kernel-version-to-sglang:
     runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.set_output.outputs.branch_name }}
+      needs_sync: ${{ steps.check_sync.outputs.needs_sync }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,6 +35,7 @@ jobs:
 
       - name: Configure Git and branch
         if: steps.check_sync.outputs.needs_sync == 'true'
+        id: set_output
         run: |
           git config user.name "sglang-bot"
           git config user.email "sglang-bot@users.noreply.github.com"
@@ -41,6 +45,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "KERNEL_VERSION=$KERNEL_VERSION" >> $GITHUB_ENV
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - name: Run kernel version bump script
         if: steps.check_sync.outputs.needs_sync == 'true'
@@ -53,3 +58,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
         run: |
           bash scripts/release/commit_and_pr_kernel_to_sglang.sh "$KERNEL_VERSION" "$BRANCH_NAME"
+
+  run-nightly-tests:
+    needs: bump-kernel-version-to-sglang
+    if: needs.bump-kernel-version-to-sglang.outputs.needs_sync == 'true'
+    uses: ./.github/workflows/nightly-test.yml
+    with:
+      ref: ${{ needs.bump-kernel-version-to-sglang.outputs.branch_name }}
+    secrets: inherit

--- a/.github/workflows/bot-bump-sglang-version.yml
+++ b/.github/workflows/bot-bump-sglang-version.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   bump-sglang-version:
     runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.set_output.outputs.branch_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +33,7 @@ jobs:
           pip install tomli
 
       - name: Configure Git and branch
+        id: set_output
         run: |
           git config user.name "sglang-bot"
           git config user.email "sglang-bot@users.noreply.github.com"
@@ -38,6 +41,7 @@ jobs:
           BRANCH_NAME="bot/bump-sglang-version-${{ github.event.inputs.new_version }}-${RANDOM_SUFFIX}"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - name: Run SGLang version bump script
         run: |
@@ -48,3 +52,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_FOR_PULL_REQUEST }}
         run: |
           bash scripts/release/commit_and_pr.sh "SGLang" "${{ github.event.inputs.new_version }}" "$BRANCH_NAME"
+
+  run-nightly-tests:
+    needs: bump-sglang-version
+    uses: ./.github/workflows/nightly-test.yml
+    with:
+      ref: ${{ needs.bump-sglang-version.outputs.branch_name }}
+    secrets: inherit

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - "python/sglang/version.py"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to test. If not provided, uses the default branch.'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   group: nightly-test-${{ github.ref }}
@@ -21,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -38,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -67,6 +78,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -84,6 +97,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -116,6 +131,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -133,6 +150,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -152,6 +171,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -171,6 +192,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -192,6 +215,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Motivation

Currently, updates to sgl version and sgl kernel version create a PR, but do not trigger nightly-tests on the change; this change adds nightly tests as part of the sgl version and sgl kernel version release workflow.

## Modifications

Added the following:
- Adding workflow_call to the nightly-test.yml to let it be called by other workflows
- Nightly-test.yml now accepts an optional input parameter in a git reference, allowing the jobs to checkout a certain branch if specified.
- Added nightly tests as a job in the bot-bump-sgl-version and bot-bump-sgl-kernel-version-to-SGLang workflows.

## Accuracy Tests

N/A.

## Benchmarking and Profiling

N/A.

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [N/A ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ N/A] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [N/A ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ Done] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
