### PR TITLE
[perf] Add two stream norm for `Olmo3` speedup 5%

### DIFF
--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -329,8 +329,6 @@ class Olmo2Model(nn.Module):
     ):
         super().__init__()
         self.config = config
-        # If no alt_stream is provided, initialize one on CUDA so that
-        # Q/K RMSNorm overlap is enabled by default (mirrors Qwen3 behaviour).
         if alt_stream is None and _is_cuda:
             alt_stream = torch.cuda.Stream()
         self.alt_stream = alt_stream

--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -43,6 +43,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
@@ -67,6 +68,7 @@ class Olmo2Attention(nn.Module):
         layer_id: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.config = config
@@ -107,6 +109,7 @@ class Olmo2Attention(nn.Module):
             prefix=add_prefix("qkv_proj", prefix),
         )
         self.tp_rank = get_tensor_model_parallel_rank()
+        self.alt_stream = alt_stream
 
         self.k_norm = RMSNorm(
             self.total_num_kv_heads * self.head_dim,
@@ -161,8 +164,29 @@ class Olmo2Attention(nn.Module):
         if self.tp_size > 1:
             q = tensor_model_parallel_all_gather(q.contiguous())
             k = tensor_model_parallel_all_gather(k.contiguous())
-        q = self.q_norm.forward_native(q)
-        k = self.k_norm.forward_native(k)
+
+        if self.alt_stream is not None and get_is_capture_mode():
+            current_stream = torch.cuda.current_stream()
+            self.alt_stream.wait_stream(current_stream)
+
+            q_shape = q.shape
+            k_shape = k.shape
+
+            q_by_last = q.reshape(-1, q_shape[-1])
+            q_by_last = self.q_norm(q_by_last)
+
+            with torch.cuda.stream(self.alt_stream):
+                k_by_last = k.reshape(-1, k_shape[-1])
+                k_by_last = self.k_norm(k_by_last)
+
+            current_stream.wait_stream(self.alt_stream)
+
+            q = q_by_last.view(q_shape)
+            k = k_by_last.view(k_shape)
+        else:
+            q = self.q_norm.forward_native(q)
+            k = self.k_norm.forward_native(k)
+
         if self.tp_size > 1:
             splitter = partial(split_tensor_along_last_dim, num_partitions=self.tp_size)
             q = splitter(q)[self.tp_rank]
@@ -246,12 +270,18 @@ class Olmo2DecoderLayer(nn.Module):
         layer_id: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.layer_id = layer_id
+        self.alt_stream = alt_stream
         # Attention block.
         self.self_attn = Olmo2Attention(
-            config, layer_id, quant_config, prefix=add_prefix("self_attn", prefix)
+            config,
+            layer_id,
+            quant_config,
+            prefix=add_prefix("self_attn", prefix),
+            alt_stream=alt_stream,
         )
 
         # MLP block.
@@ -293,6 +323,7 @@ class Olmo2Model(nn.Module):
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.config = config
@@ -309,6 +340,7 @@ class Olmo2Model(nn.Module):
                 layer_id=idx,
                 quant_config=quant_config,
                 prefix=prefix,
+                alt_stream=alt_stream,
             ),
             prefix=add_prefix("layers", prefix),
         )
@@ -357,11 +389,15 @@ class Olmo2ForCausalLM(nn.Module):
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.config = config
         self.model = Olmo2Model(
-            config, quant_config, prefix=add_prefix("model", prefix)
+            config,
+            quant_config,
+            prefix=add_prefix("model", prefix),
+            alt_stream=alt_stream,
         )
         if config.tie_word_embeddings:
             self.lm_head = self.model.embed_tokens


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
Just like https://github.com/sgl-project/sglang/pull/7740/files, and https://github.com/sgl-project/sglang/pull/5977
We could do the fetch fast stream too but minimal perf diff.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

### Summary
Around 7% faster across the main throughput metrics, and about 5.6% lower mean latency.
Roughly a 1.07× speedup in throughput too

# Add overlap stream to overlap q k  norm
Using:
```
CUDA_VISIBLE_DEVICES=6 python -m sglang.launch_server --model-path allenai/Olmo-3-7B-Instruct --mem-fraction-static 0.8 --model-loader-extra-config "{\"enable_multithread_load\": true, \"num_threads\": 8}" --trust-remote-code
```

Bench:
```
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 512 --random-input-len 4096 --random-output-len 1024 --random-range-ratio 0.0 --flush-cache --disable-stream --apply-chat-template
```

# Before
```
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 512 --random-input-len 4096 --random-output-len 1024 --random-range-ratio 0.0 --flush-cache --disable-stream --apply-chat-template
benchmark_args=Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, served_model_name=None, tokenizer=None, num_prompts=512, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=4096, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=True, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=True, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)
Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='allenai/Olmo-3-7B-Instruct', served_model_name=None, tokenizer=None, num_prompts=512, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=4096, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=True, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=True, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)

#Input tokens: 1048425
#Output tokens: 262259
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [01:22<00:00,  6.21it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     512       
Benchmark duration (s):                  82.42     
Total input tokens:                      1048425   
Total input text tokens:                 1048425   
Total input vision tokens:               0         
Total generated tokens:                  262259    
Total generated tokens (retokenized):    261688    
Request throughput (req/s):              6.21      
Input token throughput (tok/s):          12720.70  
Output token throughput (tok/s):         3182.03   
Total token throughput (tok/s):          15902.73  
Concurrency:                             291.47    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   46918.92  
Median E2E Latency (ms):                 47663.02  
---------------Time to First Token----------------
Mean TTFT (ms):                          46919.01  
Median TTFT (ms):                        47663.09  
P99 TTFT (ms):                           81733.94  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          -0.00     
Median TPOT (ms):                        -0.00     
P99 TPOT (ms):                           -0.00     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
```

# After
```
#Input tokens: 1048425
#Output tokens: 262259
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [01:17<00:00,  6.65it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     512       
Benchmark duration (s):                  77.05     
Total input tokens:                      1048425   
Total input text tokens:                 1048425   
Total input vision tokens:               0         
Total generated tokens:                  262259    
Total generated tokens (retokenized):    261630    
Request throughput (req/s):              6.64      
Input token throughput (tok/s):          13606.65  
Output token throughput (tok/s):         3403.64   
Total token throughput (tok/s):          17010.29  
Concurrency:                             294.43    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   44309.72  
Median E2E Latency (ms):                 45191.09  
---------------Time to First Token----------------
Mean TTFT (ms):                          44309.80  
Median TTFT (ms):                        45191.19  
P99 TTFT (ms):                           76490.15  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          -0.00     
Median TPOT (ms):                        -0.00     
P99 TPOT (ms):                           -0.00     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
``

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
