### PR TITLE
[CI] Fix unit-test-backend-8-gpu-b200 running on every /rerun-stage

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1209,11 +1209,14 @@ jobs:
   unit-test-backend-8-gpu-b200:
     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
     if: |
-      (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
+      always() &&
       (
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
+        (
+          !inputs.target_stage &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
       )
     runs-on: 8-gpu-b200
     env:


### PR DESCRIPTION
## Summary
- Fix bug where `unit-test-backend-8-gpu-b200` job runs on every `/rerun-stage` command regardless of which stage was targeted
- Add missing `!inputs.target_stage &&` check to the job condition

## Problem
The `unit-test-backend-8-gpu-b200` job was missing the `!inputs.target_stage` guard in its condition, causing it to run whenever any `/rerun-stage` command was issued (e.g., `/rerun-stage unit-test-backend-4-gpu` would also trigger `unit-test-backend-8-gpu-b200`).

## Test plan
- [x] Run `/rerun-stage unit-test-backend-4-gpu` and verify `unit-test-backend-8-gpu-b200` does not run
- [ ] Run `/rerun-stage unit-test-backend-8-gpu-b200` and verify only that job runs