### PR TITLE
[model-gateway] Dynamically Populate Tool Call Parser Choices

### DIFF
--- a/sgl-model-gateway/bindings/python/Cargo.toml
+++ b/sgl-model-gateway/bindings/python/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py38"] }
 tokio = { version = "1.42.0", features = ["full"] }
+once_cell = "1.19"
 
 [dependencies.sgl-model-gateway]
 path = "../.."

--- a/sgl-model-gateway/bindings/python/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/router_args.py
@@ -4,6 +4,8 @@ import logging
 import os
 from typing import Dict, List, Optional
 
+from sglang_router.sglang_router_rs import get_available_tool_call_parsers
+
 logger = logging.getLogger(__name__)
 
 
@@ -520,11 +522,14 @@ class RouterArgs:
             default=None,
             help="Specify the parser for reasoning models (e.g., deepseek-r1, qwen3)",
         )
+        # Get parser choices dynamically from the Rust implementation
+        tool_call_parser_choices = get_available_tool_call_parsers()
         parser.add_argument(
             f"--{prefix}tool-call-parser",
             type=str,
             default=None,
-            help="Specify the parser for handling tool-call interactions",
+            choices=tool_call_parser_choices,
+            help=f"Specify the parser for tool-call interactions (e.g., json, qwen)",
         )
         # MCP server configuration
         parser.add_argument(

--- a/sgl-model-gateway/bindings/python/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/router_args.py
@@ -522,7 +522,6 @@ class RouterArgs:
             default=None,
             help="Specify the parser for reasoning models (e.g., deepseek-r1, qwen3)",
         )
-        # Get parser choices dynamically from the Rust implementation
         tool_call_parser_choices = get_available_tool_call_parsers()
         parser.add_argument(
             f"--{prefix}tool-call-parser",

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -730,6 +730,13 @@ fn get_verbose_version_string() -> String {
     version::get_verbose_version_string()
 }
 
+/// Get the list of available tool call parsers from the Rust factory.
+#[pyfunction]
+fn get_available_tool_call_parsers() -> Vec<String> {
+    let factory = tool_parser::ParserFactory::new();
+    factory.list_parsers()
+}
+
 #[pymodule]
 fn sglang_router_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PolicyType>()?;
@@ -740,5 +747,6 @@ fn sglang_router_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Router>()?;
     m.add_function(wrap_pyfunction!(get_version_string, m)?)?;
     m.add_function(wrap_pyfunction!(get_verbose_version_string, m)?)?;
+    m.add_function(wrap_pyfunction!(get_available_tool_call_parsers, m)?)?;
     Ok(())
 }

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use sgl_model_gateway::*;
+use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 
 // Define the enums with PyO3 bindings
@@ -733,8 +734,13 @@ fn get_verbose_version_string() -> String {
 /// Get the list of available tool call parsers from the Rust factory.
 #[pyfunction]
 fn get_available_tool_call_parsers() -> Vec<String> {
-    let factory = tool_parser::ParserFactory::new();
-    factory.list_parsers()
+    static PARSERS: OnceCell<Vec<String>> = OnceCell::new();
+    PARSERS
+        .get_or_init(|| {
+            let factory = tool_parser::ParserFactory::new();
+            factory.list_parsers()
+        })
+        .clone()
 }
 
 #[pymodule]


### PR DESCRIPTION
## Motivation

The SGLang worker (sglang/srt/server_args.py) dynamically populates its `--tool-call-parser` choices based on the `FunctionCallParser.ToolCallParserEnum`. 

But the `--tool-call-parser` arg at the gateway level doesn't have choices available. 

Considering that the set of tool parsers supported by gateway is not exactly the same as workers (like passthrough, json, etc), it would be better user experience to dynamiclly populate its own set of tool call parser choices.

## Modifications
- A new #[pyfunction] function to return all registered parser names
- Populate the choices argument for the --tool-call-parser command-line option

## Accuracy Tests
<img width="1895" height="397" alt="Screenshot 2025-12-10 at 4 39 40 PM" src="https://github.com/user-attachments/assets/59b6cb9e-788d-4a13-8ce7-cb930fbfd8f2" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
