### PR TITLE
Add unit-test-backend-8-gpu-b200 to rerun-stage command

### DIFF
--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -151,6 +151,7 @@ def handle_rerun_stage(
         "unit-test-backend-4-gpu",
         "unit-test-backend-8-gpu-h200",
         "unit-test-backend-8-gpu-h20",
+        "unit-test-backend-8-gpu-b200",
         "performance-test-1-gpu-part-1",
         "performance-test-1-gpu-part-2",
         "performance-test-1-gpu-part-3",


### PR DESCRIPTION
## Summary
- Add `unit-test-backend-8-gpu-b200` to the list of valid NVIDIA stages that support isolated runs via the `/rerun-stage` command

## Test plan
- The change is a simple addition to the `nvidia_stages` list in the slash command handler
- No functional changes to the command logic

Follow-up to #14460 which added the `unit-test-backend-8-gpu-b200` stage to the PR test workflow.