### PR TITLE
[Bugfix] Add jit kernel files in packaging

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -131,6 +131,9 @@ sglang = "sglang.cli.main:main"
   "srt/mem_cache/storage/hf3fs/hf3fs_utils.cpp",
   "srt/speculative/cpp_ngram/*.cpp",
   "srt/speculative/cpp_ngram/*.h",
+  "jit_kernel/include/sgl_kernel/*.h",
+  "jit_kernel/include/sgl_kernel/*.cuh",
+  "jit_kernel/csrc/*.cuh"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
PR https://github.com/sgl-project/sglang/pull/13764 is missing jit kernel files when packaging. This PR fix it.

The reason why github ci didn't fail is because there were cache jit kernel files un-deleted in the folder. So the new CI happened to reuse them.

```
$SGLANG_VLM_CACHE_SIZE_MB=2048 python -m sglang.launch_server --model-path /home/admin/Qwen3-VL-2B-Thinking --host 0.0.0.0 --port 8188 --trust-remote-code --tp-size 1 --enable-cache-report --log-level info --max-running-requests 64 --mem-fraction-static 0.6 --chunked-prefill-size 8192 --attention-backend flashinfer --mm-attention-back fa3
[2025-11-24 10:46:04] INFO utils.py:148: Note: detected 192 virtual cores but NumExpr set to maximum of 64, check "NUMEXPR_MAX_THREADS" environment variable.
[2025-11-24 10:46:04] INFO utils.py:151: Note: NumExpr detected 192 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
[2025-11-24 10:46:04] INFO utils.py:164: NumExpr defaulting to 16 threads.
[2025-11-24 10:46:05] ERROR compile_cache.py:130: The following environment variables for compile cache are unset: MODEL_URL, MODEL_DEPLOY_STRATEGY_NAME, OSS_ENDPOINT, OSS_BUCKET, ACCESS_KEY_ID, ACCESS_KEY_SECRET, COMPILE_CACHE_OSS_PREFIX
INFO 11-24 10:46:06 [__init__.py:216] Automatically detected platform cuda.
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/conda/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/conda/lib/python3.10/site-packages/sglang/launch_server.py", line 33, in <module>
    run_server(server_args)
  File "/opt/conda/lib/python3.10/site-packages/sglang/launch_server.py", line 23, in run_server
    from sglang.srt.entrypoints.http_server import launch_server
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/entrypoints/http_server.py", line 50, in <module>
    from sglang.srt.entrypoints.engine import _launch_subprocesses
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/entrypoints/engine.py", line 47, in <module>
    from sglang.srt.managers.data_parallel_controller import (
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/data_parallel_controller.py", line 38, in <module>
    from sglang.srt.managers.scheduler import run_scheduler_process
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 48, in <module>
    from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/disaggregation/decode_kvcache_offload_manager.py", line 10, in <module>
    from sglang.srt.managers.cache_controller import HiCacheController
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/cache_controller.py", line 24, in <module>
    from sglang.srt.mem_cache.hicache_storage import (
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/mem_cache/hicache_storage.py", line 10, in <module>
    from sglang.srt.mem_cache.memory_pool_host import HostKVCache
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/mem_cache/memory_pool_host.py", line 10, in <module>
    from sglang.jit_kernel.hicache import can_use_hicache_jit_kernel
  File "/opt/conda/lib/python3.10/site-packages/sglang/jit_kernel/hicache.py", line 7, in <module>
    from sglang.jit_kernel.utils import load_jit, make_cpp_args
  File "/opt/conda/lib/python3.10/site-packages/sglang/jit_kernel/utils.py", line 37, in <module>
    KERNEL_PATH = _resolve_kernel_path()
  File "/opt/conda/lib/python3.10/site-packages/sglang/jit_kernel/utils.py", line 33, in _resolve_kernel_path
    raise RuntimeError("Cannot find sgl-kernel/jit path")
RuntimeError: Cannot find sgl-kernel/jit path
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
