### PR TITLE
[npu] support features of qwen3_next; fixup accuracy bugs in qwen3_next

### DIFF
--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -28,13 +28,6 @@ class AscendKVManager(MooncakeKVManager):
             disaggregation_mode=self.disaggregation_mode,
         )
 
-    def register_buffer_to_engine(self):
-        self.engine.batch_register(self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens)
-        # The Ascend backend optimize batch registration for small memory blocks.
-        self.engine.batch_register(
-            self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
-        )
-
     def send_kvcache(
         self,
         mooncake_session_id: str,

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
+import torch.nn.functional as F
 import torch_npu
 from sgl_kernel_npu.attention.sinks_attention import (
     attention_sinks_prefill_triton,
@@ -19,19 +22,27 @@ from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
     is_mla_preprocess_enabled,
 )
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.fla.fused_gdn_gating import fused_gdn_gating_v3
+from sglang.srt.layers.attention.fla.l2norm import l2norm_fwd
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
 from sglang.srt.layers.attention.nsa.utils import is_nsa_enable_prefill_cp
 from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import get_bool_env_var
 
 if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
 
-import logging
-
-import numpy as np
+from sgl_kernel_npu.fla.chunk import chunk_gated_delta_rule_npu
+from sgl_kernel_npu.fla.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_update_npu,
+)
+from sgl_kernel_npu.mamba.causal_conv1d import causal_conv1d_fn_npu
 
 
 def _reshape_kv_for_fia_nz(
@@ -329,6 +340,19 @@ class AscendAttnBackend(AttentionBackend):
                     )
                 )
 
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
+            if self.forward_metadata.seq_lens_cpu_int is None:
+                self.forward_metadata.actual_seq_lengths_kv = (
+                    self.forward_metadata.seq_lens_cpu_list
+                )
+            else:
+                self.forward_metadata.actual_seq_lengths_kv = (
+                    self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
+                )
         self.graph_mode = False
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
@@ -353,13 +377,20 @@ class AscendAttnBackend(AttentionBackend):
         metadata = ForwardMetadata()
 
         metadata.block_tables = self.graph_metadata["block_tables"][:bs, :]
+        metadata.block_tables.zero_()
         metadata.seq_lens_cpu_list = seq_lens.cpu().int().tolist()
+        metadata.seq_lens_cpu_int = seq_lens.cpu().int()
+
+        if forward_mode.is_target_verify():
+            metadata.seq_lens_cpu_int += self.speculative_num_draft_tokens
         metadata.seq_lens = seq_lens
         if (
             forward_mode.is_target_verify()
             or forward_mode.is_draft_extend_v2()
             or forward_mode.is_draft_extend()
         ):
+            metadata.actual_seq_lengths_kv = metadata.seq_lens_cpu_int.tolist()
+            metadata.seq_lens_cpu_list = metadata.seq_lens_cpu_int.tolist()
             metadata.actual_seq_lengths_q = torch.arange(
                 self.speculative_num_draft_tokens,
                 self.speculative_num_draft_tokens
@@ -406,7 +437,7 @@ class AscendAttnBackend(AttentionBackend):
         if forward_mode.is_target_verify():
             seq_lens = seq_lens + self.speculative_num_draft_tokens
         metadata.seq_lens[:bs].copy_(seq_lens[:bs])
-
+        metadata.seq_lens_cpu_list = metadata.seq_lens.cpu().int().tolist()
         self.forward_metadata = metadata
 
         self.graph_mode = True
@@ -1096,6 +1127,7 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
     ):
+        forward_batch.out_cache_loc = forward_batch.out_cache_loc.to(dtype=torch.int32)
         if save_kv_cache:
             if self.use_mla:
                 k = k.view(-1, layer.tp_k_head_num, self.kv_lora_rank)
@@ -1119,38 +1151,62 @@ class AscendAttnBackend(AttentionBackend):
             if not self.graph_mode:
                 num_token_padding = query.shape[0]
                 query = query[: forward_batch.num_token_non_padded_cpu]
-            if self.forward_metadata.seq_lens_cpu_int is None:
-                actual_seq_lengths_kv = self.forward_metadata.seq_lens_cpu_list
+            if False and layer.qk_head_dim == 256:
+                if forward_batch.extend_seq_lens_cpu is not None:
+                    bsz = len(forward_batch.extend_prefix_lens_cpu)
+                    query = query.view(bsz, -1, layer.tp_q_head_num, layer.qk_head_dim)
+                else:
+                    q_len = forward_batch.spec_info.draft_token_num
+                    query = query.view(
+                        -1, q_len, layer.tp_q_head_num, layer.qk_head_dim
+                    )
+                attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+                    query,
+                    k_cache,
+                    v_cache,
+                    block_table=self.forward_metadata.block_tables,
+                    block_size=self.page_size,
+                    num_heads=layer.tp_q_head_num,
+                    num_key_value_heads=layer.tp_k_head_num,
+                    input_layout="BSND",
+                    atten_mask=self.mtp_mask,
+                    scale=layer.scaling,
+                    actual_seq_lengths_kv=self.forward_metadata.actual_seq_lengths_kv,
+                    sparse_mode=3,
+                )
             else:
-                actual_seq_lengths_kv = (
-                    self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
-                )
-            if forward_batch.forward_mode.is_draft_extend():
-                actual_seq_lengths = (
-                    np.array(forward_batch.extend_seq_lens_cpu).cumsum().tolist()
-                )
-            else:
-                actual_seq_lengths = np.arange(
-                    self.speculative_num_draft_tokens,
-                    self.speculative_num_draft_tokens + query.shape[0],
-                    self.speculative_num_draft_tokens,
-                )
+                if self.forward_metadata.seq_lens_cpu_int is None:
+                    actual_seq_lengths_kv = self.forward_metadata.seq_lens_cpu_list
+                else:
+                    actual_seq_lengths_kv = (
+                        self.forward_metadata.seq_lens_cpu_int.cpu().int().tolist()
+                    )
+                if forward_batch.forward_mode.is_draft_extend():
+                    actual_seq_lengths = (
+                        np.array(forward_batch.extend_seq_lens_cpu).cumsum().tolist()
+                    )
+                else:
+                    actual_seq_lengths = np.arange(
+                        self.speculative_num_draft_tokens,
+                        self.speculative_num_draft_tokens + query.shape[0],
+                        self.speculative_num_draft_tokens,
+                    )
 
-            attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
-                query,
-                k_cache,
-                v_cache,
-                block_table=self.forward_metadata.block_tables,
-                block_size=self.page_size,
-                num_heads=layer.tp_q_head_num,
-                num_key_value_heads=layer.tp_k_head_num,
-                input_layout="TND",
-                atten_mask=self.mtp_mask,
-                scale=layer.scaling,
-                actual_seq_lengths=actual_seq_lengths,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                sparse_mode=3,
-            )
+                attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
+                    query,
+                    k_cache,
+                    v_cache,
+                    block_table=self.forward_metadata.block_tables,
+                    block_size=self.page_size,
+                    num_heads=layer.tp_q_head_num,
+                    num_key_value_heads=layer.tp_k_head_num,
+                    input_layout="TND",
+                    atten_mask=self.mtp_mask,
+                    scale=layer.scaling,
+                    actual_seq_lengths=actual_seq_lengths,
+                    actual_seq_lengths_kv=actual_seq_lengths_kv,
+                    sparse_mode=3,
+                )
             attn_output = attn_output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
             if (
                 not self.graph_mode
@@ -1798,3 +1854,418 @@ class AscendAttnMultiStepDraftBackend:
             )
 
         self.common_template(forward_batch, call_fn)
+
+
+class AscendGDNAttnBackend(MambaAttnBackendBase):
+    """
+    Attention backend using Mamba kernel.
+    Adapted from layers.attention.hybrid_linear_attn_backend.GDNAttnBackend
+    """
+
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__(model_runner)
+        self.enable_ascendc_fusion_gdn = get_bool_env_var(
+            "ENABLE_ASCENDC_FUSION_GDN", "false"
+        )
+        self.num_accepted_tokens = None
+        self.actual_seq_lengths = None
+        self.ssm_state_indices = None
+        self.graph_mode = False
+
+    def prepare_gdn_inputs(
+        self,
+        bs: int,
+        forward_mode: ForwardMode,
+        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+    ):
+        cache_indices = self.forward_metadata.mamba_cache_indices
+        self.num_accepted_tokens = torch.ones(
+            [bs], dtype=torch.int32, device=cache_indices.device
+        )
+        self.actual_seq_lengths = torch.ones(
+            [bs], dtype=torch.int32, device=cache_indices.device
+        )
+        if forward_mode.is_target_verify():
+            seq_len = spec_info.draft_token_num
+            self.actual_seq_lengths = self.actual_seq_lengths * seq_len
+            # indices
+            start_indices = cache_indices * seq_len
+            offset = torch.arange(seq_len, device=start_indices.device)
+            ranges = start_indices.unsqueeze(1) + offset
+            self.ssm_state_indices = ranges.flatten().to(torch.int32)
+        else:
+            self.ssm_state_indices = cache_indices
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        if forward_batch.forward_mode.is_draft_extend(True):
+            return
+        super().init_forward_metadata(forward_batch)
+        self.prepare_gdn_inputs(
+            forward_batch.batch_size,
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
+        )
+        self.graph_mode = False
+
+    def init_forward_metadata_capture_cuda_graph(
+        self,
+        bs: int,
+        num_tokens: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+    ):
+        if forward_mode.is_draft_extend(True):
+            return
+        super().init_forward_metadata_capture_cuda_graph(
+            bs,
+            num_tokens,
+            req_pool_indices,
+            seq_lens,
+            encoder_lens,
+            forward_mode,
+            spec_info,
+        )
+        self.prepare_gdn_inputs(bs, forward_mode, spec_info)
+        self.graph_mode = True
+
+    def init_forward_metadata_replay_cuda_graph(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_sum: int,
+        encoder_lens: Optional[torch.Tensor],
+        forward_mode: ForwardMode,
+        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        seq_lens_cpu: Optional[torch.Tensor],
+    ):
+        if forward_mode.is_draft_extend(True):
+            return
+        super().init_forward_metadata_replay_cuda_graph(
+            bs,
+            req_pool_indices,
+            seq_lens,
+            seq_lens_sum,
+            encoder_lens,
+            forward_mode,
+            spec_info,
+            seq_lens_cpu,
+        )
+        self.prepare_gdn_inputs(bs, forward_mode, spec_info)
+        self.graph_mode = True
+
+    def torch_causal_conv1d_update_npu(
+        self,
+        hidden_state: torch.Tensor,
+        conv_state: torch.Tensor,
+        weight: torch.Tensor,
+        conv_state_update: Optional[torch.Tensor] = None,
+        bias: Optional[torch.Tensor] = None,
+    ):
+        bsz, hidden_size, seq_len = hidden_state.shape
+        state_len = conv_state.shape[-1]
+        hidden_states_new = torch.cat([conv_state, hidden_state], dim=-1).to(
+            weight.dtype
+        )
+        if conv_state_update is not None:
+            for i in range(seq_len):
+                end = i - seq_len + 1
+                start = end - state_len
+                slice_range = slice(start, end if end != 0 else None)
+                conv_state_update[:, i] = hidden_states_new[:, :, slice_range]
+        else:
+            conv_state_update = hidden_states_new[:, :, -state_len:]
+        out = F.conv1d(
+            hidden_states_new, weight.unsqueeze(1), bias, padding=0, groups=hidden_size
+        )
+        out = F.silu(out[:, :, -seq_len:])
+        out = out.to(hidden_state.dtype)
+        return out, conv_state_update
+
+    def fused_recurrent_gated_delta_rule_update_npu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        recurrent_state: torch.Tensor,
+        beta: torch.Tensor,
+        g: torch.Tensor,
+        cache_indices: torch.Tensor,
+        intermediate_state: Optional[torch.Tensor] = None,
+    ):
+        _, num_heads, head_k_dim = query.shape  # T, N, D
+        _, num_value_heads, head_v_dim = value.shape
+        beta = beta.view(-1, num_value_heads).to(torch.bfloat16)
+        g = g.view(-1, num_value_heads).to(torch.float32)
+        batch_size = cache_indices.shape[0]
+        seq_len = query.shape[0] // batch_size
+        scale = 1 / (head_k_dim**0.5)
+
+        if intermediate_state is not None:
+            # MTP
+            intermediate_state[cache_indices, 0] = recurrent_state[cache_indices]
+            ssm_state = intermediate_state.view(
+                -1, num_value_heads, head_k_dim, head_v_dim
+            )
+        else:
+            ssm_state = recurrent_state
+
+        attn_core_out = torch_npu.npu_recurrent_gated_delta_rule(
+            query,
+            key,
+            value,
+            ssm_state,
+            beta=beta,
+            scale=scale,
+            actual_seq_lengths=self.actual_seq_lengths,
+            ssm_state_indices=self.ssm_state_indices,
+            num_accepted_tokens=self.num_accepted_tokens,
+            g=g,
+        )
+
+        if intermediate_state is not None:
+            intermediate_state = ssm_state.view(
+                -1, seq_len, num_value_heads, head_k_dim, head_v_dim
+            )
+        return attn_core_out
+
+    def forward_decode(
+        self,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs,
+    ):
+        layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
+        conv_states = layer_cache.conv[0]
+        ssm_states = layer_cache.temporal
+        query_start_loc = self.forward_metadata.query_start_loc
+        cache_indices = self.forward_metadata.mamba_cache_indices
+
+        mixed_qkv = mixed_qkv.unsqueeze(-1)
+        conv_state_update = conv_states[cache_indices]
+        mixed_qkv, conv_states[cache_indices] = (
+            self.torch_causal_conv1d_update_npu(  # todo
+                mixed_qkv,
+                conv_state_update,
+                layer.conv_weights,
+                bias=layer.bias,
+            )
+        )
+        mixed_qkv = mixed_qkv.squeeze(-1)
+        query, key, value = torch.split(
+            mixed_qkv,
+            [
+                layer.k_dim,
+                layer.k_dim,
+                layer.v_dim,
+            ],
+            dim=-1,
+        )
+        # Reshape from [l, h*d] to [1, l, h, d]
+        seq_len = query.shape[0]
+        num_heads = query.shape[1] // layer.head_k_dim
+        num_value_heads = value.shape[1] // layer.head_v_dim
+
+        if self.enable_ascendc_fusion_gdn:
+            g, beta = fused_gdn_gating_v3(layer.A_log, a, b, layer.dt_bias)
+            query = query.view(-1, num_heads, layer.head_k_dim)
+            key = key.view(-1, num_heads, layer.head_k_dim)
+            value = value.view(-1, num_value_heads, layer.head_v_dim)
+            query = l2norm_fwd(
+                query.contiguous(), eps=1e-6, output_dtype=torch.bfloat16
+            )
+            key = l2norm_fwd(key.contiguous(), eps=1e-6, output_dtype=torch.bfloat16)
+
+            core_attn_out = self.fused_recurrent_gated_delta_rule_update_npu(
+                query,
+                key,
+                value,
+                recurrent_state=ssm_states,
+                beta=beta,
+                g=g,
+                cache_indices=cache_indices,
+            )
+        else:
+            query = query.view(1, seq_len, num_heads, layer.head_k_dim)
+            key = key.view(1, seq_len, num_heads, layer.head_k_dim)
+            value = value.view(1, seq_len, num_value_heads, layer.head_v_dim)
+
+            core_attn_out = fused_sigmoid_gating_delta_rule_update_npu(
+                A_log=layer.A_log,
+                dt_bias=layer.dt_bias,
+                q=query,
+                k=key,
+                v=value,
+                a=a,
+                b=b,
+                initial_state_source=ssm_states,
+                initial_state_indices=cache_indices,
+                cu_seqlens=query_start_loc,
+                use_qk_l2norm_in_kernel=True,
+                softplus_beta=1.0,
+                softplus_threshold=20.0,
+            )
+
+        return core_attn_out
+
+    def forward_extend(
+        self,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs,
+    ):
+
+        assert isinstance(mixed_qkv, torch.Tensor)
+        seq_len = mixed_qkv.shape[0]
+
+        is_target_verify = forward_batch.forward_mode.is_target_verify()
+
+        query_start_loc = self.forward_metadata.query_start_loc
+        cache_indices = self.forward_metadata.mamba_cache_indices
+
+        mamba_cache_params = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
+        conv_states = mamba_cache_params.conv[0]
+        ssm_states = mamba_cache_params.temporal
+        batch_size = cache_indices.shape[0]
+        if is_target_verify:
+            assert isinstance(mamba_cache_params, MambaPool.SpeculativeState)
+            assert self.enable_ascendc_fusion_gdn, (
+                "When enabling MTP, you must enable the Ascendc fusion "
+                + 'GDN operator. Please set the environment variable using `export ENABLE_ASCENDC_FUSION_GDN="true"`.'
+            )
+            intermediate_state_cache = mamba_cache_params.intermediate_ssm
+            intermediate_conv_window_cache = (
+                mamba_cache_params.intermediate_conv_window[0]
+            )
+        else:
+            has_initial_states = forward_batch.extend_prefix_lens > 0
+
+        if is_target_verify:
+            num_token_padding = mixed_qkv.shape[0]
+            if (
+                not self.graph_mode
+                and forward_batch.num_token_non_padded_cpu != num_token_padding
+            ):
+                mixed_qkv = mixed_qkv[: forward_batch.num_token_non_padded_cpu]
+                a = a[: forward_batch.num_token_non_padded_cpu]
+                b = b[: forward_batch.num_token_non_padded_cpu]
+                seq_len = forward_batch.num_token_non_padded_cpu
+            head_dim = mixed_qkv.shape[-1]
+            draft_token_num = forward_batch.spec_info.draft_token_num
+            mixed_qkv_reshaped = (
+                mixed_qkv.view(-1, draft_token_num, head_dim)
+                .transpose(1, 2)
+                .contiguous()
+            )
+            conv_states_to_use = conv_states[cache_indices]
+            intermediate_conv_cache = intermediate_conv_window_cache[cache_indices]
+            mixed_qkv_processed, conv_state_update = (
+                self.torch_causal_conv1d_update_npu(
+                    mixed_qkv_reshaped,
+                    conv_states_to_use,
+                    layer.conv_weights,
+                    intermediate_conv_cache,
+                    layer.bias,
+                )
+            )
+            intermediate_conv_window_cache[cache_indices] = conv_state_update
+            mixed_qkv = (
+                mixed_qkv_processed.transpose(1, 2).contiguous().view(seq_len, -1)
+            )
+        else:
+            mixed_qkv = causal_conv1d_fn_npu(
+                mixed_qkv.transpose(0, 1),
+                layer.conv_weights,
+                layer.bias,
+                activation=layer.activation,
+                conv_states=conv_states,
+                has_initial_state=has_initial_states,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)[:seq_len]
+
+        key_split_dim = layer.k_dim
+        value_split_dim = layer.v_dim
+
+        query, key, value = torch.split(
+            mixed_qkv,
+            [key_split_dim, key_split_dim, value_split_dim],
+            dim=-1,
+        )
+
+        actual_seq_len = query.shape[0]
+        num_heads = query.shape[1] // layer.head_k_dim
+        num_value_heads = value.shape[1] // layer.head_v_dim
+
+        query = query.view(1, actual_seq_len, num_heads, layer.head_k_dim)
+        key = key.view(1, actual_seq_len, num_heads, layer.head_k_dim)
+        value = value.view(1, actual_seq_len, num_value_heads, layer.head_v_dim)
+
+        g, beta = fused_gdn_gating_v3(layer.A_log, a, b, layer.dt_bias)
+
+        if is_target_verify:
+            query = query.view(-1, num_heads, layer.head_k_dim)
+            key = key.view(-1, num_heads, layer.head_k_dim)
+            value = value.view(-1, num_value_heads, layer.head_v_dim)
+            query = l2norm_fwd(
+                query.contiguous(), eps=1e-6, output_dtype=torch.bfloat16
+            )
+            key = l2norm_fwd(key.contiguous(), eps=1e-6, output_dtype=torch.bfloat16)
+
+            core_attn_out = self.fused_recurrent_gated_delta_rule_update_npu(
+                query,
+                key,
+                value,
+                recurrent_state=ssm_states,
+                beta=beta,
+                g=g,
+                cache_indices=cache_indices,
+                intermediate_state=intermediate_state_cache,
+            )
+            if (not self.graph_mode) and core_attn_out.shape[0] < num_token_padding:
+                core_attn_out = torch.cat(
+                    [
+                        core_attn_out,
+                        core_attn_out.new_zeros(
+                            num_token_padding - core_attn_out.shape[0],
+                            *core_attn_out.shape[1:],
+                        ),
+                    ],
+                    dim=0,
+                )
+        else:
+            recurrent_state = ssm_states[cache_indices]
+            core_attn_out, last_recurrent_state, h = chunk_gated_delta_rule_npu(
+                q=query,
+                k=key,
+                v=value,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state,
+                output_final_state=True,
+                cu_seqlens=query_start_loc,
+                head_first=False,
+                use_qk_l2norm_in_kernel=True,
+            )
+            if self.enable_ascendc_fusion_gdn:
+                # AscendC GDN fusion operator requires the shape of the recurrent_state to be [b, s, Dv, Dk]
+                last_recurrent_state = last_recurrent_state.transpose(-1, -2).to(
+                    ssm_states.dtype, copy=False
+                )
+            else:
+                last_recurrent_state = last_recurrent_state.to(
+                    ssm_states.dtype, copy=False
+                )
+            ssm_states[cache_indices] = last_recurrent_state
+
+        return core_attn_out

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -212,11 +212,22 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                     or runner.server_args.attention_backend == "fa4"
                 ), "triton or trtllm_mha or fa4 backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend triton or --attention-backend trtllm_mha to specify the backend."
             if is_npu():
+                from sglang.srt.hardware_backend.npu.attention.ascend_backend import (
+                    AscendGDNAttnBackend,
+                )
+
                 assert (
                     runner.server_args.attention_backend == "ascend"
                 ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
-            logger.info(f"Using hybrid linear attention backend for hybrid GDN models.")
-            linear_attn_backend = GDNAttnBackend(runner)
+                logger.info(
+                    f"Using hybrid linear attention backend for hybrid GDN models. Using Ascend GDN attention backend for linear attention."
+                )
+                linear_attn_backend = AscendGDNAttnBackend(runner)
+            else:
+                logger.info(
+                    f"Using hybrid linear attention backend for hybrid GDN models."
+                )
+                linear_attn_backend = GDNAttnBackend(runner)
         elif runner.mamba2_config is not None:
             linear_attn_backend = Mamba2AttnBackend(runner)
         elif runner.kimi_linear_config is not None:

--- a/python/sglang/srt/layers/attention/fla/fused_gdn_gating.py
+++ b/python/sglang/srt/layers/attention/fla/fused_gdn_gating.py
@@ -67,3 +67,75 @@ def fused_gdn_gating(
         num_warps=1,
     )
     return g, beta_output
+
+
+@triton.jit
+def fused_gdn_gating_kernel_v3(
+    g,
+    A_log,
+    a,
+    dt_bias,
+    batch,
+    seq_len,
+    NUM_HEADS: tl.constexpr,
+    beta: tl.constexpr,
+    threshold: tl.constexpr,
+    BLK_BATCHES: tl.constexpr,
+    BLK_HEADS: tl.constexpr,
+):
+    i_b, i_s, i_d = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+
+    batch_off = i_b * BLK_BATCHES + tl.arange(0, BLK_BATCHES)
+    head_off = i_d * BLK_HEADS + tl.arange(0, BLK_HEADS)
+    head_mask = head_off < NUM_HEADS
+
+    a_off = (
+        batch_off[:, None] * seq_len * NUM_HEADS + i_s * NUM_HEADS + head_off[None, :]
+    )
+    a_mask = (batch_off[:, None] < batch) & head_mask[None, :]
+
+    blk_A_log = tl.load(A_log + head_off, mask=head_mask)
+    blk_bias = tl.load(dt_bias + head_off, mask=head_mask)
+
+    blk_a = tl.load(a + a_off, mask=a_mask)
+
+    x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)
+    softplus_x = tl.where(
+        beta * x <= threshold, (1 / beta) * tl.log(1 + tl.exp(beta * x)), x
+    )
+    blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
+    tl.store(g + a_off, blk_g.to(g.dtype.element_ty), mask=a_mask)
+
+
+def fused_gdn_gating_v3(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    batch, num_heads = a.shape
+    seq_len = 1
+    g = torch.empty_like(a, dtype=torch.float32)
+
+    num_cores = 48  # num_vectorcore of NPU
+    NUM_BLK_BATCHES = triton.cdiv(num_cores, triton.cdiv(num_heads, 8))
+    BLK_BATCHES = triton.cdiv(batch, NUM_BLK_BATCHES)
+    grid = (NUM_BLK_BATCHES, seq_len, triton.cdiv(num_heads, 8))
+    fused_gdn_gating_kernel_v3[grid](
+        g,
+        A_log,
+        a,
+        dt_bias,
+        batch,
+        seq_len,
+        num_heads,
+        beta,
+        threshold,
+        BLK_BATCHES=BLK_BATCHES,
+        BLK_HEADS=8,
+        num_warps=1,
+    )
+    g = g.unsqueeze(0)
+    return g, b.sigmoid().unsqueeze(0)

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -508,10 +508,12 @@ class GemmaRMSNorm(MultiPlatformOp):
         if residual is not None:
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            x = x + residual
-            residual = x
-
-        x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
+            gamma = (1.0 + self.weight).to(x.dtype)
+            x, _, residual = torch_npu.npu_add_rms_norm(
+                x, residual, gamma, self.variance_epsilon
+            )
+        else:
+            x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
         return x if residual is None else (x, residual)
 
     def forward_xpu(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -280,7 +280,7 @@ class MambaPool:
                         temporal_state_shape[2],
                     ),
                     dtype=ssm_dtype,
-                    device="cuda",
+                    device=device,
                 )
                 # Cache intermediate conv windows (last K-1 inputs) per draft token during target verify
                 # Shape: [num_layers, size + 1, speculative_num_draft_tokens, dim, K-1]
@@ -294,7 +294,7 @@ class MambaPool:
                             conv_shape[1],
                         ),
                         dtype=conv_dtype,
-                        device="cuda",
+                        device=device,
                     )
                     for conv_shape in conv_state_shape
                 ]

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -418,7 +418,7 @@ class ModelRunnerKVCacheMixin:
 
         # Initialize token_to_kv_pool
         is_nsa_model = is_deepseek_nsa(self.model_config.hf_config)
-        if self.server_args.attention_backend == "ascend":
+        if self.server_args.attention_backend == "ascend" and self.mambaish_config is None:
             if self.use_mla_backend:
                 from sglang.srt.hardware_backend.npu.memory_pool_npu import (
                     NPUMLATokenToKVPool,

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -1003,8 +1003,8 @@ class Qwen3NextForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        torch.get_device_module().empty_cache()
+        torch.get_device_module().synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight

--- a/test/srt/ascend/test_ascend_qwen3_next_tp8.py
+++ b/test/srt/ascend/test_ascend_qwen3_next_tp8.py
@@ -1,0 +1,129 @@
+import os
+import unittest
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    run_bench_offline_throughput,
+)
+
+TEST_MODEL_MATRIX = {
+    "Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "accuracy": 0.90,
+        "latency": 300,
+        "output_throughput": 30,
+    },
+}
+
+
+class TestAscendTp8Bf16(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = TEST_MODEL_MATRIX.keys()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.url = urlparse(DEFAULT_URL_FOR_TEST)
+        cls.common_args = [
+            "--tp",
+            "8",
+            "--moe-a2a-backend",
+            "deepep",
+            "--deepep-mode",
+            "auto",
+            "--mem-fraction-static",
+            "0.85",
+            "--max-total-tokens",
+            "1126400",
+            "--trust-remote-code",
+            "--attention-backend",
+            "ascend",
+            "--device",
+            "npu",
+            "--max-running-requests",
+            "32",
+            "--cuda-graph-bs",
+            "32",
+            "--disable-overlap-schedule",
+            "--mamba-ssm-dtype",
+            "bfloat16",
+            "--context-length",
+            "262144",
+            "--chunked-prefill-size",
+            "71680",
+            "--max-prefill-tokens",
+            "262144",
+            "--skip-server-warmup",
+            "--disable-radix-cache",
+        ]
+        cls.extra_envs = {
+            "HCCL_BUFFSIZE": "2048",
+            "HCCL_OP_EXPANSION_MODE": "AIV",
+            "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "32",
+            "SGLANG_DEEPEP_BF16_DISPATCH": "1",
+            "ENABLE_ASCENDC_FUSION_GDN": "false",  # only latest CANN supports this api
+            "ASCEND_USE_FIA": "true",
+        }
+        os.environ.update(cls.extra_envs)
+
+    def test_a_gsm8k(self):
+        for model in self.models:
+            with self.subTest(model=model):
+                print(f"##=== Testing accuracy: {model} ===##")
+
+                process = popen_launch_server(
+                    model,
+                    self.base_url,
+                    timeout=1800,
+                    other_args=[
+                        *self.common_args,
+                    ],
+                )
+
+                try:
+                    args = SimpleNamespace(
+                        num_shots=5,
+                        data_path=None,
+                        num_questions=200,
+                        max_new_tokens=512,
+                        parallel=32,
+                        host=f"http://{self.url.hostname}",
+                        port=int(self.url.port),
+                    )
+
+                    metrics = run_eval_few_shot_gsm8k(args)
+                    self.assertGreaterEqual(
+                        metrics["accuracy"],
+                        TEST_MODEL_MATRIX[model]["accuracy"],
+                    )
+                finally:
+                    kill_process_tree(process.pid)
+
+    def test_b_throughput(self):
+        for model in self.models:
+            with self.subTest(model=model):
+                print(f"##=== Testing throughput: {model} ===##")
+
+                output_throughput = run_bench_offline_throughput(
+                    model,
+                    [
+                        *self.common_args,
+                    ],
+                )
+
+                print(f"##=== {model} throughput: {output_throughput} ===##")
+
+                if is_in_ci():
+                    self.assertGreater(
+                        output_throughput,
+                        TEST_MODEL_MATRIX[model]["output_throughput"],
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -110,6 +110,8 @@ suite_ascend = {
     ],
     "per-commit-16-npu-a3": [
         TestFile("ascend/test_ascend_deepep.py", 3600),
+        TestFile("ascend/test_ascend_deepseek_mtp.py", 400),
+        TestFile("ascend/test_ascend_qwen3_next_tp8.py", 400),
     ],
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
- NPU supports features of qwen3_next(pd disaggregation, mtp, npugraph, fused operator, w8a8 quantizaton); 
- fixup accuracy bugs in qwen3_next on NPU
This PR needs to run togather with the modification of https://github.com/sgl-project/sgl-kernel-npu/pull/259. And one should install latest CANN/PTA packages which include our new torch_npu kernels.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
This pull request significantly advances the NPU (Ascend) compatibility and performance for the Qwen3_next model within the SGLang framework. It integrates crucial NPU-specific optimizations and features, such as disaggregation and fused operators, while also rectifying known accuracy problems. The changes span across attention mechanisms, quantization processes, and general device management, aiming to provide a more robust and efficient experience on Ascend hardware.

#### Highlights
- NPU Feature Support: Introduced comprehensive NPU (Ascend) support for Qwen3_next model features, including disaggregation, multi-token prefill (MTP), NPU graph integration, fused operators, and W8A8 quantization.
- Accuracy Bug Fixes: Addressed and resolved accuracy issues identified in the Qwen3_next model when running on NPU hardware.
- Attention Backend Enhancements: Implemented a new AscendGDNAttnBackend for Mamba kernel attention on NPU, refining the handling of sequence lengths and cache locations for improved performance and correctness.
- Quantization Improvements: Updated the W8A8 quantization logic to better support dynamic quantization on NPU and introduced a new utility script (convert_model_qwen3_next.py) for INT8 quantization of Qwen3_next models.
- Device Agnostic Operations: Refactored cache management and memory pool initialization to be device-agnostic, moving away from hardcoded 'cuda' references to torch.get_device_module().
- New AscendC Fused Operator Integration: Added integration of the AscendC fused operator torch_npu.npu_recurrent_gated_delta_rule, which can be enabled by setting the ENABLE_ASCENDC_FUSION_GDN environment variable.

## Accuracy Tests

```[shell]
export HCCL_OP_EXPANSION_MODE=AIV
export DEEP_NORMAL_MODE_USE_INT8_QUANT=1
export ASCEND_USE_FIA=1
export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
export SGLANG_ENABLE_SPEC_V2=1
export ENABLE_ASCENDC_FUSION_GDN=1
export MODEL_PATH=Qwen3-Next-80B-A3B-Instruct-A8W8

python -m sglang.launch_server --model-path ${MODEL_PATH} --trust-remote-code \
    --host 0.0.0.0 --port 8000 --nnodes 1 --node-rank 0 \
    --attention-backend ascend --device npu --quantization modelslim \
    --max-running-requests 16 \
    --context-length 102400 --chunked-prefill-size 71680 --max-prefill-tokens 102400 \
    --tp-size 8 \
    --mem-fraction-static 0.7 --max-total-tokens 1126400 \
    --moe-a2a-backend deepep --deepep-mode auto \
    --disable-overlap-schedule  --disable-radix-cache \
    --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2
```
```[shell]
python few_shot_gsm8k.py --data-path test.jsonl.txt --parallel 16 --num-question 200 --num-shots 5 --port 8000 --temperature 0
# Accuracy: 0.945
# Invaild: 0.000
# Latency: 389.107s
# Output throughput: 83.327 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
After enabling the aforementioned AscendC fused operator, the performance metrics are as follows:
By configuring startup command:
```[shell]
python -m sglang.launch_server --model-path ${MODEL_PATH} --trust-remote-code \
    --host 0.0.0.0 --port 8000 --nnodes 1 --node-rank 0 \
    --attention-backend ascend --device npu \
    --max-running-requests 96 --context-length 8192  --disable-radix-cache \
    --chunked-prefill-size 327680 --max-prefill-tokens 4000 \
    --tp-size 16 --enable-dp-attention --dp-size 4 --enable-dp-lm-head --mem-fraction-static 0.7 \
    --moe-a2a-backend deepep --deepep-mode auto \
    --cuda-graph-bs 24 \
    --max-total-tokens 229504
```
```[shell]
python -m sglang.bench_serving --base-url http://7.150.8.78:8000 --dataset-path /data/h00910141/ShareGPT_V3_unfiltered_cleaned_split.json --dataset-name=random --random-range-ratio 1 --random-input 3500 --random-output 1500 --max-concurrency 24 --num-prompts 24
```
### baseline tpot: 53.05ms, ttft: 6500ms
<img width="545" height="685" alt="image" src="https://github.com/user-attachments/assets/ad49a0f7-e553-4f87-8508-31f999718166" />

### pr tpot: 44.30ms, ttft: 6363ms
<img width="614" height="804" alt="image" src="https://github.com/user-attachments/assets/c210a243-a051-4b02-840e-d4a6c8618a4e" />


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
