### PR TITLE
[VLM] Support InternVL Vision Encoder Data Parallelism

### DIFF
--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -7,11 +7,16 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig, PreTrainedModel
-from transformers.activations import ACT2FN
 from transformers.modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 
+from sglang.srt.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from sglang.srt.layers.activation import get_act_fn
 from sglang.srt.layers.attention import vision_utils
 from sglang.srt.layers.attention.vision import SingletonCache, VisionAttention
+from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.managers.mm_utils import MultiModalityDataPaddingPatternTokenPairs
@@ -28,6 +33,8 @@ from sglang.srt.models.internlm2 import InternLM2ForCausalLM
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang.srt.models.qwen3_moe import Qwen3MoeForCausalLM
+from sglang.srt.multimodal.mm_utils import run_dp_sharded_vision_model
+from sglang.srt.server_args import get_global_server_args
 from sglang.utils import logger
 
 
@@ -36,6 +43,7 @@ class InternAttention(nn.Module):
         self,
         config,
         quant_config: QuantizationConfig = None,
+        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.config = config
@@ -57,6 +65,7 @@ class InternAttention(nn.Module):
             qk_normalization=getattr(config, "qk_normalization", False)
             or getattr(config, "use_qk_norm", False),
             flatten_batch=False,
+            use_data_parallel=use_data_parallel,
         )
 
         self.proj_drop = nn.Dropout(config.dropout)
@@ -160,17 +169,39 @@ class InternRMSNorm(nn.Module):
 
 
 class InternMLP(nn.Module):
-    def __init__(self, config: PretrainedConfig):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        use_data_parallel: bool = False,
+    ):
         super().__init__()
+        self.tp_size = (
+            1 if use_data_parallel else get_tensor_model_parallel_world_size()
+        )
+        self.tp_rank = 0 if use_data_parallel else get_tensor_model_parallel_rank()
         self.config = config
-        self.act = ACT2FN[config.hidden_act]
-        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
-        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.act = get_act_fn(config.hidden_act)
+        self.fc1 = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=True,
+            quant_config=None,
+            tp_size=self.tp_size,
+            tp_rank=self.tp_rank,
+        )
+        self.fc2 = RowParallelLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=True,
+            quant_config=None,
+            tp_size=self.tp_size,
+            tp_rank=self.tp_rank,
+        )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        hidden_states = self.fc1(hidden_states)
+        hidden_states, _ = self.fc1(hidden_states)
         hidden_states = self.act(hidden_states)
-        hidden_states = self.fc2(hidden_states)
+        hidden_states, _ = self.fc2(hidden_states)
         return hidden_states
 
 
@@ -187,13 +218,18 @@ class InternVisionEncoderLayer(nn.Module):
         config: PretrainedConfig,
         drop_path_rate: float,
         quant_config: QuantizationConfig = None,
+        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.embed_dim = config.hidden_size
         self.intermediate_size = config.intermediate_size
         self.norm_type = config.norm_type
-        self.attn = InternAttention(config=config, quant_config=quant_config)
-        self.mlp = InternMLP(config)
+        self.attn = InternAttention(
+            config=config,
+            quant_config=quant_config,
+            use_data_parallel=use_data_parallel,
+        )
+        self.mlp = InternMLP(config, use_data_parallel)
         self.norm1 = NORM2FN[self.norm_type](self.embed_dim, eps=config.layer_norm_eps)
         self.norm2 = NORM2FN[self.norm_type](self.embed_dim, eps=config.layer_norm_eps)
 
@@ -248,6 +284,7 @@ class InternVisionEncoder(nn.Module):
         self,
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.config = config
@@ -258,7 +295,9 @@ class InternVisionEncoder(nn.Module):
         ]
         self.layers = nn.ModuleList(
             [
-                InternVisionEncoderLayer(config, dpr[idx], quant_config)
+                InternVisionEncoderLayer(
+                    config, dpr[idx], quant_config, use_data_parallel
+                )
                 for idx in range(config.num_hidden_layers)
             ]
         )
@@ -319,14 +358,16 @@ class InternVisionModel(PreTrainedModel):
         self,
         config: PretrainedConfig,
         quant_config: Optional[QuantizationConfig] = None,
+        use_data_parallel: bool = False,
     ):
         super().__init__(config)
-        self.config = config
 
+        self.config = config
+        self.use_data_parallel = use_data_parallel
         self.embeddings = InternVisionEmbeddings(
             config,
         )
-        self.encoder = InternVisionEncoder(config, quant_config)
+        self.encoder = InternVisionEncoder(config, quant_config, use_data_parallel)
 
     def resize_pos_embeddings(self, old_size, new_size, patch_size):
         pos_emb = self.embeddings.position_embedding
@@ -381,23 +422,36 @@ class InternVisionModel(PreTrainedModel):
                 hidden_states = self.embeddings(pixel_values)
             else:
                 raise ValueError(f"wrong pixel_values size: {pixel_values.shape}")
-        encoder_outputs = self.encoder(
-            inputs_embeds=hidden_states,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-        )
-        last_hidden_state = encoder_outputs.last_hidden_state
+
+        if self.use_data_parallel:
+            encoder_outputs = run_dp_sharded_vision_model(hidden_states, self.encoder)
+            last_hidden_state = encoder_outputs
+        else:
+            encoder_outputs = self.encoder(
+                inputs_embeds=hidden_states,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
+            )
+            last_hidden_state = encoder_outputs.last_hidden_state
         pooled_output = last_hidden_state[:, 0, :]
 
         if not return_dict:
             return (last_hidden_state, pooled_output) + encoder_outputs[1:]
 
-        return BaseModelOutputWithPooling(
-            last_hidden_state=last_hidden_state,
-            pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
-        )
+        if self.use_data_parallel:
+            return BaseModelOutputWithPooling(
+                last_hidden_state=last_hidden_state,
+                pooler_output=pooled_output,
+                hidden_states=None,
+                attentions=None,
+            )
+        else:
+            return BaseModelOutputWithPooling(
+                last_hidden_state=last_hidden_state,
+                pooler_output=pooled_output,
+                hidden_states=encoder_outputs.hidden_states,
+                attentions=encoder_outputs.attentions,
+            )
 
 
 class InternVLChatModel(nn.Module):
@@ -409,6 +463,7 @@ class InternVLChatModel(nn.Module):
     ) -> None:
         super().__init__()
         self.config = config
+        self.use_data_parallel = get_global_server_args().mm_enable_dp_encoder
         self.quant_config = quant_config
         vision_utils.update_vit_attn_dummy_heads_config(self.config)
         image_size = config.force_image_size or config.vision_config.image_size
@@ -430,7 +485,10 @@ class InternVLChatModel(nn.Module):
         logger.info(f"num_image_token: {self.num_image_token}")
         logger.info(f"ps_version: {self.ps_version}")
 
-        self.vision_model = InternVisionModel(config.vision_config)
+        self.vision_model = InternVisionModel(
+            config.vision_config,
+            use_data_parallel=self.use_data_parallel,
+        )
         if config.llm_config.architectures[0] == "Qwen2ForCausalLM":
             self.language_model = Qwen2ForCausalLM(
                 config=config.llm_config, quant_config=quant_config

--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -428,6 +428,40 @@ def get_dp_encoder_lb_assignment(
 
 
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/vision.py
+def run_dp_sharded_vision_model(
+    image_input: torch.Tensor, vision_model: torch.nn.Module
+) -> torch.Tensor:
+    """Run a vision model with data parallelism (DP) sharding. The function
+    will shard the input image tensor on the first dimension and run the vision
+    model
+
+    Args:
+        image_input (torch.Tensor): Image input tensor.
+        vision_model (torch.nn.Module): Vision model.
+    Returns:
+        torch.Tensor: Output image embeddings
+    """
+
+    num_chunks = image_input.shape[0]
+    mp_world_size = get_tensor_model_parallel_world_size()
+    num_chunks_per_rank = (num_chunks + mp_world_size - 1) // mp_world_size
+    num_padded_chunks = num_chunks_per_rank * mp_world_size - num_chunks
+    pad = (0,) * (2 * (image_input.dim() - 1)) + (0, num_padded_chunks)
+    image_input_padded = torch.nn.functional.pad(image_input, pad)
+    rank = get_tensor_model_parallel_rank()
+    image_input_per_rank = image_input_padded[
+        rank * num_chunks_per_rank : (rank + 1) * num_chunks_per_rank, ...
+    ]
+
+    vision_embeddings = vision_model(image_input_per_rank)
+    # Ensure tensor is contiguous before all_gather
+    vision_embeddings = vision_embeddings.last_hidden_state.contiguous()
+    vision_embeddings = tensor_model_parallel_all_gather(vision_embeddings, dim=0)
+    vision_embeddings = vision_embeddings[:num_chunks, ...]
+    return vision_embeddings
+
+
+# Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/vision.py
 def run_dp_sharded_mrope_vision_model(
     vision_model: torch.nn.Module,
     pixel_values: torch.Tensor,

--- a/test/nightly/test_encoder_dp.py
+++ b/test/nightly/test_encoder_dp.py
@@ -19,6 +19,7 @@ from sglang.test.test_utils import (
 
 MODELS = [
     SimpleNamespace(model="Qwen/Qwen2.5-VL-72B-Instruct", mmmu_accuracy=0.55),
+    SimpleNamespace(model="OpenGVLab/InternVL2_5-8B", mmmu_accuracy=0.52),
 ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to support InternVL Vision-Encoder data parallelism. https://github.com/sgl-project/sglang/issues/12971

From profiling we can see InternVL Vision-Encoder is computing intensive, the CUDA command buffer is always full. This PR is to adopt Vision-Encoder data parallelism so as to dispatch the encode data computing to several ranks so as to reduce the TTFT latency.
<img width="3324" height="1568" alt="image" src="https://github.com/user-attachments/assets/a19965f8-1315-4df2-ad1d-2db63f06e877" />


Tested with Vision Encoder DP enabled and Piecewise CUDA Graph enabled. 


E2E performance is expected to improve 5-10%. More benchmark test is in progress, will update soon.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
python3 -m sglang.launch_server --host 127.0.0.1 \
    --mem-fraction-static 0.7 \
    --port 30000 \
    --trust-remote-code \
    --dtype auto \
    --max-running-requests 4 \
    --chunked-prefill-size 8192 \
    --attention-backend flashinfer \
    --tp 4 \
    --enable-multimodal \
    --chat-template internvl-2-5 \
    --model OpenGVLab/InternVL2_5-8B \
    --disable-radix-cache \
    --mm-enable-dp-encoder \
    --piecewise-cuda-graph-max-tokens 8192 \
    --enable-piecewise-cuda-graph \
    --piecewise-cuda-graph-compiler eager 
```

Accuracy result is expected.
With PR:
```
$python3 -m lmms_eval --model openai_compatible   --model_args model_version=OpenGVLab/InternVL2_5-8B   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-11-25 20:56:29 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-11-25 20:56:32 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-11-25 20:56:32 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-11-25 20:56:32 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-11-25 20:56:35 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-11-25 20:56:35 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 3563.33it/s]
2025-11-25 20:56:36 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:27<00:00,  2.57s/it]2025-11-25 21:00:03 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1355.351s, Total tokens: 1937, Avg speed: 1.4 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:27<00:00,  3.63s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11234.34it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.74167}, 'Art': {'num': 30, 'acc': 0.8}, 'Art_Theory': {'num': 30, 'acc': 0.83333}, 'Design': {'num': 30, 'acc': 0.8}, 'Music': {'num': 30, 'acc': 0.53333}, 'Overall-Business': {'num': 150, 'acc': 0.46}, 'Accounting': {'num': 30, 'acc': 0.5}, 'Economics': {'num': 30, 'acc': 0.43333}, 'Finance': {'num': 30, 'acc': 0.3}, 'Manage': {'num': 30, 'acc': 0.46667}, 'Marketing': {'num': 30, 'acc': 0.6}, 'Overall-Science': {'num': 150, 'acc': 0.42}, 'Biology': {'num': 30, 'acc': 0.53333}, 'Chemistry': {'num': 30, 'acc': 0.26667}, 'Geography': {'num': 30, 'acc': 0.46667}, 'Math': {'num': 30, 'acc': 0.46667}, 'Physics': {'num': 30, 'acc': 0.36667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.56667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.53333}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.46667}, 'Pharmacy': {'num': 30, 'acc': 0.63333}, 'Public_Health': {'num': 30, 'acc': 0.56667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.7}, 'History': {'num': 30, 'acc': 0.66667}, 'Literature': {'num': 30, 'acc': 0.86667}, 'Sociology': {'num': 30, 'acc': 0.63333}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.40952}, 'Agriculture': {'num': 30, 'acc': 0.43333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.33333}, 'Computer_Science': {'num': 30, 'acc': 0.53333}, 'Electronics': {'num': 30, 'acc': 0.43333}, 'Energy_and_Power': {'num': 30, 'acc': 0.46667}, 'Materials': {'num': 30, 'acc': 0.36667}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.3}, 'Overall': {'num': 900, 'acc': 0.52889}}
fatal: not a git repository (or any of the parent directories): .git
2025-11-25 21:00:03 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=OpenGVLab/InternVL2_5-8B), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5289|±  |   N/A|
```

Without PR:
```
$python3 -m lmms_eval --model openai_compatible   --model_args model_version=Qwen/Qwen2.5-VL-7B-Instruct   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-11-26 10:53:54 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-11-26 10:53:57 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-11-26 10:53:57 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-11-26 10:53:57 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-11-26 10:54:00 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-11-26 10:54:00 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 3409.71it/s]
2025-11-26 10:54:01 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:25<00:00,  2.59s/it]2025-11-26 10:57:26 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1336.528s, Total tokens: 1937, Avg speed: 1.4 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:25<00:00,  3.61s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11038.22it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.75}, 'Art': {'num': 30, 'acc': 0.8}, 'Art_Theory': {'num': 30, 'acc': 0.86667}, 'Design': {'num': 30, 'acc': 0.8}, 'Music': {'num': 30, 'acc': 0.53333}, 'Overall-Business': {'num': 150, 'acc': 0.46}, 'Accounting': {'num': 30, 'acc': 0.5}, 'Economics': {'num': 30, 'acc': 0.43333}, 'Finance': {'num': 30, 'acc': 0.3}, 'Manage': {'num': 30, 'acc': 0.46667}, 'Marketing': {'num': 30, 'acc': 0.6}, 'Overall-Science': {'num': 150, 'acc': 0.42}, 'Biology': {'num': 30, 'acc': 0.53333}, 'Chemistry': {'num': 30, 'acc': 0.26667}, 'Geography': {'num': 30, 'acc': 0.46667}, 'Math': {'num': 30, 'acc': 0.46667}, 'Physics': {'num': 30, 'acc': 0.36667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.56667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.53333}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.46667}, 'Pharmacy': {'num': 30, 'acc': 0.63333}, 'Public_Health': {'num': 30, 'acc': 0.56667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.7}, 'History': {'num': 30, 'acc': 0.66667}, 'Literature': {'num': 30, 'acc': 0.86667}, 'Sociology': {'num': 30, 'acc': 0.63333}, 'Psychology': {'num': 30, 'acc': 0.63333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.40476}, 'Agriculture': {'num': 30, 'acc': 0.43333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.33333}, 'Computer_Science': {'num': 30, 'acc': 0.53333}, 'Electronics': {'num': 30, 'acc': 0.43333}, 'Energy_and_Power': {'num': 30, 'acc': 0.43333}, 'Materials': {'num': 30, 'acc': 0.36667}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.3}, 'Overall': {'num': 900, 'acc': 0.52889}}
fatal: not a git repository (or any of the parent directories): .git
2025-11-26 10:57:27 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen2.5-VL-7B-Instruct), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5289|±  |   N/A|
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
