### PR TITLE
Fix B200 Nightly tests and move one manual test back to unit test to prevent the same issue

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1034,7 +1034,9 @@ class FlashInferFusedMoE(FusedMoE):
         final_hidden_states = self.quant_method.apply_with_router_logits(
             layer=self,
             dispatch_output=StandardDispatchOutput(
-                hidden_states=hidden_states, topk_output=topk_output
+                hidden_states=hidden_states,
+                hidden_states_scale=None,
+                topk_output=topk_output,
             ),
         )
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -116,6 +116,7 @@ suites = {
         TestFile("test_swa_unittest.py", 1),
         TestFile("test_torch_compile.py", 76),
         TestFile("test_torch_compile_moe.py", 210),
+        TestFile("test_triton_fused_moe.py", 80),
         TestFile("test_torch_native_attention_backend.py", 123),
         TestFile("test_torchao.py", 70),
         TestFile("test_triton_attention_kernels.py", 4),

--- a/test/srt/test_triton_fused_moe.py
+++ b/test/srt/test_triton_fused_moe.py
@@ -115,7 +115,7 @@ class TestFusedMOE(CustomTestCase):
         quant_info = TritonKernelsQuantInfo(w13_weight=w1_tri, w2_weight=w2_tri)
 
         dispatch_output = StandardDispatchOutput(
-            hidden_states=a, topk_output=triton_topk_output
+            hidden_states=a, hidden_states_scale=None, topk_output=triton_topk_output
         )
 
         torch_per_expert = self.torch_naive_moe(


### PR DESCRIPTION
Fixing error:

  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/actions-runner/_work/sglang/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 1036, in forward
    dispatch_output=StandardDispatchOutput(
TypeError: StandardDispatchOutput.__new__() missing 1 required positional argument: 'hidden_states_scale'

Verified in https://github.com/sgl-project/sglang/actions/runs/19587092071/job/56098190869 that the B200 night tests can start