### PR TITLE
[model-gateway] Fix flaky test_circuit_breaker_half_open_failure_reopens

### DIFF
--- a/sgl-router/py_test/integration_mock/test_circuit_breaker.py
+++ b/sgl-router/py_test/integration_mock/test_circuit_breaker.py
@@ -86,6 +86,19 @@ def test_circuit_breaker_half_open_failure_reopens(router_manager, mock_workers)
             timeout=3,
         )
 
+    # should see 500 when worker actually starts, before that should see 503
+    saw_500 = False
+    for _ in range(8):
+        r = post_once()
+        if r.status_code == 500:
+            # Worker starts, continue to circuit breaker test
+            saw_500 = True
+            break
+        assert (
+            r.status_code == 503
+        ), "Should only see 503 when waiting for worker to start"
+    assert saw_500, "Worker didn't start after 8 requests"
+
     opened = False
     for _ in range(8):
         r = post_once()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Fix flaky test_circuit_breaker_half_open_failure_reopens

## Modifications

Add waiting for worker to start in test_circuit_breaker_half_open_failure_reopens

Run 500 times

<img width="498" height="315" alt="Screenshot 2025-11-26 at 12 26 21 PM" src="https://github.com/user-attachments/assets/99126727-f21b-4fcf-b681-a6b691225533" />

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
