### PR TITLE
[Feat] Async KV transfer for PD disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -25,7 +25,7 @@ class FakeKVSender(BaseKVSender):
         pp_rank: int,
     ):
         self.has_sent = False
-        self.result = None
+        self.transfer_context = None
 
     def poll(self) -> KVPoll:
         if self.has_sent is False:

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -25,6 +25,7 @@ class FakeKVSender(BaseKVSender):
         pp_rank: int,
     ):
         self.has_sent = False
+        self.result = None
 
     def poll(self) -> KVPoll:
         if self.has_sent is False:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -881,8 +881,8 @@ class MooncakeKVManager(CommonKVManager):
                                         self.sync_status_to_decode_endpoint(
                                             endpoint, dst_port, room, status, local_rank
                                         )
-                                    if self.attn_tp_rank == 0:
-                                            logger.info(f"sent_success to {req.room=}")
+                                    # if self.attn_tp_rank == 0:
+                                    #         gitf"sent_success to {req.room=}")
                         else:
                             # Dummy request means the decode instance is not used, so its status can be marked as success directly
                             # Dummy request does not need to sync status to decode endpoint
@@ -1063,8 +1063,8 @@ class MooncakeKVManager(CommonKVManager):
         session_port_sum = sum(int(session.rsplit(":", 1)[1]) for session in dst_infos)
         shard_idx = session_port_sum % len(self.transfer_queues)
         self.forward_results[bootstrap_room] = result
-        if self.attn_tp_rank == 0:
-            logger.info(f"send req to transfer queue: {bootstrap_room=}")
+        # if self.attn_tp_rank == 0:
+        #     logger.info(f"send req to transfer queue: {bootstrap_room=}")
 
         self.transfer_queues[shard_idx].put(
             TransferKVChunk(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -711,93 +711,26 @@ class MooncakeKVManager(CommonKVManager):
         while True:
             try:
                 kv_chunk: TransferKVChunk = queue.get()
-                with torch.cuda.nvtx.range("transfer"):
-                    reqs_to_be_processed = (
-                        self.transfer_infos[kv_chunk.room].values()
-                        if kv_chunk.room in self.transfer_infos
-                        else []
-                    )
-                    polls = []
-                    dst_ranks_infos = []
-                    local_rank = self.attn_tp_rank * self.pp_size + self.pp_rank
-                    assert kv_chunk.room in self.transfer_contexts, f"kv_chunk.room {kv_chunk.room} not in transfer_contexts"
-                    # logger.info(f"transfer_worker: {kv_chunk.room=} {self.transfer_contexts=}")
-                    transfer_context = self.transfer_contexts[kv_chunk.room]
-                    # Resolve the context once for all requests (thread-safe, only executes once)
-                    
-                    for req in reqs_to_be_processed:
-                        if not req.is_dummy:
-                            # Early exit if the request has failed
-                            with self.session_lock:
-                                if req.mooncake_session_id in self.failed_sessions:
-                                    self.record_failure(
-                                        kv_chunk.room,
-                                        f"Decode instance could be dead, remote mooncake session {req.mooncake_session_id} is not alive",
-                                    )
-                                    self.update_status(kv_chunk.room, KVPoll.Failed)
-                                    self.sync_status_to_decode_endpoint(
-                                        req.endpoint,
-                                        req.dst_port,
-                                        req.room,
-                                        KVPoll.Failed,
-                                        local_rank,
-                                    )
-                                    break
-
-                            chunked_dst_kv_indice = req.dst_kv_indices[kv_chunk.index_slice]
-
-                            # NOTE: This is temporarily a workaround to deal with the case where the prefill_kv_indices
-                            # is mismatched with the dst_kv_indices when page size > 1, this should never happen.
-                            if len(chunked_dst_kv_indice) < len(
-                                kv_chunk.prefill_kv_indices
-                            ):
-                                logger.warning(
-                                    f"len(chunked_dst_kv_indice) = {len(chunked_dst_kv_indice)}, len(kv_chunk.prefill_kv_indices) = {len(kv_chunk.prefill_kv_indices)}"
-                                )
-                                kv_chunk.prefill_kv_indices = kv_chunk.prefill_kv_indices[
-                                    : len(chunked_dst_kv_indice)
-                                ]
-
-                            target_rank_registration_info: KVArgsRegisterInfo = (
-                                self.decode_kv_args_table[req.mooncake_session_id]
-                            )
-
-                            transfer_context.resolve()
-
-                            if self.is_mla_backend or (
-                                self.attn_tp_size
-                                == target_rank_registration_info.dst_attn_tp_size
-                            ):
-                                ret = self.send_kvcache(
-                                    req.mooncake_session_id,
-                                    kv_chunk.prefill_kv_indices,
-                                    target_rank_registration_info.dst_kv_ptrs,
-                                    chunked_dst_kv_indice,
-                                    executor,
-                                )
-                            else:
-                                ret = self.send_kvcache_slice(
-                                    req.mooncake_session_id,
-                                    kv_chunk.prefill_kv_indices,
-                                    target_rank_registration_info.dst_kv_ptrs,
-                                    chunked_dst_kv_indice,
-                                    target_rank_registration_info.dst_tp_rank,
-                                    target_rank_registration_info.dst_attn_tp_size,
-                                    target_rank_registration_info.dst_kv_item_len,
-                                    executor,
-                                )
-                            if ret != 0:
-                                with self.session_lock:
-                                    self.session_failures[req.mooncake_session_id] += 1
-                                    # Failures should never happen if the session is not dead, if the session fails once, mark it as failed
-                                    if self.session_failures[req.mooncake_session_id] >= 1:
-                                        self.failed_sessions.add(req.mooncake_session_id)
-                                        logger.error(
-                                            f"Session {req.mooncake_session_id} failed."
-                                        )
+                reqs_to_be_processed = (
+                    self.transfer_infos[kv_chunk.room].values()
+                    if kv_chunk.room in self.transfer_infos
+                    else []
+                )
+                polls = []
+                dst_ranks_infos = []
+                local_rank = self.attn_tp_rank * self.pp_size + self.pp_rank
+                assert kv_chunk.room in self.transfer_contexts, f"kv_chunk.room {kv_chunk.room} not in transfer_contexts"
+                transfer_context = self.transfer_contexts[kv_chunk.room]
+                # Resolve the context once for all requests (thread-safe, only executes once)
+                
+                for req in reqs_to_be_processed:
+                    if not req.is_dummy:
+                        # Early exit if the request has failed
+                        with self.session_lock:
+                            if req.mooncake_session_id in self.failed_sessions:
                                 self.record_failure(
                                     kv_chunk.room,
-                                    f"Failed to send kv chunk of {kv_chunk.room} to {req.endpoint}:{req.dst_port}",
+                                    f"Decode instance could be dead, remote mooncake session {req.mooncake_session_id} is not alive",
                                 )
                                 self.update_status(kv_chunk.room, KVPoll.Failed)
                                 self.sync_status_to_decode_endpoint(
@@ -809,51 +742,116 @@ class MooncakeKVManager(CommonKVManager):
                                 )
                                 break
 
-                            if kv_chunk.is_last:
-                                if kv_chunk.state_indices is not None:
-                                    if not self.is_mla_backend and (
-                                        self.attn_tp_size
-                                        != target_rank_registration_info.dst_attn_tp_size
-                                    ):
-                                        raise RuntimeError(
-                                            f"PD Disaggregation does NOT support PD different TP sizes for non-MLA hybrid models yet."
-                                        )
+                        chunked_dst_kv_indice = req.dst_kv_indices[kv_chunk.index_slice]
 
-                                    self.maybe_send_extra(
-                                        req,
-                                        kv_chunk.state_indices,
-                                        target_rank_registration_info.dst_state_data_ptrs,
-                                        executor,
+                        # NOTE: This is temporarily a workaround to deal with the case where the prefill_kv_indices
+                        # is mismatched with the dst_kv_indices when page size > 1, this should never happen.
+                        if len(chunked_dst_kv_indice) < len(
+                            kv_chunk.prefill_kv_indices
+                        ):
+                            logger.warning(
+                                f"len(chunked_dst_kv_indice) = {len(chunked_dst_kv_indice)}, len(kv_chunk.prefill_kv_indices) = {len(kv_chunk.prefill_kv_indices)}"
+                            )
+                            kv_chunk.prefill_kv_indices = kv_chunk.prefill_kv_indices[
+                                : len(chunked_dst_kv_indice)
+                            ]
+
+                        target_rank_registration_info: KVArgsRegisterInfo = (
+                            self.decode_kv_args_table[req.mooncake_session_id]
+                        )
+
+                        transfer_context.resolve()
+
+                        if self.is_mla_backend or (
+                            self.attn_tp_size
+                            == target_rank_registration_info.dst_attn_tp_size
+                        ):
+                            ret = self.send_kvcache(
+                                req.mooncake_session_id,
+                                kv_chunk.prefill_kv_indices,
+                                target_rank_registration_info.dst_kv_ptrs,
+                                chunked_dst_kv_indice,
+                                executor,
+                            )
+                        else:
+                            ret = self.send_kvcache_slice(
+                                req.mooncake_session_id,
+                                kv_chunk.prefill_kv_indices,
+                                target_rank_registration_info.dst_kv_ptrs,
+                                chunked_dst_kv_indice,
+                                target_rank_registration_info.dst_tp_rank,
+                                target_rank_registration_info.dst_attn_tp_size,
+                                target_rank_registration_info.dst_kv_item_len,
+                                executor,
+                            )
+                        if ret != 0:
+                            with self.session_lock:
+                                self.session_failures[req.mooncake_session_id] += 1
+                                # Failures should never happen if the session is not dead, if the session fails once, mark it as failed
+                                if self.session_failures[req.mooncake_session_id] >= 1:
+                                    self.failed_sessions.add(req.mooncake_session_id)
+                                    logger.error(
+                                        f"Session {req.mooncake_session_id} failed."
+                                    )
+                            self.record_failure(
+                                kv_chunk.room,
+                                f"Failed to send kv chunk of {kv_chunk.room} to {req.endpoint}:{req.dst_port}",
+                            )
+                            self.update_status(kv_chunk.room, KVPoll.Failed)
+                            self.sync_status_to_decode_endpoint(
+                                req.endpoint,
+                                req.dst_port,
+                                req.room,
+                                KVPoll.Failed,
+                                local_rank,
+                            )
+                            break
+
+                        if kv_chunk.is_last:
+                            if kv_chunk.state_indices is not None:
+                                if not self.is_mla_backend and (
+                                    self.attn_tp_size
+                                    != target_rank_registration_info.dst_attn_tp_size
+                                ):
+                                    raise RuntimeError(
+                                        f"PD Disaggregation does NOT support PD different TP sizes for non-MLA hybrid models yet."
                                     )
 
-                                if self.pp_group.is_last_rank:
-                                    # Only the last chunk we need to send the aux data
-                                    ret = self.send_aux(
-                                        req,
-                                        kv_chunk.prefill_aux_index,
-                                        target_rank_registration_info.dst_aux_ptrs,
-                                    )
-                                polls.append(True if ret == 0 else False)
-                                dst_ranks_infos.append(
-                                    (req.endpoint, req.dst_port, req.room)
+                                self.maybe_send_extra(
+                                    req,
+                                    kv_chunk.state_indices,
+                                    target_rank_registration_info.dst_state_data_ptrs,
+                                    executor,
                                 )
 
-                                # Only sync status when all the dst ranks have received the kvcache
-                                if len(polls) == req.required_dst_info_num:
-                                    status = KVPoll.Success if all(polls) else KVPoll.Failed
-                                    self.update_status(req.room, status)
+                            if self.pp_group.is_last_rank:
+                                # Only the last chunk we need to send the aux data
+                                ret = self.send_aux(
+                                    req,
+                                    kv_chunk.prefill_aux_index,
+                                    target_rank_registration_info.dst_aux_ptrs,
+                                )
+                            polls.append(True if ret == 0 else False)
+                            dst_ranks_infos.append(
+                                (req.endpoint, req.dst_port, req.room)
+                            )
 
-                                    for endpoint, dst_port, room in dst_ranks_infos:
-                                        self.sync_status_to_decode_endpoint(
-                                            endpoint, dst_port, room, status, local_rank
-                                        )
-                                    # if self.attn_tp_rank == 0:
-                                    #         gitf"sent_success to {req.room=}")
-                        else:
-                            # Dummy request means the decode instance is not used, so its status can be marked as success directly
-                            # Dummy request does not need to sync status to decode endpoint
-                            if kv_chunk.is_last and req.room in self.request_status:
-                                self.update_status(req.room, KVPoll.Success)
+                            # Only sync status when all the dst ranks have received the kvcache
+                            if len(polls) == req.required_dst_info_num:
+                                status = KVPoll.Success if all(polls) else KVPoll.Failed
+                                self.update_status(req.room, status)
+
+                                for endpoint, dst_port, room in dst_ranks_infos:
+                                    self.sync_status_to_decode_endpoint(
+                                        endpoint, dst_port, room, status, local_rank
+                                    )
+                                # if self.attn_tp_rank == 0:
+                                #         gitf"sent_success to {req.room=}")
+                    else:
+                        # Dummy request means the decode instance is not used, so its status can be marked as success directly
+                        # Dummy request does not need to sync status to decode endpoint
+                        if kv_chunk.is_last and req.room in self.request_status:
+                            self.update_status(req.room, KVPoll.Success)
 
                     if (
                         kv_chunk.room not in self.request_status
@@ -1031,8 +1029,6 @@ class MooncakeKVManager(CommonKVManager):
         # Store transfer_context if provided (shared across all chunks for the same room)
         if transfer_context is not None:
             self.transfer_contexts[bootstrap_room] = transfer_context
-        # if self.attn_tp_rank == 0:
-        #     logger.info(f"send req to transfer queue: {bootstrap_room=}")
 
         self.transfer_queues[shard_idx].put(
             TransferKVChunk(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -756,7 +756,7 @@ class MooncakeKVManager(CommonKVManager):
                 dst_ranks_infos = []
                 local_rank = self.attn_tp_rank * self.pp_size + self.pp_rank
                 assert kv_chunk.room in self.forward_results, f"kv_chunk.room {kv_chunk.room} not in forward_results"
-                logger.info(f"transfer_worker: {kv_chunk.room=} {self.forward_results=}")
+                # logger.info(f"transfer_worker: {kv_chunk.room=} {self.forward_results=}")
                 batch, result = self.forward_results[kv_chunk.room]
                 for req in reqs_to_be_processed:
                     if not req.is_dummy:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -762,6 +762,7 @@ class MooncakeKVManager(CommonKVManager):
                 polls = []
                 dst_ranks_infos = []
                 local_rank = self.attn_tp_rank * self.pp_size + self.pp_rank
+                assert kv_chunk.room in self.forward_results, f"kv_chunk.room {kv_chunk.room} not in forward_results"
                 batch, result = self.forward_results[kv_chunk.room]
                 for req in reqs_to_be_processed:
                     if not req.is_dummy:
@@ -896,6 +897,8 @@ class MooncakeKVManager(CommonKVManager):
                 ):
                     if kv_chunk.room in self.transfer_infos:
                         self.transfer_infos.pop(kv_chunk.room)
+                    if kv_chunk.room in self.forward_results:
+                        self.forward_results.pop(kv_chunk.room)
 
             except Exception as e:
                 # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -724,7 +724,6 @@ class MooncakeKVManager(CommonKVManager):
                     # logger.info(f"transfer_worker: {kv_chunk.room=} {self.transfer_contexts=}")
                     transfer_context = self.transfer_contexts[kv_chunk.room]
                     # Resolve the context once for all requests (thread-safe, only executes once)
-                    transfer_context.resolve()
                     
                     for req in reqs_to_be_processed:
                         if not req.is_dummy:
@@ -762,6 +761,8 @@ class MooncakeKVManager(CommonKVManager):
                             target_rank_registration_info: KVArgsRegisterInfo = (
                                 self.decode_kv_args_table[req.mooncake_session_id]
                             )
+
+                            transfer_context.resolve()
 
                             if self.is_mla_backend or (
                                 self.attn_tp_size

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -400,7 +400,7 @@ class SchedulerDisaggregationPrefillMixin:
             if hasattr(req.disagg_kv_sender, "result"):
                 # assert req.disagg_kv_sender.result is None
                 req.disagg_kv_sender.result = (batch.copy(), result)
-                self.send_kv_chunk(req, last_chunk=req.disagg_kv_sender.result is None)
+                self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
             else:
                 continue
                 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -373,7 +373,7 @@ class SchedulerDisaggregationPrefillMixin:
             batch_result = None
             if batch:
                 # logger.info(f"run_batch")
-                with torch.cuda.nvtx.range("forward"):
+                with torch.cuda.nvtx.range(f"forward_{batch.batch_size()}"):
                     batch_result = self.run_batch(batch)
                 self.result_queue.append((batch.copy(), batch_result))
                 self.notify_prefill_done(batch, batch_result)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -706,7 +706,8 @@ class SchedulerDisaggregationPrefillMixin:
         req.start_send_idx = end_idx
         state_indices = None
         if last_chunk:
-            if not self.enable_overlap:
+            new_overlap = hasattr(req.disagg_kv_sender, 'transfer_context') and self.enable_overlap
+            if not new_overlap:
                 self.disagg_metadata_buffers.set_buf(req)
 
             # Prepare extra pool indices for hybrid models

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -398,9 +398,11 @@ class SchedulerDisaggregationPrefillMixin:
     def notify_prefill_done(self: Scheduler,batch: ScheduleBatch,result: GenerationBatchResult) -> None:
         for i, req in enumerate(batch.reqs):
             if hasattr(req.disagg_kv_sender, "result"):
-                # assert req.disagg_kv_sender.result is None
-                req.disagg_kv_sender.result = (batch.copy(), result)
-                self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
+                if req.disagg_kv_sender.result is None:
+                    req.disagg_kv_sender.result = (batch.copy(), result)
+                    self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
+                else:
+                    assert req.rid == self.chunked_req.rid
             else:
                 continue
                 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -366,16 +366,19 @@ class SchedulerDisaggregationPrefillMixin:
                 self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
             )
             batch = self.get_next_disagg_prefill_batch_to_run()
+            logger.info(f"get_next_disagg_prefill_batch_to_run: {batch=}")
             self.cur_batch = batch
 
             batch_result = None
             if batch:
+                logger.info(f"run_batch")
                 batch_result = self.run_batch(batch)
                 self.result_queue.append((batch.copy(), batch_result))
                 self.notify_prefill_done(batch, batch_result)
 
             if self.last_batch:
                 tmp_batch, tmp_result = self.result_queue.popleft()
+                logger.info(f"process_batch_result_disagg_prefill: {tmp_batch=} {tmp_result=}")
                 self.process_batch_result_disagg_prefill(tmp_batch, tmp_result)
             elif batch is None:
                 self.self_check_during_idle()
@@ -529,6 +532,7 @@ class SchedulerDisaggregationPrefillMixin:
             return []
 
         done_reqs = []
+        logger.info(f"process_disagg_prefill_inflight_queue: {self.disagg_prefill_inflight_queue=} {self.attn_tp_cpu_group=}")
 
         polls = poll_and_all_reduce(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -613,6 +617,7 @@ class SchedulerDisaggregationPrefillMixin:
 
     def process_prefill_chunk(self: Scheduler) -> None:
         chunked_req_to_exclude = set()
+        logger.info(f"process_prefill_chunk: {self.chunked_req=} {self.enable_overlap=}")
         if self.chunked_req:
             chunked_req_to_exclude.add(self.chunked_req)
             self.tree_cache.cache_unfinished_req(self.chunked_req, chunked=True)
@@ -656,6 +661,7 @@ class SchedulerDisaggregationPrefillMixin:
         """
         Send a prefilled chunk to the decode server
         """
+        logger.info(f"send_kv_chunk: {req=} {last_chunk=} {end_idx=}")
         page_size = self.token_to_kv_pool_allocator.page_size
         start_idx = req.start_send_idx
         end_idx = (

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -401,8 +401,8 @@ class SchedulerDisaggregationPrefillMixin:
                 if req.disagg_kv_sender.result is None:
                     req.disagg_kv_sender.result = (batch.copy(), result)
                     self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
-                else:
-                    assert req.rid == self.chunked_req.rid
+                # else:
+                #     assert req.rid == self.chunked_req.rid
             else:
                 continue
                 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -398,9 +398,9 @@ class SchedulerDisaggregationPrefillMixin:
     def notify_prefill_done(self: Scheduler,batch: ScheduleBatch,result: GenerationBatchResult) -> None:
         for i, req in enumerate(batch.reqs):
             if hasattr(req.disagg_kv_sender, "result"):
-                assert req.disagg_kv_sender.result is None
+                # assert req.disagg_kv_sender.result is None
                 req.disagg_kv_sender.result = (batch.copy(), result)
-                self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
+                self.send_kv_chunk(req, last_chunk=req.disagg_kv_sender.result is None)
             else:
                 continue
                 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -372,6 +372,7 @@ class SchedulerDisaggregationPrefillMixin:
             if batch:
                 batch_result = self.run_batch(batch)
                 self.result_queue.append((batch.copy(), batch_result))
+                self.notify_prefill_done(batch, batch_result)
 
             if self.last_batch:
                 tmp_batch, tmp_result = self.result_queue.popleft()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -391,7 +391,7 @@ class SchedulerDisaggregationPrefillMixin:
     
     def notify_prefill_done(self: Scheduler,batch: ScheduleBatch,result: GenerationBatchResult) -> None:
         for i, req in enumerate(batch.reqs):
-            if isinstance(req.disagg_kv_sender, MooncakeKVSender):
+            if hasattr(req.disagg_kv_sender, "result"):
                 assert req.disagg_kv_sender.result is None
                 req.disagg_kv_sender.result = (batch.copy(), result)
                 self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -366,7 +366,7 @@ class SchedulerDisaggregationPrefillMixin:
                 self.disagg_prefill_bootstrap_queue.pop_bootstrapped()
             )
             batch = self.get_next_disagg_prefill_batch_to_run()
-            logger.info(f"get_next_disagg_prefill_batch_to_run: {batch=}")
+            # logger.info(f"get_next_disagg_prefill_batch_to_run: {batch=}")
             self.cur_batch = batch
 
             batch_result = None
@@ -532,7 +532,7 @@ class SchedulerDisaggregationPrefillMixin:
             return []
 
         done_reqs = []
-        logger.info(f"process_disagg_prefill_inflight_queue: {self.disagg_prefill_inflight_queue=} {self.attn_tp_cpu_group=}")
+        # logger.info(f"process_disagg_prefill_inflight_queue: {self.disagg_prefill_inflight_queue=} {self.attn_tp_cpu_group=}")
 
         polls = poll_and_all_reduce(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -617,7 +617,7 @@ class SchedulerDisaggregationPrefillMixin:
 
     def process_prefill_chunk(self: Scheduler) -> None:
         chunked_req_to_exclude = set()
-        logger.info(f"process_prefill_chunk: {self.chunked_req=} {self.enable_overlap=}")
+        # logger.info(f"process_prefill_chunk: {self.chunked_req=} {self.enable_overlap=}")
         if self.chunked_req:
             chunked_req_to_exclude.add(self.chunked_req)
             self.tree_cache.cache_unfinished_req(self.chunked_req, chunked=True)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -391,9 +391,12 @@ class SchedulerDisaggregationPrefillMixin:
     
     def notify_prefill_done(self: Scheduler,batch: ScheduleBatch,result: GenerationBatchResult) -> None:
         for i, req in enumerate(batch.reqs):
-            assert req.disagg_kv_sender.result is None
-            req.disagg_kv_sender.result = (batch.copy(), result)
-            self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
+            if isinstance(req.disagg_kv_sender, MooncakeKVSender):
+                assert req.disagg_kv_sender.result is None
+                req.disagg_kv_sender.result = (batch.copy(), result)
+                self.send_kv_chunk(req, last_chunk=req.is_chunked <= 0)
+            else:
+                continue
                 
 
     def process_batch_result_disagg_prefill(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -371,14 +371,14 @@ class SchedulerDisaggregationPrefillMixin:
 
             batch_result = None
             if batch:
-                logger.info(f"run_batch")
+                # logger.info(f"run_batch")
                 batch_result = self.run_batch(batch)
                 self.result_queue.append((batch.copy(), batch_result))
                 self.notify_prefill_done(batch, batch_result)
 
             if self.last_batch:
                 tmp_batch, tmp_result = self.result_queue.popleft()
-                logger.info(f"process_batch_result_disagg_prefill: {tmp_batch=} {tmp_result=}")
+                # logger.info(f"process_batch_result_disagg_prefill: {tmp_batch=} {tmp_result=}")
                 self.process_batch_result_disagg_prefill(tmp_batch, tmp_result)
             elif batch is None:
                 self.self_check_during_idle()
@@ -661,7 +661,7 @@ class SchedulerDisaggregationPrefillMixin:
         """
         Send a prefilled chunk to the decode server
         """
-        logger.info(f"send_kv_chunk: {req=} {last_chunk=} {end_idx=}")
+        # logger.info(f"send_kv_chunk: {req=} {last_chunk=} {end_idx=}")
         page_size = self.token_to_kv_pool_allocator.page_size
         start_idx = req.start_send_idx
         end_idx = (

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -88,6 +88,7 @@ class Sampler(nn.Module):
 
         # Preprocess logits (custom processors and NaN handling)
         logits = self._preprocess_logits(logits, sampling_info)
+        print(logits)
 
         if sampling_info.is_all_greedy:
             # Use torch.argmax if all requests use greedy sampling
@@ -121,7 +122,7 @@ class Sampler(nn.Module):
             ):
                 logits[:] = torch.softmax(logits, dim=-1)
             probs = logits
-            # del logits
+            del logits
 
             if can_sample_directly_from_probs:
                 # when we don't need top-k, top-p, or min-p sampling, we can directly sample from the probs

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -88,7 +88,6 @@ class Sampler(nn.Module):
 
         # Preprocess logits (custom processors and NaN handling)
         logits = self._preprocess_logits(logits, sampling_info)
-        print(logits)
 
         if sampling_info.is_all_greedy:
             # Use torch.argmax if all requests use greedy sampling

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -121,7 +121,7 @@ class Sampler(nn.Module):
             ):
                 logits[:] = torch.softmax(logits, dim=-1)
             probs = logits
-            del logits
+            # del logits
 
             if can_sample_directly_from_probs:
                 # when we don't need top-k, top-p, or min-p sampling, we can directly sample from the probs

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2011,7 +2011,9 @@ class Scheduler(
                     ).Event()
                     if batch_result.delay_sample_func is None:
                         self.future_map.store_to_map(future_indices, batch_result)
-                        batch_result.copy_to_cpu(return_logprob=batch.return_logprob)
+
+                        with torch.cuda.nvtx.range("copy_to_cpu"):git a
+                            batch_result.copy_to_cpu(return_logprob=batch.return_logprob)
                     else:
                         batch_result.future_indices = future_indices
 
@@ -2095,7 +2097,8 @@ class Scheduler(
             _batch_result = batch_result.delay_sample_func()
             assert _batch_result is batch_result
             self.future_map.store_to_map(batch_result.future_indices, batch_result)
-            batch_result.copy_to_cpu(return_logprob=self.cur_batch.return_logprob)
+            with torch.cuda.nvtx.range("copy_to_cpu"):
+                batch_result.copy_to_cpu(return_logprob=self.cur_batch.return_logprob)
 
     def process_batch_result(
         self,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2012,7 +2012,7 @@ class Scheduler(
                     if batch_result.delay_sample_func is None:
                         self.future_map.store_to_map(future_indices, batch_result)
 
-                        with torch.cuda.nvtx.range("copy_to_cpu"):git a
+                        with torch.cuda.nvtx.range("copy_to_cpu"):
                             batch_result.copy_to_cpu(return_logprob=batch.return_logprob)
                     else:
                         batch_result.future_indices = future_indices


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In disaggregated prefill mode with overlap scheduling, the KV transfer is currently triggered after synchronize() completes  for the previous batch on the main thread.  The transfer worker is blocked until these kernel launches finish.

<img width="720" height="532" alt="image" src="https://github.com/user-attachments/assets/8d0344d5-3f67-493b-b43f-d6d9899dc55c" />
Just like below the transfer gets delayed until the next batch's forward finishes.
<img width="1280" height="706" alt="image" src="https://github.com/user-attachments/assets/f0f52b5b-be36-443b-84c0-aac46e7bb4e0" />

This PR introduces an async transfer mode (--disaggregation-async-transfer) that triggers KV transfer immediately after the forward pass, moving set_buf() execution to transfer workers. This allows KV transfer to start earlier and overlap with CUDA synchronization and metadata filling.

To achieve this, we need to handle the resulting thread-safety issue: since set_buf() now runs in transfer workers while the main thread continues to modify Req objects, we introduce read-only snapshots (ReqMetadataView) to avoid race conditions.


Theoretically, though the sync process is very similiar to previous overlap schedule, it should not have race issue as there barely involves a cuda operation (only event sync).

## Modifications

### New Server Argument

- Added --disaggregation-async-transfer flag in server_args.py to enable async KV transfer mode

- Added validation: async transfer requires mooncake backend and overlap scheduling enabled

### New Classes in utils.py
ReqMetadataView: A lightweight, read-only snapshot of Req containing only fields needed by set_buf(). Creates deep copies of mutable data to avoid race conditions with main thread.
TransferContext: Encapsulates batch, result, and metadata buffers for shared access across requests. Includes thread-safe resolve() method that handles CUDA synchronization and calls set_buf() with snapshots.
process_logprobs_for_request(): Extracted common logprobs processing logic into a reusable function for both main thread and transfer worker usage.
### Changes in mooncake/conn.py

- Added transfer_contexts: Dict[int, TransferContext] to MooncakeKVManager for lifecycle management

- Modified transfer_worker() to call TransferContext.resolve() which populates metadata buffers asynchronously using snapshots

- Added transfer_context parameter to add_transfer_request() to pass context from sender

- Added transfer_context attribute to MooncakeKVSender

- Cleanup: remove TransferContext from dict when transfer completes

#### Changes in prefill.py

- Added maybe_notify_prefill_done(): When async transfer is enabled, creates TransferContext and triggers KV transfer immediately after forward pass (before copy_done.synchronize())

- Modified process_batch_result_disagg_prefill(): Skips send_kv_chunk() when async mode is enabled (already handled)

- Modified send_kv_chunk(): Skips synchronous set_buf() when async mode is enabled (handled by transfer worker)

- Refactored logprobs processing to use the new process_logprobs_for_request() function

### Minor Changes

- Added transfer_context = None to FakeKVSender for warmup request.

## Accuracy Tests

### QWEN 8b
``` bash
 python -m sglang.launch_server \
  --model /models/Qwen3-8B \
  --trust-remote-code \
  --watchdog-timeout "1000000" \
  --mem-fraction-static 0.8 \
  --max-running-requests 256 \
  --disaggregation-mode prefill \
  --tp-size 8 \
  --host 0.0.0.0 \
  --chunked-prefill-size 16384 \
  --attention-backend fa3 \
  --enable-metrics \
  --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_0 \
  --page-size 128  --disaggregation-async-transfer

python -m sglang.launch_server \
  --model /models/Qwen3-8B \
  --trust-remote-code \
  --watchdog-timeout "1000000" \
  --mem-fraction-static 0.8 \
  --max-running-requests 256 \
  --disaggregation-mode decode \
  --tp-size 8 \
  --host 0.0.0.0 \
  --chunked-prefill-size 16384 \
  --attention-backend fa3 \
  --enable-metrics \
  --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_0 \
  --page-size 128


python3 -m sglang.test.run_eval --port 8123 --eval-name mmlu --num-examples 200 
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=2048 self.reasoning_effort=None self.extra_body={}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:16<00:00, 11.86it/s]
Writing report to /tmp/mmlu__models_Qwen3-8B.html
{'other': np.float64(0.851063829787234), 'other:std': np.float64(0.3560255432059895), 'score:std': np.float64(0.4330127018922193), 'stem': np.float64(0.7857142857142857), 'stem:std': np.float64(0.41032590332414487), 'humanities': np.float64(0.6290322580645161), 'humanities:std': np.float64(0.48306384296361093), 'social_sciences': np.float64(0.7755102040816326), 'social_sciences:std': np.float64(0.4172458836787933), 'score': np.float64(0.75)}
Writing results to /tmp/mmlu__models_Qwen3-8B.json
Total latency: 16.905 s
Score: 0.750
```

### GLM4.6 FP8(compatible with MTP)
```

SGLANG_ENABLE_SPEC_V2=1 SGLANG_DISAGGREGATION_QUEUE_SIZE=1 SGLANG_DISAGGREGATION_THREAD_POOL_SIZE=1 MC_TE_METRIC=1 SGLANG_SET_CPU_AFFINITY=true  python -m sglang.launch_server --model /models/GLM-4.6-FP8/ --trust-remote-code --watchdog-timeout "1000000" --mem-fraction-static 0.8 --max-running-requests 40 --disaggregation-mode prefill --tp-size 8 --kv-cache-dtype fp8_e4m3 --host 0.0.0.0 --chunked-prefill-size 16384 --attention-backend fa3 --enable-metrics --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_0 --page-size 64 --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 1 --disaggregation-async-transfer


SGLANG_ENABLE_SPEC_V2=1 SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION=512 SGLANG_SET_CPU_AFFINITY=true python -m sglang.launch_server --model   /models/GLM-4.6-FP8/   --trust-remote-code --watchdog-timeout "1000000" --mem-fraction-static 0.9 --tp-size 8 --kv-cache-dtype fp8_e4m3 --disaggregation-mode decode  --prefill-round-robin-balance --host 0.0.0.0 --chunked-prefill-size 16384 --attention-backend fa3 --max-running-requests 80 --enable-metrics --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_0 --page-size 64 --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 1


python3 -m sglang.test.run_eval --port 8123 --eval-name mmlu --num-examples 200
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=2048 self.reasoning_effort=None self.extra_body={}
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [02:31<00:00,  1.32it/s]
Writing report to /tmp/mmlu__models_GLM-4.6-FP8_.html
{'other': np.float64(0.7021276595744681), 'other:std': np.float64(0.45732309064265286), 'score:std': np.float64(0.48), 'stem': np.float64(0.7380952380952381), 'stem:std': np.float64(0.43967107887189016), 'humanities': np.float64(0.45161290322580644), 'humanities:std': np.float64(0.49765318130779074), 'social_sciences': np.float64(0.7346938775510204), 'social_sciences:std': np.float64(0.4414960745466109), 'score': np.float64(0.64)}
Writing results to /tmp/mmlu__models_GLM-4.6-FP8_.json
Total latency: 151.656 s
Score: 0.640
````
The low scores is expected as stated in https://github.com/sgl-project/sglang/issues/14703


## Benchmarking and Profiling

#### Conducted on 2 8xH20 node

<img width="850" height="566" alt="image" src="https://github.com/user-attachments/assets/62590301-0f4a-4034-8873-bf9f8904b762" />
According to the timeline above, the transfer process starts right after the process finishes.

The following benchmark data is obtained from replaying our actual production traffic.

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Duration(s)** | 205.59 | 206.47 | +0.43% |
| **Input Token** | 2,694,705 | 2,702,360 | +0.28% |
| **Output Token** | 100,057 | 100,410 | +0.35% |
| **Input Throughput(Token/s)** | 13,107.38 | 13,088.34 | -0.15% |
| **Output Throughput(Token/s)** | 486.69 | 486.32 | -0.08% |
| **Requests** | 413 | 415 | +0.48% |
| **Success Requests** | 413 | 415 | +0.48% |
| **Avg Request Input Token** | 6,524 | 6,511 | -0.20% |
| **Avg Request Output Token** | 242 | 241 | -0.41% |
| **Avg TTFT(s)** | 6.10 | 5.51 | **-9.67%** |
| **P50 TTFT(s)** | 6.01 | 5.34 | **-11.15%** |
| **P90 TTFT(s)** | 10.02 | 9.52 | **-4.99%** |
| **Max TTFT(s)** | 12.57 | 12.06 | **-4.06%** |
| **Avg TPOT(ms)** | 18.92 | 20.66 | +9.20% |
| **P50 TPOT(ms)** | 18.90 | 20.80 | +10.05% |
| **P90 TPOT(ms)** | 21.98 | 23.61 | +7.42% |
| **Max TPOT(ms)** | 26.40 | 26.21 | **-0.72%** |
| **Avg E2E(s)** | 10.69 | 10.51 | **-1.68%** |
| **P50 E2E(s)** | 10.65 | 10.31 | **-3.19%** |
| **P90 E2E(s)** | 14.96 | 14.43 | **-3.54%** |
| **Max E2E(s)** | 18.05 | 18.22 | +0.94% |


### benchmark produced by bench_serving
Before:
```

USE_VLLM_FUSED_MOE_CONFIG=1 SGLANG_ENABLE_SPEC_V2=1 SGLANG_DISAGGREGATION_QUEUE_SIZE=1 SGLANG_DISAGGREGATION_THREAD_POOL_SIZE=1 MC_TE_METRIC=1 SGLANG_SET_CPU_AFFINITY=true  python -m sglang.launch_server --model /models/GLM-4.6-FP8/ --trust-remote-code --watchdog-timeout "1000000" --mem-fraction-static 0.8 --max-running-requests 40 --disaggregation-mode prefill --tp-size 8 --kv-cache-dtype fp8_e4m3 --host 0.0.0.0 --chunked-prefill-size 16384 --attention-backend fa3 --enable-metrics --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_0 --page-size 128 --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 1

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    2.0       
Max request concurrency:                 not set   
Successful requests:                     400       
Benchmark duration (s):                  195.84    
Total input tokens:                      1625305   
Total input text tokens:                 1625305   
Total input vision tokens:               0         
Total generated tokens:                  60438     
Total generated tokens (retokenized):    59709     
Request throughput (req/s):              2.04      
Input token throughput (tok/s):          8299.32   
Output token throughput (tok/s):         308.62    
Peak output token throughput (tok/s):    689.00    
Peak concurrent requests:                19        
Total token throughput (tok/s):          8607.94   
Concurrency:                             7.78      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3808.50   
Median E2E Latency (ms):                 3718.65   
---------------Time to First Token----------------
Mean TTFT (ms):                          1505.09   
Median TTFT (ms):                        1399.34   
P99 TTFT (ms):                           3790.40   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.40     
Median TPOT (ms):                        14.46     
P99 TPOT (ms):                           28.92     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           15.34     
Median ITL (ms):                         15.24     
P95 ITL (ms):                            30.63     
P99 ITL (ms):                            36.81     
Max ITL (ms):                            512.12    
==================================================
```
After:
 
````
USE_VLLM_FUSED_MOE_CONFIG=1 SGLANG_ENABLE_SPEC_V2=1 SGLANG_DISAGGREGATION_QUEUE_SIZE=1 SGLANG_DISAGGREGATION_THREAD_POOL_SIZE=1 MC_TE_METRIC=1 SGLANG_SET_CPU_AFFINITY=true  python -m sglang.launch_server --model /models/GLM-4.6-FP8/ --trust-remote-code --watchdog-timeout "1000000" --mem-fraction-static 0.8 --max-running-requests 40 --disaggregation-mode prefill --tp-size 8 --kv-cache-dtype fp8_e4m3 --host 0.0.0.0 --chunked-prefill-size 16384 --attention-backend fa3 --enable-metrics --disaggregation-ib-device mlx5_bond_1,mlx5_bond_2,mlx5_bond_3,mlx5_bond_4,mlx5_bond_5,mlx5_bond_6,mlx5_bond_7,mlx5_bond_0 --page-size 128 --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 1 --disaggregation-async-transfer


============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    2.0       
Max request concurrency:                 not set   
Successful requests:                     400       
Benchmark duration (s):                  195.75    
Total input tokens:                      1625305   
Total input text tokens:                 1625305   
Total input vision tokens:               0         
Total generated tokens:                  60438     
Total generated tokens (retokenized):    59667     
Request throughput (req/s):              2.04      
Input token throughput (tok/s):          8302.85   
Output token throughput (tok/s):         308.75    
Peak output token throughput (tok/s):    570.00    
Peak concurrent requests:                19        
Total token throughput (tok/s):          8611.59   
Concurrency:                             7.34      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   3590.33   
Median E2E Latency (ms):                 3454.36   
---------------Time to First Token----------------
Mean TTFT (ms):                          1244.10   
Median TTFT (ms):                        1142.99   
P99 TTFT (ms):                           3162.62   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.70     
Median TPOT (ms):                        14.62     
P99 TPOT (ms):                           27.14     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           15.63     
Median ITL (ms):                         15.24     
P95 ITL (ms):                            30.18     
P99 ITL (ms):                            35.81     
Max ITL (ms):                            50.44     
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
