### PR TITLE
[WIP]Receive requests in a separate Scheduler thread

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2254,7 +2254,7 @@ class Scheduler(
                 while True:
                     try:
                         self.recv_queue.get_nowait()
-                    except:  # queue.Empty
+                    except queue.Empty:  # queue.Empty
                         break
 
             self.num_generated_tokens = 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1069,9 +1069,13 @@ class Scheduler(
                     recv_rpc = self.recv_from_rpc.recv_pyobj()
                     self.recv_queue.put(recv_rpc)
 
+            except zmq.ZMQError as e:
+                if self.recv_thread_running:
+                    logger.error(f"ZMQError in recv thread: {e}", exc_info=True)
+                break
             except Exception as e:
                 if self.recv_thread_running:  # Only log if not intentionally stopped
-                    logger.error(f"Error in recv thread: {e}")
+                    logger.error(f"Unhandled error in recv thread: {e}", exc_info=True)
                 break
 
     def recv_requests(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1098,7 +1098,7 @@ class Scheduler(
                     try:
                         recv_req = self.recv_queue.get_nowait()
                         recv_reqs.append(recv_req)
-                    except:  # queue.Empty
+                    except queue.Empty:  # queue.Empty
                         break
             else:
                 recv_reqs = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

When transmitting larger multimodal data and handling numerous requests, the Scheduler will spend more time receiving requests. By using a separate thread to handle data reception, the main thread of the Scheduler does not need to handle all the requests at once. Also like what was mentioned in https://github.com/sgl-project/sglang/issues/6189

In specific scenarios, we can achieve a 4% to 5% improvement in throughput and TTFT/E2E latency

<img width="1892" height="761" alt="image" src="https://github.com/user-attachments/assets/623078bd-fe53-4cec-b690-0689e75276b0" />


## Modifications

Use a separate thread to handle request reception in the Scheduler.

## Accuracy Tests

`python3 -m sglang.test.few_shot_gsm8k --num-questions 200`

> Accuracy: 0.910
Invalid: 0.000
Latency: 35.407 s
Output throughput: 829.346 token/s

## Benchmarking and Profiling

|  | Before | After | Performance gain |
| --- | --- | --- | --- |
| Request throughput (req/s) | 3.86 | 4.04 |**+4.7%**|
| P99 TTFT (ms) | 24407.08 | 23275.55 |**-4.6%** |
| P99 ITL (ms) | 880.34 | 875.64 |-0.6% |
| Mean E2E Latency (ms) | 24109.25 | 23202.49 |-3.8%|

Launch server command on NVIDIA 5090

`python3 -m sglang.launch_server --model-path Qwen/Qwen3-VL-4B-Instruct-FP8 --enable-multimodal --cuda-graph-max-bs 128 --context-length 2560 --page-size 16 --stream-interval 300 --mem-fraction-static 0.7 --port 30260 --base-gpu-id 0 --disable-radix-cache --mm-attention-backend sdpa --kv-cache-dtype fp8_e4m3`

Launch client commend

`python3 -m sglang.bench_serving --backend sglang --dataset-name image --model Qwen/Qwen3-VL-4B-Instruct-FP8 --port 30260 --random-input-len 100 --random-output-len 20 --image-count 1 --image-resolution 1200x1200 --num-prompts 96 --request-rate inf --max-concurrency 128 --random-range-ratio 1`

Before

> ============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     96
Benchmark duration (s):                  24.86
Total input tokens:                      149781
Total input text tokens:                 10965
Total input vision tokens:               138816
Total generated tokens:                  1920
Total generated tokens (retokenized):    1913
Request throughput (req/s):              3.86
Input token throughput (tok/s):          6025.07
Output token throughput (tok/s):         77.23
Total token throughput (tok/s):          6102.31
Concurrency:                             93.10
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   24109.25
Median E2E Latency (ms):                 24676.35
---------------Time to First Token----------------
Mean TTFT (ms):                          16298.84
Median TTFT (ms):                        16341.09
P99 TTFT (ms):                           24407.08
---------------Inter-Token Latency----------------
Mean ITL (ms):                           415.40
Median ITL (ms):                         413.84
P95 ITL (ms):                            836.74
P99 ITL (ms):                            880.34
Max ITL (ms):                            880.36
==================================================

After

> ============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 128
Successful requests:                     96
Benchmark duration (s):                  23.76
Total input tokens:                      149624
Total input text tokens:                 10808
Total input vision tokens:               138816
Total generated tokens:                  1920
Total generated tokens (retokenized):    1920
Request throughput (req/s):              4.04
Input token throughput (tok/s):          6297.53
Output token throughput (tok/s):         80.81
Total token throughput (tok/s):          6378.34
Concurrency:                             93.75
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   23202.49
Median E2E Latency (ms):                 23566.99
---------------Time to First Token----------------
Mean TTFT (ms):                          15375.16
Median TTFT (ms):                        15518.77
P99 TTFT (ms):                           23275.55
---------------Inter-Token Latency----------------
Mean ITL (ms):                           411.96
Median ITL (ms):                         411.09
P95 ITL (ms):                            799.90
P99 ITL (ms):                            875.64
Max ITL (ms):                            896.44
==================================================

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
