### PR TITLE
[Bugfix] input prompt was not logged

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -451,6 +451,17 @@ class TokenizerManager(TokenizerCommunicatorMixin):
                 f"Receive: obj={dataclass_to_string_truncated(obj, max_length, skip_names=skip_names)}"
             )
 
+            # FIXME: This is a temporary fix to get the text from the input ids.
+            # We should remove this once we have a proper way.
+            if (
+                self.log_requests_level >= 2
+                and obj.text is None
+                and obj.input_ids is not None
+                and self.tokenizer is not None
+            ):
+                decoded = self.tokenizer.decode(obj.input_ids, skip_special_tokens=False)
+                obj.text = decoded
+
         async with self.is_pause_cond:
             await self.is_pause_cond.wait_for(lambda: not self.is_pause)
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -459,7 +459,9 @@ class TokenizerManager(TokenizerCommunicatorMixin):
                 and obj.input_ids is not None
                 and self.tokenizer is not None
             ):
-                decoded = self.tokenizer.decode(obj.input_ids, skip_special_tokens=False)
+                decoded = self.tokenizer.decode(
+                    obj.input_ids, skip_special_tokens=False
+                )
                 obj.text = decoded
 
         async with self.is_pause_cond:


### PR DESCRIPTION
## Motivation
Input prompt was not logged when --log-requests was enabled and --log-requests-level was set to 2 or 3.

log was enabled:
<img width="3830" height="226" alt="image" src="https://github.com/user-attachments/assets/c1b23337-0146-4831-b8e6-7aefef5619f3" />

while text is None:
<img width="3838" height="422" alt="image" src="https://github.com/user-attachments/assets/cb3d5b75-f199-4524-ac0a-3526859ff506" />

after fix:
<img width="3838" height="578" alt="image" src="https://github.com/user-attachments/assets/a9ad2e32-475d-4a9d-865f-6e038112c7e9" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
