### PR TITLE
[dev-tools] Support uv within sglang/python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ ipython_config.py
 #   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
 #poetry.lock
 
+# uv
+uv.lock
+
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
 #pdm.lock

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -117,6 +117,9 @@ tracing = [
   "opentelemetry-sdk",
 ]
 
+[tool.uv.sources]
+sglang = { workspace = true }
+
 [project.urls]
 "Homepage" = "https://github.com/sgl-project/sglang"
 "Bug Tracker" = "https://github.com/sgl-project/sglang/issues"


### PR DESCRIPTION
## Motivation

This allows running `uv` directly from within `sglang/python` subdirectory without spinning up a docker image or deal with pip/venv. For example:

#13711 was run with
```
uv run --active --preview-features extra-build-dependencies ../benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py \
    --model zai-org/GLM-4.5-Air-FP8 \
    --tp-size 2 \
    --dtype fp8_w8a8 \
    --tune
```

And the sglang server can be run with

```
uv run sglang/launch_server.py \
        --model-path zai-org/GLM-4.5V-FP8 \
        --port 12345 \
        --tp 2 \
        --mem-fraction-static 0.70 \
        --served-model-name glm-4.5V \
        --sleep-on-idle \
        --tool-call-parser glm45 \
        --reasoning-parser glm45
```

## Modifications

- Changed pyproject.toml so that it considers sglang within its workspace
- Ignore uv.lock

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
