### PR TITLE
Enable TRT Allreduce Fusion by default for compatible models

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1348,6 +1348,7 @@ class ServerArgs:
             and not self.enable_dp_attention
             and self.nnodes == 1
             and not is_h20_device
+            and self.moe_a2a_backend == "none"
         ):
             self.enable_flashinfer_allreduce_fusion = True
             logger.info(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -39,6 +39,7 @@ from sglang.srt.utils.common import (
     get_bool_env_var,
     get_device,
     get_device_memory_capacity,
+    get_device_name,
     get_device_sm,
     is_blackwell,
     is_blackwell_supported,
@@ -1079,12 +1080,6 @@ class ServerArgs:
 
             # common to all Deepseek MoE models
             if is_cuda() and is_sm100_supported():
-                # workaround for https://github.com/flashinfer-ai/flashinfer/issues/2006
-                if not self.enable_dp_attention and self.nnodes == 1:
-                    self.enable_flashinfer_allreduce_fusion = True
-                    logger.info(
-                        "Enable FlashInfer AllReduce Fusion on sm100 for DeepseekV3ForCausalLM"
-                    )
                 quantization_config = getattr(hf_config, "quantization_config", None)
                 quant_method = (
                     quantization_config.get("quant_method")
@@ -1136,13 +1131,6 @@ class ServerArgs:
                 f"- Decode: {decode_attn_backend}\n"
             )
 
-            if is_blackwell_supported():
-                # workaround for https://github.com/flashinfer-ai/flashinfer/issues/2006
-                if not self.enable_dp_attention and self.nnodes == 1:
-                    self.enable_flashinfer_allreduce_fusion = True
-                    logger.info(
-                        "Enable FlashInfer AllReduce Fusion on sm100 for GptOssForCausalLM"
-                    )
             quantization_config = getattr(hf_config, "quantization_config", None)
             is_mxfp4_quant_format = (
                 quantization_config is not None
@@ -1340,6 +1328,31 @@ class ServerArgs:
                     "overlap schedule currently, try to use --disable-radix-cache if overlap schedule is necessary"
                 )
                 self.disable_overlap_schedule = True
+
+        # TRTLLM AllReduce Fusion supports SM90/100/120, enable it by default
+        # for models with explicit support (DeepseekV3, GptOss, Glm4Moe, Qwen3Moe)
+        # TODO: currently, it is only supported in the single node scenario. https://github.com/flashinfer-ai/flashinfer/issues/2006
+        # TODO: there is currently a bug on H20 device specifically, https://github.com/flashinfer-ai/flashinfer/issues/2204
+        device_name = get_device_name()
+        is_h20_device = "H20" in device_name and "H200" not in device_name
+        if (
+            not self.enable_flashinfer_allreduce_fusion
+            and model_arch
+            in [
+                "DeepseekV3ForCausalLM",
+                "GptOssForCausalLM",
+                "Glm4MoeForCausalLM",
+                "Qwen3MoeForCausalLM",
+            ]
+            and (is_sm90_supported() or is_blackwell_supported())
+            and not self.enable_dp_attention
+            and self.nnodes == 1
+            and not is_h20_device
+        ):
+            self.enable_flashinfer_allreduce_fusion = True
+            logger.info(
+                f"Enable FlashInfer AllReduce Fusion by default for {model_arch}"
+            )
 
     def _handle_sampling_backend(self):
         if self.sampling_backend is None:

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -226,14 +226,14 @@ def is_blackwell():
 
 @lru_cache(maxsize=1)
 def is_blackwell_supported(device=None) -> bool:
-    if not is_cuda_alike():
+    if not is_cuda():
         return False
     return is_sm100_supported(device) or is_sm120_supported(device)
 
 
 @lru_cache(maxsize=1)
 def is_sm120_supported(device=None) -> bool:
-    if not is_cuda_alike():
+    if not is_cuda():
         return False
     return (torch.cuda.get_device_capability(device)[0] == 12) and (
         torch.version.cuda >= "12.8"


### PR DESCRIPTION
It can work on SM90+.

Note that it will increase the startup time about +-3 minutes.

H200
```
python -m sglang.bench_one_batch \
  --model-path /opt/dlami/nvme/models/DeepSeek-V3.1/ \
  --tp-size 8 \
  --batch-size 16 \
  --input-len 512 \
  --output-len 512 \
  --mem-fraction-static 0.8 \
  --enable-flashinfer-allreduce-fusion
  
Prefill. latency: 0.28894 s, throughput:  28351.92 token/s
Decode 0. Batch size: 16, latency: 0.01517 s, throughput:   1054.84 token/s
Decode 1. Batch size: 16, latency: 0.01519 s, throughput:   1053.27 token/s
Decode 2. Batch size: 16, latency: 0.01521 s, throughput:   1051.92 token/s
Decode 3. Batch size: 16, latency: 0.01532 s, throughput:   1044.51 token/s
Decode 4. Batch size: 16, latency: 0.01539 s, throughput:   1039.74 token/s
Decode.  median latency: 0.01620 s, median throughput:    987.90 token/s
Total. latency:  8.562 s, throughput:   1913.55 token/s

w/o:

Prefill. latency: 0.28827 s, throughput:  28418.14 token/s
Decode 0. Batch size: 16, latency: 0.01632 s, throughput:    980.22 token/s
Decode 1. Batch size: 16, latency: 0.01582 s, throughput:   1011.56 token/s
Decode 2. Batch size: 16, latency: 0.01684 s, throughput:    950.34 token/s
Decode 3. Batch size: 16, latency: 0.01615 s, throughput:    990.96 token/s
Decode 4. Batch size: 16, latency: 0.01565 s, throughput:   1022.64 token/s
Decode.  median latency: 0.01690 s, median throughput:    946.70 token/s
Total. latency:  8.909 s, throughput:   1839.10 token/s
```

So around 4%.

For Qwen3, in https://github.com/sgl-project/sglang/pull/9973

https://sgl-fru7574.slack.com/archives/C09NG5Q0LEP/p1765257463116389