### PR TITLE
Fix nightly test job to fail when any test fails

### DIFF
--- a/test/run_suite_nightly.py
+++ b/test/run_suite_nightly.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from sglang.test.ci.ci_utils import TestFile, run_unittest_files
@@ -75,11 +76,12 @@ def main():
     print(f"Running {len(files)} tests from suite: {args.suite}")
     print(f"Test files: {[f.name for f in files]}")
 
-    run_unittest_files(
+    exit_code = run_unittest_files(
         files,
         timeout_per_file=args.timeout_per_file,
         continue_on_error=args.continue_on_error,
     )
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixed a bug where nightly test jobs showed success even when tests failed
- The `run_suite_nightly.py` script was not using the return value from `run_unittest_files()`
- Now properly exits with non-zero code when any test fails, while still running all tests with `--continue-on-error`

## Test plan
- [x] Verify the script still runs all tests when `--continue-on-error` is set
- [x] Verify the script exits with non-zero code when any test fails

Example from failed job that incorrectly showed success:
https://github.com/sgl-project/sglang/actions/runs/19653967572/job/56286664501