### PR TITLE
fix: creating blobs only once for publish trace retries

### DIFF
--- a/scripts/ci/publish_traces.py
+++ b/scripts/ci/publish_traces.py
@@ -121,6 +121,10 @@ def create_blob(repo_owner, repo_name, content, token, max_retries=3):
             response = make_github_request(url, token, method="POST", data=data)
             return json.loads(response)["sha"]
         except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
             if attempt < max_retries - 1:
                 wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
                 print(
@@ -162,6 +166,10 @@ def create_tree(repo_owner, repo_name, base_tree_sha, tree_items, token, max_ret
             response = make_github_request(url, token, method="POST", data=data)
             return json.loads(response)["sha"]
         except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
             if attempt < max_retries - 1:
                 wait_time = 2**attempt
                 print(
@@ -196,6 +204,10 @@ def create_commit(
 
             return commit_sha
         except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
             if attempt < max_retries - 1:
                 wait_time = 2**attempt
                 print(
@@ -219,6 +231,10 @@ def update_branch_ref(repo_owner, repo_name, branch, commit_sha, token, max_retr
             make_github_request(url, token, method="PATCH", data=data)
             return
         except HTTPError as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
             # Check if this is an "Object does not exist" error
             is_object_not_exist = False
             if hasattr(e, "error_body"):
@@ -239,6 +255,10 @@ def update_branch_ref(repo_owner, repo_name, branch, commit_sha, token, max_retr
             else:
                 raise
         except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
             if attempt < max_retries - 1:
                 wait_time = 2**attempt
                 print(


### PR DESCRIPTION
## Motivation

On intermittent failures to publish traces, there could be big delays because we create the same set of blobs for every time create_tree fails. This pr creates blobs just once before entering the retryable loop, so that if create tree fails, we don't recreate the same blobs.

See this for the error:
https://github.com/sgl-project/sglang/actions/runs/20093484318/job/57693013346

## Modifications

Refactored blob creation to its function and calling it once just before the retry loop to publish traces.

## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/20115773340 (pending)

## Benchmarking and Profiling

N/A

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
