### PR TITLE
[Tool Call] Fix DeepSeekV32Detector skipping functions with no params in streaming mode

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -241,13 +241,8 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     # This ensures each function returns at most once
                     calls_for_this_invoke: list[ToolCallItem] = []
 
-                    # Check if invoke_content is empty or whitespace only
-                    # If so, skip this tool call entirely (it's likely incomplete or malformed)
-                    if not invoke_content.strip():
-                        # Remove the incomplete tool call from buffer
-                        self._buffer = current_text[invoke_match.end() :]
-                        current_text = self._buffer
-                        continue
+                    # Note: invoke_content can be empty for functions with no parameters
+                    # This is valid and should NOT be skipped
 
                     # Send tool name
                     calls_for_this_invoke.append(

--- a/test/registered/function_call/test_function_call_parser.py
+++ b/test/registered/function_call/test_function_call_parser.py
@@ -1357,7 +1357,9 @@ class TestDeepSeekV32Detector(unittest.TestCase):
                         ] += call.parameters
 
         # Verify that the no-parameter function was correctly parsed
-        self.assertEqual(len(tool_calls_by_index), 1, "Should have exactly one tool call")
+        self.assertEqual(
+            len(tool_calls_by_index), 1, "Should have exactly one tool call"
+        )
         self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
 
         # Parameters should be empty JSON object
@@ -1410,7 +1412,9 @@ class TestDeepSeekV32Detector(unittest.TestCase):
                         ] += call.parameters
 
         # Should still parse correctly even with whitespace-only content
-        self.assertEqual(len(tool_calls_by_index), 1, "Should have exactly one tool call")
+        self.assertEqual(
+            len(tool_calls_by_index), 1, "Should have exactly one tool call"
+        )
         self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
         params = json.loads(tool_calls_by_index[0]["parameters"])
         self.assertEqual(params, {})

--- a/test/registered/function_call/test_function_call_parser.py
+++ b/test/registered/function_call/test_function_call_parser.py
@@ -1277,6 +1277,144 @@ class TestDeepSeekV32Detector(unittest.TestCase):
         params = json.loads(params_str)
         self.assertEqual(params["city"], "San Francisco")
 
+    def test_detect_and_parse_no_parameters(self):
+        """Test parsing function calls with no parameters (non-streaming)"""
+        # Add a no-parameter tool
+        tools_with_no_param = self.tools + [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_date",
+                    description="Get the current date.",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+
+        text = """Let me get the current date for you.
+
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_date">
+</｜DSML｜invoke>
+</｜DSML｜function_calls>"""
+
+        result = self.detector.detect_and_parse(text, tools_with_no_param)
+
+        self.assertIn("Let me get the current date", result.normal_text)
+        self.assertEqual(len(result.calls), 1)
+
+        call = result.calls[0]
+        self.assertEqual(call.name, "get_date")
+        params = json.loads(call.parameters)
+        self.assertEqual(params, {})
+
+    def test_streaming_no_parameters(self):
+        """Test streaming parsing of function calls with no parameters.
+
+        This test verifies the fix for the bug where functions with no parameters
+        were being silently skipped in streaming mode.
+        """
+        # Add a no-parameter tool
+        tools_with_no_param = self.tools + [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_date",
+                    description="Get the current date.",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+
+        text = """<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_date">
+</｜DSML｜invoke>
+</｜DSML｜function_calls>"""
+
+        # Reset detector state
+        self.detector = DeepSeekV32Detector()
+
+        # Simulate streaming by splitting into small chunks
+        chunks = [text[i : i + 5] for i in range(0, len(text), 5)]
+
+        tool_calls_by_index = {}
+
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, tools_with_no_param)
+            for call in result.calls:
+                if call.tool_index is not None:
+                    if call.tool_index not in tool_calls_by_index:
+                        tool_calls_by_index[call.tool_index] = {
+                            "name": "",
+                            "parameters": "",
+                        }
+
+                    if call.name:
+                        tool_calls_by_index[call.tool_index]["name"] = call.name
+                    if call.parameters:
+                        tool_calls_by_index[call.tool_index][
+                            "parameters"
+                        ] += call.parameters
+
+        # Verify that the no-parameter function was correctly parsed
+        self.assertEqual(len(tool_calls_by_index), 1, "Should have exactly one tool call")
+        self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
+
+        # Parameters should be empty JSON object
+        params_str = tool_calls_by_index[0]["parameters"].strip()
+        params = json.loads(params_str)
+        self.assertEqual(params, {})
+
+    def test_streaming_no_parameters_with_whitespace(self):
+        """Test streaming parsing when invoke content has only whitespace (newlines)."""
+        tools_with_no_param = self.tools + [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_date",
+                    description="Get the current date.",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+
+        # This format has newlines inside the invoke tag (common model output)
+        text = """<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_date">
+
+</｜DSML｜invoke>
+</｜DSML｜function_calls>"""
+
+        # Reset detector state
+        self.detector = DeepSeekV32Detector()
+
+        chunks = [text[i : i + 5] for i in range(0, len(text), 5)]
+
+        tool_calls_by_index = {}
+
+        for chunk in chunks:
+            result = self.detector.parse_streaming_increment(chunk, tools_with_no_param)
+            for call in result.calls:
+                if call.tool_index is not None:
+                    if call.tool_index not in tool_calls_by_index:
+                        tool_calls_by_index[call.tool_index] = {
+                            "name": "",
+                            "parameters": "",
+                        }
+
+                    if call.name:
+                        tool_calls_by_index[call.tool_index]["name"] = call.name
+                    if call.parameters:
+                        tool_calls_by_index[call.tool_index][
+                            "parameters"
+                        ] += call.parameters
+
+        # Should still parse correctly even with whitespace-only content
+        self.assertEqual(len(tool_calls_by_index), 1, "Should have exactly one tool call")
+        self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
+        params = json.loads(tool_calls_by_index[0]["parameters"])
+        self.assertEqual(params, {})
+
 
 class TestQwen3CoderDetector(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Motivation

When using `--tool-call-parser deepseekv32` in streaming mode, tool calls for functions with no parameters (e.g., `get_date()`) were being silently skipped, while non-streaming mode worked correctly.

This caused inconsistent behavior between streaming and non-streaming modes, making it impossible to use parameter-less tool calls in streaming scenarios.

## Modifications

Removed an incorrect check in `DeepSeekV32Detector.parse_streaming_increment()` that was skipping tool calls when `invoke_content` was empty or contained only whitespace.

The original code:
```python
if not invoke_content.strip():
    # Remove the incomplete tool call from buffer
    self._buffer = current_text[invoke_match.end() :]
    current_text = self._buffer
    continue  # This incorrectly skips valid no-parameter function calls
```

This check was intended to skip "incomplete or malformed" tool calls, but it incorrectly treated functions with no parameters as invalid. For example, a valid tool call like:
```xml
<｜DSML｜invoke name="get_date">
</｜DSML｜invoke>
```
would have `invoke_content = "\n\n"`, which after `.strip()` becomes empty, causing the tool call to be skipped.

A tool call with a closing tag (`</｜DSML｜invoke>`) is complete and valid, regardless of whether it has parameters. Functions with no parameters should return `{}` as their arguments.

## Accuracy Tests

N/A - This change only affects tool call parsing logic, not model outputs.

## Benchmarking and Profiling

N/A - This change does not impact inference speed. It only removes an incorrect conditional check in the streaming parser.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).

- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).

- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).

- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
