### PR TITLE
fix: Handle spec_info length mismatch in Eagle Prefill/Extend phase

### DIFF
--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -732,13 +732,17 @@ class EagleDraftInput(SpecInput, EagleDraftInputV2Mixin):
             self.future_indices.indices = self.future_indices.indices[new_indices]
             return
 
+        if has_been_filtered and len(new_indices) != len(self.topk_p):
+            # has_been_filtered has default value True
+            # but if the lengths are not equal, the batch is not filtered yet
+            logger.debug(
+                f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, adjuesting has_been_filtered to False"
+            )
+            has_been_filtered = False
+
         if has_been_filtered:
             # in eagle_utils.py:verify, we have already filtered the batch by `unfinished_index`
             # therefore, we don't need to filter the batch again in scheduler
-            if len(new_indices) != len(self.topk_p):
-                logger.warning(
-                    f"length of new_indices: {len(new_indices)} != length of topk_p: {len(self.topk_p)}, this should not happen"
-                )
             self.topk_p = self.topk_p[: len(new_indices)]
             self.topk_index = self.topk_index[: len(new_indices)]
             self.hidden_states = self.hidden_states[: len(new_indices)]


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Try to resolve #14368 

This PR fixes a data misalignment issue in EagleDraftInput.filter_batch that caused "length of new_indices != length of topk_p" warnings and potentially incorrect behavior in Speculative Decoding (EAGLE).


## Modifications

Modified `EagleDraftInput.filter_batch` in `python/sglang/srt/speculative/eagle_info.py`.

- Added a check: if `len(new_indices) != len(self.topk_p)`, we force `has_been_filtered = False`.
- This ensures that when a length mismatch occurs (indicating the presence of extra/outdated data), we perform explicit indexing using `new_indices` to correctly filter the data, rather than relying on unsafe slicing

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
