### PR TITLE
Fix piecewise CUDA graph for hybrid SWA models (Qwen3-Next)

### DIFF
--- a/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/piecewise_cuda_graph_runner.py
@@ -521,7 +521,7 @@ class PiecewiseCudaGraphRunner:
 
         out_cache_loc_swa = (
             self.out_cache_loc_swa[:static_num_tokens]
-            if forward_batch.out_cache_loc_swa is not None
+            if self.out_cache_loc_swa is not None
             else None
         )
 


### PR DESCRIPTION
## Summary
- Fix `out_cache_loc_swa` condition in `replay_prepare` to check `self.out_cache_loc_swa` instead of `forward_batch.out_cache_loc_swa`
- This fixes TestQwen3NextPiecewiseCudaGraph test failure introduced in PR #13965

## Problem
PR #13965 introduced a bug where the condition for setting `out_cache_loc_swa` in `replay_prepare` was checking `forward_batch.out_cache_loc_swa` instead of `self.out_cache_loc_swa`. 

For hybrid SWA models like Qwen3-Next:
- `self.out_cache_loc_swa` is initialized (because `is_hybrid_swa=True`)
- But `forward_batch.out_cache_loc_swa` may be None
- This caused `out_cache_loc_swa` to be None in the static forward batch even when valid data existed

**Before fix:** TestQwen3NextPiecewiseCudaGraph had accuracy=0%, invalid=100%
**After fix:** TestQwen3NextPiecewiseCudaGraph has accuracy=95.5%, invalid=0%

## Test plan
- [x] Tested manually on B200 GPUs with the TestQwen3NextPiecewiseCudaGraph test
- [ ] CI tests should pass