### PR TITLE
fix: Support PP for Mistral Small 3.1

### DIFF
--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -41,7 +41,7 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputs,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaForCausalLM
 from sglang.srt.models.mistral import MistralForCausalLM
@@ -785,6 +785,7 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
         hidden_states = general_mm_embed_routine(
             input_ids=input_ids,
@@ -796,6 +797,7 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
             },
             placeholder_tokens=None,  # using mm_item.pad_value
             positions=positions,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
 
         return hidden_states


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Add PP support for Mistral3ForConditionalGeneration, LlavaForConditionalGeneration. 

Note that the Mistral3ForConditionalGeneration wraps LlavaForConditionalGeneration as inner.

Relevant previous PR: https://github.com/sgl-project/sglang/pull/13075

Server startup: 

```
python -m sglang.launch_server --model-path /home/models/mistralai/Mistral-Small-3.1-24B-Instruct-2503 --disable-radix-cache --trust-remote --host 0.0.0.0 --port 8001 --mem-fraction-static 0.8 --pp-size 4

... 

[2025-12-01 22:57:50 PP0] Load weight end. type=LlavaForConditionalGeneration, dtype=torch.float16, avail mem=69.15 GB, mem usage=8.22 GB.
[2025-12-01 22:57:50 PP0] Using KV cache dtype: torch.float16
[2025-12-01 22:57:50 PP0] KV Cache is allocated. #tokens: 351850, K size: 26.84 GB, V size: 26.84 GB
[2025-12-01 22:57:50 PP1] KV Cache is allocated. #tokens: 351850, K size: 26.84 GB, V size: 26.84 GB
[2025-12-01 22:57:50 PP2] KV Cache is allocated. #tokens: 351850, K size: 26.84 GB, V size: 26.84 GB
[2025-12-01 22:57:50 PP3] KV Cache is allocated. #tokens: 351850, K size: 26.84 GB, V size: 26.84 GB
[2025-12-01 22:57:50 PP2] Memory pool end. avail mem=15.61 GB
[2025-12-01 22:57:50 PP1] Memory pool end. avail mem=15.61 GB
[2025-12-01 22:57:50 PP3] Memory pool end. avail mem=15.84 GB
[2025-12-01 22:57:50 PP0] Memory pool end. avail mem=14.40 GB
[2025-12-01 22:57:50 PP1] Capture cuda graph begin. This can take up to several minutes. avail mem=15.03 GB
[2025-12-01 22:57:50 PP1] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
[2025-12-01 22:57:50 PP2] Capture cuda graph begin. This can take up to several minutes. avail mem=15.03 GB
[2025-12-01 22:57:50 PP2] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
[2025-12-01 22:57:50 PP0] Capture cuda graph begin. This can take up to several minutes. avail mem=13.83 GB
[2025-12-01 22:57:50 PP3] Capture cuda graph begin. This can take up to several minutes. avail mem=15.27 GB
[2025-12-01 22:57:50 PP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
[2025-12-01 22:57:50 PP3] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256]
Capturing batches (bs=1 avail_mem=14.17 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:01<00:00, 23.42it/s]
Capturing batches (bs=1 avail_mem=14.17 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:01<00:00, 22.81it/s]
Capturing batches (bs=1 avail_mem=12.96 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:01<00:00, 23.22it/s]
Capturing batches (bs=1 avail_mem=14.34 GB): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████| 36/36 [00:01<00:00, 20.81it/s]
[2025-12-01 22:57:53 PP2] Capture cuda graph end. Time elapsed: 2.17 s. mem usage=0.87 GB. avail mem=14.17 GB.
[2025-12-01 22:57:53 PP1] Capture cuda graph end. Time elapsed: 2.21 s. mem usage=0.87 GB. avail mem=14.17 GB.
[2025-12-01 22:57:53 PP0] Capture cuda graph end. Time elapsed: 2.28 s. mem usage=0.87 GB. avail mem=12.96 GB.
[2025-12-01 22:57:53 PP3] Capture cuda graph end. Time elapsed: 2.39 s. mem usage=0.93 GB. avail mem=14.34 GB.
[2025-12-01 22:57:54 PP2] max_total_num_tokens=351850, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=2048, context_len=131072, available_gpu_mem=14.17 GB
[2025-12-01 22:57:54 PP0] max_total_num_tokens=351850, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=2048, context_len=131072, available_gpu_mem=12.96 GB
[2025-12-01 22:57:54 PP3] max_total_num_tokens=351850, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=2048, context_len=131072, available_gpu_mem=14.34 GB
[2025-12-01 22:57:54 PP1] max_total_num_tokens=351850, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=2048, context_len=131072, available_gpu_mem=14.17 GB
[2025-12-01 22:57:55] INFO:     Started server process [129079]
[2025-12-01 22:57:55] INFO:     Waiting for application startup.
[2025-12-01 22:57:55] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.15, 'top_k': 50, 'top_p': 1.0}
[2025-12-01 22:57:55] Using default chat sampling params from model generation config: {'repetition_penalty': 1.0, 'temperature': 0.15, 'top_k': 50, 'top_p': 1.0}
[2025-12-01 22:57:55] INFO:     Application startup complete.
[2025-12-01 22:57:55] INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
```

Bench result: 

```
python -m sglang.bench_serving --host 0.0.0.0 --port 8001 --dataset-name random-ids --num-prompts 128 --random-input-len 11500 --random-output-len 550 --random-range-ratio 0.9 
benchmark_args=Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=8001, dataset_name='random-ids', dataset_path='', model=None, served_model_name=None, tokenizer=None, num_prompts=128, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=11500, random_output_len=550, random_range_ratio=0.9, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=False, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)
Namespace(backend='sglang', base_url=None, host='0.0.0.0', port=8001, dataset_name='random-ids', dataset_path='', model='/opt/tiger/ptq_mistralsmall3_24bit_sft_v6_fp8', served_model_name=None, tokenizer=None, num_prompts=128, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=11500, random_output_len=550, random_range_ratio=0.9, image_count=1, image_resolution='1080p', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=None, output_file=None, output_details=False, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=False, profile=False, profile_activities=['CPU', 'GPU'], lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=False, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)

#Input tokens: 1403308
#Output tokens: 67031
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 128/128 [01:48<00:00,  1.18it/s]

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     128       
Benchmark duration (s):                  108.38    
Total input tokens:                      1403308   
Total input text tokens:                 1403308   
Total input vision tokens:               0         
Total generated tokens:                  67031     
Total generated tokens (retokenized):    66013     
Request throughput (req/s):              1.18      
Input token throughput (tok/s):          12947.77  
Output token throughput (tok/s):         618.47    
Total token throughput (tok/s):          13566.24  
Concurrency:                             77.71     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   65803.59  
Median E2E Latency (ms):                 69396.18  
---------------Time to First Token----------------
Mean TTFT (ms):                          42866.93  
Median TTFT (ms):                        44574.26  
P99 TTFT (ms):                           95697.17  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.78     
Median TPOT (ms):                        43.83     
P99 TPOT (ms):                           129.79    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           44.01     
Median ITL (ms):                         23.23     
P95 ITL (ms):                            24.82     
P99 ITL (ms):                            520.50    
Max ITL (ms):                            84904.60  
==================================================
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
