### PR TITLE
[Draft] Use non-copying manner to avoid large multimodal request

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -16,6 +16,7 @@
 import faulthandler
 import logging
 import os
+import pickle
 import signal
 import sys
 import threading
@@ -1035,7 +1036,8 @@ class Scheduler(
 
                 while True:
                     try:
-                        recv_req = self.recv_from_tokenizer.recv_pyobj(zmq.NOBLOCK)
+                        frame = self.recv_from_tokenizer.recv(zmq.NOBLOCK, copy=False)
+                        recv_req = pickle.loads(frame)
                     except zmq.ZMQError:
                         break
                     recv_reqs.append(recv_req)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When transmitting relatively large multimodal data, the zmq.Socket.recv_pyobj used by recv_requests will, by default, make a copy to obtain the bytes content. We can switch to a non-copy mode to get the frame instead, in order to reduce the overhead of copying. Also like what was mentioned in https://github.com/sgl-project/sglang/issues/6189

We can save 7.8 ms of copy time, which accounts for 32% of the entire 23.9ms recv_requests duration, as shown in the figure below.


<img width="1321" height="578" alt="image" src="https://github.com/user-attachments/assets/aa6b42d1-be7f-4564-a6e8-76828b3a4c58" />


## Modifications

Use the zmq.Socket.recv function with copy=False to avoid the copy operation in recv.

Below is the implementation of recv_pyobj

```python
def recv_pyobj(self, flags: int = 0) -> Any:
    ...
    msg = self.recv(flags)
    return self._deserialize(msg, pickle.loads)
```


## Accuracy Tests

> python3 -m sglang.test.few_shot_gsm8k --num-questions 200
100%|████████████████████████████████████████████████████████████████████████████| 200/200 [00:35<00:00,  5.58it/s]
Accuracy: 0.910
Invalid: 0.000
Latency: 35.922 s
Output throughput: 830.888 token/s

## Benchmarking and Profiling

launch server command

> python3 -m sglang.launch_server --model-path Qwen/Qwen3-VL-4B-Instruct-FP8 --enable-multimodal --cuda-graph-max-bs 128 --context-length 2560 --page-size 16 --stream-interval 300 --mem-fraction-static 0.7 --port 30261 --base-gpu-id 0 --kv-cache-dtype fp8_e4m3 --mm-attention-backend sdpa

launch client command
> python -m sglang.bench_serving --backend sglang --dataset-name image --model Qwen/Qwen3-VL-4B-Instruct-FP8 --port 30261 --random-input-len 600 --random-output-len 230 --image-count 1 --image-resolution 1200x1200 --num-prompts 16 --request-rate inf --max-concurrency 128


<img width="1042" height="554" alt="image" src="https://github.com/user-attachments/assets/ce05ea84-1dbc-4563-a4f2-1dc0448bbbe9" />

Before

> ============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     16
Benchmark duration (s):                  59.34
Total input tokens:                      28200
Total input text tokens:                 5064
Total input vision tokens:               23136
Total generated tokens:                  1838
Total generated tokens (retokenized):    1838
Request throughput (req/s):              0.27
Input token throughput (tok/s):          475.20
Output token throughput (tok/s):         30.97
Total token throughput (tok/s):          506.17
Concurrency:                             1.67
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6200.14
Median E2E Latency (ms):                 6223.94
---------------Time to First Token----------------
Mean TTFT (ms):                          3380.04
Median TTFT (ms):                        3564.45
P99 TTFT (ms):                           4799.95
---------------Inter-Token Latency----------------
Mean ITL (ms):                           24.76
Median ITL (ms):                         20.52
P95 ITL (ms):                            43.20
P99 ITL (ms):                            59.33
Max ITL (ms):                            69.10
==================================================


After

> ============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     16
Benchmark duration (s):                  58.74
Total input tokens:                      28168
Total input text tokens:                 5032
Total input vision tokens:               23136
Total generated tokens:                  1838
Total generated tokens (retokenized):    1838
Request throughput (req/s):              0.27
Input token throughput (tok/s):          479.52
Output token throughput (tok/s):         31.29
Total token throughput (tok/s):          510.81
Concurrency:                             1.64
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6008.93
Median E2E Latency (ms):                 6033.82
---------------Time to First Token----------------
Mean TTFT (ms):                          3232.39
Median TTFT (ms):                        3391.68
P99 TTFT (ms):                           4605.66
---------------Inter-Token Latency----------------
Mean ITL (ms):                           24.38
Median ITL (ms):                         20.44
P95 ITL (ms):                            42.73
P99 ITL (ms):                            58.67
Max ITL (ms):                            68.56
==================================================

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
