### PR TITLE
ci: Add zyzshishui to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -978,5 +978,12 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override",
         "can_rerun_stage": true
+    },
+    "zyzshishui": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override",
+        "can_rerun_stage": true
     }
 }


### PR DESCRIPTION
## Summary
Add user `zyzshishui` to CI permissions with same privileges as `sunxxuns`.

## Permissions Granted
- `can_tag_run_ci_label`: true
- `can_rerun_failed_ci`: true
- `cooldown_interval_minutes`: 0
- `can_rerun_stage`: true
- `reason`: "custom override"