### PR TITLE
fix b200 ci

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -171,7 +171,7 @@ suites = {
         TestFile("test_deepseek_v3_fp4_4gpu.py", 1800),
         TestFile("test_flash_attention_4.py", 300),
         TestFile("test_fp8_blockwise_gemm.py", 280),
-        TestFile("test_gpt_oss_1gpu.py", 300),
+        TestFile("test_gpt_oss_4gpu.py", 700),
         TestFile("test_llama31_fp4.py", 90),
         TestFile("test_eagle_infer_beta_dp_attention.py", 300),
     ],

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -171,8 +171,8 @@ suites = {
         TestFile("test_deepseek_v3_fp4_4gpu.py", 1800),
         TestFile("test_flash_attention_4.py", 300),
         TestFile("test_fp8_blockwise_gemm.py", 280),
-        TestFile("test_gpt_oss_4gpu.py", 600),
-        TestFile("test_llama31_fp4.py", 300),
+        TestFile("test_gpt_oss_1gpu.py", 300),
+        TestFile("test_llama31_fp4.py", 90),
         TestFile("test_eagle_infer_beta_dp_attention.py", 300),
     ],
     # "per-commit-8-gpu-b200": [

--- a/test/srt/test_llama31_fp4.py
+++ b/test/srt/test_llama31_fp4.py
@@ -49,7 +49,7 @@ class TestLlama31FP4(unittest.TestCase):
         metrics = run_eval_few_shot_gsm8k(args)
         print(metrics)
 
-        self.assertGreater(metrics["accuracy"], 0.54)
+        self.assertGreater(metrics["accuracy"], 0.64)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After rope fix the accuracy went up...

1. Llama FP4 tests takes only around 49 seconds. Keep 90 buffer in case anything happens.

2. GPT-OSS is hogging CI, especially the weight shuffle part for MXFP4 variant. 

E.g `[2025-12-10 04:13:52] Shuffling MoE weights for FlashInfer MXFP4 moe kernel (layer: model.layers.1.mlp.experts), it might take a while...`, for the 120B it takes around 5 minutes. https://github.com/sgl-project/sglang/issues/14510

20b is the exact same thing but less layers (confirmed in HF `config.json`). Just use this it's around 2x faster.

`python test/srt/test_llama31_fp4.py`
```
Accuracy: 0.650
Invalid: 0.002
Latency: 17.051 s
Output throughput: 6909.456 token/s
{'accuracy': np.float64(0.6497346474601972), 'invalid': np.float64(0.001516300227445034), 'latency': 17.05141551700217, 'output_throughput': 6909.455691964357}
.
----------------------------------------------------------------------
Ran 1 test in 49.492s

OK
```

`CUDA_VISIBLE_DEVICES=7 python test/srt/test_gpt_oss_1gpu.py`
```
.
----------------------------------------------------------------------
Ran 2 tests in 252.578s

OK
```