### PR TITLE
[diffusion] pipeline: fix error when enable torch compile

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -834,22 +834,34 @@ class DenoisingStage(PipelineStage):
     ):
         if boundary_timestep is None or t_int >= boundary_timestep:
             # High-noise stage
-            if server_args.enable_torch_compile and not self.transformer_compiled_func:
+            if (
+                server_args.enable_torch_compile
+                and not self.transformer_compiled_func
+            ):
                 current_model = self.transformer_compiled_func
             else:
                 current_model = self.transformer
-            if server_args.enable_torch_compile and not self.transformer_2_compiled_func:
+            if (
+                server_args.enable_torch_compile
+                and not self.transformer_2_compiled_func
+            ):
                 model_to_offload = self.transformer_2_compiled_func
             else:
                 model_to_offload = self.transformer_2
             current_guidance_scale = batch.guidance_scale
         else:
             # Low-noise stage
-            if server_args.enable_torch_compile and not self.transformer_2_compiled_func:
+            if (
+                server_args.enable_torch_compile
+                and not self.transformer_2_compiled_func
+            ):
                 current_model = self.transformer_2_compiled_func
             else:
                 current_model = self.transformer_2
-            if server_args.enable_torch_compile and not self.transformer_compiled_func:
+            if (
+                server_args.enable_torch_compile
+                and not self.transformer_compiled_func
+            ):
                 model_to_offload = self.transformer_compiled_func
             else:
                 model_to_offload = self.transformer

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -111,6 +111,7 @@ class DenoisingStage(PipelineStage):
         self.transformer_2 = transformer_2
         self.transformer_compiled_func = None
         self.transformer_2_compiled_func = None
+        self.full_graph = False
 
         hidden_size = self.server_args.pipeline_config.dit_config.hidden_size
         num_attention_heads = (
@@ -120,13 +121,12 @@ class DenoisingStage(PipelineStage):
 
         # torch compile
         if self.server_args.enable_torch_compile:
-            full_graph = False
             self.transformer_compiled_func = torch.compile(
-                self.transformer, mode="max-autotune", fullgraph=full_graph
+                self.transformer, mode="max-autotune", fullgraph=self.full_graph
             )
             self.transformer_2_compiled_func = (
                 torch.compile(
-                    self.transformer_2, mode="max-autotune", fullgraph=full_graph
+                    self.transformer_2, mode="max-autotune", fullgraph=self.full_graph
                 )
                 if transformer_2 is not None
                 else None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -492,7 +492,10 @@ class DenoisingStage(PipelineStage):
             # enable cache-dit before torch.compile (delayed mounting)
             self._maybe_enable_cache_dit(batch.num_inference_steps)
 
-            if self.server_args.enable_torch_compile and not self.transformer_compiled_func:
+            if (
+                self.server_args.enable_torch_compile
+                and not self.transformer_compiled_func
+            ):
                 self.transformer_compiled_func = torch.compile(
                     self.transformer, mode="max-autotune", fullgraph=self.full_graph
                 )
@@ -834,10 +837,7 @@ class DenoisingStage(PipelineStage):
     ):
         if boundary_timestep is None or t_int >= boundary_timestep:
             # High-noise stage
-            if (
-                server_args.enable_torch_compile
-                and not self.transformer_compiled_func
-            ):
+            if server_args.enable_torch_compile and not self.transformer_compiled_func:
                 current_model = self.transformer_compiled_func
             else:
                 current_model = self.transformer
@@ -858,10 +858,7 @@ class DenoisingStage(PipelineStage):
                 current_model = self.transformer_2_compiled_func
             else:
                 current_model = self.transformer_2
-            if (
-                server_args.enable_torch_compile
-                and not self.transformer_compiled_func
-            ):
+            if server_args.enable_torch_compile and not self.transformer_compiled_func:
                 model_to_offload = self.transformer_compiled_func
             else:
                 model_to_offload = self.transformer


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

- #12799

Error when setting `--enable-torch-compile true`

`glang serve --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers --port 3000 --enable-torch-compile true`

```
Traceback (most recent call last):
  File "/home/jobuser/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/executors/parallel_executor.py", line 90, in execute
    batch = stage(batch, server_args)
  File "/home/jobuser/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/base.py", line 192, in __call__
    result = self.forward(batch, server_args)
  File "/home/jobuser/sglang/.venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/jobuser/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 784, in forward
    prepared_vars = self._prepare_denoising_loop(batch, server_args)
  File "/home/jobuser/sglang/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 421, in _prepare_denoising_loop
    self.transformer.forward,
AttributeError: 'function' object has no attribute 'forward'
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Updated the denoising.py now it runs without error.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Checked output video is the same.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling
```
glang serve --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers --port 3000
```

Tested on H100

| - | disable torch compile | enable torch compile |
| - | - | - |
| denoising time per step | 1.43s | 1.28s |
| end-to-end time | 78s | 71s |

enabled
```
[12-05 17:59:51] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[12-05 17:59:51] [InputValidationStage] started...
[12-05 17:59:51] [InputValidationStage] finished in 0.0001 seconds
[12-05 17:59:51] [TextEncodingStage] started...
[12-05 17:59:54] [TextEncodingStage] finished in 2.2956 seconds
[12-05 17:59:54] [ConditioningStage] started...
[12-05 17:59:54] [ConditioningStage] finished in 0.0001 seconds
[12-05 17:59:54] [TimestepPreparationStage] started...
[12-05 17:59:54] [TimestepPreparationStage] finished in 0.0019 seconds
[12-05 17:59:54] [LatentPreparationStage] started...
[12-05 17:59:54] [LatentPreparationStage] finished in 0.0012 seconds
[12-05 17:59:54] [DenoisingStage] started...
/home/jobuser/sglang/.venv/lib/python3.10/site-packages/torch/_dynamo/variables/functions.py:1692: UserWarning: Dynamo detected a call to a `functools.lru_cache`-wrapped function. Dynamo ignores the cache wrapper and directly traces the wrapped function. Silent incorrectness is only a *potential* risk, not something we have observed. Enable TORCH_LOGS="+dynamo" for a DEBUG stack trace.
  torch._dynamo.utils.warn_once(msg)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:04<00:00,  1.28s/it]
[12-05 18:00:58] [DenoisingStage] average time per step: 1.2820 seconds
[12-05 18:00:58] [DenoisingStage] finished in 64.1045 seconds
[12-05 18:00:58] [DecodingStage] started...
[12-05 18:01:01] [DecodingStage] finished in 2.9407 seconds
[12-05 18:01:02] Saved output to outputs/aa0220f6-4ced-4bfc-a151-c22d9606443f.mp4
[12-05 18:01:02] Pixel data generated successfully in 71.27 seconds
```

disabled
```
[12-05 18:04:52] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[12-05 18:04:52] [InputValidationStage] started...
[12-05 18:04:52] [InputValidationStage] finished in 0.0001 seconds
[12-05 18:04:52] [TextEncodingStage] started...
[12-05 18:04:55] [TextEncodingStage] finished in 2.2805 seconds
[12-05 18:04:55] [ConditioningStage] started...
[12-05 18:04:55] [ConditioningStage] finished in 0.0001 seconds
[12-05 18:04:55] [TimestepPreparationStage] started...
[12-05 18:04:55] [TimestepPreparationStage] finished in 0.0019 seconds
[12-05 18:04:55] [LatentPreparationStage] started...
[12-05 18:04:55] [LatentPreparationStage] finished in 0.0012 seconds
[12-05 18:04:55] [DenoisingStage] started...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:11<00:00,  1.43s/it]
[12-05 18:06:06] [DenoisingStage] average time per step: 1.4309 seconds
[12-05 18:06:06] [DenoisingStage] finished in 71.5495 seconds
[12-05 18:06:06] [DecodingStage] started...
[12-05 18:06:09] [DecodingStage] finished in 2.9442 seconds
[12-05 18:06:11] Saved output to outputs/acd7ef1d-9127-4a52-921a-b8cdd2dd9610.mp4
[12-05 18:06:11] Pixel data generated successfully in 78.67 seconds
[12-05 18:06:11] Completed batch processing. Generated 1 outputs in 78.67 seconds.
```

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
