### PR TITLE
Add cuda event based on waiting value

### DIFF
--- a/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
+++ b/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
@@ -15,14 +15,14 @@ __global__ void wait_flag_kernel(const std::int32_t* flag, std::int32_t target) 
   }
 }
 
-auto stream_wait_value(const tvm::ffi::TensorView flag, std::uint32_t value) -> void {
+auto stream_wait_value(const tvm::ffi::TensorView flag, std::int32_t value) -> void {
   using namespace host;
 
   auto length = SymbolicSize{"length"};
-  TensorMatcher({length}).with_dtype<int32_t, uint32_t>().with_device<kDLCUDA>().verify(flag);
+  TensorMatcher({length}).with_dtype<int32_t>().with_device<kDLCUDA>().verify(flag);
   RuntimeCheck(length.unwrap() >= 1, "wait_flag expects a non-empty tensor.");
 
-  auto* ptr = static_cast<std::uint32_t*>(flag.data_ptr());
+  auto* ptr = static_cast<std::int32_t*>(flag.data_ptr());
   const auto stream = LaunchKernel::resolve_device(flag.device());
 
   constexpr int blocks = 1;

--- a/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
+++ b/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
@@ -7,8 +7,10 @@
 
 namespace {
 
-__global__ void wait_flag_kernel(const std::int32_t* flag, std::int32_t target) {
-  while (atomicAdd((int*)flag, 0) != target) {
+__global__ void wait_flag_kernel(const int32_t* flag, int32_t target) {
+  const volatile int32_t* vflag = (volatile const int32_t*)flag;
+
+  while (*vflag != target) {
 #if __CUDA_ARCH__ >= 700
     __nanosleep(100);
 #endif

--- a/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
+++ b/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
@@ -1,0 +1,33 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.cuh>
+
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+
+namespace {
+__global__ void wait_flag_kernel(const std::uint32_t* flag, std::uint32_t target) {
+  while (atomicAdd((unsigned int*)flag, 0) != target) {
+#if __CUDA_ARCH__ >= 700
+    __nanosleep(100);
+#endif
+  }
+}
+
+auto stream_wait_value(const tvm::ffi::TensorView flag, std::uint32_t value) -> void {
+  using namespace host;
+
+  auto length = SymbolicSize{"length"};
+  TensorMatcher({length}).with_dtype<int32_t, uint32_t>().with_device<kDLCUDA>().verify(flag);
+  RuntimeCheck(length.unwrap() >= 1, "wait_flag expects a non-empty tensor.");
+
+  auto* ptr = static_cast<std::uint32_t*>(flag.data_ptr());
+  const auto stream = LaunchKernel::resolve_device(flag.device());
+
+  constexpr int blocks = 1;
+  constexpr int threads = 1;
+  wait_flag_kernel<<<blocks, threads, 0, stream>>>(ptr, value);
+  RuntimeDeviceCheck(cudaGetLastError());
+}
+
+}  // namespace

--- a/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
+++ b/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
@@ -6,8 +6,9 @@
 #include <cstdint>
 
 namespace {
-__global__ void wait_flag_kernel(const std::uint32_t* flag, std::uint32_t target) {
-  while (atomicAdd((unsigned int*)flag, 0) != target) {
+
+__global__ void wait_flag_kernel(const std::int32_t* flag, std::int32_t target) {
+  while (atomicAdd((int*)flag, 0) != target) {
 #if __CUDA_ARCH__ >= 700
     __nanosleep(100);
 #endif

--- a/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
+++ b/python/sglang/jit_kernel/csrc/cuda_wait_value.cuh
@@ -13,6 +13,8 @@ __global__ void wait_flag_kernel(const int32_t* flag, int32_t target) {
   while (*vflag != target) {
 #if __CUDA_ARCH__ >= 700
     __nanosleep(100);
+#else
+    // Note: This falls back to an inefficient busy-wait on pre-Volta architectures.
 #endif
   }
 }

--- a/python/sglang/jit_kernel/cuda_wait_value.py
+++ b/python/sglang/jit_kernel/cuda_wait_value.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import load_jit
+
+if TYPE_CHECKING:
+    import torch
+    from tvm_ffi.module import Module
+
+
+@lru_cache(maxsize=1)
+def _jit_stream_wait_value_module() -> Module:
+    return load_jit(
+        "cuda_wait_value",
+        cuda_files=["cuda_wait_value.cuh"],
+        cuda_wrappers=[("stream_wait_value", "stream_wait_value")],
+    )
+
+
+def stream_wait_value(flag: torch.Tensor, value: int) -> None:
+    module = _jit_stream_wait_value_module()
+    module.stream_wait_value(flag, value)
+
+
+class Event:
+    def __init__(self) -> None:
+        self.flag = torch.zeros(1, dtype=torch.int32, device="cuda")
+
+    def record(self, value: int = 1) -> None:
+        self.flag[0] = value
+
+    def wait(self, value: int = 1) -> None:
+        stream_wait_value(self.flag, value)
+
+
+def main():
+    import time
+
+    event = Event()
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+
+    with torch.cuda.stream(stream_a):
+        print("Stream A: waiting event to be recorded")
+        event.wait()
+
+    print("Stream B: waiting 5 seconds before recording event")
+    with torch.cuda.stream(stream_b):
+        for _ in range(5):
+            time.sleep(1)
+            print(".", end="", flush=True)
+        print("\nStream B: recording event")
+        event.record()
+
+    stream_a.synchronize()
+    print("Stream A: event recorded, proceeding")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/jit_kernel/cuda_wait_value.py
+++ b/python/sglang/jit_kernel/cuda_wait_value.py
@@ -51,11 +51,12 @@ def test_wait_before_record(event: Event | torch.cuda.Event):
 
 
 def main():
-    import os
     import threading
     import time
 
-    block_thead = threading.Thread(target=test_wait_before_record, args=(Event(),))
+    block_thead = threading.Thread(
+        target=test_wait_before_record, args=(Event(),), daemon=True
+    )
     block_thead.start()
 
     non_block_thread = threading.Thread(
@@ -72,8 +73,6 @@ def main():
     assert not non_block_thread.is_alive(), "torch.cuda.Event should not block"
     print("=" * 40)
     print("Test completed successfully.")
-
-    os._exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For the scenarios where the record happens later than the wait.

```python
stream_a = torch.cuda.Stream()
stream_b = torch.cuda.Stream()

with torch.cuda.stream(stream_a):
    event.wait()

with torch.cuda.stream(stream_b):
    event.record()
```