### PR TITLE
[Feature]Report health status while worker exit

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -81,8 +81,8 @@ from sglang.srt.utils import (
     set_prometheus_multiproc_dir,
     set_ulimit,
 )
-from sglang.srt.utils.worker_exit_reporter import worker_exit_reporter
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+from sglang.srt.utils.worker_exit_reporter import worker_exit_reporter
 from sglang.version import __version__
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -81,6 +81,7 @@ from sglang.srt.utils import (
     set_prometheus_multiproc_dir,
     set_ulimit,
 )
+from sglang.srt.utils.worker_exit_reporter import worker_exit_reporter
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.version import __version__
 
@@ -790,6 +791,11 @@ def _launch_subprocesses(
     configure_logger(server_args)
     server_args.check_server_args()
     _set_envs_and_config(server_args)
+
+    # config worker exit reporter
+    worker_exit_reporter.init_worker_exit_reporter(server_args)
+    # Main thread set child process signal handler
+    worker_exit_reporter.set_child_process_exit_signal_handler()
 
     # Allocate ports for inter-process communications
     if port_args is None:

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -58,6 +58,7 @@ from sglang.srt.utils.common import (
     kill_itself_when_parent_died,
     maybe_reindex_device_id,
 )
+from sglang.srt.utils.worker_exit_reporter import worker_exit_reporter
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
@@ -530,6 +531,9 @@ def run_data_parallel_controller_process(
 
     try:
         controller = data_parallel_controller_class(server_args, port_args)
+        # Data Parallel Controller process set child process signal handler
+        worker_exit_reporter.set_child_process_exit_signal_handler()
+
         pipe_writer.send(
             {
                 "status": "ready",

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -58,8 +58,8 @@ from sglang.srt.utils.common import (
     kill_itself_when_parent_died,
     maybe_reindex_device_id,
 )
-from sglang.srt.utils.worker_exit_reporter import worker_exit_reporter
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+from sglang.srt.utils.worker_exit_reporter import worker_exit_reporter
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -249,6 +249,7 @@ class ServerArgs:
     warmups: Optional[str] = None
     nccl_port: Optional[int] = None
     checkpoint_engine_wait_weights_before_ready: bool = False
+    router_url: Optional[str] = None
 
     # Quantization and data type
     dtype: str = "auto"
@@ -2200,6 +2201,12 @@ class ServerArgs:
             action="store_true",
             help="If set, the server will wait for initial weights to be loaded via checkpoint-engine or other update methods "
             "before serving inference requests.",
+        )
+        parser.add_argument(
+            "--router-url",
+            type=str,
+            default=ServerArgs.router_url,
+            help="Router URL for worker exit reporting (e.g., http://router:8000)",
         )
 
         # Quantization and data type

--- a/python/sglang/srt/utils/worker_exit_reporter.py
+++ b/python/sglang/srt/utils/worker_exit_reporter.py
@@ -5,6 +5,7 @@ import signal
 import threading
 
 import requests
+
 from sglang.srt.utils import kill_process_tree
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,9 @@ class WorkerExitReporter:
 
     def set_child_process_exit_signal_handler(self):
         if threading.current_thread() is threading.main_thread():
-            logger.info("Registered SIGCHLD handler,while child process exits will patch worker status to router")
+            logger.info(
+                "Registered SIGCHLD handler,while child process exits will patch worker status to router"
+            )
             signal.signal(signal.SIGCHLD, self._signal_handler)
 
     def _signal_handler(self, signum, frame):

--- a/python/sglang/srt/utils/worker_exit_reporter.py
+++ b/python/sglang/srt/utils/worker_exit_reporter.py
@@ -21,7 +21,7 @@ class WorkerExitReporter:
         if router_url:
             worker_url = f"http://{server_args.host}:{server_args.port}"
             atexit.register(self._report_exit)
-            self.router_url = worker_url
+            self.router_url = router_url
             self.worker_url = worker_url
 
     def set_child_process_exit_signal_handler(self):
@@ -31,7 +31,10 @@ class WorkerExitReporter:
 
     def _signal_handler(self, signum, frame):
         pid = os.getpid()
-        logger.warning(f"Child process {pid} terminated with signum {signum}")
+        logger.warning(
+            f"Parent process {pid} received SIGCHLD ({signum}), indicating a child process terminated. "
+            f"Reporting worker exit and shutting down."
+        )
         self._report_exit()
         kill_process_tree(pid)
 

--- a/python/sglang/srt/utils/worker_exit_reporter.py
+++ b/python/sglang/srt/utils/worker_exit_reporter.py
@@ -1,0 +1,59 @@
+import atexit
+import logging
+import os
+import signal
+import threading
+
+import requests
+from sglang.srt.utils import kill_process_tree
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerExitReporter:
+    def __init__(self):
+        self.router_url = None
+        self.worker_url = None
+        self.delete_called = False
+
+    def init_worker_exit_reporter(self, server_args):
+        router_url = getattr(server_args, "router_url", None)
+        if router_url:
+            worker_url = f"http://{server_args.host}:{server_args.port}"
+            atexit.register(self._report_exit)
+            self.router_url = worker_url
+            self.worker_url = worker_url
+
+    def set_child_process_exit_signal_handler(self):
+        if threading.current_thread() is threading.main_thread():
+            logger.info("Registered SIGCHLD handler,while child process exits will patch worker status to router")
+            signal.signal(signal.SIGCHLD, self._signal_handler)
+
+    def _signal_handler(self, signum, frame):
+        pid = os.getpid()
+        logger.warning(f"Child process {pid} terminated with signum {signum}")
+        self._report_exit()
+        kill_process_tree(pid)
+
+    def _report_exit(self):
+        if not self.worker_url or self.delete_called:
+            return
+        self.delete_called = True
+        try:
+            # Report that this worker is no longer healthy.
+            logger.info(f"Reporting worker exit for {self.worker_url}")
+            encoded_url = requests.utils.quote(self.worker_url, safe="")
+            response = requests.patch(
+                f"{self.router_url}/workers/{encoded_url}/health",
+                json={"healthy": False},
+                timeout=5,
+            )
+            if response.status_code == 200:
+                logger.info(f"Successfully queued worker exit for {self.worker_url}")
+            else:
+                logger.error(f"Failed to call PATCH endpoint: {response.status_code}")
+        except Exception as e:
+            logger.error(f"Failed to report worker exit: {e}")
+
+
+worker_exit_reporter = WorkerExitReporter()

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::{Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::{delete, get, post},
+    routing::{delete, get, post, patch},
     serve, Json, Router,
 };
 use serde::Deserialize;
@@ -113,6 +113,32 @@ async fn health(_state: State<Arc<AppState>>) -> Response {
 
 async fn health_generate(State(state): State<Arc<AppState>>, req: Request) -> Response {
     state.router.health_generate(req).await
+}
+
+#[derive(Deserialize)]
+struct SetHealthRequest {
+    healthy: bool,
+}
+
+async fn set_worker_health(
+    State(state): State<Arc<AppState>>,
+    Path(worker_url): Path<String>,
+    Json(health_request): Json<SetHealthRequest>,
+) -> Response {
+    if let Some(worker) = state.context.worker_registry.get_by_url(&worker_url) {
+        info!("set worker {:?} health  from {:?} to {:?}, worker type: {:?}",
+            worker.url(),
+            worker.is_healthy(),
+            health_request.healthy,
+            worker.worker_type()
+        );
+        worker.set_healthy(health_request.healthy);
+        (StatusCode::OK, Json(json!({"ok": "Worker's status is updated"}))).into_response()
+    } else {
+        info!("worker {:?} is not found", worker_url);
+        (StatusCode::NOT_FOUND, Json(json!({"error": "Worker not found"}))).into_response()
+    }
+
 }
 
 async fn engine_metrics(State(state): State<Arc<AppState>>) -> Response {

--- a/sgl-router/src/server.rs
+++ b/sgl-router/src/server.rs
@@ -122,10 +122,10 @@ struct SetHealthRequest {
 
 async fn set_worker_health(
     State(state): State<Arc<AppState>>,
-    Path(worker_url): Path<String>,
+    Path(url): Path<String>,
     Json(health_request): Json<SetHealthRequest>,
 ) -> Response {
-    if let Some(worker) = state.context.worker_registry.get_by_url(&worker_url) {
+    if let Some(worker) = state.context.worker_registry.get_by_url(&url) {
         info!("set worker {:?} health  from {:?} to {:?}, worker type: {:?}",
             worker.url(),
             worker.is_healthy(),
@@ -135,7 +135,7 @@ async fn set_worker_health(
         worker.set_healthy(health_request.healthy);
         (StatusCode::OK, Json(json!({"ok": "Worker's status is updated"}))).into_response()
     } else {
-        info!("worker {:?} is not found", worker_url);
+        info!("worker {:?} is not found", url);
         (StatusCode::NOT_FOUND, Json(json!({"error": "Worker not found"}))).into_response()
     }
 
@@ -698,6 +698,7 @@ pub fn build_app(
         .route("/workers", get(list_workers_rest))
         .route("/workers/{url}", get(get_worker))
         .route("/workers/{url}", delete(delete_worker))
+        .route("/workers/{url}/health", patch(set_worker_health))
         .route_layer(axum::middleware::from_fn_with_state(
             auth_config.clone(),
             middleware::auth_middleware,


### PR DESCRIPTION
sgl-router adds an interface for modifies the worker's health status. 
A new server_args --router-url is added.
When a worker service process exits, the health status interface is called to change the worker's health to False, maybe can also set the health to True.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
This pull request enhances the system's resilience by implementing a robust mechanism for worker processes to report their health status to a central router upon termination. By introducing a WorkerExitReporter that leverages Python's atexit and signal handling, and a new PATCH endpoint in the Rust router, the system can now promptly mark exiting workers as unhealthy. This prevents the router from attempting to send requests to non-existent or failed workers, thereby improving overall system stability and request routing efficiency.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
