### PR TITLE
fix: Unify the request length validation logics in tokenzier and sche…

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1441,9 +1441,10 @@ class Scheduler(
 
         # Validate prompt length
         error_msg = validate_input_length(
-            req,
+            req.origin_input_ids,
             self.max_req_input_len,
             self.server_args.allow_auto_truncate,
+            is_session_validation=True,
         )
         if error_msg:
             req.set_finish_with_abort(error_msg)
@@ -1672,9 +1673,10 @@ class Scheduler(
 
         # Validate prompts length
         error_msg = validate_input_length(
-            req,
+            req.origin_input_ids,
             self.max_req_input_len,
             self.server_args.allow_auto_truncate,
+            is_session_validation=True,
         )
         if error_msg:
             self._add_request_to_queue(req)

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -125,7 +125,7 @@ def validate_input_length(
                 "size or the max context length. Truncated. "
                 f"{input_token_num=}, {max_req_input_len=}."
             )
-            input_ids = input_ids[:max_req_input_len]
+            del input_ids[max_req_input_len:]
             return None
         else:
             error_msg = (

--- a/test/srt/openai_server/validation/test_request_length_validation.py
+++ b/test/srt/openai_server/validation/test_request_length_validation.py
@@ -45,7 +45,7 @@ class TestRequestLengthValidation(CustomTestCase):
                 temperature=0,
             )
 
-        self.assertIn("is longer than the model's context length", str(cm.exception))
+        self.assertIn("exceeds the model's context length", str(cm.exception))
 
     def test_input_length_longer_than_maximum_allowed_length(self):
         client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")
@@ -61,7 +61,7 @@ class TestRequestLengthValidation(CustomTestCase):
                 temperature=0,
             )
 
-        self.assertIn("is longer than the model's context length", str(cm.exception))
+        self.assertIn("exceeds the model's context length", str(cm.exception))
 
     def test_max_tokens_validation(self):
         client = openai.Client(api_key=self.api_key, base_url=f"{self.base_url}/v1")

--- a/test/srt/test_vision_openai_server_a.py
+++ b/test/srt/test_vision_openai_server_a.py
@@ -96,7 +96,7 @@ class TestQwen2VLContextLengthServer(CustomTestCase):
         assert (
             "Multimodal prompt is too long after expanding multimodal tokens."
             in str(cm.exception)
-            or "is longer than the model's context length" in str(cm.exception)
+            or "exceeds the model's context length" in str(cm.exception)
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Both tokenzier and scheduler needs to validate the request length to avoid exceeding the limit of model context length, etc.  This PR is to unify them to unify the logic in a single function instead of separately.

- Tokenizer will exam each signle request and avoid sending it to the scheduler if it is longer than the model context length.
- When the request is sent to an existing session, it might be aggregated with a previous request and the length of that final request should also be validated to avoid exceeding model context length.

## Modifications

- Improve the utils `validate_input_length(...)` and let tokenizer and scheduler adopt it.
- Minor: Add an enum `InputFormat` for "_detect_input_format()" to replace the original strings.

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
