### PR TITLE
Update modelopt quantization config parsing

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -630,14 +630,12 @@ class ModelConfig:
             quant_cfg = quant_cfg.to_dict()
         if quant_cfg is not None:
             # Identify modelopt quantization
-            quant_algo = quant_cfg.get("quant_algo", None)
-            if quant_algo and "quant_method" not in quant_cfg:
-                if quant_algo == "MIXED_PRECISION":
-                    quant_cfg["quant_method"] = "w4afp8"
-                elif "FP4" in quant_algo or "NVFP4" in quant_algo:
-                    quant_cfg["quant_method"] = "modelopt_fp4"
-                elif "FP8" in quant_algo:
-                    quant_cfg["quant_method"] = "modelopt_fp8"
+            if "quant_method" not in quant_cfg:
+                parsed_cfg = self._parse_modelopt_quant_config(
+                    {"quantization": quant_cfg}
+                )
+                if parsed_cfg:
+                    quant_cfg.update(parsed_cfg)
 
         if quant_cfg is None:
             # compressed-tensors uses a "compression_config" key
@@ -750,9 +748,9 @@ class ModelConfig:
     def _is_already_quantized(self) -> bool:
         """Check if the model is already quantized based on config files."""
         # Check for quantization in hf_config (config.json)
-        if getattr(self.hf_config, "quantization_config", None):
-            return True
-        if getattr(self.hf_config, "compression_config", None):
+        if getattr(self.hf_config, "quantization_config", None) or getattr(
+            self.hf_config, "compression_config", None
+        ):
             return True
 
         # Check for HuggingFace quantization config

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -197,6 +197,8 @@ def get_quant_config(
         # compressed-tensors uses a compressions_config
         hf_quant_config = getattr(model_config.hf_config, "compression_config", None)
     if hf_quant_config is not None:
+        if not isinstance(hf_quant_config, dict):
+            hf_quant_config = hf_quant_config.to_dict()
         hf_quant_config["packed_modules_mapping"] = packed_modules_mapping
         return quant_cls.from_config(hf_quant_config)
 


### PR DESCRIPTION
Update modelopt quantization config parsing such that the system can now correctly detect and load ModelOpt checkpoints using only `config.json`, without requiring `hf_quant_config.json`, which will be deprecated.

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

1. `python/sglang/srt/configs/model_config.py`:
   - Updated `_parse_quant_hf_config` to inspect quantization_config within `config.json`. It now identifies quant_algo (e.g., "NVFP4", "FP8") and maps it to the correct quant_method (modelopt_fp4 or modelopt_fp8).
   - Updated `_is_already_quantized` to return True if quantization_config is present in config.json, preventing the unnecessary fallback to `hf_quant_config.json`.
2. `python/sglang/srt/model_loader/weight_utils.py`:
   - Updated `get_quant_config` to handle cases where quantization_config is a `PretrainedConfig` object (instead of a dict) by converting it using `.to_dict()` before processing.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
