### PR TITLE
Fix/mistral large3 rope params float

### DIFF
--- a/python/sglang/srt/utils/mistral_utils.py
+++ b/python/sglang/srt/utils/mistral_utils.py
@@ -118,15 +118,20 @@ def _remap_mistral_yarn_args(config: dict) -> dict:
         "alpha": "beta_slow",
         "apply_scale": None,
     }
+    # Fields that should be converted to float for transformers compatibility
+    float_fields = {"factor", "beta_fast", "beta_slow"}
     yarn_config = config.get("yarn") or {}
     config["rope_scaling"] = {
         "rope_type": "yarn",
-        "mscale_all_dim": 1,
+        "mscale_all_dim": 1.0,
     }
     for old_name, new_name in yarn_config_map.items():
         if old_name in yarn_config:
             value = yarn_config.pop(old_name)
             if new_name is not None:
+                # Convert to float if expected by transformers rope_parameters validation
+                if new_name in float_fields:
+                    value = float(value)
                 config["rope_scaling"][new_name] = value
 
     assert len(yarn_config) == 0, f"Unparsed yarn config: {yarn_config}"


### PR DESCRIPTION
Fix Pixtral rope_theta compatibility with transformers 5.0+
In transformers 5.0+, PixtralVisionConfig changed from using rope_theta
directly to using rope_parameters dict with a 'rope_theta' key. This adds
compatibility handling to extract rope_theta from either location.

tested at: https://github.com/sgl-project/sglang/actions/runs/20092216596/job/57642042440