### PR TITLE
[VLM] Introduce Cache for positional embedding ids for Qwen-VL family

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -50,7 +50,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3Model
-from sglang.srt.models.utils import compute_cu_seqlens_from_grid_numpy
+from sglang.srt.models.utils import RotaryPosMixin, compute_cu_seqlens_from_grid_numpy
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix
@@ -257,7 +257,7 @@ class Qwen3VLMoeVisionPatchMerger(nn.Module):
         return out
 
 
-class Qwen3VLMoeVisionModel(nn.Module):
+class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
     def __init__(
         self,
@@ -336,42 +336,12 @@ class Qwen3VLMoeVisionModel(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
-    @staticmethod
-    @lru_cache(maxsize=1024)
-    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
-        hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
-        h_div = h // spatial_merge_size
-        w_div = w // spatial_merge_size
-        hpos_ids = hpos_ids.reshape(
-            h_div,
-            spatial_merge_size,
-            w_div,
-            spatial_merge_size,
-        )
-        hpos_ids = hpos_ids.transpose(0, 2, 1, 3)
-        hpos_ids = hpos_ids.flatten()
-
-        wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
-        wpos_ids = wpos_ids.reshape(
-            h_div,
-            spatial_merge_size,
-            w_div,
-            spatial_merge_size,
-        )
-        wpos_ids = wpos_ids.transpose(0, 2, 1, 3)
-        wpos_ids = wpos_ids.flatten()
-
-        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
-
     def rot_pos_emb(self, grid_thw):
-        pos_ids = [
-            (
-                self.rot_pos_ids(h, w, self.spatial_merge_size)
-                if t == 1
-                else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
-            )
-            for t, h, w in grid_thw
-        ]
+        pos_ids = []
+        for t, h, w in grid_thw:
+            base = self.rot_pos_ids(h, w, self.spatial_merge_size)
+            pos_ids.append(base if t == 1 else base.repeat(t, 1))
+
         pos_ids = torch.cat(pos_ids, dim=0)
         max_grid_size = grid_thw[:, 1:].max()
         rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -336,29 +336,42 @@ class Qwen3VLMoeVisionModel(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
-    def rot_pos_emb(self, grid_thw):
-        pos_ids = []
-        for t, h, w in grid_thw:
-            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
-            hpos_ids = hpos_ids.reshape(
-                h // self.spatial_merge_size,
-                self.spatial_merge_size,
-                w // self.spatial_merge_size,
-                self.spatial_merge_size,
-            )
-            hpos_ids = hpos_ids.permute(0, 2, 1, 3)
-            hpos_ids = hpos_ids.flatten()
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+        hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
+        h_div = h // spatial_merge_size
+        w_div = w // spatial_merge_size
+        hpos_ids = hpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        hpos_ids = hpos_ids.transpose(0, 2, 1, 3)
+        hpos_ids = hpos_ids.flatten()
 
-            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
-            wpos_ids = wpos_ids.reshape(
-                h // self.spatial_merge_size,
-                self.spatial_merge_size,
-                w // self.spatial_merge_size,
-                self.spatial_merge_size,
+        wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
+        wpos_ids = wpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        wpos_ids = wpos_ids.transpose(0, 2, 1, 3)
+        wpos_ids = wpos_ids.flatten()
+
+        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+
+    def rot_pos_emb(self, grid_thw):
+        pos_ids = [
+            (
+                self.rot_pos_ids(h, w, self.spatial_merge_size)
+                if t == 1
+                else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
             )
-            wpos_ids = wpos_ids.permute(0, 2, 1, 3)
-            wpos_ids = wpos_ids.flatten()
-            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+            for t, h, w in grid_thw
+        ]
         pos_ids = torch.cat(pos_ids, dim=0)
         max_grid_size = grid_thw[:, 1:].max()
         rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from functools import lru_cache
+
 import numpy as np
 import torch
 
@@ -82,3 +84,39 @@ def compute_cu_seqlens_from_grid_numpy(grid_thw: torch.Tensor) -> torch.Tensor:
     cu_seqlens = np.concatenate([np.zeros(1, dtype=np.int32), cu_seqlens])
     cu_seqlens = torch.from_numpy(cu_seqlens)
     return cu_seqlens
+
+
+class RotaryPosMixin:
+
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+        if isinstance(h, torch.Tensor):
+            h = int(h.item())
+        if isinstance(w, torch.Tensor):
+            w = int(w.item())
+        if isinstance(spatial_merge_size, torch.Tensor):
+            spatial_merge_size = int(spatial_merge_size.item())
+        hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
+        h_div = h // spatial_merge_size
+        w_div = w // spatial_merge_size
+        hpos_ids = hpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        hpos_ids = hpos_ids.transpose(0, 2, 1, 3)
+        hpos_ids = hpos_ids.flatten()
+
+        wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
+        wpos_ids = wpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        wpos_ids = wpos_ids.transpose(0, 2, 1, 3)
+        wpos_ids = wpos_ids.flatten()
+
+        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Introduce a cache for rot_pos_emb index computation to boost the calculation. 
Introduce a mixin class for broader reuse for this mechanism. For cached rotary position embedding, improvement is significant.
Moreover, refine the index computation to use numpy obtains extra speedup which E2E improved 7%.

```
Server:
$SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=512 \
python -m sglang.launch_server --model-path /home/admin/Qwen3-VL-8B-Instruct/ \
--host 0.0.0.0 --port 8188 --trust-remote-code --tp-size 2 --enable-cache-report \
--log-level info --max-running-requests 48 --mem-fraction-static 0.7 \
--chunked-prefill-size 8192  --attention-backend flashinfer --mm-attention-backend fa3 \
--log-level debug --log-requests --log-requests-level 1

Client:
$python3 -m sglang.bench_serving --backend sglang-oai-chat --dataset-name image    --num-prompts 500  --apply-chat-template  --random-output-len 1    --random-input-len 100     --image-resolution 1120x700     --image-format jpeg     --image-count 1     --image-content random    --random-range-ratio 1 --port 8188 --max-concurrency 20

TTFT drop 2%.

PR:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 20        
Successful requests:                     500       
Benchmark duration (s):                  48.98     
Total input tokens:                      442616    
Total input text tokens:                 56615     
Total input vision tokens:               386001    
Total generated tokens:                  500       
Total generated tokens (retokenized):    500       
Request throughput (req/s):              10.21     
Input token throughput (tok/s):          9037.23   
Output token throughput (tok/s):         10.21     
Peak output token throughput (tok/s):    18.00     
Peak concurrent requests:                38        
Total token throughput (tok/s):          9047.44   
Concurrency:                             19.67     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1926.98   
Median E2E Latency (ms):                 1908.01   
---------------Time to First Token----------------
Mean TTFT (ms):                          1926.97   
Median TTFT (ms):                        1907.99   
P99 TTFT (ms):                           2565.78   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================

Main:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 20        
Successful requests:                     500       
Benchmark duration (s):                  49.58     
Total input tokens:                      442632    
Total input text tokens:                 56632     
Total input vision tokens:               386000    
Total generated tokens:                  500       
Total generated tokens (retokenized):    500       
Request throughput (req/s):              10.08     
Input token throughput (tok/s):          8927.52   
Output token throughput (tok/s):         10.08     
Peak output token throughput (tok/s):    20.00     
Peak concurrent requests:                40        
Total token throughput (tok/s):          8937.61   
Concurrency:                             19.67     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1950.94   
Median E2E Latency (ms):                 1895.21   
---------------Time to First Token----------------
Mean TTFT (ms):                          1950.93   
Median TTFT (ms):                        1895.20   
P99 TTFT (ms):                           2609.81   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
