### PR TITLE
feat: add custom function tool support to v1/responses API

### DIFF
--- a/test/srt/openai_server/function_call/test_responses_function_calling.py
+++ b/test/srt/openai_server/function_call/test_responses_function_calling.py
@@ -1,0 +1,216 @@
+# ABOUTME: Tests for custom function tool support in v1/responses API.
+# ABOUTME: Validates tool calling, streaming, and tool_choice behavior.
+
+import json
+import unittest
+from typing import List
+
+import openai
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestResponsesFunctionCalling(CustomTestCase):
+    """Test function calling in v1/responses API."""
+
+    SYSTEM_MESSAGE = (
+        "You are a helpful assistant with tool calling capabilities. "
+        "When you need to use a tool, respond with a function call. "
+        'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}. '
+        "Do not use variables.\n\n"
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            api_key=cls.api_key,
+            other_args=[
+                "--tool-call-parser",
+                "llama3",
+            ],
+        )
+        cls.base_url += "/v1"
+        cls.client = openai.Client(api_key=cls.api_key, base_url=cls.base_url)
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def get_weather_tool(self) -> dict:
+        """Return a weather function tool definition."""
+        return {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"},
+                },
+                "required": ["location"],
+            },
+        }
+
+    def get_test_tools(self) -> List[dict]:
+        """Return list of test function tools."""
+        return [self.get_weather_tool()]
+
+    def test_function_tool_schema_validation(self):
+        """Test that function tool schema is accepted by the API."""
+        # This test validates the schema changes from Phase 1
+        tools = self.get_test_tools()
+
+        # Should not raise an error
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: Hello, how are you?",
+            tools=tools,
+            stream=False,
+        )
+
+        # Response should be valid
+        self.assertIsNotNone(response)
+        self.assertIsNotNone(response.id)
+        self.assertEqual(response.status, "completed")
+
+    def test_function_tool_non_streaming(self):
+        """Test basic function tool call in non-streaming mode."""
+        tools = self.get_test_tools()
+
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: What's the weather in Paris?",
+            tools=tools,
+            stream=False,
+        )
+
+        self.assertIsNotNone(response.output)
+        # The model should either produce a function call or a text response
+        # depending on model behavior - we just verify the response is valid
+        self.assertEqual(response.status, "completed")
+
+    def test_function_tool_streaming(self):
+        """Test function tool call in streaming mode."""
+        tools = self.get_test_tools()
+
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: What's the weather in Tokyo?",
+            tools=tools,
+            stream=True,
+        )
+
+        events_received = []
+        for event in response:
+            events_received.append(event)
+
+        # Should receive at least response.created and response.completed events
+        self.assertGreater(len(events_received), 0)
+
+    def test_tool_choice_none(self):
+        """Test tool_choice='none' prevents tool calls in output."""
+        tools = self.get_test_tools()
+
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: What's the weather in London?",
+            tools=tools,
+            tool_choice="none",
+            stream=False,
+        )
+
+        # With tool_choice="none", no function calls should be parsed
+        # (even if model outputs tool call syntax, it won't be parsed)
+        function_calls = [
+            item
+            for item in response.output
+            if getattr(item, "type", None) == "function_call"
+        ]
+        self.assertEqual(len(function_calls), 0)
+
+    def test_multiple_function_tools(self):
+        """Test with multiple function tools defined."""
+        tools = self.get_test_tools() + [
+            {
+                "type": "function",
+                "name": "get_time",
+                "description": "Get current time for a timezone",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "timezone": {"type": "string"},
+                    },
+                    "required": ["timezone"],
+                },
+            }
+        ]
+
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: What's the weather in Berlin?",
+            tools=tools,
+            stream=False,
+        )
+
+        # Should work with multiple tools
+        self.assertIsNotNone(response.output)
+        self.assertEqual(response.status, "completed")
+
+    def test_builtin_and_function_tools_mixed(self):
+        """Test that builtin tools can coexist with function tools."""
+        tools = self.get_test_tools()
+        # Note: web_search_preview requires a tool server, so this just tests
+        # schema acceptance, not actual execution
+
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: Hello!",
+            tools=tools,
+            stream=False,
+        )
+
+        self.assertEqual(response.status, "completed")
+
+    def test_function_tool_with_strict_mode(self):
+        """Test function tool with strict=True for schema validation."""
+        tools = [
+            {
+                "type": "function",
+                "name": "calculate",
+                "description": "Perform a calculation",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "expression": {"type": "string"},
+                    },
+                    "required": ["expression"],
+                },
+                "strict": True,
+            }
+        ]
+
+        response = self.client.responses.create(
+            model=self.model,
+            input=f"{self.SYSTEM_MESSAGE}\nUser: Calculate 2+2",
+            tools=tools,
+            stream=False,
+        )
+
+        self.assertEqual(response.status, "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Related to #13967

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Add support for custom function tools in the v1/responses endpoint, enabling users to define functions like get_weather or get_stock_price that the model can call. Tool calls are returned to the client for execution, matching the behavior of v1/chat/completions.

## Modifications

Changes:
- Extend ResponseTool schema to accept type="function" with name, description, parameters, and strict fields
- Add model_validator to ensure function tools have required name field
- Extend tool_choice to support specific function selection via ToolChoice
- Integrate FunctionCallParser for parsing tool calls from model output
- Add streaming support for function tool calls with SSE events
- Add tool call constraint generation for guided decoding

