### PR TITLE
[Bugfix] Fix KeyError for Mistral-Large-3 rope_scaling config

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -358,9 +358,10 @@ class ModelConfig:
                 mscale_all_dim = self.hf_config.rope_scaling.get(
                     "mscale_all_dim", False
                 )
-                scaling_factor = self.hf_config.rope_scaling["factor"]
-                mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
-                self.scaling = self.scaling * mscale * mscale
+                scaling_factor = self.hf_config.rope_scaling.get("factor")
+                if scaling_factor is not None:
+                    mscale = yarn_get_mscale(scaling_factor, float(mscale_all_dim))
+                    self.scaling = self.scaling * mscale * mscale
 
         elif "MiniCPM3ForCausalLM" in self.hf_config.architectures:
             self.head_dim = 128


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'factor'` when loading Mistral-Large-3 model
- Use `.get()` to safely access `rope_scaling["factor"]` which may not exist in Mistral-Large-3's config structure

## Root Cause
Mistral-Large-3's HuggingFace config uses a different `rope_scaling` structure (based on `rope_parameters`) that doesn't have a top-level `"factor"` key. The code at `model_config.py:361` assumed all MLA models with `rope_scaling` have this key.

## Error Reference
https://github.com/sgl-project/sglang/actions/runs/20017692847/job/57401685911?pr=14571

## Test plan
- [x] Verify Mistral-Large-3 CI test passes