### PR TITLE
feat: Add Zigzag Static Expert Load Balancing Placement Strategy for MoE Models

### DIFF
--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -114,7 +114,8 @@ class ExpertLocationMetadata:
     @staticmethod
     def init_round_robin(server_args: ServerArgs, model_config: ModelConfig):
         """Implements a static round-robin expert placement strategy.
-        Logical experts are distributed across physical experts in a round-robin fashion."""
+        Logical experts are distributed across physical experts in a round-robin fashion.
+        """
 
         common = ExpertLocationMetadata._init_common(server_args, model_config)
 
@@ -135,10 +136,11 @@ class ExpertLocationMetadata:
                 for i in range(ep_size)
                 for j in range(num_local_physical_experts)
             ]
+
             rr_physical_to_logical_map = (
-            ]
-            rr_physical_to_logical_map = (
-                torch.tensor(rr_list, dtype=torch.int32).repeat(num_layers, 1)
+                torch.tensor(
+                    physical_expert_indices_ordered_by_ep_group, dtype=torch.int32
+                ).repeat(num_layers, 1)
                 % num_logical_experts
             )
             return rr_physical_to_logical_map

--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -113,8 +113,8 @@ class ExpertLocationMetadata:
 
     @staticmethod
     def init_round_robin(server_args: ServerArgs, model_config: ModelConfig):
-        """round_robin location - logical expert i corresponds to physical expert i"""
-        """but have static round robin expert placement stragey"""
+        """Implements a static round-robin expert placement strategy.
+        Logical experts are distributed across physical experts in a round-robin fashion."""
 
         common = ExpertLocationMetadata._init_common(server_args, model_config)
 
@@ -130,10 +130,12 @@ class ExpertLocationMetadata:
         num_local_physical_experts = num_physical_experts // ep_size
 
         def _round_robin_placement():
-            rr_list = [
+            physical_expert_indices_ordered_by_ep_group = [
                 i + j * ep_size
                 for i in range(ep_size)
                 for j in range(num_local_physical_experts)
+            ]
+            rr_physical_to_logical_map = (
             ]
             rr_physical_to_logical_map = (
                 torch.tensor(rr_list, dtype=torch.int32).repeat(num_layers, 1)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -415,7 +415,7 @@ class ServerArgs:
     deepep_mode: Literal["auto", "normal", "low_latency"] = "auto"
     ep_num_redundant_experts: int = 0
     ep_dispatch_algorithm: Optional[Literal["static", "dynamic", "fake"]] = None
-    init_expert_location: str = "trivial"
+    init_expert_location: Optional[Literal["trivial", "round_robin"]] = "trivial"
     enable_eplb: bool = False
     eplb_algorithm: str = "auto"
     eplb_rebalance_num_iterations: int = 1000

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -415,7 +415,7 @@ class ServerArgs:
     deepep_mode: Literal["auto", "normal", "low_latency"] = "auto"
     ep_num_redundant_experts: int = 0
     ep_dispatch_algorithm: Optional[Literal["static", "dynamic", "fake"]] = None
-    init_expert_location: Optional[Literal["trivial", "round_robin"]] = "trivial"
+    init_expert_location: Literal["trivial", "round_robin"] = "trivial"
     enable_eplb: bool = False
     eplb_algorithm: str = "auto"
     eplb_rebalance_num_iterations: int = 1000


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->
## Description:
This PR introduces a novel static expert load balancing placement strategy, called Zigzag, specifically designed for Mixture-of-Experts (MoE) models with multiple expert groups (such as the DeepSeek series) within SGLang. The strategy optimizes the distribution of experts across available devices (e.g., GPUs in a tensor-parallel setup) by implementing a staggered placement pattern. This aims to achieve better load balancing across expert parallel groups, which is particularly beneficial for models using grouped top-k routing, where experts are organized into logical groups and routing decisions are made within these groups 

## Motivation
Through analysis of multi-expert-group MoE models like DeepSeek, it was observed that experts within the same group tend to be selected together during inference. Concentrating these related experts on the same device can lead to load imbalance. The Zigzag strategy addresses this by intentionally distributing experts from the same logical group across different physical devices. This ensures that when the routing mechanism selects multiple experts from the same group, the computational load is naturally distributed, preventing individual devices from becoming bottlenecks and improving overall system throughput 

## Additional Notes:
Compatibility: This implementation is currently validated for MoE models with grouped experts, like DeepSeek. Its effectiveness may vary based on the model's specific expert routing architecture.
Future Work: As SGLang's deterministic inference support expands to include MoE models 
, the interaction between deterministic sampling and expert placement can be further explored. Optimizing the strategy for different parallel configurations (e.g., larger tensor parallelism sizes) is also a potential area for future improvement.
Reference: This implementation is inspired by the concept and results demonstrated in the corresponding vLLM PR #23745
## Modifications

Add Zigzag Static Expert Load Balancing Placement Strategy for MoE Models

## Accuracy Tests

Dataset	Accuracy Baseline	     Accuracy (zigzag-MR)
Gpqa	             68.18%                           68.18%
GSM8K                 95%                                94.84%


## Benchmarking and Profiling

Test Platform:

SGLang version: sgl-project/sglang:v0.5.5.post3
Model: DeepSeek-R1-FP8
GPU: H20(144G) x 8
Parallel config 1: tp=8, ep=8
Benchmark config: input_len=1024, output_len=128, request_rate=8, max_concurrency=8, num_prompts=32:

Service config:
```
python3 -m sglang.launch_server \
    --trust-remote-code \
    --init-expert-location round_robin \
    --cuda-graph-max-bs 12 \
    --cuda-graph-bs 1 2 3 4 5 6 7 8 9 10 11 12 \
    --disable-custom-all-reduce \
    --disable-radix-cache \
    --ep-size 8 \
    --moe-a2a-backend deepep \
    --model-path ${MODEL_PATH} \
    --port 30000 \
    --mem-fraction-static 0.87 \
    --tp-size 8  \
    --trust-remote-code \
    --host 0.0.0.0
```
Benchmark config:
```
python3 -m sglang.bench_serving \
    --backend sglang \
    --dataset-name random \
    --model ${MODEL_PATH} \
    --random-input-len 1024 \
    --random-output-len 128 \
    --random-range-ratio 0.5 \
    --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json \
    --request-rate 8 \
    --max-concurrency 8 \
    --num-prompts 32 \
    --base-url http://127.0.0.1:30000 \
    --port 30001
```
ep_zigzag.log
<img width="663" height="863" alt="image" src="https://github.com/user-attachments/assets/c8dd5a3c-d222-4cd0-b39d-c33b7eb48bc7" />
default_ep.log
<img width="744" height="877" alt="image" src="https://github.com/user-attachments/assets/506b4997-5559-44e5-a9cf-be97b82f0db7" />

Conclusion: With only expert parallelism enabled, Zigzag improves throughput and end-to-end latency by approximately 2%.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
