### PR TITLE
Add validation and cleanup for corrupted safetensors in multimodal loader

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -162,13 +162,19 @@ def safetensors_weights_iterator(
                 if os.path.islink(file_path):
                     blob_path = os.path.realpath(file_path)
                     os.remove(file_path)
-                    logger.info("Removed corrupted symlink: %s", os.path.basename(file_path))
+                    logger.info(
+                        "Removed corrupted symlink: %s", os.path.basename(file_path)
+                    )
                     if os.path.exists(blob_path):
                         os.remove(blob_path)
-                        logger.info("Removed corrupted blob: %s", os.path.basename(blob_path))
+                        logger.info(
+                            "Removed corrupted blob: %s", os.path.basename(blob_path)
+                        )
                 elif os.path.isfile(file_path):
                     os.remove(file_path)
-                    logger.info("Removed corrupted file: %s", os.path.basename(file_path))
+                    logger.info(
+                        "Removed corrupted file: %s", os.path.basename(file_path)
+                    )
             except Exception as e:
                 logger.warning("Failed to remove corrupted file %s: %s", file_path, e)
 

--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -115,6 +115,30 @@ def filter_files_not_needed_for_inference(hf_weights_files: list[str]) -> list[s
 _BAR_FORMAT = "{desc}: {percentage:3.0f}% Completed | {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]\n"  # noqa: E501
 
 
+def _validate_safetensors_file(file_path: str) -> bool:
+    """
+    Validate that a safetensors file is readable and not corrupted.
+
+    Args:
+        file_path: Path to the safetensors file
+
+    Returns:
+        True if file is valid, False if corrupted
+    """
+    try:
+        with safe_open(file_path, framework="pt", device="cpu") as f:
+            _ = list(f.keys())
+        return True
+    except Exception as e:
+        logger.error(
+            "Corrupted safetensors file detected: %s - %s: %s",
+            file_path,
+            type(e).__name__,
+            str(e),
+        )
+        return False
+
+
 def safetensors_weights_iterator(
     hf_weights_files: list[str],
     to_cpu: bool = True,
@@ -124,6 +148,36 @@ def safetensors_weights_iterator(
         not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
     )
     device = "cpu" if to_cpu else str(get_local_torch_device())
+
+    # Validate files before loading
+    corrupted_files = []
+    for st_file in hf_weights_files:
+        if not _validate_safetensors_file(st_file):
+            corrupted_files.append(st_file)
+
+    if corrupted_files:
+        # Delete corrupted files (both symlink and blob if applicable)
+        for file_path in corrupted_files:
+            try:
+                if os.path.islink(file_path):
+                    blob_path = os.path.realpath(file_path)
+                    os.remove(file_path)
+                    logger.info("Removed corrupted symlink: %s", os.path.basename(file_path))
+                    if os.path.exists(blob_path):
+                        os.remove(blob_path)
+                        logger.info("Removed corrupted blob: %s", os.path.basename(blob_path))
+                elif os.path.isfile(file_path):
+                    os.remove(file_path)
+                    logger.info("Removed corrupted file: %s", os.path.basename(file_path))
+            except Exception as e:
+                logger.warning("Failed to remove corrupted file %s: %s", file_path, e)
+
+        raise RuntimeError(
+            f"Found {len(corrupted_files)} corrupted safetensors file(s). "
+            f"Files have been removed: {[os.path.basename(f) for f in corrupted_files]}. "
+            "Please retry - the files will be re-downloaded automatically."
+        )
+
     for st_file in tqdm(
         hf_weights_files,
         desc="Loading safetensors checkpoint shards",

--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -150,10 +150,7 @@ def safetensors_weights_iterator(
     device = "cpu" if to_cpu else str(get_local_torch_device())
 
     # Validate files before loading
-    corrupted_files = []
-    for st_file in hf_weights_files:
-        if not _validate_safetensors_file(st_file):
-            corrupted_files.append(st_file)
+    corrupted_files = [st_file for st_file in hf_weights_files if not _validate_safetensors_file(st_file)]
 
     if corrupted_files:
         # Delete corrupted files (both symlink and blob if applicable)


### PR DESCRIPTION
## Summary

Extends safetensors corruption detection and cleanup to the multimodal generation pipeline's weight loader.

## Problem

The recent fix in #13729 added validation for the SRT model loader, but the multimodal generation pipeline uses a separate weight loading code path that was still vulnerable to corruption. This caused nightly test failures with models like `Wan-AI/Wan2.2-T2V-A14B-Diffusers`:

```
safetensors_rust.SafetensorError: Error while deserializing header: 
invalid JSON in header: EOF while parsing a value at line 1 column 0
```

## Solution

Add the same validation logic to `python/sglang/multimodal_gen/runtime/loader/weight_utils.py`:

1. **Validation**: Check each safetensors file before loading
2. **Cleanup**: Remove corrupted files (both symlinks and blobs)
3. **Recovery**: Raise clear error prompting retry for automatic re-download

## Changes

- Add `_validate_safetensors_file()` function to validate file integrity
- Update `safetensors_weights_iterator()` to validate all files upfront
- Automatically clean up corrupted files when detected
- Provide actionable error message for users

## Testing

- Should fix nightly test failures in multimodal pipelines
- Corrupted files will be detected before loading attempts
- Files are automatically cleaned up for re-download on retry

Related to #13729