### PR TITLE
[VLM] Revise InternVL Piecewise CUDA Graph Supporting

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -362,6 +362,10 @@ class ModelRunner:
                     elif hasattr(layer.self_attn, "attn_mqa"):
                         # For DeepSeek model
                         self.attention_layers.append(layer.self_attn.attn_mqa)
+                # For InternVL model
+                elif hasattr(layer, "attention"):
+                    if hasattr(layer.attention, "attn"):
+                        self.attention_layers.append(layer.attention.attn)
 
             if len(self.attention_layers) < self.model_config.num_hidden_layers:
                 # TODO(yuwei): support Non-Standard GQA

--- a/test/srt/test_priority_scheduling.py
+++ b/test/srt/test_priority_scheduling.py
@@ -291,35 +291,35 @@ class TestPrioritySchedulingMultipleRunningRequests(CustomTestCase):
     def test_priority_scheduling_preemption_token_offset_calculation(self):
         """
         Verify correct token offset calculation during preemption.
-        
+
         This test specifically targets the bug where rem_total_token_offset was incorrectly
         calculated using the incoming request's tokens instead of the preempted request's tokens
         (related to issue #13111 and PR #13201).
-        
+
         THE BUG:
         In schedule_policy.py line 700, the code was using:
             self.rem_total_token_offset -= self._get_running_request_total_token_offset(req)
         Instead of:
             self.rem_total_token_offset -= self._get_running_request_total_token_offset(running_req)
-        
+
         WHY THIS TEST CATCHES THE BUG:
         - Request 1 (preempted): 8000 tokens - This is what SHOULD be freed
         - Request 3 (incoming):  1000 tokens - This is what WAS freed (bug)
         - Token difference: 8000 - 1000 = 7000 tokens incorrectly accounted
-        
+
         With the bug, the system thinks it only freed 1000 tokens instead of 8000 tokens.
         This causes incorrect memory accounting and can lead to:
         1. Scheduler believes less memory is available than actually is
         2. Subsequent requests (like Request 4) may fail to schedule or cause issues
         3. Memory calculations become increasingly inaccurate with each preemption
-        
+
         The test creates a scenario where:
         1. A low-priority request with many tokens (8000) starts running
         2. A high-priority request with few tokens (1000) arrives and triggers preemption
         3. The system must correctly free 8000 tokens from the preempted request
         4. Additional requests can be scheduled only if tokens were correctly freed
         5. Execution order validates priority-based scheduling works correctly
-        
+
         The large token difference (8x) makes the bug's impact obvious and testable.
         """
         responses = asyncio.run(
@@ -360,7 +360,7 @@ class TestPrioritySchedulingMultipleRunningRequests(CustomTestCase):
         _verify_genereate_responses(
             responses, expected_status_and_error_messages, e2e_latencies
         )
-        
+
         # Verify execution order: high priority requests finish before low priority ones
         # Request 3 (priority 100) should finish first
         # Request 4 (priority 50) should finish second


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The current Piecewise CUDA Graph framework only recognizes `self-attn` as the key word to add attention layer.
InternVL model uses key-word `attention` instead of `self-attn` to describe attention layer, which current Piecewise CUDA Graph doesn't recognize, so it regards InternVL attention as Non-Standard GQA and enters the piecewise_cuda_graph_runner==None branch. In consequence, InternVL PCG actually enters eagle mode and does not work correctly.
```
==========================
layer=InternLMDecoderLayer(
  (attention): InternLM2Attention(
    (wqkv): QKVParallelLinear(in_features=6144, output_features=2048, bias=False, tp_size=4, gather_output=False)
    (wo): RowParallelLinear(input_features=1536, output_features=6144, bias=False, tp_size=4, reduce_results=True)
    (rotary_emb): DynamicNTKScalingRotaryEmbedding(head_size=128, rotary_dim=128, max_position_embeddings=32768, base=50000000, is_neox_style=True)
    (attn): RadixAttention()
  )
  (feed_forward): InternLM2MLP(
    (gate_up_proj): MergedColumnParallelLinear(in_features=6144, output_features=8192, bias=False, tp_size=4, gather_output=False)
    (w2): RowParallelLinear(input_features=4096, output_features=6144, bias=False, tp_size=4, reduce_results=True)
    (act_fn): SiluAndMul()
  )
  (attention_norm): RMSNorm()
  (ffn_norm): RMSNorm()
)
==========================
```
```
            if len(self.attention_layers) < self.model_config.num_hidden_layers:
                # TODO(yuwei): support Non-Standard GQA
                log_info_on_rank0(
                    logger,
                    "Disable piecewise CUDA graph because some layers do not apply Standard GQA",
                )
                self.piecewise_cuda_graph_runner = None
```
The fix is to add attention key word in PCG framework to add attention layer correctly.
e2e 5% performance improve for TTFT. Analysis is in the following.

Without fix:
LLM kernel launch costs 48ms, 
<img width="2072" height="1029" alt="image" src="https://github.com/user-attachments/assets/b4905b1d-42cf-4bab-9234-788e3eeb3c59" />
<img width="2305" height="1198" alt="image" src="https://github.com/user-attachments/assets/dac2ed62-3581-480e-9c64-4791dc098a28" />


With fix:
LLM kernel launch cost 32ms, no congestion in CUDA command buffer in LLM phase
<img width="2294" height="1164" alt="image" src="https://github.com/user-attachments/assets/16c93770-a0b9-4a71-ad39-5d31d7e55de1" />
<img width="2302" height="1191" alt="image" src="https://github.com/user-attachments/assets/f2985b8c-d552-46a8-a593-d17e72cf2c48" />
<img width="2308" height="1146" alt="image" src="https://github.com/user-attachments/assets/3972ba70-c295-498f-85a4-3f9b74756fe0" />
<img width="2317" height="1156" alt="image" src="https://github.com/user-attachments/assets/473e5c36-7922-4505-8ad4-948edd2776f8" />
<img width="2323" height="1151" alt="image" src="https://github.com/user-attachments/assets/f28e62dc-14aa-42e4-aab5-a4a85ffff21f" />


**Profiling Analysis**
The whole part time cost analysis.

Without fix, LLM kernel_launch + kernel_run costs 391ms.
<img width="2307" height="1197" alt="image" src="https://github.com/user-attachments/assets/f39ef32c-0bad-46d7-a1f1-ad01bafd739b" />
<img width="2321" height="1167" alt="image" src="https://github.com/user-attachments/assets/54833ad7-2cec-4573-a42c-2a875aaa6a48" />


With fix, LLM kernel_launch + kernel_run costs 354ms.
<img width="2286" height="1161" alt="image" src="https://github.com/user-attachments/assets/f4ee52e5-b35b-4b02-a121-fed25ede5839" />
<img width="2300" height="1168" alt="image" src="https://github.com/user-attachments/assets/8c79f5b3-6b3e-4d00-a39e-9785fa6111f3" />


We can see from the profiling, for InternVL model, ViT cost 430ms, while LLM cost 354ms. So the improvement of Piecewise CUDA Graph for this model is 40ms/780ms = 5%. That gives us an opportunity to improve PCG to support ViT in the next step. 

Moreover, InternVL AWQ utilizes Marlin kernel, which performs pretty good, the CPU cycles are relatively small. It is also an example for the other VLM quant optimizations.

**Command to reproduce**
```
SGLANG_TORCH_PROFILER_DIR=/root/luoyuan.luo/profile_data \
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
python3 -m sglang.launch_server --host 127.0.0.1 \
    --mem-fraction-static 0.7 \
    --port 30000 \
    --trust-remote-code \
    --dtype auto \
    --max-running-requests 4 \
    --chunked-prefill-size 8192 \
    --attention-backend flashinfer \
    --tp 4 \
    --enable-multimodal \
    --chat-template internvl-2-5 \
    --model /home/admin/InternVL2_5-26B_AWQ_EYES \
    --disable-radix-cache \
    --piecewise-cuda-graph-max-tokens 8192 --enable-piecewise-cuda-graph --piecewise-cuda-graph-compiler eager 
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
