### PR TITLE
fix: making rate limit a warning instead of error 

### DIFF
--- a/scripts/ci/publish_traces.py
+++ b/scripts/ci/publish_traces.py
@@ -340,15 +340,15 @@ def publish_traces(traces_dir, run_id, run_number):
                 error_type = f"HTTP {e.code}"
 
             # Check for rate limit errors (non-fatal - just warn and skip)
-            if isinstance(e, HTTPError) and e.code == 403:
-                if (
-                    hasattr(e, "error_body")
-                    and "rate limit exceeded" in e.error_body.lower()
-                ):
-                    warnings.warn(
-                        "GitHub API rate limit exceeded. Skipping trace upload."
-                    )
-                    return
+            if (
+                isinstance(e, HTTPError)
+                and e.code in [403, 429]
+                and "rate limit exceeded" in getattr(e, "error_body", "").lower()
+            ):
+                warnings.warn(
+                    "GitHub API rate limit exceeded. Skipping trace upload."
+                )
+                return
 
             if is_retryable and attempt < max_retries - 1:
                 print(

--- a/scripts/ci/publish_traces.py
+++ b/scripts/ci/publish_traces.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 import time
+import warnings
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
@@ -337,6 +338,17 @@ def publish_traces(traces_dir, run_id, run_number):
             if isinstance(e, HTTPError) and e.code in [422, 500, 502, 503, 504]:
                 is_retryable = True
                 error_type = f"HTTP {e.code}"
+
+            # Check for rate limit errors (non-fatal - just warn and skip)
+            if isinstance(e, HTTPError) and e.code == 403:
+                if (
+                    hasattr(e, "error_body")
+                    and "rate limit exceeded" in e.error_body.lower()
+                ):
+                    warnings.warn(
+                        "GitHub API rate limit exceeded. Skipping trace upload."
+                    )
+                    return
 
             if is_retryable and attempt < max_retries - 1:
                 print(

--- a/scripts/ci/publish_traces.py
+++ b/scripts/ci/publish_traces.py
@@ -345,9 +345,7 @@ def publish_traces(traces_dir, run_id, run_number):
                 and e.code in [403, 429]
                 and "rate limit exceeded" in getattr(e, "error_body", "").lower()
             ):
-                warnings.warn(
-                    "GitHub API rate limit exceeded. Skipping trace upload."
-                )
+                warnings.warn("GitHub API rate limit exceeded. Skipping trace upload.")
                 return
 
             if is_retryable and attempt < max_retries - 1:


### PR DESCRIPTION
## Motivation

Currently, when API rate limits are hit, the script fails and marks the CI job as failed, even though the actual tests passed. This PR treats rate limit errors as warnings instead of failures, since trace uploads are optional and shouldn't block CI success.

From lianmin:
> make the rate limit a warning instead of error https://github.com/sgl-project/sglang/actions/runs/20047593006/job/57496485946#step:6:27

## Modifications

Added warning for rate limit error 403.

## Accuracy Tests

(https://github.com/sgl-project/sglang/actions/runs/20077062056/job/57594163954)

## Benchmarking and Profiling

N/A.

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [n/a] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [n/a] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
