### PR TITLE
fix rope parameter initialization error caused by transformers v5.0 update

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -80,7 +80,7 @@ def get_nsa_index_n_heads(config: PretrainedConfig) -> int:
     return config.index_n_heads
 
 
-def handle_rope_parameters(config: PretrainedConfig) -> PretrainedConfig:
+def handle_rope_parameters(config: PretrainedConfig):
     if hasattr(config, "rope_scaling"):
         rope_scaling = config.rope_scaling
         if isinstance(rope_scaling, dict):

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -80,6 +80,16 @@ def get_nsa_index_n_heads(config: PretrainedConfig) -> int:
     return config.index_n_heads
 
 
+def handle_rope_parameters(config: PretrainedConfig) -> PretrainedConfig:
+    if hasattr(config, "rope_scaling"):
+        rope_scaling = config.rope_scaling
+        if isinstance(rope_scaling, dict):
+            for k, v in rope_scaling.items():
+                if not hasattr(config, k):
+                    setattr(config, k, v)
+    return
+
+
 class ModelConfig:
     def __init__(
         self,
@@ -127,6 +137,8 @@ class ModelConfig:
             **kwargs,
         )
         self.hf_text_config = get_hf_text_config(self.hf_config)
+        handle_rope_parameters(self.hf_text_config)
+        handle_rope_parameters(self.hf_config)
         self.hf_generation_config = get_generation_config(
             self.model_path,
             trust_remote_code=trust_remote_code,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation



Many model configurations (e.g., Qwen3) follow a structure where `rope_theta` is located at the top level of the configuration dictionary.

**Example Config:**
```json
{
  "architectures": ["Qwen3ForCausalLM"],
  "model_type": "qwen3",
  "rope_scaling": null,
  "rope_theta": 1000000,
  "transformers_version": "4.51.0",
  ...
}
```

Legacy modeling code typically retrieves this parameter directly via `getattr(config, "rope_theta", None)`.

### The Issue
With the upgrade to **Transformers 5.0.0rc0+**, RoPE-related parameters (including `rope_theta`) are no longer guaranteed to be at the root level. They must often be retrieved from `config.rope_scaling` or `config.rope_parameters`.

This causes backward compatibility issues where models fail to load the correct RoPE configuration, leading to incorrect calculations or runtime errors.

### Temporary Solution
To quickly resolve this and maintain compatibility without rewriting every model architecture immediately, we introduce a temporary helper function: `handle_rope_parameters`.

```python
def handle_rope_parameters(config: PretrainedConfig) -> PretrainedConfig:
    """
    Temporary workaround to flatten rope_scaling parameters back into the main config
    for backward compatibility with Transformers v5.0+.
    """
    if hasattr(config, "rope_scaling"):
        rope_scaling = config.rope_scaling
        if isinstance(rope_scaling, dict):
            for k, v in rope_scaling.items():
                # If the parameter is missing in the root config, inject it from rope_scaling
                if not hasattr(config, k):
                    setattr(config, k, v)
    return
```

**Logic:**
This function checks if `rope_scaling` exists and is a dictionary. It then iterates through the keys (e.g., `rope_theta`, `type`, etc.) and sets them as direct attributes of the `config` object if they are missing. This allows existing modeling code to continue using `config.rope_theta` without modification.

### Long-term Goal
While the above solution works as a patch, the correct long-term fix is to refactor the modeling code for each architecture. We should update the models to natively fetch parameters from `config.rope_scaling` or `config.rope_parameters` instead of relying on this flattening workaround.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
