### PR TITLE
fix: IndexError in pipeline parallelism for triton backend

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -195,9 +195,9 @@ class TritonAttnBackend(AttentionBackend):
             self.v_head_dim = model_runner.token_to_kv_pool.get_v_head_dim()
             self.swa_v_head_dim = None
         else:
-            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[
-                -1
-            ]
+            self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(
+                model_runner.start_layer
+            ).shape[-1]
             self.swa_v_head_dim = None
         self.max_context_len = model_runner.model_config.context_len
         self.device = model_runner.device


### PR DESCRIPTION
## Motivation

Running a model with pipeline parallelism on the Triton backend results in an "IndexError: list index out of range". This occurs because the get_value_buffer method uses layer_id - self.start_layer to index the array. When pipeline parallelism is enabled, mem_pool's start_layer is greater than 0, causing the index to become negative or out of bounds when calling get_value_buffer(0).

### Error 
[2025-11-20 09:46:27 PP3 TP1] Scheduler hit an exception: Traceback (most recent call last):
  File "/app/sglang/python/sglang/srt/managers/scheduler.py", line 2712, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/managers/scheduler.py", line 312, in __init__
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/managers/tp_worker.py", line 237, in __init__
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/model_executor/model_runner.py", line 329, in __init__
    self.initialize(min_per_gpu_memory)
  File "/app/sglang/python/sglang/srt/model_executor/model_runner.py", line 509, in initialize
    self.init_attention_backend()
  File "/app/sglang/python/sglang/srt/model_executor/model_runner.py", line 1958, in init_attention_backend
    self.attn_backend = self._get_attention_backend()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/model_executor/model_runner.py", line 1992, in _get_attention_backend
    attn_backend = self._get_attention_backend_from_str(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/model_executor/model_runner.py", line 2009, in _get_attention_backend_from_str
    full_attention_backend = ATTENTION_BACKENDS[backend_str] (self)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/layers/attention/attention_registry.py", line 100, in create_triton_backend
    return TritonAttnBackend(runner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/layers/attention/triton_backend.py", line 102, in __init__
    self.v_head_dim = model_runner.token_to_kv_pool.get_value_buffer(0).shape[
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 1465, in get_value_buffer
    return self.kv_buffer[layer_id - self.start_layer][..., : self.kv_lora_rank]
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IndexError: list index out of range


## Modifications

Change get_value_buffer(0) to get_value_buffer(model_runner.start_layer) to use the correct starting layer index.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29400867428](https://github.com/sgl-project/sglang/actions/runs/29400867428)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29400867087](https://github.com/sgl-project/sglang/actions/runs/29400867087)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->