### PR TITLE
[model-gateway][doc] Add STDIO Explicitly to Example in README

### DIFF
--- a/sgl-router/README.md
+++ b/sgl-router/README.md
@@ -263,6 +263,7 @@ servers:
   - name: "filesystem"
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    protocol: "stdio"
     required: false
 
   - name: "github"
@@ -298,7 +299,7 @@ inventory:
 - `command` + `args`: For STDIO transport (local process execution)
 - `url`: For SSE or Streamable transports (HTTP/HTTPS endpoints)
 - `token`: Optional authentication token for HTTP-based transports
-- `protocol`: Protocol type (`"sse"` or `"streamable"`; STDIO is inferred from `command`)
+- `protocol`: Protocol type (`"sse"`, `"streamable"` or `"stdio"`)
 - `required`: If `true`, router fails to start if server is unreachable (default: `false`)
 - `envs`: Environment variables for STDIO processes (optional)
 - `proxy`: Per-server proxy override (set to `null` to bypass global proxy)

--- a/sgl-router/README.md
+++ b/sgl-router/README.md
@@ -299,7 +299,7 @@ inventory:
 - `command` + `args`: For STDIO transport (local process execution)
 - `url`: For SSE or Streamable transports (HTTP/HTTPS endpoints)
 - `token`: Optional authentication token for HTTP-based transports
-- `protocol`: Protocol type (`"sse"`, `"streamable"` or `"stdio"`)
+- `protocol`: Protocol type (`"sse"`, `"streamable"`, or `"stdio"`)
 - `required`: If `true`, router fails to start if server is unreachable (default: `false`)
 - `envs`: Environment variables for STDIO processes (optional)
 - `proxy`: Per-server proxy override (set to `null` to bypass global proxy)


### PR DESCRIPTION
## Motivation
There's a small discrepancy between the README and the current implementation,
The [README.md](https://github.com/sgl-project/sglang/blob/main/sgl-router/README.md#mcp-configuration-file) suggests that for an `stdio` transport, the `protocol` field is optional and can be inferred from the presence of a command
with example
```
servers:
  - name: "filesystem"
    command: "npx"
    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
    required: false

...
`protocol`: Protocol type (`"sse"` or `"streamable"`; STDIO is inferred from `command`)
...
```

But i realized that protocol field could be mandatory during McpTransport deserialization, and omitting protocol: "stdio" will cause an error

<img width="1508" height="44" alt="Screenshot 2025-12-04 at 12 02 35 PM" src="https://github.com/user-attachments/assets/632081a7-bb29-42b2-b2f8-9295c4aba86f" />


## Modifications
Update README to explictly set `protocol` as `stdio`.

## Accuracy Tests
Can successfully connect with `protocol: "stdio"` added.

```
servers:
  - name: "filesystem"
    command: "npx"
    args: ["-y", "@modelcontextprotocol/server-filesystem", "./tmp"]
    protocol: "stdio"
    required: false
```

<img width="1500" height="60" alt="Screenshot 2025-12-04 at 12 16 12 PM" src="https://github.com/user-attachments/assets/c2a324ab-6a45-481d-85d9-cfcc3e6365f6" />

<img width="1510" height="59" alt="Screenshot 2025-12-04 at 12 16 32 PM" src="https://github.com/user-attachments/assets/41c03d3d-6f9c-452c-b2b7-c0a481004c81" />



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
