### PR TITLE
[fix]:Added the missing field to avoid KeyError when streaming request abort

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1967,6 +1967,12 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 and not self.server_args.skip_tokenizer_init,
             )
 
+        # Add prompt_tokens to meta_info
+        prompt_tokens = 0
+        if hasattr(state.obj, "input_ids") and state.obj.input_ids is not None:
+            prompt_tokens = len(state.obj.input_ids)
+        meta_info["prompt_tokens"] = prompt_tokens
+
         output_ids = state.output_ids
         meta_info["completion_tokens"] = len(output_ids)
         if is_stream:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/opentelemetry/instrumentation/sglang/_wrapper.py", line 643, in instrumented_stream_generator
    async for chunk in original_generator:
  File "/sgl-workspace/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py", line 517, in _generate_chat_stream
    prompt_tokens[index] = content["meta_info"]["prompt_tokens"]
                           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'prompt_tokens'
```
When a request is aborted in the _handle_abort_req function, the meta_info dictionary is created with only two fields:
`id`,`finish_reason`. The `completion_tokens` field is added but the `prompt_tokens` field is not included in the abort response.

Resulting Error:
At line 517 in serving_chat.py, the code attempts to directly access the missing field:
```
prompt_tokens[index] = content["meta_info"]["prompt_tokens"]  # KeyError occurs here
```
Since the .get() method is not used for safe dictionary access, this causes a KeyError: 'prompt_tokens' when requests are aborted.

This error only occurs when a **streaming request is aborted**.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Add the `prompt_tokens` field in the `_handle_abort_req` function.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
