### PR TITLE
update CI permission list

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1,4 +1,10 @@
 {
+    "1pikachu": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "Alcanderian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -29,6 +35,12 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
+    "CaoE": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "CatherineSue": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -36,12 +48,6 @@
         "reason": "top contributor"
     },
     "DarkSharpness": {
-        "can_tag_run_ci_label": true,
-        "can_rerun_failed_ci": true,
-        "cooldown_interval_minutes": 0,
-        "reason": "custom override"
-    },
-    "DiweiSun": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "cooldown_interval_minutes": 0,
@@ -173,6 +179,12 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "Valentine233": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "XiaotongJiang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -245,6 +257,12 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "blzheng": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "byjiang1996": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -262,6 +280,12 @@
         "can_rerun_failed_ci": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
+    },
+    "chunyuan-w": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
     },
     "cicirori": {
         "can_tag_run_ci_label": true,
@@ -292,6 +316,12 @@
         "can_rerun_failed_ci": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
+    },
+    "gaopengff": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
     },
     "gongwei-130": {
         "can_tag_run_ci_label": true,
@@ -347,6 +377,12 @@
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
+    "huaiyuzh": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "huangtingwei9988": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -399,6 +435,12 @@
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "cooldown_interval_minutes": 60,
+        "reason": "custom override"
+    },
+    "jianan-gu": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jinleic": {
@@ -629,6 +671,12 @@
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
+    "sunjiweiswift": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "sunxxuns": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -684,6 +732,12 @@
         "reason": "top contributor"
     },
     "xutizhou": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
+    "yanbing-j": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "cooldown_interval_minutes": 0,


### PR DESCRIPTION
This is to add several SGL CPU & XPU dev contributors into `CI_PERMISSIONS.json`. Most of them have been actively submitting PRs for new model enabling/optimizations, backend support for new precisions, bug fixes, etc.
A specific change is to add @1pikachu (Du, Jun) into the list, as he is the new maintainer of CPU/XPU CI as the successor of Diwei, who left the team recently. Jun is already in an active role, refining the XPU UT test PR #11712 .