### PR TITLE
Modify data_hash to use full SHA-256 digest

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -793,7 +793,7 @@ def get_multimodal_data_bounds(
 
 
 def data_hash(data) -> int:
-    hash_bytes = hashlib.sha256(data).digest()[:8]
+    hash_bytes = hashlib.sha256(data).digest()
     return int.from_bytes(hash_bytes, byteorder="big", signed=False)
 
 

--- a/python/sglang/srt/mem_cache/multimodal_cache.py
+++ b/python/sglang/srt/mem_cache/multimodal_cache.py
@@ -17,10 +17,12 @@ class MultimodalCache(abc.ABC):
     def combine_hashes(mm_hashes: List[int]) -> Optional[int]:
         """
         Get a combined hash from individual mm item hashes
+        Uses a string to enable hash randomization, protecting against maliciously crafted collisions.
+        Like CVE-2025-25183.
         """
         if not mm_hashes:
             return None
-        return hash(tuple(mm_hashes))
+        return hash(("random_seed", tuple(mm_hashes)))
 
     @abc.abstractmethod
     def get(


### PR DESCRIPTION
## Motivation

 identified a security vulnerability in the data_hash function. Currently, the function truncates the SHA-256 hash to the first 64 bits (8 bytes). Furthermore, when used as a cache key, it relies on Python's built-in hash(), which further reduces the security entropy to approximately 2^61. 

This truncation drasticially reduces collision resistance, enabling the construction of adversarial images that share the same hash. This vulnerability could be exploited to bypass image moderation filters or perform cache poisoning.
By removing the [:8] truncation and returning the full hash value, we significantly improve security and prevent these collisions. Additionally, by introducing a string component to the hash input, we increase the randomness of the cache key, preventing attackers from pre-computing cache values.

Note: This PR is a preliminary solution. A collision issue caused by **pad_value** still exists, but is not addressed in this PR as fixing the limited pad value space would require extensive code modifications.


## Modifications

Updated data_hash to return the complete SHA-256 hash string instead of a truncated version.

I investigated the usage of this function and confirmed it is primarily used for cache key generation in schedule_batch.py, so it will not affect other components:
https://github.com/sgl-project/sglang/blob/842807843671e1f469fe272a3f69a5582925004b/python/sglang/srt/managers/schedule_batch.py#L254


https://github.com/sgl-project/sglang/blob/842807843671e1f469fe272a3f69a5582925004b/python/sglang/srt/managers/schedule_batch.py#L288

Full Hash Return: Updated data_hash to return the complete SHA-256 hash string instead of the truncated version.

Randomized Cache Keys:

Changed the return statement from return hash(tuple(mm_hashes)) to return hash(("random_seed", tuple(mm_hashes))).

This change ensures that cache keys differ across processes, mitigating predictability.

## Accuracy Tests

I tested the changes using Qwen3-VL-2B-Instruct.

Inference: Normal inference functionality is preserved.

Collision Resolution: The system can now correctly distinguish between the collision images that previously generated identical hashes

Test Images (Hash Collision Proof of Concept):
<img width="448" height="448" alt="A" src="https://github.com/user-attachments/assets/fa267a4b-c192-4d90-ace3-9a9b9dc3137c" />
<img width="448" height="448" alt="B" src="https://github.com/user-attachments/assets/ca35f4ad-f3a0-4192-8025-dadd1fcf7594" />


## Benchmarking and Profiling

The impact on performance is negligible, as the change only involves storing and comparing slightly longer string keys (full hash vs. truncated) during cache lookups.


**Distributed Context:** The inclusion of the string makes cache keys inconsistent across different processes. While this creates a risk of non-reusability in multi-node sharing, SGLang's current image caching mechanism is single-node/local. Therefore, this does not constitute a functional or security regression.

**Reference:** This issue is similar to the vulnerability found in vLLM (GHSA-rm76-4mrf-v9r8), and the adopted solution follows a similar approach.
