### PR TITLE
Fix flashinfer cutlass MoE output shape for non-FP4-packed inputs

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1654,11 +1654,15 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
 
             output_dtype = torch.bfloat16
 
+            # If x_sf is not None, x is FP4 packed (half size), so we need * 2
+            # If x_sf is None, x is not packed, so output_col = x.shape[1]
+            output_col = x.shape[1] * 2 if x_sf is not None else x.shape[1]
+
             with use_symmetric_memory(
                 get_tp_group(), disabled=not is_allocation_symmetric()
             ):
                 symm_output = torch.empty(
-                    x.shape[0], x.shape[1] * 2, dtype=output_dtype, device=x.device
+                    x.shape[0], output_col, dtype=output_dtype, device=x.device
                 )
 
             output = flashinfer_cutlass_fused_moe(


### PR DESCRIPTION
## Summary

Fixes `nightly-test-perf-4-gpu-b200` failure caused by `ValueError: Invalid shape of output: expected (512, 7168), got torch.Size([512, 14336])` when starting DeepSeek-V3-FP4 with flashinfer_cutlass MoE backend.

## Root Cause

PR #13327 introduced a regression in `ModelOptNvFp4FusedMoEMethod.apply()` when refactoring the MoE dispatcher implementation. The output tensor allocation was changed from:

```python
symm_output = torch.empty(x.shape[0], original_col, ...)
```

to:

```python
symm_output = torch.empty(x.shape[0], x.shape[1] * 2, ...)
```

The `* 2` multiplier was intended for when `x` is FP4-packed (where each byte holds 2 FP4 values, so `x.shape[1]` is half the original hidden_size). However, when `should_use_flashinfer_cutlass_moe_fp4_allgather()` returns False (as in the failing test with `--tp 4 --ep 4`), the hidden_states are NOT FP4-packed and already have the full `hidden_size`. This caused the output to be allocated with double the expected size (7168 * 2 = 14336 instead of 7168).

## Fix

The output size is now conditional based on whether `x_sf` (hidden_states_scale) is provided:
- When `x_sf is not None`: hidden_states are FP4-packed, use `x.shape[1] * 2`
- When `x_sf is None`: hidden_states are not packed, use `x.shape[1]`

## Test plan

- [x] Syntax check passes
- [ ] `nightly-test-perf-4-gpu-b200` should pass with this fix