### PR TITLE
fix: checking if tokenizer is in cache before downloading from HF

### DIFF
--- a/python/sglang/srt/utils/hf_transformers_utils.py
+++ b/python/sglang/srt/utils/hf_transformers_utils.py
@@ -417,9 +417,17 @@ def find_local_tokenizer_snapshot_dir(
     """If the tokenizer files are already local, skip downloading and return the path.
     Only applied in CI.
     """
-    if not is_in_ci() or os.path.isdir(model_name_or_path):
+    if not is_in_ci():
         return None
 
+    if os.path.isdir(model_name_or_path):
+        if is_in_ci():
+            print(
+                f"[TOKENIZER CACHE] {model_name_or_path} is already a local directory, skipping cache check"
+            )
+        return None
+
+    print(f"[TOKENIZER CACHE] Checking for cached tokenizer: {model_name_or_path}")
     found_local_snapshot_dir = None
 
     # Check custom cache_dir (if provided)
@@ -483,6 +491,11 @@ def find_local_tokenizer_snapshot_dir(
             model_name_or_path,
             found_local_snapshot_dir,
         )
+        if is_in_ci():
+            print(
+                f"[TOKENIZER CACHE] Found local snapshot for {model_name_or_path}, "
+                f"skipping HF API call. Cache: {found_local_snapshot_dir}"
+            )
         return found_local_snapshot_dir
     else:
         logger.info(
@@ -490,6 +503,11 @@ def find_local_tokenizer_snapshot_dir(
             found_local_snapshot_dir,
             allow_patterns,
         )
+        if is_in_ci():
+            print(
+                f"[TOKENIZER CACHE] No cached files for {model_name_or_path}, "
+                f"will download from HuggingFace"
+            )
     return None
 
 


### PR DESCRIPTION
## Motivation

Currently, CI tests are hitting HuggingFace rate limits when loading tokenizers:
```
huggingface_hub.errors.HfHubHTTPError: 429 Client Error: Too Many Requests
We had to rate limit you, you hit the quota of 3000 api requests per 5 minutes period.
```
This occurred in tests like test_srt_backend.py where AutoTokenizer.from_pretrained() was called with model IDs (e.g., "meta-llama/Llama-3.1-8B-Instruct"), triggering HuggingFace API calls even when files were already cached locally.


## Modifications

We check the cache before loading tokenizers; if tokenizers are in cache, we don't make an HF call. Solution inspired by: https://github.com/sgl-project/sglang/pull/11015

## Accuracy Tests

Added print logs, verifying that we are able to skip the HF call: https://github.com/sgl-project/sglang/actions/runs/20052365424/job/57510848576#step:5:690

## Benchmarking and Profiling

N/A

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [N/A] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ N/A] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
