### PR TITLE
[GLM-4.6V] Support Pipeline Parallelism for GLM-4.6V & GLM-4.1V

### DIFF
--- a/python/sglang/srt/models/glm4v.py
+++ b/python/sglang/srt/models/glm4v.py
@@ -51,7 +51,7 @@ from sglang.srt.managers.mm_utils import (
     general_mm_embed_routine,
 )
 from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.glm4 import Glm4Model
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
@@ -659,6 +659,7 @@ class Glm4vForConditionalGeneration(nn.Module):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ):
         """Run forward pass for GLM-4.1V.
 
@@ -691,6 +692,7 @@ class Glm4vForConditionalGeneration(nn.Module):
             language_model=self.model,
             multimodal_model=self,
             positions=positions,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
 
         aux_hidden_states = None
@@ -750,6 +752,17 @@ class Glm4vForConditionalGeneration(nn.Module):
             (".gate_up_proj", ".gate_proj", 0),
         ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        # For the PP case, we add special handling for lm_head.weight,
+        # - On non–last ranks: we continue, because this stage is supposed to
+        #   be just an empty PPMissingLayer shell.
+        # - On the last rank: params_dict is expected to contain lm_head.weight,
+        #   so it will never hit the branch "if name not in params_dict".
+        #
+        # For all other parameters, such like
+        # "model.visual.blocks.20.mlp.gate_proj.weight", the unified rule is:
+        # If this name does not exist in the current rank’s params_dict,
+        # it does not belong to this pipeline stage, thus we simply continue.
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -757,6 +770,8 @@ class Glm4vForConditionalGeneration(nn.Module):
                 name = name.replace(r"model.language_model.", r"model.")
             if "model.visual." in name:
                 name = name.replace("model.visual.", "visual.")
+            if name.startswith("lm_head.") and not self.pp_group.is_last_rank:
+                continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
@@ -766,6 +781,10 @@ class Glm4vForConditionalGeneration(nn.Module):
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue
+
+                if name not in params_dict:
+                    continue
+
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -779,6 +798,10 @@ class Glm4vForConditionalGeneration(nn.Module):
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
                         continue
+
+                    if name not in params_dict:
+                        continue
+
                     param = params_dict[name]
                 except KeyError:
                     print(params_dict.keys())

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -57,6 +57,9 @@ DEFAULT_MLA_FP8_MODEL_NAME_FOR_TEST = "neuralmagic/DeepSeek-Coder-V2-Lite-Instru
 DEFAULT_MODEL_NAME_FOR_TEST_MLA = "lmsys/sglang-ci-dsv3-test"
 DEFAULT_MODEL_NAME_FOR_TEST_MLA_NEXTN = "lmsys/sglang-ci-dsv3-test-NextN"
 
+# VL test models
+DEFAULT_MODEL_NAME_FOR_TEST_GLM_41V_PP = "zai-org/GLM-4.1V-9B-Thinking"
+
 # NVFP4 models
 DEFAULT_DEEPSEEK_NVFP4_MODEL_FOR_TEST = "nvidia/DeepSeek-V3-0324-FP4"
 DEFAULT_MODEL_NAME_FOR_TEST_MOE_NVFP4 = "nvidia/Qwen3-30B-A3B-FP4"

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -150,7 +150,7 @@ suites = {
         TestFile("test_gpt_oss_4gpu.py", 300),
         TestFile("test_local_attn.py", 411),
         TestFile("test_multi_instance_release_memory_occupation.py", 64),
-        TestFile("test_pp_single_node.py", 481),
+        TestFile("test_pp_single_node.py", 800),
         TestFile("test_piecewise_cuda_graph.py", 1200),
     ],
     "per-commit-8-gpu-h200": [

--- a/test/srt/test_pp_single_node.py
+++ b/test/srt/test_pp_single_node.py
@@ -19,6 +19,7 @@ from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_MLA_MODEL_NAME_FOR_TEST,
     DEFAULT_MODEL_NAME_FOR_TEST,
+    DEFAULT_MODEL_NAME_FOR_TEST_GLM_41V_PP,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
@@ -316,6 +317,43 @@ class TestFixedBugs(unittest.TestCase):
             bench_args,
             other_server_args,
         )
+
+
+class TestGLM41VPPAccuracy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_GLM_41V_PP
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            DEFAULT_MODEL_NAME_FOR_TEST_GLM_41V_PP,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                1,
+                "--pp-size",
+                2,
+                "--chunked-prefill-size",
+                8192,
+                "--enable-multimodal",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_mmmu(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="mmmu",
+            num_examples=None,
+            num_threads=32,
+        )
+        metrics = run_eval(args)
+        print(f"{metrics=}")
+        self.assertGreater(metrics["score"], 0.55)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to support GLM-4.6V and GLM-4.1V Pipeline Parallelism.
In main branch GLM-4.6V and GLM-4.1V PP don't work correctly. There are two reasons:

1. In pp-size > 1, some pipeline shard doesn't have lm_head weight, but the current code attempt to load it in all shards, so it gets assert with errorkey lm_head.weights. There are some other layers have the similar issue, this PR fixes them. 
Why pp=1 have no this problem, is because GLM-4.1V's tie_word_embeddings=False, then 
a. if pp=1, lm_head is always set to ParallelLMHead()
b. if pp>1, lm_head is only set on the last_rank, for intermediate stage, no lm_head is set.
```
if self.pp_group.is_last_rank:
    if self.pp_group.world_size == 1 and self.config.tie_word_embeddings:
        self.lm_head = self.model.embed_tokens.  
    else:
        self.lm_head = ParallelLMHead(...) <<<<<< last rank enters this branch.
else:
    self.lm_head = PPMissingLayer(). <<<<<< intermediate stage enter this branch, no lm_head
```
Some issues are related with this topic https://github.com/sgl-project/sglang/pull/1508 https://github.com/sgl-project/sglang/issues/2935.
2. general_mm_embed_routine is missing PPProxyTensors parameters.

For the first point, when training/saving checkpoints, some frameworks only save model.embed_tokens.weight and don’t save lm_head.weight separately. 

When the inference framework implements the model structure, some model classes, such as Gemma3_mm, Gemma3n_mm, Granite or some EAGLE draft model, actually define a self.lm_head = nn.Linear(...), and then in tie_weights() make lm_head.weight and embed_tokens.weight point to the same Parameter. There can be cases that even don’t define an lm_head module at all, and instead directly use F.linear(hidden, embed_tokens.weight) in forward to produce the output.

In the current setup, suppose we have pp_size = 2 with GLM-4.1V (where tie_word_embeddings = False is used):
- On the previous stage: There is only PPMissingLayer(), and no lm_head.weight.
- On the last stage: There is a real lm_head module, so lm_head.weight must be loaded.

The modification is when lm_head.weight is encountered there, we choose to skip it, based on the fact that the current rank is not the last rank. 

GLM-4.6V Server:
```
$SGLANG_USE_CUDA_IPC_TRANSPORT=1 python -m sglang.launch_server --model-path /home/admin/GLM-4.6V --mm-attention-backend fa3 --port 30000 --chunked-prefill-size 8192 --disable-radix-cache --disable-overlap-schedule --attention-backend fa3 --tp 4 --pp-size 2
```

Client:
```
$bash bench_n_image.sh 
{"id":"07cdbe828ef6470db12e99d17f63f64a","object":"chat.completion","created":1765271843,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中的植物是**刺儿菜**（学名：*Cirsium setosum*），属于菊科蓟属。其典型特征为：茎直立，具纵棱；叶片边缘具刺状齿，两面被蛛丝状毛；头状花序单生于茎顶或枝端，总苞片多层，具刺。  \n\n刺儿菜为多年生草本，常见于田间、路旁、荒地等处，适应性较强。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151336}],"usage":{"prompt_tokens":960,"total_tokens":1058,"completion_tokens":98,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m3.419s
user    0m0.002s
sys     0m0.003s
{"id":"08d083ae213c43478342e73ea6fad238","object":"chat.completion","created":1765271844,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中的植物是**刺儿菜**（学名：*Cirsium setosum*），属于菊科蓟属。其典型特征为：茎直立，具纵棱；叶片边缘具刺状齿，两面被蛛丝状毛；头状花序单生于茎顶或枝端，总苞片多层，具刺。  \n\n刺儿菜为多年生草本，常见于田间、路旁、荒地等处，适应性较强。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151336}],"usage":{"prompt_tokens":960,"total_tokens":1058,"completion_tokens":98,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m1.254s
user    0m0.002s
sys     0m0.003s
```

GLM-4.1V
Server:
```
$SGLANG_USE_CUDA_IPC_TRANSPORT=1 python -m sglang.launch_server --model-path /home/admin/GLM-4.1V-9B-Thinking --mm-attention-backend fa3 --port 30000 --chunked-prefill-size 8192 --disable-radix-cache --disable-overlap-schedule --attention-backend fa3 --tp 1 --pp-size 2
```

```
$bash bench_n_image.sh 
{"id":"7bb67e024d4c4230a4891038318b233b","object":"chat.completion","created":1765272124,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"用户现在需要识别图中的植物，从图片看，这种植物有带刺的叶片，可能是刺儿菜（Cirsium setosum），不过也可能是其他蓟属植物。先看特征：叶片边缘有刺，茎和叶有刺，属于菊科蓟属。刺儿菜学名Cirsium setosum（有时也叫Cirsium arvense？不对，要确认）。不过更常见的可能是刺儿菜，学名Cirsium setosum（Beauv.）Bess.，别名小蓟、刺菜等。需要确认形态：叶片羽状深裂，边缘有刺，茎直立，有刺，符合蓟属特征。所以判断为刺儿菜，学名Cirsium setosum。图中的植物是刺儿菜，其学名是 **Cirsium setosum**（也常被称为 *Cirsium arvense* ，不过二者在分类和形态上有一定差异，需结合地域等判断，刺儿菜更偏向 *Cirsium setosum* 这类形态，叶片等特征符合刺儿菜常见形态）。刺儿菜属于菊科蓟属植物，常生长在草地、路边等处，叶片边缘和茎部有刺，是常见的野生草本植物，部分地区也用于药用等。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151348}],"usage":{"prompt_tokens":956,"total_tokens":1237,"completion_tokens":281,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m3.268s
user    0m0.003s
sys     0m0.001s
{"id":"0379a48690704a5ab774dd4d6e6ed131","object":"chat.completion","created":1765272127,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"用户现在需要识别图中的植物，从图片看，这种植物有带刺的叶片，可能是刺儿菜（Cirsium setosum），不过也可能是其他蓟属植物。先看特征：叶片边缘有刺，茎和叶有刺，属于菊科蓟属。刺儿菜学名Cirsium setosum（有时也叫Cirsium arvense？不对，要确认）。不过更常见的可能是刺儿菜，学名Cirsium setosum（Beauv.）Bess.，别名小蓟、刺菜等。需要确认形态：叶片羽状深裂，边缘有刺，茎直立，有刺，符合蓟属特征。所以判断为刺儿菜，学名Cirsium setosum。图中的植物是刺儿菜，其学名是 **Cirsium setosum**（也常被称为 *Cirsium arvense* ，不过二者在分类和形态上有一定差异，需结合地域等判断，刺儿菜更偏向 *Cirsium setosum* 这类形态，叶片等特征符合刺儿菜常见形态）。刺儿菜属于菊科蓟属植物，常生长在草地、路边等处，叶片边缘和茎部有刺，是常见的野生草本植物，部分地区也用于药用等。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151348}],"usage":{"prompt_tokens":956,"total_tokens":1237,"completion_tokens":281,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m3.097s
user    0m0.001s
sys     0m0.003s
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
