### PR TITLE
fix test_lora_update.py starvation message check

### DIFF
--- a/test/srt/lora/test_lora_update.py
+++ b/test/srt/lora/test_lora_update.py
@@ -713,7 +713,7 @@ MAX_LOADED_LORAS_TESTS = [
                     "lora_path": "pbevan11/llama-3.1-8b-ocr-correction",
                     "pinned": True,
                 },
-                expected_error="unpin some adapters",
+                expected_error="starvation",
             ),
             Operation(
                 type=OperationType.UNLOAD,
@@ -768,7 +768,7 @@ EVICTION_TESTS = [
                     "lora_path": "Nutanix/Meta-Llama-3.1-8B-Instruct_lora_4_alpha_16",
                     "pinned": True,
                 },
-                expected_error="unpin some adapters",
+                expected_error="starvation",
             ),
             Operation(
                 type=OperationType.LOAD,
@@ -809,7 +809,7 @@ EVICTION_TESTS = [
                     "lora_path": "philschmid/code-llama-3-1-8b-text-to-sql-lora",
                     "pinned": True,
                 },
-                expected_error="unpin some adapters",
+                expected_error="starvation",
             ),
             Operation(
                 type=OperationType.LOAD,


### PR DESCRIPTION
## Motivation

#11526 originally changed the message check in `test_lora_update.py` to match what was happening in the main branch. Then, #13619 removed a duplicate starvation check for pinned GPUs, but the message check didn't reflect the new starvation error message that is reached. We can revert the message check to be what it was prior to #11526. 


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
