### PR TITLE
Add AMD stage support to /rerun-stage command and fix related bugs

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -20,6 +20,12 @@ on:
       - "sgl-kernel/**"
       - ".github/workflows/pr-test-amd.yml"
   workflow_dispatch:
+    inputs:
+      target_stage:
+        description: "Specific stage to run (optional, for quick testing)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: pr-test-amd-${{ github.ref }}
@@ -54,7 +60,15 @@ jobs:
   # =============================================== sgl-kernel ====================================================
   sgl-kernel-unit-test-amd:
     needs: [check-changes]
-    if: needs.check-changes.outputs.sgl_kernel == 'true'
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'sgl-kernel-unit-test-amd') ||
+        (
+          !inputs.target_stage &&
+          needs.check-changes.outputs.sgl_kernel == 'true'
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -90,8 +104,16 @@ jobs:
 
   stage-a-test-1-amd:
     needs: [check-changes]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'stage-a-test-1-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -120,8 +142,16 @@ jobs:
 
   unit-test-backend-1-gpu-amd:
     needs: [check-changes, stage-a-test-1-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'unit-test-backend-1-gpu-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -150,8 +180,16 @@ jobs:
 
   unit-test-backend-2-gpu-amd:
     needs: [check-changes, stage-a-test-1-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'unit-test-backend-2-gpu-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -181,8 +219,17 @@ jobs:
   unit-test-backend-8-gpu-amd:
     needs: [check-changes, unit-test-backend-2-gpu-amd]
     # Temporarily disabled - uncomment when ready to re-enable
-    if: false && always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'unit-test-backend-8-gpu-amd') ||
+        (
+          false &&
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     env:
       RUNNER_LABELS: linux-mi300-gpu-8
     strategy:
@@ -219,8 +266,16 @@ jobs:
 
   performance-test-1-gpu-part-1-amd:
     needs: [check-changes, stage-a-test-1-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'performance-test-1-gpu-part-1-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -264,8 +319,16 @@ jobs:
 
   performance-test-1-gpu-part-2-amd:
     needs: [check-changes, stage-a-test-1-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'performance-test-1-gpu-part-2-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -303,8 +366,16 @@ jobs:
 
   performance-test-2-gpu-amd:
     needs: [check-changes, unit-test-backend-2-gpu-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'performance-test-2-gpu-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -352,8 +423,16 @@ jobs:
 
   accuracy-test-1-gpu-amd:
     needs: [check-changes, stage-a-test-1-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'accuracy-test-1-gpu-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -383,8 +462,16 @@ jobs:
 
   accuracy-test-2-gpu-amd:
     needs: [check-changes, accuracy-test-1-gpu-amd]
-    if: always() && !failure() && !cancelled() &&
-      ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'accuracy-test-2-gpu-amd') ||
+        (
+          !inputs.target_stage &&
+          (!failure() && !cancelled()) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -343,12 +343,14 @@ jobs:
   stage-a-test-1:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: |
-      (inputs.target_stage == 'stage-a-test-1') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'stage-a-test-1') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 1-gpu-runner
     env:
@@ -381,12 +383,14 @@ jobs:
   multimodal-gen-test-1-gpu:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: |
-      (inputs.target_stage == 'multimodal-gen-test-1-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        needs.check-changes.outputs.multimodal_gen == 'true'
+        (inputs.target_stage == 'multimodal-gen-test-1-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          needs.check-changes.outputs.multimodal_gen == 'true'
+        )
       )
     runs-on: 1-gpu-runner
     strategy:
@@ -426,12 +430,14 @@ jobs:
   multimodal-gen-test-2-gpu:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: |
-      (inputs.target_stage == 'multimodal-gen-test-2-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        needs.check-changes.outputs.multimodal_gen == 'true'
+        (inputs.target_stage == 'multimodal-gen-test-2-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          needs.check-changes.outputs.multimodal_gen == 'true'
+        )
       )
     runs-on: 2-gpu-runner
     strategy:
@@ -471,12 +477,14 @@ jobs:
   quantization-test:
       needs: [check-changes, call-gate, stage-a-test-1]
       if: |
-        (inputs.target_stage == 'quantization-test') ||
+        always() &&
         (
-          inputs.target_stage == '' &&
-          always() &&
-          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+          (inputs.target_stage == 'quantization-test') ||
+          (
+            inputs.target_stage == '' &&
+            (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+            ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+          )
         )
       runs-on: 1-gpu-runner
       steps:
@@ -504,12 +512,14 @@ jobs:
   unit-test-backend-1-gpu:
     needs: [check-changes, call-gate, stage-a-test-1]
     if: |
-      (inputs.target_stage == 'unit-test-backend-1-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-1-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 1-gpu-runner
     env:
@@ -544,12 +554,14 @@ jobs:
   unit-test-backend-2-gpu:
     needs: [check-changes, call-gate, unit-test-backend-1-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-backend-2-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-2-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 2-gpu-runner
     env:
@@ -583,12 +595,14 @@ jobs:
   unit-test-backend-4-gpu:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-backend-4-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-4-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 4-gpu-h100
     env:
@@ -622,12 +636,14 @@ jobs:
   unit-test-backend-8-gpu-h200:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-backend-8-gpu-h200') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-8-gpu-h200') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 8-gpu-h200
     env:
@@ -661,12 +677,14 @@ jobs:
   unit-test-backend-8-gpu-h20:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-backend-8-gpu-h20') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-8-gpu-h20') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 8-gpu-h20
     env:
@@ -701,12 +719,14 @@ jobs:
   performance-test-1-gpu-part-1:
     needs: [check-changes, call-gate, stage-a-test-1]
     if: |
-      (inputs.target_stage == 'performance-test-1-gpu-part-1') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'performance-test-1-gpu-part-1') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 1-gpu-runner
     env:
@@ -768,12 +788,14 @@ jobs:
   performance-test-1-gpu-part-2:
     needs: [check-changes, call-gate, stage-a-test-1]
     if: |
-      (inputs.target_stage == 'performance-test-1-gpu-part-2') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'performance-test-1-gpu-part-2') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 1-gpu-runner
     env:
@@ -827,12 +849,14 @@ jobs:
   performance-test-1-gpu-part-3:
     needs: [check-changes, call-gate, stage-a-test-1]
     if: |
-      (inputs.target_stage == 'performance-test-1-gpu-part-3') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'performance-test-1-gpu-part-3') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 1-gpu-runner
     env:
@@ -880,12 +904,14 @@ jobs:
   performance-test-2-gpu:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'performance-test-2-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'performance-test-2-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 2-gpu-runner
     env:
@@ -945,12 +971,14 @@ jobs:
   accuracy-test-1-gpu:
     needs: [check-changes, call-gate, stage-a-test-1]
     if: |
-      (inputs.target_stage == 'accuracy-test-1-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'accuracy-test-1-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 1-gpu-runner
     env:
@@ -983,12 +1011,14 @@ jobs:
   accuracy-test-2-gpu:
     needs: [check-changes, call-gate, accuracy-test-1-gpu]
     if: |
-      (inputs.target_stage == 'accuracy-test-2-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'accuracy-test-2-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 2-gpu-runner
     env:
@@ -1021,12 +1051,14 @@ jobs:
   unit-test-deepep-4-gpu:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-deepep-4-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-deepep-4-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 4-gpu-h100
     env:
@@ -1056,12 +1088,14 @@ jobs:
   unit-test-deepep-8-gpu:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-deepep-8-gpu') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-deepep-8-gpu') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 8-gpu-h200
     env:
@@ -1091,12 +1125,14 @@ jobs:
   unit-test-backend-4-gpu-b200:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-backend-4-gpu-b200') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-4-gpu-b200') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 4-gpu-b200
     env:
@@ -1131,12 +1167,14 @@ jobs:
   unit-test-backend-4-gpu-gb200:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu, sgl-kernel-build-wheels-arm]
     if: |
-      (inputs.target_stage == 'unit-test-backend-4-gpu-gb200') ||
+      always() &&
       (
-        inputs.target_stage == '' &&
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-4-gpu-gb200') ||
+        (
+          inputs.target_stage == '' &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 4-gpu-gb200
     env:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -345,6 +345,7 @@ jobs:
     if: |
       (inputs.target_stage == 'stage-a-test-1') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -382,6 +383,7 @@ jobs:
     if: |
       (inputs.target_stage == 'multimodal-gen-test-1-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         needs.check-changes.outputs.multimodal_gen == 'true'
@@ -426,6 +428,7 @@ jobs:
     if: |
       (inputs.target_stage == 'multimodal-gen-test-2-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         needs.check-changes.outputs.multimodal_gen == 'true'
@@ -470,6 +473,7 @@ jobs:
       if: |
         (inputs.target_stage == 'quantization-test') ||
         (
+          inputs.target_stage == '' &&
           always() &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -502,6 +506,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-1-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -541,6 +546,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-2-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -579,6 +585,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-4-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -617,6 +624,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-8-gpu-h200') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -655,6 +663,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-8-gpu-h20') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -694,6 +703,7 @@ jobs:
     if: |
       (inputs.target_stage == 'performance-test-1-gpu-part-1') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -760,6 +770,7 @@ jobs:
     if: |
       (inputs.target_stage == 'performance-test-1-gpu-part-2') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -818,6 +829,7 @@ jobs:
     if: |
       (inputs.target_stage == 'performance-test-1-gpu-part-3') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -870,6 +882,7 @@ jobs:
     if: |
       (inputs.target_stage == 'performance-test-2-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -934,6 +947,7 @@ jobs:
     if: |
       (inputs.target_stage == 'accuracy-test-1-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -971,6 +985,7 @@ jobs:
     if: |
       (inputs.target_stage == 'accuracy-test-2-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -1008,6 +1023,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-deepep-4-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -1042,6 +1058,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-deepep-8-gpu') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -1076,6 +1093,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-4-gpu-b200') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
@@ -1115,6 +1133,7 @@ jobs:
     if: |
       (inputs.target_stage == 'unit-test-backend-4-gpu-gb200') ||
       (
+        inputs.target_stage == '' &&
         always() &&
         (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
         ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -347,7 +347,7 @@ jobs:
       (
         (inputs.target_stage == 'stage-a-test-1') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -387,7 +387,7 @@ jobs:
       (
         (inputs.target_stage == 'multimodal-gen-test-1-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           needs.check-changes.outputs.multimodal_gen == 'true'
         )
@@ -434,7 +434,7 @@ jobs:
       (
         (inputs.target_stage == 'multimodal-gen-test-2-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           needs.check-changes.outputs.multimodal_gen == 'true'
         )
@@ -481,7 +481,7 @@ jobs:
         (
           (inputs.target_stage == 'quantization-test') ||
           (
-            inputs.target_stage == '' &&
+            !inputs.target_stage &&
             (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
             ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
           )
@@ -516,7 +516,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-1-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -558,7 +558,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-2-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -599,7 +599,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-4-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -640,7 +640,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-8-gpu-h200') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -681,7 +681,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-8-gpu-h20') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -723,7 +723,7 @@ jobs:
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-1') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -792,7 +792,7 @@ jobs:
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-2') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -853,7 +853,7 @@ jobs:
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-3') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -908,7 +908,7 @@ jobs:
       (
         (inputs.target_stage == 'performance-test-2-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -975,7 +975,7 @@ jobs:
       (
         (inputs.target_stage == 'accuracy-test-1-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1015,7 +1015,7 @@ jobs:
       (
         (inputs.target_stage == 'accuracy-test-2-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1055,7 +1055,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-deepep-4-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1092,7 +1092,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-deepep-8-gpu') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1129,7 +1129,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-4-gpu-b200') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1171,7 +1171,7 @@ jobs:
       (
         (inputs.target_stage == 'unit-test-backend-4-gpu-gb200') ||
         (
-          inputs.target_stage == '' &&
+          !inputs.target_stage &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )

--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -140,8 +140,8 @@ def handle_rerun_stage(
 
     print(f"Permission granted. Triggering workflow_dispatch for stage '{stage_name}'.")
 
-    # Valid stage names that support target_stage
-    valid_stages = [
+    # Valid NVIDIA stage names that support target_stage
+    nvidia_stages = [
         "stage-a-test-1",
         "multimodal-gen-test-1-gpu",
         "multimodal-gen-test-2-gpu",
@@ -163,36 +163,62 @@ def handle_rerun_stage(
         "unit-test-backend-4-gpu-gb200",
     ]
 
+    # Valid AMD stage names that support target_stage
+    amd_stages = [
+        "sgl-kernel-unit-test-amd",
+        "stage-a-test-1-amd",
+        "unit-test-backend-1-gpu-amd",
+        "unit-test-backend-2-gpu-amd",
+        "unit-test-backend-8-gpu-amd",
+        "performance-test-1-gpu-part-1-amd",
+        "performance-test-1-gpu-part-2-amd",
+        "performance-test-2-gpu-amd",
+        "accuracy-test-1-gpu-amd",
+        "accuracy-test-2-gpu-amd",
+    ]
+
+    valid_stages = nvidia_stages + amd_stages
+    is_amd_stage = stage_name in amd_stages
+
     if stage_name not in valid_stages:
         comment.create_reaction("confused")
         pr.create_issue_comment(
             f"❌ Stage `{stage_name}` doesn't support isolated runs yet.\n\n"
-            f"Currently supported stages:\n"
-            + "\n".join(f"- `{s}`" for s in valid_stages)
+            f"**NVIDIA stages:**\n"
+            + "\n".join(f"- `{s}`" for s in nvidia_stages)
+            + "\n\n**AMD stages:**\n"
+            + "\n".join(f"- `{s}`" for s in amd_stages)
             + "\n\nOther stages will be added soon. For now, use `/rerun-failed-ci` for those stages."
         )
         return False
 
     try:
-        # Get the PR Test workflow
+        # Get the appropriate workflow based on stage type
+        workflow_name = "PR Test (AMD)" if is_amd_stage else "PR Test"
         workflows = gh_repo.get_workflows()
-        pr_test_workflow = None
+        target_workflow = None
         for wf in workflows:
-            if wf.name == "PR Test":
-                pr_test_workflow = wf
+            if wf.name == workflow_name:
+                target_workflow = wf
                 break
 
-        if not pr_test_workflow:
-            print("Error: PR Test workflow not found")
+        if not target_workflow:
+            print(f"Error: {workflow_name} workflow not found")
             return False
 
         # Trigger workflow_dispatch on the PR's head branch
         ref = pr.head.ref
-        print(f"Triggering workflow on branch: {ref}")
+        print(f"Triggering {workflow_name} workflow on branch: {ref}")
 
-        success = pr_test_workflow.create_dispatch(
+        # AMD workflow doesn't have version input, only target_stage
+        if is_amd_stage:
+            inputs = {"target_stage": stage_name}
+        else:
+            inputs = {"version": "release", "target_stage": stage_name}
+
+        success = target_workflow.create_dispatch(
             ref=ref,
-            inputs={"version": "release", "target_stage": stage_name},
+            inputs=inputs,
         )
 
         if success:

--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -132,7 +132,7 @@ def handle_rerun_stage(
     if not stage_name:
         print("Error: No stage name provided")
         comment.create_reaction("confused")
-        comment.create_comment(
+        pr.create_issue_comment(
             f"❌ Please specify a stage name: `/rerun-stage <stage-name>`\n\n"
             f"Examples: `/rerun-stage unit-test-backend-4-gpu`, `/rerun-stage accuracy-test-1-gpu`"
         )
@@ -165,7 +165,7 @@ def handle_rerun_stage(
 
     if stage_name not in valid_stages:
         comment.create_reaction("confused")
-        comment.create_comment(
+        pr.create_issue_comment(
             f"❌ Stage `{stage_name}` doesn't support isolated runs yet.\n\n"
             f"Currently supported stages:\n"
             + "\n".join(f"- `{s}`" for s in valid_stages)
@@ -199,7 +199,7 @@ def handle_rerun_stage(
             print(f"Successfully triggered workflow for stage '{stage_name}'")
             if react_on_success:
                 comment.create_reaction("+1")
-                comment.create_comment(
+                pr.create_issue_comment(
                     f"✅ Triggered `{stage_name}` to run independently (skipping dependencies).\n\n"
                     f"Check the [Actions tab](https://github.com/{gh_repo.full_name}/actions) for progress."
                 )
@@ -211,7 +211,7 @@ def handle_rerun_stage(
     except Exception as e:
         print(f"Error triggering workflow_dispatch: {e}")
         comment.create_reaction("confused")
-        comment.create_comment(
+        pr.create_issue_comment(
             f"❌ Failed to trigger workflow: {str(e)}\n\n"
             f"Please check the logs or contact maintainers."
         )


### PR DESCRIPTION
## Summary

Fixes the `/rerun-stage <stage-name>` slash command to properly isolate and run only the targeted stage.

**Bugs fixed:**

1. **Missing `inputs.target_stage == ''` check**: Added this check to all targetable jobs so non-matching jobs skip when a specific stage is targeted.

2. **`always()` at wrong level**: Moved `always()` from inside the second branch to the **outer level** of the condition. In GitHub Actions, when a dependency is skipped, dependent jobs are automatically skipped UNLESS their `if` condition has `always()` at the outer level.

3. **`null` vs empty string for pull_request events**: Changed `inputs.target_stage == ''` to `!inputs.target_stage` to handle both `null` (for pull_request events) and empty string (for workflow_dispatch).

4. **Wrong API method**: Fixed `comment.create_comment()` to `pr.create_issue_comment()` in slash_command_handler.py.

5. **Added AMD stage support**: Extended `/rerun-stage` to support AMD workflows with 10 additional stages.

## Supported Stages (29 total)

**NVIDIA stages (19):**
- `stage-a-test-1`, `multimodal-gen-test-1-gpu`, `multimodal-gen-test-2-gpu`
- `quantization-test`
- `unit-test-backend-1-gpu`, `unit-test-backend-2-gpu`, `unit-test-backend-4-gpu`
- `unit-test-backend-8-gpu-h200`, `unit-test-backend-8-gpu-h20`
- `performance-test-1-gpu-part-1`, `performance-test-1-gpu-part-2`, `performance-test-1-gpu-part-3`, `performance-test-2-gpu`
- `accuracy-test-1-gpu`, `accuracy-test-2-gpu`
- `unit-test-deepep-4-gpu`, `unit-test-deepep-8-gpu`
- `unit-test-backend-4-gpu-b200`, `unit-test-backend-4-gpu-gb200`

**AMD stages (10):**
- `sgl-kernel-unit-test-amd`, `stage-a-test-1-amd`
- `unit-test-backend-1-gpu-amd`, `unit-test-backend-2-gpu-amd`, `unit-test-backend-8-gpu-amd`
- `performance-test-1-gpu-part-1-amd`, `performance-test-1-gpu-part-2-amd`, `performance-test-2-gpu-amd`
- `accuracy-test-1-gpu-amd`, `accuracy-test-2-gpu-amd`

## Test plan

- [x] Test `target_stage=unit-test-backend-8-gpu-h200` via workflow_dispatch - verified only that stage runs while others skip: https://github.com/sgl-project/sglang/actions/runs/19951643761
- [x] Verify normal PR flow still respects job dependencies
- [ ] Test `/rerun-stage` slash command on a PR after merge
- [x] Test AMD stage isolation via workflow_dispatch