### PR TITLE
[bug fix] fix ima with get_mla_kv_buffer_kernel overflow

### DIFF
--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -43,7 +43,7 @@ def set_mla_kv_buffer_kernel(
     total_dim = nope_dim + rope_dim
     mask = offs < total_dim
 
-    loc = tl.load(loc_ptr + pid_loc)
+    loc = tl.load(loc_ptr + pid_loc).to(tl.int64)
     dst_ptr = kv_buffer_ptr + loc * buffer_stride + offs
 
     if base + BLOCK <= nope_dim:
@@ -168,7 +168,7 @@ def get_mla_kv_buffer_kernel(
     rope_dim: tl.constexpr,
 ):
     pid_loc = tl.program_id(0)
-    loc = tl.load(loc_ptr + pid_loc)
+    loc = tl.load(loc_ptr + pid_loc).to(tl.int64)
     loc_src_ptr = kv_buffer_ptr + loc * buffer_stride
 
     nope_offs = tl.arange(0, nope_dim)


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

when test with below command on H20：

server：
`SGLANG_PP_LAYER_PARTITION="3,3,4,4,4,4,4,4,4,4,4,4,4,4,4,3"
CUDA_LAUNCH_BLOCKING=1 python3 -m sglang.launch_server --model-path /work/models/DeepSeek3.1/  --nnodes 2 --port 30000 --dist-init-addr 26.5.27.241:62001 --node-rank 0 --tp 1 --pp-size 16 --trust-remote-code --disable-radix-cache --mem-fraction-static 0.8 --max-running-requests 512 --chunked-prefill-size 6144 --attention-backend fa3 --watchdog-timeout 3600 --host 0.0.0.0`

`SGLANG_PP_LAYER_PARTITION="3,3,4,4,4,4,4,4,4,4,4,4,4,4,4,3" 
CUDA_LAUNCH_BLOCKING=1 python3 -m sglang.launch_server --model-path /work/models/DeepSeek3.1/ --nnodes 2 --port 30000 --dist-init-addr 26.5.27.241:62001 --node-rank 1 --tp 1 --pp-size 16 --trust-remote-code --disable-radix-cache --mem-fraction-static 0.8 --max-running-requests 512 --chunked-prefill-size 6144 --attention-backend fa3 --watchdog-timeout 3600`

client：
`python3 -m sglang.bench_serving --host 127.0.0.1 --port 30000 --dataset-path /root/.cache/modelscope/hub/datasets/gliang1001/ShareGPT_V3_unfiltered_cleaned_split/ShareGPT_V3_unfiltered_cleaned_split.json --num-prompt 512 --random-input 13107 --random-output 1 --request-rate 10 --max-concurrency 512 --warmup-requests 0 --backend sglang --dataset-name random --random-range-ratio 1 `


An ima will show up with below stack：

> [2025-12-01 09:06:35 PP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/root/sgl-dev/sglang/python/sglang/srt/managers/scheduler.py", line 2767, in run_scheduler_process
    scheduler.event_loop_pp()
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/managers/scheduler_pp_mixin.py", line 35, in event_loop_pp
    result = self.run_batch(self.cur_batch)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/managers/scheduler.py", line 1955, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/managers/tp_worker.py", line 419, in forward_batch_generation
    pp_proxy_tensors, can_run_cuda_graph = self.model_runner.forward(
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/model_executor/model_runner.py", line 2206, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/model_executor/model_runner.py", line 2257, in _forward_raw
    ret = self.forward_extend(
          ^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/model_executor/model_runner.py", line 2151, in forward_extend
    return self.model.forward(
           ^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 3033, in forward
    hidden_states = self.model(
                    ^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 2886, in forward
    hidden_states, residual = layer(
                              ^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 2615, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 1344, in forward
    return self.forward_core(s)
           ^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 1433, in forward_core
    return self.forward_normal_chunked_kv_core(*inner_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 2365, in forward_normal_chunked_kv_core
    attn_output = self._chunked_prefix_attn_mha(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 2299, in _chunked_prefix_attn_mha
    kv_a_normed, k_pe = self._get_mla_kv_buffer(
                        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/models/deepseek_v2.py", line 2433, in _get_mla_kv_buffer
    kv_a, k_pe = forward_batch.token_to_kv_pool.get_mla_kv_buffer(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 1445, in get_mla_kv_buffer
    get_mla_kv_buffer_triton(kv_buffer, loc, cache_k_nope, cache_k_rope)
  File "/root/sgl-dev/sglang/python/sglang/srt/mem_cache/memory_pool.py", line 1262, in get_mla_kv_buffer_triton
    get_mla_kv_buffer_kernel[grid](
  File "/root/sgl-dev/lib/python3.12/site-packages/triton/runtime/jit.py", line 390, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/sgl-dev/lib/python3.12/site-packages/triton/runtime/jit.py", line 617, in run
    kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
  File "/root/sgl-dev/lib/python3.12/site-packages/triton/backends/nvidia/driver.py", line 708, in __call__
    self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered

Reported by @whybeyoung 
## Modifications

Fix it by extend loc to int64.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
