### PR TITLE
Add RL and Training Framework Integrations documentation

### DIFF
--- a/docs/references/RL and Training Framework Integrations
+++ b/docs/references/RL and Training Framework Integrations
@@ -1,0 +1,228 @@
+# RL and Training Framework Integrations
+
+SGLang integrates with popular RL and training frameworks for efficient fine-tuning and alignment.
+
+> **📘 Looking for detailed integration guides?** Some frameworks provide dedicated SGLang integration documentation (like [Unsloth's guide](https://docs.unsloth.ai/basics/inference-and-deployment/sglang-guide)). Check each framework's documentation for detailed setup instructions. Framework maintainers: we welcome contributions of dedicated integration guides!
+
+---
+
+## MILES
+
+**GitHub**: https://github.com/radixark/miles  
+**Blog**: https://lmsys.org/blog/2025-11-19-miles/
+
+MILES is an enterprise-facing reinforcement learning framework for large-scale MoE post-training. Born from slime, MILES focuses on new hardware support (GB200+), stable RL for large MoE models, and production-grade features.
+
+### Key Features
+- **SGLang-native**: Built for high-performance training with SGLang rollout backend
+- **Deterministic training**: Zero mismatch between training and inference
+- **Speculative training**: 25%+ rollout speedup with online draft model training
+- **Production-ready**: Graceful OOM handling, memory optimization, FSDP improvements
+
+### Integration with SGLang
+
+MILES natively integrates SGLang for the rollout subsystem. All SGLang server arguments can be passed with the `--sglang-` prefix:
+
+```bash
+# Example: Launch MILES training with SGLang
+python train.py \
+  --tensor-model-parallel-size 2 \
+  --sglang-mem-fraction-static 0.85 \
+  --sglang-port 30000
+```
+
+Arguments like `--mem-fraction-static`, `--tp`, `--max-running-requests` become `--sglang-mem-fraction-static`, `--sglang-tp`, etc.
+
+**Resources**: [Quick Start Guide](https://github.com/radixark/miles/blob/main/docs/en/get_started/quickstart.md) | [Examples](https://github.com/radixark/miles/tree/main/examples)
+
+---
+
+## Slime
+
+**GitHub**: https://github.com/THUDM/slime  
+**Blog**: https://lmsys.org/blog/2025-07-09-slime/
+
+Slime is an LLM post-training framework for RL scaling that connects Megatron with SGLang. Used for training GLM-4.5.
+
+### Key Features
+- **High-performance training**: Efficient training via Megatron + SGLang
+- **Flexible data generation**: Custom data generation workflows
+- **SGLang-native rollout**: Fast inference during RL training
+
+### Integration with SGLang
+
+Slime integrates SGLang for the rollout engine. Pass SGLang arguments with `--sglang-` prefix:
+
+```bash
+# Example: Launch slime training with SGLang
+python train.py \
+  --tensor-model-parallel-size 4 \
+  --sglang-mem-fraction-static 0.8 \
+  --sglang-port 30000
+```
+
+**Resources**: [Quick Start Guide](https://github.com/THUDM/slime/blob/main/docs/en/get_started/quickstart.md) | [Examples](https://github.com/THUDM/slime/tree/main/examples)
+
+---
+
+## VERL
+
+**GitHub**: https://github.com/volcengine/verl  
+**Documentation**: https://verl.readthedocs.io
+
+VERL (Volcano Engine Reinforcement Learning) is a full-stack RLHF framework supporting PPO, GRPO, and ReMax algorithms. Designed for production-scale training with seamless integration of existing LLM frameworks.
+
+### Key Features
+- **Flexible RL algorithms**: PPO, GRPO, ReMax, and more
+- **Modular design**: Easy integration with SGLang, Megatron-LM, FSDP
+- **Production-ready**: Used for training models like Seed-Thinking-v1.5
+
+### Integration with SGLang
+
+VERL supports SGLang as a rollout backend. Install with:
+
+```bash
+# Install VERL with SGLang support
+git clone https://github.com/volcengine/verl.git
+cd verl
+pip install -e .[sglang]
+```
+
+Configure your training script to use SGLang for inference during rollout generation.
+
+**Resources**: [Installation Guide](https://verl.readthedocs.io/en/latest/start/install.html) | [Examples](https://github.com/volcengine/verl/tree/main/examples)
+
+---
+
+## AReaL
+
+**GitHub**: https://github.com/inclusionAI/AReaL  
+**Paper**: https://arxiv.org/abs/2505.24298
+
+AReaL is a fully asynchronous RL system that decouples generation from training. Achieves up to 2.77x training speedup with state-of-the-art results on math and code reasoning.
+
+### Key Features
+- **Fully asynchronous**: Continuous generation without waiting for training
+- **SGLang backend**: Uses SGLang v0.4.0+ for efficient rollout generation
+- **High performance**: 2.77x speedup vs synchronous systems
+
+### Integration with SGLang
+
+AReaL v0.2.0+ uses SGLang as the generation backend, leveraging RadixAttention for improved throughput:
+
+```python
+# AReaL automatically uses SGLang for rollout generation
+# Configure in your training script
+python -m areal.launcher.local \
+  examples/math/gsm8k_grpo.py \
+  --config examples/math/gsm8k_grpo.yaml
+```
+
+**Resources**: [Quick Start](https://github.com/inclusionAI/AReaL#quick-start) | [Blog](https://github.com/inclusionAI/AReaL/blob/main/blog/AReaL_v0_2.md)
+
+---
+
+## OpenRLHF
+
+**GitHub**: https://github.com/OpenRLHF/OpenRLHF  
+**Paper**: https://arxiv.org/abs/2405.11143
+
+OpenRLHF is an easy-to-use, scalable RLHF framework built on Ray and HuggingFace Transformers. Supports PPO, DPO, GRPO, and REINFORCE++.
+
+### Key Features
+- **Ray-based distributed training**: Efficient distributed scheduling
+- **Multiple algorithms**: PPO, DPO, GRPO, REINFORCE++, KTO
+- **Easy to use**: Seamless integration with HuggingFace models
+
+### Integration with SGLang
+
+OpenRLHF can use SGLang for accelerated generation during RLHF training. Launch SGLang server and configure OpenRLHF to use it as the inference backend:
+
+```bash
+# 1. Launch SGLang server
+python -m sglang.launch_server \
+  --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
+  --port 30000
+
+# 2. Configure OpenRLHF to use SGLang endpoint
+# (See OpenRLHF documentation for configuration details)
+```
+
+**Resources**: [Documentation](https://github.com/OpenRLHF/OpenRLHF#getting-started) | [Examples](https://github.com/OpenRLHF/OpenRLHF/tree/main/examples)
+
+---
+
+## Unsloth
+
+**GitHub**: https://github.com/unslothai/unsloth  
+**SGLang Deployment Guide**: https://docs.unsloth.ai/basics/inference-and-deployment/sglang-guide
+
+Unsloth provides 2x faster fine-tuning with reduced memory usage through optimized kernels. Supports LoRA, QLoRA, and full fine-tuning.
+
+### Deploy with SGLang
+
+Train models with Unsloth, then deploy with SGLang. See the [official Unsloth SGLang Guide](https://docs.unsloth.ai/basics/inference-and-deployment/sglang-guide) for detailed instructions.
+
+```python
+# 1. Train with Unsloth
+from unsloth import FastLanguageModel
+model, tokenizer = FastLanguageModel.from_pretrained(
+    model_name="meta-llama/Meta-Llama-3.1-8B-Instruct",
+    max_seq_length=2048,
+)
+# ... training code ...
+model.save_pretrained("output_model")
+```
+
+```bash
+# 2. Deploy with SGLang
+python -m sglang.launch_server --model-path output_model
+```
+
+---
+
+## LLaMAFactory
+
+**GitHub**: https://github.com/hiyouga/LLaMA-Factory
+
+Unified framework for training 100+ LLMs with various fine-tuning methods including LoRA, QLoRA, full tuning, and more.
+
+### Deploy with SGLang
+
+```bash
+# 1. Train with LLaMAFactory
+llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
+
+# 2. Deploy with SGLang
+python -m sglang.launch_server --model-path path/to/trained/model
+```
+
+---
+
+## General Integration Pattern
+
+Most training frameworks can integrate with SGLang by:
+
+1. **Launch SGLang server** for inference:
+```bash
+python -m sglang.launch_server \
+  --model-path <your-model> \
+  --port 30000 \
+  --tp <num-gpus>
+```
+
+2. **Configure framework** to use `http://localhost:30000` as the inference endpoint
+
+3. **For native integrations** (MILES, slime, VERL, AReaL): Use framework-specific configuration to enable SGLang
+
+---
+
+## Resources
+
+- **SGLang Documentation**: https://docs.sglang.ai
+- **SGLang GitHub**: https://github.com/sgl-project/sglang
+- **SGLang Discord**: https://discord.gg/sglang
+
+---
+
+**Need help?** Check each framework's documentation or ask in the SGLang community channels.


### PR DESCRIPTION
## Add RL and Training Framework Integrations Documentation

This PR adds documentation for integrating SGLang with popular RL and training frameworks.

### Frameworks Covered:
- **MILES** - Enterprise RL framework (SGLang-native)
- **Slime** - Post-training framework used for GLM-4.5 (SGLang-native)
- **VERL** - Full-stack RLHF framework
- **AReaL** - Asynchronous RL system
- **OpenRLHF** - Ray-based RLHF framework
- **Unsloth** - Fast fine-tuning
- **LLaMAFactory** - Unified LLM training

### What's Included:
- Overview of each framework's SGLang integration
- Quick start examples
- Links to official documentation
- General integration pattern for other frameworks

### Location:
`/docs/references/rl_training_integrations.md`

### Testing:
- [x] All main GitHub links verified
- [ ] Subdirectory links tested (need community help)
- [ ] OpenRLHF integration confirmed (need verification)

### Follow-up Work:
Community can contribute:
1. Detailed integration guides (like Unsloth's example)
2. Performance benchmarks
3. Additional frameworks
