### PR TITLE
Support qwen3-omni with DP Encoder

### DIFF
--- a/python/sglang/srt/models/qwen3_omni_moe.py
+++ b/python/sglang/srt/models/qwen3_omni_moe.py
@@ -49,6 +49,7 @@ from sglang.srt.models.qwen3_vl_moe import (
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, logger
 
+
 class Qwen3OmniMoeAudioEncoderLayer(nn.Module):
     def __init__(
         self,

--- a/test/nightly/test_encoder_dp.py
+++ b/test/nightly/test_encoder_dp.py
@@ -21,6 +21,7 @@ from sglang.test.test_utils import (
 register_cuda_ci(est_time=500, suite="nightly-4-gpu", nightly=True)
 
 MODELS = [
+    SimpleNamespace(model="Qwen/Qwen3-Omni-30B-A3B-Instruct", mmmu_accuracy=0.55),
     SimpleNamespace(model="Qwen/Qwen2.5-VL-72B-Instruct", mmmu_accuracy=0.55),
     SimpleNamespace(model="Qwen/Qwen3-VL-32B-Instruct", mmmu_accuracy=0.55),
     SimpleNamespace(model="OpenGVLab/InternVL2_5-8B", mmmu_accuracy=0.52),


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Add support for Qwen3-Omni with vision model DP based on [#13724
](https://github.com/sgl-project/sglang/pull/13724)

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Tested Qwen/Qwen3-Omni-30B-A3B-Instruct 

with dp

| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5867|±  |   N/A|

without dp
| Tasks  |Version|Filter|n-shot| Metric |   |Value|   |Stderr|
|--------|------:|------|-----:|--------|---|----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  | 0.59|±  |   N/A|

## Benchmarking and Profiling
On H20, we benchmarked the server with the `--mm-enable-dp-encoder`option enabled against the baseline performance without any code modifications. We found that enabling `--mm-enable-dp-encoder` reduces TTFT for multi-modal workloads under some testing conditions.

```bash
SGLANG_VLM_CACHE_SIZE_MB=0  
python3 -m sglang.launch_server \
         --model-path /root/workspace/Qwen3-Omni-30B-A3B-Instruct/   \
         --host localhost \
         --port 40000 \
         --tp-size 4 \
        --trust-remote-code \
         --mem-fraction-static 0.85  \
        --disable-radix-cache   \
        --cuda-graph-max-bs 32 \
        --mm-attention-backend fa3 \
        --attention-backend flashinfer\
        --mm-enable-dp-encoder
```

| tp | Img count | Img resolution | TTFT base(ms) | TTFT with dp(ms) | improment |
 | --- | --- | --- | --- | --- | --- |
 | 4 | 4 | 960x1280 | 6733.54 | 6543.15 | -2.83% |
 |  4 | 8 | 960x1280 | 16671.97 | 14916.71 | -10.53%% |

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
