### PR TITLE
Avoid failed import of aiter in `QuarkW4A4MXFP4` when using vLLM

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -3,6 +3,7 @@
 from typing import Any, Callable, Optional
 
 import torch
+import warnings
 
 from sglang.srt.layers.parameter import GroupQuantScaleParameter, PackedvLLMParameter
 from sglang.srt.layers.quantization.quark.schemes import QuarkScheme
@@ -10,9 +11,14 @@ from sglang.srt.utils import is_hip
 
 _is_hip = is_hip()
 if _is_hip:
-    from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4
-    from aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic import gemm_afp4wfp4_pre_quant
-    from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    try:
+        from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4
+        from aiter.ops.triton.gemm_afp4wfp4_pre_quant_atomic import gemm_afp4wfp4_pre_quant
+        from aiter.ops.triton.quant import dynamic_mxfp4_quant
+    except ImportError as e:
+        warnings.warn(
+            "QuarkW4A4MXFP4 requires AMD's aiter. Please make sure aiter is installed on your AMD device."
+        )
 
 
 __all__ = ["QuarkW4A4MXFP4"]


### PR DESCRIPTION
## Motivation

When I compiled and run sglang on AMD GPU, force to use the vLLM inference engine, it still failed due to not-installed aiter in the quantization:

```shell
$ SGLANG_USE_AITER=false python3 -m sglang.launch_server --model-path Qwen/Qwen3-4B-Instruct-2507 --trust-remote-code --host 0.0.0.0 --port 30000
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/inoki/Projects/Builds/sglang/python/sglang/launch_server.py", line 24, in <module>
    server_args = prepare_server_args(sys.argv[1:])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/server_args.py", line 4215, in prepare_server_args
    return ServerArgs.from_cli_args(raw_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/server_args.py", line 3813, in from_cli_args
    return cls(**{attr: getattr(args, attr) for attr in attrs})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 287, in __init__
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/server_args.py", line 608, in __post_init__
    self._handle_gpu_memory_settings(gpu_mem)
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/server_args.py", line 859, in _handle_gpu_memory_settings
    model_config = self.get_model_config()
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/server_args.py", line 3834, in get_model_config
    from sglang.srt.configs.model_config import ModelConfig
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/configs/model_config.py", line 26, in <module>
    from sglang.srt.layers.quantization import QUANTIZATION_METHODS
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/layers/quantization/__init__.py", line 38, in <module>
    from sglang.srt.layers.quantization.quark.quark import QuarkConfig
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/layers/quantization/quark/quark.py", line 17, in <module>
    from sglang.srt.layers.quantization.quark.schemes import (
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/layers/quantization/quark/schemes/__init__.py", line 4, in <module>
    from .quark_w4a4_mxfp4 import QuarkW4A4MXFP4
  File "/home/inoki/Projects/Builds/sglang/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py", line 15, in <module>
    from aiter.ops.triton.gemm_afp4wfp4 import gemm_afp4wfp4
ModuleNotFoundError: No module named 'aiter'
```

## Modifications

This PR avoids this failure, similar to `python/sglang/srt/layers/attention/nsa_backend.py`:

```
if _is_hip:
    try:
        from aiter import (  # noqa: F401
            flash_attn_varlen_func,
            mha_batch_prefill_func,
            paged_attention_ragged,
        )
        from aiter.mla import mla_decode_fwd, mla_prefill_fwd  # noqa: F401
    except ImportError:
        print(
            "aiter is AMD specific kernel library. Please make sure aiter is installed on your AMD device."
        )
```

but issuing just a warning.

## Accuracy Tests

Non-applied

## Benchmarking and Profiling

Non-applied

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
