### PR TITLE
[BugFix] fix outplace_fused_experts missing is_gated

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py
@@ -325,6 +325,7 @@ def fused_experts(
             b1,
             b2,
             moe_runner_config.activation,
+            moe_runner_config.is_gated,
             moe_runner_config.apply_router_weight_on_input,
             use_fp8_w8a8,
             use_int8_w8a8,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
This [change](https://github.com/sgl-project/sglang/pull/12690/files) recently introduced is_gated, but missed passing it for `outplace_fused_experts`

`python3 -m sglang.launch_server --model /shared/public/elr-models/xai-org/grok-2/ --tokenizer-path /shared/public/elr-models/xai-org/grok-2/tokenizer.tok.json --tp 8 --quantization fp8 --attention-backend triton`

Before:

```
  File "/home/jobuser/zminglei/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/zminglei/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/models/grok.py", line 165, in forward
    return self.experts(hidden_states, topk_output)
  File "/home/jobuser/zminglei/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/jobuser/zminglei/sglang/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 886, in forward
    combine_input = self.run_moe_core(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 907, in run_moe_core
    return self.quant_method.apply(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/quantization/fp8.py", line 1144, in apply
    return self.runner.run(dispatch_output, quant_info)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/moe/moe_runner/runner.py", line 63, in run
    return self.fused_func(dispatch_output, quant_info, self.config)
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/moe/moe_runner/triton.py", line 337, in fused_experts_none_to_triton
    output = fused_experts(
  File "/home/jobuser/zminglei/sglang/python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py", line 319, in fused_experts
    return torch.ops.sglang.outplace_fused_experts(
  File "/home/jobuser/zminglei/sglang/venv/lib/python3.10/site-packages/torch/_ops.py", line 1243, in __call__
    return self._op(*args, **kwargs)
RuntimeError: sglang::outplace_fused_experts() Expected a value of type 'bool' for argument 'per_channel_quant' but instead found type 'Parameter'.
Position: 14
Value: Parameter containing:
tensor([0.0003, 0.0004, 0.0003, 0.0004, 0.0004, 0.0003, 0.0004, 0.0004],
       device='cuda:2')

```
After:
```
[2025-11-24 19:58:32] Start of co-locate warmup ...
[2025-11-24 19:58:32 TP0] Prefill batch, #new-seq: 1, #new-token: 10, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
[2025-11-24 19:58:34] INFO:     127.0.0.1:51230 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-11-24 19:58:34] The server is fired up and ready to roll!
```
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
