### PR TITLE
Adding nightly tests for Kimi-K2-thinking, Qwen3, minimax-m2, GLM4.6

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -92,6 +92,25 @@ jobs:
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_qwen3_235b
 
+      - name: Run Kimi-K2-Thinking nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-h200"
+        run: |
+          rm -rf test/srt/performance_profiles_kimi_k2_thinking/
+          cd test
+          python3 nightly/test_kimi_k2_thinking_perf.py
+
+      - name: Publish Kimi-K2-Thinking traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_kimi_k2_thinking
+
       # MiniMax-M2 test temporarily disabled due to compatibility issues
       # See MINIMAX_M2_ISSUES.md for details
       # - name: Run MiniMax-M2 nightly performance test

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -384,6 +384,25 @@ jobs:
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_deepseek_v32
 
+      - name: Run Kimi-K2-Thinking nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-b200"
+        run: |
+          rm -rf test/srt/performance_profiles_kimi_k2_thinking/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_kimi_k2_thinking_perf.py
+
+      - name: Publish Kimi-K2-Thinking traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_kimi_k2_thinking
+
       - name: Run Qwen3-235B nightly performance test
         timeout-minutes: 180
         env:

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -80,7 +80,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-h200"
         run: |
-          rm -rf test/srt/performance_profiles_qwen3_235b/
+          rm -rf test/performance_profiles_qwen3_235b/
           cd test
           python3 nightly/test_qwen3_235b_perf.py
 
@@ -90,7 +90,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_qwen3_235b
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_qwen3_235b
 
       - name: Run Kimi-K2-Thinking nightly performance test
         timeout-minutes: 180
@@ -99,7 +99,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-h200"
         run: |
-          rm -rf test/srt/performance_profiles_kimi_k2_thinking/
+          rm -rf test/performance_profiles_kimi_k2_thinking/
           cd test
           python3 nightly/test_kimi_k2_thinking_perf.py
 
@@ -109,7 +109,26 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_kimi_k2_thinking
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_kimi_k2_thinking
+
+      - name: Run GLM-4.6 nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-h200"
+        run: |
+          rm -rf test/performance_profiles_glm_4_6/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_glm_4_6_perf.py
+
+      - name: Publish GLM-4.6 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_glm_4_6
 
       # MiniMax-M2 test temporarily disabled due to compatibility issues
       # See MINIMAX_M2_ISSUES.md for details
@@ -120,7 +139,7 @@ jobs:
       #     PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
       #     GPU_CONFIG: "8-gpu-h200"
       #   run: |
-      #     rm -rf test/srt/performance_profiles_minimax_m2/
+      #     rm -rf test/performance_profiles_minimax_m2/
       #     cd test
       #     python3 nightly/test_minimax_m2_perf.py
 
@@ -130,26 +149,7 @@ jobs:
       #     GITHUB_RUN_ID: ${{ github.run_id }}
       #     GITHUB_RUN_NUMBER: ${{ github.run_number }}
       #   run: |
-      #     python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_minimax_m2
-
-      - name: Run GLM-4.6 nightly performance test
-        timeout-minutes: 180
-        env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
-          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
-          GPU_CONFIG: "8-gpu-h200"
-        run: |
-          rm -rf test/srt/performance_profiles_glm_4_6/
-          cd test
-          IS_BLACKWELL=1 python3 nightly/test_glm_4_6_perf.py
-
-      - name: Publish GLM-4.6 traces to storage repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_glm_4_6
+      #     python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_minimax_m2
 
   # General tests - 8 GPU H20
   nightly-test-general-8-gpu-h20:
@@ -410,7 +410,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-b200"
         run: |
-          rm -rf test/srt/performance_profiles_kimi_k2_thinking/
+          rm -rf test/performance_profiles_kimi_k2_thinking/
           cd test
           IS_BLACKWELL=1 python3 nightly/test_kimi_k2_thinking_perf.py
 
@@ -420,7 +420,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_kimi_k2_thinking
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_kimi_k2_thinking
 
       - name: Run Qwen3-235B nightly performance test
         timeout-minutes: 180
@@ -429,7 +429,7 @@ jobs:
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-b200"
         run: |
-          rm -rf test/srt/performance_profiles_qwen3_235b/
+          rm -rf test/performance_profiles_qwen3_235b/
           cd test
           IS_BLACKWELL=1 python3 nightly/test_qwen3_235b_perf.py
 
@@ -439,7 +439,26 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_qwen3_235b
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_qwen3_235b
+
+      - name: Run GLM-4.6 nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-b200"
+        run: |
+          rm -rf test/performance_profiles_glm_4_6/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_glm_4_6_perf.py
+
+      - name: Publish GLM-4.6 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_glm_4_6
 
       # MiniMax-M2 test temporarily disabled due to compatibility issues
       # See MINIMAX_M2_ISSUES.md for details
@@ -450,7 +469,7 @@ jobs:
       #     PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
       #     GPU_CONFIG: "8-gpu-b200"
       #   run: |
-      #     rm -rf test/srt/performance_profiles_minimax_m2/
+      #     rm -rf test/performance_profiles_minimax_m2/
       #     cd test
       #     IS_BLACKWELL=1 python3 nightly/test_minimax_m2_perf.py
 
@@ -460,26 +479,7 @@ jobs:
       #     GITHUB_RUN_ID: ${{ github.run_id }}
       #     GITHUB_RUN_NUMBER: ${{ github.run_number }}
       #   run: |
-      #     python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_minimax_m2
-
-      - name: Run GLM-4.6 nightly performance test
-        timeout-minutes: 180
-        env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
-          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
-          GPU_CONFIG: "8-gpu-b200"
-        run: |
-          rm -rf test/srt/performance_profiles_glm_4_6/
-          cd test
-          IS_BLACKWELL=1 python3 nightly/test_glm_4_6_perf.py
-
-      - name: Publish GLM-4.6 traces to storage repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_glm_4_6
+      #     python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_minimax_m2
 
   # Final check job
   check-all-jobs:

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -73,6 +73,65 @@ jobs:
           cd test
           python3 run_suite_nightly.py --suite nightly-8-gpu-h200 --continue-on-error
 
+      - name: Run Qwen3-235B nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-h200"
+        run: |
+          rm -rf test/srt/performance_profiles_qwen3_235b/
+          cd test
+          python3 nightly/test_qwen3_235b_perf.py
+
+      - name: Publish Qwen3-235B traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_qwen3_235b
+
+      # MiniMax-M2 test temporarily disabled due to compatibility issues
+      # See MINIMAX_M2_ISSUES.md for details
+      # - name: Run MiniMax-M2 nightly performance test
+      #   timeout-minutes: 180
+      #   env:
+      #     TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+      #     PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+      #     GPU_CONFIG: "8-gpu-h200"
+      #   run: |
+      #     rm -rf test/srt/performance_profiles_minimax_m2/
+      #     cd test
+      #     python3 nightly/test_minimax_m2_perf.py
+
+      # - name: Publish MiniMax-M2 traces to storage repo
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+      #     GITHUB_RUN_ID: ${{ github.run_id }}
+      #     GITHUB_RUN_NUMBER: ${{ github.run_number }}
+      #   run: |
+      #     python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_minimax_m2
+
+      - name: Run GLM-4.6 nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-h200"
+        run: |
+          rm -rf test/srt/performance_profiles_glm_4_6/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_glm_4_6_perf.py
+
+      - name: Publish GLM-4.6 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_glm_4_6
+
   # General tests - 8 GPU H20
   nightly-test-general-8-gpu-h20:
     if: github.repository == 'sgl-project/sglang'
@@ -324,6 +383,65 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_deepseek_v32
+
+      - name: Run Qwen3-235B nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-b200"
+        run: |
+          rm -rf test/srt/performance_profiles_qwen3_235b/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_qwen3_235b_perf.py
+
+      - name: Publish Qwen3-235B traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_qwen3_235b
+
+      # MiniMax-M2 test temporarily disabled due to compatibility issues
+      # See MINIMAX_M2_ISSUES.md for details
+      # - name: Run MiniMax-M2 nightly performance test
+      #   timeout-minutes: 180
+      #   env:
+      #     TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+      #     PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+      #     GPU_CONFIG: "8-gpu-b200"
+      #   run: |
+      #     rm -rf test/srt/performance_profiles_minimax_m2/
+      #     cd test
+      #     IS_BLACKWELL=1 python3 nightly/test_minimax_m2_perf.py
+
+      # - name: Publish MiniMax-M2 traces to storage repo
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+      #     GITHUB_RUN_ID: ${{ github.run_id }}
+      #     GITHUB_RUN_NUMBER: ${{ github.run_number }}
+      #   run: |
+      #     python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_minimax_m2
+
+      - name: Run GLM-4.6 nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-b200"
+        run: |
+          rm -rf test/srt/performance_profiles_glm_4_6/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_glm_4_6_perf.py
+
+      - name: Publish GLM-4.6 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/srt/performance_profiles_glm_4_6
 
   # Final check job
   check-all-jobs:

--- a/test/nightly/test_glm_4_6_perf.py
+++ b/test/nightly/test_glm_4_6_perf.py
@@ -1,0 +1,49 @@
+import unittest
+
+from nightly_utils import NightlyBenchmarkRunner
+
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+GLM_4_6_MODEL_PATH = "zai-org/GLM-4.6"
+PROFILE_DIR = "performance_profiles_glm_4_6"
+
+
+class TestNightlyGLM46Performance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = GLM_4_6_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        # GLM-4.6 is a 357B MoE model
+        cls.other_args = [
+            "--tp",
+            "8",
+            "--trust-remote-code",
+        ]
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+
+    def test_bench_one_batch(self):
+        results, success = self.runner.run_benchmark_for_model(
+            model_path=self.model,
+            batch_sizes=self.batch_sizes,
+            input_lens=self.input_lens,
+            output_lens=self.output_lens,
+            other_args=self.other_args,
+        )
+
+        self.runner.add_report(results)
+        self.runner.write_final_report()
+
+        if not success:
+            raise AssertionError(
+                f"Benchmark failed for {self.model}. Check the logs for details."
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/nightly/test_kimi_k2_thinking_perf.py
+++ b/test/nightly/test_kimi_k2_thinking_perf.py
@@ -1,0 +1,54 @@
+import unittest
+
+from nightly_utils import NightlyBenchmarkRunner
+
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+KIMI_K2_THINKING_MODEL_PATH = "moonshotai/Kimi-K2-Thinking"
+PROFILE_DIR = "performance_profiles_kimi_k2_thinking"
+
+
+class TestNightlyKimiK2ThinkingPerformance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = KIMI_K2_THINKING_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        # Kimi-K2-Thinking requires specific launch arguments
+        cls.other_args = [
+            "--tp",
+            "8",
+            "--trust-remote-code",
+            "--tool-call-parser",
+            "kimi_k2",
+            "--reasoning-parser",
+            "kimi_k2",
+        ]
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+
+    def test_bench_one_batch(self):
+        results, success = self.runner.run_benchmark_for_model(
+            model_path=self.model,
+            batch_sizes=self.batch_sizes,
+            input_lens=self.input_lens,
+            output_lens=self.output_lens,
+            other_args=self.other_args,
+            extra_bench_args=["--trust-remote-code"],
+        )
+
+        self.runner.add_report(results)
+        self.runner.write_final_report()
+
+        if not success:
+            raise AssertionError(
+                f"Benchmark failed for {self.model}. Check the logs for details."
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/nightly/test_minimax_m2_perf.py
+++ b/test/nightly/test_minimax_m2_perf.py
@@ -1,0 +1,49 @@
+import unittest
+
+from nightly_utils import NightlyBenchmarkRunner
+
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+MINIMAX_M2_MODEL_PATH = "MiniMaxAI/MiniMax-M2"
+PROFILE_DIR = "performance_profiles_minimax_m2"
+
+
+class TestNightlyMiniMaxM2Performance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = MINIMAX_M2_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        # MiniMax-M2 is a 230B MoE model with 10B active params
+        cls.other_args = [
+            "--tp",
+            "8",
+            "--trust-remote-code",
+        ]
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+
+    def test_bench_one_batch(self):
+        results, success = self.runner.run_benchmark_for_model(
+            model_path=self.model,
+            batch_sizes=self.batch_sizes,
+            input_lens=self.input_lens,
+            output_lens=self.output_lens,
+            other_args=self.other_args,
+        )
+
+        self.runner.add_report(results)
+        self.runner.write_final_report()
+
+        if not success:
+            raise AssertionError(
+                f"Benchmark failed for {self.model}. Check the logs for details."
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/nightly/test_qwen3_235b_perf.py
+++ b/test/nightly/test_qwen3_235b_perf.py
@@ -1,0 +1,49 @@
+import unittest
+
+from nightly_utils import NightlyBenchmarkRunner
+
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+QWEN3_235B_MODEL_PATH = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+PROFILE_DIR = "performance_profiles_qwen3_235b"
+
+
+class TestNightlyQwen3235BPerformance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_235B_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        # Qwen3-235B requires TP=8 for 8 GPUs
+        cls.other_args = [
+            "--tp",
+            "8",
+            "--trust-remote-code",
+        ]
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+
+    def test_bench_one_batch(self):
+        results, success = self.runner.run_benchmark_for_model(
+            model_path=self.model,
+            batch_sizes=self.batch_sizes,
+            input_lens=self.input_lens,
+            output_lens=self.output_lens,
+            other_args=self.other_args,
+        )
+
+        self.runner.add_report(results)
+        self.runner.write_final_report()
+
+        if not success:
+            raise AssertionError(
+                f"Benchmark failed for {self.model}. Check the logs for details."
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Currently, nightly tests are only run on Deepseek models. This PR adds 4 more models to the H200 and B200 nightly test suites to expand and diversify model coverage in Kimi-K2-thinking, Qwen3, Minimax-M2, and GLM4.6.

## Modifications

Added:
- Test files for each model under test/nightly
- Modified workflow by adding test steps under both B200 and H200 jobs in the nightly-test-nvidia workflow
- Note: minimax-m2 is commented out now as we investigate fp8 quantization and weight sharding architectural compatibility issue.

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [ Done.] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [N/A ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ N/A] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ N/A] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
