### PR TITLE
Revert "Try to remove wrong logic about max total token in spec decoding"

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1689,8 +1689,25 @@ class ModelRunner:
 
         if self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone():
             if self.is_draft_worker:
+                self.max_total_num_tokens = self.server_args.draft_runner_cache_size
                 max_num_reqs = self.server_args.max_num_reqs
             else:
+                # We are sharing the `token_to_kv_pool`, and both verify and draft tokens
+                # can be concurrently allocated, so we should give a headroom for it.
+                self.server_args.draft_runner_cache_size = (
+                    self.max_total_num_tokens
+                    # draft
+                    + max_num_reqs
+                    * self.server_args.speculative_num_steps
+                    * self.server_args.speculative_eagle_topk
+                    # verify
+                    + max_num_reqs * self.server_args.speculative_num_draft_tokens
+                    # buffer
+                    + 100
+                )
+                # Target worker and draft worker shares the same indices for the
+                # token_to_kv_pool, so we should make sure to match max_total_num_tokens.
+                self.max_total_num_tokens = self.server_args.draft_runner_cache_size
                 self.server_args.max_num_reqs = max_num_reqs
 
         if max_total_tokens is not None:


### PR DESCRIPTION
Reverts sgl-project/sglang#14167


git bisect to find the first commit which cause MTP to use more memory:

```
f4a0c5c76b065474dfea9e4801bdacea9f34ed17 is the first bad commit
commit f4a0c5c76b065474dfea9e4801bdacea9f34ed17
Author: fzyzcjy <5236035+fzyzcjy@users.noreply.github.com>
Date:   Mon Dec 1 15:29:58 2025 +0800

    Try to remove wrong logic about max total token in spec decoding (#14167)

 python/sglang/srt/model_executor/model_runner.py | 17 -----------------
 1 file changed, 17 deletions(-)
```