### PR TITLE
Add Mistral Large 3 to nightly CI tests

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -420,6 +420,13 @@ jobs:
         run: |
           IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
 
+      - name: Pre-download Mistral-Large-3 model
+        timeout-minutes: 120
+        run: |
+          echo "Pre-downloading Mistral-Large-3 model to ensure cache is complete..."
+          python3 -c "from huggingface_hub import snapshot_download; snapshot_download('mistralai/Mistral-Large-3-675B-Instruct-2512')"
+          echo "Download complete."
+
       - name: Run Mistral-Large-3 nightly performance test
         timeout-minutes: 180
         env:

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -420,7 +420,28 @@ jobs:
         run: |
           IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
 
+      - name: Run Mistral-Large-3 nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-b200"
+          SGLANG_ENABLE_JIT_DEEPGEMM: "0"
+        run: |
+          rm -rf test/performance_profiles_mistral_large3/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_mistral_large3_perf.py
+
+      - name: Publish Mistral-Large-3 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_mistral_large3
+
       - name: Run DeepSeek v3.1 nightly performance test
+        if: always()
         timeout-minutes: 180
         env:
           TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
@@ -538,27 +559,6 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_minimax_m2
-
-      - name: Run Mistral-Large-3 nightly performance test
-        if: always()
-        timeout-minutes: 180
-        env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
-          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
-          GPU_CONFIG: "8-gpu-b200"
-          SGLANG_ENABLE_JIT_DEEPGEMM: "0"
-        run: |
-          rm -rf test/performance_profiles_mistral_large3/
-          cd test
-          IS_BLACKWELL=1 python3 nightly/test_mistral_large3_perf.py
-
-      - name: Publish Mistral-Large-3 traces to storage repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_mistral_large3
 
   # Final check job
   check-all-jobs:

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -188,26 +188,6 @@ jobs:
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_minimax_m2
 
-      - name: Run Mistral-Large-3 nightly performance test
-        timeout-minutes: 180
-        env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
-          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
-          GPU_CONFIG: "8-gpu-h200"
-          SGLANG_ENABLE_JIT_DEEPGEMM: "0"
-        run: |
-          rm -rf test/performance_profiles_mistral_large3/
-          cd test
-          python3 nightly/test_mistral_large3_perf.py
-
-      - name: Publish Mistral-Large-3 traces to storage repo
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_mistral_large3
-
   # General tests - 8 GPU H20
   nightly-test-general-8-gpu-h20:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h20')
@@ -558,6 +538,27 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_minimax_m2
+
+      - name: Run Mistral-Large-3 nightly performance test
+        if: always()
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-b200"
+          SGLANG_ENABLE_JIT_DEEPGEMM: "0"
+        run: |
+          rm -rf test/performance_profiles_mistral_large3/
+          cd test
+          IS_BLACKWELL=1 python3 nightly/test_mistral_large3_perf.py
+
+      - name: Publish Mistral-Large-3 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_mistral_large3
 
   # Final check job
   check-all-jobs:

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -420,13 +420,6 @@ jobs:
         run: |
           IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
 
-      - name: Pre-download Mistral-Large-3 model
-        timeout-minutes: 60
-        run: |
-          echo "Pre-downloading Mistral-Large-3 model to ensure cache is complete..."
-          python3 -c "from huggingface_hub import snapshot_download; snapshot_download('mistralai/Mistral-Large-3-675B-Instruct-2512')"
-          echo "Download complete."
-
       - name: Run Mistral-Large-3 nightly performance test
         timeout-minutes: 180
         env:

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -421,7 +421,7 @@ jobs:
           IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
 
       - name: Pre-download Mistral-Large-3 model
-        timeout-minutes: 120
+        timeout-minutes: 60
         run: |
           echo "Pre-downloading Mistral-Large-3 model to ensure cache is complete..."
           python3 -c "from huggingface_hub import snapshot_download; snapshot_download('mistralai/Mistral-Large-3-675B-Instruct-2512')"

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -188,6 +188,26 @@ jobs:
         run: |
           python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_minimax_m2
 
+      - name: Run Mistral-Large-3 nightly performance test
+        timeout-minutes: 180
+        env:
+          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
+          GPU_CONFIG: "8-gpu-h200"
+          SGLANG_ENABLE_JIT_DEEPGEMM: "0"
+        run: |
+          rm -rf test/performance_profiles_mistral_large3/
+          cd test
+          python3 nightly/test_mistral_large3_perf.py
+
+      - name: Publish Mistral-Large-3 traces to storage repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 scripts/ci/publish_traces.py --traces-dir test/performance_profiles_mistral_large3
+
   # General tests - 8 GPU H20
   nightly-test-general-8-gpu-h20:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h20')

--- a/test/nightly/test_mistral_large3_perf.py
+++ b/test/nightly/test_mistral_large3_perf.py
@@ -6,7 +6,7 @@ from nightly_utils import NightlyBenchmarkRunner
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
-register_cuda_ci(est_time=600, suite="nightly-8-gpu-h200", nightly=True)
+register_cuda_ci(est_time=600, suite="nightly-8-gpu-b200", nightly=True)
 
 MISTRAL_LARGE3_MODEL_PATH = "mistralai/Mistral-Large-3-675B-Instruct-2512"
 PROFILE_DIR = "performance_profiles_mistral_large3"

--- a/test/nightly/test_mistral_large3_perf.py
+++ b/test/nightly/test_mistral_large3_perf.py
@@ -3,7 +3,10 @@ import unittest
 
 from nightly_utils import NightlyBenchmarkRunner
 
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+register_cuda_ci(est_time=600, suite="nightly-8-gpu-h200", nightly=True)
 
 MISTRAL_LARGE3_MODEL_PATH = "mistralai/Mistral-Large-3-675B-Instruct-2512"
 PROFILE_DIR = "performance_profiles_mistral_large3"

--- a/test/nightly/test_mistral_large3_perf.py
+++ b/test/nightly/test_mistral_large3_perf.py
@@ -1,0 +1,64 @@
+import os
+import unittest
+
+from nightly_utils import NightlyBenchmarkRunner
+
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+MISTRAL_LARGE3_MODEL_PATH = "mistralai/Mistral-Large-3-675B-Instruct-2512"
+PROFILE_DIR = "performance_profiles_mistral_large3"
+
+
+class TestNightlyMistralLarge3Performance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Set environment variable to disable JIT DeepGemm
+        os.environ["SGLANG_ENABLE_JIT_DEEPGEMM"] = "0"
+
+        cls.model = MISTRAL_LARGE3_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        # Mistral-Large-3-675B requires TP=8 and trtllm_mla attention backend
+        cls.other_args = [
+            "--tp",
+            "8",
+            "--attention-backend",
+            "trtllm_mla",
+            "--model-loader-extra-config",
+            '{"enable_multithread_load": true}',
+            "--chat-template",
+            "mistral",
+        ]
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Clean up environment variable
+        if "SGLANG_ENABLE_JIT_DEEPGEMM" in os.environ:
+            del os.environ["SGLANG_ENABLE_JIT_DEEPGEMM"]
+
+    def test_bench_one_batch(self):
+        results, success = self.runner.run_benchmark_for_model(
+            model_path=self.model,
+            batch_sizes=self.batch_sizes,
+            input_lens=self.input_lens,
+            output_lens=self.output_lens,
+            other_args=self.other_args,
+        )
+
+        self.runner.add_report(results)
+        self.runner.write_final_report()
+
+        if not success:
+            raise AssertionError(
+                f"Benchmark failed for {self.model}. Check the logs for details."
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add nightly performance test for `mistralai/Mistral-Large-3-675B-Instruct-2512`
- Test configuration:
  - TP=8
  - `--attention-backend trtllm_mla`
  - `--model-loader-extra-config '{"enable_multithread_load": true}'`
  - `--chat-template mistral`
  - `SGLANG_ENABLE_JIT_DEEPGEMM=0`

## Test plan
- [ ] Verify nightly CI workflow runs successfully on 8-gpu-h200 runner
- [ ] Check performance traces are published correctly