### PR TITLE
[CI] Move mistral large 3 basic to nightly

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1206,34 +1206,34 @@ jobs:
           cd test/srt
           python3 run_suite.py --suite per-commit-4-gpu-gb200 --auto-partition-id 0 --auto-partition-size 1 --timeout-per-file 3600
 
-#   unit-test-backend-8-gpu-b200:
-#     needs: [check-changes, call-gate, unit-test-backend-2-gpu]
-#     if: |
-#       always() &&
-#       (
-#         (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
-#         (
-#           !inputs.target_stage &&
-#           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-#           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
-#         )
-#       )
-#     runs-on: 8-gpu-b200
-#     env:
-#       RUNNER_LABELS: 8-gpu-b200
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v4
+  unit-test-backend-8-gpu-b200:
+    needs: [check-changes, call-gate, unit-test-backend-2-gpu]
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
+        (
+          !inputs.target_stage &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
+    runs-on: 8-gpu-b200
+    env:
+      RUNNER_LABELS: 8-gpu-b200
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Install dependencies
-  #       run: |
-  #         IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
+      - name: Install dependencies
+        run: |
+          IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
 
-  #     - name: Run test
-  #       timeout-minutes: 45
-  #       run: |
-  #         cd test/srt
-  #         python3 run_suite.py --suite per-commit-8-gpu-b200 --timeout-per-file 1800
+      # - name: Run test
+      #   timeout-minutes: 45
+      #   run: |
+      #     cd test/srt
+      #     python3 run_suite.py --suite per-commit-8-gpu-b200 --timeout-per-file 1800
 
   pr-test-finish:
     needs:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -775,11 +775,11 @@ jobs:
           cd test/srt
           python3 -m unittest test_bench_serving.TestBenchServing.test_offline_throughput_non_stream_small_batch_size
 
-      # - name: Benchmark online latency (EAGLE)  # Moved to nightly - large model
-      #   timeout-minutes: 10
-      #   run: |
-      #     cd test/srt
-      #     python3 -m unittest test_bench_serving.TestBenchServing.test_online_latency_eagle
+      - name: Benchmark online latency (EAGLE)  # Moved to nightly - large model
+        timeout-minutes: 10
+        run: |
+          cd test/srt
+          python3 -m unittest test_bench_serving.TestBenchServing.test_online_latency_eagle
 
       - name: Benchmark online latency (LoRA)
         timeout-minutes: 10

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -775,7 +775,7 @@ jobs:
           cd test/srt
           python3 -m unittest test_bench_serving.TestBenchServing.test_offline_throughput_non_stream_small_batch_size
 
-      - name: Benchmark online latency (EAGLE)  # Moved to nightly - large model
+      - name: Benchmark online latency (EAGLE)
         timeout-minutes: 10
         run: |
           cd test/srt

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -775,11 +775,11 @@ jobs:
           cd test/srt
           python3 -m unittest test_bench_serving.TestBenchServing.test_offline_throughput_non_stream_small_batch_size
 
-      - name: Benchmark online latency (EAGLE)
-        timeout-minutes: 10
-        run: |
-          cd test/srt
-          python3 -m unittest test_bench_serving.TestBenchServing.test_online_latency_eagle
+      # - name: Benchmark online latency (EAGLE)  # Moved to nightly - large model
+      #   timeout-minutes: 10
+      #   run: |
+      #     cd test/srt
+      #     python3 -m unittest test_bench_serving.TestBenchServing.test_online_latency_eagle
 
       - name: Benchmark online latency (LoRA)
         timeout-minutes: 10
@@ -1206,31 +1206,31 @@ jobs:
           cd test/srt
           python3 run_suite.py --suite per-commit-4-gpu-gb200 --auto-partition-id 0 --auto-partition-size 1 --timeout-per-file 3600
 
-  unit-test-backend-8-gpu-b200:
-    needs: [check-changes, call-gate, unit-test-backend-2-gpu]
-    if: |
-      (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
-      (
-        always() &&
-        (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
-        ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
-      )
-    runs-on: 8-gpu-b200
-    env:
-      RUNNER_LABELS: 8-gpu-b200
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # unit-test-backend-8-gpu-b200:  # Moved to nightly - large models only
+  #   needs: [check-changes, call-gate, unit-test-backend-2-gpu]
+  #   if: |
+  #     (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
+  #     (
+  #       always() &&
+  #       (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+  #       ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+  #     )
+  #   runs-on: 8-gpu-b200
+  #   env:
+  #     RUNNER_LABELS: 8-gpu-b200
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
+  #     - name: Install dependencies
+  #       run: |
+  #         IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
 
-      - name: Run test
-        timeout-minutes: 45
-        run: |
-          cd test/srt
-          python3 run_suite.py --suite per-commit-8-gpu-b200 --timeout-per-file 1800
+  #     - name: Run test
+  #       timeout-minutes: 45
+  #       run: |
+  #         cd test/srt
+  #         python3 run_suite.py --suite per-commit-8-gpu-b200 --timeout-per-file 1800
 
   pr-test-finish:
     needs:
@@ -1264,7 +1264,7 @@ jobs:
         unit-test-deepep-8-gpu,
         unit-test-backend-4-gpu-b200,
         unit-test-backend-4-gpu-gb200,
-        unit-test-backend-8-gpu-b200,
+        # unit-test-backend-8-gpu-b200,  # Moved to nightly - large models only
       ]
     if: always()
     runs-on: ubuntu-latest

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -181,7 +181,7 @@ suites = {
         # TestFile("test_eagle_infer_beta_dp_attention.py", 200),
     ],
     "per-commit-8-gpu-b200": [
-        TestFile("test_mistral_large3_basic.py", 275),
+        # TestFile("test_mistral_large3_basic.py", 275),  # Moved to nightly - large model
     ],
     "per-commit-4-gpu-gb200": [
         TestFile("test_cutedsl_moe.py", 300),

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -180,8 +180,8 @@ suites = {
         TestFile("test_eagle_infer_beta_dp_attention.py", 300),
     ],
     # "per-commit-8-gpu-b200": [
-        # TestFile("test_mistral_large3_basic.py", 275),  # Moved to nightly - large model
-    ],
+    #     TestFile("test_mistral_large3_basic.py", 275),  # Moved to nightly - large model
+    # ],
     "per-commit-4-gpu-gb200": [
         TestFile("test_cutedsl_moe.py", 300),
         TestFile("test_deepseek_v3_cutedsl_4gpu.py", 590),
@@ -216,6 +216,7 @@ suites = {
         TestFile("test_vision_openai_server_common.py"),
         TestFile("test_profile_v2.py"),
         TestFile("models/test_ministral3_models.py"),
+        TestFile("test_mistral_large3_basic.py"),
     ],
 }
 

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -180,7 +180,7 @@ suites = {
         # TODO: Add it back after the bug is fixed
         # TestFile("test_eagle_infer_beta_dp_attention.py", 200),
     ],
-    "per-commit-8-gpu-b200": [
+    # "per-commit-8-gpu-b200": [
         # TestFile("test_mistral_large3_basic.py", 275),  # Moved to nightly - large model
     ],
     "per-commit-4-gpu-gb200": [


### PR DESCRIPTION
## Summary
- Comment out Mistral Large 3 basic test from `per-commit-8-gpu-b200` suite
- Comment out entire `unit-test-backend-8-gpu-b200` job (only contained Mistral Large 3 test)