### PR TITLE
[CI] Fix 4-GPU test timeout by using 3 partitions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -563,7 +563,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: [0, 1]
+        part: [0, 1, 2]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -584,7 +584,7 @@ jobs:
         timeout-minutes: 20
         run: |
           cd test/srt
-          python3 run_suite.py --suite per-commit-4-gpu --auto-partition-id ${{ matrix.part }} --auto-partition-size 2
+          python3 run_suite.py --suite per-commit-4-gpu --auto-partition-id ${{ matrix.part }} --auto-partition-size 3
 
   unit-test-backend-8-gpu-h200:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]


### PR DESCRIPTION
## Summary

Fixes the `unit-test-backend-4-gpu` timeout issue introduced by #14222.

PR #14222 moved `test_piecewise_cuda_graph.py` (estimated 1200s) to the `per-commit-4-gpu` suite, which caused the LPT partition algorithm to create an unbalanced distribution with only 2 partitions:

- **Partition 0**: 1264s (2 tests) ✓
- **Partition 1**: 1483s (4 tests) ✗ exceeds 20min timeout

This PR increases the number of partitions from 2 to 3:

- **Partition 0**: ~1200s (1 test) - test_piecewise_cuda_graph.py
- **Partition 1**: ~772s (2 tests) - test_pp_single_node.py, test_qwen3_next_models.py
- **Partition 2**: ~775s (3 tests) - test_local_attn.py, test_gpt_oss_4gpu.py, test_multi_instance_release_memory_occupation.py

All partitions now fit within the 20-minute timeout.

## Example failure

https://github.com/sgl-project/sglang/actions/runs/19845982270/job/56878342316?pr=14253

```
args=Namespace(timeout_per_file=1200, suite='per-commit-4-gpu', auto_partition_id=1, auto_partition_size=2, continue_on_error=False)
The running tests are  ['test_pp_single_node.py', 'test_local_attn.py', 'test_gpt_oss_4gpu.py', 'models/test_qwen3_next_models.py']
...
Error: The action 'Run test' has timed out after 20 minutes.
```

## Test plan

- [ ] CI passes with the new 3-partition configuration