### PR TITLE
EPLB: Improve d2d overhead

### DIFF
--- a/python/sglang/srt/eplb/expert_location.py
+++ b/python/sglang/srt/eplb/expert_location.py
@@ -274,12 +274,15 @@ class ExpertLocationMetadata:
             self_field = getattr(self, field)
             assert (other_field is not None) == (self_field is not None)
             if self_field is not None:
-                mask_update = torch.tensor(
-                    [i in update_layer_ids for i in range(self.num_layers)]
-                )
-                mask_update = mask_update.view(*([-1] + [1] * (self_field.dim() - 1)))
-                mask_update = mask_update.to(self_field.device, non_blocking=True)
-                self_field[...] = torch.where(mask_update, other_field, self_field)
+                if len(update_layer_ids) == 1:
+                    self_field[update_layer_ids] = other_field[update_layer_ids]
+                else:
+                    mask_update = torch.tensor(
+                        [i in update_layer_ids for i in range(self.num_layers)]
+                    )
+                    mask_update = mask_update.view(*([-1] + [1] * (self_field.dim() - 1)))
+                    mask_update = mask_update.to(self_field.device, non_blocking=True)
+                    self_field[...] = torch.where(mask_update, other_field, self_field)
 
     # -------------------------------- usage ------------------------------------
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -739,7 +739,7 @@ class DeepseekV2MoE(nn.Module):
 
     def get_moe_weights(self):
         return [
-            x.data
+            [i for i in x.data]
             for name, x in self.experts.named_parameters()
             if name not in ["correction_bias"]
         ]


### PR DESCRIPTION
## Motivation

In the EPLB scenario, expert relocation (D2D) incurs high overhead due to:

1. Temporary buffer allocation on each EPLB update;
2. Tensor copy operations (weight → buffer and buffer → weight) triggering repeated temporary tensor views;
3. Non-negligible update cost of `ExpertLocationMetadata`, especially in single-layer/forward cases (`eplb_rebalance_layers_per_chunk = 1`), where `mask_update` is more expensive than direct assignment: `self_field[update_layer_ids] = other_field[update_layer_ids]`.

---

## Modifications

1. **Optimize ExpertLocationMetadata updates**  
   - Single-layer updates use direct assignment  
   - Multi-layer updates retain the original mask_update logic

2. **D2D buffer reuse**  
   - Allocate tensor buffer on first EPLB update
   - Reuse buffer if size does not change for subsequent updates

3. **Tensor view optimization**  
   - Precompute view shapes when constructing buffer tensors and in `get_moe_weights` function  
   - Reuse views during relocation to reduce temporary tensor view calls

---

## Accuracy Tests
python3 -m sglang.test.few_shot_gsm8k --num-questions 1318 --max-new-tokens 2048 --port 6699 
100%|███████████████████████████████████████| 1318/1318 [17:59<00:00,  1.22it/s]
Accuracy: 0.961
Invalid: 0.000
Latency: 1079.904 s
Output throughput: 129.821 token/s


---

## Benchmarking and Profiling
**EPLB(Baseline)**
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1024      
Successful requests:                     2048      
Benchmark duration (s):                  359.73    
Total input tokens:                      3732131   
Total input text tokens:                 3732131   
Total input vision tokens:               0         
Total generated tokens:                  1584743   
Total generated tokens (retokenized):    1581078   
Request throughput (req/s):              5.69      
Input token throughput (tok/s):          10374.92  
Output token throughput (tok/s):         4405.41   
Total token throughput (tok/s):          14780.33  
Concurrency:                             740.90    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   130137.52 
Median E2E Latency (ms):                 129622.27 
---------------Time to First Token----------------
Mean TTFT (ms):                          57236.63  
Median TTFT (ms):                        50414.76  
P99 TTFT (ms):                           114534.85 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          92.41     
Median TPOT (ms):                        93.21     
P99 TPOT (ms):                           139.94    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           94.27     
Median ITL (ms):                         85.89     
P95 ITL (ms):                            122.27    
P99 ITL (ms):                            177.19    
Max ITL (ms):                            7508.37 


**EPLB(Optimized)**
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1024      
Successful requests:                     2048      
Benchmark duration (s):                  356.99    
Total input tokens:                      3732131   
Total input text tokens:                 3732131   
Total input vision tokens:               0         
Total generated tokens:                  1584743   
Total generated tokens (retokenized):    1580437   
Request throughput (req/s):              5.74      
Input token throughput (tok/s):          10454.30  
Output token throughput (tok/s):         4439.12   
Total token throughput (tok/s):          14893.42  
Concurrency:                             739.72    
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   128943.28 
Median E2E Latency (ms):                 129601.86 
---------------Time to First Token----------------
Mean TTFT (ms):                          57788.16  
Median TTFT (ms):                        51580.91  
P99 TTFT (ms):                           115523.41 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          90.32     
Median TPOT (ms):                        90.99     
P99 TPOT (ms):                           126.18    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           92.04     
Median ITL (ms):                         85.89     
P95 ITL (ms):                            102.42    
P99 ITL (ms):                            176.83    
Max ITL (ms):                            6468.25


\
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
