### PR TITLE
[VLM] support qwen3-vl eagle infer

### DIFF
--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -116,9 +116,16 @@ class LlamaModel(nn.Module):
             and config.rope_scaling is not None
             and "mrope_section" in config.rope_scaling
         )
-        # fix rope_scaling for qwen2.5-vl
+        # fix rope_scaling for qwen2.5-vl/qwen3-vl
         if self.is_mrope_enabled:
-            config.rope_scaling["rope_type"] = "default"
+            rope_scaling = config.rope_scaling
+            mrope_interleaved = rope_scaling.get("mrope_interleaved", False)
+            if not mrope_interleaved:
+                rope_scaling["rope_type"] = "default"
+            rope_scaling["mrope_interleaved"] = mrope_interleaved
+        else:
+            mrope_interleaved = False
+        self.mrope_interleaved = mrope_interleaved
 
         self.vocab_size = config.vocab_size
         self.embed_tokens = VocabParallelEmbedding(

--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -119,13 +119,11 @@ class LlamaModel(nn.Module):
         # fix rope_scaling for qwen2.5-vl/qwen3-vl
         if self.is_mrope_enabled:
             rope_scaling = config.rope_scaling
-            mrope_interleaved = rope_scaling.get("mrope_interleaved", False)
-            if not mrope_interleaved:
+            self.mrope_interleaved = rope_scaling.setdefault("mrope_interleaved", False)
+            if not self.mrope_interleaved:
                 rope_scaling["rope_type"] = "default"
-            rope_scaling["mrope_interleaved"] = mrope_interleaved
         else:
-            mrope_interleaved = False
-        self.mrope_interleaved = mrope_interleaved
+            self.mrope_interleaved = False
 
         self.vocab_size = config.vocab_size
         self.embed_tokens = VocabParallelEmbedding(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Support qwen3-vl dense model eagle infer.

use [qwen3-vl-8b eagle model](https://modelscope.cn/models/MNN/Qwen3-VL-8B-Instruct-Eagle3) for test.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

server:
```
python -m sglang.launch_server --host 0.0.0.0 --port 8080 --model-path Qwen/Qwen3-VL-8B-Instruct --served-model-name test --trust-remote-code --tp 1 --mem-fraction-static 0.85 --speculative-draft-model-path MNN/Qwen3-VL-8B-Instruct-Eagle3 --speculative-algo EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 6 --speculative-num-draft-tokens 16
```
acc_bench:
```
OPENAI_API_BASE=http://0.0.0.0:8080/v1 OPENAI_API_KEY="" python3 -m lmms_eval     --model openai_compatible     --model_args model_version=Qwen/Qwen3-VL-8B-Instruct  --tasks mmmu_val     --batch_size 16
```
result:
- with eagle:
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5022|±  |   N/A|

- without eagle:
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5089|±  |   N/A|


## Benchmarking and Profiling

server:
```
python -m sglang.launch_server --host 0.0.0.0 --port 8080 --model-path Qwen/Qwen3-VL-8B-Instruct --served-model-name test --trust-remote-code --tp 1 --mem-fraction-static 0.85 --speculative-draft-model-path MNN/Qwen3-VL-8B-Instruct-Eagle3 --speculative-algo EAGLE3 --speculative-num-steps 3 --speculative-eagle-topk 6 --speculative-num-draft-tokens 16
```

perf bench:
use [mmstar](https://github.com/sgl-project/SpecForge/blob/main/benchmarks/benchmarker/mmstar.py) in specforge
```
python run_mmstar.py --host http://0.0.0.0 --port 8080 --parallel 1 --num-questions 50
```

result:
- without eagle:
Latency: 62.841 s
Output throughput: 152.131 token/s
Accept length: 1.000

- with eagle:
Latency: 43.339 s
Output throughput: 215.856 token/s
Accept length: 2.501
Deleted temporary directory: .cache/mmstar_specforge

**e2e speedup:  1.41x**

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
