### PR TITLE
[CI] Enable /rerun-stage for fork PRs using repository_dispatch

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -26,6 +26,9 @@ on:
         required: false
         type: string
         default: ""
+  repository_dispatch:
+    types: [rerun-stage-amd]
+    # Expected client_payload: { "target_stage": "stage-name", "pr_number": 12345 }
 
 concurrency:
   group: pr-test-amd-${{ github.ref }}
@@ -39,14 +42,23 @@ jobs:
     needs: [call-gate]
     runs-on: ubuntu-latest
     outputs:
-      main_package: ${{ steps.filter.outputs.main_package }}
-      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel }}
+      main_package: ${{ steps.filter.outputs.main_package || steps.repo_dispatch.outputs.main_package }}
+      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.repo_dispatch.outputs.sgl_kernel }}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
+
       - name: Detect file changes
         id: filter
         uses: dorny/paths-filter@v3
+        if: github.event_name != 'repository_dispatch'
         with:
           filters: |
             main_package:
@@ -57,6 +69,13 @@ jobs:
             sgl_kernel:
               - "sgl-kernel/**"
 
+      - name: Set all changes to true for repository_dispatch (rerun-stage)
+        id: repo_dispatch
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          echo "main_package=true" >> $GITHUB_OUTPUT
+          echo "sgl_kernel=true" >> $GITHUB_OUTPUT
+
   # =============================================== sgl-kernel ====================================================
   sgl-kernel-unit-test-amd:
     needs: [check-changes]
@@ -64,8 +83,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'sgl-kernel-unit-test-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'sgl-kernel-unit-test-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           needs.check-changes.outputs.sgl_kernel == 'true'
         )
       )
@@ -76,7 +97,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -108,8 +136,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'stage-a-test-1-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'stage-a-test-1-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -121,7 +151,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -146,8 +183,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-1-gpu-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-1-gpu-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -160,7 +199,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -184,8 +230,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-2-gpu-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-2-gpu-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -198,7 +246,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -223,9 +278,11 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-8-gpu-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-8-gpu-amd') ||
         (
           false &&
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -240,7 +297,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -270,8 +334,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-1-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-1-gpu-part-1-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -283,7 +349,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -323,8 +396,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-2-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-1-gpu-part-2-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -336,7 +411,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -370,8 +452,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-2-gpu-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-2-gpu-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -383,7 +467,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -427,8 +518,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'accuracy-test-1-gpu-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'accuracy-test-1-gpu-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -440,7 +533,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm
@@ -466,8 +566,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'accuracy-test-2-gpu-amd') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'accuracy-test-2-gpu-amd') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (!failure() && !cancelled()) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -479,7 +581,14 @@ jobs:
     runs-on: ${{matrix.runner}}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Ensure VRAM is clear
         run: bash scripts/ensure_vram_clear.sh rocm

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,6 +20,9 @@ on:
         required: false
         type: string
         default: ""
+  repository_dispatch:
+    types: [rerun-stage]
+    # Expected client_payload: { "target_stage": "stage-name", "pr_number": 12345 }
 
 concurrency:
   group: pr-test-${{ github.ref }}
@@ -33,18 +36,25 @@ jobs:
   check-changes:
     runs-on: ubuntu-latest
     outputs:
-      main_package: ${{ steps.filter.outputs.main_package || steps.scheduled.outputs.main_package }}
-      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }}
-      multimodal_gen: ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen }}
+      main_package: ${{ steps.filter.outputs.main_package || steps.scheduled.outputs.main_package || steps.repo_dispatch.outputs.main_package }}
+      sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel || steps.repo_dispatch.outputs.sgl_kernel }}
+      multimodal_gen: ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen || steps.repo_dispatch.outputs.multimodal_gen }}
       max_parallel: ${{ steps.set-parallel.outputs.max_parallel }}
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Detect file changes
         id: filter
         uses: dorny/paths-filter@v3
-        if: github.event_name != 'schedule'
+        if: github.event_name != 'schedule' && github.event_name != 'repository_dispatch'
         with:
           filters: |
             main_package:
@@ -69,6 +79,14 @@ jobs:
           echo "sgl_kernel=false" >> $GITHUB_OUTPUT
           echo "multimodal_gen=true" >> $GITHUB_OUTPUT
 
+      - name: Set all changes to true for repository_dispatch (rerun-stage)
+        id: repo_dispatch
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          echo "main_package=true" >> $GITHUB_OUTPUT
+          echo "sgl_kernel=true" >> $GITHUB_OUTPUT
+          echo "multimodal_gen=true" >> $GITHUB_OUTPUT
+
       - name: Set max-parallel based on high-priority label
         id: set-parallel
         run: |
@@ -87,9 +105,9 @@ jobs:
             echo ""
             echo "| Component       | Changed |"
             echo "|----------------|---------|"
-            echo "| main_package   | ${{ steps.filter.outputs.main_package || steps.scheduled.outputs.main_package }} |"
-            echo "| sgl_kernel     | ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }} |"
-            echo "| multimodal_gen | ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen }} |"
+            echo "| main_package   | ${{ steps.filter.outputs.main_package || steps.scheduled.outputs.main_package || steps.repo_dispatch.outputs.main_package }} |"
+            echo "| sgl_kernel     | ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel || steps.repo_dispatch.outputs.sgl_kernel }} |"
+            echo "| multimodal_gen | ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen || steps.repo_dispatch.outputs.multimodal_gen }} |"
             echo "| max_parallel   | ${{ steps.set-parallel.outputs.max_parallel }} |"
           } >> $GITHUB_STEP_SUMMARY
 
@@ -362,8 +380,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'stage-a-test-1') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'stage-a-test-1') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -373,7 +393,14 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -402,8 +429,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'multimodal-gen-test-1-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'multimodal-gen-test-1-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           needs.check-changes.outputs.multimodal_gen == 'true'
         )
@@ -415,7 +444,14 @@ jobs:
         part: [0, 1]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Cleanup
         run: |
@@ -449,8 +485,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'multimodal-gen-test-2-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'multimodal-gen-test-2-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           needs.check-changes.outputs.multimodal_gen == 'true'
         )
@@ -462,7 +500,14 @@ jobs:
         part: [0, 1]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Cleanup
         run: |
@@ -496,8 +541,10 @@ jobs:
         always() &&
         (
           (inputs.target_stage == 'quantization-test') ||
+          (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'quantization-test') ||
           (
             !inputs.target_stage &&
+            github.event_name != 'repository_dispatch' &&
             (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
             ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
           )
@@ -505,7 +552,14 @@ jobs:
       runs-on: 1-gpu-runner
       steps:
         - name: Checkout code
+          if: github.event_name != 'repository_dispatch'
           uses: actions/checkout@v4
+
+        - name: Checkout PR code (repository_dispatch)
+          if: github.event_name == 'repository_dispatch'
+          uses: actions/checkout@v4
+          with:
+            ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
         - name: Download artifacts
           if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -531,8 +585,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-1-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-1-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -547,7 +603,14 @@ jobs:
         part: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -573,8 +636,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-2-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-2-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -588,7 +653,14 @@ jobs:
         part: [0, 1]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -614,8 +686,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-4-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-4-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -629,7 +703,14 @@ jobs:
         part: [0, 1, 2]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -655,8 +736,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-8-gpu-h200') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-8-gpu-h200') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -670,7 +753,14 @@ jobs:
         part: [0, 1, 2]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -696,8 +786,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-8-gpu-h20') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-8-gpu-h20') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -712,7 +804,14 @@ jobs:
         part: [0, 1]
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -738,8 +837,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-1') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-1-gpu-part-1') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -749,7 +850,14 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -807,8 +915,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-2') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-1-gpu-part-2') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -818,7 +928,14 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -868,8 +985,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-1-gpu-part-3') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-1-gpu-part-3') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -879,7 +998,14 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -923,8 +1049,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'performance-test-2-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'performance-test-2-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -934,7 +1062,14 @@ jobs:
       RUNNER_LABELS: 2-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -990,8 +1125,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'accuracy-test-1-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'accuracy-test-1-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1001,7 +1138,14 @@ jobs:
       RUNNER_LABELS: 1-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1030,8 +1174,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'accuracy-test-2-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'accuracy-test-2-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1041,7 +1187,14 @@ jobs:
       RUNNER_LABELS: 2-gpu-runner
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1070,8 +1223,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-deepep-4-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-deepep-4-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1081,7 +1236,14 @@ jobs:
       RUNNER_LABELS: 4-gpu-h100
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1107,8 +1269,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-deepep-8-gpu') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-deepep-8-gpu') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1118,7 +1282,14 @@ jobs:
       RUNNER_LABELS: 8-gpu-h200
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1144,8 +1315,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-4-gpu-b200') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-4-gpu-b200') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1160,7 +1333,14 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1186,8 +1366,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-4-gpu-gb200') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-4-gpu-gb200') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1199,7 +1381,14 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Download artifacts
         if: needs.check-changes.outputs.sgl_kernel == 'true'
@@ -1225,8 +1414,10 @@ jobs:
       always() &&
       (
         (inputs.target_stage == 'unit-test-backend-8-gpu-b200') ||
+        (github.event_name == 'repository_dispatch' && github.event.client_payload.target_stage == 'unit-test-backend-8-gpu-b200') ||
         (
           !inputs.target_stage &&
+          github.event_name != 'repository_dispatch' &&
           (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
@@ -1236,7 +1427,14 @@ jobs:
       RUNNER_LABELS: 8-gpu-b200
     steps:
       - name: Checkout code
+        if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout PR code (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pr_number }}/merge
 
       - name: Install dependencies
         run: |

--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -122,7 +122,9 @@ def handle_rerun_stage(
 ):
     """
     Handles the /rerun-stage <stage-name> command.
-    Triggers a workflow_dispatch to run only the specified stage, skipping dependencies.
+    Triggers a workflow to run only the specified stage, skipping dependencies.
+    - For branches in the main repo: uses workflow_dispatch
+    - For fork PRs: uses repository_dispatch (since workflow_dispatch can't target fork branches)
     Returns True if action was taken, False otherwise.
     """
     if not user_perms.get("can_rerun_stage", False):
@@ -138,7 +140,7 @@ def handle_rerun_stage(
         )
         return False
 
-    print(f"Permission granted. Triggering workflow_dispatch for stage '{stage_name}'.")
+    print(f"Permission granted. Triggering stage '{stage_name}'.")
 
     # Valid NVIDIA stage names that support target_stage
     nvidia_stages = [
@@ -194,36 +196,27 @@ def handle_rerun_stage(
         return False
 
     try:
-        # Get the appropriate workflow based on stage type
-        workflow_name = "PR Test (AMD)" if is_amd_stage else "PR Test"
-        workflows = gh_repo.get_workflows()
-        target_workflow = None
-        for wf in workflows:
-            if wf.name == workflow_name:
-                target_workflow = wf
-                break
+        # Check if PR is from a fork
+        is_fork = pr.head.repo.full_name != gh_repo.full_name
+        print(f"PR head repo: {pr.head.repo.full_name}, main repo: {gh_repo.full_name}, is_fork: {is_fork}")
 
-        if not target_workflow:
-            print(f"Error: {workflow_name} workflow not found")
-            return False
+        if is_fork:
+            # For fork PRs, use repository_dispatch since workflow_dispatch can't target fork branches
+            print(f"Using repository_dispatch for fork PR #{pr.number}")
 
-        # Trigger workflow_dispatch on the PR's head branch
-        ref = pr.head.ref
-        print(f"Triggering {workflow_name} workflow on branch: {ref}")
+            # Determine the event type based on stage type
+            event_type = "rerun-stage-amd" if is_amd_stage else "rerun-stage"
 
-        # AMD workflow doesn't have version input, only target_stage
-        if is_amd_stage:
-            inputs = {"target_stage": stage_name}
-        else:
-            inputs = {"version": "release", "target_stage": stage_name}
+            # Create repository_dispatch event
+            gh_repo.create_repository_dispatch(
+                event_type=event_type,
+                client_payload={
+                    "target_stage": stage_name,
+                    "pr_number": pr.number,
+                },
+            )
 
-        success = target_workflow.create_dispatch(
-            ref=ref,
-            inputs=inputs,
-        )
-
-        if success:
-            print(f"Successfully triggered workflow for stage '{stage_name}'")
+            print(f"Successfully triggered repository_dispatch for stage '{stage_name}'")
             if react_on_success:
                 comment.create_reaction("+1")
                 pr.create_issue_comment(
@@ -232,14 +225,55 @@ def handle_rerun_stage(
                 )
             return True
         else:
-            print("Failed to trigger workflow_dispatch")
-            return False
+            # For branches in the main repo, use workflow_dispatch (more direct)
+            print(f"Using workflow_dispatch for main repo branch: {pr.head.ref}")
+
+            # Get the appropriate workflow based on stage type
+            workflow_name = "PR Test (AMD)" if is_amd_stage else "PR Test"
+            workflows = gh_repo.get_workflows()
+            target_workflow = None
+            for wf in workflows:
+                if wf.name == workflow_name:
+                    target_workflow = wf
+                    break
+
+            if not target_workflow:
+                print(f"Error: {workflow_name} workflow not found")
+                return False
+
+            # Trigger workflow_dispatch on the PR's head branch
+            ref = pr.head.ref
+            print(f"Triggering {workflow_name} workflow on branch: {ref}")
+
+            # AMD workflow doesn't have version input, only target_stage
+            if is_amd_stage:
+                inputs = {"target_stage": stage_name}
+            else:
+                inputs = {"version": "release", "target_stage": stage_name}
+
+            success = target_workflow.create_dispatch(
+                ref=ref,
+                inputs=inputs,
+            )
+
+            if success:
+                print(f"Successfully triggered workflow for stage '{stage_name}'")
+                if react_on_success:
+                    comment.create_reaction("+1")
+                    pr.create_issue_comment(
+                        f"✅ Triggered `{stage_name}` to run independently (skipping dependencies).\n\n"
+                        f"Check the [Actions tab](https://github.com/{gh_repo.full_name}/actions) for progress."
+                    )
+                return True
+            else:
+                print("Failed to trigger workflow_dispatch")
+                return False
 
     except Exception as e:
-        print(f"Error triggering workflow_dispatch: {e}")
+        print(f"Error triggering stage: {e}")
         comment.create_reaction("confused")
         pr.create_issue_comment(
-            f"❌ Failed to trigger workflow: {str(e)}\n\n"
+            f"❌ Failed to trigger stage: {str(e)}\n\n"
             f"Please check the logs or contact maintainers."
         )
         return False

--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -198,7 +198,9 @@ def handle_rerun_stage(
     try:
         # Check if PR is from a fork
         is_fork = pr.head.repo.full_name != gh_repo.full_name
-        print(f"PR head repo: {pr.head.repo.full_name}, main repo: {gh_repo.full_name}, is_fork: {is_fork}")
+        print(
+            f"PR head repo: {pr.head.repo.full_name}, main repo: {gh_repo.full_name}, is_fork: {is_fork}"
+        )
 
         if is_fork:
             # For fork PRs, use repository_dispatch since workflow_dispatch can't target fork branches
@@ -216,7 +218,9 @@ def handle_rerun_stage(
                 },
             )
 
-            print(f"Successfully triggered repository_dispatch for stage '{stage_name}'")
+            print(
+                f"Successfully triggered repository_dispatch for stage '{stage_name}'"
+            )
             if react_on_success:
                 comment.create_reaction("+1")
                 pr.create_issue_comment(


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch` trigger to pr-test.yml and pr-test-amd.yml workflows
- For fork PRs: uses `repository_dispatch` with PR number, checks out `refs/pull/<pr_number>/merge`
- For main repo branches: continues using `workflow_dispatch` (unchanged behavior)

## Test plan
- [ ] After merging, test `/rerun-stage stage-a-test-1` on a fork PR
- [ ] Verify it triggers the workflow and runs only the specified stage
- [ ] Confirm existing behavior on main repo branches still works