### PR TITLE
[1/N] Optimize All Reduce - Benchmark different AR operations

### DIFF
--- a/benchmark/kernels/all_reduce/benchmark_all_reduce.py
+++ b/benchmark/kernels/all_reduce/benchmark_all_reduce.py
@@ -1,0 +1,351 @@
+"""
+Benchmark SGLang custom all-reduce vs Torch symm-mem all-reduce across message sizes.
+Usage:
+    torchrun --nproc_per_node=2 benchmark_all_reduce.py
+    torchrun --nproc_per_node=4 benchmark_all_reduce.py
+    torchrun --nproc_per_node=8 benchmark_all_reduce.py
+"""
+
+import argparse
+import os
+import sys
+import time
+from typing import List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.distributed.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark SGLang custom all-reduce vs Torch symm-mem all-reduce across message sizes."
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="gloo",
+        help="Process group backend for the custom-AR control path (must NOT be nccl).",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=5,
+        help="Warmup iterations per size per implementation.",
+    )
+    parser.add_argument(
+        "--iters-small",
+        type=int,
+        default=50,
+        help="Benchmark iterations for sizes <= 1MB.",
+    )
+    parser.add_argument(
+        "--iters-large",
+        type=int,
+        default=20,
+        help="Benchmark iterations for sizes > 1MB.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print per-iteration timings on rank 0 for debugging.",
+    )
+    return parser.parse_args()
+
+
+def get_env_rank_world() -> Tuple[int, int, int]:
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", str(rank)))
+    return rank, world_size, local_rank
+
+
+def init_dist(backend: str):
+    rank, world_size, _ = get_env_rank_world()
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend=backend,
+            init_method="env://",
+            rank=rank,
+            world_size=world_size,
+        )
+
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    distributed_init_method = f"tcp://localhost:23456"
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        distributed_init_method=distributed_init_method,
+        local_rank=rank,
+    )
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+    return dist.group.WORLD
+
+
+def get_device(local_rank: int) -> torch.device:
+    torch.cuda.set_device(local_rank)
+    return torch.device(f"cuda:{local_rank}")
+
+
+def human_size(num_bytes: int) -> str:
+    units = [("B", 1), ("K", 1024), ("M", 1024 * 1024), ("G", 1024 * 1024 * 1024)]
+    for suf, base in reversed(units):
+        if num_bytes % base == 0 and num_bytes >= base:
+            val = num_bytes // base
+            return f"{val}{suf}"
+    return f"{num_bytes}B"
+
+
+def get_message_sizes() -> List[int]:
+    return [
+        32 * 1024,
+        64 * 1024,
+        128 * 1024,
+        256 * 1024,
+        512 * 1024,
+        1 * 1024 * 1024,
+        2 * 1024 * 1024,
+        4 * 1024 * 1024,
+        8 * 1024 * 1024,
+        16 * 1024 * 1024,
+        32 * 1024 * 1024,
+        64 * 1024 * 1024,
+    ]
+
+
+@torch.inference_mode()
+def run_once(comm, inp: torch.Tensor) -> Optional[torch.Tensor]:
+    if hasattr(comm, "custom_all_reduce"):
+        return comm.custom_all_reduce(inp)
+    if hasattr(comm, "all_reduce"):
+        return comm.all_reduce(inp)
+    raise RuntimeError("No known all-reduce method found on the communicator.")
+
+
+@torch.inference_mode()
+def bench_impl(
+    name: str,
+    comm,
+    sizes: List[int],
+    device: torch.device,
+    warmup: int,
+    iters_small: int,
+    iters_large: int,
+    verbose: bool,
+    pg: Optional[dist.ProcessGroup] = None,
+) -> List[Tuple[int, Optional[float]]]:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    results: List[Tuple[int, Optional[float]]] = []
+
+    for size_bytes in sizes:
+        elems = size_bytes // 2  # float16: 2 bytes per element
+        inp = torch.empty(elems, dtype=torch.float16, device=device)
+        inp.uniform_(0, 1)
+
+        disabled = False
+        dist.barrier(group=pg)
+        for _ in range(warmup):
+            torch.cuda.synchronize()
+            out = run_once(comm, inp)
+            torch.cuda.synchronize()
+            if out is None:
+                disabled = True
+                break
+        dist.barrier(group=pg)
+
+        if disabled:
+            if rank == 0:
+                print(
+                    f"[{name}] {human_size(size_bytes)}: custom AR disabled (skipped)"
+                )
+            results.append((size_bytes, None))
+            continue
+
+        num_iters = iters_small if size_bytes <= (1 * 1024 * 1024) else iters_large
+
+        times_ms: List[float] = []
+        for it in range(num_iters):
+            dist.barrier(group=pg)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            out = run_once(comm, inp)
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            dist.barrier(group=pg)
+
+            if out is None:
+                disabled = True
+                break
+
+            dt_ms = (t1 - t0) * 1000.0
+            times_ms.append(dt_ms)
+
+            if verbose and rank == 0:
+                print(
+                    f"[{name}] size={human_size(size_bytes)} iter={it} time={dt_ms:.3f} ms"
+                )
+
+        if disabled or not times_ms:
+            if rank == 0:
+                print(
+                    f"[{name}] {human_size(size_bytes)}: custom AR disabled (no timings)"
+                )
+            results.append((size_bytes, None))
+            continue
+
+        avg_ms_local = sum(times_ms) / len(times_ms)
+        avg_tensor = torch.tensor([avg_ms_local], dtype=torch.float64, device=device)
+        gather_list = [torch.zeros_like(avg_tensor) for _ in range(world_size)]
+        dist.all_gather(gather_list, avg_tensor, group=pg)
+        if rank == 0:
+            avg_ms = float(torch.stack(gather_list).mean().item())
+            print(
+                f"[{name}] {human_size(size_bytes)}: {avg_ms:.3f} ms (avg across ranks)"
+            )
+            results.append((size_bytes, avg_ms))
+        else:
+            results.append((size_bytes, None))
+
+    return results
+
+
+def main():
+    args = parse_args()
+    rank, world_size, local_rank = get_env_rank_world()
+
+    if world_size not in (2, 4, 6, 8):
+        print(
+            f"[rank {rank}] WARNING: world_size={world_size} not in supported set (2,4,6,8). "
+            "Custom AR may disable itself.",
+            file=sys.stderr,
+        )
+
+    group = init_dist(args.backend)
+    device = get_device(local_rank)
+
+    # Import after dist init; some libs query torch dist state on import
+    torch_symm_mem_comm = None
+    HAVE_SGLANG_CUSTOM = False
+    HAVE_TORCH_SYMM_MEM = False
+
+    try:
+        from sglang.srt.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce as SGLCustomAllreduce,
+        )
+
+        HAVE_SGLANG_CUSTOM = True
+    except Exception as e:
+        if rank == 0:
+            print(f"SGLang CustomAllreduce import failed: {e}", file=sys.stderr)
+
+    try:
+        from sglang.srt.distributed.device_communicators.torch_symm_mem import (
+            TorchSymmMemCommunicator as TorchSymmMemAllreduce,
+        )
+
+        HAVE_TORCH_SYMM_MEM = True
+    except Exception as e:
+        if rank == 0:
+            print(f"TorchSymmMemAllreduce import failed: {e}", file=sys.stderr)
+
+    if rank == 0:
+        print(f"Initialized PG backend={args.backend} world_size={world_size}")
+        print(f"Device: {device.type}:{device.index}")
+        print(
+            f"SGLang Custom available: {HAVE_SGLANG_CUSTOM}, Torch Symm-Mem available: {HAVE_TORCH_SYMM_MEM}"
+        )
+
+    sizes = get_message_sizes()
+    max_size = max(sizes) if sizes else (128 * 1024 * 1024)
+
+    if HAVE_SGLANG_CUSTOM:
+        try:
+            sgl_custom_comm = SGLCustomAllreduce(
+                group=group, device=device, max_size=max_size
+            )
+        except Exception as e:
+            if rank == 0:
+                print(
+                    f"Failed to construct SGLangCustomAllreduce: {e}", file=sys.stderr
+                )
+            sgl_custom_comm = None
+
+    if HAVE_TORCH_SYMM_MEM:
+        try:
+            torch_symm_mem_comm = TorchSymmMemAllreduce(group=group, device=device)
+        except Exception as e:
+            if rank == 0:
+                print(
+                    f"Failed to construct TorchSymmMemAllreduce: {e}", file=sys.stderr
+                )
+            torch_symm_mem_comm = None
+
+    sgl_custom_results: List[Tuple[int, Optional[float]]] = []
+    symm_mem_results: List[Tuple[int, Optional[float]]] = []
+
+    if sgl_custom_comm is not None:
+        sgl_custom_results = bench_impl(
+            name="SGLangCustom",
+            comm=sgl_custom_comm,
+            sizes=sizes,
+            device=device,
+            warmup=args.warmup,
+            iters_small=args.iters_small,
+            iters_large=args.iters_large,
+            verbose=args.verbose,
+            pg=group,
+        )
+
+    if torch_symm_mem_comm is not None:
+        symm_mem_results = bench_impl(
+            name="TorchSymmMem",
+            comm=torch_symm_mem_comm,
+            sizes=sizes,
+            device=device,
+            warmup=args.warmup,
+            iters_small=args.iters_small,
+            iters_large=args.iters_large,
+            verbose=args.verbose,
+            pg=group,
+        )
+
+    for comm in (sgl_custom_comm, torch_symm_mem_comm):
+        if comm is not None and hasattr(comm, "close"):
+            try:
+                comm.close()
+            except Exception:
+                pass
+
+    if dist.get_rank() == 0:
+        print(
+            f"\nResults (avg ms across {world_size} ranks; None = disabled/unavailable):"
+        )
+        header = f"{'Size':>8}  {'CustomAR(ms)':>12}  {'TorchSymmMem(ms)':>11}"
+        print(header)
+        print("-" * len(header))
+
+        sgl_custom_map = {s: v for s, v in sgl_custom_results if v is not None}
+        symm_mem_map = {s: v for s, v in symm_mem_results if v is not None}
+
+        for s in sizes:
+            sgl_ms = sgl_custom_map.get(s, None)
+            symm_mem_ms = symm_mem_map.get(s, None)
+            print(
+                f"{human_size(s):>8}  {('%.3f' % sgl_ms) if sgl_ms is not None else 'None':>12}  "
+                f"{('%.3f' % symm_mem_ms) if symm_mem_ms is not None else 'None':>11}"
+            )
+    torch.distributed.barrier(group=group)
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -325,12 +325,12 @@ class CustomAllreduce:
         # little performance improvement over NCCL.
         if not _is_hip:
             if self.world_size == 2 or self.full_nvlink:
-                return inp_size < self.max_size
+                return inp_size <= self.max_size
             return False
 
         if _is_hip:
             if self.full_nvlink:
-                return inp_size < self.max_size
+                return inp_size <= self.max_size
             return False
 
         return False


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Aiming to address step-4 in https://github.com/sgl-project/sglang/issues/13363.

We observed that in some MoE models, especially VLM with MoE models, All-Reduce occupied quite a lot GPU cycles. (Some non-MoE VLM model also has similar symptom, but not that worse) The reason is as the model is small, the MoE activated experts are small, so is the data computing and transferring between ranks is. (We can see large gap in GPU. But this is another issue out of this PR's scope which only focuses on All-Reduce.) The overhead of some operations inside All-Reduce is inevitable but a waste. (RS+AG) It is highly-required to choose the highest performance AR for the inference system. For example for small data portion, should use one-shot or other light-weight designed AR, for large data portion, should use two-shot AR.

<img width="2994" height="1598" alt="image" src="https://github.com/user-attachments/assets/b542722a-0836-4adc-a096-c2e7c9af7fa0" />

The following is Qwen3-VL-MoE TP8 torch profiling, the AR in prefill phase occupies more than 80% GPU cycles.
While in decode phase, the AR cost reduces dramatically, which has two reasons:
1. CUDA graph impacts on AR operations. The Piecewise CUDA Graph in prefill is expected to improve VLM_MoE models' performance in large TP size.
2. The data transfer in decode between ranks is much smaller. 

We will follow up to check which factor imposes more. 
<img width="2990" height="1530" alt="image" src="https://github.com/user-attachments/assets/df03debc-bb6c-4f96-be55-47697b026f9b" />

The requirement to provide a benchmark tool to evaluate different all-reduce's performance is desperate, so as the end-user can choose best approach in different TP size and environment.

The next step is to optimize the choose AR algorithm such as choose one-shot or two-shot based on the traffic. This will be done in the following PR.

```
[root  /root/luoyuan.luo/workspace/sglang_dev] 日 11月 23 21:42:24 
$torchrun --nproc_per_node=4 benchmark_all_reduce.py
W1123 21:42:26.503000 494401 site-packages/torch/distributed/run.py:774] 
W1123 21:42:26.503000 494401 site-packages/torch/distributed/run.py:774] *****************************************
W1123 21:42:26.503000 494401 site-packages/torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W1123 21:42:26.503000 494401 site-packages/torch/distributed/run.py:774] *****************************************
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank [Gloo] Rank 32 is connected to  is connected to 33 peer ranks.  peer ranks. Expected number of connected peer ranks is : Expected number of connected peer ranks is : 33

[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3[Gloo] Rank  is connected to 3 peer ranks. 2Expected number of connected peer ranks is :  is connected to 33
 peer ranks. Expected number of connected peer ranks is : 3
[2025-11-23 21:42:38] INFO pynccl.py:83: sglang is using nccl==2.27.3
[2025-11-23 21:42:41] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:42:41] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:42:41] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:42:41] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
Initialized PG backend=gloo world_size=4
Device: cuda:0
SGLang Custom available: True, Torch Symm-Mem available: True
[SGLangCustom] 32K: 0.049 ms (avg across ranks)
[SGLangCustom] 64K: 0.051 ms (avg across ranks)
[SGLangCustom] 128K: 0.049 ms (avg across ranks)
[SGLangCustom] 256K: 0.036 ms (avg across ranks)
[SGLangCustom] 512K: 0.037 ms (avg across ranks)
[SGLangCustom] 1M: 0.044 ms (avg across ranks)
[SGLangCustom] 2M: 0.056 ms (avg across ranks)
[SGLangCustom] 4M: 0.061 ms (avg across ranks)
[SGLangCustom] 8M: 0.094 ms (avg across ranks)
[SGLangCustom] 16M: 0.147 ms (avg across ranks)
[SGLangCustom] 32M: 0.251 ms (avg across ranks)
[TorchSymmMem] 32K: 0.090 ms (avg across ranks)
[TorchSymmMem] 64K: 0.050 ms (avg across ranks)
[TorchSymmMem] 128K: 0.047 ms (avg across ranks)
[TorchSymmMem] 256K: 0.050 ms (avg across ranks)
[TorchSymmMem] 512K: 0.055 ms (avg across ranks)
[TorchSymmMem] 1M: 0.045 ms (avg across ranks)
[TorchSymmMem] 2M: 0.049 ms (avg across ranks)
[TorchSymmMem] 4M: 0.069 ms (avg across ranks)
[TorchSymmMem] 8M: 0.096 ms (avg across ranks)
[TorchSymmMem] 16M: 0.167 ms (avg across ranks)
[TorchSymmMem] 32M: 0.312 ms (avg across ranks)

Results (avg ms across 4 ranks; None = disabled/unavailable):
    Size  CustomAR(ms)  TorchSymmMem(ms)
----------------------------------------
     32K         0.049        0.090
     64K         0.051        0.050
    128K         0.049        0.047
    256K         0.036        0.050
    512K         0.037        0.055
      1M         0.044        0.045
      2M         0.056        0.049
      4M         0.061        0.069
      8M         0.094        0.096
     16M         0.147        0.167
     32M         0.251        0.312

[root  /root/luoyuan.luo/workspace/sglang_dev] 日 11月 23 21:42:46 
$torchrun --nproc_per_node=8 benchmark_all_reduce.py
W1123 21:42:52.146000 494633 site-packages/torch/distributed/run.py:774] 
W1123 21:42:52.146000 494633 site-packages/torch/distributed/run.py:774] *****************************************
W1123 21:42:52.146000 494633 site-packages/torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W1123 21:42:52.146000 494633 site-packages/torch/distributed/run.py:774] *****************************************
[Gloo] Rank 0 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 1 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 3 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank [Gloo] Rank 24 is connected to  is connected to 77 peer ranks.  peer ranks. Expected number of connected peer ranks is : Expected number of connected peer ranks is : 77

[Gloo] Rank 5 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank [Gloo] Rank 7 is connected to 76 peer ranks.  is connected to Expected number of connected peer ranks is : 77 peer ranks. 
Expected number of connected peer ranks is : 7
[Gloo] Rank 1 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 3 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 7 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 0 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 2 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 4 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 5 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 6 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 5 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 0 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 1 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 3 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 4 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank 2 is connected to 7 peer ranks. Expected number of connected peer ranks is : 7
[Gloo] Rank [Gloo] Rank 67 is connected to  is connected to 77 peer ranks.  peer ranks. Expected number of connected peer ranks is : Expected number of connected peer ranks is : 77

[2025-11-23 21:43:03] INFO pynccl.py:83: sglang is using nccl==2.27.3
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[2025-11-23 21:43:08] INFO custom_all_reduce_utils.py:305: reading GPU P2P access cache from /root/.cache/sglang/gpu_p2p_access_cache_for_0,1,2,3,4,5,6,7.json
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank [Gloo] Rank 0 is connected to 00 is connected to  peer ranks. 0[Gloo] Rank  peer ranks. Expected number of connected peer ranks is : 0[Gloo] Rank Expected number of connected peer ranks is : 0 is connected to 
000
 is connected to  peer ranks. 0Expected number of connected peer ranks is :  peer ranks. 0Expected number of connected peer ranks is : 
0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
Initialized PG backend=gloo world_size=8
Device: cuda:0
SGLang Custom available: True, Torch Symm-Mem available: True
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank [Gloo] Rank 00 is connected to [Gloo] Rank  is connected to 000 peer ranks.  peer ranks.  is connected to Expected number of connected peer ranks is : Expected number of connected peer ranks is : 000 peer ranks. 

Expected number of connected peer ranks is : 0
[SGLangCustom] 32K: 0.046 ms (avg across ranks)
[SGLangCustom] 64K: 0.059 ms (avg across ranks)
[SGLangCustom] 128K: 0.075 ms (avg across ranks)
[SGLangCustom] 256K: 0.056 ms (avg across ranks)
[SGLangCustom] 512K: 0.085 ms (avg across ranks)
[SGLangCustom] 1M: 0.071 ms (avg across ranks)
[SGLangCustom] 2M: 0.089 ms (avg across ranks)
[SGLangCustom] 4M: 0.085 ms (avg across ranks)
[SGLangCustom] 8M: 0.133 ms (avg across ranks)
[SGLangCustom] 16M: 0.179 ms (avg across ranks)
[SGLangCustom] 32M: 0.286 ms (avg across ranks)
[TorchSymmMem] 32K: 0.056 ms (avg across ranks)
[TorchSymmMem] 64K: 0.067 ms (avg across ranks)
[TorchSymmMem] 128K: 0.060 ms (avg across ranks)
[TorchSymmMem] 256K: 0.081 ms (avg across ranks)
[TorchSymmMem] 512K: 0.073 ms (avg across ranks)
[TorchSymmMem] 1M: 0.075 ms (avg across ranks)
[TorchSymmMem] 2M: 0.089 ms (avg across ranks)
[TorchSymmMem] 4M: 0.101 ms (avg across ranks)
[TorchSymmMem] 8M: 0.107 ms (avg across ranks)
[TorchSymmMem] 16M: 0.186 ms (avg across ranks)
[TorchSymmMem] 32M: 0.335 ms (avg across ranks)

Results (avg ms across 8 ranks; None = disabled/unavailable):
    Size  CustomAR(ms)  TorchSymmMem(ms)
----------------------------------------
     32K         0.046        0.056
     64K         0.059        0.067
    128K         0.075        0.060
    256K         0.056        0.081
    512K         0.085        0.073
      1M         0.071        0.075
      2M         0.089        0.089
      4M         0.085        0.101
      8M         0.133        0.107
     16M         0.179        0.186
     32M         0.286        0.335
``` 

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
