### PR TITLE
Add olmo3 dp atten

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -305,6 +305,11 @@ class LayerCommunicator:
         allow_reduce_scatter: bool = False,
         is_last_layer: bool = False,
         qkv_latent_func: Optional[Callable] = None,
+        # When comm_only is True, LayerCommunicator is used only for scatter/gather
+        # and group-size transitions, and should avoid changing hidden_states or
+        # residual via layernorm. This is useful for post-LN architectures like
+        # OLMo2/3 where layer norms live strictly outside the communicator.
+        comm_only: bool = False,
     ):
         self.layer_scatter_modes = layer_scatter_modes
         self.input_layernorm = input_layernorm
@@ -312,6 +317,7 @@ class LayerCommunicator:
         self.allow_reduce_scatter = allow_reduce_scatter
         self.is_last_layer = is_last_layer
         self.qkv_latent_func = qkv_latent_func
+        self.comm_only = comm_only
 
         self._context = CommunicateContext.init_new()
         self._communicate_simple_fn = CommunicateSimpleFn.get_fn(
@@ -375,83 +381,100 @@ class LayerCommunicator:
                 hidden_states,
                 residual,
             )
-        if hidden_states.shape[0] == 0:
-            residual = hidden_states
-        else:
-            if (
-                residual is not None
-                and hasattr(hidden_states, "_sglang_needs_allreduce_fusion")
-                and hidden_states._sglang_needs_allreduce_fusion
-            ):
-                hidden_states, residual = (
-                    self.input_layernorm.forward_with_allreduce_fusion(
-                        hidden_states, residual
-                    )
-                )
+        if not self.comm_only:
+            if hidden_states.shape[0] == 0:
+                residual = hidden_states
             else:
-                if residual is None:
-                    residual = hidden_states
-
-                    if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
-                        hidden_states, *_, _ = fused_rms_mxfp4_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            None,
-                            None,
-                            None,
-                            None,
-                        )
-                    elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
-
-                        hidden_states, _, _, _res = fused_rms_fp8_group_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            inp2=None,
-                            inp2_weight=None,
-                            inp2_epsilon=None,
-                            group_size=128,
-                            dtype_quant=torch.float8_e4m3fn,
-                            res1=None,
-                            output_unquantized_inp1=False,
-                        )
-
-                    else:
-                        hidden_states = self.input_layernorm(hidden_states)
-                else:
-
-                    if _use_aiter and _is_gfx95_supported and ("mxfp4" in quant_format):
-                        hidden_states, *_, residual = fused_rms_mxfp4_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            None,
-                            None,
-                            None,
-                            residual,
-                        )
-                    elif _use_aiter and _is_gfx95_supported and ("fp8" in quant_format):
-                        # RMSNorm + FP8 per-group quant
-                        # return hidden_states：
-                        #   out_fp8  : FP8 activation →  a8w8 GEMM
-                        #   out_bs   : block-scale →  gemm_a8w8_blockscale.x_scale
-                        hidden_states, _, _, residual = fused_rms_fp8_group_quant(
-                            hidden_states,
-                            self.input_layernorm.weight,
-                            self.input_layernorm.variance_epsilon,
-                            inp2=None,
-                            inp2_weight=None,
-                            inp2_epsilon=None,
-                            group_size=128,
-                            dtype_quant=torch.float8_e4m3fn,
-                            res1=residual,
-                            output_unquantized_inp1=False,
-                        )
-                    else:
-                        hidden_states, residual = self.input_layernorm(
+                if (
+                    residual is not None
+                    and hasattr(hidden_states, "_sglang_needs_allreduce_fusion")
+                    and hidden_states._sglang_needs_allreduce_fusion
+                ):
+                    hidden_states, residual = (
+                        self.input_layernorm.forward_with_allreduce_fusion(
                             hidden_states, residual
                         )
+                    )
+                else:
+                    if residual is None:
+                        residual = hidden_states
+
+                        if (
+                            _use_aiter
+                            and _is_gfx95_supported
+                            and ("mxfp4" in quant_format)
+                        ):
+                            hidden_states, *_, _ = fused_rms_mxfp4_quant(
+                                hidden_states,
+                                self.input_layernorm.weight,
+                                self.input_layernorm.variance_epsilon,
+                                None,
+                                None,
+                                None,
+                                None,
+                            )
+                        elif (
+                            _use_aiter
+                            and _is_gfx95_supported
+                            and ("fp8" in quant_format)
+                        ):
+
+                            hidden_states, _, _, _res = fused_rms_fp8_group_quant(
+                                hidden_states,
+                                self.input_layernorm.weight,
+                                self.input_layernorm.variance_epsilon,
+                                inp2=None,
+                                inp2_weight=None,
+                                inp2_epsilon=None,
+                                group_size=128,
+                                dtype_quant=torch.float8_e4m3fn,
+                                res1=None,
+                                output_unquantized_inp1=False,
+                            )
+
+                        else:
+                            hidden_states = self.input_layernorm(hidden_states)
+                    else:
+
+                        if (
+                            _use_aiter
+                            and _is_gfx95_supported
+                            and ("mxfp4" in quant_format)
+                        ):
+                            hidden_states, *_, residual = fused_rms_mxfp4_quant(
+                                hidden_states,
+                                self.input_layernorm.weight,
+                                self.input_layernorm.variance_epsilon,
+                                None,
+                                None,
+                                None,
+                                residual,
+                            )
+                        elif (
+                            _use_aiter
+                            and _is_gfx95_supported
+                            and ("fp8" in quant_format)
+                        ):
+                            # RMSNorm + FP8 per-group quant
+                            # return hidden_states：
+                            #   out_fp8  : FP8 activation →  a8w8 GEMM
+                            #   out_bs   : block-scale →  gemm_a8w8_blockscale.x_scale
+                            hidden_states, _, _, residual = fused_rms_fp8_group_quant(
+                                hidden_states,
+                                self.input_layernorm.weight,
+                                self.input_layernorm.variance_epsilon,
+                                inp2=None,
+                                inp2_weight=None,
+                                inp2_epsilon=None,
+                                group_size=128,
+                                dtype_quant=torch.float8_e4m3fn,
+                                res1=residual,
+                                output_unquantized_inp1=False,
+                            )
+                        else:
+                            hidden_states, residual = self.input_layernorm(
+                                hidden_states, residual
+                            )
 
         hidden_states = self._communicate_simple_fn(
             hidden_states=hidden_states,
@@ -500,6 +523,7 @@ class LayerCommunicator:
             forward_batch=forward_batch,
             layernorm=self.post_attention_layernorm,
             context=self._context,
+            apply_layernorm=not self.comm_only,
         )
 
     def postprocess_layer(
@@ -707,9 +731,10 @@ class CommunicateWithAllReduceAndLayerNormFn:
         forward_batch: ForwardBatch,
         layernorm: torch.nn.Module,
         context: CommunicateContext,
+        apply_layernorm: bool = True,
     ):
         # TODO move these `if shape != 0` into LayerNorm itself
-        if hidden_states.shape[0] != 0:
+        if hidden_states.shape[0] != 0 and apply_layernorm:
             hidden_states, residual = layernorm(hidden_states, residual)
         return hidden_states, residual
 
@@ -722,6 +747,7 @@ class CommunicateWithAllReduceAndLayerNormFn:
         context: CommunicateContext,
         *,
         residual_input_mode,
+        apply_layernorm: bool = True,
     ):
         if get_attn_tp_context().input_scattered:
             return CommunicateWithAllReduceAndLayerNormFn._tp_all_reduce_with_scattered_residual(
@@ -738,12 +764,16 @@ class CommunicateWithAllReduceAndLayerNormFn:
             )
             attn_tp_all_gather_into_tensor(residual, local_residual)
         if context.attn_dp_size != 1:
-            if context.attn_tp_rank == 0:
+            if apply_layernorm and context.attn_tp_rank == 0:
                 hidden_states += residual
 
             # Perform layernorm on smaller data before comm. Only valid when attn_tp_size is 1 (tp_size == dp_size)
             use_layer_norm_before_gather = context.attn_tp_size == 1
-            if use_layer_norm_before_gather and hidden_states.shape[0] != 0:
+            if (
+                use_layer_norm_before_gather
+                and hidden_states.shape[0] != 0
+                and apply_layernorm
+            ):
                 residual = hidden_states
                 with use_symmetric_memory(
                     get_tp_group(),
@@ -759,26 +789,32 @@ class CommunicateWithAllReduceAndLayerNormFn:
 
             if not use_layer_norm_before_gather:
                 dp_scatter(residual, hidden_states, forward_batch)
-                if hidden_states.shape[0] != 0:
+                if hidden_states.shape[0] != 0 and apply_layernorm:
                     hidden_states = layernorm(hidden_states)
         else:
             # According to the discussion in https://github.com/flashinfer-ai/flashinfer/issues/1223#issuecomment-3047256465
             # We set the max token num to 128 for allreduce fusion with min-latency case(use_oneshot=True).
-            if (
-                (_is_sm100_supported or _is_sm90_supported)
-                and _is_flashinfer_available
-                and hasattr(layernorm, "forward_with_allreduce_fusion")
-                and get_global_server_args().enable_flashinfer_allreduce_fusion
-                and hidden_states.shape[0] <= 2048
-            ):
-                hidden_states, residual = layernorm.forward_with_allreduce_fusion(
-                    hidden_states, residual
-                )
+            if apply_layernorm:
+                if (
+                    (_is_sm100_supported or _is_sm90_supported)
+                    and _is_flashinfer_available
+                    and hasattr(layernorm, "forward_with_allreduce_fusion")
+                    and get_global_server_args().enable_flashinfer_allreduce_fusion
+                    and hidden_states.shape[0] <= 2048
+                ):
+                    hidden_states, residual = layernorm.forward_with_allreduce_fusion(
+                        hidden_states, residual
+                    )
+                else:
+                    hidden_states = tensor_model_parallel_all_reduce(hidden_states)
+                    if context.cache is not None:
+                        _ = prepare_weight_cache(hidden_states, context.cache)
+                    hidden_states, residual = layernorm(hidden_states, residual)
             else:
+                # Comm-only path: keep allreduce/cache behavior but skip layernorm.
                 hidden_states = tensor_model_parallel_all_reduce(hidden_states)
                 if context.cache is not None:
                     _ = prepare_weight_cache(hidden_states, context.cache)
-                hidden_states, residual = layernorm(hidden_states, residual)
         return hidden_states, residual
 
     @staticmethod
@@ -790,6 +826,7 @@ class CommunicateWithAllReduceAndLayerNormFn:
         context: CommunicateContext,
         *,
         residual_input_mode,
+        apply_layernorm: bool = True,
     ):
         input_hidden_states = hidden_states
         hidden_states = hidden_states.tensor_split(context.attn_tp_size)[
@@ -798,7 +835,7 @@ class CommunicateWithAllReduceAndLayerNormFn:
         attn_tp_reduce_scatter_tensor(hidden_states, input_hidden_states)
         if residual_input_mode == ScatterMode.TP_ATTN_FULL:
             residual = residual.tensor_split(context.attn_tp_size)[context.attn_tp_rank]
-        if hidden_states.shape[0] != 0:
+        if hidden_states.shape[0] != 0 and apply_layernorm:
             hidden_states, residual = layernorm(hidden_states, residual)
         return hidden_states, residual
 

--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -329,8 +329,6 @@ class Olmo2Model(nn.Module):
     ):
         super().__init__()
         self.config = config
-        # If no alt_stream is provided, initialize one on CUDA so that
-        # Q/K RMSNorm overlap is enabled by default (mirrors Qwen3 behaviour).
         if alt_stream is None and _is_cuda:
             alt_stream = torch.cuda.Stream()
         self.alt_stream = alt_stream

--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -43,6 +43,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
+from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix, make_layers
@@ -67,6 +68,7 @@ class Olmo2Attention(nn.Module):
         layer_id: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.config = config
@@ -107,6 +109,7 @@ class Olmo2Attention(nn.Module):
             prefix=add_prefix("qkv_proj", prefix),
         )
         self.tp_rank = get_tensor_model_parallel_rank()
+        self.alt_stream = alt_stream
 
         self.k_norm = RMSNorm(
             self.total_num_kv_heads * self.head_dim,
@@ -161,8 +164,29 @@ class Olmo2Attention(nn.Module):
         if self.tp_size > 1:
             q = tensor_model_parallel_all_gather(q.contiguous())
             k = tensor_model_parallel_all_gather(k.contiguous())
-        q = self.q_norm.forward_native(q)
-        k = self.k_norm.forward_native(k)
+
+        if self.alt_stream is not None and get_is_capture_mode():
+            current_stream = torch.cuda.current_stream()
+            self.alt_stream.wait_stream(current_stream)
+
+            q_shape = q.shape
+            k_shape = k.shape
+
+            q_by_last = q.reshape(-1, q_shape[-1])
+            q_by_last = self.q_norm(q_by_last)
+
+            with torch.cuda.stream(self.alt_stream):
+                k_by_last = k.reshape(-1, k_shape[-1])
+                k_by_last = self.k_norm(k_by_last)
+
+            current_stream.wait_stream(self.alt_stream)
+
+            q = q_by_last.view(q_shape)
+            k = k_by_last.view(k_shape)
+        else:
+            q = self.q_norm.forward_native(q)
+            k = self.k_norm.forward_native(k)
+
         if self.tp_size > 1:
             splitter = partial(split_tensor_along_last_dim, num_partitions=self.tp_size)
             q = splitter(q)[self.tp_rank]
@@ -246,12 +270,18 @@ class Olmo2DecoderLayer(nn.Module):
         layer_id: int = 0,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.layer_id = layer_id
+        self.alt_stream = alt_stream
         # Attention block.
         self.self_attn = Olmo2Attention(
-            config, layer_id, quant_config, prefix=add_prefix("self_attn", prefix)
+            config,
+            layer_id,
+            quant_config,
+            prefix=add_prefix("self_attn", prefix),
+            alt_stream=alt_stream,
         )
 
         # MLP block.
@@ -293,6 +323,7 @@ class Olmo2Model(nn.Module):
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.config = config
@@ -309,6 +340,7 @@ class Olmo2Model(nn.Module):
                 layer_id=idx,
                 quant_config=quant_config,
                 prefix=prefix,
+                alt_stream=alt_stream,
             ),
             prefix=add_prefix("layers", prefix),
         )
@@ -357,11 +389,15 @@ class Olmo2ForCausalLM(nn.Module):
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
     ):
         super().__init__()
         self.config = config
         self.model = Olmo2Model(
-            config, quant_config, prefix=add_prefix("model", prefix)
+            config,
+            quant_config,
+            prefix=add_prefix("model", prefix),
+            alt_stream=alt_stream,
         )
         if config.tie_word_embeddings:
             self.lm_head = self.model.embed_tokens

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1447,9 +1447,9 @@ class ServerArgs:
             self.enable_dp_lm_head = False
 
         if self.enable_dp_attention:
-            self.schedule_conservativeness = self.schedule_conservativeness * 0.3
+            # self.schedule_conservativeness = self.schedule_conservativeness * 0.3
             assert self.tp_size % self.dp_size == 0
-            self.chunked_prefill_size = self.chunked_prefill_size // self.dp_size
+            # self.chunked_prefill_size = self.chunked_prefill_size // self.dp_size
             logger.warning(
                 f"DP attention is enabled. The chunked prefill size is adjusted to {self.chunked_prefill_size} to avoid MoE kernel issues. "
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
- Support DP attn in Olmo3
- Refactor LayerCommunicator to prevent pre-attention norm apply (previously forced this behaviour)
- Correctness tested (send one)
- Think model spends lots of time on decode (emphasis on high decode proportion), could be better without Think? -Instruct model

```
python -m sglang.launch_server --model-path allenai/Olmo-3-32B-Think --mem-fraction-static 0.8 --model-loader-extra-config "{\"enable_multithread_load\": true, \"num_threads\": 8}" --trust-remote-code --tp-size 4 --enable-dp-attention --dp-size 4
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

It's worse unsurprisingly, since dp atten best for large MoE, etc.
Even after commenting out the changes in schedule conservativeness and chunked prefill size, its not better. benchmark result with the revert speed is ~= the same as without comment out lines.

```
# Without DP Attention
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 512 --random-input-len 4096 --random-output-len 1024 --random-range-ratio 0.0 --flush-cache --disable-stream --apply-chat-template
benchmark_args=Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, served_model_name=None, tokenizer=None, num_prompts=512, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=4096, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=True, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=True, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)
Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='allenai/Olmo-3-32B-Think', served_model_name=None, tokenizer=None, num_prompts=512, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=4096, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=True, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=True, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)

#Input tokens: 1048425
#Output tokens: 262259
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:27<00:00, 18.55it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     512       
Benchmark duration (s):                  27.62     
Total input tokens:                      1048425   
Total input text tokens:                 1048425   
Total input vision tokens:               0         
Total generated tokens:                  262259    
Total generated tokens (retokenized):    260962    
Request throughput (req/s):              18.54     
Input token throughput (tok/s):          37963.79  
Output token throughput (tok/s):         9496.48   
Total token throughput (tok/s):          47460.27  
Concurrency:                             312.03    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   16830.52  
Median E2E Latency (ms):                 17544.55  
---------------Time to First Token----------------
Mean TTFT (ms):                          16830.59  
Median TTFT (ms):                        17544.63  
P99 TTFT (ms):                           27485.62  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          -0.00     
Median TPOT (ms):                        -0.00     
P99 TPOT (ms):                           -0.00     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================

# WIth DP Attention
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 512 --random-input-len 4096 --random-output-len 1024 --random-range-ratio 0.0 --flush-cache --disable-stream --apply-chat-template
benchmark_args=Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=None, dataset_name='random', dataset_path='', model=None, served_model_name=None, tokenizer=None, num_prompts=512, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=4096, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=True, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=True, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)
Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=30000, dataset_name='random', dataset_path='', model='allenai/Olmo-3-32B-Think', served_model_name=None, tokenizer=None, num_prompts=512, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=4096, random_output_len=1024, random_range_ratio=0.0, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=True, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=True, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)

#Input tokens: 1048425
#Output tokens: 262259
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:42<00:00, 12.12it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     512       
Benchmark duration (s):                  42.25     
Total input tokens:                      1048425   
Total input text tokens:                 1048425   
Total input vision tokens:               0         
Total generated tokens:                  262259    
Total generated tokens (retokenized):    261463    
Request throughput (req/s):              12.12     
Input token throughput (tok/s):          24816.51  
Output token throughput (tok/s):         6207.74   
Total token throughput (tok/s):          31024.26  
Concurrency:                             390.92    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   32256.48  
Median E2E Latency (ms):                 32855.67  
---------------Time to First Token----------------
Mean TTFT (ms):                          32256.56  
Median TTFT (ms):                        32855.76  
P99 TTFT (ms):                           42079.24  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          -0.00     
Median TPOT (ms):                        -0.00     
P99 TPOT (ms):                           -0.00     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================

```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
