### PR TITLE
[Bug fix] Fix DP attention IndexError in draft_extend mode

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -767,7 +767,6 @@ class ForwardBatch:
         if (
             self.forward_mode.is_decode()
             or self.forward_mode.is_target_verify()
-            or self.forward_mode.is_draft_extend(include_v2=True)
             or self.forward_mode.is_idle()
         ):
             if self.is_extend_in_batch and dp_padding_mode.is_max_len():


### PR DESCRIPTION
## Summary
- Fix deterministic failure in `unit-test-deepep-8-gpu` test
- Remove `is_draft_extend(include_v2=True)` from DP attention batch preparation condition

## Problem

When running Eagle speculative decoding with DP attention and DeepEP, the draft model forward triggers `get_dp_local_info()` which expects `global_num_tokens_gpu` to have `dp_size` elements. However, in some configurations (when `require_mlp_tp_gather` is False), this tensor only has 1 element, causing an IndexError.

**Example failure:** https://github.com/sgl-project/sglang/actions/runs/20001177440/job/57360950954

**Error:**
```
File "dp_attention.py", line 393, in get_dp_local_info
    local_start_pos = cumtokens[dp_rank - 1]
IndexError: index 4 is out of bounds for dimension 0 with size 1
```

## Fix

Remove `is_draft_extend(include_v2=True)` from the DP attention batch preparation condition in `forward_batch_info.py`. Draft extend mode should not use this DP attention padding logic as the `global_num_tokens_gpu` tensor may not be properly sized for it.

## Test plan
- [ ] Verify `unit-test-deepep-8-gpu` passes after this fix