### PR TITLE
Add adapter_model.safetensors to corruption validation for LoRA

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -393,7 +393,8 @@ def find_local_hf_snapshot_dir(
         for f in local_weight_files:
             base_name = os.path.basename(f)
             # Check if this is a single model file (not sharded)
-            if base_name in ["model.safetensors", "pytorch_model.safetensors"]:
+            # Include adapter_model.safetensors for LoRA adapters
+            if base_name in ["model.safetensors", "pytorch_model.safetensors", "adapter_model.safetensors"]:
                 if not _validate_safetensors_file(f):
                     logger.info(
                         "Corrupted model file %s for %s. "

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -394,7 +394,11 @@ def find_local_hf_snapshot_dir(
             base_name = os.path.basename(f)
             # Check if this is a single model file (not sharded)
             # Include adapter_model.safetensors for LoRA adapters
-            if base_name in ["model.safetensors", "pytorch_model.safetensors", "adapter_model.safetensors"]:
+            if base_name in [
+                "model.safetensors",
+                "pytorch_model.safetensors",
+                "adapter_model.safetensors",
+            ]:
                 if not _validate_safetensors_file(f):
                     logger.info(
                         "Corrupted model file %s for %s. "


### PR DESCRIPTION
## Summary
- Add `adapter_model.safetensors` to the list of files validated for corruption in CI

The existing safetensors corruption detection added in #13729 only validates `model.safetensors` and `pytorch_model.safetensors`, but LoRA adapters use `adapter_model.safetensors`. This causes CI failures when cached LoRA adapter files are corrupted.

Error seen in CI:
```
RuntimeError: Failed to load LoRA adapter philschmid/code-llama-3-1-8b-text-to-sql-lora: Error while deserializing header: invalid JSON in header: EOF while parsing a value at line 1 column 0
```

## Test plan
- CI should now detect and clean up corrupted LoRA adapter files