### PR TITLE
Fix attention backend logic for Qwen3-Next on SM100

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1282,6 +1282,8 @@ class ServerArgs:
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
                     )
+                if self.attention_backend is None:
+                    self.attention_backend = "triton"
                 if (
                     not self.disable_radix_cache
                     and self.attention_backend == "trtllm_mha"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1284,6 +1284,9 @@ class ServerArgs:
                     )
                 if self.attention_backend is None:
                     self.attention_backend = "triton"
+                    logger.info(
+                        "Use triton as attention backend on sm100 for Qwen3NextForCausalLM"
+                    )
                 if (
                     not self.disable_radix_cache
                     and self.attention_backend == "trtllm_mha"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1282,6 +1282,16 @@ class ServerArgs:
                     logger.info(
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Qwen3NextForCausalLM"
                     )
+                if (
+                    not self.disable_radix_cache
+                    and self.attention_backend == "trtllm_mha"
+                ):
+                    logger.warning(
+                        "Disabling radix cache since trtllm_mha is not supports page_size = 1, which is required by MambaRadixCache."
+                        "try to use --attention-backend triton if radix cache is necessary"
+                    )
+                    self.disable_radix_cache = True
+                    self.disable_overlap_schedule = False
         elif model_arch in [
             "NemotronHForCausalLM",
             "FalconH1ForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1287,8 +1287,8 @@ class ServerArgs:
                     and self.attention_backend == "trtllm_mha"
                 ):
                     logger.warning(
-                        "Disabling radix cache since trtllm_mha is not supports page_size = 1, which is required by MambaRadixCache."
-                        "try to use --attention-backend triton if radix cache is necessary"
+                        "Disabling radix cache since trtllm_mha does not support page_size = 1, which is required by MambaRadixCache. "
+                        "Try to use --attention-backend triton if radix cache is necessary."
                     )
                     self.disable_radix_cache = True
                     self.disable_overlap_schedule = False


### PR DESCRIPTION
## Motivation
After https://github.com/sgl-project/sglang/pull/14291 set trtllm_mha as the default attention backend, but mamba cache requires `page_size = 1`, while `trtllm_mha` only supports `page_size > 1.` This can lead to issues  https://github.com/sgl-project/sglang/issues/14527

This PR prevents such conflicts.

## Modifications
1. use `triton` backend by default for Qwen3-Next on SM100.
2. disable radix-cache when `trtllm_mha` is selected as the attention backend for Qwen3-Next on SM100.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).