### PR TITLE
Fix nonetype error for ci failure monitor

### DIFF
--- a/scripts/ci_monitor/ci_failures_analysis.py
+++ b/scripts/ci_monitor/ci_failures_analysis.py
@@ -179,14 +179,13 @@ class SGLangFailuresAnalyzer:
                     f"Processing run {i}/{total_runs_processed} for runner analysis: #{run.get('run_number')}"
                 )
 
+            head_commit = run.get("head_commit") or {}
             run_info = {
                 "run_number": run.get("run_number"),
                 "run_id": run.get("id"),
                 "created_at": run.get("created_at"),
                 "head_sha": run.get("head_sha", "")[:8],
-                "author": run.get("head_commit", {})
-                .get("author", {})
-                .get("name", "Unknown"),
+                "author": head_commit.get("author", {}).get("name", "Unknown"),
                 "url": f"https://github.com/{self.repo}/actions/runs/{run.get('id')}",
             }
 
@@ -750,14 +749,13 @@ class SGLangFailuresAnalyzer:
                     f"Processing run {i}/{total_runs_processed}: #{run.get('run_number')}"
                 )
 
+            head_commit = run.get("head_commit") or {}
             run_info = {
                 "run_number": run.get("run_number"),
                 "run_id": run.get("id"),
                 "created_at": run.get("created_at"),
                 "head_sha": run.get("head_sha", "")[:8],
-                "author": run.get("head_commit", {})
-                .get("author", {})
-                .get("name", "Unknown"),
+                "author": head_commit.get("author", {}).get("name", "Unknown"),
                 "url": f"https://github.com/{self.repo}/actions/runs/{run.get('id')}",
             }
 


### PR DESCRIPTION
## Motivation

For runs with no head commit, the current code returns none for run.get("head_commit",{}) instead of an empty dict, so the subsequent .get("author", {}) call is throwing a Nonetype error.

## Modifications

`run.get("head_commit",{}).get("author", {}).get("name", "Unknown")` was edited for safety into head_commit = run.get("head_commit") or {}, "author": head_commit.get("author", {}).get("name", "Unknown").

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [N/A] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [N/A ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [N/A ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [N/A] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
