### PR TITLE
Support FP8 MLA prefill and 128k context.

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -198,7 +198,9 @@ def unpad_draft_extend_output_kernel(
 def _quantize_fp8_qkv(q, k, v, layer):
     q = q.to(torch.float8_e4m3fn)
 
-    k_scale = getattr(layer, "k_scale_float", 1.0)
+    k_scale = getattr(layer, "k_scale_float", None)
+    if k_scale is None:
+        k_scale = 1.0
     if k_scale != 1.0:
         assert hasattr(layer, "k_scale"), "k_scale is not set"
         k_2d, _ = scaled_fp8_quant(
@@ -208,7 +210,9 @@ def _quantize_fp8_qkv(q, k, v, layer):
     else:
         k = k.to(torch.float8_e4m3fn)
 
-    v_scale = getattr(layer, "v_scale_float", 1.0)
+    v_scale = getattr(layer, "v_scale_float", None)
+    if v_scale is None:
+        v_scale = 1.0
     if v_scale != 1.0:
         assert hasattr(layer, "v_scale"), "v_scale is not set"
         v_2d, _ = scaled_fp8_quant(

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -21,6 +21,7 @@ from sglang.srt.layers.attention.utils import (
     get_num_page_per_block_flashmla,
 )
 from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.quantization.fp8_kernel import scaled_fp8_quant
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_cuda, is_flashinfer_available, is_float4_e2m1fn_x2
@@ -39,7 +40,7 @@ if _is_cuda:
     from sgl_kernel import concat_mla_absorb_q
 
 # Constants
-DEFAULT_WORKSPACE_SIZE_MB = 128  # Memory workspace size in MB
+DEFAULT_WORKSPACE_SIZE_MB = 150  # Memory workspace size in MB
 
 # Block constraint from flashinfer requirements
 # From flashinfer.decode._check_trtllm_gen_mla_shape:
@@ -192,6 +193,32 @@ def unpad_draft_extend_output_kernel(
         data,
         mask=head_mask[:, None] & dim_mask[None, :],
     )
+
+
+def _quantize_fp8_qkv(q, k, v, layer):
+    q = q.to(torch.float8_e4m3fn)
+
+    k_scale = getattr(layer, "k_scale_float", 1.0)
+    if k_scale != 1.0:
+        assert hasattr(layer, "k_scale"), "k_scale is not set"
+        k_2d, _ = scaled_fp8_quant(
+            k.reshape(-1, k.shape[-1]).contiguous(), layer.k_scale
+        )
+        k = k_2d.reshape(k.shape)
+    else:
+        k = k.to(torch.float8_e4m3fn)
+
+    v_scale = getattr(layer, "v_scale_float", 1.0)
+    if v_scale != 1.0:
+        assert hasattr(layer, "v_scale"), "v_scale is not set"
+        v_2d, _ = scaled_fp8_quant(
+            v.reshape(-1, v.shape[-1]).contiguous(), layer.v_scale
+        )
+        v = v_2d.reshape(v.shape)
+    else:
+        v = v.to(torch.float8_e4m3fn)
+
+    return q, k, v, k_scale, v_scale
 
 
 global_zero_init_workspace_buffer = None
@@ -1035,6 +1062,25 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             k = torch.cat([k, k_rope], dim=-1)
         k = k.view(-1, layer.tp_k_head_num, layer.head_dim)
         v = v.view(-1, layer.tp_k_head_num, layer.v_head_dim)
+
+        q_scale = k_scale = v_scale = 1.0
+        if self.data_type == torch.float8_e4m3fn:
+            q, k, v, k_scale, v_scale = _quantize_fp8_qkv(q, k, v, layer)
+
+        common_trtllm_args = {
+            "query": q,
+            "key": k,
+            "value": v,
+            "workspace_buffer": self.workspace_buffer,
+            "batch_size": forward_batch.batch_size,
+            "window_left": -1,
+            "enable_pdl": False,
+            "max_q_len": self.forward_prefill_metadata.max_seq_len,
+            "bmm1_scale": q_scale * k_scale * layer.scaling,
+            "bmm2_scale": v_scale,
+            "cum_seq_lens_q": self.forward_prefill_metadata.cum_seq_lens,
+        }
+
         # When chunked prefix cache is enabled, dispatch to different path for ragged attention.
         if forward_batch.attn_attend_prefix_cache:
             # MHA for chunked prefix kv cache when running model with MLA
@@ -1044,47 +1090,41 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             assert k_rope is None
             chunk_idx = forward_batch.prefix_chunk_idx
 
-            output_shape = (q.shape[0], layer.tp_q_head_num, layer.v_head_dim)
+            out = torch.zeros(
+                q.shape[0],
+                layer.tp_q_head_num,
+                layer.v_head_dim,
+                dtype=self.q_data_type,
+                device=q.device,
+            )
             return flashinfer.prefill.trtllm_ragged_attention_deepseek(
-                query=q,
-                key=k,
-                value=v,
-                workspace_buffer=self.workspace_buffer,
+                **common_trtllm_args,
                 seq_lens=forward_batch.prefix_chunk_seq_lens[chunk_idx],
-                max_q_len=self.forward_prefill_metadata.max_seq_len,
                 max_kv_len=forward_batch.prefix_chunk_max_seq_lens[chunk_idx],
-                bmm1_scale=layer.scaling,
-                bmm2_scale=1.0,
                 o_sf_scale=-1.0,
-                batch_size=forward_batch.batch_size,
-                window_left=-1,
-                cum_seq_lens_q=self.forward_prefill_metadata.cum_seq_lens,
                 cum_seq_lens_kv=forward_batch.prefix_chunk_cu_seq_lens[chunk_idx],
-                enable_pdl=False,
                 is_causal=False,
                 return_lse=True,
-                out=torch.zeros(*output_shape, dtype=q.dtype, device=q.device),
+                out=out,
             )
-
-        return flashinfer.prefill.trtllm_ragged_attention_deepseek(
-            query=q,
-            key=k,
-            value=v,
-            workspace_buffer=self.workspace_buffer,
-            seq_lens=self.forward_prefill_metadata.seq_lens,
-            max_q_len=self.forward_prefill_metadata.max_seq_len,
-            max_kv_len=self.forward_prefill_metadata.max_seq_len,
-            bmm1_scale=layer.scaling,
-            bmm2_scale=1.0,
-            o_sf_scale=1.0,
-            batch_size=forward_batch.batch_size,
-            window_left=-1,
-            cum_seq_lens_q=self.forward_prefill_metadata.cum_seq_lens,
-            cum_seq_lens_kv=self.forward_prefill_metadata.cum_seq_lens,
-            enable_pdl=False,
-            is_causal=True,
-            return_lse=forward_batch.mha_return_lse,
-        )
+        else:
+            out = torch.empty(
+                q.shape[0],
+                q.shape[1],
+                v.shape[2],
+                device=q.device,
+                dtype=self.q_data_type,
+            )
+            return flashinfer.prefill.trtllm_ragged_attention_deepseek(
+                **common_trtllm_args,
+                seq_lens=self.forward_prefill_metadata.seq_lens,
+                max_kv_len=self.forward_prefill_metadata.max_seq_len,
+                o_sf_scale=1.0,
+                cum_seq_lens_kv=self.forward_prefill_metadata.cum_seq_lens,
+                is_causal=True,
+                return_lse=forward_batch.mha_return_lse,
+                out=out,
+            )
 
 
 class TRTLLMMLAMultiStepDraftBackend(FlashInferMLAMultiStepDraftBackend):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation
MLA prefill always use 16-bit despite set `kv-cache-dtype` to fp8. We have fp8 kernel now, so this fixed it.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- convert qkv to fp8 to make attention faster.
- increase workspace size to make 128k runable.
- ~~remove `tile_tokens_dim` to be compatible with newer flashinfer.~~

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.956|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.956|±  |0.0056|
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
my command:
```
DYN_SKIP_SGLANG_LOG_FORMATTING=1  MC_FORCE_MNNVL=1  NCCL_CUMEM_ENABLE=1  NCCL_MNNVL_ENABLE=1  PYTHONUNBUFFERED=1  SGLANG_DECODE_BOOTSTRAP_TIMEOUT=1000  SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1  SGLANG_ENABLE_FLASHINFER_GEMM=true  SGLANG_ENABLE_JIT_DEEPGEMM=false  SGLANG_MOONCAKE_CUSTOM_MEM_POOL=True  SGLANG_USE_MESSAGE_QUEUE_BROADCASTER=0  TORCH_DISTRIBUTED_DEFAULT_TIMEOUT=1800  SGLANG_TORCH_PROFILER_DIR=/logs/profiles/prefill python3 -m sglang.launch_server --attention-backend trtllm_mla --chunked-prefill-size -1 --context-length 136000 --cuda-graph-max-bs 4 --data-parallel-size 1 --disable-radix-cache --disaggregation-bootstrap-port 30001 --disaggregation-transfer-backend nixl --enable-symm-mem --expert-parallel-size 1 --kv-cache-dtype fp8_e4m3 --load-balance-method round_robin --max-running-requests 4 --max-total-tokens 544000 --mem-fraction-static 0.95 --model-path /model/ --moe-dense-tp-size 1 --moe-runner-backend flashinfer_trtllm --pipeline-parallel-size 4 --quantization modelopt_fp4 --scheduler-recv-interval 1 --served-model-name deepseek-ai/DeepSeek-R1 --stream-interval 10 --tensor-parallel-size 1 --trust-remote-code --watchdog-timeout 1000000 --dist-init-addr 10.66.5.212:29500 --nnodes 1 --node-rank 0 --host 0.0.0.0
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
