### PR TITLE
[Bug fix] Add /model_info endpoint to mini_lb

### DIFF
--- a/sgl-model-gateway/bindings/python/sglang_router/mini_lb.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/mini_lb.py
@@ -341,8 +341,7 @@ async def get_server_info():
         }
 
 
-@app.get("/get_model_info")
-async def get_model_info():
+async def _get_model_info_impl():
     if not lb or not lb.prefill_urls:
         raise HTTPException(
             status_code=HTTPStatus.SERVICE_UNAVAILABLE,
@@ -350,7 +349,7 @@ async def get_model_info():
         )
 
     target_server_url = lb.prefill_urls[0]
-    endpoint_url = f"{target_server_url}/get_model_info"
+    endpoint_url = f"{target_server_url}/model_info"
 
     async with aiohttp.ClientSession() as session:
         try:
@@ -373,6 +372,16 @@ async def get_model_info():
                 status_code=HTTPStatus.SERVICE_UNAVAILABLE,
                 detail=f"Failed to get model info from backend",
             )
+
+
+@app.get("/model_info")
+async def model_info():
+    return await _get_model_info_impl()
+
+
+@app.get("/get_model_info")
+async def get_model_info():
+    return await _get_model_info_impl()
 
 
 @app.post("/generate")


### PR DESCRIPTION
## Summary
- Add `/model_info` endpoint to mini_lb to fix regression introduced by #13607
- Keep `/get_model_info` for backwards compatibility  
- Update backend call to use `/model_info` (the non-deprecated endpoint)

## Root Cause
PR #13607 changed `runtime_endpoint.py` to use `/model_info` instead of `/get_model_info`, but `mini_lb.py` was not updated to support the new endpoint. This caused `test_disaggregation_basic.py` to fail with 404 errors when accessing `/model_info` through the mini load balancer.

Error example: https://github.com/sgl-project/sglang/actions/runs/19977384736/job/57312528074

## Test plan
- [x] Verify `test_disaggregation_basic.py` passes in CI after this fix