### PR TITLE
Fix  IMA with flashinfer  + spec + topk & Add radix attention test cases for eagle

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -188,9 +188,7 @@ class EagleVerifyInput(SpecInput, EagleVerifyInputV2Mixin):
             + (self.draft_token_num**2) * batch_size
         )
         if self.custom_mask.numel() < mask_numel:
-            logger.warning(
-                f"Custom mask size mismatch: expected {mask_numel}, got {self.custom_mask.numel()}. Padding with True."
-            )
+            # FIXME(attn): temporary fix for custom mask padding with cuda graph
             self.custom_mask = torch.cat(
                 [
                     self.custom_mask,

--- a/test/registered/spec/eagle/test_eagle_infer_b.py
+++ b/test/registered/spec/eagle/test_eagle_infer_b.py
@@ -41,9 +41,8 @@ class TestEAGLEServerBasic(EagleServerBase):
             p.join()
 
     def test_radix_attention(self):
-        # python -m unittest test_eagle_infer_b.TestEAGLERetract.test_radix_attention
         run_radix_attention_test(self.base_url)
-        assert self.process.poll() is None
+        self.assertIsNone(self.process.poll())
 
     def test_max_token_one(self):
         requests.get(self.base_url + "/flush_cache")

--- a/test/registered/spec/eagle/test_eagle_infer_b.py
+++ b/test/registered/spec/eagle/test_eagle_infer_b.py
@@ -13,6 +13,7 @@ import requests
 from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_gsm8k_eval
+from sglang.test.kits.radix_cache_server_kit import run_radix_attention_test
 from sglang.test.server_fixtures.eagle_fixture import EagleServerBase
 from sglang.test.test_utils import (
     DEFAULT_EAGLE_TARGET_MODEL_FOR_TEST,
@@ -38,6 +39,11 @@ class TestEAGLEServerBasic(EagleServerBase):
             worker.start()
         for p in threads:
             p.join()
+
+    def test_radix_attention(self):
+        # python -m unittest test_eagle_infer_b.TestEAGLERetract.test_radix_attention
+        run_radix_attention_test(self.base_url)
+        assert self.process.poll() is None
 
     def test_max_token_one(self):
         requests.get(self.base_url + "/flush_cache")


### PR DESCRIPTION
By adding test radix attention in `test_spec_infer_b.py`, there is a decode OOM issue.

Reproduction

```bash
python -m unittest test_eagle_infer_b.TestEAGLERetract.test_radix_attention
```

The out-of-memory error has been fixed by #14939.

The flashinfer IMA bugs were reported in #14624.


### Why is there an IMA issue?

The custom mask is generated inside the Eagle worker with `build_tree_kernel_efficient`.

But the `mask_indptr` was generated inside flashinfer's `begin_forward`, and the `mask_indptr` is calculated with padded `qo_indptr` and padded `kv_indptr` when applying CUDA graph padding.

The shape diff between `custom_mask` and `mask_indptr` will cause flashinfer to access illegal memory.

*Note that the current fix is not perfect; we want the padding logic to be natural with the attention init logic*
