### PR TITLE
[VLM] Support VLM ViT Piecewise CUDA Graph

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -51,7 +51,7 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.quantization import QuantizationConfig
 from sglang.srt.layers.rotary_embedding import apply_rotary_pos_emb
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, get_bool_env_var
 
 ROTARY_EMBED_CLASSES = {
     "normal": apply_rotary_pos_emb,
@@ -290,22 +290,42 @@ class VisionTritonAttention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
-        cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
+        if get_bool_env_var("SGLANG_VIT_CUDA_GRAPH"):
+            if "output_ws" not in kwargs:
+                raise RuntimeError("output_ws should be prepared for cuda-graph mode")
 
-        # [b * s, head, head_size]
-        output = torch.empty_like(q)
-        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-        max_seqlen = seq_lens.max().item()
-        context_attention_fwd(
-            q,
-            k,
-            v,
-            output,
-            cu_seqlens.cuda(),
-            seq_lens.cuda(),
-            max_seqlen,
-            is_causal=False,
-        )
+            if not isinstance(cu_seqlens, list):
+                raise RuntimeError("cuda-graph mode cu_seqlens should be a list")
+
+            output = kwargs["output_ws"]
+            context_attention_fwd(
+                q,
+                k,
+                v,
+                output,
+                cu_seqlens[0],
+                cu_seqlens[1],
+                cu_seqlens[2],
+                is_causal=False,
+            )
+        else:
+            cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
+
+            # [b * s, head, head_size]
+            output = torch.empty_like(q)
+
+            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+            max_seqlen = seq_lens.max().item()
+            context_attention_fwd(
+                q,
+                k,
+                v,
+                output,
+                cu_seqlens.cuda(),
+                seq_lens.cuda(),
+                max_seqlen,
+                is_causal=False,
+            )
 
         return output
 
@@ -335,21 +355,32 @@ class VisionFlash3Attention(nn.Module):
         Returns:
              [b * s, h, head_size]
         """
-        cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
+        if get_bool_env_var("SGLANG_VIT_CUDA_GRAPH"):
+            max_seqlen = cu_seqlens[1]
+            output = flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_seqlens[0],
+                cu_seqlens_k=cu_seqlens[0],
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+            )
+        else:
+            cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
+            cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
+            seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+            max_seqlen = seq_lens.max().item()
 
-        cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-        seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-        max_seqlen = seq_lens.max().item()
-
-        output = flash_attn_varlen_func(
-            q,
-            k,
-            v,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-        )
+            output = flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+            )
 
         return output
 
@@ -652,6 +683,8 @@ class VisionAttention(nn.Module):
         bsz, s, _ = x_shape
         head = self.num_attention_heads_per_partition
         kv_head = self.num_attention_kv_heads_per_partition
+
+        attn_output_ws = kwargs["output_ws"] if "output_ws" in kwargs else None
         if self.use_qkv_parallel:
             # [b, s, embed_dim] --> [b, s, embed_dim]
             qkv, _ = self.qkv_proj(x)
@@ -729,6 +762,7 @@ class VisionAttention(nn.Module):
             seq_len=s,
             cu_seqlens=cu_seqlens,
             attention_mask=attention_mask,
+            output_ws=attn_output_ws,
         )
 
         assert output.dim() == 3, output.shape

--- a/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
+++ b/python/sglang/srt/multimodal/vit_cuda_graph_runner.py
@@ -1,0 +1,263 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""ViT CUDA Graph Runner class."""
+from __future__ import annotations
+
+import inspect
+from typing import Dict, Hashable, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang.srt.layers.attention.vision import VisionAttention
+from sglang.srt.server_args import get_global_server_args
+
+
+class ViTCudaGraphRunner:
+    """ViT CUDA Graph Runner
+
+    Cached with graph_key = seq_len, for each seq_len capture once.
+    expose run(), internally call create_graph().
+    exceed call invokes replay().
+    """
+
+    def __init__(
+        self,
+        vit: nn.Module,
+    ) -> None:
+        self.vit = vit
+
+        # graph_key -> buffers / graphs
+        self.block_input: Dict[Hashable, torch.Tensor] = {}
+        self.block_ws: Dict[Hashable, torch.Tensor] = {}
+        self.block_graphs: Dict[Hashable, torch.cuda.CUDAGraph] = {}
+        self.block_output: Dict[Hashable, torch.Tensor] = {}
+
+        # captured seqlens buffers (addresses must be stable for cuda-graph replay)
+        self.cu_full_len: Dict[Hashable, torch.Tensor] = {}
+        self.cu_window_len: Dict[Hashable, torch.Tensor] = {}
+        self.cu_full_len_kk: Dict[Hashable, torch.Tensor] = {}
+        self.cu_window_len_kk: Dict[Hashable, torch.Tensor] = {}
+
+        # rotary position buffers shared across graphs
+        self.sin_cos_ws: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+        self.max_context_len = getattr(vit, "max_context_len", None)
+
+        self._fullatt_block_indexes = set(getattr(vit, "fullatt_block_indexes", ()))
+
+        first_blk = vit.blocks[0]
+        self._blk_accepts_output_ws = (
+            "output_ws" in inspect.signature(first_blk.forward).parameters
+        )
+
+        self._attn: Optional[VisionAttention] = getattr(first_blk, "attn", None)
+        self._attn_backend = getattr(self._attn, "qkv_backend", None)
+
+    @property
+    def device(self) -> torch.device:
+        return self.vit.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.vit.dtype
+
+    def _ensure_sin_cos_ws(self, seq_len: int, head_dim: int):
+        if self.sin_cos_ws is None:
+            max_shape = self.max_context_len or seq_len
+            max_shape = max(max_shape, seq_len)
+            cos_ws = torch.empty(
+                max_shape, head_dim, dtype=self.dtype, device=self.device
+            )
+            sin_ws = torch.empty(
+                max_shape, head_dim, dtype=self.dtype, device=self.device
+            )
+            self.sin_cos_ws = (cos_ws, sin_ws)
+        else:
+            if self.sin_cos_ws[0].size(0) < seq_len:
+                max_shape = max(self.sin_cos_ws[0].size(0) * 2, seq_len)
+                cos_ws = torch.empty(
+                    max_shape, head_dim, dtype=self.dtype, device=self.device
+                )
+                sin_ws = torch.empty(
+                    max_shape, head_dim, dtype=self.dtype, device=self.device
+                )
+                self.sin_cos_ws = (cos_ws, sin_ws)
+
+    def _get_graph_key(self, x_3d: torch.Tensor) -> int:
+        # x_3d: [S, B, H], B=1, S as graph_key
+        return x_3d.shape[0]
+
+    def _create_graph(self, graph_key: int, temp_cos_sin):
+        graph = torch.cuda.CUDAGraph()
+        vit = self.vit
+
+        cu_window = self.cu_window_len[graph_key]
+        cu_full = self.cu_full_len[graph_key]
+        cu_window_kk = self.cu_window_len_kk[graph_key]
+        cu_full_kk = self.cu_full_len_kk[graph_key]
+
+        max_full_len = int(cu_full_kk.max().item())
+        max_window_len = int(cu_window_kk.max().item())
+
+        override_backend = get_global_server_args().mm_attention_backend
+
+        with torch.cuda.graph(graph):
+            y = None
+            for layer_num, blk in enumerate(vit.blocks):
+                if layer_num in vit.fullatt_block_indexes:
+                    cu_seqlens_now = cu_full
+                    cu_seqlens_kk_now = cu_full_kk
+                    max_len = max_full_len
+                else:
+                    cu_seqlens_now = cu_window
+                    cu_seqlens_kk_now = cu_window_kk
+                    max_len = max_window_len
+
+                if override_backend == "triton_attn":
+                    cu_seq_len_ws = [cu_seqlens_now, cu_seqlens_kk_now, max_len]
+                elif override_backend == "fa3":
+                    cu_seq_len_ws = [cu_seqlens_now, max_len]
+                else:
+                    raise RuntimeError("Not supported ViT attention backend")
+
+                if layer_num == 0:
+                    y = blk(
+                        self.block_input[graph_key],
+                        cu_seqlens=cu_seq_len_ws,
+                        position_embeddings=temp_cos_sin,
+                        output_ws=self.block_ws[graph_key],
+                    )
+                else:
+                    y = blk(
+                        y,
+                        cu_seqlens=cu_seq_len_ws,
+                        position_embeddings=temp_cos_sin,
+                        output_ws=self.block_ws[graph_key],
+                    )
+
+            self.block_output[graph_key] = vit.merger(y)
+
+        self.block_graphs[graph_key] = graph
+
+    def create_graph(
+        self,
+        x_3d: torch.Tensor,  # [S, 1, H]
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],  # (cos, sin), [S, D]
+        cu_seqlens: torch.Tensor,
+        cu_window_seqlens: torch.Tensor,
+    ) -> int:
+        vit = self.vit
+        graph_key = self._get_graph_key(x_3d)
+
+        if graph_key in self.block_graphs:
+            return graph_key
+
+        # make sure rotary workspace
+        head_dim = position_embeddings[0].shape[1]
+        self._ensure_sin_cos_ws(graph_key, head_dim)
+
+        used_cos_ws = self.sin_cos_ws[0][:graph_key, :]
+        used_sin_ws = self.sin_cos_ws[1][:graph_key, :]
+        used_cos_ws.copy_(position_embeddings[0])
+        used_sin_ws.copy_(position_embeddings[1])
+        temp_cos_sin = (used_cos_ws, used_sin_ws)
+
+        # pre-allocate workspace
+        attn_module: VisionAttention = vit.blocks[0].attn
+        num_heads = attn_module.num_attention_heads_per_partition
+        attn_head_dim = attn_module.head_size
+
+        if graph_key not in self.block_output:
+            self.block_output[graph_key] = torch.empty_like(
+                x_3d, device=self.device
+            ).contiguous()
+            self.block_input[graph_key] = torch.empty_like(
+                x_3d, device=self.device
+            ).contiguous()
+            self.block_ws[graph_key] = torch.empty(
+                graph_key,
+                num_heads,
+                attn_head_dim,
+                device=self.device,
+                dtype=self.dtype,
+            )
+
+        if graph_key not in self.cu_window_len:
+            self.cu_window_len[graph_key] = cu_window_seqlens
+            self.cu_full_len[graph_key] = cu_seqlens
+            self.cu_window_len_kk[graph_key] = (
+                cu_window_seqlens[1:] - cu_window_seqlens[:-1]
+            )
+            self.cu_full_len_kk[graph_key] = cu_seqlens[1:] - cu_seqlens[:-1]
+
+        self._create_graph(graph_key, temp_cos_sin)
+
+        return graph_key
+
+    def replay(
+        self,
+        graph_key: int,
+        x_3d: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        output_indices: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # update rotary workspace content
+        head_dim = position_embeddings[0].shape[1]
+        self._ensure_sin_cos_ws(graph_key, head_dim)
+        used_cos_ws = self.sin_cos_ws[0][:graph_key, :]
+        used_sin_ws = self.sin_cos_ws[1][:graph_key, :]
+        used_cos_ws.copy_(position_embeddings[0])
+        used_sin_ws.copy_(position_embeddings[1])
+
+        # copy input
+        self.block_input[graph_key].copy_(x_3d)
+
+        # replay
+        self.block_graphs[graph_key].replay()
+
+        out = self.block_output[graph_key]
+
+        # Optional output reordering (Qwen2.5-VL window permutation inverse)
+        if output_indices is not None:
+            out = out.index_select(0, output_indices)
+
+        return out
+
+    def run(
+        self,
+        x: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        cu_seqlens: torch.Tensor,
+        cu_window_seqlens: torch.Tensor,
+        output_indices: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # x: [seq_len, hidden] -> [S, B=1, H]
+        x_3d = x.unsqueeze(1)
+        graph_key = self._get_graph_key(x_3d)
+
+        if graph_key not in self.block_graphs:
+            self.create_graph(
+                x_3d=x_3d,
+                position_embeddings=position_embeddings,
+                cu_seqlens=cu_seqlens,
+                cu_window_seqlens=cu_window_seqlens,
+            )
+
+        return self.replay(
+            graph_key=graph_key,
+            x_3d=x_3d,
+            position_embeddings=position_embeddings,
+            output_indices=output_indices,
+        )

--- a/test/manual/nightly/test_vlms_vit_cuda_graph.py
+++ b/test/manual/nightly/test_vlms_vit_cuda_graph.py
@@ -45,7 +45,7 @@ class TestVLMViTCudaGraph(CustomTestCase):
         # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
         os.environ["OPENAI_API_KEY"] = cls.api_key
         os.environ["OPENAI_API_BASE"] = f"{cls.base_url}/v1"
-        os.environ["SGLANG_VIT_CUDA_GRAPH"] = cls.enable_vit_cuda_graph
+        os.environ["SGLANG_VIT_ENABLE_CUDA_GRAPH"] = cls.enable_vit_cuda_graph
 
     def run_mmmu_eval(
         self,
@@ -125,7 +125,7 @@ class TestVLMViTCudaGraph(CustomTestCase):
                 process_env.update(custom_env)
             # if test vlm with cuda_ipc feature, open this env_var
             process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
-            process_env["SGLANG_VIT_CUDA_GRAPH"] = "1"
+            process_env["SGLANG_VIT_ENABLE_CUDA_GRAPH"] = "1"
 
             # Prepare stdout/stderr redirection if needed
             stdout_file = None

--- a/test/manual/nightly/test_vlms_vit_cuda_graph.py
+++ b/test/manual/nightly/test_vlms_vit_cuda_graph.py
@@ -1,0 +1,271 @@
+import argparse
+import glob
+import json
+import os
+import random
+import subprocess
+import sys
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+)
+
+MODELS = [
+    SimpleNamespace(model="Qwen/Qwen2.5-VL-7B-Instruct", mmmu_accuracy=0.60),
+]
+
+
+# Set default mem_fraction_static to 0.8
+DEFAULT_MEM_FRACTION_STATIC = 0.8
+
+
+class TestVLMViTCudaGraph(CustomTestCase):
+    parsed_args = None  # Class variable to store args
+
+    @classmethod
+    def setUpClass(cls):
+        # Removed argument parsing from here
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.api_key = "sk-123456"
+        cls.time_out = DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+        cls.enable_vit_cuda_graph = "1"
+
+        if cls.parsed_args is None:
+            cls.parsed_args = SimpleNamespace(
+                mem_fraction_static=DEFAULT_MEM_FRACTION_STATIC
+            )
+
+        # Set OpenAI API key and base URL environment variables. Needed for lmm-evals to work.
+        os.environ["OPENAI_API_KEY"] = cls.api_key
+        os.environ["OPENAI_API_BASE"] = f"{cls.base_url}/v1"
+        os.environ["SGLANG_VIT_CUDA_GRAPH"] = cls.enable_vit_cuda_graph
+
+    def run_mmmu_eval(
+        self,
+        model_version: str,
+        output_path: str,
+        *,
+        env: dict | None = None,
+    ):
+        """
+        Evaluate a VLM on the MMMU validation set with lmms‑eval.
+        Only `model_version` (checkpoint) and `chat_template` vary;
+        We are focusing only on the validation set due to resource constraints.
+        """
+        # -------- fixed settings --------
+        model = "openai_compatible"
+        tp = 1
+        tasks = "mmmu_val"
+        batch_size = 32
+        log_suffix = "openai_compatible"
+        os.makedirs(output_path, exist_ok=True)
+
+        # -------- compose --model_args --------
+        model_args = f'model_version="{model_version}",' f"tp={tp}"
+
+        # -------- build command list --------
+        cmd = [
+            "python3",
+            "-m",
+            "lmms_eval",
+            "--model",
+            model,
+            "--model_args",
+            model_args,
+            "--tasks",
+            tasks,
+            "--batch_size",
+            str(batch_size),
+            "--output_path",
+            str(output_path),
+        ]
+
+        subprocess.run(
+            cmd,
+            check=True,
+            timeout=3600,
+        )
+
+    def _run_vlm_mmmu_test(
+        self,
+        model,
+        output_path,
+        test_name="",
+        custom_env=None,
+        log_level="info",
+        capture_output=False,
+    ):
+        """
+        Common method to run VLM MMMU benchmark test.
+        Args:
+            model: Model to test
+            output_path: Path for output logs
+            test_name: Optional test name for logging
+            custom_env: Optional custom environment variables
+            log_level: Log level for server (default: "info")
+            capture_output: Whether to capture server stdout/stderr
+        """
+        print(f"\nTesting model: {model.model}{test_name}")
+
+        process = None
+        mmmu_accuracy = 0  # Initialize to handle potential exceptions
+        server_output = ""
+
+        try:
+            # Prepare environment variables
+            process_env = os.environ.copy()
+            if custom_env:
+                process_env.update(custom_env)
+            # if test vlm with cuda_ipc feature, open this env_var
+            process_env["SGLANG_USE_CUDA_IPC_TRANSPORT"] = "1"
+            process_env["SGLANG_VIT_CUDA_GRAPH"] = "1"
+
+            # Prepare stdout/stderr redirection if needed
+            stdout_file = None
+            stderr_file = None
+            if capture_output:
+                stdout_file = open("/tmp/server_stdout.log", "w")
+                stderr_file = open("/tmp/server_stderr.log", "w")
+
+            # Launch server for testing
+            process = popen_launch_server(
+                model.model,
+                base_url=self.base_url,
+                timeout=self.time_out,
+                api_key=self.api_key,
+                other_args=[
+                    "--mm-attention-backend",
+                    "fa3",
+                    "--enable-piecewise-cuda-graph",
+                    "--piecewise-cuda-graph-max-tokens",
+                    "8192",
+                    "--chunked-prefill-size",
+                    "8192",
+                    "--disable-radix-cache",
+                    "--disable-overlap-schedule",
+                    "--piecewise-cuda-graph-compiler",
+                    "eager",
+                ],
+                env=process_env,
+                return_stdout_stderr=(
+                    (stdout_file, stderr_file) if capture_output else None
+                ),
+            )
+
+            # Run evaluation
+            self.run_mmmu_eval(model.model, output_path)
+
+            # Get the result file
+            # Search recursively for JSON result files (lmms-eval v0.4.1+ creates subdirectories)
+            result_files = glob.glob(f"{output_path}/**/*.json", recursive=True)
+            if not result_files:
+                result_files = glob.glob(f"{output_path}/*.json")
+
+            if not result_files:
+                raise FileNotFoundError(f"No JSON result files found in {output_path}")
+
+            result_file_path = result_files[0]
+
+            with open(result_file_path, "r") as f:
+                result = json.load(f)
+                print(f"Result{test_name}\n: {result}")
+
+            # Process the result
+            mmmu_accuracy = result["results"]["mmmu_val"]["mmmu_acc,none"]
+            print(
+                f"Model {model.model} achieved accuracy{test_name}: {mmmu_accuracy:.4f}"
+            )
+
+            # Capture server output if requested
+            if capture_output and process:
+                server_output = self._read_output_from_files()
+
+            # Assert performance meets expected threshold
+            self.assertGreaterEqual(
+                mmmu_accuracy,
+                model.mmmu_accuracy,
+                f"Model {model.model} accuracy ({mmmu_accuracy:.4f}) below expected threshold ({model.mmmu_accuracy:.4f}){test_name}",
+            )
+
+            return server_output
+
+        except Exception as e:
+            print(f"Error testing {model.model}{test_name}: {e}")
+            self.fail(f"Test failed for {model.model}{test_name}: {e}")
+
+        finally:
+            # Ensure process cleanup happens regardless of success/failure
+            if process is not None and process.poll() is None:
+                print(f"Cleaning up process {process.pid}")
+                try:
+                    kill_process_tree(process.pid)
+                except Exception as e:
+                    print(f"Error killing process: {e}")
+
+            # clean up temporary files
+            if capture_output:
+                if stdout_file:
+                    stdout_file.close()
+                if stderr_file:
+                    stderr_file.close()
+                for filename in ["/tmp/server_stdout.log", "/tmp/server_stderr.log"]:
+                    try:
+                        if os.path.exists(filename):
+                            os.remove(filename)
+                    except Exception as e:
+                        print(f"Error removing {filename}: {e}")
+
+    def _read_output_from_files(self):
+        output_lines = []
+
+        log_files = [
+            ("/tmp/server_stdout.log", "[STDOUT]"),
+            ("/tmp/server_stderr.log", "[STDERR]"),
+        ]
+        for filename, tag in log_files:
+            try:
+                if os.path.exists(filename):
+                    with open(filename, "r") as f:
+                        for line in f:
+                            output_lines.append(f"{tag} {line.rstrip()}")
+            except Exception as e:
+                print(f"Error reading {tag.lower()} file: {e}")
+
+        return "\n".join(output_lines)
+
+    def test_vlm_mmmu_benchmark(self):
+        """Test VLM models against MMMU benchmark."""
+        models_to_test = MODELS
+
+        if is_in_ci():
+            models_to_test = [random.choice(MODELS)]
+
+        for model in models_to_test:
+            self._run_vlm_mmmu_test(model, "./logs")
+
+
+if __name__ == "__main__":
+    # Define and parse arguments here, before unittest.main
+    parser = argparse.ArgumentParser(description="Test VLM models")
+    parser.add_argument(
+        "--mem-fraction-static",
+        type=float,
+        help="Static memory fraction for the model",
+        default=DEFAULT_MEM_FRACTION_STATIC,
+    )
+
+    # Parse args intended for unittest
+    args = parser.parse_args()
+
+    # Store the parsed args object on the class
+    TestVLMViTCudaGraph.parsed_args = args
+
+    # Pass args to unittest
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Previously VLM supports Piecewise CUDA Graph in LLM.
But ViT was not included inside due to some Tensors addresses in ViT are not fixed. This PR is to support Piecewise CUDA Graph for ViT. Currently Triton Attention and FA3 as MM-Attention are supported. Qwen2.5-VL is supported as the first target VLM model.

Co-author: @kousakawang 

Notes:
TP>1 is supported now due to custom all-reduce is disabled by default.

Before this PR, no CUDA Graph is supported in ViT, the kernels launch have some gaps.
<img width="3344" height="1640" alt="image" src="https://github.com/user-attachments/assets/c56d7f36-3e21-4f9c-9726-b14e959905b7" />


With this PR, Piecewise CUDA Graph is supported in ViT, the kernels are launched simultaneously.
<img width="2986" height="1626" alt="image" src="https://github.com/user-attachments/assets/8d7f6e51-11b6-4d24-b2de-a8364c825f77" />
<img width="3362" height="1652" alt="image" src="https://github.com/user-attachments/assets/1cd26668-3b06-4090-9b29-87fadae154e3" />

This PR supports Qwen2.5-VL, more models will be supported.
```
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
python3 -m sglang.launch_server --host 127.0.0.1 \
    --mem-fraction-static 0.7 \
    --port 30000 \
    --max-running-requests 64 \
    --chunked-prefill-size 8192 \
    --attention-backend fa3 \
    --mm-attention-backend fa3 \
    --enable-multimodal \
    --model /home/admin/Qwen2.5-VL-7B-Instruct \
    --disable-radix-cache \
    --piecewise-cuda-graph-max-tokens 8192 \
    --enable-piecewise-cuda-graph \
    --piecewise-cuda-graph-compiler eager 
```
```
$SGLANG_TORCH_PROFILER_DIR=/root/luoyuan.luo/profile_data SGLANG_MM_FEATURE_CACHE_MB=4096 SGLANG_USE_CUDA_IPC_TRANSPORT=1 SGLANG_VLM_CACHE_SIZE_MB=0 SGLANG_VIT_CUDA_GRAPH=1 python3 -m sglang.launch_server --host 127.0.0.1     --mem-fraction-static 0.7     --port 30000     --max-running-requests 4     --chunked-prefill-size 8192     --attention-backend fa3     --enable-multimodal     --model /home/admin/Qwen2.5-VL-7B-Instruct     --disable-radix-cache     --piecewise-cuda-graph-max-tokens 8192     --enable-piecewise-cuda-graph     --piecewise-cuda-graph-compiler eager --mm-attention-backend fa3
[2025-12-04 20:58:32] server_args=ServerArgs(model_path='/home/admin/Qwen2.5-VL-7B-Instruct', tokenizer_path='/home/admin/Qwen2.5-VL-7B-Instruct', tokenizer_mode='auto', tokenizer_worker_num=1, skip_tokenizer_init=False, load_format='auto', model_loader_extra_config='{}', trust_remote_code=False, context_length=None, is_embedding=False, enable_multimodal=True, revision=None, model_impl='auto', host='127.0.0.1', port=30000, fastapi_root_path='', grpc_mode=False, skip_server_warmup=False, warmups=None, nccl_port=None, checkpoint_engine_wait_weights_before_ready=False, dtype='auto', quantization=None, quantization_param_path=None, kv_cache_dtype='auto', enable_fp32_lm_head=False, modelopt_quant=None, modelopt_checkpoint_restore_path=None, modelopt_checkpoint_save_path=None, modelopt_export_path=None, quantize_and_serve=False, mem_fraction_static=0.7, max_running_requests=4, max_queued_requests=None, max_total_tokens=None, chunked_prefill_size=8192, max_prefill_tokens=16384, schedule_policy='fcfs', enable_priority_scheduling=False, abort_on_priority_when_disabled=False, schedule_low_priority_values_first=False, priority_scheduling_preemption_threshold=10, schedule_conservativeness=1.0, page_size=1, hybrid_kvcache_ratio=None, swa_full_tokens_ratio=0.8, disable_hybrid_swa_memory=False, radix_eviction_policy='lru', device='cuda', tp_size=1, pp_size=1, pp_max_micro_batch_size=None, stream_interval=1, stream_output=False, random_seed=1005910386, constrained_json_whitespace_pattern=None, constrained_json_disable_any_whitespace=False, watchdog_timeout=300, dist_timeout=None, download_dir=None, base_gpu_id=0, gpu_id_step=1, sleep_on_idle=False, mm_process_config={}, log_level='info', log_level_http=None, log_requests=False, log_requests_level=2, crash_dump_folder=None, show_time_cost=False, enable_metrics=False, enable_metrics_for_all_schedulers=False, tokenizer_metrics_custom_labels_header='x-custom-labels', tokenizer_metrics_allowed_custom_labels=None, bucket_time_to_first_token=None, bucket_inter_token_latency=None, bucket_e2e_request_latency=None, collect_tokens_histogram=False, prompt_tokens_buckets=None, generation_tokens_buckets=None, gc_warning_threshold_secs=0.0, decode_log_interval=40, enable_request_time_stats_logging=False, kv_events_config=None, enable_trace=False, otlp_traces_endpoint='localhost:4317', export_metrics_to_file=False, export_metrics_to_file_dir=None, api_key=None, served_model_name='/home/admin/Qwen2.5-VL-7B-Instruct', weight_version='default', chat_template=None, completion_template=None, file_storage_path='sglang_storage', enable_cache_report=False, reasoning_parser=None, tool_call_parser=None, tool_server=None, sampling_defaults='model', dp_size=1, load_balance_method='round_robin', load_watch_interval=0.1, prefill_round_robin_balance=False, dist_init_addr=None, nnodes=1, node_rank=0, json_model_override_args='{}', preferred_sampling_params=None, enable_lora=None, max_lora_rank=None, lora_target_modules=None, lora_paths=None, max_loaded_loras=None, max_loras_per_batch=8, lora_eviction_policy='lru', lora_backend='csgmv', max_lora_chunk_size=16, attention_backend='fa3', decode_attention_backend=None, prefill_attention_backend=None, sampling_backend='flashinfer', grammar_backend='xgrammar', mm_attention_backend='fa3', nsa_prefill_backend='flashmla_sparse', nsa_decode_backend='fa3', enable_flashinfer_autotune=False, speculative_algorithm=None, speculative_draft_model_path=None, speculative_draft_model_revision=None, speculative_draft_load_format=None, speculative_num_steps=None, speculative_eagle_topk=None, speculative_num_draft_tokens=None, speculative_accept_threshold_single=1.0, speculative_accept_threshold_acc=1.0, speculative_token_map=None, speculative_attention_mode='prefill', speculative_moe_runner_backend=None, speculative_ngram_min_match_window_size=1, speculative_ngram_max_match_window_size=12, speculative_ngram_min_bfs_breadth=1, speculative_ngram_max_bfs_breadth=10, speculative_ngram_match_type='BFS', speculative_ngram_branch_length=18, speculative_ngram_capacity=10000000, ep_size=1, moe_a2a_backend='none', moe_runner_backend='auto', flashinfer_mxfp4_moe_precision='default', enable_flashinfer_allreduce_fusion=False, deepep_mode='auto', ep_num_redundant_experts=0, ep_dispatch_algorithm=None, init_expert_location='trivial', enable_eplb=False, eplb_algorithm='auto', eplb_rebalance_num_iterations=1000, eplb_rebalance_layers_per_chunk=None, eplb_min_rebalancing_utilization_threshold=1.0, expert_distribution_recorder_mode=None, expert_distribution_recorder_buffer_size=1000, enable_expert_distribution_metrics=False, deepep_config=None, moe_dense_tp_size=None, elastic_ep_backend=None, mooncake_ib_device=None, max_mamba_cache_size=None, mamba_ssm_dtype='float32', mamba_full_memory_ratio=0.9, enable_hierarchical_cache=False, hicache_ratio=2.0, hicache_size=0, hicache_write_policy='write_through', hicache_io_backend='kernel', hicache_mem_layout='layer_first', hicache_storage_backend=None, hicache_storage_prefetch_policy='best_effort', hicache_storage_backend_extra_config=None, enable_lmcache=False, kt_weight_path=None, kt_method='AMXINT4', kt_cpuinfer=None, kt_threadpool_count=2, kt_num_gpu_experts=None, kt_max_deferred_experts_per_token=None, dllm_algorithm=None, dllm_block_size=None, enable_double_sparsity=False, ds_channel_config_path=None, ds_heavy_channel_num=32, ds_heavy_token_num=256, ds_heavy_channel_type='qk', ds_sparse_decode_threshold=4096, cpu_offload_gb=0, offload_group_size=-1, offload_num_in_group=1, offload_prefetch_step=1, offload_mode='cpu', multi_item_scoring_delimiter=None, disable_radix_cache=True, cuda_graph_max_bs=256, cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], disable_cuda_graph=False, disable_cuda_graph_padding=False, enable_profile_cuda_graph=False, enable_cudagraph_gc=False, enable_layerwise_nvtx_marker=False, enable_nccl_nvls=False, enable_symm_mem=False, disable_flashinfer_cutlass_moe_fp4_allgather=False, enable_tokenizer_batch_encode=False, disable_tokenizer_batch_decode=False, disable_outlines_disk_cache=False, disable_custom_all_reduce=False, enable_mscclpp=False, enable_torch_symm_mem=False, disable_overlap_schedule=False, enable_mixed_chunk=False, enable_dp_attention=False, enable_dp_lm_head=False, enable_two_batch_overlap=False, enable_single_batch_overlap=False, tbo_token_distribution_threshold=0.48, enable_torch_compile=False, enable_piecewise_cuda_graph=True, enable_torch_compile_debug_mode=False, torch_compile_max_bs=32, piecewise_cuda_graph_max_tokens=8192, piecewise_cuda_graph_tokens=[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 768, 896, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096, 4352, 4608, 4864, 5120, 5376, 5632, 5888, 6144, 6400, 6656, 6912, 7168, 7424, 7680, 7936, 8192], piecewise_cuda_graph_compiler='eager', torchao_config='', enable_nan_detection=False, enable_p2p_check=False, triton_attention_reduce_in_fp32=False, triton_attention_num_kv_splits=8, triton_attention_split_tile_size=None, num_continuous_decode_steps=1, delete_ckpt_after_loading=False, enable_memory_saver=False, enable_weights_cpu_backup=False, enable_draft_weights_cpu_backup=False, allow_auto_truncate=False, enable_custom_logit_processor=False, flashinfer_mla_disable_ragged=False, disable_shared_experts_fusion=False, disable_chunked_prefix_cache=False, disable_fast_image_processor=False, keep_mm_feature_on_device=False, enable_return_hidden_states=False, scheduler_recv_interval=1, numa_node=None, enable_deterministic_inference=False, rl_on_policy_target=None, enable_attn_tp_input_scattered=False, enable_nsa_prefill_context_parallel=False, enable_dynamic_batch_tokenizer=False, dynamic_batch_tokenizer_batch_size=32, dynamic_batch_tokenizer_batch_timeout=0.002, debug_tensor_dump_output_folder=None, debug_tensor_dump_layers=None, debug_tensor_dump_input_file=None, debug_tensor_dump_inject=False, disaggregation_mode='null', disaggregation_transfer_backend='mooncake', disaggregation_bootstrap_port=8998, disaggregation_decode_tp=None, disaggregation_decode_dp=None, disaggregation_prefill_pp=1, disaggregation_ib_device=None, disaggregation_decode_enable_offload_kvcache=False, num_reserved_decode_tokens=512, disaggregation_decode_polling_interval=1, custom_weight_loader=[], weight_loader_disable_mmap=False, remote_instance_weight_loader_seed_instance_ip=None, remote_instance_weight_loader_seed_instance_service_port=None, remote_instance_weight_loader_send_weights_group_ports=None, enable_pdmux=False, pdmux_config_path=None, sm_group_num=8, mm_max_concurrent_calls=32, mm_per_request_timeout=10.0, enable_broadcast_mm_inputs_process=False, decrypted_config_file=None, decrypted_draft_config_file=None, mm_enable_dp_encoder=False, forward_hooks=None)
[2025-12-04 20:58:36] Using default HuggingFace chat template with detected content format: openai
[2025-12-04 20:58:41] Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2025-12-04 20:59:14] Init torch distributed ends. mem usage=0.00 GB
[2025-12-04 20:59:14] MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2025-12-04 20:59:17] Ignore import error when loading sglang.srt.models.mindspore: name 'ms' is not defined
[2025-12-04 20:59:17] Load weight begin. avail mem=90.36 GB
[2025-12-04 20:59:17] Using fa3 as multimodal attention backend.
Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  20% Completed | 1/5 [00:00<00:00,  4.56it/s]
Loading safetensors checkpoint shards:  40% Completed | 2/5 [00:00<00:01,  1.83it/s]
Loading safetensors checkpoint shards:  60% Completed | 3/5 [00:01<00:01,  1.35it/s]
Loading safetensors checkpoint shards:  80% Completed | 4/5 [00:02<00:00,  1.26it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:03<00:00,  1.22it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:03<00:00,  1.35it/s]

[2025-12-04 20:59:21] Load weight end. type=Qwen2_5_VLForConditionalGeneration, dtype=torch.bfloat16, avail mem=74.61 GB, mem usage=15.76 GB.
[2025-12-04 20:59:21] Using KV cache dtype: torch.bfloat16
[2025-12-04 20:59:21] KV Cache is allocated. #tokens: 889384, K size: 23.75 GB, V size: 23.75 GB
[2025-12-04 20:59:21] Memory pool end. avail mem=26.96 GB
[2025-12-04 20:59:21] Capture cuda graph begin. This can take up to several minutes. avail mem=26.86 GB
[2025-12-04 20:59:21] Capture cuda graph bs [1, 2, 4]
Capturing batches (bs=1 avail_mem=26.82 GB): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  4.07it/s]
[2025-12-04 20:59:23] Capture cuda graph end. Time elapsed: 1.35 s. mem usage=0.04 GB. avail mem=26.82 GB.
[2025-12-04 20:59:23] Capture piecewise CUDA graph begin. avail mem=26.82 GB
[2025-12-04 20:59:23] Capture cuda graph num tokens [4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 640, 768, 896, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096, 4352, 4608, 4864, 5120, 5376, 5632, 5888, 6144, 6400, 6656, 6912, 7168, 7424, 7680, 7936, 8192]
[2025-12-04 20:59:23] install_torch_compiled
/opt/conda/lib/python3.10/site-packages/torch/_dynamo/variables/functions.py:1692: UserWarning: Dynamo detected a call to a `functools.lru_cache`-wrapped function. Dynamo ignores the cache wrapper and directly traces the wrapped function. Silent incorrectness is only a *potential* risk, not something we have observed. Enable TORCH_LOGS="+dynamo" for a DEBUG stack trace.
  torch._dynamo.utils.warn_once(msg)
[2025-12-04 20:59:25] Initializing SGLangBackend
[2025-12-04 20:59:25] SGLangBackend __call__
[2025-12-04 20:59:26] Compiling a graph for dynamic shape takes 0.37 s
[2025-12-04 20:59:26] Computation graph saved to /root/.cache/sglang/torch_compile_cache/rank_0_0/backbone/computation_graph_1764853166.0034235.py
Capturing num tokens (num_tokens=8192 avail_mem=26.76 GB):   0%|                                                                                                                                      | 0/74 [00:00<?, ?it/s][2025-12-04 20:59:29] Initializing SGLangBackend
[2025-12-04 20:59:29] SGLangBackend __call__
[2025-12-04 20:59:30] Compiling a graph for dynamic shape takes 0.40 s
[2025-12-04 20:59:30] Computation graph saved to /root/.cache/sglang/torch_compile_cache/rank_0_0/backbone/computation_graph_1764853170.0029142.py
Capturing num tokens (num_tokens=7936 avail_mem=25.28 GB):   1%|█▋                                                                                                                            | 1/74 [00:05<07:01,  5.78s/it][2025-12-04 20:59:35] Initializing SGLangBackend
[2025-12-04 20:59:35] SGLangBackend __call__
[2025-12-04 20:59:35] Compiling a graph for dynamic shape takes 0.39 s
[2025-12-04 20:59:35] Computation graph saved to /root/.cache/sglang/torch_compile_cache/rank_0_0/backbone/computation_graph_1764853175.6422136.py
Capturing num tokens (num_tokens=4 avail_mem=24.84 GB): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 74/74 [00:54<00:00,  1.37it/s]
[2025-12-04 21:00:21] Capture piecewise CUDA graph end. Time elapsed: 58.13 s. mem usage=1.99 GB. avail mem=24.83 GB.
[2025-12-04 21:00:21] max_total_num_tokens=889384, chunked_prefill_size=8192, max_prefill_tokens=16384, max_running_requests=4, context_len=128000, available_gpu_mem=24.83 GB
[2025-12-04 21:00:22] INFO:     Started server process [467518]
[2025-12-04 21:00:22] INFO:     Waiting for application startup.
[2025-12-04 21:00:22] Using default chat sampling params from model generation config: {'repetition_penalty': 1.05, 'temperature': 1e-06, 'top_k': 50, 'top_p': 1.0}
[2025-12-04 21:00:22] Using default chat sampling params from model generation config: {'repetition_penalty': 1.05, 'temperature': 1e-06, 'top_k': 50, 'top_p': 1.0}
[2025-12-04 21:00:22] INFO:     Application startup complete.
[2025-12-04 21:00:22] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2025-12-04 21:00:23] Endpoint '/get_model_info' is deprecated and will be removed in a future version. Please use '/model_info' instead.
[2025-12-04 21:00:23] INFO:     127.0.0.1:55770 - "GET /get_model_info HTTP/1.1" 200 OK
[2025-12-04 21:00:23] Prefill batch, #new-seq: 1, #new-token: 29, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-04 21:00:23] Multimodal embedding cache is full. This typically occurs when a single embedding exceeds the cache size limit. Consider increasing the `SGLANG_VLM_CACHE_SIZE_MB` environment variable or reducing the input embedding size.
[2025-12-04 21:00:23] INFO:     127.0.0.1:55784 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-12-04 21:00:23] The server is fired up and ready to roll!
[2025-12-04 21:02:12] INFO:     127.0.0.1:36568 - "GET /v1/models HTTP/1.1" 200 OK
[2025-12-04 21:02:13] INFO:     127.0.0.1:36582 - "POST /generate HTTP/1.1" 200 OK
[2025-12-04 21:02:13] Warning: More image data items provided than corresponding tokens found in the prompt.
[2025-12-04 21:02:13] Prefill batch, #new-seq: 1, #new-token: 38, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-04 21:02:14] Profiling starts. Traces will be saved to: /root/luoyuan.luo/profile_data (with profile id: 1764853334.8045125)
[2025-12-04 21:02:14] INFO:     127.0.0.1:53634 - "POST /start_profile HTTP/1.1" 200 OK
[2025-12-04 21:02:14] INFO:     127.0.0.1:53640 - "POST /generate HTTP/1.1" 200 OK
[2025-12-04 21:02:14] Warning: More image data items provided than corresponding tokens found in the prompt.
[2025-12-04 21:02:14] Prefill batch, #new-seq: 1, #new-token: 38, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-04 21:02:15] Stop profiling...
[2025-12-04 21:02:16] Profiling done. Traces are saved to: /root/luoyuan.luo/profile_data
[2025-12-04 21:02:16] INFO:     127.0.0.1:53652 - "POST /stop_profile HTTP/1.1" 200 OK
[2025-12-04 21:02:16] Endpoint '/get_server_info' is deprecated and will be removed in a future version. Please use '/server_info' instead.
[2025-12-04 21:02:16] INFO:     127.0.0.1:53654 - "GET /get_server_info HTTP/1.1" 200 OK
[2025-12-04 21:02:16] Endpoint '/get_server_info' is deprecated and will be removed in a future version. Please use '/server_info' instead.
[2025-12-04 21:02:16] INFO:     127.0.0.1:53666 - "GET /get_server_info HTTP/1.1" 200 OK
[2025-12-04 21:03:19] INFO:     127.0.0.1:54492 - "GET /v1/models HTTP/1.1" 200 OK
[2025-12-04 21:03:20] INFO:     127.0.0.1:54508 - "POST /generate HTTP/1.1" 200 OK
[2025-12-04 21:03:20] Warning: More image data items provided than corresponding tokens found in the prompt.
[2025-12-04 21:03:20] Prefill batch, #new-seq: 1, #new-token: 38, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-04 21:03:21] Profiling starts. Traces will be saved to: /root/luoyuan.luo/profile_data (with profile id: 1764853401.4882326)
[2025-12-04 21:03:21] INFO:     127.0.0.1:54510 - "POST /start_profile HTTP/1.1" 200 OK
[2025-12-04 21:03:21] INFO:     127.0.0.1:54526 - "POST /generate HTTP/1.1" 200 OK
[2025-12-04 21:03:21] Warning: More image data items provided than corresponding tokens found in the prompt.
[2025-12-04 21:03:21] Prefill batch, #new-seq: 1, #new-token: 38, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-04 21:03:21] Stop profiling...
[2025-12-04 21:03:23] Profiling done. Traces are saved to: /root/luoyuan.luo/profile_data
```

```
$bash bench_n_image.sh 
{"id":"86718677c492451b90693e5e2384cf19","object":"chat.completion","created":1764852535,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中植物是飞廉（学名：Cirsium vulgare），也叫刺儿菜。飞廉是一种常见的多年生草本植物，属于菊科飞廉属。它的叶子边缘有锯齿，茎上有刺，花朵呈紫色或粉红色。飞廉在欧洲和亚洲的一些地区较为常见，但在中国的一些地区也可能生长。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":970,"total_tokens":1047,"completion_tokens":77,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m0.762s
user    0m0.002s
sys     0m0.002s
{"id":"f14d5800d9c7467f92af3ccdd52eab74","object":"chat.completion","created":1764852536,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中植物是飞廉（学名：Cirsium vulgare），也叫刺儿菜。飞廉是一种常见的多年生草本植物，属于菊科飞廉属。它的叶子边缘有锯齿，茎上有刺，花朵呈紫色或粉红色。飞廉在欧洲和亚洲的一些地区较为常见，但在中国的一些地区也可能生长。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":970,"total_tokens":1047,"completion_tokens":77,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m0.652s
user    0m0.001s
sys     0m0.003s
{"id":"9a8b8b68260e4409b852fce26d68808c","object":"chat.completion","created":1764852537,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中植物是飞廉（学名：Cirsium vulgare），也叫刺儿菜。飞廉是一种常见的多年生草本植物，属于菊科飞廉属。它的叶子边缘有锯齿，茎上有刺，花朵呈紫色或粉红色。飞廉在欧洲和亚洲的一些地区较为常见，但在中国的一些地区也可能生长。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":970,"total_tokens":1047,"completion_tokens":77,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m0.663s
user    0m0.003s
sys     0m0.001s
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

8 x H20
TP=2 TTFT drop 3.8%

Server:
```
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
python3 -m sglang.launch_server --host 127.0.0.1 \
    --mem-fraction-static 0.7 \
    --port 30000 \
    --max-running-requests 64 \
    --chunked-prefill-size 8192 \
    --attention-backend fa3 \
    --mm-attention-backend fa3 \
    --enable-multimodal \
    --model /home/admin/Qwen2.5-VL-7B-Instruct \
    --disable-radix-cache \
    --piecewise-cuda-graph-max-tokens 8192 \
    --enable-piecewise-cuda-graph \
    --piecewise-cuda-graph-compiler eager \
    --tp-size 2
```

Client:
```
python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 256 \
  --apply-chat-template \
  --random-input-len 128 \
  --random-output-len 32 \
  --image-resolution 560x560 \
  --image-format jpeg \
  --image-count 1 \
  --image-content random \
  --random-range-ratio 0.1 \
  --port 30000 \
  --max-concurrency 32
```
PR:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  15.92     
Total input tokens:                      126325    
Total input text tokens:                 23413     
Total input vision tokens:               102912    
Total generated tokens:                  4541      
Total generated tokens (retokenized):    4542      
Request throughput (req/s):              16.08     
Input token throughput (tok/s):          7936.11   
Output token throughput (tok/s):         285.28    
Peak output token throughput (tok/s):    421.00    
Peak concurrent requests:                69        
Total token throughput (tok/s):          8221.39   
Concurrency:                             31.62     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1966.26   
Median E2E Latency (ms):                 1989.28   
---------------Time to First Token----------------
Mean TTFT (ms):                          776.93    
Median TTFT (ms):                        707.10    
P99 TTFT (ms):                           2029.49   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          68.69     
Median TPOT (ms):                        69.07     
P99 TPOT (ms):                           182.20    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           90.40     
Median ITL (ms):                         14.30     
P95 ITL (ms):                            518.26    
P99 ITL (ms):                            909.30    
Max ITL (ms):                            1646.17   
==================================================
```
Baseline:
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  15.89     
Total input tokens:                      126267    
Total input text tokens:                 23355     
Total input vision tokens:               102912    
Total generated tokens:                  4541      
Total generated tokens (retokenized):    4538      
Request throughput (req/s):              16.11     
Input token throughput (tok/s):          7947.60   
Output token throughput (tok/s):         285.82    
Peak output token throughput (tok/s):    505.00    
Peak concurrent requests:                61        
Total token throughput (tok/s):          8233.43   
Concurrency:                             31.74     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1969.58   
Median E2E Latency (ms):                 1955.85   
---------------Time to First Token----------------
Mean TTFT (ms):                          807.33    
Median TTFT (ms):                        688.92    
P99 TTFT (ms):                           2168.49   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          65.26     
Median TPOT (ms):                        68.50     
P99 TPOT (ms):                           163.11    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           90.79     
Median ITL (ms):                         7.42      
P95 ITL (ms):                            600.60    
P99 ITL (ms):                            901.48    
Max ITL (ms):                            1069.79   
==================================================
```

TP=1 TTFT 1016ms -> 990ms, drop 2.5%.

Server:
```
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
SGLANG_VIT_ENABLE_CUDA_GRAPH=1 \
python3 -m sglang.launch_server --host 127.0.0.1 \
    --mem-fraction-static 0.7 \
    --port 30000 \
    --max-running-requests 64 \
    --chunked-prefill-size 8192 \
    --attention-backend fa3 \
    --mm-attention-backend fa3 \
    --enable-multimodal \
    --model /home/admin/Qwen2.5-VL-7B-Instruct \
    --disable-radix-cache \
    --piecewise-cuda-graph-max-tokens 8192 \
    --enable-piecewise-cuda-graph \
    --piecewise-cuda-graph-compiler eager
```

Client:
```
python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 256 \
  --apply-chat-template \
  --random-input-len 128 \
  --random-output-len 32 \
  --image-resolution 560x560 \
  --image-format jpeg \
  --image-count 1 \
  --image-content random \
  --random-range-ratio 0.1 \
  --port 30000 \
  --max-concurrency 32
```

PR: SGLANG_VIT_ENABLE_CUDA_GRAPH=1
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  24.03     
Total input tokens:                      126395    
Total input text tokens:                 23483     
Total input vision tokens:               102912    
Total generated tokens:                  4541      
Total generated tokens (retokenized):    4541      
Request throughput (req/s):              10.65     
Input token throughput (tok/s):          5259.16   
Output token throughput (tok/s):         188.95    
Peak output token throughput (tok/s):    434.00    
Peak concurrent requests:                52        
Total token throughput (tok/s):          5448.11   
Concurrency:                             31.61     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   2967.16   
Median E2E Latency (ms):                 2966.01   
---------------Time to First Token----------------
Mean TTFT (ms):                          990.00    
Median TTFT (ms):                        828.60    
P99 TTFT (ms):                           2824.02   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          119.19    
Median TPOT (ms):                        120.31    
P99 TPOT (ms):                           346.58    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           154.93    
Median ITL (ms):                         20.98     
P95 ITL (ms):                            818.11    
P99 ITL (ms):                            1373.44   
Max ITL (ms):                            2436.96   
==================================================
```

Main：
```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  25.09     
Total input tokens:                      126345    
Total input text tokens:                 23433     
Total input vision tokens:               102912    
Total generated tokens:                  4541      
Total generated tokens (retokenized):    4510      
Request throughput (req/s):              10.20     
Input token throughput (tok/s):          5035.99   
Output token throughput (tok/s):         181.00    
Peak output token throughput (tok/s):    398.00    
Peak concurrent requests:                50        
Total token throughput (tok/s):          5216.99   
Concurrency:                             31.61     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3098.09   
Median E2E Latency (ms):                 3082.96   
---------------Time to First Token----------------
Mean TTFT (ms):                          1016.51   
Median TTFT (ms):                        780.48    
P99 TTFT (ms):                           3009.71   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          123.70    
Median TPOT (ms):                        125.81    
P99 TPOT (ms):                           262.10    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           162.29    
Median ITL (ms):                         20.52     
P95 ITL (ms):                            952.77    
P99 ITL (ms):                            1420.52   
Max ITL (ms):                            2420.67   
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
