### PR TITLE
Revert "Fix nightly test failures: NSA indexer dtype and CPP radix cache init"

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -169,10 +169,9 @@ class Indexer(CustomOp):
 
     @torch.compile(dynamic=True)
     def _get_logits_head_gate(self, x: torch.Tensor, q_scale: torch.Tensor):
-        # Keep x in original dtype (bfloat16) for projection, then convert to float32
-        weights, _ = self.weights_proj(x)
-        weights = weights.float() * self.n_heads**-0.5
-        weights = weights.unsqueeze(-1) * q_scale.float() * self.softmax_scale
+        weights, _ = self.weights_proj(x.float())
+        weights = weights * self.n_heads**-0.5
+        weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
 
     def _get_q_k_bf16(

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -45,8 +45,8 @@ class RadixCacheCpp(BasePrefixCache):
         self.write_through_threshold = (
             1 if server_args.hicache_write_policy == "write_through" else 2
         )
-        self.token_to_kv_pool_allocator = params.token_to_kv_pool_allocator
         self.device = self.token_to_kv_pool_allocator.device
+        self.token_to_kv_pool_allocator = params.token_to_kv_pool_allocator
         self.req_to_token_pool = params.req_to_token_pool
         self.page_size = params.page_size
         self.kv_cache = self.token_to_kv_pool_allocator.get_kvcache()


### PR DESCRIPTION
Reverts sgl-project/sglang#13958

This change caused dpsk v32 to break
https://github.com/sgl-project/sglang/actions/runs/19694975166/job/56476095353?pr=13151

@alisonshao  Please only change the tensor data types in the failing nightly test.
