### PR TITLE
[Fix] add contiguous assert

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/kernels.py
+++ b/python/sglang/srt/layers/moe/ep_moe/kernels.py
@@ -744,6 +744,25 @@ def ep_scatter(
     ), f"recv_x_scale.dtype: {recv_x_scale.dtype}, output_tensor_scale.dtype: {output_tensor_scale.dtype}"
     assert recv_x_scale.shape[1] == output_tensor_scale.shape[1] == scale_hidden_size
 
+    assert (
+        recv_x.stride(1) == 1
+    ), f"recv_x must be contiguous (stride1 == 1), got stride1={recv_x.stride(1)}"
+    assert (
+        recv_x_scale.stride(1) == 1
+    ), f"recv_x_scale must be contiguous (stride1 == 1), got stride1={recv_x_scale.stride(1)}"
+    assert (
+        recv_topk.stride(1) == 1
+    ), f"recv_topk must be contiguous (stride1 == 1), got stride1={recv_topk.stride(1)}"
+    assert (
+        output_tensor.stride(1) == 1
+    ), f"output_tensor must be contiguous (stride1 == 1), got stride1={output_tensor.stride(1)}"
+    assert (
+        output_tensor_scale.stride(1) == 1
+    ), f"output_tensor_scale must be contiguous (stride1 == 1), got stride1={output_tensor_scale.stride(1)}"
+    assert (
+        output_index.stride(1) == 1
+    ), f"output_index must be contiguous (stride1 == 1), got stride1={output_index.stride(1)}"
+
     _fwd_kernel_ep_scatter_1[(grid,)](
         num_recv_tokens_per_expert,
         expert_start_loc,
@@ -866,6 +885,23 @@ def ep_gather(
     hidden_size = input_tensor.shape[1]
     BLOCK_D = 128 if hidden_size % 1024 != 0 else 1024  # block size of quantization
     assert hidden_size % BLOCK_D == 0
+
+    assert (
+        input_tensor.stride(1) == 1
+    ), f"input_tensor must be contiguous (stride1 == 1), got stride1={input_tensor.stride(1)}"
+    assert (
+        recv_topk_ids.stride(1) == 1
+    ), f"recv_topk_ids must be contiguous (stride1 == 1), got stride1={recv_topk_ids.stride(1)}"
+    assert (
+        recv_topk_weight.stride(1) == 1
+    ), f"recv_topk_weight must be contiguous (stride1 == 1), got stride1={recv_topk_weight.stride(1)}"
+    assert (
+        input_index.stride(1) == 1
+    ), f"input_index must be contiguous (stride1 == 1), got stride1={input_index.stride(1)}"
+    assert (
+        output_tensor.stride(1) == 1
+    ), f"output_tensor must be contiguous (stride1 == 1), got stride1={output_tensor.stride(1)}"
+
     grid = (triton.cdiv(hidden_size, BLOCK_D), min(num_tokens, 1024))
     _fwd_kernel_ep_gather[grid](
         num_tokens,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When `recv_topk` is not contiguous (e.g., shape: `torch.Size([1024, 8])`, stride0: 1, stride1: 1024), the `_fwd_kernel_ep_scatter_2` function will trigger an "illegal memory access" error.
<img width="678" height="274" alt="image" src="https://github.com/user-attachments/assets/1da59fcf-e016-4c68-b545-0fc46fd330c8" />


This occurs because the kernel accesses memory using:
```python
expert_id = tl.load(recv_topk + token_id * recv_topk_stride0 + topk_index)
```
where `topk_index` is not multiplied by `recv_topk_stride1`, implicitly assuming `stride1 == 1`.

For a transposed tensor with stride0=1 and stride1=1024, the correct memory access should be `base + token_id * 1 + topk_index * 1024`, but the kernel computes `base + token_id * 1 + topk_index`, resulting in out-of-bounds memory access.

Since `_fwd_kernel_ep_scatter_2` assumes all input tensors are row-major contiguous (stride1 == 1), assertions have been added before the kernel call to validate this requirement and provide clear error messages when violated.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
