### PR TITLE
diffusion: fix LoRA dtype handling and weight attribute access for z-image model

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -59,6 +59,14 @@ class BaseLayerWithLoRA(nn.Module):
         self.lora_A = None
         self.lora_B = None
 
+    @property
+    def weight(self):
+        return self.base_layer.weight
+
+    @property
+    def bias(self):
+        return getattr(self.base_layer, 'bias', None)
+
     @torch.compile()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         lora_A = self.lora_A
@@ -79,7 +87,7 @@ class BaseLayerWithLoRA(nn.Module):
             return out + delta, output_bias
         else:
             out, output_bias = self.base_layer(x)
-            return out.to(x), output_bias
+            return out, output_bias
 
     def slice_lora_a_weights(self, A: torch.Tensor) -> torch.Tensor:
         return A

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -65,7 +65,7 @@ class BaseLayerWithLoRA(nn.Module):
 
     @property
     def bias(self):
-        return getattr(self.base_layer, 'bias', None)
+        return getattr(self.base_layer, "bias", None)
 
     @torch.compile()
     def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes two critical issues when using LoRA with the zimage model:

1. **Weight attribute access in LoRA-wrapped layers**: The zimage model accesses `self.mlp[0].weight.dtype` in `TimestepEmbedder.forward()`, but when layers are wrapped with LoRA, the `weight` attribute is not directly accessible. This PR adds `weight` and `bias` properties to `BaseLayerWithLoRA` that proxy to the underlying `base_layer`, allowing code like `layer.weight.dtype` to work correctly.

2. **Incorrect output dtype in LoRA forward pass**: When using LoRA with autocast enabled, the output dtype should follow the weight's dtype (bf16) rather than the input dtype (fp32), matching the behavior without LoRA. The previous implementation used `out.to(x.dtype)`, which incorrectly converted the output to the input dtype (fp32) instead of preserving the autocast behavior (bf16). This PR removes the unnecessary dtype conversion, allowing `F.linear` to handle dtype promotion correctly under autocast, ensuring consistent behavior with and without LoRA.

These fixes ensure that:
- LoRA-wrapped layers maintain the same dtype behavior as unwrapped layers
- Mixed precision (autocast) works correctly with LoRA
- The zimage model can access weight attributes on LoRA-wrapped layers without errors

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
Use the lora is `elusarca-anime-style-lora-z-image-turbo` , prompt is "elusarca anime style.  A female demon sitting on a thrown chair.  Fire burns around her"
After resolving the issues mentioned above, Lora was able to function normally.

<img width="792" height="412" alt="image" src="https://github.com/user-attachments/assets/61f3409e-7533-4c91-92c3-ea23a494b1e6" />


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
