### PR TITLE
Fix arguments for http_server for multimodal_gen

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -1,6 +1,7 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 
 import asyncio
+import sys
 from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, FastAPI
@@ -65,7 +66,7 @@ def create_app(server_args: ServerArgs):
 if __name__ == "__main__":
     import uvicorn
 
-    server_args = prepare_server_args([])
+    server_args = prepare_server_args(sys.argv[1:])
     configure_logger(server_args)
     app = create_app(server_args)
     uvicorn.run(


### PR DESCRIPTION
## Motivation
I want to use the image generation inside a container with OpenAI Compatible interface.

## Modifications
I was not able to start the http_server, as the parameter "model_path" was missing, even when I added it as an argument.

## Additional work necessary
- The current container is missing the diffusors library
  Fixed by adding RUN python3 -m pip install -e "python[diffusion]" to the Dockerfile
- Publish documentation how to start the http_server with a container

