### PR TITLE
Add seprate metrics endpoint for grpc and optionally http server

### DIFF
--- a/docs/advanced_features/observability.md
+++ b/docs/advanced_features/observability.md
@@ -2,6 +2,9 @@
 
 ## Production Metrics
 SGLang exposes the following metrics via Prometheus. You can enable them by adding `--enable-metrics` when launching the server.
+
+By default, metrics are served on the main server's `/metrics` endpoint. You can optionally serve metrics on a separate port by specifying `--metrics-port <port>`.
+
 You can query them by:
 ```
 curl http://localhost:30000/metrics

--- a/docs/references/production_metrics.md
+++ b/docs/references/production_metrics.md
@@ -2,6 +2,8 @@
 
 SGLang exposes the following metrics via Prometheus. You can enable it by adding `--enable-metrics` when you launch the server.
 
+By default, metrics are served on the main server's `/metrics` endpoint. You can optionally serve metrics on a separate port by specifying `--metrics-port <port>`, which is useful when you want to isolate metrics traffic from the main API server.
+
 An example of the monitoring dashboard is available in [examples/monitoring/grafana.json](https://github.com/sgl-project/sglang/blob/main/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json).
 
 Here is an example of the metrics:

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -712,6 +712,9 @@ async def serve_grpc(
     # This ensures the environment variable is inherited by child processes
     if server_args.enable_metrics:
         set_prometheus_multiproc_dir()
+        # Launch metrics server on separate port if specified
+        if server_args.metrics_port is not None:
+            launch_metrics_server(server_args.host, server_args.metrics_port)
 
     # Start bootstrap server BEFORE launching scheduler processes (only in PREFILL mode)
     # This ensures the bootstrap server is ready when prefill schedulers try to register

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -35,7 +35,11 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.sampling.sampling_params import SamplingParams as SGLSamplingParams
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import (
+    kill_process_tree,
+    launch_metrics_server,
+    set_prometheus_multiproc_dir,
+)
 from sglang.utils import get_exception_traceback
 
 logger = logging.getLogger(__name__)
@@ -703,6 +707,11 @@ async def serve_grpc(
     model_info: Optional[Dict] = None,
 ):
     """Start the standalone gRPC server with integrated scheduler."""
+
+    # Set prometheus multiproc dir BEFORE launching scheduler processes
+    # This ensures the environment variable is inherited by child processes
+    if server_args.enable_metrics:
+        set_prometheus_multiproc_dir()
 
     # Start bootstrap server BEFORE launching scheduler processes (only in PREFILL mode)
     # This ensures the bootstrap server is ready when prefill schedulers try to register

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -331,6 +331,7 @@ class ServerArgs:
     crash_dump_folder: Optional[str] = None
     show_time_cost: bool = False
     enable_metrics: bool = False
+    metrics_port: Optional[int] = None
     enable_metrics_for_all_schedulers: bool = False
     tokenizer_metrics_custom_labels_header: str = "x-custom-labels"
     tokenizer_metrics_allowed_custom_labels: Optional[List[str]] = None
@@ -2757,6 +2758,12 @@ class ServerArgs:
             "--enable-metrics",
             action="store_true",
             help="Enable log prometheus metrics.",
+        )
+        parser.add_argument(
+            "--metrics-port",
+            type=int,
+            default=ServerArgs.metrics_port,
+            help="Port to serve metrics on a separate server. If not specified, metrics will be served on the main server's /metrics endpoint.",
         )
         parser.add_argument(
             "--enable-metrics-for-all-schedulers",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1535,6 +1535,7 @@ def add_prometheus_track_response_middleware(app):
 
         return response
 
+
 def launch_metrics_server(host: str, port: int):
     """Launch a separate metrics server on the specified port.
 
@@ -1545,9 +1546,13 @@ def launch_metrics_server(host: str, port: int):
 
     import uvicorn
     from fastapi import FastAPI
-    from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess
 
-    set_prometheus_multiproc_dir()
+    # Ensure PROMETHEUS_MULTIPROC_DIR is set BEFORE importing prometheus_client
+    # The multiprocess module checks for this env var at import time
+    if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+        set_prometheus_multiproc_dir()
+
+    from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess
 
     metrics_app = FastAPI()
 


### PR DESCRIPTION
Prometheus cannot scrape server metrics with grpc ports