### PR TITLE
fix b200 fa4 ci

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -169,7 +169,7 @@ suites = {
     ],
     "per-commit-4-gpu-b200": [
         TestFile("test_deepseek_v3_fp4_4gpu.py", 1800),
-        TestFile("test_flash_attention_4.py", 300),
+        TestFile("test_flash_attention_4.py", 90),
         TestFile("test_fp8_blockwise_gemm.py", 280),
         TestFile("test_gpt_oss_4gpu.py", 600),
         TestFile("test_llama31_fp4.py", 300),

--- a/test/srt/test_flash_attention_4.py
+++ b/test/srt/test_flash_attention_4.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from urllib.parse import urlparse
 
 from sglang.srt.utils import get_device_sm, kill_process_tree
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
@@ -18,8 +19,6 @@ class TestFlashAttention4(unittest.TestCase):
         cls.base_url = DEFAULT_URL_FOR_TEST
         other_args = [
             "--trust-remote-code",
-            "--mem-fraction-static",
-            "0.8",
             "--prefill-attention-backend",
             "fa4",
             "--decode-attention-backend",
@@ -37,14 +36,15 @@ class TestFlashAttention4(unittest.TestCase):
         kill_process_tree(cls.process.pid)
 
     def test_gsm8k(self):
+        parsed_url = urlparse(self.base_url)
         args = SimpleNamespace(
-            num_shots=4,
+            num_shots=5,
             data_path=None,
-            num_questions=100,
+            num_questions=1319,
             max_new_tokens=512,
-            parallel=128,
-            host="http://127.0.0.1",
-            port=int(self.base_url.split(":")[-1]),
+            parallel=200,
+            host=f"{parsed_url.scheme}://{parsed_url.hostname}",
+            port=parsed_url.port,
         )
         metrics = run_eval_few_shot_gsm8k(args)
         print(metrics)

--- a/test/srt/test_flash_attention_4.py
+++ b/test/srt/test_flash_attention_4.py
@@ -49,7 +49,7 @@ class TestFlashAttention4(unittest.TestCase):
         metrics = run_eval_few_shot_gsm8k(args)
         print(metrics)
 
-        self.assertGreater(metrics["accuracy"], 0.75)
+        self.assertGreater(metrics["accuracy"], 0.89)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Even before the changes of this PR, this is the result of the local test. So weird... https://github.com/sgl-project/sglang/pull/11606 I have no idea what has happened since then.

```
Accuracy: 0.920
Invalid: 0.000
Latency: 1.814 s
Output throughput: 6058.936 token/s
{'accuracy': np.float64(0.92), 'invalid': np.float64(0.0), 'latency': 1.8141797830030555, 'output_throughput': 6058.936442233237}
.
----------------------------------------------------------------------
Ran 1 test in 54.161s

OK
```

Make it more robust.

After:

```
Accuracy: 0.907
Invalid: 0.000
Latency: 21.144 s
Output throughput: 7664.840 token/s
{'accuracy': np.float64(0.9067475360121304), 'invalid': np.float64(0.0), 'latency': 21.144082323000475, 'output_throughput': 7664.839623884033}
.
----------------------------------------------------------------------
Ran 1 test in 73.358s

OK
```