### PR TITLE
fix: race condition between validation and download locks

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -263,13 +263,19 @@ def get_quant_config(
         return quant_cls.from_config(config)
 
 
-def find_local_hf_snapshot_dir(
+def _find_local_hf_snapshot_dir_unlocked(
     model_name_or_path: str,
     cache_dir: Optional[str],
     allow_patterns: List[str],
     revision: Optional[str] = None,
 ) -> Optional[str]:
-    """If the weights are already local, skip downloading and returns the path."""
+    """Find local HF snapshot directory without locking.
+
+    IMPORTANT: Caller MUST hold the model lock before calling this function
+    to prevent race conditions during validation and cleanup.
+
+    If the weights are already local, skip downloading and returns the path.
+    """
     if os.path.isdir(model_name_or_path):
         return None
 
@@ -315,124 +321,143 @@ def find_local_hf_snapshot_dir(
     if found_local_snapshot_dir is None:
         return None
 
+    # Check if snapshot dir exists (might have been cleaned by another process
+    # before we acquired the lock)
+    if not os.path.isdir(found_local_snapshot_dir):
+        return None
+
+    # Check for incomplete files and clean up if found
+    repo_folder = os.path.abspath(
+        os.path.join(found_local_snapshot_dir, "..", "..")
+    )
+    blobs_dir = os.path.join(repo_folder, "blobs")
+
+    # Check for incomplete download markers
+    incomplete_files = []
+    if os.path.isdir(blobs_dir):
+        incomplete_files = glob.glob(os.path.join(blobs_dir, "*.incomplete"))
+
+    if incomplete_files:
+        log_info_on_rank0(
+            logger,
+            f"Found {len(incomplete_files)} .incomplete files in {blobs_dir} for "
+            f"{model_name_or_path}. Will clean up and re-download.",
+        )
+        _cleanup_corrupted_model_cache(
+            model_name_or_path,
+            found_local_snapshot_dir,
+            f"Incomplete download detected ({len(incomplete_files)} incomplete files)",
+        )
+        return None
+
+    local_weight_files: List[str] = []
+    try:
+        for pattern in allow_patterns:
+            matched_files = glob.glob(
+                os.path.join(found_local_snapshot_dir, pattern)
+            )
+            for f in matched_files:
+                # os.path.exists returns False for broken symlinks.
+                if not os.path.exists(f):
+                    continue
+                local_weight_files.append(f)
+    except Exception as e:
+        logger.warning(
+            "Failed to scan local snapshot %s with patterns %s: %s",
+            found_local_snapshot_dir,
+            allow_patterns,
+            e,
+        )
+        local_weight_files = []
+
+    # Validate sharded models and check for corruption
+    if local_weight_files:
+        is_valid, error_msg, corrupted_files = _validate_sharded_model(
+            found_local_snapshot_dir, local_weight_files
+        )
+        if not is_valid:
+            if corrupted_files:
+                # Selective cleanup: only remove corrupted files
+                log_info_on_rank0(
+                    logger,
+                    f"Found {len(corrupted_files)} corrupted file(s) for "
+                    f"{model_name_or_path}: {error_msg}. "
+                    "Will selectively clean and re-download only these files.",
+                )
+                _cleanup_corrupted_files_selective(
+                    model_name_or_path, corrupted_files
+                )
+                return None
+            else:
+                # Cannot selectively clean (e.g., missing shards) - remove entire cache
+                log_info_on_rank0(
+                    logger,
+                    f"Validation failed for {model_name_or_path}: {error_msg}. "
+                    "Will remove entire cache and re-download.",
+                )
+                _cleanup_corrupted_model_cache(
+                    model_name_or_path, found_local_snapshot_dir, error_msg
+                )
+                return None
+
+        # Also validate single (non-sharded) safetensors files
+        for f in local_weight_files:
+            base_name = os.path.basename(f)
+            # Check if this is a single model file (not sharded)
+            # Include adapter_model.safetensors for LoRA adapters
+            if base_name in [
+                "model.safetensors",
+                "pytorch_model.safetensors",
+                "adapter_model.safetensors",
+            ]:
+                if not _validate_safetensors_file(f):
+                    log_info_on_rank0(
+                        logger,
+                        f"Corrupted model file {base_name} for {model_name_or_path}. "
+                        "Will selectively clean and re-download this file.",
+                    )
+                    # Selective cleanup for single file
+                    _cleanup_corrupted_files_selective(model_name_or_path, [f])
+                    return None
+
+    if len(local_weight_files) > 0:
+        log_info_on_rank0(
+            logger,
+            f"Found local HF snapshot for {model_name_or_path} at "
+            f"{found_local_snapshot_dir}; skipping download.",
+        )
+        return found_local_snapshot_dir
+    else:
+        log_info_on_rank0(
+            logger,
+            f"Local HF snapshot at {found_local_snapshot_dir} has no files matching "
+            f"{allow_patterns}; will attempt download.",
+        )
+        return None
+
+
+def find_local_hf_snapshot_dir(
+    model_name_or_path: str,
+    cache_dir: Optional[str],
+    allow_patterns: List[str],
+    revision: Optional[str] = None,
+) -> Optional[str]:
+    """If the weights are already local, skip downloading and returns the path.
+
+    This function acquires a lock to prevent race conditions during validation
+    and cleanup. For use within download_weights_from_hf, use
+    _find_local_hf_snapshot_dir_unlocked instead with an external lock.
+    """
+    # For local paths, no locking needed
+    if os.path.isdir(model_name_or_path):
+        return None
+
     # Use file lock to prevent multiple processes (TP ranks) from
     # validating and cleaning up the same model cache simultaneously.
-    # This prevents race conditions where multiple ranks detect corruption
-    # and try to delete the same files at the same time.
-    with get_lock(model_name_or_path, cache_dir, suffix="-validation"):
-        # Re-check if snapshot dir still exists after acquiring lock
-        # (another process may have already cleaned it up)
-        if not os.path.isdir(found_local_snapshot_dir):
-            return None
-
-        # Check for incomplete files and clean up if found
-        repo_folder = os.path.abspath(
-            os.path.join(found_local_snapshot_dir, "..", "..")
+    with get_lock(model_name_or_path, cache_dir):
+        return _find_local_hf_snapshot_dir_unlocked(
+            model_name_or_path, cache_dir, allow_patterns, revision
         )
-        blobs_dir = os.path.join(repo_folder, "blobs")
-
-        # Check for incomplete download markers
-        incomplete_files = []
-        if os.path.isdir(blobs_dir):
-            incomplete_files = glob.glob(os.path.join(blobs_dir, "*.incomplete"))
-
-        if incomplete_files:
-            log_info_on_rank0(
-                logger,
-                f"Found {len(incomplete_files)} .incomplete files in {blobs_dir} for "
-                f"{model_name_or_path}. Will clean up and re-download.",
-            )
-            _cleanup_corrupted_model_cache(
-                model_name_or_path,
-                found_local_snapshot_dir,
-                f"Incomplete download detected ({len(incomplete_files)} incomplete files)",
-            )
-            return None
-
-        local_weight_files: List[str] = []
-        try:
-            for pattern in allow_patterns:
-                matched_files = glob.glob(
-                    os.path.join(found_local_snapshot_dir, pattern)
-                )
-                for f in matched_files:
-                    # os.path.exists returns False for broken symlinks.
-                    if not os.path.exists(f):
-                        continue
-                    local_weight_files.append(f)
-        except Exception as e:
-            logger.warning(
-                "Failed to scan local snapshot %s with patterns %s: %s",
-                found_local_snapshot_dir,
-                allow_patterns,
-                e,
-            )
-            local_weight_files = []
-
-        # Validate sharded models and check for corruption
-        if local_weight_files:
-            is_valid, error_msg, corrupted_files = _validate_sharded_model(
-                found_local_snapshot_dir, local_weight_files
-            )
-            if not is_valid:
-                if corrupted_files:
-                    # Selective cleanup: only remove corrupted files
-                    log_info_on_rank0(
-                        logger,
-                        f"Found {len(corrupted_files)} corrupted file(s) for "
-                        f"{model_name_or_path}: {error_msg}. "
-                        "Will selectively clean and re-download only these files.",
-                    )
-                    _cleanup_corrupted_files_selective(
-                        model_name_or_path, corrupted_files
-                    )
-                    return None
-                else:
-                    # Cannot selectively clean (e.g., missing shards) - remove entire cache
-                    log_info_on_rank0(
-                        logger,
-                        f"Validation failed for {model_name_or_path}: {error_msg}. "
-                        "Will remove entire cache and re-download.",
-                    )
-                    _cleanup_corrupted_model_cache(
-                        model_name_or_path, found_local_snapshot_dir, error_msg
-                    )
-                    return None
-
-            # Also validate single (non-sharded) safetensors files
-            for f in local_weight_files:
-                base_name = os.path.basename(f)
-                # Check if this is a single model file (not sharded)
-                # Include adapter_model.safetensors for LoRA adapters
-                if base_name in [
-                    "model.safetensors",
-                    "pytorch_model.safetensors",
-                    "adapter_model.safetensors",
-                ]:
-                    if not _validate_safetensors_file(f):
-                        log_info_on_rank0(
-                            logger,
-                            f"Corrupted model file {base_name} for {model_name_or_path}. "
-                            "Will selectively clean and re-download this file.",
-                        )
-                        # Selective cleanup for single file
-                        _cleanup_corrupted_files_selective(model_name_or_path, [f])
-                        return None
-
-        if len(local_weight_files) > 0:
-            log_info_on_rank0(
-                logger,
-                f"Found local HF snapshot for {model_name_or_path} at "
-                f"{found_local_snapshot_dir}; skipping download.",
-            )
-            return found_local_snapshot_dir
-        else:
-            log_info_on_rank0(
-                logger,
-                f"Local HF snapshot at {found_local_snapshot_dir} has no files matching "
-                f"{allow_patterns}; will attempt download.",
-            )
-            return None
 
 
 def _validate_weights_after_download(
@@ -508,34 +533,41 @@ def download_weights_from_hf(
     Returns:
         str: The path to the downloaded model weights.
     """
+    # For local paths, no HF operations needed
+    if os.path.isdir(model_name_or_path):
+        return model_name_or_path
 
-    # Always check for valid local cache first.
-    # This validates cached files and cleans up corrupted ones.
-    path = find_local_hf_snapshot_dir(
-        model_name_or_path, cache_dir, allow_patterns, revision
-    )
-    if path is not None:
-        # Valid local cache found, skip download
-        return path
-
-    # In CI, skip HF API calls if we're in offline mode or want to avoid rate limits
-    # But we already checked for local cache above, so if we're here we need to download
-    if not huggingface_hub.constants.HF_HUB_OFFLINE:
-        # Before we download we look at what is available:
-        fs = HfFileSystem()
-        file_list = fs.ls(model_name_or_path, detail=False, revision=revision)
-
-        # depending on what is available we download different things
-        for pattern in allow_patterns:
-            matching = fnmatch.filter(file_list, pattern)
-            if len(matching) > 0:
-                allow_patterns = [pattern]
-                break
-
-    log_info_on_rank0(logger, f"Using model weights format {allow_patterns}")
-    # Use file lock to prevent multiple processes from
-    # downloading the same model weights at the same time.
+    # Use a SINGLE lock for the entire operation (validation + cleanup + download)
+    # to prevent race conditions where:
+    # 1. Process A validates, finds corruption, deletes corrupted file
+    # 2. Process B validates, sees missing file, deletes ENTIRE cache
+    # 3. Process A tries to download but cache is gone
+    # By using one lock, validation/cleanup and download are atomic.
     with get_lock(model_name_or_path, cache_dir):
+        # Check for valid local cache first (validates and cleans up if needed)
+        path = _find_local_hf_snapshot_dir_unlocked(
+            model_name_or_path, cache_dir, allow_patterns, revision
+        )
+        if path is not None:
+            # Valid local cache found, skip download
+            return path
+
+        # In CI, skip HF API calls if we're in offline mode or want to avoid rate limits
+        # But we already checked for local cache above, so if we're here we need to download
+        if not huggingface_hub.constants.HF_HUB_OFFLINE:
+            # Before we download we look at what is available:
+            fs = HfFileSystem()
+            file_list = fs.ls(model_name_or_path, detail=False, revision=revision)
+
+            # depending on what is available we download different things
+            for pattern in allow_patterns:
+                matching = fnmatch.filter(file_list, pattern)
+                if len(matching) > 0:
+                    allow_patterns = [pattern]
+                    break
+
+        log_info_on_rank0(logger, f"Using model weights format {allow_patterns}")
+
         hf_folder = snapshot_download(
             model_name_or_path,
             allow_patterns=allow_patterns,
@@ -546,10 +578,10 @@ def download_weights_from_hf(
             local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
         )
 
-    # Validate downloaded files to catch corruption early
-    _validate_weights_after_download(hf_folder, allow_patterns, model_name_or_path)
+        # Validate downloaded files to catch corruption early
+        _validate_weights_after_download(hf_folder, allow_patterns, model_name_or_path)
 
-    return hf_folder
+        return hf_folder
 
 
 def download_safetensors_index_file_from_hf(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -327,9 +327,7 @@ def _find_local_hf_snapshot_dir_unlocked(
         return None
 
     # Check for incomplete files and clean up if found
-    repo_folder = os.path.abspath(
-        os.path.join(found_local_snapshot_dir, "..", "..")
-    )
+    repo_folder = os.path.abspath(os.path.join(found_local_snapshot_dir, "..", ".."))
     blobs_dir = os.path.join(repo_folder, "blobs")
 
     # Check for incomplete download markers
@@ -353,9 +351,7 @@ def _find_local_hf_snapshot_dir_unlocked(
     local_weight_files: List[str] = []
     try:
         for pattern in allow_patterns:
-            matched_files = glob.glob(
-                os.path.join(found_local_snapshot_dir, pattern)
-            )
+            matched_files = glob.glob(os.path.join(found_local_snapshot_dir, pattern))
             for f in matched_files:
                 # os.path.exists returns False for broken symlinks.
                 if not os.path.exists(f):
@@ -384,9 +380,7 @@ def _find_local_hf_snapshot_dir_unlocked(
                     f"{model_name_or_path}: {error_msg}. "
                     "Will selectively clean and re-download only these files.",
                 )
-                _cleanup_corrupted_files_selective(
-                    model_name_or_path, corrupted_files
-                )
+                _cleanup_corrupted_files_selective(model_name_or_path, corrupted_files)
                 return None
             else:
                 # Cannot selectively clean (e.g., missing shards) - remove entire cache


### PR DESCRIPTION
## Summary
- Fix a race condition in weight validation that could cause the entire model cache to be deleted when only a single file was corrupted
- Use a single lock for the entire validation + cleanup + download operation

## Root Cause
The race condition occurred because validation/cleanup and download used **separate locks**:
- Validation lock: `get_lock(..., suffix="-validation")`
- Download lock: `get_lock(...)` (no suffix)

This created a window where:
1. **TP0** holds validation lock → detects corruption → deletes corrupted file → releases lock
2. **TP2** immediately acquires validation lock → sees missing file → **deletes entire model**
3. **TP0** tries to download but model directory is gone

## Solution
Use a **single lock** for the entire operation (validation + cleanup + download):

1. Renamed `find_local_hf_snapshot_dir` to `_find_local_hf_snapshot_dir_unlocked` - internal function without lock (caller must hold lock)
2. Added new `find_local_hf_snapshot_dir` as public wrapper with lock for external callers
3. Modified `download_weights_from_hf` to use single lock covering both validation/cleanup AND download

## Test plan
- [x] Test with multi-TP setup and corrupted safetensor file
- [ ] Verify only corrupted file is re-downloaded, not entire model

Fixes #14754