### PR TITLE
[SMG]feat: implement TokenGuardBody for managing token return

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = { version = "1.0", default-features = false, features = [
 ] }
 serde_bytes = "0.11"
 bytes = "1.8.0"
+http-body = "1.0"
 rand = "0.9.2"
 reqwest = { version = "0.12.8", features = ["stream", "blocking", "json", "rustls-tls"], default-features = false }
 futures-util = "0.3"

--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -1,8 +1,10 @@
 use std::{
+    pin::Pin,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
+    task::{Context, Poll},
     time::{Duration, Instant},
 };
 
@@ -13,6 +15,8 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
+use bytes::Bytes;
+use http_body::Frame;
 use rand::Rng;
 use subtle::ConstantTimeEq;
 use tokio::sync::{mpsc, oneshot};
@@ -35,6 +39,67 @@ use crate::{
         types::WasmComponentInput,
     },
 };
+
+/// A body wrapper that holds a token and returns it when the body is fully consumed or dropped.
+/// This ensures that for streaming responses, the token is only returned after the entire
+/// stream has been sent to the client.
+pub struct TokenGuardBody {
+    inner: Body,
+    /// The token bucket to return tokens to. Uses Option so we can take() on drop.
+    token_bucket: Option<Arc<TokenBucket>>,
+    /// Number of tokens to return.
+    tokens: f64,
+}
+
+impl TokenGuardBody {
+    /// Create a new TokenGuardBody that will return tokens when dropped.
+    pub fn new(inner: Body, token_bucket: Arc<TokenBucket>, tokens: f64) -> Self {
+        Self {
+            inner,
+            token_bucket: Some(token_bucket),
+            tokens,
+        }
+    }
+}
+
+impl Drop for TokenGuardBody {
+    fn drop(&mut self) {
+        if let Some(bucket) = self.token_bucket.take() {
+            let tokens = self.tokens;
+            debug!(
+                "TokenGuardBody: stream ended, returning {} tokens to bucket",
+                tokens
+            );
+            // Spawn a task to return tokens asynchronously since drop is sync
+            tokio::spawn(async move {
+                bucket.return_tokens(tokens).await;
+            });
+        }
+    }
+}
+
+impl http_body::Body for TokenGuardBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        // SAFETY: We never move the inner body, and Body is Unpin
+        // (it's a type alias for UnsyncBoxBody which is Unpin)
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_frame(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
 
 #[derive(Clone)]
 pub struct AuthConfig {
@@ -149,14 +214,14 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = std::pin::Pin<
+    type Future = Pin<
         Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
     >;
 
     fn poll_ready(
         &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
@@ -492,10 +557,12 @@ pub async fn concurrency_limit_middleware(
         debug!("Acquired token immediately");
         let response = next.run(request).await;
 
-        // Return the token to the bucket
-        token_bucket.return_tokens(1.0).await;
-
-        response
+        // Wrap the response body with TokenGuardBody to return token when stream ends
+        // This ensures that for streaming responses, the token is only returned
+        // after the entire stream has been sent to the client.
+        let (parts, body) = response.into_parts();
+        let guarded_body = TokenGuardBody::new(body, token_bucket, 1.0);
+        Response::from_parts(parts, Body::new(guarded_body))
     } else {
         // No tokens available, try to queue if enabled
         if let Some(queue_tx) = &app_state.concurrency_queue_tx {
@@ -531,10 +598,10 @@ pub async fn concurrency_limit_middleware(
 
                             let response = next.run(request).await;
 
-                            // Return the token to the bucket
-                            token_bucket.return_tokens(1.0).await;
-
-                            response
+                            // Wrap the response body with TokenGuardBody to return token when stream ends
+                            let (parts, body) = response.into_parts();
+                            let guarded_body = TokenGuardBody::new(body, token_bucket, 1.0);
+                            Response::from_parts(parts, Body::new(guarded_body))
                         }
                         Ok(Err(status)) => {
                             warn!("Queue returned error status: {}", status);


### PR DESCRIPTION
Hi from [novita.ai](https://novita.ai/) team 👋

## Motivation

stream request cannot handle correctly

### Before

```mermaid
sequenceDiagram
    participant Client
    participant Middleware
    participant TokenBucket
    participant Backend

    Note over Middleware: arrive
    Middleware->>TokenBucket: acquire token (1.0)
    TokenBucket-->>Middleware: ✅ OK

    Middleware->>Backend: next.run(request)
    Backend-->>Middleware: Response (headers only)
    
    Note over Middleware: ⚠️ return token!
    Middleware->>TokenBucket: return_tokens(1.0)
    
    Middleware->>Client: HTTP 200 OK + Headers
    
    rect rgb(255, 200, 200)
        Note over Client,Backend: ❌ Token returned，but still Streaming！
        Backend-->>Client: data: {"content":"A"}
        Backend-->>Client: data: {"content":"B"}
        Backend-->>Client: data: {"content":"C"}
        Backend-->>Client: data: [DONE]
    end
    
    Note over Client: Stream finish
```

### after
```mermaid
sequenceDiagram
    participant Client
    participant Middleware
    participant TokenGuardBody
    participant TokenBucket
    participant Backend

    Note over Middleware: arrive
    Middleware->>TokenBucket: acquire token (1.0)
    TokenBucket-->>Middleware: ✅ OK

    Middleware->>Backend: next.run(request)
    Backend-->>Middleware: Response
    
    Note over Middleware: wrap with TokenGuardBody
    Middleware->>TokenGuardBody: new(body, token_bucket, 1.0)
    
    Middleware->>Client: HTTP 200 OK + Headers
    
    rect rgb(200, 255, 200)
        Note over Client,TokenGuardBody: ✅ Token still in TokenGuardBody
        TokenGuardBody-->>Client: data: {"content":"A"}
        TokenGuardBody-->>Client: data: {"content":"B"}
        TokenGuardBody-->>Client: data: {"content":"C"}
        TokenGuardBody-->>Client: data: [DONE]
    end
    
    Note over TokenGuardBody: Stream finish，trigger Drop
    TokenGuardBody->>TokenBucket: return_tokens(1.0)
    Note over TokenBucket: ✅ Token returned
```

## Modifications

- Added TokenGuardBody struct to wrap response bodies and ensure tokens are returned only after the entire stream is sent.
- Updated concurrency_limit_middleware to utilize TokenGuardBody for response handling.
- Introduced http-body dependency for body management.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
