### PR TITLE
diffusion: Fix LoRA weight merging for torch.nn.Linear layers in diffusers modules

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -351,6 +351,46 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
         return B
 
 
+class LinearWithLoRA(BaseLayerWithLoRA):
+    """
+    Wrapper for standard torch.nn.Linear to support LoRA.
+    Unlike custom LinearBase classes, nn.Linear.forward() returns a single tensor,
+    not a tuple of (output, bias).
+    """
+
+    def __init__(
+        self,
+        base_layer: nn.Linear,
+        lora_rank: int | None = None,
+        lora_alpha: int | None = None,
+    ) -> None:
+        super().__init__(base_layer, lora_rank, lora_alpha)
+
+    @torch.compile()
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        lora_A = self.lora_A
+        lora_B = self.lora_B
+        if isinstance(self.lora_B, DTensor):
+            lora_B = self.lora_B.to_local()
+            lora_A = self.lora_A.to_local()
+
+        if not self.merged and not self.disable_lora:
+            lora_A_sliced = self.slice_lora_a_weights(lora_A.to(x, non_blocking=True))
+            lora_B_sliced = self.slice_lora_b_weights(lora_B.to(x, non_blocking=True))
+            delta = x @ lora_A_sliced.T @ lora_B_sliced.T
+            if self.lora_alpha != self.lora_rank:
+                delta = delta * (
+                    self.lora_alpha / self.lora_rank  # type: ignore
+                )  # type: ignore
+            # nn.Linear.forward() returns a single tensor, not a tuple
+            out = self.base_layer(x)
+            return out + delta
+        else:
+            # nn.Linear.forward() returns a single tensor
+            out = self.base_layer(x)
+            return out
+
+
 def wrap_with_lora_layer(
     layer: nn.Module,
     lora_rank: int | None = None,
@@ -359,7 +399,7 @@ def wrap_with_lora_layer(
     """
     transform the given layer to its corresponding LoRA layer
     """
-    supported_layer_types: dict[type[LinearBase], type[BaseLayerWithLoRA]] = {
+    supported_layer_types: dict[type[LinearBase] | type[nn.Linear], type[BaseLayerWithLoRA]] = {
         # the order matters
         # VocabParallelEmbedding: VocabParallelEmbeddingWithLoRA,
         QKVParallelLinear: QKVParallelLinearWithLoRA,
@@ -367,6 +407,7 @@ def wrap_with_lora_layer(
         ColumnParallelLinear: ColumnParallelLinearWithLoRA,
         RowParallelLinear: RowParallelLinearWithLoRA,
         ReplicatedLinear: BaseLayerWithLoRA,
+        nn.Linear: LinearWithLoRA, 
     }
     for src_layer_type, lora_layer_type in supported_layer_types.items():
         if isinstance(layer, src_layer_type):  # pylint: disable=unidiomatic-typecheck

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -410,7 +410,7 @@ def wrap_with_lora_layer(
         nn.Linear: LinearWithLoRA, 
     }
     for src_layer_type, lora_layer_type in supported_layer_types.items():
-        if isinstance(layer, src_layer_type):  # pylint: disable=unidiomatic-typecheck
+        if isinstance(layer, src_layer_type):
             ret = lora_layer_type(
                 layer,
                 lora_rank=lora_rank,

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -399,7 +399,9 @@ def wrap_with_lora_layer(
     """
     transform the given layer to its corresponding LoRA layer
     """
-    supported_layer_types: dict[type[LinearBase] | type[nn.Linear], type[BaseLayerWithLoRA]] = {
+    supported_layer_types: dict[
+        type[LinearBase] | type[nn.Linear], type[BaseLayerWithLoRA]
+    ] = {
         # the order matters
         # VocabParallelEmbedding: VocabParallelEmbeddingWithLoRA,
         QKVParallelLinear: QKVParallelLinearWithLoRA,
@@ -407,10 +409,10 @@ def wrap_with_lora_layer(
         ColumnParallelLinear: ColumnParallelLinearWithLoRA,
         RowParallelLinear: RowParallelLinearWithLoRA,
         ReplicatedLinear: BaseLayerWithLoRA,
-        nn.Linear: LinearWithLoRA, 
+        nn.Linear: LinearWithLoRA,
     }
     for src_layer_type, lora_layer_type in supported_layer_types.items():
-        if isinstance(layer, src_layer_type):
+        if isinstance(layer, src_layer_type):  # type: ignore[arg-type]
             ret = lora_layer_type(
                 layer,
                 lora_rank=lora_rank,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

The Flux and qwen-image models use components from the `diffusers` library that internally contain standard `torch.nn.Linear` layers. Specifically:
- `FeedForward` modules (e.g., `ff` and `ff_context` in `FluxTransformerBlock`, `img_mlp` and `txt_mlp` in `QwenImageTransformerBlock`) used for MLP layers
- `AdaLayerNormZero` and `AdaLayerNormContinuous` modules (e.g., `norm1` and `norm1_context` in `FluxTransformerBlock`, `norm_out` in qwen-image models) used for adaptive layer normalization
- Direct `nn.Linear` layers (e.g., `img_mod` and `txt_mod` in `QwenImageTransformerBlock`)

However, when loading LoRA weights, the `wrap_with_lora_layer` function only supported custom `LinearBase` subclasses (such as `ColumnParallelLinear`, `RowParallelLinear`, `ReplicatedLinear`, etc.) and did not handle standard `torch.nn.Linear` layers.

As a result, when converting model layers to LoRA layers during weight loading, the `torch.nn.Linear` layers within these `diffusers` components (e.g., MLP's `FeedForward` and normalization's `AdaLayerNormZero`/`AdaLayerNormContinuous`) as well as direct `nn.Linear` layers were not recognized and wrapped with LoRA support. This caused the LoRA weights for these layers to be skipped during the merge process, leading to degraded model performance when using LoRA adapters.

## Modifications

1. **Added `LinearWithLoRA` class** (`python/sglang/multimodal_gen/runtime/layers/lora/linear.py`):
   - Implemented a new LoRA wrapper class specifically for standard `torch.nn.Linear` layers
   - Unlike custom `LinearBase` classes that return tuples `(output, bias)`, `nn.Linear.forward()` returns a single tensor, so the forward method was adapted accordingly
   - The class inherits from `BaseLayerWithLoRA` and handles LoRA weight merging/unmerging for standard PyTorch linear layers

2. **Updated `wrap_with_lora_layer` function** (`python/sglang/multimodal_gen/runtime/layers/lora/linear.py`):
   - Added `nn.Linear: LinearWithLoRA` mapping to the `supported_layer_types` dictionary
   - This enables the function to recognize and wrap `torch.nn.Linear` layers with LoRA support
   - The mapping is placed at the end of the dictionary to ensure custom layer types are checked first

These changes ensure that all linear layers in the model, including those from `diffusers.FeedForward` and `AdaLayerNormZero`/`AdaLayerNormContinuous` modules, as well as direct `nn.Linear` layers, are properly wrapped with LoRA support, allowing LoRA weights to be correctly merged and applied during inference for both Flux and qwen-image models.

## Accuracy Tests
Use the flux lora `dvyio/flux-lora-simple-illustration` to test the performance. 
The prompt is "a bicycle, illustration in the style of SMPL, thick black lines on a white background".

The result with  no lora.
![no-lora|200](https://xsj-niehen.oss-cn-hangzhou.aliyuncs.com/Docs_assert/no-lora.jpg)
The result with  before fix.
![before_fix_lora](https://xsj-niehen.oss-cn-hangzhou.aliyuncs.com/Docs_assert/before_fix_lora.jpg)
The result with fix lora.
![before_fix_lora](https://xsj-niehen.oss-cn-hangzhou.aliyuncs.com/Docs_assert/with-fix-lora.jpg)


## Benchmarking and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
