### PR TITLE
Clean up logs for unregistered tests for test/run_suite.py

### DIFF
--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -1,5 +1,4 @@
 import ast
-import warnings
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import List, Optional
@@ -198,16 +197,21 @@ def ut_parse_one_file(filename: str) -> List[CIRegistry]:
 
 def collect_tests(files: list[str], sanity_check: bool = True) -> List[CIRegistry]:
     ci_tests = []
+    unregistered_count = 0
+
     for file in files:
         registries = ut_parse_one_file(file)
         if len(registries) == 0:
-            msg = f"No CI registry found in {file}"
             if sanity_check:
-                raise ValueError(msg)
-            else:
-                warnings.warn(msg)
-                continue
+                raise ValueError(f"No CI registry found in {file}")
+            unregistered_count += 1
+            continue
 
         ci_tests.extend(registries)
+
+    if not sanity_check and unregistered_count > 0:
+        print(
+            f"Warning: Skipped {unregistered_count} unregistered test files (out of {len(files)} total)"
+        )
 
     return ci_tests


### PR DESCRIPTION
## Motivation

Currently, test logs are flooded with warnings when a unregistered test file is skipped. We add a simplification to show the number of skipped tests instead.

## Modifications

Removed per-skip warnings and added a counter and display at the end.

## Accuracy Tests

N/A.

## Benchmarking and Profiling

N/A.

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [N/A] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [N/A] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [N/A] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
