### PR TITLE
Fix duplicate download log messages in multi-process environment

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -322,12 +322,10 @@ def find_local_hf_snapshot_dir(
             incomplete_files = glob.glob(os.path.join(blobs_dir, "*.incomplete"))
 
         if incomplete_files:
-            logger.info(
-                "Found %d .incomplete files in %s for %s. "
-                "Will clean up and re-download.",
-                len(incomplete_files),
-                blobs_dir,
-                model_name_or_path,
+            log_info_on_rank0(
+                logger,
+                f"Found {len(incomplete_files)} .incomplete files in {blobs_dir} for "
+                f"{model_name_or_path}. Will clean up and re-download.",
             )
             _cleanup_corrupted_model_cache(
                 model_name_or_path,
@@ -367,22 +365,20 @@ def find_local_hf_snapshot_dir(
         if not is_valid:
             if corrupted_files:
                 # Selective cleanup: only remove corrupted files
-                logger.info(
-                    "Found %d corrupted file(s) for %s: %s. "
+                log_info_on_rank0(
+                    logger,
+                    f"Found {len(corrupted_files)} corrupted file(s) for "
+                    f"{model_name_or_path}: {error_msg}. "
                     "Will selectively clean and re-download only these files.",
-                    len(corrupted_files),
-                    model_name_or_path,
-                    error_msg,
                 )
                 _cleanup_corrupted_files_selective(model_name_or_path, corrupted_files)
                 return None
             else:
                 # Cannot selectively clean (e.g., missing shards) - remove entire cache
-                logger.info(
-                    "Validation failed for %s: %s. "
+                log_info_on_rank0(
+                    logger,
+                    f"Validation failed for {model_name_or_path}: {error_msg}. "
                     "Will remove entire cache and re-download.",
-                    model_name_or_path,
-                    error_msg,
                 )
                 _cleanup_corrupted_model_cache(
                     model_name_or_path, found_local_snapshot_dir, error_msg
@@ -400,28 +396,27 @@ def find_local_hf_snapshot_dir(
                 "adapter_model.safetensors",
             ]:
                 if not _validate_safetensors_file(f):
-                    logger.info(
-                        "Corrupted model file %s for %s. "
+                    log_info_on_rank0(
+                        logger,
+                        f"Corrupted model file {base_name} for {model_name_or_path}. "
                         "Will selectively clean and re-download this file.",
-                        base_name,
-                        model_name_or_path,
                     )
                     # Selective cleanup for single file
                     _cleanup_corrupted_files_selective(model_name_or_path, [f])
                     return None
 
     if len(local_weight_files) > 0:
-        logger.info(
-            "Found local HF snapshot for %s at %s; skipping download.",
-            model_name_or_path,
-            found_local_snapshot_dir,
+        log_info_on_rank0(
+            logger,
+            f"Found local HF snapshot for {model_name_or_path} at "
+            f"{found_local_snapshot_dir}; skipping download.",
         )
         return found_local_snapshot_dir
     else:
-        logger.info(
-            "Local HF snapshot at %s has no files matching %s; will attempt download.",
-            found_local_snapshot_dir,
-            allow_patterns,
+        log_info_on_rank0(
+            logger,
+            f"Local HF snapshot at {found_local_snapshot_dir} has no files matching "
+            f"{allow_patterns}; will attempt download.",
         )
     return None
 


### PR DESCRIPTION
## Summary

- When running with multiple processes (e.g., DP=8), `find_local_hf_snapshot_dir()` was using `logger.info()` causing all processes to print the same download-related messages
- Changed 6 `logger.info()` calls to use `log_info_on_rank0()` which only logs on tensor parallel rank 0
- This reduces log noise and makes output cleaner

**Before (8 duplicate messages):**
```
[DP0 TP0] Found local HF snapshot for deepseek-ai/DeepSeek-V3.2-Exp...
[DP1 TP1] Found local HF snapshot for deepseek-ai/DeepSeek-V3.2-Exp...
[DP2 TP2] Found local HF snapshot for deepseek-ai/DeepSeek-V3.2-Exp...
... (8 times)
```

**After (single message):**
```
[DP0 TP0] Found local HF snapshot for deepseek-ai/DeepSeek-V3.2-Exp...
```

Related nightly test log: https://github.com/sgl-project/sglang/actions/runs/19793660464/job/56710854401

## Test plan

- [ ] Verify with multi-GPU setup that only rank 0 prints download-related messages
- [ ] Ensure download functionality still works correctly