### PR TITLE
fix fp8 gemm nightly CI

### DIFF
--- a/test/nightly/test_flashinfer_trtllm_gen_moe_backend.py
+++ b/test/nightly/test_flashinfer_trtllm_gen_moe_backend.py
@@ -30,8 +30,6 @@ class TestFlashinferTrtllmGenMoeBackend(CustomTestCase):
                 "triton",
                 "--moe-runner-backend",
                 "flashinfer_trtllm",
-                "--cuda-graph-max-bs",
-                "512",
                 "--tp-size",
                 "4",
                 "--ep-size",
@@ -40,8 +38,6 @@ class TestFlashinferTrtllmGenMoeBackend(CustomTestCase):
                 "0.7",
                 "--mamba-ssm-dtype",
                 "bfloat16",
-                "--quantization",
-                "fp8",
             ],
         )
 


### PR DESCRIPTION
See https://github.com/sgl-project/sglang/actions/runs/20093484318/job/57693013261

Basically this happened because now, when DeepGEMM is disabled, we fall back to Flashinfer when available (before, it was Triton, which is a lot less performant), but it has some restrictions on the `k dimension` for (M, K) @ (K, N)

> 

Anyway, there should be a better solution to this, but I followed the pattern of deepgemm/cutlass fallback, I'll clean them up in the future anyway.

It doesn't need `--quantization fp8` flag (unrelated)

After this fix, it can pass:

```
Accuracy: 0.940
Invalid: 0.000
Latency: 18.928 s
Output throughput: 1737.442 token/s
metrics={'accuracy': np.float64(0.94), 'invalid': np.float64(0.0), 'latency': 18.927831359000265, 'output_throughput': 1737.4415154202316}
.
----------------------------------------------------------------------
Ran 1 test in 110.056s

OK
```