### PR TITLE
Fix: `ReasonerGrammarBackend` can handle tokenizer that does not have "think_end_id" as attribute. (ex: GLM 4.6)

### DIFF
--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -50,11 +50,9 @@ class ReasonerGrammarObject(BaseGrammarObject):
             self.tokens_after_think_end -= 1
 
     def accept_token(self, token: int):
-        is_accepted = True
         if self.tokens_after_think_end >= 0:
-            is_accepted = self.grammar.accept_token(token)
+            self.grammar.accept_token(token)
         self.transfer_state(token)
-        return is_accepted
 
     def is_terminated(self):
         return self.grammar.is_terminated()

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -50,9 +50,11 @@ class ReasonerGrammarObject(BaseGrammarObject):
             self.tokens_after_think_end -= 1
 
     def accept_token(self, token: int):
+        is_accepted = True
         if self.tokens_after_think_end >= 0:
-            self.grammar.accept_token(token)
+            is_accepted = self.grammar.accept_token(token)
         self.transfer_state(token)
+        return is_accepted
 
     def is_terminated(self):
         return self.grammar.is_terminated()

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -73,16 +73,11 @@ class XGrammarGrammar(BaseGrammarObject):
     def accept_token(self, token: int):
         if not self.is_terminated():
             self.current_token = token
-            accepted = self.matcher.accept_token(token)
-            if not accepted:
-                # log for debugging
-                raise ValueError(
-                    f"Tokens not accepted: {token}\n"
-                    f"Accepted tokens: {self.accepted_tokens}\n"
-                    f"Key string: {self.key_string}"
-                )
-            else:
+            is_accepted = self.matcher.accept_token(token)
+            if is_accepted:
                 self.accepted_tokens.append(token)
+            return is_accepted
+        return False
 
     def rollback(self, k: int):
         self.matcher.rollback(k)

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -73,16 +73,12 @@ class XGrammarGrammar(BaseGrammarObject):
     def accept_token(self, token: int):
         if not self.is_terminated():
             self.current_token = token
-            accepted = self.matcher.accept_token(token)
-            if not accepted:
-                # log for debugging
-                raise ValueError(
-                    f"Tokens not accepted: {token}\n"
-                    f"Accepted tokens: {self.accepted_tokens}\n"
-                    f"Key string: {self.key_string}"
-                )
-            else:
+            is_accepted = self.matcher.accept_token(token)
+            if is_accepted:
                 self.accepted_tokens.append(token)
+            # rather than crash the server loudly, silently return is_accepted
+            return is_accepted
+        return False
 
     def rollback(self, k: int):
         self.matcher.rollback(k)

--- a/python/sglang/srt/constrained/xgrammar_backend.py
+++ b/python/sglang/srt/constrained/xgrammar_backend.py
@@ -73,11 +73,16 @@ class XGrammarGrammar(BaseGrammarObject):
     def accept_token(self, token: int):
         if not self.is_terminated():
             self.current_token = token
-            is_accepted = self.matcher.accept_token(token)
-            if is_accepted:
+            accepted = self.matcher.accept_token(token)
+            if not accepted:
+                # log for debugging
+                raise ValueError(
+                    f"Tokens not accepted: {token}\n"
+                    f"Accepted tokens: {self.accepted_tokens}\n"
+                    f"Key string: {self.key_string}"
+                )
+            else:
                 self.accepted_tokens.append(token)
-            return is_accepted
-        return False
 
     def rollback(self, k: int):
         self.matcher.rollback(k)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -354,6 +354,9 @@ class Envs:
     # Numa
     SGLANG_NUMA_BIND_V2 = EnvBool(True)
 
+    # Reasoning Grammar
+    SGLANG_TOKENIZER_THINK_END_TOKEN_ID = EnvInt(-1)
+
     # fmt: on
 
 

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -77,7 +77,7 @@ class BaseFormatDetector(ABC):
         for act in action:
             name = act.get("name")
             if not (name and name in tool_indices):
-                logger.warning(f"Model attempted to call undefined function: {name}")
+                logger.warning(f"Model attempted to call undefined function: {name}, Available tools: {tool_indices}")
                 if not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get():
                     continue  # Skip unknown tools (default legacy behavior)
 

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -175,12 +175,15 @@ class NgramVerifyInput(SpecInput):
                     break
                 else:
                     if req.grammar is not None:
-                        is_accepted = req.grammar.accept_token(id)
-                        assert is_accepted is not None
-                        if not is_accepted:
-                            has_finished = True
-                            self.accept_index[i, j+1:] = -1
-                            break
+                        try:
+                            req.grammar.accept_token(id)
+                        except ValueError as e:
+                            logger.info(
+                                f"{i=}, {req=}\n"
+                                f"{self.accept_index=}\n"
+                                f"{self.predict=}\n"
+                            )
+                            raise e
             req.spec_verify_ct += 1
             req.spec_accepted_tokens += (
                 sum(1 for idx in accept_index_row if idx != -1) - 1

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -199,7 +199,7 @@ class NgramVerifyInput(SpecInput):
                             # ted_size=0
                             # ```
                             logger.error("Grammar rejected")
-                            req.grammar.rollback(0)
+                            # req.grammar.rollback(0)
                             self.accept_index[i, j + 1:] = -1
                             break
                         is_accepting = is_accepted

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -198,6 +198,9 @@ class NgramVerifyInput(SpecInput):
                             # al_num_tokens=462400, available_size=378013, evictable_size=84388, protec
                             # ted_size=0
                             # ```
+                            logger.error("Grammar rejected")
+                            # req.grammar.force_terminate = True
+                            req.grammar.rollback(0)
                             self.accept_index[i, j + 1:] = -1
                             break
                         is_accepting = is_accepted

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -199,7 +199,6 @@ class NgramVerifyInput(SpecInput):
                             # ted_size=0
                             # ```
                             logger.error("Grammar rejected")
-                            # req.grammar.force_terminate = True
                             req.grammar.rollback(0)
                             self.accept_index[i, j + 1:] = -1
                             break

--- a/python/sglang/srt/speculative/ngram_info.py
+++ b/python/sglang/srt/speculative/ngram_info.py
@@ -175,15 +175,12 @@ class NgramVerifyInput(SpecInput):
                     break
                 else:
                     if req.grammar is not None:
-                        try:
-                            req.grammar.accept_token(id)
-                        except ValueError as e:
-                            logger.info(
-                                f"{i=}, {req=}\n"
-                                f"{self.accept_index=}\n"
-                                f"{self.predict=}\n"
-                            )
-                            raise e
+                        is_accepted = req.grammar.accept_token(id)
+                        assert is_accepted is not None
+                        if not is_accepted:
+                            has_finished = True
+                            self.accept_index[i, j+1:] = -1
+                            break
             req.spec_verify_ct += 1
             req.spec_accepted_tokens += (
                 sum(1 for idx in accept_index_row if idx != -1) - 1


### PR DESCRIPTION
## Find Thinking End Token More Smart

In GLM 4.6, the "think_end_id" attribute does not exist in the tokenizer. Therefore, the current logic to detect the think end token ID could not detect the think end token IDs even if the reasoning parser is activated. 

```py
import transformers
tokenizer = transformers.AutoTokenizer.from_pretrained("zai-org/GLM-4.6-FP8")
hasattr(tokenizer, "think_end_id")
>>>>>
False
```

To fix this, I improved the `create_grammar_backend` function in `python/sglang/srt/constrained/base_grammar_backend.py`.

## Prevent Server Crash When Grammar is Wrong

In a previous setting, if the grammar is wrong and any tokens are accepted, the server decoding loop crashes.

To prevent this, I changed `accept_token` to return the `is_accepted` value. This fix will also silently fix the thinking grammar bug. (non-grammar content prefix.)

---

I tested with GLM 4.6 FP8, 8x H100 80GB.

Thanks!