### PR TITLE
[CI] Increase max-parallel to 15 for high priority PRs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,6 +36,7 @@ jobs:
       main_package: ${{ steps.filter.outputs.main_package || steps.scheduled.outputs.main_package }}
       sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }}
       multimodal_gen: ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen }}
+      max_parallel: ${{ steps.set-parallel.outputs.max_parallel }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,6 +69,17 @@ jobs:
           echo "sgl_kernel=false" >> $GITHUB_OUTPUT
           echo "multimodal_gen=true" >> $GITHUB_OUTPUT
 
+      - name: Set max-parallel based on high-priority label
+        id: set-parallel
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ contains(github.event.pull_request.labels.*.name, 'high priority') }}" == "true" ]]; then
+            echo "max_parallel=15" >> $GITHUB_OUTPUT
+            echo "High priority PR detected, setting max_parallel to 15"
+          else
+            echo "max_parallel=8" >> $GITHUB_OUTPUT
+            echo "Using default max_parallel of 8"
+          fi
+
       - name: Show filter results in summary (table)
         run: |
           {
@@ -78,6 +90,7 @@ jobs:
             echo "| main_package   | ${{ steps.filter.outputs.main_package || steps.scheduled.outputs.main_package }} |"
             echo "| sgl_kernel     | ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }} |"
             echo "| multimodal_gen | ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen }} |"
+            echo "| max_parallel   | ${{ steps.set-parallel.outputs.max_parallel }} |"
           } >> $GITHUB_STEP_SUMMARY
 
   # =============================================== PR Gate ====================================================
@@ -529,7 +542,7 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: ${{ fromJson(needs.check-changes.outputs.max_parallel) }}
       matrix:
         part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     steps:


### PR DESCRIPTION
## Summary
- Add dynamic max-parallel setting for `unit-test-backend-1-gpu` job
- PRs with `high priority` label get `max-parallel=15` instead of default `8`
- Display max_parallel value in CI summary table

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with a PR that has "high priority" label