### PR TITLE
[FIX][DS32]openai protocol: support openai message role: developer

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -387,7 +387,7 @@ class ToolCall(BaseModel):
 
 
 class ChatCompletionMessageGenericParam(BaseModel):
-    role: Literal["system", "assistant", "tool", "function"]
+    role: Literal["system", "assistant", "tool", "function", "developer"]
     content: Union[str, List[ChatCompletionMessageContentPart], None] = Field(
         default=None
     )
@@ -395,15 +395,16 @@ class ChatCompletionMessageGenericParam(BaseModel):
     name: Optional[str] = None
     reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
+    tools: Optional[List[Tool]] = Field(default=None, examples=[None])
 
     @field_validator("role", mode="before")
     @classmethod
     def _normalize_role(cls, v):
         if isinstance(v, str):
             v_lower = v.lower()
-            if v_lower not in {"system", "assistant", "tool", "function"}:
+            if v_lower not in {"system", "assistant", "tool", "function", "developer"}:
                 raise ValueError(
-                    "'role' must be one of 'system', 'assistant', 'tool', or 'function' (case-insensitive)."
+                    "'role' must be one of 'system', 'developer', 'assistant', 'tool', or 'function' (case-insensitive)."
                 )
             return v_lower
         raise ValueError("'role' must be a string")


### PR DESCRIPTION
Hi from [novita.ai](https://novita.ai/) team 👋

## Motivation

support for deepseeek v3.2.

example [test_input_search_w_data.json](https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/test_input_search_w_date.json)

got error 
```json
{
    "object": "error",
    "message": "[{'type': 'value_error', 'loc': ('body', 'messages', 0, 'ChatCompletionMessageGenericParam', 'role'), 'msg': \"Value error, 'role' must be one of 'system', 'assistant', 'tool', or 'function' (case-insensitive).\", 'input': 'developer', 'ctx': {'error': ValueError(\"'role' must be one of 'system', 'assistant', 'tool', or 'function' (case-insensitive).\")}}, {'type': 'literal_error', 'loc': ('body', 'messages', 0, 'ChatCompletionMessageUserParam', 'role'), 'msg': \"Input should be 'user'\", 'input': 'developer', 'ctx': {'expected': \"'user'\"}}]",
    "type": "Bad Request",
    "param": null,
    "code": 400
}
```
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

