### PR TITLE
Tiny remove wrong import from `python.sglang`

### DIFF
--- a/python/sglang/srt/models/mistral_large_3_eagle.py
+++ b/python/sglang/srt/models/mistral_large_3_eagle.py
@@ -4,8 +4,8 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
-from python.sglang.srt.layers.attention.nsa.utils import is_nsa_enable_prefill_cp
 from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.attention.nsa.utils import is_nsa_enable_prefill_cp
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import RowParallelLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig


### PR DESCRIPTION
This error is due to some IDE's auto-completion and should not be adopted by a library's code.