### PR TITLE
fix: small changes to enable test_mrope.py

### DIFF
--- a/test/srt/rotary_embedding/test_mrope.py
+++ b/test/srt/rotary_embedding/test_mrope.py
@@ -7,6 +7,7 @@ from transformers import AutoConfig
 from transformers import __version__ as TRANSFORMERS_VERSION
 
 from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
@@ -85,6 +86,8 @@ def test_mrope(
     dtype: torch.dtype,
     num_tokens: int,
 ):
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
     atol = model_info.atol
     rtol = model_info.rtol
 
@@ -124,7 +127,7 @@ def test_mrope(
         num_tokens, num_heads, num_kv_heads, head_dim, max_position, dtype, device
     )
 
-    query_native, key_native = mrope_helper_class.forward_native(
+    query_native, key_native = mrope_helper_class._forward_native(
         positions,
         query.clone(),
         key.clone(),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Currently `test_mrope.py` is broken. There are two issues: one related to server args, and one related to using `forward_native` and not `_forward_native`

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Add dummy server args and change the test back to `_forward_native`.  The original pr (https://github.com/sgl-project/sglang/pull/11859) used `forward_native` but in a follow-up pr this was changed to `_forward_native`: https://github.com/sgl-project/sglang/pull/11859

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
