### PR TITLE
feat: Implement Multi-Head MTP (MHMTP) for improved speculative decoding

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -259,6 +259,9 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "Glm4MoeForCausalLM":
             self.hf_config.architectures[0] = "Glm4MoeForCausalLMNextN"
 
+        if is_draft_model and self.hf_config.architectures[0] == "MiniMaxM2ForCausalLM":
+            self.hf_config.architectures[0] = "MiniMaxM2ForCausalLMNextN"
+
         if (
             is_draft_model
             and self.hf_config.architectures[0] == "LongcatFlashForCausalLM"

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1658,7 +1658,9 @@ class Scheduler(
             # Merge the new batch into the running batch.
             # For prefill-only batch, we can avoid going through decoding step.
             if not self.last_batch.is_empty() and not self.last_batch.is_prefill_only:
-                if self.running_batch.is_empty() or all(req.finished() for req in self.running_batch.reqs):
+                if self.running_batch.is_empty() or all(
+                    req.finished() for req in self.running_batch.reqs
+                ):
                     self.running_batch = self.last_batch
                 else:
                     # Merge running_batch with prefill batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1658,7 +1658,7 @@ class Scheduler(
             # Merge the new batch into the running batch.
             # For prefill-only batch, we can avoid going through decoding step.
             if not self.last_batch.is_empty() and not self.last_batch.is_prefill_only:
-                if self.running_batch.is_empty():
+                if self.running_batch.is_empty() or all(req.finished() for req in self.running_batch.reqs):
                     self.running_batch = self.last_batch
                 else:
                     # Merge running_batch with prefill batch

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -343,6 +343,9 @@ class ForwardBatch:
     # For Qwen2-VL
     mrope_positions: torch.Tensor = None
 
+    # For mhmtp
+    mtp_index: int = 0
+
     # For two-batch overlap
     tbo_split_seq_index: Optional[int] = None
     tbo_parent_token_range: Optional[Tuple[int, int]] = None
@@ -384,14 +387,14 @@ class ForwardBatch:
             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
             global_forward_mode=batch.global_forward_mode,
             is_prefill_only=batch.is_prefill_only,
-            lora_ids=batch.lora_ids,
+            lora_ids=getattr(batch, "lora_ids", None),
             sampling_info=batch.sampling_info,
             req_to_token_pool=model_runner.req_to_token_pool,
             token_to_kv_pool=model_runner.token_to_kv_pool,
             attn_backend=model_runner.attn_backend,
             spec_algorithm=batch.spec_algorithm,
             spec_info=batch.spec_info,
-            capture_hidden_mode=batch.capture_hidden_mode,
+            capture_hidden_mode=getattr(batch, "capture_hidden_mode", False),
             input_embeds=batch.input_embeds,
             token_type_ids=batch.token_type_ids,
             tbo_split_seq_index=batch.tbo_split_seq_index,

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -155,7 +155,7 @@ class MiniMaxM2MoE(nn.Module):
 
         self.experts = get_moe_impl_class(quant_config)(
             num_experts=config.num_local_experts
-                        + get_global_server_args().ep_num_redundant_experts,
+            + get_global_server_args().ep_num_redundant_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
@@ -399,7 +399,7 @@ class MiniMaxM2Attention(nn.Module):
             reduce_results=False,
             quant_config=quant_config,
             prefix=add_prefix("o_proj", prefix),
-            )
+        )
 
         # Setup RoPE with partial rotary dimension
         rope_scaling = getattr(config, "rope_scaling", None)

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -155,7 +155,7 @@ class MiniMaxM2MoE(nn.Module):
 
         self.experts = get_moe_impl_class(quant_config)(
             num_experts=config.num_local_experts
-            + get_global_server_args().ep_num_redundant_experts,
+                        + get_global_server_args().ep_num_redundant_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,
             intermediate_size=config.intermediate_size,
@@ -399,7 +399,7 @@ class MiniMaxM2Attention(nn.Module):
             reduce_results=False,
             quant_config=quant_config,
             prefix=add_prefix("o_proj", prefix),
-        )
+            )
 
         # Setup RoPE with partial rotary dimension
         rope_scaling = getattr(config, "rope_scaling", None)
@@ -807,6 +807,9 @@ class MiniMaxM2ForCausalLM(nn.Module):
             input_ids, hidden_states, self.lm_head, forward_batch, aux_hidden_states
         )
 
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.weight, self.lm_head.weight
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load model weights with proper mapping for MiniMax architecture."""
 
@@ -831,13 +834,9 @@ class MiniMaxM2ForCausalLM(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
-            if "rotary_emb.inv_freq" in name:
+            # Skip loading weights that belong to MTP layers
+            if "rotary_emb.inv_freq" in name or "mtp_layers" in name:
                 continue
-
-            spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
-            if spec_layer is not None:
-                continue  # skip spec decode layers for main model
-
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
@@ -903,17 +902,6 @@ class MiniMaxM2ForCausalLM(nn.Module):
             num_logical_experts=config.num_local_experts,
             num_groups=None,
         )
-
-
-def get_spec_layer_idx_from_weight_name(
-    config: PretrainedConfig, weight_name: str
-) -> Optional[int]:
-    if hasattr(config, "num_mtp_modules") and (config.num_mtp_modules > 0):
-        layer_idx = config.num_hidden_layers
-        for i in range(config.num_mtp_modules):
-            if weight_name.startswith(f"model.layers.{layer_idx + i}."):
-                return layer_idx + i
-    return None
 
 
 # Entry class for model registration

--- a/python/sglang/srt/models/minimax_m2_nextn.py
+++ b/python/sglang/srt/models/minimax_m2_nextn.py
@@ -1,0 +1,242 @@
+import os
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.distributed import get_tensor_model_parallel_world_size
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.minimax_m2 import MiniMaxM2DecoderLayer, MiniMaxM2ForCausalLM
+import logging
+logger = logging.getLogger(__name__)
+
+DEBUG_MODE = os.getenv('DEBUG_MODE', 'false').lower() == 'true'
+
+
+class MiniMaxM2MultiTokenPredictorLayer(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        prefix: str,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+    ) -> None:
+        super().__init__()
+
+        self.e_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.h_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.linear_projection = nn.Linear(
+            config.hidden_size * 2, config.hidden_size, bias=False
+        )
+        # Minimax M2 has 1 MTP layers
+        self.mtp_block = MiniMaxM2DecoderLayer(
+            config=config, quant_config=quant_config, prefix=prefix, layer_id=layer_id
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+
+        # logger.warning(f"(gaoji:m2_nextn:forward: input_embeds: {input_embeds.shape}\n"
+        #       f"forward_batch.spec_info.hidden_states: {forward_batch.spec_info.hidden_states.shape}\n")
+        hidden_states = self.linear_projection(
+            torch.cat(
+                (
+                    self.h_norm(forward_batch.spec_info.hidden_states),
+                    self.e_norm(input_embeds),
+                ),
+                dim=-1,
+            )
+        )
+
+        hidden_states, residual = self.mtp_block(
+            positions=positions,
+            hidden_states=hidden_states,
+            forward_batch=forward_batch,
+            residual=None,
+        )
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class MiniMaxM2ForCausalLMNextN(MiniMaxM2ForCausalLM):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        self.config = config
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.quant_config = quant_config
+        self.num_mtp_layers = getattr(
+            config, "num_nextn_predict_layers", None
+        )
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+        ) # mtp layers share the same embed_tokens
+        self.mtp_layers = nn.ModuleList(
+            [
+                MiniMaxM2MultiTokenPredictorLayer(
+                    config=config, quant_config=quant_config, prefix=prefix,layer_id = i
+                )
+                for i in range(self.num_mtp_layers)
+            ]
+        )
+        self.final_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+        )
+        self.logits_processor = LogitsProcessor(config)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_idx: int = 0,
+    ) -> torch.Tensor:
+
+        input_embeds = self.embed_tokens(input_ids)
+        if os.getenv('DEBUG_MODE', 'false').lower() == 'true':
+            logger.warning(f"(gaoji:m2_nextn:forward: layer_idx: {layer_idx}\n"
+              f"input_ids: {input_ids.shape}\n"
+              f"input_embeds: {input_embeds.shape}\n")
+        input_embeds[positions == 0] = 0
+        hidden_states = self.mtp_layers[layer_idx](positions, forward_batch, input_embeds) #TODO(zhongyu): support multiple MTP layers
+        hidden_states = self.final_layernorm(hidden_states)
+        return self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+            num_experts=self.config.num_local_experts,
+        )
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name or "projector" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                # Models trained using ColossalAI may include these tensors in
+                # the checkpoint. Skip them.
+                continue
+            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                continue
+            if name.startswith("model.vision_tower") and name not in params_dict:
+                continue
+            name = self.map_model_name_to_mtp_param_name(name)
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                # Only merge q/k/v or gate/up for MTP layers, ignore base model
+                if weight_name not in name:
+                    continue
+                if not self.is_mtp_param(name):
+                    break
+                merged_name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if merged_name.endswith(".bias") and merged_name not in params_dict:
+                    continue
+                if merged_name not in params_dict:
+                    break
+                param = params_dict[merged_name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                # Only accept weights that belong to MTP layers
+                if not self.is_mtp_param(name):
+                    continue
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(
+                        param,
+                        loaded_weight,
+                        name,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                    )
+                    break
+                else:
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight)
+
+    def map_model_name_to_mtp_param_name(self, name: str) -> str:
+        import re
+        mtp_specific_params = ['e_norm', 'h_norm', 'linear_projection']
+        shared_params_name_map = {
+            'model.norm': 'final_layernorm',
+            'model.embed_tokens': 'embed_tokens',
+        }
+        for origin_name, mtp_name in shared_params_name_map.items():
+            if origin_name in name:
+                return name.replace(origin_name, mtp_name)
+        pattern = r"model\.mtp_layers\.(\d+)\."
+        group = re.match(pattern, name)
+        if group is None:
+            return name
+        layer_id = group.group(1)
+        for param in mtp_specific_params:
+            if param in name:
+                return name.replace(group.group(), f"mtp_layers.{layer_id}.")
+        else:
+            return name.replace(group.group(), f"mtp_layers.{layer_id}.mtp_block.")
+
+    def is_mtp_param(self, name: str) -> bool:
+        if 'mtp_layers' in name or 'final_layernorm' in name or 'embed_tokens' in name or 'lm_head' in name:
+            return True
+        return False
+
+    def set_embed_and_head(self, embed, head):
+        del self.embed_tokens.weight
+        del self.lm_head.weight
+        self.embed_tokens.weight = embed
+        self.lm_head.weight = head
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+
+EntryClass = [MiniMaxM2ForCausalLMNextN]
+

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1636,7 +1636,7 @@ class ServerArgs:
         if self.speculative_algorithm == "NEXTN":
             self.speculative_algorithm = "EAGLE"
 
-        if self.speculative_algorithm in ("EAGLE", "EAGLE3", "STANDALONE"):
+        if self.speculative_algorithm in ("EAGLE", "EAGLE3", "STANDALONE", "MHMTP"):
             if self.speculative_algorithm == "STANDALONE" and self.enable_dp_attention:
                 # TODO: support dp attention for standalone speculative decoding
                 raise ValueError(
@@ -2852,7 +2852,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "NGRAM"],
+            choices=["EAGLE", "EAGLE3", "NEXTN", "STANDALONE", "NGRAM", "MHMTP"],
             help="Speculative algorithm.",
         )
         parser.add_argument(

--- a/python/sglang/srt/speculative/mhmtp_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/mhmtp_draft_cuda_graph_runner.py
@@ -25,7 +25,8 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
     ForwardMode,
 )
-from sglang.srt.speculative.mhmtp_utils import MhmtpDraftInput, fast_topk
+from sglang.srt.speculative.mhmtp_utils import MhmtpDraftInput
+from sglang.srt.utils.common import fast_topk
 from sglang.srt.speculative.spec_utils import select_top_k_tokens
 from sglang.srt.utils import (
     require_attn_tp_gather,
@@ -114,6 +115,7 @@ class MHMTPDraftCudaGraphRunner:
         self.require_gathered_buffer = require_gathered_buffer(
             self.model_runner.server_args
         )
+        self.enable_pdmux = False
         self.require_mlp_tp_gather = require_mlp_tp_gather(
             self.model_runner.server_args
         )
@@ -266,7 +268,7 @@ class MHMTPDraftCudaGraphRunner:
         CudaGraphRunner.capture(self)
 
     def capture_one_batch_size(
-        self, bs: int, forward: Callable
+        self, bs: int, forward: Callable, stream_idx: Optional[int] = None
     ) -> tuple[torch.cuda.CUDAGraph, MultiLayerForwardOutput]:
         """Capture CUDA graph for one batch size.
 

--- a/python/sglang/srt/speculative/mhmtp_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/mhmtp_draft_cuda_graph_runner.py
@@ -1,0 +1,705 @@
+"""MHMTP Draft Model CUDA Graph Runner for Speculative Decoding.
+
+This module provides efficient CUDA graph capture and replay for multi-step
+draft token generation using the MHMTP speculative decoding algorithm.
+"""
+
+from __future__ import annotations
+
+import bisect
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+from sglang.srt.model_executor.cuda_graph_runner import (
+    CUDA_GRAPH_CAPTURE_FAILED_MSG,
+    CudaGraphRunner,
+    get_batch_sizes_to_capture,
+    get_global_graph_memory_pool,
+    model_capture_mode,
+    set_global_graph_memory_pool,
+    set_torch_compile_config,
+)
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.speculative.mhmtp_utils import MhmtpDraftInput, fast_topk
+from sglang.srt.speculative.spec_utils import select_top_k_tokens
+from sglang.srt.utils import (
+    require_attn_tp_gather,
+    require_gathered_buffer,
+    require_mlp_sync,
+    require_mlp_tp_gather,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.speculative.mhmtp_worker import MhmtpWorker
+
+
+class MultiLayerForwardOutput:
+    """Container for outputs from N forward passes in multi-step generation.
+
+    Stores tree information (scores, tokens, parents) from N consecutive
+    forward passes through the draft model.
+
+    Attributes:
+        num_layers: Number of forward passes/layers.
+        tree_infos: List of (scores, tokens, parents) tuples for each layer.
+    """
+
+    def __init__(self, num_layers: int):
+        """Initialize MultiLayerForwardOutput with variable number of layers.
+
+        Args:
+            num_layers: Number of forward passes/layers.
+        """
+        self.num_layers = num_layers
+        # Store tree info as list: tree_infos[i] = (scores, tokens, parents)
+        self.tree_infos = [None] * num_layers
+
+    def set_layer(self, layer_idx: int, scores, tokens, parents):
+        """Set tree info for a layer.
+
+        Args:
+            layer_idx: The layer index.
+            scores: Token scores for this layer.
+            tokens: Token indices for this layer.
+            parents: Parent relationships for this layer.
+        """
+        self.tree_infos[layer_idx] = (scores, tokens, parents)
+
+    def __getitem__(self, idx: int):
+        """Support indexing to access layers.
+
+        Args:
+            idx: The layer index.
+
+        Returns:
+            Tuple of (scores, tokens, parents) for the layer.
+        """
+        return self.tree_infos[idx]
+
+
+class MHMTPDraftCudaGraphRunner:
+    """CUDA Graph runner for MHMTP draft model multi-step generation.
+
+    Captures and replays CUDA graphs for efficient execution of N consecutive
+    forward passes through the draft model, enabling fast speculative token generation.
+    Supports arbitrary number of forward passes through configurable parameters.
+    Requires speculative_num_steps >= 3.
+    """
+
+    def __init__(self, mhmtp_worker: MhmtpWorker, mtp_layer: int):
+        """Initialize the CUDA graph runner.
+
+        Args:
+            mhmtp_worker: The mhmtp worker instance containing draft model.
+            mtp_layer: Multi-token prediction layer index.
+
+        Raises:
+            ValueError: If speculative_num_steps < 3.
+            Exception: If CUDA graph capture fails.
+        """
+        self.mhmtp_worker = mhmtp_worker
+        self.model_runner = mhmtp_worker.model_runner
+        self.graphs = {}
+        self.output_buffers = {}
+        self.mtp_layer = mtp_layer
+
+        # Configuration from server args
+        self.enable_torch_compile = self.model_runner.server_args.enable_torch_compile
+        self.disable_padding = self.model_runner.server_args.disable_cuda_graph_padding
+        self.require_gathered_buffer = require_gathered_buffer(
+            self.model_runner.server_args
+        )
+        self.require_mlp_tp_gather = require_mlp_tp_gather(
+            self.model_runner.server_args
+        )
+        self.require_mlp_sync = require_mlp_sync(self.model_runner.server_args)
+        self.require_attn_tp_gather = require_attn_tp_gather(
+            self.model_runner.server_args
+        )
+
+        # Parallelism configuration
+        self.tp_size = self.model_runner.tp_size
+        self.dp_size = self.model_runner.server_args.dp_size
+
+        # Speculative decoding parameters
+        self.speculative_num_steps = self.model_runner.server_args.speculative_num_steps
+
+        # Validate speculative_num_steps >= 3
+        if self.speculative_num_steps < 3:
+            raise ValueError(
+                f"speculative_num_steps must be >= 3, got {self.speculative_num_steps}"
+            )
+
+        self.topk = self.model_runner.server_args.speculative_eagle_topk
+        self.num_tokens_per_bs = self.speculative_num_steps + 1
+
+        # Use variable instead of hardcoded 3
+        self.num_forward_passes = self.speculative_num_steps
+
+        # Graph capture configuration
+        self.enable_profile_cuda_graph = (
+            self.model_runner.server_args.enable_profile_cuda_graph
+        )
+        self.capture_bs, self.compile_bs = get_batch_sizes_to_capture(self.model_runner)
+        self.padded_static_len = -1
+
+        # Maximum sizes for tensor allocation
+        self.max_bs = max(self.capture_bs)
+        self.max_num_token = self.max_bs * self.num_tokens_per_bs
+
+        # Initialize attention backends for all N layers
+        self._init_attention_backends()
+
+        # Allocate input and output tensors
+        self._allocate_graph_tensors()
+
+        # Capture CUDA graphs
+        if self.enable_torch_compile:
+            set_torch_compile_config()
+
+        try:
+            with model_capture_mode():
+                self.capture()
+        except RuntimeError as e:
+            raise Exception(
+                f"Capture cuda graph failed: {e}\n{CUDA_GRAPH_CAPTURE_FAILED_MSG}"
+            )
+
+    def _init_attention_backends(self) -> None:
+        """Initialize CUDA graph state for all N attention backends."""
+        attn_backends = (
+            self.mhmtp_worker.draft_model_runner.draft_attn_backend.attn_backends
+        )
+
+        for i in range(self.num_forward_passes):
+            backend = attn_backends[i]
+            backend.init_cuda_graph_state(self.max_bs, self.max_num_token)
+            if i == 0:
+                self.seq_len_fill_value = backend.get_cuda_graph_seq_len_fill_value()
+
+    def _allocate_graph_tensors(self) -> None:
+        """Allocate GPU tensors for CUDA graph capture and replay."""
+        with torch.device("cuda"):
+            # Input and hidden tensors for N layers
+            self.input_ids_layers = [
+                torch.zeros((self.max_num_token,), dtype=torch.int64)
+                for _ in range(self.num_forward_passes)
+            ]
+
+            hidden_size = self.model_runner.model_config.hidden_size
+            dtype = self.model_runner.dtype
+
+            self.hidden_states_layers = [
+                torch.zeros((self.max_num_token, hidden_size), dtype=dtype)
+                for _ in range(self.num_forward_passes)
+            ]
+
+            # Batch-level tensors (shared across all layers)
+            self.req_pool_indices = torch.zeros((self.max_bs,), dtype=torch.int32)
+            self.out_cache_loc = torch.ones((self.max_num_token,), dtype=torch.int64)
+            self.positions = torch.zeros((self.max_num_token,), dtype=torch.int64)
+
+            # Sequence length tensors
+            self.seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
+            self.extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
+            self.accept_length = torch.full(
+                (self.max_bs,), self.num_tokens_per_bs, dtype=torch.int32
+            )
+            self.seq_lens_cpu = torch.full(
+                (self.max_bs,), self.seq_len_fill_value, dtype=torch.int32
+            )
+
+            # Gather buffers for distributed execution
+            if self.require_gathered_buffer:
+                self.gathered_buffer = torch.zeros(
+                    (self.max_num_token, hidden_size),
+                    dtype=dtype,
+                )
+                if self.require_mlp_tp_gather:
+                    self.global_num_tokens_gpu = torch.zeros(
+                        (self.dp_size,), dtype=torch.int32
+                    )
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (self.dp_size,), dtype=torch.int32
+                    )
+                else:
+                    assert self.require_attn_tp_gather
+                    self.global_num_tokens_gpu = torch.zeros((1,), dtype=torch.int32)
+                    self.global_num_tokens_for_logprob_gpu = torch.zeros(
+                        (1,), dtype=torch.int32
+                    )
+
+    def can_run(self, forward_batch: ForwardBatch) -> bool:
+        """Check if the forward batch can be executed with this runner.
+
+        Args:
+            forward_batch: The forward batch to check.
+
+        Returns:
+            True/False for mhmtp CUDA graph runner.
+        """
+        if self.require_mlp_tp_gather:
+            cuda_graph_bs = (
+                sum(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
+            )
+        else:
+            cuda_graph_bs = forward_batch.seq_lens.numel()
+
+        is_bs_supported = (
+            cuda_graph_bs in self.graphs
+            if self.disable_padding
+            else cuda_graph_bs <= self.max_bs
+        )
+
+        if self.require_mlp_sync:
+            is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
+
+        return is_bs_supported
+
+    def capture(self) -> None:
+        """Capture CUDA graphs for all batch sizes."""
+        CudaGraphRunner.capture(self)
+
+    def capture_one_batch_size(
+        self, bs: int, forward: Callable
+    ) -> tuple[torch.cuda.CUDAGraph, MultiLayerForwardOutput]:
+        """Capture CUDA graph for one batch size.
+
+        Performs N forward passes through the draft model, capturing
+        the computation graph. Uses streaming token selection to build
+        a tree of candidate tokens.
+
+        Args:
+            bs: Batch size to capture.
+            forward: Forward function (unused, for compatibility).
+
+        Returns:
+            Tuple of (CUDA graph, MultiLayerForwardOutput with tree information).
+        """
+        graph = torch.cuda.CUDAGraph()
+        stream = self.stream
+        num_tokens = bs * self.num_tokens_per_bs
+
+        # Prepare graph inputs
+        input_ids = self.input_ids_layers[0][:num_tokens]
+        req_pool_indices = self.req_pool_indices[:bs]
+        seq_lens = self.seq_lens[:bs]
+        extend_seq_lens = self.extend_seq_lens[:bs]
+        accept_length = self.accept_length[:bs]
+        out_cache_loc = self.out_cache_loc[:num_tokens]
+        positions = self.positions[:num_tokens]
+        hidden_states = self.hidden_states_layers[0][:num_tokens]
+
+        # Setup distributed synchronization tensors
+        global_num_tokens, gathered_buffer, global_num_tokens_for_logprob = (
+            self._setup_distributed_tensors(num_tokens)
+        )
+
+        # Create forward batch for graph capture
+        forward_batch = self._create_forward_batch_for_capture(
+            bs=bs,
+            input_ids=input_ids,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            out_cache_loc=out_cache_loc,
+            positions=positions,
+            extend_seq_lens=extend_seq_lens,
+            hidden_states=hidden_states,
+            accept_length=accept_length,
+            num_tokens=num_tokens,
+            global_num_tokens=global_num_tokens,
+            global_num_tokens_for_logprob=global_num_tokens_for_logprob,
+            gathered_buffer=gathered_buffer,
+        )
+
+        # Define computation to capture
+        def run_once() -> MultiLayerForwardOutput:
+            """Execute N forward passes and return tree information."""
+            return self._run_multi_forward_passes(forward_batch, bs, num_tokens)
+
+        # Warmup runs
+        for _ in range(2):
+            torch.cuda.synchronize()
+            self.model_runner.tp_group.barrier()
+            run_once()
+
+        # Capture graph
+        with torch.cuda.graph(
+            graph, pool=get_global_graph_memory_pool(), stream=stream
+        ):
+            out = run_once()
+
+        set_global_graph_memory_pool(graph.pool())
+        return graph, out
+
+    def _setup_distributed_tensors(self, num_tokens: int) -> tuple:
+        """Setup tensors for distributed synchronization.
+
+        Args:
+            num_tokens: Total number of tokens in the batch.
+
+        Returns:
+            Tuple of (global_num_tokens, gathered_buffer, global_num_tokens_for_logprob).
+        """
+        if not self.require_gathered_buffer:
+            return None, None, None
+
+        gathered_buffer = self.gathered_buffer[:num_tokens]
+
+        if self.require_mlp_tp_gather:
+            token_per_dp = [
+                num_tokens // self.dp_size + (i < (num_tokens % self.dp_size))
+                for i in range(self.dp_size)
+            ]
+            self.global_num_tokens_gpu.copy_(
+                torch.tensor(
+                    token_per_dp,
+                    dtype=torch.int32,
+                    device=self.input_ids_layers[0].device,
+                )
+            )
+            self.global_num_tokens_for_logprob_gpu.copy_(
+                torch.tensor(
+                    token_per_dp,
+                    dtype=torch.int32,
+                    device=self.input_ids_layers[0].device,
+                )
+            )
+        else:
+            assert self.require_attn_tp_gather
+            self.global_num_tokens_gpu.copy_(
+                torch.tensor(
+                    [num_tokens],
+                    dtype=torch.int32,
+                    device=self.input_ids_layers[0].device,
+                )
+            )
+            self.global_num_tokens_for_logprob_gpu.copy_(
+                torch.tensor(
+                    [num_tokens],
+                    dtype=torch.int32,
+                    device=self.input_ids_layers[0].device,
+                )
+            )
+
+        return (
+            self.global_num_tokens_gpu,
+            gathered_buffer,
+            self.global_num_tokens_for_logprob_gpu,
+        )
+
+    def _create_forward_batch_for_capture(
+        self,
+        bs: int,
+        input_ids: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        positions: torch.Tensor,
+        extend_seq_lens: torch.Tensor,
+        hidden_states: torch.Tensor,
+        accept_length: torch.Tensor,
+        num_tokens: int,
+        global_num_tokens: torch.Tensor,
+        global_num_tokens_for_logprob: torch.Tensor,
+        gathered_buffer: torch.Tensor,
+    ) -> ForwardBatch:
+        """Create forward batch for CUDA graph capture.
+
+        Args:
+            bs: Batch size.
+            input_ids: Input token IDs.
+            req_pool_indices: Request pool indices.
+            seq_lens: Sequence lengths.
+            out_cache_loc: Output cache locations.
+            positions: Position indices.
+            extend_seq_lens: Extended sequence lengths.
+            hidden_states: Hidden states from previous layer.
+            accept_length: Accepted token lengths.
+            num_tokens: Total number of tokens.
+            global_num_tokens: Global token counts for distributed execution.
+            global_num_tokens_for_logprob: Global token counts for logprob.
+            gathered_buffer: Gathered buffer for distributed execution.
+
+        Returns:
+            ForwardBatch configured for graph capture.
+        """
+        spec_info = MhmtpDraftInput(
+            hidden_states=hidden_states,
+            accept_length=accept_length,
+        )
+        spec_info.positions = None
+
+        forward_batch = ForwardBatch(
+            forward_mode=ForwardMode.DRAFT_EXTEND,
+            batch_size=bs,
+            input_ids=input_ids,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            req_to_token_pool=self.model_runner.req_to_token_pool,
+            token_to_kv_pool=self.model_runner.token_to_kv_pool,
+            out_cache_loc=out_cache_loc,
+            seq_lens_sum=seq_lens.sum().item(),
+            return_logprob=False,
+            positions=positions,
+            global_num_tokens_gpu=global_num_tokens,
+            global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob,
+            spec_algorithm=self.model_runner.spec_algorithm,
+            spec_info=spec_info,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            attn_backend=(
+                self.mhmtp_worker.draft_model_runner.draft_attn_backend.attn_backends[0]
+            ),
+            extend_seq_lens=extend_seq_lens,
+            padded_static_len=self.padded_static_len,
+        )
+
+        # Initialize forward metadata for all N layers
+        attn_backends = (
+            self.mhmtp_worker.draft_model_runner.draft_attn_backend.attn_backends
+        )
+        for i in range(self.num_forward_passes):
+            attn_backends[i].init_forward_metadata_capture_cuda_graph(
+                bs=bs,
+                num_tokens=num_tokens,
+                req_pool_indices=req_pool_indices,
+                seq_lens=seq_lens,
+                encoder_lens=None,
+                forward_mode=ForwardMode.DRAFT_EXTEND,
+                spec_info=spec_info,
+            )
+
+        forward_batch.mtp_index = 0
+        return forward_batch
+
+    def _run_multi_forward_passes(
+        self,
+        forward_batch: ForwardBatch,
+        bs: int,
+        num_tokens: int,
+    ) -> MultiLayerForwardOutput:
+        """Execute N sequential forward passes through draft model.
+
+        N must be >= 3 (validated in __init__).
+        """
+        scores = None
+        attn_backends = (
+            self.mhmtp_worker.draft_model_runner.draft_attn_backend.attn_backends
+        )
+
+        output = MultiLayerForwardOutput(self.num_forward_passes)
+        topk_indices_per_layer = []
+
+        # Run N forward passes
+        for layer_idx in range(self.num_forward_passes):
+            forward_batch.mtp_index = layer_idx
+            forward_batch.attn_backend = attn_backends[layer_idx]
+
+            # Forward pass
+            ret = self.mhmtp_worker.draft_model_runner.model.forward(
+                forward_batch.input_ids,
+                forward_batch.positions,
+                forward_batch,
+            )
+
+            # Get probabilities and top-k tokens
+            probs = torch.softmax(ret.next_token_logits[3::4], dim=-1)
+            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            topk_indices_per_layer.append(topk_index)
+
+            # Update scores for tree
+            _, _, scores, tree_info = select_top_k_tokens(
+                layer_idx,
+                topk_p,
+                topk_index,
+                ret.hidden_states[3::4],
+                scores,
+                self.topk,
+            )
+
+            # Store tree info for this layer
+            output.set_layer(layer_idx, tree_info[0], tree_info[1], tree_info[2])
+
+            # Prepare input for next layer (if not last layer)
+            if layer_idx < self.num_forward_passes - 1:
+                next_layer_idx = layer_idx + 1
+
+                input_view = forward_batch.input_ids.view(bs, self.num_tokens_per_bs)
+                next_input_view = self.input_ids_layers[next_layer_idx][
+                    :num_tokens
+                ].view(bs, self.num_tokens_per_bs)
+
+                # For layer i -> layer i+1:
+                # - Keep the last (num_tokens_per_bs - i - 1) original tokens
+                # - Add topk tokens from layers 0..i in reverse order (i down to 0)
+
+                num_keep = self.num_tokens_per_bs - layer_idx - 1
+
+                # Copy last num_keep tokens from current input to next input
+                if num_keep > 0:
+                    next_input_view[:, :num_keep].copy_(input_view[:, -(num_keep):])
+
+                # Add topk tokens at the end in reverse order
+                for j in range(layer_idx + 1):
+                    # Position: num_keep + (layer_idx - j)
+                    # Token: topk_indices_per_layer[layer_idx - j]
+                    next_input_view[:, num_keep + layer_idx - j].copy_(
+                        topk_indices_per_layer[layer_idx - j].view(bs, 1)[:, 0]
+                    )
+
+                self.hidden_states_layers[next_layer_idx][:num_tokens].copy_(
+                    ret.hidden_states
+                )
+
+                # Update for next iteration
+                self.input_ids_layers[0].copy_(self.input_ids_layers[next_layer_idx])
+                self.hidden_states_layers[0].copy_(
+                    self.hidden_states_layers[next_layer_idx]
+                )
+
+        return output
+
+    def replay(self, forward_batch: ForwardBatch) -> MultiLayerForwardOutput:
+        """Replay captured CUDA graph for forward batch execution.
+
+        Args:
+            forward_batch: The forward batch to execute.
+
+        Returns:
+            MultiLayerForwardOutput with tree information from N forward passes.
+        """
+        raw_bs = forward_batch.batch_size
+        num_tokens = forward_batch.input_ids.shape[0]
+
+        # Find appropriate batch size for graph execution
+        if self.require_mlp_tp_gather:
+            total_batch_size = (
+                sum(forward_batch.global_num_tokens_cpu) // self.num_tokens_per_bs
+            )
+            index = bisect.bisect_left(self.capture_bs, total_batch_size)
+        else:
+            index = bisect.bisect_left(self.capture_bs, raw_bs)
+
+        bs = self.capture_bs[index]
+
+        # Reset padding tensors if batch size changed
+        if bs * self.num_tokens_per_bs != num_tokens:
+            self.seq_lens.fill_(self.seq_len_fill_value)
+            self.out_cache_loc.zero_()
+            self.accept_length.fill_(1)
+            self.extend_seq_lens.fill_(1)
+
+        # Copy batch inputs to graph tensors
+        self._copy_batch_inputs_to_graph(forward_batch, raw_bs, bs, num_tokens)
+
+        # Initialize attention metadata for all N layers
+        self._init_attention_metadata_for_replay(forward_batch, raw_bs, bs, num_tokens)
+
+        # Replay CUDA graph
+        self.graphs[bs].replay()
+
+        # Extract and trim outputs to actual batch size
+        out = self.output_buffers[bs]
+        if bs != raw_bs:
+            forward_batch.spec_info.accept_length = self.accept_length[:raw_bs]
+
+        # Trim all layers to actual batch size
+        trimmed_output = MultiLayerForwardOutput(self.num_forward_passes)
+        for i in range(self.num_forward_passes):
+            scores, tokens, parents = out[i]
+            trimmed_output.set_layer(
+                i, scores[:raw_bs], tokens[:raw_bs], parents[:raw_bs]
+            )
+
+        return trimmed_output
+
+    def _copy_batch_inputs_to_graph(
+        self,
+        forward_batch: ForwardBatch,
+        raw_bs: int,
+        bs: int,
+        num_tokens: int,
+    ) -> None:
+        """Copy batch inputs to graph tensors.
+
+        Args:
+            forward_batch: The forward batch to copy from.
+            raw_bs: Raw batch size.
+            bs: Padded batch size for graph execution.
+            num_tokens: Total number of tokens.
+        """
+        self.input_ids_layers[0][:num_tokens].copy_(forward_batch.input_ids)
+        self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
+
+        if forward_batch.extend_seq_lens is not None:
+            self.extend_seq_lens[:raw_bs].copy_(forward_batch.extend_seq_lens)
+
+        self.out_cache_loc[:num_tokens].copy_(forward_batch.out_cache_loc)
+        self.positions[:num_tokens].copy_(forward_batch.positions)
+        self.hidden_states_layers[0][:num_tokens].copy_(
+            forward_batch.spec_info.hidden_states
+        )
+
+        if forward_batch.spec_info.accept_length is not None:
+            self.accept_length[:raw_bs].copy_(forward_batch.spec_info.accept_length)
+
+        self.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
+
+        # Copy distributed execution tensors
+        if self.require_gathered_buffer:
+            self.global_num_tokens_gpu.copy_(forward_batch.global_num_tokens_gpu)
+            self.global_num_tokens_for_logprob_gpu.copy_(
+                forward_batch.global_num_tokens_for_logprob_gpu
+            )
+            forward_batch.gathered_buffer = self.gathered_buffer
+
+        # Copy CPU sequence lengths
+        if forward_batch.seq_lens_cpu is not None:
+            if bs != raw_bs:
+                self.seq_lens_cpu.fill_(self.seq_len_fill_value)
+            self.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
+
+        # Update spec info with padded tensors
+        if bs != raw_bs:
+            forward_batch.spec_info.positions = self.positions[:num_tokens]
+            forward_batch.spec_info.accept_length = self.accept_length[:bs]
+
+    def _init_attention_metadata_for_replay(
+        self,
+        forward_batch: ForwardBatch,
+        raw_bs: int,
+        bs: int,
+        num_tokens: int,
+    ) -> None:
+        """Initialize attention metadata for all N layers before replay.
+
+        Args:
+            forward_batch: The forward batch being replayed.
+            raw_bs: Raw batch size.
+            bs: Padded batch size.
+            num_tokens: Total number of tokens.
+        """
+        attn_backends = (
+            self.mhmtp_worker.draft_model_runner.draft_attn_backend.attn_backends
+        )
+
+        padded_seq_lens_sum = (
+            forward_batch.seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value
+        )
+
+        for i in range(self.num_forward_passes):
+            attn_backends[i].init_forward_metadata_replay_cuda_graph(
+                bs=bs,
+                req_pool_indices=self.req_pool_indices,
+                seq_lens=self.seq_lens,
+                seq_lens_sum=padded_seq_lens_sum,
+                encoder_lens=None,
+                forward_mode=ForwardMode.DRAFT_EXTEND,
+                spec_info=forward_batch.spec_info,
+                seq_lens_cpu=self.seq_lens_cpu,
+            )

--- a/python/sglang/srt/speculative/mhmtp_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/mhmtp_draft_cuda_graph_runner.py
@@ -7,7 +7,7 @@ draft token generation using the MHMTP speculative decoding algorithm.
 from __future__ import annotations
 
 import bisect
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 
@@ -26,7 +26,6 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
 )
 from sglang.srt.speculative.mhmtp_utils import MhmtpDraftInput
-from sglang.srt.utils.common import fast_topk
 from sglang.srt.speculative.spec_utils import select_top_k_tokens
 from sglang.srt.utils import (
     require_attn_tp_gather,
@@ -34,6 +33,7 @@ from sglang.srt.utils import (
     require_mlp_sync,
     require_mlp_tp_gather,
 )
+from sglang.srt.utils.common import fast_topk
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.mhmtp_worker import MhmtpWorker

--- a/python/sglang/srt/speculative/mhmtp_utils.py
+++ b/python/sglang/srt/speculative/mhmtp_utils.py
@@ -1,0 +1,374 @@
+"""MHMTP Speculative Decoding Data Structures.
+
+This module defines data structures for MHMTP speculative decoding algorithm,
+which extends EAGLE's verification and draft input with additional state for
+multi-step token generation and tree-based verification.
+
+Key Classes:
+- MhmtpDraftInput: Speculative decoding draft input with multi-step state
+- MhmtpVerifyInput: Input for target model verification phase
+- MhmtpVerifyOutput: Output from target model verification
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional
+
+import torch
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.speculative.eagle_info import (
+    EagleDraftInput,
+    EagleVerifyInput,
+    EagleVerifyOutput,
+)
+from sglang.srt.speculative.spec_info import SpecInputType
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class MhmtpDraftInput(EagleDraftInput):
+    """Draft input for MHMTP speculative decoding with multi-step state.
+
+    Extends EagleDraftInput with additional fields needed for multi-step
+    draft token generation. Maintains state across multiple forward passes
+    to enable efficient batch processing of token candidate trees.
+
+    Attributes:
+        pre_hiddens: Previous hidden states from last forward pass.
+            Shape: (batch_size * 4, hidden_size)
+            Used for sliding window context in multi-step generation.
+
+        pre_verify_ids: Previously verified token IDs.
+            Shape: (batch_size * 4,)
+            Maintains recent token history for next step input construction.
+
+        pre_out_locs: Output cache locations from previous steps.
+            Type: List[List[torch.Tensor]]
+            Structure: [step_index][batch_index]
+            Tracks KV cache locations for efficient cache management.
+
+        last_hidden_states: Hidden states from last step in each position.
+            Type: List[List[torch.Tensor]]
+            Structure: [step_index][batch_index]
+            Maintains sliding window of hidden states for context.
+    """
+
+    # Multi-step state tensors
+    pre_hiddens: Optional[torch.Tensor] = None
+    """Previous hidden states from last forward pass (batch*4, hidden_size)."""
+
+    pre_verify_ids: Optional[torch.Tensor] = None
+    """Previously verified token IDs (batch*4,)."""
+
+    # Cache location tracking
+    pre_out_locs: List[List[torch.Tensor]] = field(default_factory=list)
+    """Output cache locations per step and batch element."""
+
+    # Hidden state history
+    last_hidden_states: List[List[torch.Tensor]] = field(default_factory=list)
+    """Hidden states history for sliding window context."""
+
+    def __post_init__(self):
+        self.spec_input_type = SpecInputType.MHMTP_DRAFT
+
+    def prepare_for_draft_extend(
+        self,
+        batch: ScheduleBatch,
+        speculative_num_steps: int,
+    ) -> None:
+        """Prepare batch state for draft extend phase.
+
+        Configures the batch with state needed for multi-step draft token
+        generation. Updates sequence lengths and request pool indices based
+        on previous verification results.
+
+        Args:
+            batch: The schedule batch to prepare.
+            speculative_num_steps: Number of speculative steps (typically 3).
+        """
+        # Use verified token IDs as input for draft extend
+        batch.input_ids = self.verified_id
+
+        # Calculate extended lengths (verified tokens + 1 for new prediction)
+        batch.extend_lens = [x + 1 for x in batch.spec_info.accept_length_cpu]
+        batch.extend_num_tokens = sum(batch.extend_lens)
+
+        # Update sequence lengths for draft model
+        batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
+
+        # Update request pool indices for draft extend
+        batch.req_pool_indices = batch.spec_info.req_pool_indices_for_draft_extend
+
+        # Disable logprob calculation during draft extend
+        batch.return_logprob = False
+
+    def merge_batch(self, spec_info: MhmtpDraftInput) -> None:
+        """Merge another draft input into this one.
+
+        Combines two draft inputs, concatenating tensors and merging
+        list-based state. Used when batching multiple requests together.
+
+        Args:
+            spec_info: The draft input to merge.
+        """
+        # Merge parent class state
+        super().merge_batch(spec_info)
+
+        # Merge cache locations (list of lists)
+        self.pre_out_locs = [
+            self.pre_out_locs[i] + spec_info.pre_out_locs[i]
+            for i in range(len(self.pre_out_locs))
+        ]
+
+        # Merge hidden state history (list of lists)
+        self.last_hidden_states = [
+            self.last_hidden_states[i] + spec_info.last_hidden_states[i]
+            for i in range(len(self.last_hidden_states))
+        ]
+
+
+@dataclass
+class MhmtpVerifyInput(EagleVerifyInput):
+    """Input for target model verification phase in MHMTP speculative decoding.
+
+    Prepares draft token candidates for verification by target model.
+    Stores tree structure information and maintains state for verifying
+    multiple candidate sequences in a single batch.
+
+    Extends EagleVerifyInput with MHMTP-specific state tracking for
+    multi-step generation.
+
+    Attributes:
+        pre_hiddens: Hidden states before verification (batch*4, hidden_size).
+        pre_verify_ids: Verified token IDs from previous steps (batch*4,).
+        pre_out_locs: Cache locations per step and batch (List[torch.Tensor]).
+        last_hidden_states: Hidden state history per step (List[torch.Tensor]).
+    """
+
+    # Hidden state and verification tracking
+    pre_hiddens: Optional[torch.Tensor] = None
+    """Hidden states before verification for sliding window context."""
+
+    pre_verify_ids: Optional[torch.Tensor] = None
+    """Previously verified token IDs for context."""
+
+    # Cache and history tracking
+    pre_out_locs: List[torch.Tensor] = field(default_factory=list)
+    """Output cache locations from previous steps."""
+
+    last_hidden_states: List[torch.Tensor] = field(default_factory=list)
+    """Hidden state history for sliding window."""
+
+    def __post_init__(self):
+        self.spec_input_type = SpecInputType.MHMTP_VERIFY
+
+    def verify(
+        self,
+        batch: ScheduleBatch,
+        logits_output: torch.Tensor,
+        token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+        page_size: int,
+        vocab_mask: Optional[torch.Tensor] = None,
+    ) -> MhmtpVerifyOutput:
+        """Verify draft tokens using target model logits.
+
+        Runs the EAGLE verification algorithm and converts the result
+        to MhmtpVerifyOutput with additional state tracking.
+
+        Args:
+            batch: The schedule batch being verified.
+            logits_output: Logits from target model forward pass.
+            token_to_kv_pool_allocator: KV cache allocator for managing memory.
+            page_size: Page size for KV cache (typically 16).
+            vocab_mask: Optional grammar mask for vocabulary constraint.
+
+        Returns:
+            MhmtpVerifyOutput with verification results and draft input
+            for next iteration.
+        """
+        # Run parent EAGLE verification
+        eagle_verify_output = super().verify(
+            batch,
+            logits_output,
+            token_to_kv_pool_allocator,
+            page_size,
+            vocab_mask,
+        )
+
+        # Convert to MHMTP-specific output type
+        mhmtp_verify_output = eagle_verify_output
+        mhmtp_verify_output.__class__ = MhmtpVerifyOutput
+
+        # Extract EAGLE draft input and convert to MHMTP format
+        eagle_draft_input = mhmtp_verify_output.draft_input
+        mhmtp_draft_input = self._create_mhmtp_draft_input(eagle_draft_input, batch)
+
+        mhmtp_verify_output.draft_input = mhmtp_draft_input
+        return mhmtp_verify_output
+
+    def _create_mhmtp_draft_input(
+        self,
+        eagle_draft_input: EagleDraftInput,
+        batch: ScheduleBatch,
+    ) -> MhmtpDraftInput:
+        """Convert EAGLE draft input to MHMTP draft input.
+
+        Maps EAGLE output to MHMTP-specific fields, preserving all
+        necessary state for multi-step generation.
+
+        Args:
+            eagle_draft_input: Output from EAGLE verification.
+            batch: The schedule batch with previous state.
+
+        Returns:
+            MhmtpDraftInput with all required fields initialized.
+        """
+        mhmtp_draft_input = MhmtpDraftInput()
+
+        # Copy core verification results
+        mhmtp_draft_input.hidden_states = eagle_draft_input.hidden_states
+        mhmtp_draft_input.verified_id = eagle_draft_input.verified_id
+        mhmtp_draft_input.accept_length = eagle_draft_input.accept_length
+        mhmtp_draft_input.accept_length_cpu = eagle_draft_input.accept_length_cpu
+
+        # Copy draft extend metadata (if available)
+        if hasattr(eagle_draft_input, "seq_lens_for_draft_extend"):
+            mhmtp_draft_input.seq_lens_for_draft_extend = (
+                eagle_draft_input.seq_lens_for_draft_extend
+            )
+
+        if hasattr(eagle_draft_input, "req_pool_indices_for_draft_extend"):
+            mhmtp_draft_input.req_pool_indices_for_draft_extend = (
+                eagle_draft_input.req_pool_indices_for_draft_extend
+            )
+
+        # Copy request state (for handling finished requests)
+        if hasattr(eagle_draft_input, "unfinished_index_device"):
+            mhmtp_draft_input.unfinished_index_device = (
+                eagle_draft_input.unfinished_index_device
+            )
+
+        if hasattr(eagle_draft_input, "unfinished_index"):
+            mhmtp_draft_input.unfinished_index = eagle_draft_input.unfinished_index
+
+        # Copy KV cache metadata
+        mhmtp_draft_input.kv_indices = eagle_draft_input.kv_indices
+        mhmtp_draft_input.kv_indptr = eagle_draft_input.kv_indptr
+
+        # Copy top-k selection results
+        mhmtp_draft_input.topk_p = eagle_draft_input.topk_p
+        mhmtp_draft_input.topk_index = eagle_draft_input.topk_index
+
+        # Copy generation metadata
+        mhmtp_draft_input.capture_hidden_mode = eagle_draft_input.capture_hidden_mode
+
+        # Copy MHMTP-specific state from batch
+        mhmtp_draft_input.pre_out_locs = batch.spec_info.pre_out_locs
+        mhmtp_draft_input.last_hidden_states = batch.spec_info.last_hidden_states
+        mhmtp_draft_input.pre_hiddens = batch.spec_info.pre_hiddens
+        mhmtp_draft_input.pre_verify_ids = batch.spec_info.pre_verify_ids
+
+        return mhmtp_draft_input
+
+    @staticmethod
+    def _safe_cat(
+        tensor_a: Optional[torch.Tensor],
+        tensor_b: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        """Safely concatenate two tensors, handling None values.
+
+        Args:
+            tensor_a: First tensor or None.
+            tensor_b: Second tensor or None.
+
+        Returns:
+            Concatenated tensor, or the non-None tensor if one is None.
+        """
+        if tensor_a is not None and tensor_b is not None:
+            return torch.cat([tensor_a, tensor_b])
+        elif tensor_a is not None:
+            return tensor_a
+        else:
+            return tensor_b
+
+    def merge_batch(self, spec_info: MhmtpVerifyInput) -> None:
+        """Merge another verification input into this one.
+
+        Combines two verification inputs, concatenating tree information
+        and merging batch state. Used when batching multiple requests.
+
+        Args:
+            spec_info: The verification input to merge.
+        """
+        # Safely concatenate tensor fields
+        self.draft_token = self._safe_cat(self.draft_token, spec_info.draft_token)
+        self.custom_mask = self._safe_cat(self.custom_mask, spec_info.custom_mask)
+        self.positions = self._safe_cat(self.positions, spec_info.positions)
+
+        # Merge tree structure with adjusted indices
+        self.retrive_index = self._safe_cat(
+            self.retrive_index,
+            spec_info.retrive_index + self.retrive_index[-1][-1] + 1,
+        )
+        self.retrive_next_sibling = self._safe_cat(
+            self.retrive_next_sibling, spec_info.retrive_next_sibling
+        )
+        self.retrive_next_token = self._safe_cat(
+            self.retrive_next_token, spec_info.retrive_next_token
+        )
+
+        # Merge MHMTP-specific state (list-based)
+        self.pre_out_locs = [
+            self.pre_out_locs[i] + spec_info.pre_out_locs[i]
+            for i in range(len(self.pre_out_locs))
+        ]
+        self.last_hidden_states = [
+            self.last_hidden_states[i] + spec_info.last_hidden_states[i]
+            for i in range(len(self.last_hidden_states))
+        ]
+
+        # Merge tensor-based state (concatenate)
+        self.pre_hiddens = torch.cat([self.pre_hiddens, spec_info.pre_hiddens], dim=0)
+        self.pre_verify_ids = torch.cat(
+            [self.pre_verify_ids, spec_info.pre_verify_ids], dim=0
+        )
+
+    def filter_batch(
+        self,
+        new_indices: torch.Tensor,
+        has_been_filtered: bool = True,
+    ) -> None:
+        """Filter batch by keeping only specified indices.
+
+        This operation is typically handled by parent class verification.
+        Currently a no-op for MHMTP as filtering is managed elsewhere.
+
+        Args:
+            new_indices: Indices to keep.
+            has_been_filtered: Whether batch has already been filtered.
+        """
+        # Filtering handled by parent class or batch manager
+        pass
+
+
+@dataclass
+class MhmtpVerifyOutput(EagleVerifyOutput):
+    """Output from target model verification in MHMTP speculative decoding.
+
+    Contains verification results and provides the draft input for the next
+    iteration of speculative generation.
+
+    Extends EagleVerifyOutput with MHMTP-specific draft input that includes
+    multi-step state tracking for efficient candidate generation.
+
+    Attributes:
+        draft_input: MhmtpDraftInput for next draft extend phase.
+    """
+
+    draft_input: MhmtpDraftInput
+    """Draft input prepared for next speculative generation iteration."""

--- a/python/sglang/srt/speculative/mhmtp_worker.py
+++ b/python/sglang/srt/speculative/mhmtp_worker.py
@@ -1,0 +1,1103 @@
+import logging
+import os
+import time
+from contextlib import contextmanager
+from typing import List, Optional, Tuple
+
+import torch
+from huggingface_hub import snapshot_download
+
+from sglang.srt.distributed import GroupCoordinator, patch_tensor_parallel_group
+from sglang.srt.layers.dp_attention import disable_dp_size
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.eagle_utils import build_tree_kernel_efficient
+from sglang.srt.speculative.mhmtp_draft_cuda_graph_runner import (
+    MHMTPDraftCudaGraphRunner,
+)
+from sglang.srt.speculative.mhmtp_utils import (
+    MhmtpDraftInput,
+    MhmtpVerifyInput,
+    MhmtpVerifyOutput,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import (
+    generate_token_bitmask,
+    select_top_k_tokens,
+)
+from sglang.srt.utils import empty_context, fast_topk, get_available_gpu_memory, is_cuda
+
+if is_cuda():
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def draft_tp_context(tp_group: GroupCoordinator):
+    """Context manager for draft model tensor parallelism.
+
+    The draft model doesn't use data parallelism and has its own tensor parallel group.
+    Note: We disable mscclpp because it doesn't support multiple communication groups.
+    """
+    with disable_dp_size(), patch_tensor_parallel_group(tp_group):
+        yield
+
+
+class MhmtpWorker(TpModelWorker):
+    """Mhmtp speculative decoding worker implementation."""
+
+    def __init__(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        tp_rank: int,
+        dp_rank: Optional[int],
+        nccl_port: int,
+        target_worker: TpModelWorker,
+        is_mtp: bool = False,
+        moe_ep_rank=None,
+    ):
+        """Initialize MhmtpWorker.
+
+        Args:
+            server_args: Server configuration arguments.
+            gpu_id: GPU device ID.
+            tp_rank: Tensor parallel rank.
+            dp_rank: Data parallel rank.
+            nccl_port: NCCL communication port.
+            target_worker: Target model worker for token verification.
+            is_mtp: Whether to use multi-token prediction model.
+            moe_ep_rank: Expert parallel rank for Mixture of Experts models.
+        """
+        self.server_args = server_args
+        self.topk = 1
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.padded_static_len = self.speculative_num_steps + 1
+        self.enable_nan_detection = server_args.enable_nan_detection
+        self.gpu_id = gpu_id
+        self.device = server_args.device
+        self.target_worker = target_worker
+        self.page_size = server_args.page_size
+        self.is_custom = is_mtp
+        self.hot_token_id = None
+
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+
+        server_args.context_length = target_worker.model_runner.model_config.context_len
+
+        backup_disable_cuda_graph = server_args.disable_cuda_graph
+        server_args.disable_cuda_graph = True
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
+            target_worker.get_memory_pool()
+        )
+
+        with empty_context():
+            super().__init__(
+                server_args=server_args,
+                gpu_id=gpu_id,
+                tp_rank=tp_rank,
+                pp_rank=0,
+                dp_rank=dp_rank,
+                nccl_port=nccl_port,
+                is_draft_worker=True,
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                moe_ep_rank=None,
+            )
+
+        self.draft_model_runner.server_args.disable_cuda_graph = (
+            backup_disable_cuda_graph
+        )
+        self.draft_tp_context = (
+            draft_tp_context if server_args.enable_dp_attention else empty_context
+        )
+        with self.draft_tp_context(self.draft_model_runner.tp_group):
+            self.init_attention_backend()
+            self.init_cuda_graphs()
+
+    def init_attention_backend(self) -> None:
+        """Initialize multi-step attention backends for draft model."""
+        if self.server_args.attention_backend != "flashinfer":
+            raise ValueError(
+                f"MHMTP speculative decoding not supported with "
+                f"attention backend: {self.server_args.attention_backend}"
+            )
+
+        self._init_flashinfer_backend()
+        self.draft_extend_attn_backend = None
+        self.padded_static_len = self.speculative_num_steps + 1
+        self.has_prefill_wrapper_verify = True
+        self.draft_model_runner.draft_attn_backend = self.draft_attn_backend
+
+    def _init_flashinfer_backend(self) -> None:
+        """Initialize FlashInfer attention backend for draft model."""
+        from sglang.srt.layers.attention.flashinfer_backend import (
+            FlashInferMultiStepDraftBackend,
+        )
+
+        self.draft_attn_backend = FlashInferMultiStepDraftBackend(
+            self.draft_model_runner,
+            self.topk,
+            self.speculative_num_steps,
+        )
+
+    def init_cuda_graphs(self) -> None:
+        """Capture CUDA graphs for draft model inference."""
+        self.cuda_graph_runner_for_draft_extend = None
+
+        if self.server_args.disable_cuda_graph:
+            return
+
+        tic = time.perf_counter()
+        before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        logger.info(
+            f"Starting CUDA graph capture for draft model. "
+            f"Available GPU memory: {before_mem:.2f} GB"
+        )
+
+        self.cuda_graph_runner_for_draft_extend = MHMTPDraftCudaGraphRunner(
+            self, self.speculative_num_steps
+        )
+
+        after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        elapsed_time = time.perf_counter() - tic
+        mem_used = before_mem - after_mem
+        logger.info(
+            f"Completed CUDA graph capture. "
+            f"Time: {elapsed_time:.2f}s, "
+            f"Available GPU memory: {after_mem:.2f} GB, "
+            f"Memory used: {mem_used:.2f} GB"
+        )
+
+    @property
+    def draft_model_runner(self):
+        """Get the draft model runner instance."""
+        return self.model_runner
+
+    def forward_batch_speculative_generation(
+        self, batch: ScheduleBatch
+    ) -> GenerationBatchResult:
+        """Main forward pass for speculative generation."""
+        if batch.forward_mode.is_decode():
+            return self._forward_decode_mode(batch)
+        elif batch.forward_mode.is_idle():
+            return self._forward_idle_mode(batch)
+        else:
+            return self._forward_extend_mode(batch)
+
+    def _forward_decode_mode(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        """Forward pass in decode mode (verification phase)."""
+        spec_info = batch.spec_info
+        logits_output, verify_output, model_worker_batch, can_run_cuda_graph = (
+            self.verify(batch, spec_info)
+        )
+
+        accept_length = verify_output.draft_input.accept_length_cpu
+        if not accept_length or len(accept_length) == 0:
+            batch.forward_mode = ForwardMode.DECODE
+            return GenerationBatchResult(
+                logits_output=logits_output,
+                next_token_ids=verify_output.verified_id,
+                num_accepted_tokens=0,
+                can_run_cuda_graph=False,
+            )
+
+        if batch.spec_info.verified_id is not None:
+            with self.draft_tp_context(self.draft_model_runner.tp_group):
+                batch.input_ids = batch.spec_info.verified_id
+                batch.spec_info.hidden_states = verify_output.draft_input.pre_hiddens
+                verify_input = self.draft_extend(batch)
+                batch.spec_info = verify_input
+                batch.forward_mode = ForwardMode.DECODE
+
+        num_accepted = (
+            sum(accept_length)
+            if isinstance(accept_length, list)
+            else accept_length.sum().item()
+        )
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=verify_output.verified_id,
+            num_accepted_tokens=num_accepted,
+            can_run_cuda_graph=can_run_cuda_graph,
+        )
+
+    def _forward_idle_mode(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        """Forward pass in idle mode (prefill phase)."""
+        model_worker_batch = batch.get_model_worker_batch()
+        batch_result = self.target_worker.forward_batch_generation(model_worker_batch)
+
+        return GenerationBatchResult(
+            logits_output=batch_result.logits_output,
+            next_token_ids=batch_result.next_token_ids,
+            num_accepted_tokens=0,
+            can_run_cuda_graph=False,
+        )
+
+    def _forward_extend_mode(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        """Forward pass in extend mode (target extend + draft extend)."""
+        logits_output, next_token_ids, bid = self.forward_target_extend(batch)
+
+        with self.draft_tp_context(self.draft_model_runner.tp_group):
+            self.forward_draft_extend(batch, logits_output, next_token_ids)
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            next_token_ids=next_token_ids,
+            num_accepted_tokens=0,
+            can_run_cuda_graph=False,
+        )
+
+    def forward_target_extend(
+        self, batch: ScheduleBatch
+    ) -> Tuple[LogitsProcessorOutput, List[int], int]:
+        """Run target model for one step to get full hidden states."""
+        batch.seq_lens_cpu = None
+        model_worker_batch = batch.get_model_worker_batch()
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        batch_result = self.target_worker.forward_batch_generation(model_worker_batch)
+        bid = getattr(model_worker_batch, "bid", None) or id(batch)
+        logits_output = batch_result.logits_output
+        next_token_ids = batch_result.next_token_ids
+        return logits_output, next_token_ids, bid
+
+    def verify(
+        self, batch: ScheduleBatch, spec_info: MhmtpVerifyInput
+    ) -> Tuple[LogitsProcessorOutput, MhmtpVerifyOutput, ForwardBatch, bool]:
+        """Verify draft tokens using the target model."""
+        spec_info.prepare_for_verify(batch, self.page_size)
+        batch.forward_mode = ForwardMode.TARGET_VERIFY
+        batch.spec_info = spec_info
+        model_worker_batch = batch.get_model_worker_batch()
+
+        if batch.has_grammar:
+            retrieve_next_token_cpu = spec_info.retrive_next_token.cpu()
+            retrieve_next_sibling_cpu = spec_info.retrive_next_sibling.cpu()
+            draft_tokens_cpu = spec_info.draft_token.view(
+                spec_info.retrive_next_token.shape
+            ).cpu()
+
+        batch_result = self.target_worker.forward_batch_generation(model_worker_batch)
+
+        logits_output = batch_result.logits_output
+        can_run_cuda_graph = (
+            batch_result.can_run_cuda_graph
+            if hasattr(batch_result, "can_run_cuda_graph")
+            else False
+        )
+
+        vocab_mask = None
+        if batch.has_grammar:
+            vocab_mask = generate_token_bitmask(
+                batch.reqs,
+                spec_info,
+                retrieve_next_token_cpu,
+                retrieve_next_sibling_cpu,
+                draft_tokens_cpu,
+                batch.sampling_info.vocab_size,
+            )
+            if vocab_mask is not None:
+                assert spec_info.grammar is not None
+                vocab_mask = vocab_mask.to(spec_info.retrive_next_token.device)
+                batch.sampling_info.vocab_mask = None
+
+        self._detect_nan_if_needed(logits_output)
+        spec_info.hidden_states = logits_output.hidden_states
+
+        res: MhmtpVerifyOutput = spec_info.verify(
+            batch,
+            logits_output,
+            self.token_to_kv_pool_allocator,
+            self.page_size,
+            vocab_mask,
+        )
+
+        logits_output.next_token_logits = logits_output.next_token_logits[
+            res.accepted_indices
+        ]
+        logits_output.hidden_states = logits_output.hidden_states[res.accepted_indices]
+
+        batch.forward_mode = ForwardMode.DECODE
+        batch.spec_info = res.draft_input
+
+        if (
+            hasattr(res.draft_input, "req_pool_indices_for_draft_extend")
+            and res.draft_input.req_pool_indices_for_draft_extend is not None
+        ):
+            batch.req_pool_indices = res.draft_input.req_pool_indices_for_draft_extend
+
+        if batch.spec_info.verified_id is None:
+            return logits_output, res, model_worker_batch, can_run_cuda_graph
+
+        accept_length_cpu = res.draft_input.accept_length_cpu
+
+        if not accept_length_cpu or len(accept_length_cpu) == 0:
+            batch.forward_mode = ForwardMode.DECODE
+            batch.spec_info = res.draft_input
+
+            if (
+                hasattr(res.draft_input, "req_pool_indices_for_draft_extend")
+                and res.draft_input.req_pool_indices_for_draft_extend is not None
+            ):
+                batch.req_pool_indices = (
+                    res.draft_input.req_pool_indices_for_draft_extend
+                )
+
+            return logits_output, res, model_worker_batch, can_run_cuda_graph
+
+        # Similar to the truncation in “forward_draft_extend”, after verification,
+        # we also need to replenish the states to facilitate subsequent
+        # “draft_extend” processing with CUDA graph.
+        split_lengths = [length + 1 for length in accept_length_cpu]
+
+        split_hiddens = torch.split(res.draft_input.hidden_states, split_lengths, dim=0)
+        split_verify_ids = torch.split(
+            batch.spec_info.verified_id, split_lengths, dim=0
+        )
+        split_out_locs = torch.split(batch.out_cache_loc, split_lengths, dim=0)
+
+        spec_pre_hiddens = spec_info.pre_hiddens
+        spec_pre_verify_ids = spec_info.pre_verify_ids
+
+        size = self.server_args.speculative_num_draft_tokens
+        spec_per_batch = torch.split(
+            spec_pre_hiddens, [size] * len(split_hiddens), dim=0
+        )
+        spec_verify_per_batch = torch.split(
+            spec_pre_verify_ids, [size] * len(split_hiddens), dim=0
+        )
+
+        pre_hiddens_parts = []
+        pre_verify_parts = []
+        outloc_parts = []
+
+        for i, (
+            verify_h,
+            verify_v,
+            verify_loc,
+            pre_h,
+            pre_v,
+            length,
+        ) in enumerate(
+            zip(
+                split_hiddens,
+                split_verify_ids,
+                split_out_locs,
+                spec_per_batch,
+                spec_verify_per_batch,
+                accept_length_cpu,
+            )
+        ):
+            combined_hidden = torch.cat([pre_h, verify_h], dim=0)[-size:]
+            combined_verify = torch.cat([pre_v, verify_v], dim=0)[-size:]
+
+            pre_hiddens_parts.append(combined_hidden)
+            pre_verify_parts.append(combined_verify)
+
+            current_loc = verify_loc
+            if len(verify_v) < size:
+                if res.draft_input.unfinished_index is not None:
+                    unfinished_req_index = res.draft_input.unfinished_index[i]
+                else:
+                    unfinished_req_index = i
+
+                pre_loc = batch.spec_info.pre_out_locs[0][i]
+                current_loc = torch.cat([pre_loc, current_loc], dim=0)[-size:]
+                self.set_last_out_loc(batch.spec_info, current_loc, 0, i)
+
+            outloc_parts.append(current_loc)
+
+        res.draft_input.pre_hiddens = torch.cat(pre_hiddens_parts, dim=0)
+        res.draft_input.pre_verify_ids = torch.cat(pre_verify_parts, dim=0)
+
+        if batch.return_logprob:
+            self.add_logprob_values(batch, res, logits_output)
+
+        batch.spec_info.verified_id = res.draft_input.pre_verify_ids
+        batch.out_cache_loc = torch.cat(outloc_parts, dim=0)
+
+        return logits_output, res, model_worker_batch, can_run_cuda_graph
+
+    def _detect_nan_if_needed(self, logits_output: LogitsProcessorOutput) -> None:
+        """Detect NaN values in logits if enabled."""
+        if self.enable_nan_detection:
+            logits = logits_output.next_token_logits
+            if torch.any(torch.isnan(logits)):
+                logger.error("NaN detected in logits during sampling!")
+                raise ValueError("Detected errors during sampling! NaN in the logits.")
+
+    def _append_tensor(
+        self,
+        cur_tensor: Optional[torch.Tensor],
+        tensor: Optional[torch.Tensor],
+        dim: int = 0,
+    ) -> Optional[torch.Tensor]:
+        """Helper method to append tensors along a dimension."""
+        if cur_tensor is None:
+            return tensor
+        if tensor is not None:
+            return torch.cat([cur_tensor, tensor], dim=dim)
+        return cur_tensor
+
+    def append_out_locs(
+        self,
+        cur_out_locs: Optional[torch.Tensor],
+        out_locs: torch.Tensor,
+    ) -> torch.Tensor:
+        """Append output cache locations."""
+        return self._append_tensor(cur_out_locs, out_locs)
+
+    def append_hidden_states(
+        self,
+        cur_hidden_states: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Append hidden state tensors."""
+        return self._append_tensor(cur_hidden_states, hidden_states)
+
+    def append_input_ids(
+        self,
+        cur_input_ids: Optional[torch.Tensor],
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Append input ID tensors."""
+        return self._append_tensor(cur_input_ids, input_ids)
+
+    def append_positions(
+        self,
+        cur_positions: Optional[torch.Tensor],
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Append position tensors."""
+        return self._append_tensor(cur_positions, positions)
+
+    def build_sliding_positions(
+        self, cur_positions: torch.Tensor, size: torch.Tensor
+    ) -> torch.Tensor:
+        """Build sliding window positions."""
+        return torch.arange(
+            cur_positions[-1] - size,
+            cur_positions[-1],
+            device=cur_positions.device,
+        )
+
+    def set_last_hidden_states(
+        self,
+        spec_info: MhmtpDraftInput,
+        hidden_states: torch.Tensor,
+        mtp_index: int = 0,
+        batch_index: int = 0,
+    ) -> None:
+        """Set last hidden states for speculative info."""
+        if len(spec_info.last_hidden_states) == 0:
+            for _ in range(self.speculative_num_steps):
+                spec_info.last_hidden_states.append([])
+
+        if len(spec_info.last_hidden_states[mtp_index]) > batch_index:
+            spec_info.last_hidden_states[mtp_index][batch_index] = hidden_states
+        else:
+            spec_info.last_hidden_states[mtp_index].append(hidden_states)
+
+    def set_last_out_loc(
+        self,
+        spec_info: MhmtpDraftInput,
+        out_loc: torch.Tensor,
+        mtp_index: int = 0,
+        batch_index: int = 0,
+    ) -> None:
+        """Set last output location for speculative info."""
+        if len(spec_info.pre_out_locs) == 0:
+            for _ in range(self.speculative_num_steps):
+                spec_info.pre_out_locs.append([])
+
+        if len(spec_info.pre_out_locs[mtp_index]) > batch_index:
+            spec_info.pre_out_locs[mtp_index][batch_index] = out_loc
+        else:
+            spec_info.pre_out_locs[mtp_index].append(out_loc)
+
+    def add_logprob_values(
+        self,
+        batch: ScheduleBatch,
+        res: MhmtpVerifyOutput,
+        logits_output: LogitsProcessorOutput,
+    ) -> None:
+        """Add log probability values to batch results."""
+        logits_output = res.logits_output
+        top_logprobs_nums = batch.top_logprobs_nums
+        token_ids_logprobs = batch.token_ids_logprobs
+        logprobs = torch.nn.functional.log_softmax(
+            logits_output.next_token_logits, dim=-1
+        )
+        batch_next_token_ids = res.verified_id
+        num_tokens_per_req = [accept + 1 for accept in res.accept_length_per_req_cpu]
+
+        top_logprobs_nums_repeat_interleaved = []
+        token_ids_logprobs_repeat_interleaved = []
+        for num, num_tokens in zip(top_logprobs_nums, num_tokens_per_req):
+            top_logprobs_nums_repeat_interleaved.extend([num] * num_tokens)
+        for token_ids, num_tokens in zip(token_ids_logprobs, num_tokens_per_req):
+            token_ids_logprobs_repeat_interleaved.extend([token_ids] * num_tokens)
+
+        if any(x > 0 for x in top_logprobs_nums):
+            (
+                logits_output.next_token_top_logprobs_val,
+                logits_output.next_token_top_logprobs_idx,
+            ) = get_top_logprobs(logprobs, top_logprobs_nums_repeat_interleaved)
+
+        if any(x is not None for x in token_ids_logprobs):
+            (
+                logits_output.next_token_token_ids_logprobs_val,
+                logits_output.next_token_token_ids_logprobs_idx,
+            ) = get_token_ids_logprobs(logprobs, token_ids_logprobs_repeat_interleaved)
+
+        logits_output.next_token_logprobs = logprobs[
+            torch.arange(len(batch_next_token_ids), device=batch.sampling_info.device),
+            batch_next_token_ids,
+        ]
+
+        pt = 0
+        next_token_logprobs = logits_output.next_token_logprobs.tolist()
+        verified_ids = batch_next_token_ids.tolist()
+        for req, num_tokens in zip(batch.reqs, num_tokens_per_req):
+            for _ in range(num_tokens):
+                if req.return_logprob:
+                    req.output_token_logprobs_val.append(next_token_logprobs[pt])
+                    req.output_token_logprobs_idx.append(verified_ids[pt])
+                    if req.top_logprobs_num > 0:
+                        req.output_top_logprobs_val.append(
+                            res.logits_output.next_token_top_logprobs_val[pt]
+                        )
+                        req.output_top_logprobs_idx.append(
+                            res.logits_output.next_token_top_logprobs_idx[pt]
+                        )
+                pt += 1
+
+    def _preprocess_tree_inputs(
+        self,
+        verified_id: torch.Tensor,
+        score_list: List[torch.Tensor],
+        token_list: List[torch.Tensor],
+        parents_list: List[torch.Tensor],
+        num_verify_tokens: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Preprocess tree structure inputs for speculative tree generation."""
+        score_list = torch.cat(score_list, dim=1).flatten(1)
+        ss_token_list = torch.cat(token_list, dim=1)
+
+        top_scores = torch.topk(score_list, num_verify_tokens - 1, dim=-1)
+        top_scores_index = torch.sort(top_scores.indices).values
+
+        draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
+
+        if len(parents_list) > 1:
+            parent_list = torch.cat(parents_list[:-1], dim=1)
+        else:
+            batch_size = parents_list[0].shape[0]
+            parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
+
+        return parent_list, top_scores_index, draft_tokens
+
+    def capture_for_decode(
+        self, logits_output: LogitsProcessorOutput, draft_input: MhmtpDraftInput
+    ) -> None:
+        """Capture information needed for subsequent decode steps."""
+        probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+        draft_input.topk_p, draft_input.topk_index = fast_topk(probs, self.topk, dim=-1)
+        draft_input.hidden_states = logits_output.hidden_states
+
+    def draft_extend(self, batch: ScheduleBatch) -> MhmtpVerifyInput:
+        """Extend draft tokens using draft model."""
+        seq_len_bak = batch.seq_lens
+        req_pool_bak = batch.req_pool_indices
+
+        batch_size = min(batch.batch_size(), len(batch.spec_info.accept_length))
+        batch.spec_info.prepare_for_draft_extend(batch, self.speculative_num_steps)
+        batch.spec_info.accept_length = batch.spec_info.accept_length.add_(1)
+        batch.forward_mode = ForwardMode.DRAFT_EXTEND
+        batch.return_logprob = False
+
+        cur_full_hidden_states = [None] * batch_size
+        cur_full_input_ids = [None] * batch_size
+        input_ids = batch.spec_info.verified_id
+        hidden_states = batch.spec_info.hidden_states
+
+        score_list: List[torch.Tensor] = []
+        token_list: List[torch.Tensor] = []
+        parents_list: List[torch.Tensor] = []
+        scores = None
+        raw_out_loc = batch.out_cache_loc
+        out_loc = raw_out_loc
+        real_valid_id = None
+
+        model_worker_batch = batch.get_model_worker_batch()
+        if real_valid_id is None:
+            a = batch.spec_info.accept_length.clone()
+            a.fill_(self.server_args.speculative_num_draft_tokens)
+            verified_indices = a.cumsum(dim=0).add_(-1)
+            real_valid_id = input_ids[verified_indices]
+
+        forward_batch = ForwardBatch.init_new(
+            model_worker_batch, self.draft_model_runner
+        )
+        forward_batch.input_ids = input_ids
+
+        batch_size = len(batch.spec_info.accept_length)
+        forward_batch.batch_size = batch_size
+        seq_lens_sum = forward_batch.seq_lens.sum().item()
+        batch.seq_lens_sum = seq_lens_sum
+        forward_batch.seq_lens_sum = seq_lens_sum
+
+        verified_length = self.server_args.speculative_num_draft_tokens
+        verified_lengths = [verified_length] * batch_size
+        batch_out_locs = out_loc.split(verified_lengths)
+
+        device = input_ids.device
+        start_positions = forward_batch.seq_lens - verified_length
+        offsets = torch.arange(verified_length, device=device).repeat(batch_size)
+        repeated_starts = torch.repeat_interleave(start_positions, verified_length)
+        positions = repeated_starts + offsets
+
+        can_cuda_graph = (
+            self.cuda_graph_runner_for_draft_extend
+            and self.cuda_graph_runner_for_draft_extend.can_run(forward_batch)
+        )
+        if can_cuda_graph:
+            self._draft_extend_with_cuda_graph(
+                forward_batch,
+                batch,
+                hidden_states,
+                positions,
+                out_loc,
+                input_ids,
+                score_list,
+                token_list,
+                parents_list,
+            )
+        else:  # TODO: Fix and validate this implementation
+            self._draft_extend_without_cuda_graph(
+                forward_batch,
+                batch,
+                forward_batch.seq_lens,
+                hidden_states,
+                input_ids,
+                batch_out_locs,
+                verified_lengths,
+                score_list,
+                token_list,
+                parents_list,
+                cur_full_hidden_states,
+                cur_full_input_ids,
+            )
+
+        parent_list, top_scores_index, draft_tokens = self._preprocess_tree_inputs(
+            real_valid_id,
+            score_list,
+            token_list,
+            parents_list,
+            self.server_args.speculative_num_draft_tokens,
+        )
+        (
+            tree_mask,
+            position,
+            retrive_index,
+            retrive_next_token,
+            retrive_next_sibling,
+            draft_tokens,
+        ) = build_tree_kernel_efficient(
+            real_valid_id,
+            parent_list,
+            top_scores_index,
+            draft_tokens,
+            batch.seq_lens,
+            batch.seq_lens_sum,
+            self.topk,
+            self.speculative_num_steps,
+            self.server_args.speculative_num_draft_tokens,
+        )
+
+        ret = MhmtpVerifyInput(
+            draft_token=draft_tokens,
+            custom_mask=tree_mask,
+            positions=position,
+            retrive_index=retrive_index,
+            retrive_next_token=retrive_next_token,
+            retrive_next_sibling=retrive_next_sibling,
+            retrive_cum_len=None,
+            spec_steps=self.speculative_num_steps,
+            topk=self.topk,
+            draft_token_num=self.server_args.speculative_num_draft_tokens,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            seq_lens_sum=forward_batch.seq_lens_sum,
+            seq_lens_cpu=forward_batch.seq_lens_cpu,
+        )
+
+        ret.pre_out_locs = batch.spec_info.pre_out_locs
+        ret.last_hidden_states = batch.spec_info.last_hidden_states
+        ret.pre_hiddens = batch.spec_info.pre_hiddens
+        ret.pre_verify_ids = batch.spec_info.pre_verify_ids
+        batch.seq_lens = seq_len_bak
+        batch.req_pool_indices = req_pool_bak
+        return ret
+
+    def _draft_extend_with_cuda_graph(
+        self,
+        forward_batch: ForwardBatch,
+        batch: ScheduleBatch,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        out_loc: torch.Tensor,
+        input_ids: torch.Tensor,
+        score_list: List[torch.Tensor],
+        token_list: List[torch.Tensor],
+        parents_list: List[torch.Tensor],
+    ) -> None:
+        """Draft extend using CUDA graph for performance."""
+        batch_size = len(batch.spec_info.accept_length)
+        forward_batch.spec_info.hidden_states = hidden_states
+        forward_batch.spec_info.accept_length.fill_(
+            self.server_args.speculative_num_draft_tokens
+        )
+        forward_batch.positions = positions
+        forward_batch.out_cache_loc = out_loc
+        forward_batch.input_ids = input_ids
+        forward_batch.extend_seq_lens = batch.spec_info.accept_length
+        forward_batch.extend_num_tokens = batch.spec_info.accept_length
+
+        forward_batch.attn_backend = self.draft_attn_backend.attn_backends[0]
+        forward_batch.mtp_index = 0
+
+        output = self.cuda_graph_runner_for_draft_extend.replay(forward_batch)
+        for i in range(self.server_args.speculative_num_steps):
+            scores, tokens, parents = output[i]
+            score_list.append(scores)
+            token_list.append(tokens)
+            parents_list.append(parents)
+
+    def _draft_extend_without_cuda_graph(
+        self,
+        forward_batch: ForwardBatch,
+        batch: ScheduleBatch,
+        seq_lens: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        batch_out_locs: List[torch.Tensor],
+        verified_lengths: List[int],
+        score_list: List[torch.Tensor],
+        token_list: List[torch.Tensor],
+        parents_list: List[torch.Tensor],
+        cur_full_hidden_states: List,
+        cur_full_input_ids: List,
+    ) -> None:
+        """
+        Draft extend without CUDA graph (slower but more flexible).
+
+        NOTE: This is a legacy implementation used as fallback when CUDA graph
+        optimization is unavailable. Due to performance overhead without CUDA graphs,
+        this code path has not been actively maintained and may have compatibility
+        issues with recent model changes.
+
+        TODO: Fix and validate this implementation:
+        Ensure compatibility with multi-layer MTP models
+        """
+        scores = None
+        batch_size = len(verified_lengths)
+        verified_lengths_bak = verified_lengths.copy()
+
+        for i in range(self.speculative_num_steps):
+            updated_hidden_states = None
+            updated_out_locs = None
+            updated_input_ids = None
+            updated_positions = None
+            batch_hidden_states = hidden_states.split(verified_lengths)
+            token_verified_lengths = [1] * batch_size
+
+            batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+            for j, vlen in enumerate(verified_lengths_bak):
+                size = torch.tensor(vlen, device=input_ids.device)
+                one_hidden_states = batch_hidden_states[j]
+                batch_input_ids_split = input_ids.split(verified_lengths)
+                one_input_ids = batch_input_ids_split[j]
+                one_out_locs = batch_out_locs[j]
+                offset = max(0, -vlen + i + 1)
+                if offset:
+                    size += offset
+                    one_hidden_states = torch.cat(
+                        [
+                            batch.spec_info.last_hidden_states[i][j],
+                            one_hidden_states,
+                        ],
+                        dim=0,
+                    )
+                    one_out_locs = torch.cat(
+                        [
+                            batch.spec_info.pre_out_locs[i][j][-offset:],
+                            one_out_locs,
+                        ]
+                    )
+                self.set_last_hidden_states(
+                    batch.spec_info, one_hidden_states[-i - 1 : -i], i, j
+                )
+                self.set_last_out_loc(batch.spec_info, one_out_locs, i, j)
+                updated_hidden_states = self.append_hidden_states(
+                    updated_hidden_states, one_hidden_states
+                )
+                updated_out_locs = self.append_out_locs(updated_out_locs, one_out_locs)
+                batch.spec_info.accept_length[j] = size
+                verified_lengths[j] = size
+                cur_full_input_ids[j] = self.append_input_ids(
+                    cur_full_input_ids[j], one_input_ids
+                )
+                one_input_ids = cur_full_input_ids[j][-size:]
+                updated_input_ids = self.append_input_ids(
+                    updated_input_ids, one_input_ids
+                )
+                end_positions = forward_batch.seq_lens[j].unsqueeze(0)
+                positions = self.build_sliding_positions(end_positions, size)
+                updated_positions = self.append_positions(updated_positions, positions)
+            hidden_states = updated_hidden_states
+            input_ids = updated_input_ids
+            out_loc = updated_out_locs
+            positions = updated_positions
+
+            forward_batch.spec_info.hidden_states = hidden_states
+            forward_batch.positions = positions
+            forward_batch.out_cache_loc = out_loc
+            forward_batch.input_ids = input_ids
+            forward_batch.extend_seq_lens = batch.spec_info.accept_length
+            forward_batch.extend_num_tokens = batch.spec_info.accept_length
+            forward_batch.mtp_index = i
+            self.draft_attn_backend.attn_backends[i].init_forward_metadata(
+                forward_batch
+            )
+            forward_batch.attn_backend = self.draft_attn_backend.attn_backends[i]
+            logits_output = self.draft_model_runner.model.forward(
+                forward_batch.input_ids, forward_batch.positions, forward_batch
+            )
+            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+            hidden_states = logits_output.hidden_states
+            self._detect_nan_if_needed(logits_output)
+            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            hidden_states_bak = hidden_states
+            hidden_states = hidden_states[
+                torch.tensor(verified_lengths).cumsum(dim=0) - 1
+            ]
+            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p, topk_index, hidden_states, scores, self.topk
+            )
+            num_groups = len(input_ids)
+            group_size = len(forward_batch.input_ids) // num_groups
+            input_id_parts = []
+            for idx in range(num_groups):
+                current_input = input_ids[idx]
+                start_idx = idx * group_size
+                end_idx = start_idx + group_size
+                current_group = forward_batch.input_ids[start_idx:end_idx]
+                current_group = torch.cat(
+                    [current_group, current_input.unsqueeze(0)], dim=0
+                )[-self.server_args.speculative_num_draft_tokens :]
+                input_id_parts.append(current_group)
+            final_input_ids = torch.cat(input_id_parts, dim=0)
+            forward_batch.input_ids = final_input_ids
+            hidden_states = hidden_states_bak
+            score_list.append(tree_info[0])
+            token_list.append(tree_info[1])
+            parents_list.append(tree_info[2])
+
+    def forward_draft_extend(
+        self,
+        batch: ScheduleBatch,
+        logits_output: LogitsProcessorOutput,
+        next_token_ids: torch.Tensor,
+    ) -> LogitsProcessorOutput:
+        """Forward draft extend from target model output."""
+        batch_size = batch.batch_size()
+        seq_lens = batch.seq_lens.tolist()
+        hidden_states = logits_output.hidden_states
+        input_hidden_states = hidden_states
+        cur_full_hidden_states = [None] * batch_size
+        cur_full_input_ids = list(batch.input_ids.split(seq_lens))
+
+        batch.spec_info = MhmtpDraftInput(
+            hidden_states=hidden_states,
+            verified_id=next_token_ids,
+        )
+        probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+        topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+        scores = None
+        score_list = []
+        token_list = []
+        parents_list = []
+        input_ids = next_token_ids
+        model_worker_batch = batch.get_model_worker_batch()
+        forward_batch = ForwardBatch.init_new(
+            model_worker_batch, self.draft_model_runner
+        )
+
+        for i in range(self.speculative_num_steps):
+            updated_input_ids = None
+
+            if self.is_custom:
+                batch.spec_info.capture_hidden_mode = CaptureHiddenMode.FULL
+                forward_batch.spec_info.hidden_states = hidden_states
+            else:
+                batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
+                cur_full_hidden_states = self.append_hidden_states(
+                    cur_full_hidden_states,
+                    hidden_states,
+                )
+                forward_batch.spec_info.hidden_states = cur_full_hidden_states[-0:]
+
+            for j in range(batch_size):
+                cur_full_input_ids[j] = self.append_input_ids(
+                    cur_full_input_ids[j],
+                    input_ids[j].unsqueeze(0),
+                )
+                self.set_last_hidden_states(
+                    batch.spec_info, hidden_states[-i - 1 : -i], i, j
+                )
+                self.set_last_out_loc(batch.spec_info, batch.out_cache_loc, i, j)
+
+                one_input_ids = cur_full_input_ids[j][-seq_lens[j] :]
+                updated_input_ids = self.append_input_ids(
+                    updated_input_ids, one_input_ids
+                )
+
+            forward_batch.return_logprob = False
+            forward_batch.mtp_index = i
+            forward_batch.input_ids = updated_input_ids
+
+            logits_output, _ = self.draft_model_runner.forward(forward_batch)
+
+            self._detect_nan_if_needed(logits_output)
+            assert isinstance(forward_batch.spec_info, MhmtpDraftInput)
+            assert forward_batch.spec_info is batch.spec_info
+            self.capture_for_decode(logits_output, forward_batch.spec_info)
+
+            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            hidden_states_bak = logits_output.hidden_states
+            topk_p = topk_p
+            topk_index = topk_index
+            hidden_states = hidden_states_bak[torch.tensor(seq_lens).cumsum(dim=0) - 1]
+            input_ids, hidden_states, scores, tree_info = select_top_k_tokens(
+                i, topk_p, topk_index, hidden_states, scores, self.topk
+            )
+            hidden_states = hidden_states_bak
+            score_list.append(tree_info[0])
+            token_list.append(tree_info[1])
+            parents_list.append(tree_info[2])
+
+        parent_list, top_scores_index, draft_tokens = self._preprocess_tree_inputs(
+            next_token_ids,
+            score_list,
+            token_list,
+            parents_list,
+            self.server_args.speculative_num_draft_tokens,
+        )
+        (
+            tree_mask,
+            position,
+            retrive_index,
+            retrive_next_token,
+            retrive_next_sibling,
+            draft_tokens,
+        ) = build_tree_kernel_efficient(
+            next_token_ids,
+            parent_list,
+            top_scores_index,
+            draft_tokens,
+            batch.seq_lens,
+            batch.seq_lens_sum,
+            self.topk,
+            self.speculative_num_steps,
+            self.server_args.speculative_num_draft_tokens,
+        )
+
+        ret = MhmtpVerifyInput(
+            draft_token=draft_tokens,
+            custom_mask=tree_mask,
+            positions=position,
+            retrive_index=retrive_index,
+            retrive_next_token=retrive_next_token,
+            retrive_next_sibling=retrive_next_sibling,
+            retrive_cum_len=None,
+            spec_steps=self.speculative_num_steps,
+            topk=self.topk,
+            draft_token_num=self.server_args.speculative_num_draft_tokens,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            seq_lens_sum=forward_batch.seq_lens_sum,
+            seq_lens_cpu=forward_batch.seq_lens_cpu,
+        )
+
+        # Before verification, we need to concatenate some states to ensure the length
+        # of the context window passed equals the number of MTP heads + 1. (for cuda graph)
+        # If the number of generated tokens is insufficient, pad the beginning with
+        # ids, hidden states, and cache locations from the previous stage.
+        split_hiddens = torch.split(input_hidden_states, seq_lens, dim=0)
+        split_verify_ids = torch.split(forward_batch.input_ids, seq_lens, dim=0)
+        batch_size = len(split_hiddens)
+        hidden_dim = split_hiddens[0].shape[1]
+        size = self.server_args.speculative_num_draft_tokens
+        ret.pre_hiddens = torch.empty(
+            batch_size * size,
+            hidden_dim,
+            dtype=split_hiddens[0].dtype,
+            device=split_hiddens[0].device,
+        )
+        ret.pre_verify_ids = torch.empty(
+            batch_size * size,
+            dtype=split_verify_ids[0].dtype,
+            device=split_verify_ids[0].device,
+        )
+        for i, (hidden, verify_ids) in enumerate(zip(split_hiddens, split_verify_ids)):
+            start_idx = i * size
+            end_idx = start_idx + size
+
+            for tensor_data, output_tensor in [
+                (hidden, ret.pre_hiddens),
+                (verify_ids, ret.pre_verify_ids),
+            ]:
+                last_four = (
+                    tensor_data[-size:] if tensor_data.shape[0] >= size else tensor_data
+                )
+                if last_four.shape[0] == size:
+                    output_tensor[start_idx:end_idx] = last_four
+                else:
+                    actual_len = last_four.shape[0]
+                    output_tensor[start_idx : start_idx + actual_len] = last_four
+                    output_tensor[start_idx + actual_len : end_idx].zero_()
+        ret.pre_out_locs = batch.spec_info.pre_out_locs
+        ret.last_hidden_states = batch.spec_info.last_hidden_states
+        batch.spec_info = ret
+        return logits_output
+
+
+def load_token_map(token_map_path: str) -> torch.Tensor:
+    """Load token map from file or Hugging Face hub.
+
+    Args:
+        token_map_path: Path to the token map file.
+
+    Returns:
+        Token map as a tensor.
+    """
+    if not os.path.exists(token_map_path):
+        cache_dir = snapshot_download(
+            os.path.dirname(token_map_path),
+            ignore_patterns=["*.bin", "*.safetensors"],
+        )
+        token_map_path = os.path.join(cache_dir, os.path.basename(token_map_path))
+    hot_token_id = torch.load(token_map_path, weights_only=True)
+    return torch.tensor(hot_token_id, dtype=torch.int32)


### PR DESCRIPTION
Introduce the first version of Multi-Head MTP (MHMTP) worker to enable speculative decoding with multi-layer MTP models.

Evaluated on our in-house 3-layer MTP model, MHMTP achieves:
- ~15% inference throughput improvement compared to single-layer MTP
- Higher token acceptance rate through multi-layer draft coordination

For a comprehensive understanding of the design, please see the detailed specification at  [#11002](https://github.com/sgl-project/sglang/issues/11002) . 
The implementation has been thoroughly tested and demonstrates good performance on our internal 3-layer MTP model.

## Motivation

Experiments demonstrate that training multi-layer MTP achieves higher token acceptance rates 
compared to single-layer MTP, thereby enabling greater throughput gains. We now support this 
capability on SGLang and seek additional open-source multi-layer MTP models for adaptation 
and refinement.

## Benchmarking and Profiling

Performance evaluation is conducted using sglang.bench_serving, comparing MHMTP 
against EAGLE on our model:

**Token Acceptance Rate:**
| Dataset | MHMTP | EAGLE | Improvement |
|---------|-------|-------|-------------|
| ShareGPT_V3 (input 4096  output 2048) | 3.9 | 3.4 | +14.7% |
| Proprietary dataset | 2.0 | 1.6 | +25.0% |

**Throughput Improvement**: 10-15% in production deployment

The current implementation has several optimization opportunities and eliminable 
bottlenecks, leaving substantial room for further performance enhancement.

## Server Launch Command

```bash
python -m sglang.launch_server \
    --model-path xxx \
    --chunked-prefill-size -1 \
    --tp 4 \
    --trust-remote-code \
    --speculative-algorithm MHMTP \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --speculative-draft-model-path xxx \
    --mem-fraction 0.6 \
    --skip-server-warmup \
    --disable-radix-cache \
    --max-running-requests 16 \
    --cuda-graph-max-bs 16
```
## Checklist

**MHMTP requires a multi-layer MTP model with the following specifications**
- **Minimum**: 3 MTP layers
- **Recommended**: 3 layers (performance validated)
- **Extended**: >3 layers (code compatible, performance untested)

**Implement Multi-Head MTP in Model File**
   - File location: `models/xxx_nextn.py`
   - Add multi-layer MTP head definitions
   - Implement forward pass for all MTP layers

**Some speculative draft model weights are co-located with the main model.**
- ✅ Weights automatically loaded from main model checkpoint
- ✅ No additional flag needed
- ❌ Do NOT provide --speculative-draft-model-path

**If you encounter OOM errors**
```python
python -m sglang.launch_server \
    --model-path <model> \
    --mem-fraction 0.6
``` 
- ⚠️ Note: Memory management is still being optimized.

**DO NOT disable CUDA Graph (--disable-cudagraph)**
- ❌ Non-CUDA Graph path: Poor performance, currently non-functional
- ✅ CUDA Graph path: Required and recommended
- 😷 Working on fixing the non-CUDA Graph code path.

## Authors / Contributors
- @Qing-zy
- @yinan1995 
- @xsank 
- @attack204
- @Denji-kk

## Todo
- [ ] DP support
- [ ] Radix cache, page-size > 1 and chunk prefill
- [ ] PD separate
- [ ] TopK > 1
- [ ] Other attention backend
- ...
