### PR TITLE
multimodal: precompute hash for MultimodalDataItem

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -36,6 +36,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_DECODE` | Weight increment for decode forward mode in scheduler recv skipper. Works with `--scheduler-recv-interval` to control polling frequency during decode phase. | `1` |
 | `SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_VERIFY` | Weight increment for target verify forward mode in scheduler recv skipper. Works with `--scheduler-recv-interval` to control polling frequency during verification phase. | `1` |
 | `SGLANG_SCHEDULER_RECV_SKIPPER_WEIGHT_NONE` | Weight increment when forward mode is None in scheduler recv skipper. Works with `--scheduler-recv-interval` to control polling frequency when no specific forward mode is active. | `1` |
+| `SGLANG_MM_PRECOMPUTE_HASH` | Enable precomputing of hash values for MultimodalDataItem | `false` |
 
 
 ## DeepGEMM Configuration (Advanced Optimization)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -323,6 +323,7 @@ class Envs:
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
+    SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)
 
     # Release & Resume Memory
     SGLANG_MEMORY_SAVER_CUDA_GRAPH = EnvBool(False)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -242,6 +242,9 @@ class MultimodalDataItem:
         """
         Set the pad value after first hashing the data
         """
+        if self.pad_value is not None:
+            return
+
         from sglang.srt.managers.mm_utils import hash_feature
 
         if self.hash is None:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -718,11 +718,14 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             )
             if mm_inputs and "input_ids" in mm_inputs:
                 input_ids = mm_inputs["input_ids"]
-            if envs.SGLANG_MM_PRECOMPUTE_HASH.get():
-                if mm_inputs and "mm_items" in mm_inputs:
-                    for item in mm_inputs["mm_items"]:
-                        if isinstance(item, MultimodalDataItem):
-                            item.set_pad_value()
+            if (
+                envs.SGLANG_MM_PRECOMPUTE_HASH.get()
+                and mm_inputs
+                and "mm_items" in mm_inputs
+            ):
+                for item in mm_inputs["mm_items"]:
+                    if isinstance(item, MultimodalDataItem):
+                        item.set_pad_value()
         else:
             mm_inputs = None
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -74,7 +74,7 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.mm_utils import TensorTransportMode
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.request_metrics_exporter import RequestMetricsExporterManager
-from sglang.srt.managers.schedule_batch import RequestStage
+from sglang.srt.managers.schedule_batch import MultimodalDataItem, RequestStage
 from sglang.srt.managers.scheduler import is_health_check_generate_req
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_communicator_mixin import TokenizerCommunicatorMixin
@@ -718,6 +718,11 @@ class TokenizerManager(TokenizerCommunicatorMixin):
             )
             if mm_inputs and "input_ids" in mm_inputs:
                 input_ids = mm_inputs["input_ids"]
+            if envs.SGLANG_MM_PRECOMPUTE_HASH.get():
+                if mm_inputs and "mm_items" in mm_inputs:
+                    for item in mm_inputs["mm_items"]:
+                        if isinstance(item, MultimodalDataItem):
+                            item.set_pad_value()
         else:
             mm_inputs = None
 


### PR DESCRIPTION
Co-authored-by: Junjie Mao <junjie.mao@linux.alibaba.com>

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

In VLM scenarios, computing the hash code of a MultimodalDataItem is a relatively time-consuming operation. Currently, this step is implemented in the scheduler, and for large input data, it directly blocks the entire scheduler, resulting in reduced throughput and increased latency. 

## Modifications

This PR moves this step earlier into the tokenizer and introduces an environment variable SGLANG_MM_PRECOMPUTE_HASH to control whether this feature is enabled.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

### test parameters
server:
```bash
export SGLANG_ENABLE_TORCH_INFERENCE_MODE=true
export OMP_NUM_THREADS=4
export SGLANG_SUPPORT_CUTLASS_BLOCK_FP8=1
export SGLANG_ENABLE_JIT_DEEPGEMM=0
export FLASHINFER_DISABLE_VERSION_CHECK=1
python3 -m sglang.launch_server --model-path Qwen/Qwen3-VL-4B-Instruct-FP8 --enable-multimodal --cuda-graph-max-bs 128 --context-length 2560 --page-size 16 --stream-interval 300 --mem-fraction-static 0.7 --port 30260 --base-gpu-id 0 --kv-cache-dtype fp8_e4m3 --mm-attention-backend sdpa --enable-torch-compile --torch-compile-max-bs 128
```
client:
```bash
vllm bench serve --port 30260 --backend openai-chat --model Qwen/Qwen3-VL-4B-Instruct-FP8 --trust-remote-code --percentile-metrics ttft,tpot,itl,e2el --num-prompts 1024 --dataset-name random-mm --random-mm-base-items-per-request 1 --random-mm-num-mm-items-range-ratio 0 --random-mm-bucket-config '{(1280, 720, 1): 1.0}' --seed 18347 --request-rate inf --random-prefix-len 500 --random-input-len 600 --random-output-len 230 --endpoint /v1/chat/completions --max-concurrency 128
```

### Reuslt
Multimodal data size is approximately 20 MB, achieving a 15% throughput improvement.

Original:
```
============ Serving Benchmark Result ============
Successful requests:                     1024
Maximum request concurrency:             128
Benchmark duration (s):                  176.54
Total input tokens:                      1125742
Total generated tokens:                  235520
Request throughput (req/s):              5.80
Output token throughput (tok/s):         1334.08
Peak output token throughput (tok/s):    260.00
Peak concurrent requests:                256.00
Total Token throughput (tok/s):          7710.74
---------------Time to First Token----------------
Mean TTFT (ms):                          9802.54
Median TTFT (ms):                        9904.23
P99 TTFT (ms):                           16485.20
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          53.15
Median TPOT (ms):                        52.82
P99 TPOT (ms):                           91.85
---------------Inter-token Latency----------------
Mean ITL (ms):                           4056.81
Median ITL (ms):                         0.01
P99 ITL (ms):                            19928.47
----------------End-to-end Latency----------------
Mean E2EL (ms):                          21972.98
Median E2EL (ms):                        21944.38
P99 E2EL (ms):                           23086.19
==================================================
```

Optimized:
```
============ Serving Benchmark Result ============
Successful requests:                     1024
Maximum request concurrency:             128
Benchmark duration (s):                  152.39
Total input tokens:                      1125915
Total generated tokens:                  235520
Request throughput (req/s):              6.72
Output token throughput (tok/s):         1545.52
Peak output token throughput (tok/s):    256.00
Peak concurrent requests:                253.00
Total Token throughput (tok/s):          8933.94
---------------Time to First Token----------------
Mean TTFT (ms):                          7355.01
Median TTFT (ms):                        6660.50
P99 TTFT (ms):                           13171.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          50.04
Median TPOT (ms):                        52.04
P99 TPOT (ms):                           77.22
---------------Inter-token Latency----------------
Mean ITL (ms):                           3819.53
Median ITL (ms):                         0.01
P99 ITL (ms):                            17521.99
----------------End-to-end Latency----------------
Mean E2EL (ms):                          18813.59
Median E2EL (ms):                        19404.14
P99 E2EL (ms):                           19809.06
==================================================
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
