### PR TITLE
[model-gateway] fix WASM memory limit per module

### DIFF
--- a/sgl-model-gateway/src/wasm/types.rs
+++ b/sgl-model-gateway/src/wasm/types.rs
@@ -3,7 +3,7 @@
 //! Provides generic input/output types for WASM component execution
 //! based on attach points.
 
-use wasmtime::component::ResourceTable;
+use wasmtime::{component::ResourceTable, StoreLimits};
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 
 use crate::wasm::{
@@ -89,6 +89,7 @@ impl WasmComponentOutput {
 pub struct WasiState {
     pub ctx: WasiCtx,
     pub table: ResourceTable,
+    pub limits: StoreLimits,
 }
 
 impl WasiView for WasiState {


### PR DESCRIPTION

| Component              | Description                                                          |
|------------------------|----------------------------------------------------------------------|
| `StoreLimits`          | Wasmtime's built-in resource limiter                                 |
| `memory_size()`        | Sets max bytes a linear memory can grow to                           |
| `trap_on_grow_failure` | Raises trap instead of returning -1 for easier debugging             |
| `store.limiter()`      | Applies limits to all memory operations in the store                 |

**Example** (default config with `max_memory_pages = 1024`):
- Memory limit: 1024 pages × 64KB = 64MB
- Any `memory.grow` beyond 64MB will trap with an error

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
