### PR TITLE
[model-gateway] fix WASM unbounded request/response body read vuln

### DIFF
--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -612,7 +612,8 @@ pub async fn wasm_middleware(
     let method = request.method().clone();
     let uri = request.uri().clone();
     let mut headers = request.headers().clone();
-    let body_bytes = match axum::body::to_bytes(request.into_body(), usize::MAX).await {
+    let max_body_size = wasm_manager.get_max_body_size();
+    let body_bytes = match axum::body::to_bytes(request.into_body(), max_body_size).await {
         Ok(bytes) => bytes.to_vec(),
         Err(e) => {
             error!("Failed to read request body: {}", e);
@@ -708,7 +709,7 @@ pub async fn wasm_middleware(
     // Extract response data once before processing modules
     let mut status = response.status();
     let mut headers = response.headers().clone();
-    let mut body_bytes = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+    let mut body_bytes = match axum::body::to_bytes(response.into_body(), max_body_size).await {
         Ok(bytes) => bytes.to_vec(),
         Err(e) => {
             error!("Failed to read response body: {}", e);

--- a/sgl-model-gateway/src/wasm/module_manager.rs
+++ b/sgl-model-gateway/src/wasm/module_manager.rs
@@ -128,6 +128,11 @@ impl WasmModuleManager {
         &self.runtime
     }
 
+    /// Get the configured maximum body size for HTTP request/response processing
+    pub fn get_max_body_size(&self) -> usize {
+        self.runtime.get_config().max_body_size
+    }
+
     /// Execute WASM module using WebAssembly component model based on attach_point
     pub async fn execute_module_interface(
         &self,


### PR DESCRIPTION

| Component              | Description                                                       |
|------------------------|-------------------------------------------------------------------|
| `max_body_size` config | New configurable limit for HTTP body processing (default: 10MB)   |
| Validation             | Must be >0 and ≤100MB for safety                                  |
| Applied in middleware  | Both request and response body reads now respect the limit        |

**Example** (default config with `max_body_size = 10485760`):
- Requests/responses with bodies >10MB will fail gracefully
- Error is logged and request continues with empty body (graceful degradation)
- Prevents memory exhaustion from oversized payloads

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
