### PR TITLE
[BugFix] Support skip_special_tokens in bench_serving to fix multimodal processing logic

### DIFF
--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -774,7 +774,7 @@ def get_dataset(args, tokenizer, model_id=None):
             image_format=args.image_format,
             image_resolution=args.image_resolution,
             backend=args.backend,
-            skip_special_tokens = skip_special_tokens,
+            skip_special_tokens=skip_special_tokens,
         )
     elif args.dataset_name == "generated-shared-prefix":
         assert not tokenize_prompt

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1477,7 +1477,7 @@ def sample_image_requests(
         text_prompt = gen_mm_prompt(
             processor.tokenizer,
             int(input_lens[i]),
-            special_tokens = special_tokens
+            special_tokens=special_tokens
         )
 
         # Generate image list

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -2708,7 +2708,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--skip-special-tokens",
         action="store_true",
-        help="Skip special tokens when generating random prompt.  " 
+        help="Skip special tokens when generating random prompt. "
         "Useful in multimodal preprocessing to avoid generating tokens like image_token_id, audio_token_id"
         "which could trigger special handling during preprocessing.",
     )

--- a/python/sglang/bench_serving.py
+++ b/python/sglang/bench_serving.py
@@ -1418,7 +1418,7 @@ def sample_image_requests(
     image_format: str,
     image_resolution: str,
     backend: str,
-    skip_special_tokens: bool
+    skip_special_tokens: bool,
 ) -> List[DatasetRow]:
     """Generate requests with images.
 
@@ -1470,14 +1470,16 @@ def sample_image_requests(
     total_image_bytes = 0
 
     special_tokens = None
-    if skip_special_tokens and hasattr(processor.tokenizer, "all_special_ids") and processor.tokenizer.all_special_ids is not None:
+    if (
+        skip_special_tokens
+        and hasattr(processor.tokenizer, "all_special_ids")
+        and processor.tokenizer.all_special_ids is not None
+    ):
         special_tokens = set(processor.tokenizer.all_special_ids)
     for i in range(num_requests):
         # Generate text prompt
         text_prompt = gen_mm_prompt(
-            processor.tokenizer,
-            int(input_lens[i]),
-            special_tokens=special_tokens
+            processor.tokenizer, int(input_lens[i]), special_tokens=special_tokens
         )
 
         # Generate image list
@@ -1520,7 +1522,7 @@ def gen_prompt(tokenizer, token_num):
 
 def gen_mm_prompt(tokenizer, token_num, special_tokens):
     """Generate a random prompt of specified token length using tokenizer vocabulary."""
-    if special_tokens is not None: 
+    if special_tokens is not None:
         all_available_tokens = [
             t for t in tokenizer.get_vocab().values() if t not in special_tokens
         ]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
When running the multimodal benchmark, randomly generated token ids can trigger special preprocessing logic, leading to errors. A previous PR (#13254 ) fixed this issue for some cases, but it did not cover **Qwen3-Omni-30B-A3B-Instruct**. This change adds the `skip_special_tokens` as benchmark option to prevent such tokens from being generated, avoiding the erroneous processing logic.
## Error manifestation

<!-- Detail the changes made in this pull request. -->
```bash
> python3 -m sglang.launch_server --model Qwen3-Omni-30B-A3B-Instruct
> python3 -m sglang.bench_serving --backend sglang-oai-chat  --dataset-name image  --num-prompts 128 --image-count 1     --image-resolution 960x1280 --random-input-len 2000  --random-output-len 100  --flush-cache  --max-concurrency 16
```
I found that the problem occurs more frequently when generating a large `random-input-len` with a large `num-prompts`. The error is somewhat non-deterministic. Example cases include:
```
File "/sgl-workspace/sglang/python/sglang/bench_serving.py", line 1350, in create_mm_data_row
    prompt_len = processor(
                 ^^^^^^^^^^
File "/root/workspace/xisun/llm-benchmark-tools/inference/sglang/transformers/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py", line 200, in __call__
    text = self.replace_multimodal_special_tokens(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/workspace/xisun/llm-benchmark-tools/inference/sglang/transformers/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py", line 243, in replace_multimodal_special_tokens
    sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
```
or
```
  File "/sgl-workspace/sglang/python/sglang/bench_serving.py", line 1350, in create_mm_data_row
    prompt_len = processor(
                 ^^^^^^^^^^
  File "/root/workspace/xisun/llm-benchmark-tools/inference/sglang/transformers/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py", line 200, in __call__
    text = self.replace_multimodal_special_tokens(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/workspace/xisun/llm-benchmark-tools/inference/sglang/transformers/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py", line 249, in replace_multimodal_special_tokens
    video_seq_length = next(video_grid_thw).prod() // merge_length_video
                       ^^^^^^^^^^^^^^^^^^^^
StopIteration
```
Due to the model's complex preprocessing(https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py#L254-L262), random token IDs can accidentally match special token IDs, which triggers the special token processing logic.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
After this change, users can pass `--skip-special-tokens` in the client command line when running the benchmark.


```
> python3 -m sglang.bench_serving --backend sglang-oai-chat  --dataset-name image  --num-prompts 128 --image-count 1     --image-resolution 960x1280 --random-input-len 2000  --random-output-len 100  --flush-cache  --max-concurrency 16  --skip-special-tokens

Created 128 random jpeg images with average 1236941 bytes per request
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [00:42<00:00,  3.03it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 16
Successful requests:                     128
Benchmark duration (s):                  42.32
Total input tokens:                      301917
Total input text tokens:                 148061
Total input vision tokens:               153856
Total generated tokens:                  6605
Total generated tokens (retokenized):    6360
Request throughput (req/s):              3.02
Input token throughput (tok/s):          7133.91
Output token throughput (tok/s):         156.07
Total token throughput (tok/s):          7289.98
Concurrency:                             15.76
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   5211.55
Median E2E Latency (ms):                 5044.87
---------------Time to First Token----------------
Mean TTFT (ms):                          1332.49
Median TTFT (ms):                        880.66
P99 TTFT (ms):                           6118.40
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          99.82
Median TPOT (ms):                        76.35
P99 TPOT (ms):                           242.33
---------------Inter-Token Latency----------------
Mean ITL (ms):                           78.83
Median ITL (ms):                         11.60
P95 ITL (ms):                            556.87
P99 ITL (ms):                            1027.90
Max ITL (ms):                            3860.78
==================================================


```


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
