### PR TITLE
Add test_dummy_grok_models.py to not_in_ci section

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -200,6 +200,7 @@ suites = {
     ],
     # Nightly test suites have been moved to test/run_suite_nightly.py
     "__not_in_ci__": [
+        TestFile("models/test_dummy_grok_models.py"),
         TestFile("test_bench_one_batch.py"),
         TestFile("test_bench_serving.py"),
         TestFile("test_eval_accuracy_large.py"),


### PR DESCRIPTION
Temporary fix for: https://github.com/sgl-project/sglang/actions/runs/19662098997/job/56310368144?pr=12441

## Summary
- Add `models/test_dummy_grok_models.py` to `__not_in_ci__` section in `test/srt/run_suite.py`
- Fix CI sanity check failure: `AssertionError: Some test files are not in test suite`

## Test plan
- [ ] CI sanity check passes