### PR TITLE
Remove cargo config also in `.zshenv`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -295,7 +295,7 @@ RUN --mount=type=cache,target=/root/.cache/pip curl --proto '=https' --tlsv1.2 -
     && ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist \
     && python3 -m pip install --force-reinstall dist/*.whl \
     && rm -rf /root/.cargo /root/.rustup target dist ~/.cargo \
-    && sed -i '/\.cargo\/env/d' /root/.profile /root/.bashrc 2>/dev/null || true
+    && sed -i '/\.cargo\/env/d' /root/.profile /root/.bashrc /root/.zshenv 2>/dev/null || true
 
 
 # Add yank script


### PR DESCRIPTION
When executing zsh in a SGLang Docker:

```zsh
/root/.zshenv:.:1: no such file or directory: /root/.cargo/env
```

Remove this

```bash
cat .zshenv
. "$HOME/.cargo/env"
```

Following #12941