### PR TITLE
[model-gateway] reducing cpu overhead in various of places

### DIFF
--- a/sgl-model-gateway/Cargo.toml
+++ b/sgl-model-gateway/Cargo.toml
@@ -70,6 +70,7 @@ parking_lot = "0.12.4"
 rayon = "1.10"
 thiserror = "2.0.12"
 regex = "1.10"
+memchr = "2.7"  # SIMD-optimized byte pattern searching
 url = "2.5.4"
 validator = { version = "0.20.0", features = ["derive"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -355,11 +355,15 @@ impl std::str::FromStr for RuntimeType {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "sglang" => Ok(RuntimeType::Sglang),
-            "vllm" => Ok(RuntimeType::Vllm),
-            "external" => Ok(RuntimeType::External),
-            _ => Err(format!("Unknown runtime type: {}", s)),
+        // Use eq_ignore_ascii_case to avoid to_lowercase() allocation
+        if s.eq_ignore_ascii_case("sglang") {
+            Ok(RuntimeType::Sglang)
+        } else if s.eq_ignore_ascii_case("vllm") {
+            Ok(RuntimeType::Vllm)
+        } else if s.eq_ignore_ascii_case("external") {
+            Ok(RuntimeType::External)
+        } else {
+            Err(format!("Unknown runtime type: {}", s))
         }
     }
 }
@@ -1111,7 +1115,7 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
         worker_type: worker_type_str.to_string(),
         is_healthy: worker.is_healthy(),
         load: worker.load(),
-        connection_mode: format!("{:?}", worker.connection_mode()),
+        connection_mode: worker.connection_mode().to_string(),
         runtime_type,
         tokenizer_path: worker.tokenizer_path(model_id).map(String::from),
         reasoning_parser: worker.reasoning_parser(model_id).map(String::from),

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -520,22 +520,18 @@ impl fmt::Debug for BasicWorker {
 
 impl BasicWorker {
     pub fn normalised_url(&self) -> WorkerResult<&str> {
-        if self.url().contains("@") {
-            // Use rfind to split from the right, handling IPv6 addresses with brackets
-            // e.g., "http://[::1]:8080@0" -> "http://[::1]:8080" and "0"
-            if let Some(at_pos) = self.url().rfind('@') {
-                let base_url = &self.url()[..at_pos];
-                let rank_str = &self.url()[at_pos + 1..];
+        // Use rfind directly - no need for redundant contains() check
+        // rfind already returns None if '@' is not found
+        // e.g., "http://[::1]:8080@0" -> "http://[::1]:8080" and "0"
+        if let Some(at_pos) = self.url().rfind('@') {
+            let base_url = &self.url()[..at_pos];
+            let rank_str = &self.url()[at_pos + 1..];
 
-                // Validate that the rank part is actually a number
-                match rank_str.parse::<usize>() {
-                    Ok(_) => Ok(base_url),
-                    Err(_) => {
-                        // The '@' is not a DP rank separator, return full URL
-                        Ok(self.url())
-                    }
-                }
+            // Validate that the rank part is actually a number
+            if rank_str.parse::<usize>().is_ok() {
+                Ok(base_url)
             } else {
+                // The '@' is not a DP rank separator, return full URL
                 Ok(self.url())
             }
         } else {
@@ -1089,33 +1085,38 @@ impl HealthChecker {
 
 /// Helper to convert Worker trait object to WorkerInfo struct
 pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
-    let worker_type_str = match worker.worker_type() {
+    // Cache values that are used multiple times to avoid redundant clones/allocations
+    let worker_type = worker.worker_type();
+    let connection_mode = worker.connection_mode();
+    let url = worker.url();
+    let model_id = worker.model_id();
+
+    let worker_type_str = match &worker_type {
         WorkerType::Regular => "regular",
         WorkerType::Prefill { .. } => "prefill",
         WorkerType::Decode => "decode",
     };
 
-    let bootstrap_port = match worker.worker_type() {
-        WorkerType::Prefill { bootstrap_port } => bootstrap_port,
+    let bootstrap_port = match &worker_type {
+        WorkerType::Prefill { bootstrap_port } => *bootstrap_port,
         _ => None,
     };
 
-    let runtime_type = match worker.connection_mode() {
+    let runtime_type = match &connection_mode {
         ConnectionMode::Grpc { .. } => Some(worker.metadata().runtime_type.to_string()),
         ConnectionMode::Http => None,
     };
 
-    let model_id = worker.model_id();
     WorkerInfo {
-        id: worker.url().to_string(),
-        url: worker.url().to_string(),
+        id: url.to_string(),
+        url: url.to_string(),
         model_id: model_id.to_string(),
         priority: worker.priority(),
         cost: worker.cost(),
         worker_type: worker_type_str.to_string(),
         is_healthy: worker.is_healthy(),
         load: worker.load(),
-        connection_mode: worker.connection_mode().to_string(),
+        connection_mode: connection_mode.to_string(),
         runtime_type,
         tokenizer_path: worker.tokenizer_path(model_id).map(String::from),
         reasoning_parser: worker.reasoning_parser(model_id).map(String::from),

--- a/sgl-model-gateway/src/core/worker_registry.rs
+++ b/sgl-model-gateway/src/core/worker_registry.rs
@@ -342,7 +342,12 @@ impl WorkerRegistry {
     /// Get worker statistics
     pub fn stats(&self) -> WorkerRegistryStats {
         let total_workers = self.workers.len();
-        let total_models = self.get_models().len();
+        // Count models directly instead of allocating Vec via get_models()
+        let total_models = self
+            .model_workers
+            .iter()
+            .filter(|entry| !entry.value().is_empty())
+            .count();
 
         let mut healthy_count = 0;
         let mut total_load = 0;

--- a/sgl-model-gateway/src/core/worker_registry.rs
+++ b/sgl-model-gateway/src/core/worker_registry.rs
@@ -350,7 +350,9 @@ impl WorkerRegistry {
         let mut prefill_count = 0;
         let mut decode_count = 0;
 
-        for worker in self.get_all() {
+        // Iterate DashMap directly to avoid cloning all workers via get_all()
+        for entry in self.workers.iter() {
+            let worker = entry.value();
             if worker.is_healthy() {
                 healthy_count += 1;
             }

--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -79,6 +79,9 @@ pub async fn auth_middleware(
     Ok(next.run(request).await)
 }
 
+/// Alphanumeric characters for request ID generation (as bytes for O(1) indexing)
+const REQUEST_ID_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
 /// Generate OpenAI-compatible request ID based on endpoint
 fn generate_request_id(path: &str) -> String {
     let prefix = if path.contains("/chat/completions") {
@@ -94,12 +97,12 @@ fn generate_request_id(path: &str) -> String {
     };
 
     // Generate a random string similar to OpenAI's format
-    let chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    // Use byte array indexing (O(1)) instead of chars().nth() (O(n))
     let mut rng = rand::rng();
     let random_part: String = (0..24)
         .map(|_| {
-            let idx = rng.random_range(0..chars.len());
-            chars.chars().nth(idx).unwrap()
+            let idx = rng.random_range(0..REQUEST_ID_CHARS.len());
+            REQUEST_ID_CHARS[idx] as char
         })
         .collect();
 

--- a/sgl-model-gateway/src/policies/bucket.rs
+++ b/sgl-model-gateway/src/policies/bucket.rs
@@ -7,7 +7,7 @@ use std::{
 
 use dashmap::DashMap;
 use rand::Rng;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use super::{get_healthy_worker_indices, BucketConfig, LoadBalancingPolicy};
@@ -259,14 +259,14 @@ impl LoadBalancingPolicy for BucketPolicy {
             let rel_threshold = self.config.balance_rel_threshold * min_load as f32;
             let is_imbalanced =
                 abs_diff > self.config.balance_abs_threshold && max_load as f32 > rel_threshold;
-            info!(
+            debug!(
                 "Current PD instance status | is_imbalanced={}",
                 is_imbalanced
             );
 
             let mut rng = rand::rng();
             let prefill_url = if is_imbalanced {
-                info!("select prefill instance by Load Balance policy");
+                debug!("select prefill instance by Load Balance policy");
                 let min_url = chars_per_url_snapshot
                     .iter()
                     .min_by_key(|(_, &chars)| chars)
@@ -279,7 +279,7 @@ impl LoadBalancingPolicy for BucketPolicy {
                     });
                 min_url
             } else {
-                info!("select prefill instance by Bucket policy");
+                debug!("select prefill instance by Bucket policy");
                 match choiced_url {
                     Some(url) if !url.is_empty() => url,
                     _ => {

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -233,10 +233,12 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             first_model
         };
 
-        // Get current load statistics
-        let loads: Vec<usize> = workers.iter().map(|w| w.load()).collect();
-        let max_load = *loads.iter().max().unwrap_or(&0);
-        let min_load = *loads.iter().min().unwrap_or(&0);
+        // Get current load statistics - compute min/max in single pass without allocation
+        let (min_load, max_load) = workers.iter().fold((usize::MAX, 0usize), |(min, max), w| {
+            let load = w.load();
+            (min.min(load), max.max(load))
+        });
+        let min_load = if min_load == usize::MAX { 0 } else { min_load };
 
         // Check if load is imbalanced
         let is_imbalanced = max_load.saturating_sub(min_load) > self.config.balance_abs_threshold

--- a/sgl-model-gateway/src/policies/power_of_two.rs
+++ b/sgl-model-gateway/src/policies/power_of_two.rs
@@ -61,7 +61,8 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
         let mut rng = rand::rng();
         let idx1 = rng.random_range(0..healthy_indices.len());
         // Pick idx2 from remaining indices: offset by 1 + random from (len-1) to guarantee different
-        let idx2 = (idx1 + 1 + rng.random_range(0..healthy_indices.len() - 1)) % healthy_indices.len();
+        let idx2 =
+            (idx1 + 1 + rng.random_range(0..healthy_indices.len() - 1)) % healthy_indices.len();
 
         let worker_idx1 = healthy_indices[idx1];
         let worker_idx2 = healthy_indices[idx2];

--- a/sgl-model-gateway/src/policies/power_of_two.rs
+++ b/sgl-model-gateway/src/policies/power_of_two.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use rand::Rng;
-use tracing::info;
+use tracing::debug;
 
 use super::{get_healthy_worker_indices, LoadBalancingPolicy};
 use crate::{core::Worker, observability::metrics::RouterMetrics};
@@ -57,15 +57,11 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
             return Some(healthy_indices[0]);
         }
 
-        // Select two random workers
+        // Select two random workers - use offset to guarantee different selection in O(1)
         let mut rng = rand::rng();
         let idx1 = rng.random_range(0..healthy_indices.len());
-        let mut idx2 = rng.random_range(0..healthy_indices.len());
-
-        // Ensure we pick two different workers
-        while idx2 == idx1 {
-            idx2 = rng.random_range(0..healthy_indices.len());
-        }
+        // Pick idx2 from remaining indices: offset by 1 + random from (len-1) to guarantee different
+        let idx2 = (idx1 + 1 + rng.random_range(0..healthy_indices.len() - 1)) % healthy_indices.len();
 
         let worker_idx1 = healthy_indices[idx1];
         let worker_idx2 = healthy_indices[idx2];
@@ -81,7 +77,7 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
             worker_idx2
         };
 
-        info!(
+        debug!(
             "Power-of-two selection: {}={} vs {}={} -> selected {}",
             workers[worker_idx1].url(),
             load1,

--- a/sgl-model-gateway/src/policies/registry.rs
+++ b/sgl-model-gateway/src/policies/registry.rs
@@ -281,19 +281,20 @@ impl PolicyRegistry {
             power_of_two_policies.push(Arc::clone(&self.default_policy));
         }
 
-        if let Some(ref policy) = *self.prefill_policy.read().unwrap() {
+        // Cache prefill and decode policies to avoid double-locking prefill_policy
+        let prefill_policy_opt = self.prefill_policy.read().unwrap().clone();
+        let decode_policy_opt = self.decode_policy.read().unwrap().clone();
+
+        if let Some(ref policy) = prefill_policy_opt {
             if policy.name() == "power_of_two" && !Arc::ptr_eq(policy, &self.default_policy) {
                 power_of_two_policies.push(Arc::clone(policy));
             }
         }
 
-        if let Some(ref policy) = *self.decode_policy.read().unwrap() {
+        if let Some(ref policy) = decode_policy_opt {
             if policy.name() == "power_of_two"
                 && !Arc::ptr_eq(policy, &self.default_policy)
-                && !self
-                    .prefill_policy
-                    .read()
-                    .unwrap()
+                && !prefill_policy_opt
                     .as_ref()
                     .is_some_and(|p| Arc::ptr_eq(p, policy))
             {

--- a/sgl-model-gateway/src/protocols/chat.rs
+++ b/sgl-model-gateway/src/protocols/chat.rs
@@ -122,9 +122,9 @@ impl MessageContent {
     pub fn has_text(&self) -> bool {
         match self {
             MessageContent::Text(text) => !text.is_empty(),
-            MessageContent::Parts(parts) => parts.iter().any(|part| {
-                matches!(part, ContentPart::Text { text } if !text.is_empty())
-            }),
+            MessageContent::Parts(parts) => parts
+                .iter()
+                .any(|part| matches!(part, ContentPart::Text { text } if !text.is_empty())),
         }
     }
 }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -585,7 +585,10 @@ impl Router {
                             if memmem::find(&bytes, b"data: [DONE]").is_some() {
                                 if let Some(ref w) = stream_worker {
                                     w.decrement_load();
-                                    RouterMetrics::set_running_requests(&worker_url_owned, w.load());
+                                    RouterMetrics::set_running_requests(
+                                        &worker_url_owned,
+                                        w.load(),
+                                    );
                                     decremented = true;
                                 }
                             }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -11,6 +11,7 @@ use axum::{
     Json,
 };
 use futures_util::StreamExt;
+use memchr::memmem;
 use reqwest::Client;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error};
@@ -91,8 +92,10 @@ impl Router {
             Ok(worker_url) => {
                 let mut request_builder = self.client.get(format!("{}/{}", worker_url, endpoint));
                 for (name, value) in headers {
-                    let name_lc = name.to_lowercase();
-                    if name_lc != "content-type" && name_lc != "content-length" {
+                    // Use eq_ignore_ascii_case to avoid string allocation
+                    if !name.eq_ignore_ascii_case("content-type")
+                        && !name.eq_ignore_ascii_case("content-length")
+                    {
                         request_builder = request_builder.header(name, value);
                     }
                 }
@@ -300,6 +303,18 @@ impl Router {
             return (StatusCode::SERVICE_UNAVAILABLE, "No available workers").into_response();
         }
 
+        // Pre-filter headers once before the loop to avoid repeated lowercasing
+        let filtered_headers: Vec<_> = headers
+            .map(|hdrs| {
+                hdrs.iter()
+                    .filter(|(name, _)| {
+                        !name.as_str().eq_ignore_ascii_case("content-type")
+                            && !name.as_str().eq_ignore_ascii_case("content-length")
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         let mut last_response: Option<Response> = None;
         for worker in workers {
             let worker_url = worker.url();
@@ -323,13 +338,9 @@ impl Router {
                     request_builder.header("Authorization", format!("Bearer {}", api_key));
             }
 
-            if let Some(hdrs) = headers {
-                for (name, value) in hdrs {
-                    let name_lc = name.as_str().to_lowercase();
-                    if name_lc != "content-type" && name_lc != "content-length" {
-                        request_builder = request_builder.header(name, value);
-                    }
-                }
+            // Apply pre-filtered headers
+            for (name, value) in &filtered_headers {
+                request_builder = request_builder.header(*name, *value);
             }
 
             match request_builder.send().await {
@@ -417,11 +428,9 @@ impl Router {
         is_stream: bool,
         load_incremented: bool, // Whether load was incremented for this request
     ) -> Response {
-        // Get the worker's API key if available
-        let api_key = self
-            .worker_registry
-            .get_by_url(worker_url)
-            .and_then(|w| w.api_key().clone());
+        // Get the worker once and reuse for API key and load tracking
+        let worker = self.worker_registry.get_by_url(worker_url);
+        let api_key = worker.as_ref().and_then(|w| w.api_key().clone());
 
         let mut request_builder = if self.dp_aware {
             let (worker_url_prefix, dp_rank) = match Self::extract_dp_rank(worker_url) {
@@ -452,10 +461,13 @@ impl Router {
                     String::from("data_parallel_rank"),
                     serde_json::json!(dp_rank),
                 );
-                debug!(
-                    "Modified request body: {}",
-                    serde_json::to_string(&json_val).unwrap_or(String::from("ERR"))
-                );
+                // Only serialize if debug logging is enabled to avoid CPU overhead
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    debug!(
+                        "Modified request body: {}",
+                        serde_json::to_string(&json_val).unwrap_or_else(|_| String::from("ERR"))
+                    );
+                }
             } else {
                 return (
                     StatusCode::BAD_REQUEST,
@@ -497,9 +509,9 @@ impl Router {
 
                 // Decrement load on error if it was incremented
                 if load_incremented {
-                    if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(worker_url, worker.load());
+                    if let Some(ref w) = worker {
+                        w.decrement_load();
+                        RouterMetrics::set_running_requests(worker_url, w.load());
                     }
                 }
 
@@ -528,9 +540,9 @@ impl Router {
                 Err(e) => {
                     // IMPORTANT: Decrement load on error before returning
                     if load_incremented {
-                        if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                            worker.decrement_load();
-                            RouterMetrics::set_running_requests(worker_url, worker.load());
+                        if let Some(ref w) = worker {
+                            w.decrement_load();
+                            RouterMetrics::set_running_requests(worker_url, w.load());
                         }
                     }
 
@@ -541,17 +553,18 @@ impl Router {
 
             // Decrement load counter for non-streaming requests if it was incremented
             if load_incremented {
-                if let Some(worker) = self.worker_registry.get_by_url(worker_url) {
-                    worker.decrement_load();
-                    RouterMetrics::set_running_requests(worker_url, worker.load());
+                if let Some(ref w) = worker {
+                    w.decrement_load();
+                    RouterMetrics::set_running_requests(worker_url, w.load());
                 }
             }
 
             response
         } else if load_incremented {
             // For streaming with load tracking, we need to manually decrement when done
-            let registry = Arc::clone(&self.worker_registry);
-            let worker_url = worker_url.to_string();
+            // Clone the worker Arc for the async block instead of looking it up again
+            let stream_worker = worker.clone();
+            let worker_url_owned = worker_url.to_string();
 
             // Preserve headers for streaming response
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
@@ -568,15 +581,11 @@ impl Router {
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(bytes) => {
-                            // Check for stream end marker
-                            if bytes
-                                .as_ref()
-                                .windows(12)
-                                .any(|window| window == b"data: [DONE]")
-                            {
-                                if let Some(worker) = registry.get_by_url(&worker_url) {
-                                    worker.decrement_load();
-                                    RouterMetrics::set_running_requests(&worker_url, worker.load());
+                            // Check for stream end marker using memmem for efficiency
+                            if memmem::find(&bytes, b"data: [DONE]").is_some() {
+                                if let Some(ref w) = stream_worker {
+                                    w.decrement_load();
+                                    RouterMetrics::set_running_requests(&worker_url_owned, w.load());
                                     decremented = true;
                                 }
                             }
@@ -591,9 +600,9 @@ impl Router {
                     }
                 }
                 if !decremented {
-                    if let Some(worker) = registry.get_by_url(&worker_url) {
-                        worker.decrement_load();
-                        RouterMetrics::set_running_requests(&worker_url, worker.load());
+                    if let Some(ref w) = stream_worker {
+                        w.decrement_load();
+                        RouterMetrics::set_running_requests(&worker_url_owned, w.load());
                     }
                 }
             });

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -269,13 +269,13 @@ impl RouterManager {
         let mut best_router = None;
         let mut best_score = 0.0;
 
-        let num_regular_workers = self
-            .worker_registry
-            .get_all()
+        // Cache worker list to avoid duplicate get_all() calls
+        let all_workers = self.worker_registry.get_all();
+        let num_regular_workers = all_workers
             .iter()
             .filter(|w| matches!(w.worker_type(), WorkerType::Regular))
             .count();
-        let num_pd_workers = self.worker_registry.get_all().len() - num_regular_workers;
+        let num_pd_workers = all_workers.len() - num_regular_workers;
 
         for router in candidate_routers {
             let mut score = 1.0;


### PR DESCRIPTION
## Summary

This PR reduces CPU overhead in the HTTP router hot path through a series of targeted optimizations across multiple layers: routing, validation, middleware, worker management, and load balancing policies.

## Changes by Layer

### HTTP Router (`src/routers/`)

- **Worker lookup caching**: Reduced redundant `worker_registry.get_by_url()` calls from 4+ to 1 per request
- **SIMD stream scanning**: Replaced `windows(12)` byte scanning with `memchr::memmem::find()` for `data: [DONE]` detection
- **Header pre-filtering**: Filter headers once before worker loop instead of inside each iteration
- **Conditional debug logging**: Wrap expensive `serde_json::to_string()` in `tracing::enabled!()` check
- **String comparison**: Use `eq_ignore_ascii_case()` instead of `to_lowercase()` throughout header handling

### Request Validation (`src/protocols/`)

- **Request ID generation**: Changed from `chars().nth()` (O(n) per char) to byte array indexing (O(1))
- **Text extraction**: Rewrote `extract_text_for_routing()` to use single buffer instead of `Vec<String>.join()`
- **Zero-copy iterators**: Added `StringOrArray::iter()` returning `&str` references instead of cloning

### Middleware (`src/middleware.rs`)

- **Latency recording**: Changed from `format!("{:?}", latency)` to `latency.as_micros() as u64`
- **WASM string caching**: Pre-compute method/path/query strings before WASM module loop

### Worker Management (`src/core/`)

- **RuntimeType parsing**: Use `eq_ignore_ascii_case()` instead of `to_lowercase().as_str()`
- **worker_to_info()**: Cache `worker_type()`, `connection_mode()`, `url()` to avoid redundant clones
- **normalised_url()**: Remove redundant `contains("@")` check before `rfind('@')`
- **WorkerRegistry::stats()**: Iterate DashMap directly instead of cloning all workers via `get_all()`
- **Model counting**: Count models by iteration instead of allocating `Vec<String>`

### Policy Registry (`src/policies/registry.rs`)

- **Double lock fix**: Cache `prefill_policy` and `decode_policy` to avoid acquiring `prefill_policy` lock twice in `get_all_power_of_two_policies()`

### Load Balancing Policies (`src/policies/`)

- **power_of_two.rs**: 
  - Change `info!` to `debug!` for per-request logging
  - O(1) deterministic second random selection instead of retry loop
- **cache_aware.rs**: Compute min/max load in single pass without `Vec` allocation
- **bucket.rs**: Change `info!` to `debug!` for per-request status logging

## Checklist

- [x] No breaking API changes
- [x] All optimizations are backward compatible
- [x] Debug logging preserved for troubleshooting (just demoted from info level)
- [x] No changes to external behavior


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
