### PR TITLE
[Fix] Enable applying different LoRA adapters to different transformers in multi-transformer pipelines

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -344,27 +344,57 @@ class DiffGenerator:
             )
             raise RuntimeError(f"{failure_msg}: {error_msg}")
 
-    def set_lora(self, lora_nickname: str, lora_path: str | None = None) -> None:
-        req = SetLoraReq(lora_nickname=lora_nickname, lora_path=lora_path)
+    def set_lora(
+        self, lora_nickname: str, lora_path: str | None = None, target: str = "all"
+    ) -> None:
+        """
+        Set a LoRA adapter for the specified transformer(s).
+
+        Args:
+            lora_nickname: The nickname of the adapter.
+            lora_path: Path to the LoRA adapter.
+            target: Which transformer(s) to apply the LoRA to. One of:
+                - "all": Apply to all transformers (default)
+                - "transformer": Apply only to the primary transformer (high noise for Wan2.2)
+                - "transformer_2": Apply only to transformer_2 (low noise for Wan2.2)
+                - "critic": Apply only to the critic model
+        """
+        req = SetLoraReq(
+            lora_nickname=lora_nickname, lora_path=lora_path, target=target
+        )
         self._send_lora_request(
             req,
-            f"Successfully set LoRA adapter: {lora_nickname}",
+            f"Successfully set LoRA adapter: {lora_nickname} (target: {target})",
             "Failed to set LoRA adapter",
         )
 
-    def unmerge_lora_weights(self) -> None:
-        req = UnmergeLoraWeightsReq()
+    def unmerge_lora_weights(self, target: str = "all") -> None:
+        """
+        Unmerge LoRA weights from the base model.
+
+        Args:
+            target: Which transformer(s) to unmerge.
+        """
+        req = UnmergeLoraWeightsReq(target=target)
         self._send_lora_request(
             req,
-            "Successfully unmerged LoRA weights",
+            f"Successfully unmerged LoRA weights (target: {target})",
             "Failed to unmerge LoRA weights",
         )
         self._is_lora_merged = False
 
-    def merge_lora_weights(self) -> None:
-        req = MergeLoraWeightsReq()
+    def merge_lora_weights(self, target: str = "all") -> None:
+        """
+        Merge LoRA weights into the base model.
+
+        Args:
+            target: Which transformer(s) to merge.
+        """
+        req = MergeLoraWeightsReq(target=target)
         self._send_lora_request(
-            req, "Successfully merged LoRA weights", "Failed to merge LoRA weights"
+            req,
+            f"Successfully merged LoRA weights (target: {target})",
+            "Failed to merge LoRA weights",
         )
         self._is_lora_merged = True
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
@@ -37,26 +37,61 @@ async def _handle_lora_request(req: Any, success_msg: str, failure_msg: str):
 async def set_lora(
     lora_nickname: str = Body(..., embed=True),
     lora_path: Optional[str] = Body(None, embed=True),
+    target: str = Body("all", embed=True),
 ):
-    req = SetLoraReq(lora_nickname=lora_nickname, lora_path=lora_path)
+    """
+    Set a LoRA adapter for the specified transformer(s).
+
+    Args:
+        lora_nickname: The nickname of the adapter.
+        lora_path: Path to the LoRA adapter (local path or HF repo id).
+        target: Which transformer(s) to apply the LoRA to. One of:
+            - "all": Apply to all transformers (default)
+            - "transformer": Apply only to the primary transformer (high noise for Wan2.2)
+            - "transformer_2": Apply only to transformer_2 (low noise for Wan2.2)
+            - "critic": Apply only to the critic model
+    """
+    req = SetLoraReq(lora_nickname=lora_nickname, lora_path=lora_path, target=target)
     return await _handle_lora_request(
         req,
-        f"Successfully set LoRA adapter: {lora_nickname}",
+        f"Successfully set LoRA adapter: {lora_nickname} (target: {target})",
         "Failed to set LoRA adapter",
     )
 
 
 @router.post("/merge_lora_weights")
-async def merge_lora_weights():
-    req = MergeLoraWeightsReq()
+async def merge_lora_weights(
+    target: str = Body("all", embed=True),
+):
+    """
+    Merge LoRA weights into the base model.
+
+    Args:
+        target: Which transformer(s) to merge. One of "all", "transformer",
+                "transformer_2", "critic".
+    """
+    req = MergeLoraWeightsReq(target=target)
     return await _handle_lora_request(
-        req, "Successfully merged LoRA weights", "Failed to merge LoRA weights"
+        req,
+        f"Successfully merged LoRA weights (target: {target})",
+        "Failed to merge LoRA weights",
     )
 
 
 @router.post("/unmerge_lora_weights")
-async def unmerge_lora_weights():
-    req = UnmergeLoraWeightsReq()
+async def unmerge_lora_weights(
+    target: str = Body("all", embed=True),
+):
+    """
+    Unmerge LoRA weights from the base model.
+
+    Args:
+        target: Which transformer(s) to unmerge. One of "all", "transformer",
+                "transformer_2", "critic".
+    """
+    req = UnmergeLoraWeightsReq(target=target)
     return await _handle_lora_request(
-        req, "Successfully unmerged LoRA weights", "Failed to unmerge LoRA weights"
+        req,
+        f"Successfully unmerged LoRA weights (target: {target})",
+        "Failed to unmerge LoRA weights",
     )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -25,16 +25,17 @@ logger = init_logger(__name__)
 class SetLoraReq:
     lora_nickname: str
     lora_path: Optional[str] = None
+    target: str = "all"  # "all", "transformer", "transformer_2", "critic"
 
 
 @dataclasses.dataclass
 class MergeLoraWeightsReq:
-    pass
+    target: str = "all"  # "all", "transformer", "transformer_2", "critic"
 
 
 @dataclasses.dataclass
 class UnmergeLoraWeightsReq:
-    pass
+    target: str = "all"  # "all", "transformer", "transformer_2", "critic"
 
 
 def post_process_sample(

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -51,7 +51,8 @@ class BaseLayerWithLoRA(nn.Module):
         self.cpu_weight = base_layer.weight.to("cpu")
         # indicates adapter weights don't contain this layer
         # (which shouldn't normally happen, but we want to separate it from the case of erroneous merging)
-        self.disable_lora: bool = False
+        # Default to True to prevent using uninitialized weights; set to False when weights are loaded
+        self.disable_lora: bool = True
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha
         self.lora_path: str | None = None

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -121,26 +121,39 @@ class GPUWorker:
         finally:
             return output_batch
 
-    def set_lora(self, lora_nickname: str, lora_path: str | None = None) -> None:
+    def set_lora(
+        self, lora_nickname: str, lora_path: str | None = None, target: str = "all"
+    ) -> None:
         """
         Set the LoRA adapter for the pipeline.
+
+        Args:
+            lora_nickname: The nickname of the adapter.
+            lora_path: Path to the LoRA adapter.
+            target: Which transformer(s) to apply the LoRA to.
         """
         assert self.pipeline is not None
-        self.pipeline.set_lora(lora_nickname, lora_path)
+        self.pipeline.set_lora(lora_nickname, lora_path, target)
 
-    def merge_lora_weights(self) -> None:
+    def merge_lora_weights(self, target: str = "all") -> None:
         """
         Merge LoRA weights.
+
+        Args:
+            target: Which transformer(s) to merge.
         """
         assert self.pipeline is not None
-        self.pipeline.merge_lora_weights()
+        self.pipeline.merge_lora_weights(target)
 
-    def unmerge_lora_weights(self) -> None:
+    def unmerge_lora_weights(self, target: str = "all") -> None:
         """
         Unmerge LoRA weights.
+
+        Args:
+            target: Which transformer(s) to unmerge.
         """
         assert self.pipeline is not None
-        self.pipeline.unmerge_lora_weights()
+        self.pipeline.unmerge_lora_weights(target)
 
 
 def run_scheduler_process(

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -78,15 +78,17 @@ class Scheduler:
     def _handle_set_lora(self, reqs: List[Any]):
         # TODO: return set status
         req = reqs[0]
-        self.worker.set_lora(req.lora_nickname, req.lora_path)
+        self.worker.set_lora(req.lora_nickname, req.lora_path, req.target)
         return {"status": "ok"}
 
-    def _handle_merge_lora(self, _reqs: List[Any]):
-        self.worker.merge_lora_weights()
+    def _handle_merge_lora(self, reqs: List[Any]):
+        req = reqs[0]
+        self.worker.merge_lora_weights(req.target)
         return {"status": "ok"}
 
-    def _handle_unmerge_lora(self, _reqs: List[Any]):
-        self.worker.unmerge_lora_weights()
+    def _handle_unmerge_lora(self, reqs: List[Any]):
+        req = reqs[0]
+        self.worker.unmerge_lora_weights(req.target)
         return {"status": "ok"}
 
     def _handle_generation(self, reqs: List[Req]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Enable applying different LoRA adapters to different transformers in multi-transformer pipelines (e.g., Wan2.2 with separate high-noise and low-noise transformers). Previously, LoRA operations applied to all transformers uniformly.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Add target parameter to set_lora, merge_lora_weights, and unmerge_lora_weights APIs
  - Valid targets: "all", "transformer", "transformer_2", "critic"
  - Default is "all" for backward compatibility
- Update request classes (SetLoraReq, MergeLoraWeightsReq, UnmergeLoraWeightsReq) to include target field
- Change cur_adapter_name, cur_adapter_path, and is_lora_merged from single values to per-module dicts
- Add _get_target_lora_layers helper method with improved error handling (returns error messages instead of raising)
- Update is_lora_effective and is_lora_set methods to accept target parameter
- Propagate target parameter through API endpoints, scheduler, and GPU worker

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
| Test | Description | Purpose |
|------|-------------|---------|
| 1_test_baseline | Generate without LoRA | Establish baseline for comparison |
| 2_test_full_lora | Full LoRA (both transformers) | Verify LoRA loading and effect |
| 3_test_high_noise_only | High-noise transformer LoRA only | Test partial LoRA application |
| 4_test_low_noise_only | Low-noise transformer LoRA only | Test partial LoRA application |
| 5_test_merge_unmerge | Merge/Unmerge cycling | Verify weight management |



https://github.com/user-attachments/assets/057a06cf-6c3b-4252-b2f7-48287d3e4e70



https://github.com/user-attachments/assets/eb4ef4d7-4710-4f0e-a52c-5127efd62db4


https://github.com/user-attachments/assets/c76db330-812b-42cd-a8c4-ede3589a0f47


https://github.com/user-attachments/assets/c3196715-b36c-44e3-b8c3-578b5ef68a22



https://github.com/user-attachments/assets/988e8e90-ebbb-48fb-af8e-71d6e3f99e61


https://github.com/user-attachments/assets/e8b3493a-509a-4dea-84f2-27a08356174f



https://github.com/user-attachments/assets/2c0a6243-c9f5-46d1-b42a-7486593cb03d



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
