### PR TITLE
Temporarily disable test_update_weights_from_disk.py in CI

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -53,7 +53,7 @@ suites = {
         TestFile("quant/test_w8a8_quantization.py", 160),
         TestFile("quant/test_autoround.py", 60),
         TestFile("rl/test_fp32_lm_head.py", 30),
-        TestFile("rl/test_update_weights_from_disk.py", 210),
+        # TestFile("rl/test_update_weights_from_disk.py", 210),  # Temporarily disabled, see https://github.com/sgl-project/sglang/pull/13998
         TestFile("rl/test_update_weights_from_tensor.py", 80),
         TestFile("test_abort.py", 190),
         TestFile("test_build_eagle_tree.py", 8),
@@ -201,6 +201,9 @@ suites = {
     # Nightly test suites have been moved to test/run_suite_nightly.py
     "__not_in_ci__": [
         TestFile("models/test_dummy_grok_models.py"),
+        TestFile(
+            "rl/test_update_weights_from_disk.py"
+        ),  # Temporarily disabled, see https://github.com/sgl-project/sglang/pull/13998
         TestFile("test_bench_one_batch.py"),
         TestFile("test_bench_serving.py"),
         TestFile("test_eval_accuracy_large.py"),
@@ -247,7 +250,7 @@ suite_amd = {
         TestFile("quant/test_awq_dequant.py", 2),
         TestFile("quant/test_block_int8.py", 22),
         TestFile("quant/test_fused_rms_fp8_group_quant.py", 10),
-        TestFile("rl/test_update_weights_from_disk.py", 210),
+        # TestFile("rl/test_update_weights_from_disk.py", 210),  # Temporarily disabled, see https://github.com/sgl-project/sglang/pull/13998
         TestFile("test_abort.py", 51),
         TestFile("test_bench_typebaseddispatcher.py", 10),
         TestFile("test_chunked_prefill.py", 410),


### PR DESCRIPTION
## Summary
- Temporarily disables `test_update_weights_from_disk.py` from the `per-commit-1-gpu` and `per-commit-amd` test suites
- Recent changes may have caused issues with this test (see [failing CI run](https://github.com/sgl-project/sglang/actions/runs/19709205149/job/56481198350?pr=13998))

## Test plan
- [ ] CI should pass without running this test
- [ ] Re-enable test once the underlying issue is fixed