### PR TITLE
[model-gateway] hacky env to enforce ignore-eos

### DIFF
--- a/sgl-router/src/protocols/chat.rs
+++ b/sgl-router/src/protocols/chat.rs
@@ -6,8 +6,8 @@ use validator::Validate;
 
 use super::{
     common::{
-        default_model, default_true, validate_stop, ChatLogProbs, ContentPart, Function,
-        FunctionCall, FunctionChoice, GenerationRequest, ResponseFormat, StreamOptions,
+        default_ignore_eos, default_model, default_true, validate_stop, ChatLogProbs, ContentPart,
+        Function, FunctionCall, FunctionChoice, GenerationRequest, ResponseFormat, StreamOptions,
         StringOrArray, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolChoiceValue, ToolReference,
         Usage,
     },
@@ -261,8 +261,9 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     pub no_stop_trim: bool,
 
-    /// Ignore end-of-sequence tokens during generation
-    #[serde(default)]
+    /// Ignore end-of-sequence tokens during generation.
+    /// Can be forced to true by setting SGLANG_FORCE_IGNORE_EOS=1 environment variable.
+    #[serde(default = "default_ignore_eos")]
     pub ignore_eos: bool,
 
     /// Continue generating from final assistant message

--- a/sgl-router/src/protocols/completion.rs
+++ b/sgl-router/src/protocols/completion.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use super::common::*;
+use super::common::{
+    default_ignore_eos, default_true, GenerationRequest, LogProbs, StreamOptions, StringOrArray,
+    Usage,
+};
 
 // ============================================================================
 // Completions API (v1/completions) - DEPRECATED but still supported
@@ -118,8 +121,9 @@ pub struct CompletionRequest {
     #[serde(default)]
     pub no_stop_trim: bool,
 
-    /// Ignore end-of-sequence tokens during generation
-    #[serde(default)]
+    /// Ignore end-of-sequence tokens during generation.
+    /// Can be forced to true by setting SGLANG_FORCE_IGNORE_EOS=1 environment variable.
+    #[serde(default = "default_ignore_eos")]
     pub ignore_eos: bool,
 
     /// Skip special tokens during detokenization

--- a/sgl-router/src/protocols/sampling_params.rs
+++ b/sgl-router/src/protocols/sampling_params.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
-use super::common::StringOrArray;
+use super::common::{default_ignore_eos_option, StringOrArray};
 
 /// Sampling parameters for text generation
 #[derive(Debug, Clone, Deserialize, Serialize, Default, Validate)]
@@ -34,7 +34,12 @@ pub struct SamplingParams {
     pub repetition_penalty: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<StringOrArray>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Ignore end-of-sequence tokens during generation.
+    /// Can be forced to true by setting SGLANG_FORCE_IGNORE_EOS=1 environment variable.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default = "default_ignore_eos_option"
+    )]
     pub ignore_eos: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_special_tokens: Option<bool>,


### PR DESCRIPTION
add a hacky env var to force ignore-eos for benchmark

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
