### PR TITLE
Support configuring the request limit per receiving poll

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -30,6 +30,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGL_CHUNKED_PREFIX_CACHE_THRESHOLD` | Sets the threshold for enabling chunked prefix caching | `8192` |
 | `SGLANG_FUSED_MLA_ENABLE_ROPE_FUSION` | Enable RoPE fusion in Fused Multi-Layer Attention | `1` |
 | `SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP` | Disable overlap schedule for consecutive prefill batches | `false` |
+| `SGLANG_SCHEDULER_MAX_RECV_PER_POLL` | Set the maximum number of requests per poll, with a negative value indicating no limit | `-1` |
 | `SGLANG_DISABLE_FA4_WARMUP` | Disable Flash Attention 4 warmup passes (set to `1`, `true`, `yes`, or `on` to disable) | `false` |
 | `SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_DEFAULT` | Default weight value for scheduler recv skipper counter (used when forward mode doesn't match specific modes). Only active when `--scheduler-recv-interval > 1`. The counter accumulates weights and triggers request polling when reaching the interval threshold. | `1000` |
 | `SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_DECODE` | Weight increment for decode forward mode in scheduler recv skipper. Works with `--scheduler-recv-interval` to control polling frequency during decode phase. | `1` |

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -178,6 +178,7 @@ class Envs:
     # Scheduler: others:
     SGLANG_EMPTY_CACHE_INTERVAL = EnvFloat(-1)  # in seconds. Set if you observe high memory accumulation over a long serving period.
     SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP = EnvBool(False)
+    SGLANG_SCHEDULER_MAX_RECV_PER_POLL = EnvInt(-1)
     SGLANG_EXPERIMENTAL_CPP_RADIX_TREE = EnvBool(False)
 
     # Test: pd-disaggregation

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1048,9 +1048,9 @@ class Scheduler(
                 self.self_check_during_busy()
 
     def recv_limit_reached(self, num_recv_reqs: int) -> bool:
-        if self.max_recv_per_poll < 0 or num_recv_reqs < self.max_recv_per_poll:
+        if self.max_recv_per_poll < 0:
             return False
-        return True
+        return num_recv_reqs >= self.max_recv_per_poll
 
     def recv_requests(
         self,


### PR DESCRIPTION
Co-authored-by:: Feng Su <sufeng@linux.alibaba.com>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In offline inference scenarios, when processing continuous multimodal perfill requests, the launch of the next batch will be blocked by the request reception, preventing overlapping. Since chunked perfill may only handle a small number of requests at a time, receiving too many requests at once will extend the blocking time. Adjusting the number of requests can help avoid excessive blocking. Also like what was mentioned in https://github.com/sgl-project/sglang/issues/6189

<img width="1508" height="754" alt="image" src="https://github.com/user-attachments/assets/b46e66ed-b8df-43b9-b596-3b371bacd96b" />


## Modifications

Add an environment variable to adjust the number of requests received each time.

## Accuracy Tests

`python3 -m sglang.test.few_shot_gsm8k --num-questions 200`

without patch

> Accuracy: 0.910
Invalid: 0.000
Latency: 34.452 s
Output throughput: 844.600 token/s

with SGLANG_SCHEDULER_MAX_RECV_PER_POLL=1

> Accuracy: 0.910
Invalid: 0.000
Latency: 34.414 s
Output throughput: 845.272 token/s

## Benchmarking and Profiling

|  | Before | Limit=1 | Performance gain |
| --- | --- | --- | --- |
| Request throughput (req/s) | 6.50 | 7.21 |**+10.9%**|
| P99 TTFT (ms) | 23163.05 | 21314.10 |**-8%** |
| P99 ITL (ms) | 14950.17 | 12981.17 |**-13.1%** |
| Mean E2E Latency (ms) | 35092.79 | 31335.18 |**-10.7%**|

launch server command on Nvidia 5090

`python3 -m sglang.launch_server 
    --model-path Qwen/Qwen3-VL-4B-Instruct-FP8 
    --enable-multimodal 
    --cuda-graph-max-bs 128 
    --context-length 2560 
    --page-size 16 
    --stream-interval 300 
    --mem-fraction-static 0.7 
    --port 30260 
    --base-gpu-id 3 
    --mm-attention-backend sdpa 
    --kv-cache-dtype fp8_e4m3 
    --disable-radix-cache 
    --enable-metrics`

launch client command

`vllm bench serve 
        --port 30260
        --backend openai-chat
        --model Qwen/Qwen3-VL-4B-Instruct-FP8 --trust-remote-code 
        --percentile-metrics ttft,tpot,itl,e2el 
        --num-prompts 1024
        --dataset-name random-mm 
        --random-mm-base-items-per-request 1 
        --random-mm-num-mm-items-range-ratio 0 
        --random-mm-bucket-config '{(1280, 720, 1): 1.0}' 
        --request-rate inf 
        --random-prefix-len 500 
        --random-input-len 600 
        --random-output-len 20 
        --endpoint /v1/chat/completions 
        --max-concurrency 128 `

without patch

> ============ Serving Benchmark Result ============
Successful requests:                     1024
Maximum request concurrency:             128
Benchmark duration (s):                  157.50
Total input tokens:                      1125763
Total generated tokens:                  20480
Request throughput (req/s):              6.50
Output token throughput (tok/s):         130.03
Peak output token throughput (tok/s):    232.00
Peak concurrent requests:                238.00
Total Token throughput (tok/s):          7277.86
---------------Time to First Token----------------
Mean TTFT (ms):                          12010.84
Median TTFT (ms):                        11553.04
P99 TTFT (ms):                           23163.05
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          378.41
Median TPOT (ms):                        377.12
P99 TPOT (ms):                           876.33
---------------Inter-token Latency----------------
Mean ITL (ms):                           2396.62
Median ITL (ms):                         0.01
P99 ITL (ms):                            14950.17
----------------End-to-end Latency----------------
Mean E2EL (ms):                          19200.69
Median E2EL (ms):                        16787.21
P99 E2EL (ms):                           35092.79
==================================================

with patch

> ============ Serving Benchmark Result ============
Successful requests:                     1024
Maximum request concurrency:             128
Benchmark duration (s):                  142.07
Total input tokens:                      1125903
Total generated tokens:                  20480
Request throughput (req/s):              7.21
Output token throughput (tok/s):         144.16
Peak output token throughput (tok/s):    226.00
Peak concurrent requests:                239.00
Total Token throughput (tok/s):          8069.40
---------------Time to First Token----------------
Mean TTFT (ms):                          10368.31
Median TTFT (ms):                        9485.29
P99 TTFT (ms):                           21314.10
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          363.68
Median TPOT (ms):                        402.88
P99 TPOT (ms):                           767.39
---------------Inter-token Latency----------------
Mean ITL (ms):                           2303.28
Median ITL (ms):                         0.01
P99 ITL (ms):                            12981.17
----------------End-to-end Latency----------------
Mean E2EL (ms):                          17278.16
Median E2EL (ms):                        15147.70
P99 E2EL (ms):                           31335.18
==================================================

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
