### PR TITLE
[BugFix] terminating reasoner-grammar correctly.

### DIFF
--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -99,6 +99,9 @@ class ReasonerGrammarObject(BaseGrammarObject):
             old_output_ids, new_output_ids, next_state
         )
 
+    def is_terminated(self):
+        return self.grammar.is_terminated()
+
 
 class ReasonerGrammarBackend(BaseGrammarBackend):
     def __init__(self, grammar_backend: BaseGrammarBackend, think_end_id):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
ref #14478 


It will be unexpected exit when eagle & grammar are enabled at the same time. It dues to that reasonerGrammar is not terminated correctly.

```
[2025-12-04 22:10:40] Scheduler hit an exception: Traceback (most recent call last):
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 2679, in run_scheduler_process
    scheduler.event_loop_normal()
  File "/spec/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 980, in event_loop_normal
    result = self.run_batch(batch)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/managers/scheduler.py", line 2034, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/speculative/eagle_worker.py", line 295, in forward_batch_generation
    self.verify(batch, spec_info)
  File "/sglang/python/sglang/srt/speculative/eagle_worker.py", line 701, in verify
    vocab_mask = generate_token_bitmask(
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/sglang/python/sglang/srt/speculative/spec_utils.py", line 654, in generate_token_bitmask
    traverse_tree(
  File "/sglang/python/sglang/srt/speculative/spec_utils.py", line 620, in traverse_tree
    dfs(0, retrieve_next_token, retrieve_next_sibling, -1)
  File "/sglang/python/sglang/srt/speculative/spec_utils.py", line 600, in dfs
    dfs(
  File "/sglang/python/sglang/srt/speculative/spec_utils.py", line 597, in dfs
    grammar.fill_vocab_mask(allocate_token_bitmask, curr)
  File "/sglang/python/sglang/srt/constrained/reasoner_grammar_backend.py", line 69, in fill_vocab_mask
    self.grammar.fill_vocab_mask(vocab_mask, idx)
  File "/sglang/python/sglang/srt/constrained/xgrammar_backend.py", line 100, in fill_vocab_mask
    self.matcher.fill_next_token_bitmask(vocab_mask, idx)
  File "/spec/lib/python3.11/site-packages/xgrammar/matcher.py", line 308, in fill_next_token_bitmask
    return self._handle.fill_next_token_bitmask(bitmask, index, debug_print)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: [22:10:40] /project/cpp/grammar_matcher.cc:556: Check failed: (!IsStopTokenAccepted()) is false: GrammarMatcher has terminated after accepting the stop token, but is trying to find the next token mask
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
