### PR TITLE
[AMD] Add RDNA (gfx1201/Navi48) support

### DIFF
--- a/docker/rocm.rdna.Dockerfile
+++ b/docker/rocm.rdna.Dockerfile
@@ -1,0 +1,88 @@
+# Usage (to build SGLang ROCm RDNA docker image for Navi GPUs):
+#   docker build --build-arg SGL_BRANCH=v0.5.15.post1 --build-arg GPU_ARCH=gfx1201 -t v0.5.15.post1-rocm721-navi48 -f rocm.rdna.Dockerfile .
+
+# NOTE: Building this Dockerfile requires gfx1201 support in sgl-kernel/setup_rocm.py.
+# The target GPU arch must be listed in the supported architectures check.
+# Use SGL_BRANCH to point to a branch/commit that includes this support.
+
+# Default base image — ROCm 7.2.1 Navi-optimised image with PyTorch + vLLM
+ARG BASE_IMAGE="rocm/vllm-dev:rocm7.2.1_navi_ubuntu24.04_py3.12_pytorch_2.9_vllm_0.16.0"
+
+FROM $BASE_IMAGE
+
+ARG GPU_ARCH=gfx1201
+ENV GPU_ARCH_LIST=${GPU_ARCH}
+
+ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
+ARG SGL_DEFAULT="main"
+ARG SGL_BRANCH=${SGL_DEFAULT}
+
+# Version override for setuptools_scm (used in nightly builds)
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
+
+ARG AITER_REPO="https://github.com/ROCm/aiter.git"
+ARG AITER_COMMIT=""
+ENV AITER_COMMIT_DEFAULT="9127c94a18e4398e1eba91f6639e910f0994ad02"
+ENV AITER_COMMIT="${AITER_COMMIT:-${AITER_COMMIT_DEFAULT}}"
+
+# Optional Ubuntu mirror override + apt hardening.
+ARG UBUNTU_MIRROR=
+USER root
+
+RUN if [ -n "$UBUNTU_MIRROR" ]; then \
+        sed -i "s|http://[^[:space:]/]*archive.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list && \
+        sed -i "s|http://[^[:space:]/]*security.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list; \
+    fi && \
+    printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+        > /etc/apt/apt.conf.d/80-net-hardening
+
+# Install some basic utilities
+RUN python -m pip install --upgrade pip && pip install setuptools_scm
+
+WORKDIR /sgl-workspace
+
+# -----------------------
+# AITER (minimal install — no prebuild kernels for RDNA)
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=
+ENV AITER_USE_SYSTEM_TRITON=1
+RUN pip uninstall -y aiter
+RUN git clone ${AITER_REPO} \
+    && cd aiter \
+    && git checkout -f ${AITER_COMMIT} \
+    && git submodule update --init --recursive \
+    && pip install -r requirements.txt \
+    && echo "[AITER] GPU_ARCH=${GPU_ARCH} (RDNA — minimal install)" \
+    && sh -c "GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ." \
+    && echo "export PYTHONPATH=/sgl-workspace/aiter:\${PYTHONPATH}" >> /etc/bash.bashrc
+
+# -----------------------
+# Build SGLang
+ARG BUILD_TYPE=all
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+
+RUN pip uninstall -y sgl_kernel sglang
+RUN git clone ${SGL_REPO} \
+    && cd sglang \
+    && if [ "${SGL_BRANCH}" = ${SGL_DEFAULT} ]; then \
+         echo "Using ${SGL_DEFAULT}, default branch."; \
+         git checkout ${SGL_DEFAULT}; \
+       else \
+         echo "Using ${SGL_BRANCH} branch."; \
+         git checkout ${SGL_BRANCH}; \
+       fi \
+    && cd sgl-kernel \
+    && rm -f pyproject.toml \
+    && mv pyproject_rocm.toml pyproject.toml \
+    && AMDGPU_TARGET=$GPU_ARCH_LIST python setup_rocm.py install \
+    && cd .. \
+    && rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml \
+    && if [ "$BUILD_TYPE" = "srt" ]; then \
+         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[srt_hip,diffusion_hip]"; \
+       else \
+         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[all_hip]"; \
+       fi
+
+ENV SGLANG_USE_AITER=0
+ENV SGLANG_USE_AITER_AR=0
+
+CMD ["/bin/bash"]

--- a/sgl-kernel/setup_rocm.py
+++ b/sgl-kernel/setup_rocm.py
@@ -74,9 +74,9 @@ if torch.cuda.is_available():
 else:
     print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
+if amdgpu_target not in ["gfx942", "gfx950", "gfx1201"]:
     print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
+        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950' or 'gfx1201'."
     )
     sys.exit(1)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

SGLang currently does not support AMD RDNA GPUs (e.g. Navi48/RX 9070 series). This PR adds initial gfx1201 support, enabling SGLang to build and run on RDNA4 GPUs with ROCm 7.2.1.


## Modifications

sgl-kernel/setup_rocm.py: Add gfx1201 to the list of supported GPU architectures so sgl-kernel can be built for RDNA4.
docker/rocm.rdna.Dockerfile (new): Dockerfile for building SGLang on RDNA GPUs. Intentionally separated from rocm.Dockerfile (which targets MI series CDNA GPUs) to avoid mixing CDNA/RDNA concerns.

## Accuracy Tests

SGLANG_USE_AITER=0 python3 -m sglang.launch_server --model Qwen/Qwen2.5-7B-Instruct --attention-backend triton

/sgl-workspace/sglang# python3 -m sglang.test.few_shot_gsm8k --num-questions 200
/sgl-workspace/sglang/python/sglang/test/few_shot_gsm8k.py:166: DeprecationWarning: sglang.test.few_shot_gsm8k is deprecated. Use sglang.test.run_eval with eval_name='gsm8k' instead.
  run_eval(args)
100%|██████████████████████████████████| 200/200 [00:31<00:00,  6.39it/s]
Accuracy: 0.880
Invalid: 0.000
Latency: 31.492 s
Output throughput: 1052.244 token/s

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)



















































































<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29552490092](https://github.com/sgl-project/sglang/actions/runs/29552490092)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29552490017](https://github.com/sgl-project/sglang/actions/runs/29552490017)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->