### PR TITLE
[apply][2/2] Fused qk_norm_rope for Qwen3-MoE

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -18,10 +18,13 @@
 """Inference-only Qwen3MoE model compatible with HuggingFace weights."""
 
 import logging
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import torch
+import transformers
 from torch import nn
+from transformers import PretrainedConfig
 
 from sglang.srt.distributed import (
     get_moe_expert_parallel_world_size,
@@ -73,6 +76,8 @@ from sglang.srt.utils import (
     is_npu,
 )
 
+TConfig = TypeVar("TConfig", bound=transformers.PretrainedConfig)
+
 Qwen3MoeConfig = None
 
 _is_flashinfer_available = is_flashinfer_available()
@@ -83,6 +88,121 @@ _is_npu = is_npu()
 
 if _is_npu:
     from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import split_qkv_rmsnorm_rope
+
+if _is_cuda:
+    from sgl_kernel import fused_qk_norm_rope
+
+
+def compute_yarn_parameters(
+    config: PretrainedConfig,
+) -> tuple[float, float, float, float]:
+    """
+    Refer to https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_rope_utils.py#L197C1-L288C1
+    Computes the inverse frequencies with NTK scaling. Please refer to the
+    [original paper](https://huggingface.co/papers/2309.00071)
+    Args:
+        config ([`~transformers.PretrainedConfig`]):
+            The model configuration.
+    Returns:
+        factor: float, the scaling factor for the RoPE embeddings
+        low: float, the lower bound of the dimension range
+        high: float, the upper bound of the dimension range
+        attention_factor: float, the post-processing scaling factor applied to the computed cos/sin
+    """
+
+    # The config does not contain rope_scaling, which means the model is not using yarn
+    rope_scaling = getattr(config, "rope_scaling", None)
+    if rope_scaling is None:
+        return 1.0, 0, 0, 1.0
+
+    base = config.rope_theta
+    partial_rotary_factor = (
+        config.partial_rotary_factor
+        if hasattr(config, "partial_rotary_factor")
+        else 1.0
+    )
+    head_dim = getattr(
+        config, "head_dim", config.hidden_size // config.num_attention_heads
+    )
+    dim = int(head_dim * partial_rotary_factor)
+    factor = getattr(rope_scaling, "factor", 1.0)
+    attention_factor = rope_scaling.get("attention_factor")
+    mscale = rope_scaling.get("mscale")
+    mscale_all_dim = rope_scaling.get("mscale_all_dim")
+
+    if "original_max_position_embeddings" in rope_scaling:
+        original_max_position_embeddings = rope_scaling[
+            "original_max_position_embeddings"
+        ]
+        factor = config.max_position_embeddings / original_max_position_embeddings
+    else:
+        original_max_position_embeddings = config.max_position_embeddings
+
+    def get_mscale(scale, mscale=1):
+        if scale <= 1:
+            return 1.0
+        return 0.1 * mscale * math.log(scale) + 1.0
+
+    # Sets the attention factor as suggested in the paper
+    if attention_factor is None:
+        if mscale and mscale_all_dim:
+            attention_factor = float(
+                get_mscale(factor, mscale) / get_mscale(factor, mscale_all_dim)
+            )
+        else:
+            attention_factor = get_mscale(factor)
+
+    # Optional config options
+    # beta_fast/beta_slow: as suggested in the paper, default to 32/1 (correspondingly)
+    beta_fast = rope_scaling.get("beta_fast") or 32
+    beta_slow = rope_scaling.get("beta_slow") or 1
+
+    # Compute the inverse frequencies
+    def find_correction_dim(num_rotations, dim, base, max_position_embeddings):
+        """Inverse dimension formula to find the dimension based on the number of rotations"""
+        return (
+            dim * math.log(max_position_embeddings / (num_rotations * 2 * math.pi))
+        ) / (2 * math.log(base))
+
+    def find_correction_range(
+        low_rot, high_rot, dim, base, max_position_embeddings, truncate
+    ):
+        """Find dimension range bounds based on rotations"""
+        low = find_correction_dim(low_rot, dim, base, max_position_embeddings)
+        high = find_correction_dim(high_rot, dim, base, max_position_embeddings)
+        if truncate:
+            low = math.floor(low)
+            high = math.ceil(high)
+        return max(low, 0), min(high, dim - 1)
+
+    truncate = rope_scaling.get("truncate", True)
+    low, high = find_correction_range(
+        beta_fast, beta_slow, dim, base, original_max_position_embeddings, truncate
+    )
+
+    # These parts are implemented in the fusedQKNormRopeKernel.cu
+    # # def linear_ramp_factor(min, max, dim):
+    # #     if min == max:
+    # #         max += 0.001  # Prevent singularity
+
+    # #     linear_func = (torch.arange(dim, dtype=torch.float32) - min) / (max - min)
+    # #     ramp_func = torch.clamp(linear_func, 0, 1)
+    # #     return ramp_func
+
+    # # Note on variable naming: "interpolation" comes from the original technique, where we interpolate the position IDs
+    # # to expand the possible context length. In other words, interpolation = apply scaling factor.
+    # # pos_freqs = base ** (torch.arange(0, dim, 2).to(device=device, dtype=torch.float) / dim)
+    # # inv_freq_extrapolation = 1.0 / pos_freqs
+    # # inv_freq_interpolation = 1.0 / (factor * pos_freqs)
+
+    # # # Get n-dimensional rotational scaling corrected for extrapolation
+    # # inv_freq_extrapolation_factor = 1 - linear_ramp_factor(low, high, dim // 2).to(device=device, dtype=torch.float)
+    # # inv_freq = (
+    # #     inv_freq_interpolation * (1 - inv_freq_extrapolation_factor)
+    # #     + inv_freq_extrapolation * inv_freq_extrapolation_factor
+    # # )
+    # # return inv_freq, attention_factor
+    return factor, low, high, attention_factor
 
 
 class Qwen3MoeSparseMoeBlock(nn.Module):
@@ -286,6 +406,7 @@ class Qwen3MoeAttention(nn.Module):
         head_dim: Optional[int] = None,
         rms_norm_eps: float = 1e-06,
         attention_bias: bool = False,
+        config: Optional[TConfig] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         dual_chunk_attention_config: Optional[dict[str, Any]] = None,
@@ -352,6 +473,9 @@ class Qwen3MoeAttention(nn.Module):
         self.compatible_with_fused_kv_buffer = (
             False if isinstance(self.rotary_emb, MRotaryEmbedding) else True
         )
+        self.compatible_with_fused_qk_norm_rope = (
+            False if isinstance(self.rotary_emb, MRotaryEmbedding) else True
+        )
 
         self.attn = RadixAttention(
             self.num_heads,
@@ -379,6 +503,9 @@ class Qwen3MoeAttention(nn.Module):
                 k_by_head = k.reshape(-1, self.head_dim)
                 k_by_head = self.k_norm(k_by_head)
             current_stream.wait_stream(self.alt_stream)
+            q = q_by_head.view(q.shape)
+            k = k_by_head.view(k.shape)
+            return q, k
         else:
             q_by_head = q.reshape(-1, self.head_dim)
             q_by_head = self.q_norm(q_by_head)
@@ -433,26 +560,53 @@ class Qwen3MoeAttention(nn.Module):
         forward_batch: ForwardBatch,
     ):
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self._apply_qk_norm(q, k)
-        q, k = self.rotary_emb(
-            positions,
-            q,
-            k,
-            fused_set_kv_buffer_arg=(
-                create_fused_set_kv_buffer_arg(
-                    value=v,
-                    layer=self.attn,
-                    forward_batch=forward_batch,
-                )
-                if enable_fused_set_kv_buffer(forward_batch)
-                and self.compatible_with_fused_kv_buffer
-                else None
-            ),
-        )
+
+        q, k, v = self.apply_qk_norm_rope(qkv, positions, forward_batch)
 
         inner_state = q, k, v, forward_batch
         return None, forward_batch, inner_state
+
+    def apply_qk_norm_rope(self, qkv, positions, forward_batch):
+        if self.use_fused_qk_norm_rope:
+            factor, low, high, attention_factor = compute_yarn_parameters(self.config)
+            fused_qk_norm_rope(
+                qkv,
+                self.num_heads,
+                self.num_kv_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.q_norm.variance_epsilon,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                self.rotary_emb.cos_sin_cache,
+                self.rotary_emb.is_neox_style,
+                positions.view(-1),
+                factor,
+                low,
+                high,
+                attention_factor,
+            )
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            # Fallback to non-fused QK Norm & RoPE implementation
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            q, k = self._apply_qk_norm(q, k)
+            q, k = self.rotary_emb(
+                positions,
+                q,
+                k,
+                fused_set_kv_buffer_arg=(
+                    create_fused_set_kv_buffer_arg(
+                        value=v,
+                        layer=self.attn,
+                        forward_batch=forward_batch,
+                    )
+                    if enable_fused_set_kv_buffer(forward_batch)
+                    and self.compatible_with_fused_kv_buffer
+                    else None
+                ),
+            )
+        return q, k, v
 
     def forward_prepare(
         self,
@@ -543,6 +697,7 @@ class Qwen3MoeDecoderLayer(nn.Module):
             head_dim=head_dim,
             rms_norm_eps=rms_norm_eps,
             attention_bias=attention_bias,
+            config=config,
             quant_config=quant_config,
             prefix=add_prefix("self_attn", prefix),
             dual_chunk_attention_config=dual_chunk_attention_config,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -542,6 +542,7 @@ class ServerArgs:
     enable_attn_tp_input_scattered: bool = False
     # Context parallelism used in the long sequence prefill phase of DeepSeek v3.2
     enable_nsa_prefill_context_parallel: bool = False
+    enable_fused_qk_norm_rope: bool = False
 
     # Dynamic batch tokenizer
     enable_dynamic_batch_tokenizer: bool = False
@@ -3737,6 +3738,11 @@ class ServerArgs:
             "--enable-nsa-prefill-context-parallel",
             action="store_true",
             help="Enable context parallelism used in the long sequence prefill phase of DeepSeek v3.2.",
+        )
+        parser.add_argument(
+            "--enable-fused-qk-norm-rope",
+            action="store_true",
+            help="Enable fused qk normalization and rope rotary embedding.",
         )
 
         # Dynamic batch tokenizer


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
 Qwen3-MoE qk_norm and rope ops account for a non-trivial proportion in model inference. See below:
<img width="2315" height="1154" alt="image" src="https://github.com/user-attachments/assets/efd9141d-c712-452d-b43a-bf70ed289a90" />
Take Qwen3-30B-A3B for example, it has 48 Decode Layers. Each layer runs qk_norm and rope embedding ops. So this kernel enhancement can be amplified in linear along with the scale of the model layers.
<img width="2072" height="1091" alt="image" src="https://github.com/user-attachments/assets/d5a5473f-39b9-43ae-b547-c28af9257c9a" />

This PR is to fuse qk_norm and rope into one kernel so as to improve performance. 

Note:
- [x] - sgl-kernel PR: https://github.com/sgl-project/sglang/pull/14036
- [x] - apply srt PR: this PR. 

## Modifications

<!-- Detail the changes made in this pull request. -->
1. Add CUDA kernel for the fusion.
2. Revise Qwen3-MoE model to adapt for the new kernel.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
```
Without PR:
server:
python3 -m sglang.launch_server --model Qwen/Qwen3-30B-A3B --tp-size 4 --port 30000 --attention-backend flashinfer

gsm8k client result:
➜  sglang_dev git:(fused_qk_norm_rope) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30010
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:10<00:00, 18.62it/s]
Accuracy: 0.730
Invalid: 0.000
Latency: 10.876 s
Output throughput: 5015.168 token/s

With PR:
server:
python3 -m sglang.launch_server --model Qwen/Qwen3-30B-A3B --tp-size 4 --port 30000 --attention-backend flashinfer --enable-fused-qk-norm-rope

gsm8k client:
➜  sglang_dev git:(fused_qk_norm_rope) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30010
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:09<00:00, 21.31it/s]
Accuracy: 0.740
Invalid: 0.000
Latency: 9.483 s
Output throughput: 5529.482 token/s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Test Qwen3-235B-A22B on 8xH20.
TTFT: 6.0% drop    from 990.23ms to 935.69ms

Server:
```
python3 -m sglang.launch_server --model /home/admin/Qwen3-235B-A22B \
  --tp-size 8 --port 30000 --attention-backend flashinfer \
  --disable-radix-cache \
  # --enable-fused-qk-norm-rope
```

Benchmark client:
```
python3 -m sglang.bench_serving --backend sglang \
  --num-prompts 500 --dataset-name random \
  --random-input 500 --random-output 100 \
  --port 30000 --random-range-ratio 1.0 \
  --max-concurrency 32 \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json
```

```
PR:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     500       
Benchmark duration (s):                  55.29     
Total input tokens:                      250000    
Total input text tokens:                 250000    
Total input vision tokens:               0         
Total generated tokens:                  50000     
Total generated tokens (retokenized):    50000     
Request throughput (req/s):              9.04      
Input token throughput (tok/s):          4521.59   
Output token throughput (tok/s):         904.32    
Peak output token throughput (tok/s):    1344.00   
Peak concurrent requests:                64        
Total token throughput (tok/s):          5425.91   
Concurrency:                             31.34     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3465.24   
Median E2E Latency (ms):                 3470.12   
---------------Time to First Token----------------
Mean TTFT (ms):                          935.69    
Median TTFT (ms):                        903.84    
P99 TTFT (ms):                           1580.97   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.55     
Median TPOT (ms):                        25.73     
P99 TPOT (ms):                           31.25     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.55     
Median ITL (ms):                         24.20     
P95 ITL (ms):                            25.02     
P99 ITL (ms):                            28.21     
Max ITL (ms):                            1129.26   
==================================================

Main:
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     500       
Benchmark duration (s):                  55.69     
Total input tokens:                      250000    
Total input text tokens:                 250000    
Total input vision tokens:               0         
Total generated tokens:                  50000     
Total generated tokens (retokenized):    50000     
Request throughput (req/s):              8.98      
Input token throughput (tok/s):          4488.99   
Output token throughput (tok/s):         897.80    
Peak output token throughput (tok/s):    1376.00   
Peak concurrent requests:                64        
Total token throughput (tok/s):          5386.78   
Concurrency:                             31.35     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3491.58   
Median E2E Latency (ms):                 3452.26   
---------------Time to First Token----------------
Mean TTFT (ms):                          990.23    
Median TTFT (ms):                        994.89    
P99 TTFT (ms):                           1672.83   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.27     
Median TPOT (ms):                        25.39     
P99 TPOT (ms):                           31.14     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.27     
Median ITL (ms):                         23.83     
P95 ITL (ms):                            24.61     
P99 ITL (ms):                            27.60     
Max ITL (ms):                            1163.50   
==================================================
```


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
