### PR TITLE
handling incomplete rope_scaling confign ci after transformers upgrade

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1287,7 +1287,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
             if "factor" not in rope_scaling:
-                rope_scaling["factor"] = 40
+                rope_scaling["factor"] = 4096
             if "original_max_position_embeddings" not in rope_scaling:
                 rope_scaling["original_max_position_embeddings"] = 4096
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1286,6 +1286,10 @@ class DeepseekV2AttentionMLA(nn.Module):
         # NOTE modification to rope_scaling must be done early enough, b/c e.g. Indexer needs it
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
+            if "factor" not in rope_scaling:
+                rope_scaling["factor"] = 40
+            if "original_max_position_embeddings" not in rope_scaling:
+                rope_scaling["original_max_position_embeddings"] = 4096
 
         # For tensor parallel attention
         if self.q_lora_rank is not None:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1287,7 +1287,7 @@ class DeepseekV2AttentionMLA(nn.Module):
         if rope_scaling:
             rope_scaling["rope_type"] = "deepseek_yarn"
             if "factor" not in rope_scaling:
-                rope_scaling["factor"] = 4096
+                rope_scaling["factor"] = 40
             if "original_max_position_embeddings" not in rope_scaling:
                 rope_scaling["original_max_position_embeddings"] = 4096
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In previous versions, if `rope_scaling` was not empty, sglang would assume that certain keys existed in `rope_scaling` by default.

During the upgrade, many RoPE-related parameters were moved into `rope_scaling`, which caused many `rope_scaling` fields to become non-empty. As a result, the above assumption no longer holds.

Specifically for this issue:

The `rope_scaling` in the config of `lmsys/sglang-ci-dsv3-test` is `null` (which is incomplete, since it is inconsistent with dpskv3).
Under older versions of Transformers, sglang detected that `rope_scaling` was `null`, so it did not throw an error.
In newer versions of Transformers, `rope_scaling` is no longer `null`; instead, it contains values such as `rope_type` and `rope_theta`. sglang then assumes that keys like `factor` and `original_max_position_embeddings` also exist in `rope_scaling`, which leads to errors.

I believe that a proper model config would not trigger this problem. The root cause is the incomplete config of `lmsys/sglang-ci-dsv3-test`, so I applied a targeted fix for it.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
