### PR TITLE
[VLM] Boost Memory Pool based CUDA IPC

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -23,6 +23,7 @@ from sglang.srt.utils import (
 )
 from sglang.srt.utils.cuda_ipc_transport_utils import (
     MM_FEATURE_CACHE_SIZE,
+    MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
     CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
 )
@@ -227,7 +228,7 @@ class BaseMultimodalProcessor(ABC):
         if SGL_USE_CUDA_IPC:
             self.cudaipc_mmfeature_pool = MmItemMemoryPool(
                 MM_FEATURE_CACHE_SIZE,
-                self.server_args.mm_item_memory_pool_recycle_interval,
+                MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
             )
 
     def process_mm_data(

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -225,7 +225,10 @@ class BaseMultimodalProcessor(ABC):
         ]
 
         if SGL_USE_CUDA_IPC:
-            self.cudaipc_mmfeature_pool = MmItemMemoryPool(MM_FEATURE_CACHE_SIZE)
+            self.cudaipc_mmfeature_pool = MmItemMemoryPool(
+                MM_FEATURE_CACHE_SIZE,
+                self.server_args.mm_item_memory_pool_recycle_interval,
+            )
 
     def process_mm_data(
         self, input_text, images=None, videos=None, audios=None, **kwargs

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -579,7 +579,6 @@ class ServerArgs:
     # For Multi-Modal
     mm_max_concurrent_calls: int = 32
     mm_per_request_timeout: float = 10.0
-    mm_item_memory_pool_recycle_interval: float = 0.05
     enable_broadcast_mm_inputs_process: bool = False
 
     # For checkpoint decryption
@@ -3859,12 +3858,6 @@ class ServerArgs:
             type=int,
             default=ServerArgs.mm_per_request_timeout,
             help="The timeout for each multi-modal request in seconds.",
-        )
-        parser.add_argument(
-            "--mm-item-memory-pool-recycle-interval",
-            type=float,
-            default=ServerArgs.mm_item_memory_pool_recycle_interval,
-            help="The interval to recycle mm item in memory pool in seconds.",
         )
         parser.add_argument(
             "--enable-broadcast-mm-inputs-process",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -579,6 +579,7 @@ class ServerArgs:
     # For Multi-Modal
     mm_max_concurrent_calls: int = 32
     mm_per_request_timeout: float = 10.0
+    mm_item_memory_pool_recycle_interval: float = 0.05
     enable_broadcast_mm_inputs_process: bool = False
 
     # For checkpoint decryption
@@ -3858,6 +3859,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.mm_per_request_timeout,
             help="The timeout for each multi-modal request in seconds.",
+        )
+        parser.add_argument(
+            "--mm-item-memory-pool-recycle-interval",
+            type=float,
+            default=ServerArgs.mm_item_memory_pool_recycle_interval,
+            help="The interval to recycle mm item in memory pool in seconds.",
         )
         parser.add_argument(
             "--enable-broadcast-mm-inputs-process",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -284,6 +284,17 @@ def get_int_env_var(name: str, default: int = 0) -> int:
         return default
 
 
+def get_float_env_var(name: str, default: float = 0.0) -> float:
+    # FIXME: move your environment variable to sglang.srt.environ
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
 def support_triton(backend: str) -> bool:
     return backend not in ["torch_native", "intel_amx"]
 

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -1,5 +1,7 @@
 import fcntl
 import logging
+import threading
+import time
 from multiprocessing import shared_memory
 from typing import Tuple
 
@@ -12,7 +14,7 @@ from sglang.srt.utils import get_int_env_var
 logger = logging.getLogger(__name__)
 
 MM_FEATURE_CACHE_SIZE = (
-    2 * 1024 * 1024 * 1024
+    4 * 1024 * 1024 * 1024
     if not get_int_env_var("SGLANG_MM_FEATURE_CACHE_MB")
     else get_int_env_var("SGLANG_MM_FEATURE_CACHE_MB") * 1024 * 1024
 )
@@ -57,20 +59,24 @@ class MmItemMemoryChunk:
     def try_to_recycle(self) -> bool:
         try:
             tp_num = get_global_server_args().tp_size
-        except:
+        except Exception:
             logger.info(
                 "get_global_server_args has not been inited , skip this turn 's recycle"
             )
-            tp_num = -1
-        if self.sync_flag.buffer_wrapper.item() == float(tp_num):
-            self.sync_flag.buffer_wrapper *= 0
+            return False
+
+        val = float(self.sync_flag.buffer_wrapper.item())
+        logger.debug(f"[try_to_recycle] area={self.area}, flag={val}, tp_size={tp_num}")
+
+        if val == float(tp_num):
+            self.sync_flag.buffer_wrapper *= 0.0
             return True
 
         return False
 
 
 class MmItemMemoryPool:
-    def __init__(self, memory_size):
+    def __init__(self, memory_size, recycle_interval: float = 0.05):
         self.memory_pool = torch.empty(
             memory_size, dtype=torch.int8, device="cuda"
         ).contiguous()
@@ -80,6 +86,38 @@ class MmItemMemoryPool:
         init_chunk = MmItemMemoryChunk((0, memory_size), self.pop_sync_buffer())
         self.available_chunks = [init_chunk]
         self.occupied_chunks = []
+
+        self._lock = threading.Lock()
+
+        self._recycle_interval = recycle_interval
+        self._stop_recycler = False
+        self._recycle_thread = threading.Thread(
+            target=self._recycle_loop, name="MmItemMemoryPoolRecycler", daemon=True
+        )
+        self._recycle_thread.start()
+
+        logger.debug(
+            f"[MmItemMemoryPool] init: memory_size={memory_size}, "
+            f"recycle_interval={self._recycle_interval}s"
+        )
+
+    def shutdown(self):
+        self._stop_recycler = True
+        if self._recycle_thread.is_alive():
+            self._recycle_thread.join(timeout=1.0)
+
+    def _recycle_loop(self):
+        while not self._stop_recycler:
+            try:
+                with self._lock:
+                    self.recycle_chunks()
+                    self.merge_chunks()
+            except Exception as e:
+                logger.warning(
+                    f"[MmItemMemoryPool] recycle loop error: {e}", exc_info=True
+                )
+
+            time.sleep(self._recycle_interval)
 
     def clear_sync_flag_list(self):
         # call each chunk's __del__
@@ -137,15 +175,13 @@ class MmItemMemoryPool:
         return None
 
     def return_a_slice_tensor_with_flag(self, src_tensor: torch.Tensor):
-        self.recycle_chunks()
-        self.merge_chunks()
-
-        available_chunk = self.get_available_chunk(src_tensor)
-        if available_chunk is not None:
-            return (
-                available_chunk.sync_flag.meta_data,
-                self.memory_pool[available_chunk.start : available_chunk.end],
-            )
+        with self._lock:
+            available_chunk = self.get_available_chunk(src_tensor)
+            if available_chunk is not None:
+                return (
+                    available_chunk.sync_flag.meta_data,
+                    self.memory_pool[available_chunk.start : available_chunk.end],
+                )
         return None, None
 
     def recycle_chunks(self):

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import get_int_env_var
+from sglang.srt.utils import get_float_env_var, get_int_env_var
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +17,12 @@ MM_FEATURE_CACHE_SIZE = (
     4 * 1024 * 1024 * 1024
     if not get_int_env_var("SGLANG_MM_FEATURE_CACHE_MB")
     else get_int_env_var("SGLANG_MM_FEATURE_CACHE_MB") * 1024 * 1024
+)
+
+MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL = (
+    0.05
+    if not get_float_env_var("SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC")
+    else get_float_env_var("SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC")
 )
 
 SHM_LOCK_FILE = "/tmp/shm_wr_lock.lock"
@@ -76,7 +82,7 @@ class MmItemMemoryChunk:
 
 
 class MmItemMemoryPool:
-    def __init__(self, memory_size, recycle_interval: float = 0.05):
+    def __init__(self, memory_size, recycle_interval):
         self.memory_pool = torch.empty(
             memory_size, dtype=torch.int8, device="cuda"
         ).contiguous()
@@ -98,7 +104,7 @@ class MmItemMemoryPool:
 
         logger.debug(
             f"[MmItemMemoryPool] init: memory_size={memory_size}, "
-            f"recycle_interval={self._recycle_interval}s"
+            f"recycle_interval={recycle_interval}s"
         )
 
     def shutdown(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
To address https://github.com/sgl-project/sglang/issues/13940
To speedup memory pool based CUDA IPC mechanism introduced in https://github.com/sgl-project/sglang/pull/11917.

During investigating issue #13940 we found that OOM occured in high traffic VLM when both conditions of SGLANG_USE_CUDA_IPC_TRANSPORT enabled and TP > 1 are fulfilled.

After digging into it, we found that instead of leaking GPU memory, the memory is held by MMItemMemoryPool and not recycled in time. In more specific, `try_to_recycle` always returns False.  For the current implementation, try_to_recycle is only invoked in process_and_combine_mm_data -> return_a_slice_tensor_with_flag -> recycle_chunks -> try_to_recycle. It is a point that newly-incoming request processed, in case the traffic is high, the try_to_recycle will be high possibility miss to recycle the chunk and allocate new chunk. 

The reason is due to high load, there can be TP-skew, naming some TP returns slower, some faster. The recycler, which needs to collect all the ref-cnt of the ranks, regards the data chunk is still in use, so it doesn't reuse the available chunk but acquires a new chunk. In consequence, the GPU consumption keeps increasing.

This PR is to introduce an independent recycle and merge chunk background thread in the MemoryPool, so as to harvest the available chunks in more efficient manner. The performance improved 10% comparing to baseline #11917.


Server:
```
$SGLANG_MM_FEATURE_CACHE_MB=4096 SGLANG_USE_CUDA_IPC_TRANSPORT=1 SGLANG_VLM_CACHE_SIZE_MB=512 python -m sglang.launch_server --model-path /home/admin/Qwen3-VL-8B-Instruct/ --host 0.0.0.0 --port 8188 --trust-remote-code --tp-size 2 --enable-cache-report --log-level info --max-running-requests 48 --mem-fraction-static 0.7 --chunked-prefill-size 8192  --attention-backend flashinfer --mm-attention-backend fa3 --log-level debug --log-requests --log-requests-level 1
```

Client:
```
$SGLANG_MM_FEATURE_CACHE_MB=4096 SGLANG_USE_CUDA_IPC_TRANSPORT=1 SGLANG_VLM_CACHE_SIZE_MB=512 python -m sglang.launch_server --model-path /home/admin/Qwen3-VL-8B-Instruct/ --host 0.0.0.0 --port 8188 --trust-remote-code --tp-size 2 --enable-cache-report --log-level info --max-running-requests 48 --mem-fraction-static 0.7 --chunked-prefill-size 8192  --attention-backend flashinfer --mm-attention-backend fa3 --log-level debug --log-requests --log-requests-level 1
```

Baseline:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 100       
Successful requests:                     100       
Benchmark duration (s):                  73.55     
Total input tokens:                      551796    
Total input text tokens:                 11396     
Total input vision tokens:               540400    
Total generated tokens:                  10000     
Total generated tokens (retokenized):    9381      
Request throughput (req/s):              1.36      
Input token throughput (tok/s):          7502.13   
Output token throughput (tok/s):         135.96    
Total token throughput (tok/s):          7638.09   
Concurrency:                             75.63     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   55626.50  
Median E2E Latency (ms):                 69387.46  
---------------Time to First Token----------------
Mean TTFT (ms):                          41101.45  
Median TTFT (ms):                        42196.12  
P99 TTFT (ms):                           71681.80  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          146.72    
Median TPOT (ms):                        143.76    
P99 TPOT (ms):                           345.20    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           154.05    
Median ITL (ms):                         14.64     
P95 ITL (ms):                            16.38     
P99 ITL (ms):                            224.18    
Max ITL (ms):                            33229.49  
==================================================
```

PR:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 100       
Successful requests:                     100       
Benchmark duration (s):                  66.99     
Total input tokens:                      551679    
Total input text tokens:                 11279     
Total input vision tokens:               540400    
Total generated tokens:                  10000     
Total generated tokens (retokenized):    9357      
Request throughput (req/s):              1.49      
Input token throughput (tok/s):          8235.44   
Output token throughput (tok/s):         149.28    
Total token throughput (tok/s):          8384.72   
Concurrency:                             73.21     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   49045.41  
Median E2E Latency (ms):                 62736.73  
---------------Time to First Token----------------
Mean TTFT (ms):                          35076.29  
Median TTFT (ms):                        35944.46  
P99 TTFT (ms):                           65012.49  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          141.10    
Median TPOT (ms):                        143.32    
P99 TPOT (ms):                           292.08    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           149.54    
Median ITL (ms):                         14.66     
P95 ITL (ms):                            28.18     
P99 ITL (ms):                            408.13    
Max ITL (ms):                            28165.59  
==================================================
```

**For concurrency = 10, speed-up 8x than legacy.**

TTFT 465.59ms vs 4222.62ms

```

$python3 -m sglang.bench_serving     --backend sglang-oai-chat     --dataset-name image     --num-prompts 100     --apply-chat-template     --random-output-len 100     --random-input-len 100     --image-resolution 1120x700     --image-format jpeg     --image-count 7     --image-content random     --random-range-ratio 1 --port 8188 --max-concurrency 10

PR:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 10        
Successful requests:                     100       
Benchmark duration (s):                  12.90     
Total input tokens:                      551721    
Total input text tokens:                 11321     
Total input vision tokens:               540400    
Total generated tokens:                  10000     
Total generated tokens (retokenized):    9328      
Request throughput (req/s):              7.75      
Input token throughput (tok/s):          42778.64  
Output token throughput (tok/s):         775.37    
Total token throughput (tok/s):          43554.00  
Concurrency:                             9.67      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1247.11   
Median E2E Latency (ms):                 1178.10   
---------------Time to First Token----------------
Mean TTFT (ms):                          465.59    
Median TTFT (ms):                        315.18    
P99 TTFT (ms):                           1183.91   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.89      
Median TPOT (ms):                        8.03      
P99 TPOT (ms):                           11.53     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           12.56     
Median ITL (ms):                         1.54      
P95 ITL (ms):                            94.47     
P99 ITL (ms):                            114.04    
Max ITL (ms):                            632.19    
==================================================

main:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 10        
Successful requests:                     100       
Benchmark duration (s):                  69.83     
Total input tokens:                      551724    
Total input text tokens:                 11324     
Total input vision tokens:               540400    
Total generated tokens:                  10000     
Total generated tokens (retokenized):    9244      
Request throughput (req/s):              1.43      
Input token throughput (tok/s):          7900.68   
Output token throughput (tok/s):         143.20    
Total token throughput (tok/s):          8043.87   
Concurrency:                             9.92      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6926.60   
Median E2E Latency (ms):                 6938.30   
---------------Time to First Token----------------
Mean TTFT (ms):                          4222.62   
Median TTFT (ms):                        4320.61   
P99 TTFT (ms):                           6328.97   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.31     
Median TPOT (ms):                        25.63     
P99 TPOT (ms):                           59.12     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           29.18     
Median ITL (ms):                         6.78      
P95 ITL (ms):                            13.48     
P99 ITL (ms):                            35.81     
Max ITL (ms):                            5269.30   
==================================================

``` 


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
