### PR TITLE
[AMD/NPU] Pin transformers to stable 4.57.1

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -59,7 +59,7 @@ runtime_common = [
   "timm==1.0.16",
   "torchao==0.9.0",
   "tqdm",
-  "transformers==5.0.0rc0",
+  "transformers==4.57.1",  # Stable version for AMD/NPU (5.0.0rc0 has logprob regression on AMD)
   "uvicorn",
   "uvloop",
   "xgrammar==0.1.27",


### PR DESCRIPTION
## Summary

Fix `test_hellaswag_select` and `test_select` failures on AMD/ROCm in `stage-a-test-1-amd`.

## Root Cause

`transformers==5.0.0rc0` has a regression on AMD where `input_token_logprobs` returns only 1 aggregated entry with `None` values instead of per-token logprobs. This breaks the select functionality.

## Solution

Change `pyproject_other.toml` (used by AMD and NPU) to use the stable `4.57.1` version instead of the release candidate `5.0.0rc0`.

## Testing

Tested locally on MI300x:
- `transformers 4.57.1`: works correctly (3 logprob entries per choice)
- `transformers 5.0.0rc0`: broken (1 entry with None values)

## Test plan

- [x] `stage-a-test-1-amd` should pass
- [x] Existing tests on CUDA should still pass (uses main pyproject.toml with 5.0.0rc0)