### PR TITLE
Fix safetensors validation to catch corruption after download

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -47,6 +47,9 @@ concurrency:
   group: nightly-test-nvidia-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SGLANG_IS_IN_CI: true
+
 jobs:
   # General tests - 1 GPU
   nightly-test-general-1-gpu-runner:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,6 +25,9 @@ concurrency:
   group: pr-test-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SGLANG_IS_IN_CI: true
+
 jobs:
   # =============================================== check changes ====================================================
   check-changes:

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -47,7 +47,6 @@ from sglang.srt.model_loader.weight_validation import (
     _validate_sharded_model,
 )
 from sglang.srt.utils import find_local_repo_dir, log_info_on_rank0, print_warning_once
-from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -421,6 +421,55 @@ def find_local_hf_snapshot_dir(
     return None
 
 
+def _validate_weights_after_download(
+    hf_folder: str,
+    allow_patterns: List[str],
+    model_name_or_path: str,
+) -> None:
+    """Validate downloaded weight files to catch corruption early.
+
+    This function validates safetensors files after download to catch
+    corruption issues (truncated downloads, network errors, etc.) before
+    model loading fails with cryptic errors.
+
+    Args:
+        hf_folder: Path to the downloaded model folder
+        allow_patterns: Patterns used to match weight files
+        model_name_or_path: Model identifier for error messages
+
+    Raises:
+        RuntimeError: If any weight files are corrupted
+    """
+    import glob as glob_module
+
+    # Find all weight files that were downloaded
+    weight_files: List[str] = []
+    for pattern in allow_patterns:
+        weight_files.extend(glob_module.glob(os.path.join(hf_folder, pattern)))
+
+    if not weight_files:
+        return  # No weight files to validate
+
+    # Validate safetensors files
+    corrupted_files = []
+    for f in weight_files:
+        if f.endswith(".safetensors") and os.path.exists(f):
+            if not _validate_safetensors_file(f):
+                corrupted_files.append(os.path.basename(f))
+
+    if corrupted_files:
+        # Clean up corrupted files so next attempt re-downloads them
+        _cleanup_corrupted_files_selective(
+            model_name_or_path,
+            [os.path.join(hf_folder, f) for f in corrupted_files],
+        )
+        raise RuntimeError(
+            f"Downloaded model files are corrupted for {model_name_or_path}: "
+            f"{corrupted_files}. The corrupted files have been removed. "
+            "Please retry to re-download the model."
+        )
+
+
 def download_weights_from_hf(
     model_name_or_path: str,
     cache_dir: Optional[str],
@@ -446,17 +495,19 @@ def download_weights_from_hf(
         str: The path to the downloaded model weights.
     """
 
-    if is_in_ci():
-        # If the weights are already local, skip downloading and returns the path.
-        # This is used to skip too-many Huggingface API calls in CI.
-        path = find_local_hf_snapshot_dir(
-            model_name_or_path, cache_dir, allow_patterns, revision
-        )
-        if path is not None:
-            return path
+    # Always check for valid local cache first.
+    # This validates cached files and cleans up corrupted ones.
+    path = find_local_hf_snapshot_dir(
+        model_name_or_path, cache_dir, allow_patterns, revision
+    )
+    if path is not None:
+        # Valid local cache found, skip download
+        return path
 
+    # In CI, skip HF API calls if we're in offline mode or want to avoid rate limits
+    # But we already checked for local cache above, so if we're here we need to download
     if not huggingface_hub.constants.HF_HUB_OFFLINE:
-        # Before we download we look at that is available:
+        # Before we download we look at what is available:
         fs = HfFileSystem()
         file_list = fs.ls(model_name_or_path, detail=False, revision=revision)
 
@@ -480,6 +531,10 @@ def download_weights_from_hf(
             revision=revision,
             local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
         )
+
+    # Validate downloaded files to catch corruption early
+    _validate_weights_after_download(hf_folder, allow_patterns, model_name_or_path)
+
     return hf_folder
 
 


### PR DESCRIPTION
## Summary
- Always validate local cache first (removed `is_in_ci()` gate around validation)
- Add post-download validation via new `_validate_weights_after_download()` function
- Add `SGLANG_IS_IN_CI=true` to GPU CI workflows (pr-test.yml, nightly-test-nvidia.yml)

## Problem
The safetensors validation only ran when `SGLANG_IS_IN_CI=true` was set, but this env var was missing from GPU workflows. Additionally, validation only checked cached files - freshly downloaded files were never validated.

This caused CI failures like:
```
safetensors_rust.SafetensorError: Error while deserializing header:
invalid JSON in header: EOF while parsing a value at line 1 column 0
```

Related CI failure: https://github.com/sgl-project/sglang/actions/runs/19948236909/job/57203231359

## Test plan
- [x] Verify existing CI tests pass
- [x] Verify corrupted safetensors files are detected both in cache and after download