### PR TITLE
[Bugfix] when use cuda graph, the accept rate of MTP2 is about doubled with this fix

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -1044,7 +1044,7 @@ class FlashInferMLAMultiStepDraftBackend:
                 encoder_lens=None,
                 forward_mode=ForwardMode.DECODE,
                 spec_info=forward_batch.spec_info,
-                seq_lens_cpu=forward_batch.seq_lens_cpu,
+                seq_lens_cpu=forward_batch.seq_lens_cpu.to(torch.int32),
             )
 
         self.common_template(forward_batch, self.cuda_graph_kv_indices, call_fn)


### PR DESCRIPTION


The dtype of ForwardBatch.seq_lens_cpu is long.  The data type of kv_len_arr of BatchMLAPagedAttentionWrapper.plan is int32.  So a long type is used as the arg of BatchMLAPagedAttentionWrapper.plan , which causes half of the attention result is all 0. So the MTP2 accept rate is low when use cuda graph. 

This PR fix this bug.

