### PR TITLE
[VLM] Refactor load_mm_data to improve performance

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -415,6 +415,49 @@ class BaseMultimodalProcessor(ABC):
         except Exception as e:
             raise RuntimeError(f"Error while loading data {data}: {e}")
 
+    def _submit_mm_data_loading_tasks_simple(
+        self,
+        data_list: Optional[list],
+        modality: Modality,
+        audio_sample_rate: Optional[int],
+        discard_alpha_channel: bool,
+    ) -> List[Tuple[Modality, int, concurrent.futures.Future]]:
+        """
+        Simple version: For one modal data submit IO load task.
+
+        Return:
+            List[(modality, index_in_that_modality, future)]
+        """
+        futures: List[Tuple[Modality, int, concurrent.futures.Future]] = []
+
+        if not data_list:
+            logger.debug(
+                "[_submit_mm_data_loading_tasks_simple] no data for modality=%s",
+                modality.name,
+            )
+            return futures
+
+        for idx, data in enumerate(data_list):
+            logger.debug(
+                "[_submit_mm_data_loading_tasks_simple] submit load task: "
+                "modality=%s, index=%d, data_type=%s",
+                modality.name,
+                idx,
+                type(data),
+            )
+            future = self.io_executor.submit(
+                BaseMultimodalProcessor._load_single_item,
+                data,
+                modality,
+                None,  # frame_count_limit: no consider for fast path
+                audio_sample_rate,
+                discard_alpha_channel,
+            )
+            futures.append((modality, idx, future))
+
+        return futures
+
+    # TODO(yuan-luo): To be obsoleted.
     def submit_data_loading_tasks(
         self,
         text_parts: List[str],
@@ -559,6 +602,127 @@ class BaseMultimodalProcessor(ABC):
         return is_precomputed, images, videos, audios
 
     def load_mm_data(
+        self,
+        prompt: str,
+        multimodal_tokens: MultimodalSpecialTokens,
+        image_data: Optional[list] = None,
+        video_data: Optional[list] = None,
+        audio_data: Optional[list] = None,
+        return_text: Optional[bool] = True,
+        discard_alpha_channel: bool = True,
+        audio_sample_rate: Optional[int] = None,
+    ) -> BaseMultiModalProcessorOutput:
+
+        # For MiniCPMO and MiniCPMV
+        if getattr(self, "support_dynamic_frame_expansion", False):
+            return self.legacy_load_mm_data(
+                prompt=prompt,
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+                video_data=video_data,
+                audio_data=audio_data,
+                return_text=return_text,
+                discard_alpha_channel=discard_alpha_channel,
+                audio_sample_rate=audio_sample_rate,
+            )
+        # For models other than MiniCPMO and MiniCPMV
+        else:
+            return self.fast_load_mm_data(
+                prompt=prompt,
+                multimodal_tokens=multimodal_tokens,
+                image_data=image_data,
+                video_data=video_data,
+                audio_data=audio_data,
+                return_text=return_text,
+                discard_alpha_channel=discard_alpha_channel,
+                audio_sample_rate=audio_sample_rate,
+            )
+
+    def fast_load_mm_data(
+        self,
+        prompt: str,
+        multimodal_tokens: MultimodalSpecialTokens,
+        image_data: Optional[list] = None,
+        video_data: Optional[list] = None,
+        audio_data: Optional[list] = None,
+        return_text: Optional[bool] = True,
+        discard_alpha_channel: bool = True,
+        audio_sample_rate: Optional[int] = None,
+    ) -> BaseMultiModalProcessorOutput:
+        """
+        A fast version of `load_mm_data` that loads multimodal data directly.
+        This version does not scan the prompt to recognize tokens. It assumes
+        that the caller has already aligned the tokens and data in a 1:1 manner.
+        The behavior is as follows:
+          1. It runs `_load_single_item` for all input data concurrently.
+          2. It returns the loaded images, videos, and audios in their original order.
+          3. It returns the input prompt as a string.
+        """
+
+        # Convert prompt into str
+        if isinstance(prompt, list) and return_text:
+            assert len(prompt) and isinstance(prompt[0], int)
+            prompt_str = self._processor.tokenizer.decode(prompt)
+        else:
+            assert isinstance(prompt, str)
+            prompt_str = prompt
+
+        futures: List[Tuple[Modality, int, concurrent.futures.Future]] = []
+
+        modalities_data = [
+            (image_data, Modality.IMAGE),
+            (video_data, Modality.VIDEO),
+            (audio_data, Modality.AUDIO),
+        ]
+
+        for data_list, modality in modalities_data:
+            futures.extend(
+                self._submit_mm_data_loading_tasks_simple(
+                    data_list, modality, audio_sample_rate, discard_alpha_channel
+                )
+            )
+
+        logger.debug("[load_mm_data(simple)] total futures submitted: %d", len(futures))
+
+        images: List[Any] = [None] * len(image_data) if image_data else []
+        videos: List[Any] = [None] * len(video_data) if video_data else []
+        audios: List[Any] = [None] * len(audio_data) if audio_data else []
+
+        for modality, idx, future in futures:
+            try:
+                result = future.result()
+            except Exception as e:
+                logger.exception(
+                    "[load_mm_data(simple)] error loading %s data at index=%d",
+                    modality.name,
+                    idx,
+                )
+                raise RuntimeError(
+                    f"An exception occurred while loading {modality.name} data at index {idx}: {e}"
+                )
+
+            if modality == Modality.IMAGE:
+                images[idx] = result
+            elif modality == Modality.VIDEO:
+                videos[idx] = result
+            elif modality == Modality.AUDIO:
+                audios[idx] = result
+
+        logger.debug(
+            "[load_mm_data(simple)] loaded counts: images=%d, videos=%d, audios=%d",
+            len(images),
+            len(videos),
+            len(audios),
+        )
+
+        return BaseMultiModalProcessorOutput(
+            images=images,
+            audios=audios,
+            videos=videos,
+            input_text=prompt_str,
+        )
+
+    def legacy_load_mm_data(
         self,
         prompt: str,
         multimodal_tokens: MultimodalSpecialTokens,

--- a/python/sglang/srt/multimodal/processors/minicpm.py
+++ b/python/sglang/srt/multimodal/processors/minicpm.py
@@ -14,6 +14,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 # Compatible with both 'O' and 'V'
 class MiniCPMMultimodalProcessor(BaseMultimodalProcessor):
     models = [MiniCPMV, MiniCPMO]
+    support_dynamic_frame_expansion = True
 
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Inspired by @mickqian .

In the load_mm_data method, there’s currently a redundant approach where we manually detect various tokens and then load them. This could be changed to simply loading all the passed data directly, but we previously made it this way because minicpmo model has a mechanism for adjusting video frames. We decide to simplify it in order to improve majority VLM models' performance.

For example, in both `load_mm_data()` and `submit_data_loading_tasks()` there are redundant `for text_part in text_parts loop`.

In the new implementation, `load_mm_data` works as “1 token → 1 data”: it doesn’t expand frames or rewrite the prompt, it just loads all the incoming data and aligns them with the tokens in order.

We keep legacy  `load_mm_data` dedicated for the MiniCPM model: support MiniCPM’s “1 token → multiple frames” behavior.

Log printing, result is as expected.

Server:
```
SGLANG_VIT_CUDA_GRAPH=1 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
python -m sglang.launch_server \
  --model-path /home/admin/Qwen2.5-VL-7B-Instruct \
  --enable-piecewise-cuda-graph \
  --piecewise-cuda-graph-max-tokens 8192 \
  --mm-attention-backend fa3 \
  --port 30000 \
  --chunked-prefill-size 8192 \
  --disable-radix-cache \
  --disable-overlap-schedule \
  --piecewise-cuda-graph-compiler eager \
  --attention-backend fa3 \
  --tp 2 \
  --log-level debug \
  --log-level-http debug \
  --log-requests
```

Client:
```
$cat bench_remote_video.sh 
for i in {1..1}; do
    time curl 'http://127.0.0.1:30000/v1/chat/completions' --header 'Content-Type: application/json' --data '{
        "model": "auto",
        "messages": [
            {
                "role": "user",
                "content": [
                                  {"type": "video_url", "video_url": {"url": "http://dmsint.cn-hangzhou.alipay.aliyun-inc.com/....../video_test.mp4"}},
                  {"type": "text", "text": "视频里的招牌写的什么"}
                ]
            }
        ],
                                                  
        "temperature":0.0,
        "max_tokens":1000,
        "stream": false,
        "chat_template_kwargs": {"enable_thinking": false}
    }'
done
```

```
[root  /root/luoyuan.luo/workspace/bench_script] 一 12月 08 20:37:24 
$bash bench_remote_video.sh 
{"id":"cdb06d6d5c1b428b89473566f40ad2f3","object":"chat.completion","created":1765197964,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频里的招牌上写着“小鞋匠洗鞋”，并附有电话号码“1529521190”。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":7682,"total_tokens":7712,"completion_tokens":30,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default","e2e_latency":1310.2936744689941,"ttft_latency":1310.302734375,"queue_latency":1.2103579938411713}}
real    0m1.318s
user    0m0.001s
sys     0m0.003s
```

```
2025-12-08 20:46:02.862 INFO 104744 [ tokenizer_manager.py:480] Receive: obj="GenerateReqInput(rid='cdb06d6d5c1b428b89473566f40ad2f3', http_worker_ipc=None, metrics={'api_server_arrive_time': 1765197962.8611393}, text='<|im_start|>system\\nYou are a helpful assistant.<|im_end|>\\n<|im_start|>user\\n<|vision_start|><|video_pad|><|vision_end|>视频里的招牌写的什么<|im_end|>\\n<|im_start|>assistant\\n', video_data=['http://dmsint.cn-hangzhou.alipay.aliyun-inc.com/aistudio/temp/20250910/208156dafb7b44a8/video_test.mp4'], sampling_params={'temperature': 0.0, 'max_new_tokens': 1000, 'min_new_tokens': 0, 'stop': None, 'stop_token_ids': None, 'stop_regex': None, 'top_p': 1.0, 'top_k': 50, 'min_p': 0.0, 'presence_penalty': 0.0, 'frequency_penalty': 0.0, 'repetition_penalty': 1.05, 'regex': None, 'ebnf': None, 'n': 1, 'no_stop_trim': False, 'ignore_eos': False, 'skip_special_tokens': True, 'logit_bias': None, 'custom_params': None}, return_logprob=False, logprob_start_len=-1, top_logprobs_num=0, token_ids_logprob=None, return_text_in_logprobs=True, stream=False, log_metrics=True, return_hidden_states=False, modalities=[], session_params=None, lora_path=None, lora_id=None, custom_logit_processor=None, bootstrap_host=None, bootstrap_port=None, bootstrap_room=None, bootstrap_pair_key=None, validation_time=8.022785186767578e-05, data_parallel_rank=None, background=False, conversation_id=None, priority=None, extra_key=None, no_logs=False, custom_labels=None, return_bytes=False, return_entropy=False, mm_sampling_kwargs=None, external_trace_headers=None)"
2025-12-08 20:46:02.863 DEBUG 104744 [ tokenizer_manager.py:710] Using regular tokenizer for 1 inputs
2025-12-08 20:46:02.864 DEBUG 104744 [ base_processor.py:791] [_submit_mm_data_loading_tasks_simple] no data for modality=IMAGE
2025-12-08 20:46:02.864 DEBUG 104744 [ base_processor.py:798] [_submit_mm_data_loading_tasks_simple] submit load task: modality=VIDEO, index=0, data_type=<class 'str'>
2025-12-08 20:46:02.864 DEBUG 104744 [ base_processor.py:791] [_submit_mm_data_loading_tasks_simple] no data for modality=AUDIO
2025-12-08 20:46:02.864 DEBUG 104744 [ base_processor.py:411] [_load_single_item] start loading data, modality=VIDEO, frame_count_limit=None, audio_sample_rate=None, raw_type=<class 'str'>
2025-12-08 20:46:02.864 DEBUG 104744 [ base_processor.py:938] [load_mm_data(simple)] total futures submitted: 1
2025-12-08 20:46:03.162 DEBUG 104744 [ base_processor.py:435] [_load_single_item][VIDEO] loaded video: len=389, shape[0]=(720, 1280, 3)
2025-12-08 20:46:03.162 DEBUG 104744 [ base_processor.py:966] [load_mm_data(simple)] loaded counts: images=0, videos=1, audios=0
2025-12-08 20:46:03.508 INFO 104744 [ qwen_vl.py:304] [preprocess_video Perf], get_batch_time: 260.65 ms, smart_resize_time: 0.05 ms, torchvision_resize_time: 84.61 ms, total_time: 345.30 ms
2025-12-08 20:46:03.530 INFO 104744 [ qwen_vl.py:497] [QwenVLProcessor Perf] rid='cdb06d6d5c1b428b89473566f40ad2f3', load_time: 298.95 ms, preprocess_time: 352.29 ms, process_time: 14.30 ms, get_rope_index_time: 0.69 ms, total_time: 666.24 ms
2025-12-08 20:46:03.540 DEBUG 104744 [ cuda_ipc_transport_utils.py:75] [try_to_recycle] area=(0, 144055296), flag=1.0, tp_size=2
2025-12-08 20:46:03.541 INFO 104895 [ TP0 scheduler_metrics_mixin.py:154] Prefill batch, #new-seq: 1, #new-token: 7682, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, 
2025-12-08 20:46:03.590 DEBUG 104744 [ cuda_ipc_transport_utils.py:75] [try_to_recycle] area=(0, 144055296), flag=2.0, tp_size=2
2025-12-08 20:46:04.111 INFO 104895 [ TP0 scheduler_metrics_mixin.py:309] Decode batch, #running-req: 1, #token: 7699, token usage: 0.00, cuda graph: True, gen throughput (token/s): 0.08, #queue-req: 0, 
2025-12-08 20:46:04.170 INFO 104895 [ TP0 schedule_batch.py:1043] Req Time Stats(rid=cdb06d6d5c1b428b89473566f40ad2f3, input len=7682, output len=30, type=unified): queue_duration=1.21ms, forward_duration=627.68ms, start_time=9661822.019
2025-12-08 20:46:04.172 INFO 104744 [ tokenizer_manager.py:1150] "Finish: obj=GenerateReqInput(rid='cdb06d6d5c1b428b89473566f40ad2f3', http_worker_ipc=None, metrics={'api_server_arrive_time': 1765197962.8611393, 'mm_entry_time_ts': 1765197962.8640013, 'mm_entry_time': 9661821.34138114, 'mm_load_time': 9661821.640335323, 'mm_preprocess_time': 9661821.992624268, 'mm_process_time': 9661822.006922927, 'mm_get_rope_index_time': 9661822.007616928}, text='<|im_start|>system\\nYou are a helpful assistant.<|im_end|>\\n<|im_start|>user\\n<|vision_start|><|video_pad|><|vision_end|>视频里的招牌写的什么<|im_end|>\\n<|im_start|>assistant\\n', video_data=['http://dmsint.cn-hangzhou.alipay.aliyun-inc.com/aistudio/temp/20250910/208156dafb7b44a8/video_test.mp4'], sampling_params={'temperature': 0.0, 'max_new_tokens': 1000, 'min_new_tokens': 0, 'stop': None, 'stop_token_ids': None, 'stop_regex': None, 'top_p': 1.0, 'top_k': 50, 'min_p': 0.0, 'presence_penalty': 0.0, 'frequency_penalty': 0.0, 'repetition_penalty': 1.05, 'regex': None, 'ebnf': None, 'n': 1, 'no_stop_trim': False, 'ignore_eos': False, 'skip_special_tokens': True, 'logit_bias': None, 'custom_params': None}, return_logprob=False, logprob_start_len=-1, top_logprobs_num=0, token_ids_logprob=None, return_text_in_logprobs=True, stream=False, log_metrics=True, return_hidden_states=False, modalities=[], session_params=None, lora_path=None, lora_id=None, custom_logit_processor=None, bootstrap_host=None, bootstrap_port=None, bootstrap_room=None, bootstrap_pair_key=None, validation_time=8.022785186767578e-05, data_parallel_rank=None, background=False, conversation_id=None, priority=None, extra_key=None, no_logs=False, custom_labels=None, return_bytes=False, return_entropy=False, mm_sampling_kwargs=None, external_trace_headers=None), out={'text': '视频里的招牌上写着“小鞋匠洗鞋”，并附有电话号码“1529521190”。', 'meta_info': {'id': 'cdb06d6d5c1b428b89473566f40ad2f3', 'finish_reason': {'type': 'stop', 'matched': 151645}, 'prompt_tokens': 7682, 'weight_version': 'default', 'total_retractions': 0, 'queue_time': 0.0012103579938411713, 'prefill_launch_delay': 0.001300731673836708, 'prefill_launch_latency': 0.17800299264490604, 'completion_tokens': 30, 'cached_tokens': 0, 'e2e_latency': 1.3102936744689941, 'request_received_ts': 1765197962.8611393, 'request_sent_to_scheduler_ts': 1765197963.531742, 'decode_finished_ts': 1765197964.171433, 'inference_time': 0.6288455203175545, 'ttft_latency': 1.310302734375, 'response_sent_to_client_ts': 1765197964.172052}}"
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
lmms_eval result no drop.
```
$python3 -m lmms_eval --model openai_compatible --model_args model_version=Qwen/Qwen2.5-VL-7B-Instruct   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-12-10 15:39:50 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-12-10 15:39:52 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-12-10 15:39:52 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-12-10 15:39:52 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-12-10 15:39:56 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-12-10 15:39:56 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 14037.16it/s]
2025-12-10 15:39:56 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [02:56<00:00,  2.31s/it]2025-12-10 15:42:52 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1251.369s, Total tokens: 2040, Avg speed: 1.6 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [02:56<00:00,  3.09s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11417.73it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.75}, 'Art': {'num': 30, 'acc': 0.8}, 'Art_Theory': {'num': 30, 'acc': 0.93333}, 'Design': {'num': 30, 'acc': 0.83333}, 'Music': {'num': 30, 'acc': 0.43333}, 'Overall-Business': {'num': 150, 'acc': 0.62667}, 'Accounting': {'num': 30, 'acc': 0.63333}, 'Economics': {'num': 30, 'acc': 0.7}, 'Finance': {'num': 30, 'acc': 0.46667}, 'Manage': {'num': 30, 'acc': 0.63333}, 'Marketing': {'num': 30, 'acc': 0.7}, 'Overall-Science': {'num': 150, 'acc': 0.57333}, 'Biology': {'num': 30, 'acc': 0.5}, 'Chemistry': {'num': 30, 'acc': 0.46667}, 'Geography': {'num': 30, 'acc': 0.73333}, 'Math': {'num': 30, 'acc': 0.5}, 'Physics': {'num': 30, 'acc': 0.66667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.68}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.7}, 'Clinical_Medicine': {'num': 30, 'acc': 0.73333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.46667}, 'Pharmacy': {'num': 30, 'acc': 0.76667}, 'Public_Health': {'num': 30, 'acc': 0.73333}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.8}, 'History': {'num': 30, 'acc': 0.76667}, 'Literature': {'num': 30, 'acc': 0.9}, 'Sociology': {'num': 30, 'acc': 0.76667}, 'Psychology': {'num': 30, 'acc': 0.76667}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.4619}, 'Agriculture': {'num': 30, 'acc': 0.53333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.43333}, 'Computer_Science': {'num': 30, 'acc': 0.6}, 'Electronics': {'num': 30, 'acc': 0.4}, 'Energy_and_Power': {'num': 30, 'acc': 0.46667}, 'Materials': {'num': 30, 'acc': 0.4}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.4}, 'Overall': {'num': 900, 'acc': 0.62778}}
fatal: not a git repository (or any of the parent directories): .git
2025-12-10 15:42:52 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen2.5-VL-7B-Instruct), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.6278|±  |   N/A|
```

## Benchmarking and Profiling

As the function portion is small, there's no significant improvement for the e2e performance. Whereas the function cost time reduces.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
```
SGLANG_MM_FEATURE_CACHE_MB=4096 \
SGLANG_USE_CUDA_IPC_TRANSPORT=1 \
SGLANG_VLM_CACHE_SIZE_MB=0 \
python -m sglang.launch_server --model-path /home/admin/Qwen3-VL-30B-A3B-Instruct \
--host 0.0.0.0 --port 30000 --trust-remote-code --tp-size 2 --enable-cache-report \
--log-level info --max-running-requests 48 --mem-fraction-static 0.7 --chunked-prefill-size 8192  \
--attention-backend flashinfer --mm-attention-backend fa3 
                                                                                               
Benchmark:
python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 256 \
  --apply-chat-template \
  --random-input-len 128 \
  --random-output-len 1 \
  --image-resolution 560x560 \
  --image-format jpeg \
  --image-count 1 \
  --image-content random \
  --random-range-ratio 0.1 \
  --port 30000 \
  --max-concurrency 32
                                                                                               
Baseline:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  10.06     
Total input tokens:                      104023    
Total input text tokens:                 20567     
Total input vision tokens:               83456     
Total generated tokens:                  115       
Total generated tokens (retokenized):    115       
Request throughput (req/s):              25.46     
Input token throughput (tok/s):          10344.45  
Output token throughput (tok/s):         11.44     
Peak output token throughput (tok/s):    39.00     
Peak concurrent requests:                72        
Total token throughput (tok/s):          10355.89  
Concurrency:                             30.69     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1205.71   
Median E2E Latency (ms):                 1204.62   
---------------Time to First Token----------------
Mean TTFT (ms):                          531.57    
Median TTFT (ms):                        0.00      
P99 TTFT (ms):                           1818.75   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================                                                                                        

                                                                                         
PR:
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 32        
Successful requests:                     256       
Benchmark duration (s):                  10.10     
Total input tokens:                      104043    
Total input text tokens:                 20587     
Total input vision tokens:               83456     
Total generated tokens:                  115       
Total generated tokens (retokenized):    115       
Request throughput (req/s):              25.34     
Input token throughput (tok/s):          10298.52  
Output token throughput (tok/s):         11.38     
Peak output token throughput (tok/s):    37.00     
Peak concurrent requests:                65        
Total token throughput (tok/s):          10309.90  
Concurrency:                             30.62     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1208.55   
Median E2E Latency (ms):                 1238.95   
---------------Time to First Token----------------
Mean TTFT (ms):                          535.38    
Median TTFT (ms):                        0.00      
P99 TTFT (ms):                           1729.77   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P95 ITL (ms):                            0.00      
P99 ITL (ms):                            0.00      
Max ITL (ms):                            0.00      
==================================================    
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
