### PR TITLE
[model-gateway] add ModelCard support to WorkerMetadata

### DIFF
--- a/sgl-router/src/core/worker_builder.rs
+++ b/sgl-router/src/core/worker_builder.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::{
     circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
+    model_type::ModelType,
     worker::{
         BasicWorker, ConnectionMode, DPAwareWorker, HealthConfig, RuntimeType, WorkerMetadata,
         WorkerType,
@@ -154,6 +155,9 @@ impl BasicWorkerBuilder {
             health_config: self.health_config,
             bootstrap_host,
             bootstrap_port,
+            models: Vec::new(),                 // Empty = accepts any model
+            default_provider: None,             // Native/passthrough
+            default_model_type: ModelType::LLM, // Standard LLM capabilities
         };
 
         let grpc_client = Arc::new(RwLock::new(self.grpc_client.map(Arc::new)));


### PR DESCRIPTION
## Summary
Extends WorkerMetadata with model configuration fields to enable per-model routing and provider selection.

## Changes

### New fields:
  - models: Vec<ModelCard> - models this worker can serve
  - default_provider: Option<ProviderType> - fallback provider
  - default_model_type: ModelType - fallback capabilities

### New WorkerMetadata methods:
  - find_model() - lookup by ID or alias
  - supports_model() - check if worker serves a model
  - supports_endpoint() - check endpoint support per model
  - provider_for_model() - get provider for a model
  - model_ids() - iterate over model IDs

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
