### PR TITLE
Fix pagination bug in CI monitor preventing performance-test-2-gpu data collection

### DIFF
--- a/scripts/ci_monitor/ci_analyzer_perf.py
+++ b/scripts/ci_monitor/ci_analyzer_perf.py
@@ -477,9 +477,9 @@ class SGLangPerfAnalyzer:
     def get_job_logs(self, run_id: int, job_name: str) -> Optional[str]:
         """Get logs for specific job with early exit optimization"""
         try:
-            # First get job list
+            # First get job list with pagination to ensure we get all jobs
             jobs_url = f"{self.base_url}/repos/{self.repo}/actions/runs/{run_id}/jobs"
-            response = self.session.get(jobs_url)
+            response = self.session.get(jobs_url, params={"per_page": 100})
             response.raise_for_status()
             jobs_data = response.json()
 


### PR DESCRIPTION
## Problem
CI monitor showed 0 records for performance-test-2-gpu tests after Nov 11, even though tests were running successfully.
https://github.com/sgl-project/sglang/actions/runs/19587274768

## Root Cause
The `get_job_logs()` function wasn't using pagination when fetching jobs. GitHub API defaults to 30 jobs per page, but PR test workflows have 46 jobs. Since performance-test-2-gpu appears after the 30th job, it was being missed.

## Fix
Added `params={"per_page": 100}` to the jobs API request to retrieve all jobs.

## Verification
Tested on runs with successful 2-GPU data - now collects all 6 performance-test-2-gpu tests correctly.