### PR TITLE
fix: adding temporary bypass for nightly tests

### DIFF
--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -105,8 +105,19 @@ def run_a_suite(args):
     auto_partition_id = args.auto_partition_id
     auto_partition_size = args.auto_partition_size
 
-    files = glob.glob("registered/**/*.py", recursive=True)
-    ci_tests = filter_tests(collect_tests(files, sanity_check=True), hw, suite, nightly)
+    # Temporary: search broadly for nightly tests during migration to registered/
+    if nightly:
+        files = glob.glob("**/*.py", recursive=True)
+        sanity_check = False  # Allow files without registration during migration
+    else:
+        files = glob.glob("registered/**/*.py", recursive=True)
+        sanity_check = (
+            True  # Strict: all registered files must have proper registration
+        )
+
+    ci_tests = filter_tests(
+        collect_tests(files, sanity_check=sanity_check), hw, suite, nightly
+    )
     test_files = [TestFile(t.filename, t.est_time) for t in ci_tests]
 
     if not test_files:


### PR DESCRIPTION
## Motivation

Currently, general 1 gpu, general 4 gpu h100, general 8 gpu h20, and the run_test portion of general 8 gpu h200 are all skipped due to the following changes:L

1. test search path changed to /registered 
2. sanity_check=true is applied to limit unregistered test UserWarnings.

We apply to temporary bypass for nightly, and keep this logic for per-commit changes.

## Modifications

Adding a conditional statement for nightly tests.

## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/20124997196/job/57752700554

## Benchmarking and Profiling

N/A

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [n/a] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
