### PR TITLE
[Fix] add block size logic for sm120 smem size

### DIFF
--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -65,11 +65,20 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
         num_warps = 4
     else:
         if _is_cuda and CUDA_CAPABILITY[0] >= 9:
-            # Hopper architecture (H100, etc.)
-            if Lq <= 256:
-                BLOCK_M, BLOCK_N = (128, 64)
+            # sm120 consumer Blackwell architecture (RTX Pro 6000) has a much smaller shared memory size (100K)
+            if CUDA_CAPABILITY[0] == 12:
+                if Lq <= 128:
+                    BLOCK_M, BLOCK_N = (64, 128)
+                elif Lq <= 256:
+                    BLOCK_M, BLOCK_N = (64, 64)
+                else:
+                    BLOCK_M, BLOCK_N = (32, 32)
             else:
-                BLOCK_M, BLOCK_N = (32, 64)
+                # Hopper architecture (H100, etc.)
+                if Lq <= 256:
+                    BLOCK_M, BLOCK_N = (128, 64)
+                else:
+                    BLOCK_M, BLOCK_N = (32, 64)
         elif _is_cuda and CUDA_CAPABILITY[0] >= 8:
             # Ampere architecture (A100, etc.)
             # sm86/sm89 has a much smaller shared memory size (100K) than sm80 (160K)

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -65,7 +65,7 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
         num_warps = 4
     else:
         if _is_cuda and CUDA_CAPABILITY[0] == 12:
-            # sm120 consumer Blackwell architecture (RTX Pro 6000) has a much smaller shared memory size (100K)
+            # sm120 workstation Blackwell architecture (RTX Pro 6000) has a much smaller shared memory size (100K)
             if Lq <= 128:
                 BLOCK_M, BLOCK_N = (64, 128)
             elif Lq <= 256:

--- a/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
+++ b/python/sglang/srt/layers/attention/triton_ops/extend_attention.py
@@ -64,21 +64,20 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
         BLOCK_M, BLOCK_N = (64, 64)
         num_warps = 4
     else:
-        if _is_cuda and CUDA_CAPABILITY[0] >= 9:
+        if _is_cuda and CUDA_CAPABILITY[0] == 12:
             # sm120 consumer Blackwell architecture (RTX Pro 6000) has a much smaller shared memory size (100K)
-            if CUDA_CAPABILITY[0] == 12:
-                if Lq <= 128:
-                    BLOCK_M, BLOCK_N = (64, 128)
-                elif Lq <= 256:
-                    BLOCK_M, BLOCK_N = (64, 64)
-                else:
-                    BLOCK_M, BLOCK_N = (32, 32)
+            if Lq <= 128:
+                BLOCK_M, BLOCK_N = (64, 128)
+            elif Lq <= 256:
+                BLOCK_M, BLOCK_N = (64, 64)
             else:
-                # Hopper architecture (H100, etc.)
-                if Lq <= 256:
-                    BLOCK_M, BLOCK_N = (128, 64)
-                else:
-                    BLOCK_M, BLOCK_N = (32, 64)
+                BLOCK_M, BLOCK_N = (32, 32)
+        elif _is_cuda and CUDA_CAPABILITY[0] >= 9:
+            # Hopper architecture (H100, etc.)
+            if Lq <= 256:
+                BLOCK_M, BLOCK_N = (128, 64)
+            else:
+                BLOCK_M, BLOCK_N = (32, 64)
         elif _is_cuda and CUDA_CAPABILITY[0] >= 8:
             # Ampere architecture (A100, etc.)
             # sm86/sm89 has a much smaller shared memory size (100K) than sm80 (160K)


### PR DESCRIPTION
Update block size assignments for consumer Blackwell sm120 architecture.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

Kimi K2 thinking crashes after the first request on 8x RTX Pro 6000:

```
sglang-kimi-k2  | [2025-12-02 18:40:16 TP0] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 2212, token usage: 0.02, #running-req: 0, #queue-req: 0, 
sglang-kimi-k2  | [2025-12-02 18:40:17 TP7] Scheduler hit an exception: Traceback (most recent call last):
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 2677, in run_scheduler_process
sglang-kimi-k2  |     scheduler.event_loop_overlap()
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
sglang-kimi-k2  |     return func(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1036, in event_loop_overlap
sglang-kimi-k2  |     batch_result = self.run_batch(batch)
sglang-kimi-k2  |                    ^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1999, in run_batch
sglang-kimi-k2  |     batch_result = self.model_worker.forward_batch_generation(
sglang-kimi-k2  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/managers/tp_worker.py", line 392, in forward_batch_generation
sglang-kimi-k2  |     logits_output, can_run_cuda_graph = self.model_runner.forward(
sglang-kimi-k2  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2622, in forward
sglang-kimi-k2  |     output = self._forward_raw(
sglang-kimi-k2  |              ^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2681, in _forward_raw
sglang-kimi-k2  |     ret = self.forward_extend(
sglang-kimi-k2  |           ^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 2567, in forward_extend
sglang-kimi-k2  |     return self.model.forward(
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
sglang-kimi-k2  |     return func(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 3480, in forward
sglang-kimi-k2  |     hidden_states = self.model(
sglang-kimi-k2  |                     ^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
sglang-kimi-k2  |     return self._call_impl(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
sglang-kimi-k2  |     return forward_call(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 3291, in forward
sglang-kimi-k2  |     hidden_states, residual = layer(
sglang-kimi-k2  |                               ^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
sglang-kimi-k2  |     return self._call_impl(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
sglang-kimi-k2  |     return forward_call(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 3004, in forward
sglang-kimi-k2  |     hidden_states = self.self_attn(
sglang-kimi-k2  |                     ^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
sglang-kimi-k2  |     return self._call_impl(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
sglang-kimi-k2  |     return forward_call(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 1474, in forward
sglang-kimi-k2  |     return self.forward_core(s)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 1573, in forward_core
sglang-kimi-k2  |     return self.forward_absorb_core(*inner_state)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/models/deepseek_v2.py", line 1979, in forward_absorb_core
sglang-kimi-k2  |     attn_output = self.attn_mqa(
sglang-kimi-k2  |                   ^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
sglang-kimi-k2  |     return self._call_impl(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
sglang-kimi-k2  |     return forward_call(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/layers/radix_attention.py", line 123, in forward
sglang-kimi-k2  |     return forward_batch.attn_backend.forward(
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/base_attn_backend.py", line 113, in forward
sglang-kimi-k2  |     return self.forward_extend(
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/triton_backend.py", line 838, in forward_extend
sglang-kimi-k2  |     self.extend_attention_fwd(
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
sglang-kimi-k2  |     return fn(*args, **kwargs)
sglang-kimi-k2  |            ^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/triton_ops/extend_attention.py", line 597, in extend_attention_fwd
sglang-kimi-k2  |     _fwd_kernel[grid](
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 419, in <lambda>
sglang-kimi-k2  |     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
sglang-kimi-k2  |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/triton/runtime/jit.py", line 756, in run
sglang-kimi-k2  |     launch_metadata = kernel.launch_metadata(grid, stream, *bound_args.values())
sglang-kimi-k2  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 490, in launch_metadata
sglang-kimi-k2  |     self._init_handles()
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 464, in _init_handles
sglang-kimi-k2  |     raise_(OutOfResources(self.metadata.shared, max_shared, "shared memory"))
sglang-kimi-k2  |   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 456, in raise_
sglang-kimi-k2  |     raise err
sglang-kimi-k2  | triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 106496, Hardware limit: 101376. Reducing block sizes or `num_stages` may help.
```


## Modifications

I updated the block sizes to account for the correct amount of smem on these cards. It uses the same setup as the other 100k smem GPU from older generations.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
