### PR TITLE
[VLM] Support chunked vit attention

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -41,6 +41,9 @@ TensorTransportMode = Literal["cuda_ipc", "auto", "default"]
 _GPU_FEATURE_BUFFER: Optional[torch.Tensor] = None
 _BUFFER_OFFSET = 0
 
+_EXTRA_PRE_TOKENS = 0  # pre chunk extra token (0 for the moment)
+_EXTRA_POST_TOKENS = 0  # post chunk extra token (0 for the moment)
+
 
 def init_feature_buffer(device):
     global _GPU_FEATURE_BUFFER, _BUFFER_OFFSET
@@ -414,6 +417,67 @@ def _get_precomputed_embedding(
     return None
 
 
+def get_embedding_items_per_chunk_with_extra_padding(
+    embedding_items_per_req: List["MultimodalDataItem"],
+    extend_prefix_len: int,
+    extend_seq_len: int,
+    items_offset: List[Tuple[int, int]],
+) -> List["MultimodalDataItem"]:
+    """
+    From all multimodal items of a request, select the subset that is "relevant to
+    this prefill chunk", and allow a small amount of extra padding on both sides
+    of the chunk boundary (for easier caching or cross-chunk reuse).
+
+    Assumptions:
+        - len(embedding_items_per_req) == len(items_offset)
+        - items_offset[j] = (start, end), meaning the multimodal tokens of the j-th
+        item correspond to [start, end) (left-closed, right-open) in the entire
+        token sequence
+        - The item order in embedding_items_per_req is one-to-one aligned with
+        items_offset
+
+    Args:
+        embedding_items_per_req: all items of this modality under the current
+            request (e.g. each frame in a 500-frame video)
+        extend_prefix_len: number of tokens already prefilled before the current
+            chunk
+        extend_seq_len: number of tokens in the current chunk
+        items_offset: (start, end) position of each item in the whole sentence
+
+    Returns:
+        The subset of items to feed into ViT for this chunk (preserving the
+        original order)
+    """
+    assert len(embedding_items_per_req) == len(
+        items_offset
+    ), f"items_per_req({len(embedding_items_per_req)}) vs items_offset({len(items_offset)}) mismatch"
+
+    if extend_seq_len <= 0:
+        return []
+
+    # Current chunk's token range
+    chunk_start = extend_prefix_len
+    chunk_end = extend_prefix_len + extend_seq_len
+
+    # Current chunk's token range with extra padding
+    window_start = max(0, chunk_start - _EXTRA_PRE_TOKENS)
+    window_end = chunk_end + _EXTRA_POST_TOKENS
+
+    selected_items: List["MultimodalDataItem"] = []
+
+    for item, (start, end) in zip(embedding_items_per_req, items_offset):
+        if start >= end:
+            continue
+
+        # Check whether this item has overlap with [window_start, window_end)
+        # If has overlap, add the item into selected_item.
+        if end > window_start and start < window_end:
+            selected_items.append(item)
+
+    return selected_items
+
+
+# TODO: To be obsoleted.
 def _get_chunked_prefill_embedding(
     data_embedding_func: Callable[[List[MultimodalDataItem]], torch.Tensor],
     embedding_items: List[MultimodalDataItem],
@@ -458,6 +522,208 @@ def _get_chunked_prefill_embedding(
     if len(embedding_list) == 0:
         return None
     return torch.concat(embedding_list, dim=0)
+
+
+def get_embedding_chunk_remove_extra_padding(
+    embedding: torch.Tensor,
+    extend_prefix_len: int,
+    extend_seq_len: int,
+    items_offset: List[Tuple[int, int]],
+) -> Tuple[Optional[torch.Tensor], int, int]:
+    """
+    From the embedding computed on "items related to this chunk + extra padding",
+    trim out the token embeddings that are not needed for the current chunk, and
+    keep only those mm tokens covered by
+    [extend_prefix_len, extend_prefix_len + extend_seq_len).
+
+    Assumptions:
+        - Each (start, end) in items_offset represents an item's multimodal token
+        interval [start, end) in the whole token sequence, and their order is
+        consistent with the order of items in `embedding`.
+        - The layout of `embedding`: each selected item is concatenated in order,
+        and item j occupies seg_len_j = end_j - start_j rows.
+
+    Args:
+        embedding: output of data_embedding_func(embedding_items_per_chunk),
+                shape = (T_total, D)
+        extend_prefix_len: number of tokens before the chunk (prefix_len)
+        extend_seq_len: number of tokens in this chunk (chunk_len)
+        items_offset: list of (start, end) for all items of the current request
+
+    Returns:
+        - trimmed_embedding: embedding that contains only the mm tokens needed
+        by this chunk, concatenated in token order
+        - num_tokens_before: number of mm tokens "before the chunk" that are
+        trimmed off (optional info, not used by the current caller)
+        - num_tokens_after: number of mm tokens "after the chunk" that are
+        trimmed off (optional info, not used by the current caller)
+    """
+    if embedding is None or embedding.numel() == 0:
+        return None, 0, 0
+
+    chunk_start = extend_prefix_len
+    chunk_end = extend_prefix_len + extend_seq_len
+
+    if extend_seq_len <= 0 or chunk_start >= chunk_end:
+        return None, 0, 0
+
+    # The window with extra padding
+    window_start = max(0, chunk_start - _EXTRA_PRE_TOKENS)
+    window_end = chunk_end + _EXTRA_POST_TOKENS
+
+    # Iterate item_offset to choose item.
+    # We need to forward an embedding_idx to locate the item start-end position in embedding.
+    embedding_idx = 0
+    kept_slices: List[torch.Tensor] = []
+
+    num_tokens_before = 0
+    num_tokens_after = 0
+
+    for start, end in items_offset:
+        if start >= end:
+            continue
+
+        seg_len = end - start
+
+        # Check whether this item has been chosen into embedding_items_per_chunk or not.
+        selected = end > window_start and start < window_end
+
+        if not selected:
+            # Not in embedding_items_per_chunk, not forward embedding_idx.
+            continue
+
+        # embedding has the whole item
+        # embedding[embedding_idx : embedding_idx + seg_len]
+
+        # Calculate the overlap range between item and the current chunk
+        overlap_start = max(start, chunk_start)
+        overlap_end = min(end, chunk_end)
+
+        if overlap_start < overlap_end:
+            # The item has a portion mm tokens in the current chunk
+            # The offset inside item
+            local_start = overlap_start - start
+            local_end = overlap_end - start
+
+            # The embedding index
+            slice_start = embedding_idx + local_start
+            slice_end = embedding_idx + local_end
+
+            kept_slices.append(embedding[slice_start:slice_end])
+
+            # Stats the token number before and after this chunk
+            num_tokens_before += max(0, local_start)
+            num_tokens_after += max(0, seg_len - local_end)
+        else:
+            # Although item is chosen into embedding_items_per_chunk as extra padding,
+            # Its mm tokens has no overlap with chunk, so don't count into the current
+            # chunk's embedding.
+            if end <= chunk_start:
+                num_tokens_before += seg_len
+            elif start >= chunk_end:
+                num_tokens_after += seg_len
+
+        # No matter whether this item has overlap with chunk, once it's selected, it
+        # counts seg_len in embedding, so embedding_idx has to forward.
+        embedding_idx += seg_len
+
+    if not kept_slices:
+        # No mm tokens in this chunk
+        return None, num_tokens_before, num_tokens_after
+
+    trimmed_embedding = torch.cat(kept_slices, dim=0)
+    return trimmed_embedding, num_tokens_before, num_tokens_after
+
+
+# This function is for chunked prefill vit for multiple items in the next feature.
+def _get_chunked_prefill_embedding_for_chunked_items(
+    data_embedding_func: Callable[[List["MultimodalDataItem"]], torch.Tensor],
+    embedding_items: List["MultimodalDataItem"],
+    items_size: List[int],
+    prefix_length: List[int],
+    extend_length: List[int],
+    items_offset_list: List[List[Tuple[int, int]]],
+) -> Optional[torch.Tensor]:
+    """
+    Multi-modal embedding computation for chunked prefill.
+
+    For each request:
+    1. Use items_size to split embedding_items into per-request sublists embedding_items_per_req;
+    2. Use get_embedding_items_per_chunk_with_extra_padding to select the subset of items related to this chunk;
+    3. Call data_embedding_func (ViT) on this subset to obtain embedding_per_chunk;
+    4. Concatenate embedding_per_req_chunk for all requests in order.
+
+    In this way, the ViT for each request only processes the frames / images related to the current chunk,
+    avoiding OOM caused by processing all the frames at once.
+    """
+    # Calculate embedding for each request, try to get it from cache to avoid repeated calculation
+    embedding_list = []
+    # FIXME(Xinyuan): temporary workaround for eagle3, which may have len(items_size) > len(prefix_length)
+    max_iterations = min(len(items_size) - 1, len(prefix_length))
+
+    for i in range(max_iterations):
+        if items_size[i] == items_size[i + 1]:
+            continue
+        embedding_items_per_req = embedding_items[items_size[i] : items_size[i + 1]]
+        items_offset = items_offset_list[i]
+        assert items_offset is not None, items_offset
+
+        # if all items has been prefixed, we do not need to calculate embedding
+        if all([offset_end < prefix_length[i] for _, offset_end in items_offset]):
+            continue
+
+        # 1) Pick up items related with this chunk
+        embedding_items_per_chunk = get_embedding_items_per_chunk_with_extra_padding(
+            embedding_items_per_req,
+            extend_prefix_len=prefix_length[i],
+            extend_seq_len=extend_length[i] if i < len(extend_length) else 0,
+            items_offset=items_offset,
+        )
+
+        if not embedding_items_per_chunk:
+            continue
+
+        # 2) construct cache key
+        # embedding_items_hash = MultiModalStaticCache.combine_hashes(
+        #     embedding_items_per_chunk
+        # )
+        item_hashes = [item.hash for item in embedding_items_per_chunk]
+        embedding_items_hash = MultiModalStaticCache.combine_hashes(item_hashes)
+
+        embedding_per_chunk = embedding_cache.get(embedding_items_hash)
+        if embedding_per_chunk is None:
+            # ViT forward for items related with per chunk
+            embedding_per_chunk = data_embedding_func(embedding_items_per_chunk)
+
+            embedding_for_cache = embedding_per_chunk.detach().cpu()
+            if not embedding_cache.set(embedding_items_hash, embedding_for_cache):
+                print(
+                    "[WARN] Multimodal embedding cache is full. "
+                    "Consider increasing `SGLANG_VLM_CACHE_SIZE_MB` or reducing "
+                    "video frame count / resolution for a single request."
+                )
+        else:
+            target_device = embedding_items_per_req[0].feature.device
+            if embedding_per_chunk.device != target_device:
+                embedding_per_chunk = embedding_per_chunk.to(target_device)
+
+        # 3) remove extra padding from embedding_per_chunk, only keep current chunk part
+        #    We probably don't need this part.
+        # embedding_per_req_chunk, _, _ = get_embedding_chunk_remove_extra_padding(
+        #     embedding=embedding_per_chunk,
+        #     extend_prefix_len=prefix_len,
+        #     extend_seq_len=chunk_len,
+        #     items_offset=items_offset,
+        # )
+
+        if embedding_per_chunk is not None and embedding_per_chunk.numel() > 0:
+            embedding_list.append(embedding_per_chunk)
+
+    if not embedding_list:
+        return None
+
+    # concat all the request's chunk embedding in token
+    return torch.cat(embedding_list, dim=0)
 
 
 def _get_multimodal_mask(

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Inference-only Qwen3-VL model compatible with HuggingFace weights."""
 import logging
+import math
 import re
 from functools import lru_cache, partial
 from typing import Callable, Iterable, List, Optional, Tuple, Union
@@ -53,7 +54,7 @@ from sglang.srt.models.qwen3 import Qwen3Model
 from sglang.srt.models.utils import RotaryPosMixin, compute_cu_seqlens_from_grid_numpy
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, get_int_env_var
 from sglang.srt.utils.hf_transformers_utils import get_processor
 
 logger = logging.getLogger(__name__)
@@ -666,13 +667,101 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         image_grid_thw = torch.concat([item.image_grid_thw for item in items], dim=0)
         assert pixel_values.dim() == 2, pixel_values.dim()
         assert image_grid_thw.dim() == 2, image_grid_thw.dim()
-        if self.use_data_parallel:
-            return run_dp_sharded_mrope_vision_model(
-                self.visual, pixel_values, image_grid_thw.tolist(), rope_type="rope_3d"
-            )
-        else:
-            image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
-        return image_embeds
+
+        max_patches_per_call = get_int_env_var("SGLANG_VLM_MAX_PATCHES_PER_VIT", 0)
+        max_images_per_call = get_int_env_var("SGLANG_VLM_MAX_IMAGES_PER_VIT", 0)
+
+        if max_patches_per_call == 0 and max_images_per_call == 0:
+            if self.use_data_parallel:
+                return run_dp_sharded_mrope_vision_model(
+                    self.visual,
+                    pixel_values,
+                    image_grid_thw.tolist(),
+                    rope_type="rope_3d",
+                )
+            else:
+                return self.visual(pixel_values, grid_thw=image_grid_thw)
+
+        # compute the number of patches per image and the slice positions in pixel_values
+        grid_thw_list = (
+            image_grid_thw.tolist()
+        )  # List[List[int]], each is [T, H, W] or similar
+        patches_per_image = [int(math.prod(g)) for g in grid_thw_list]
+        num_images = len(patches_per_image)
+
+        # cumulative sum used to slice pixel_values along the image dimension
+        cum_patches = [0]
+        for p in patches_per_image:
+            cum_patches.append(cum_patches[-1] + p)
+        total_patches = cum_patches[-1]
+
+        assert pixel_values.size(0) == total_patches, (
+            f"pixel_values rows ({pixel_values.size(0)}) "
+            f"!= total patches ({total_patches})"
+        )
+
+        # split into chunks in image order, each chunk obeys the patch/image limits
+        all_chunk_embeds: List[torch.Tensor] = []
+        img_start = 0
+
+        while img_start < num_images:
+            img_end = img_start
+            patches_in_chunk = 0
+            images_in_chunk = 0
+
+            # try to pack more images into the current chunk until some limit would be exceeded
+            while img_end < num_images:
+                next_patches = patches_per_image[img_end]
+
+                # if adding this image would exceed the patch limit, stop
+                if (
+                    max_patches_per_call > 0
+                    and patches_in_chunk + next_patches > max_patches_per_call
+                ):
+                    break
+
+                # if adding this image would exceed the image-count limit, also stop
+                if (
+                    max_images_per_call > 0
+                    and images_in_chunk + 1 > max_images_per_call
+                ):
+                    break
+
+                patches_in_chunk += next_patches
+                images_in_chunk += 1
+                img_end += 1
+
+            # extreme case: the first image alone exceeds the patch limit -> at least ensure img_end > img_start
+            if img_end == img_start:
+                img_end = img_start + 1
+                patches_in_chunk = patches_per_image[img_start]
+                images_in_chunk = 1
+
+            # slice pixel_values and grid_thw according to [img_start:img_end]
+            patch_start = cum_patches[img_start]
+            patch_end = cum_patches[img_end]
+            pixel_chunk = pixel_values[patch_start:patch_end]
+            grid_chunk = image_grid_thw[img_start:img_end]
+
+            # run ViT once on this chunk without extra padding
+            if self.use_data_parallel:
+                chunk_embeds = run_dp_sharded_mrope_vision_model(
+                    self.visual,
+                    pixel_chunk,
+                    grid_chunk.tolist(),
+                    rope_type="rope_3d",
+                )
+            else:
+                chunk_embeds = self.visual(pixel_chunk, grid_thw=grid_chunk)
+
+            # chunk_embeds: (sum_patches_after_merge_this_chunk, hidden)
+            all_chunk_embeds.append(chunk_embeds)
+
+            # next batch
+            img_start = img_end
+
+        # concatenate back the full image embedding sequence
+        return torch.cat(all_chunk_embeds, dim=0)
 
     def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         # in qwen-vl, last dim is the same


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Inspired by @merrymercy @mickqian .
One request with 500 images (or a video with 500 frames) on Qwen3-VL-235B-A22B-Instruct-FP8 will have OOM.

The PR have two parts:

- Adds support for batching when there are multiple items, but this approach is not enabled yet (those changes are in mm_utils). Currently, a single request with 500 images will put all of them into mm_items[0], so there’s no way to form batches based on items. 

- In get_image_feature, where pixel_values is split by patches into several chunks (these changes are in qwen3-vl) and send request to vision attention in a batch manner instead of sending them all in one forward. This part counts most for resolving the OOM of this issue.

Before PR there's OOM.
```
$export SGLANG_VLM_MAX_IMAGES_PER_VIT=32
$export SGLANG_VLM_MAX_PATCHES_PER_VIT=10000

python -m sglang.launch_server \
  --model-path Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
  --host 0.0.0.0 \
  --port 30000 \
  --tp 8 \
  --ep 8 \
  --mem-fraction-static 0.55 \
  --max-running-requests 8 \
  --mm-enable-dp-encoder \
  --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 2}' 

python3 -m sglang.bench_serving \
  --backend sglang-oai-chat \
  --dataset-name image \
  --num-prompts 1 \
  --apply-chat-template \
  --random-input-len 128 \
  --random-output-len 32 \
  --image-resolution 560x560 \
  --image-format jpeg \
  --image-count 500 \
  --image-content random \
  --random-range-ratio 0.1 \
  --port 30000 \
  --max-concurrency 1

[2025-12-11 11:21:11] INFO:     127.0.0.1:34872 - "POST /v1/chat/completions HTTP/1.1" 200 OK
[2025-12-11 11:21:33 TP0 EP0] Prefill batch, #new-seq: 1, #new-token: 8192, #cached-token: 4, token usage: 0.00, #running-req: 0, #queue-req: 0, 
[2025-12-11 11:21:34 TP0 EP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 2704, in run_scheduler_process
    scheduler.event_loop_overlap()
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 1049, in event_loop_overlap
    batch_result = self.run_batch(batch)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/scheduler.py", line 2015, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/tp_worker.py", line 392, in forward_batch_generation
    logits_output, can_run_cuda_graph = self.model_runner.forward(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2653, in forward
    output = self._forward_raw(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2712, in _forward_raw
    ret = self.forward_extend(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/model_executor/model_runner.py", line 2598, in forward_extend
    return self.model.forward(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/qwen3_vl.py", line 735, in forward
    hidden_states = general_mm_embed_routine(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/mm_utils.py", line 752, in general_mm_embed_routine
    input_embeds, other_info = embed_mm_inputs(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/mm_utils.py", line 627, in embed_mm_inputs
    embedding, mask = get_embedding_and_mask(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/mm_utils.py", line 532, in get_embedding_and_mask
    embedding = _get_chunked_prefill_embedding(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/managers/mm_utils.py", line 442, in _get_chunked_prefill_embedding
    embedding_per_req = data_embedding_func(embedding_items_per_req)
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/models/qwen3_vl.py", line 670, in get_image_feature
    return run_dp_sharded_mrope_vision_model(
  File "/opt/conda/lib/python3.10/site-packages/sglang/srt/multimodal/mm_utils.py", line 650, in run_dp_sharded_mrope_vision_model
    out_embeddings = torch.cat(original_order_embeddings, dim=0)
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 4.95 GiB. GPU 0 has a total capacity of 79.33 GiB of which 4.19 GiB is free. Process 497728 has 15.55 GiB memory in use. Process 503513 has 59.57 GiB memory in use. Of the allocated memory 55.85 GiB is allocated by PyTorch, with 24.00 MiB allocated in private pools (e.g., CUDA Graphs), and 1.62 GiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)

[2025-12-11 11:21:34] SIGQUIT received. signum=None, frame=None. It usually means one child failed.
Killed

```

With PR no OOM.
```
$python3 -m sglang.bench_serving   --backend sglang-oai-chat   --dataset-name image   --num-prompts 1   --apply-chat-template   --random-input-len 128   --random-output-len 32   --image-resolution 560x560   --image-format jpeg   --image-count 500   --image-content random   --random-range-ratio 0.1   --port 30000   --max-concurrency 1
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
benchmark_args=Namespace(backend='sglang-oai-chat', base_url=None, host='0.0.0.0', port=30000, dataset_name='image', dataset_path='', model=None, served_model_name=None, tokenizer=None, num_prompts=1, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=32, random_range_ratio=0.1, image_count=500, image_resolution='560x560', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=1, output_file=None, output_details=False, print_requests=False, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, plot_throughput=False, profile_activities=['CPU', 'GPU'], profile_num_steps=None, profile_by_stage=False, profile_stages=None, lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=False, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)
Namespace(backend='sglang-oai-chat', base_url=None, host='0.0.0.0', port=30000, dataset_name='image', dataset_path='', model='Qwen/Qwen3-VL-235B-A22B-Instruct-FP8', served_model_name=None, tokenizer=None, num_prompts=1, sharegpt_output_len=None, sharegpt_context_len=None, random_input_len=128, random_output_len=32, random_range_ratio=0.1, image_count=500, image_resolution='560x560', image_format='jpeg', image_content='random', request_rate=inf, use_trace_timestamps=False, max_concurrency=1, output_file=None, output_details=False, print_requests=False, disable_tqdm=False, disable_stream=False, return_logprob=False, seed=1, disable_ignore_eos=False, extra_request_body=None, apply_chat_template=True, profile=False, plot_throughput=False, profile_activities=['CPU', 'GPU'], profile_num_steps=None, profile_by_stage=False, profile_stages=None, lora_name=None, lora_request_distribution='uniform', lora_zipf_alpha=1.5, prompt_suffix='', pd_separated=False, profile_prefill_url=None, profile_decode_url=None, flush_cache=False, warmup_requests=1, tokenize_prompt=False, gsp_num_groups=64, gsp_prompts_per_group=16, gsp_system_prompt_len=2048, gsp_question_len=128, gsp_output_len=256, mooncake_slowdown_factor=1.0, mooncake_num_rounds=1, mooncake_workload='conversation', tag=None)

#Input tokens: 163060
#Output tokens: 14

Created 1 random jpeg images with average 158153736 bytes per request
Starting warmup with 1 sequences...
Warmup completed with 1 sequences. Starting main benchmark run...
  0%|                                                                                                                                                                                                                                                                                            | 0/1 [00:00<?, ?it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:29<00:00, 29.94s/it]

============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     1         
Benchmark duration (s):                  29.95     
Total input tokens:                      163060    
Total input text tokens:                 60        
Total input vision tokens:               163000    
Total generated tokens:                  14        
Total generated tokens (retokenized):    14        
Request throughput (req/s):              0.03      
Input token throughput (tok/s):          5443.73   
Output token throughput (tok/s):         0.47      
Peak output token throughput (tok/s):    14.00     
Peak concurrent requests:                1         
Total token throughput (tok/s):          5444.20   
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   29940.25  
Median E2E Latency (ms):                 29940.25  
---------------Time to First Token----------------
Mean TTFT (ms):                          29725.74  
Median TTFT (ms):                        29725.74  
P99 TTFT (ms):                           29725.74  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.50     
Median TPOT (ms):                        16.50     
P99 TPOT (ms):                           16.50     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           16.50     
Median ITL (ms):                         16.05     
P95 ITL (ms):                            23.37     
P99 ITL (ms):                            32.07     
Max ITL (ms):                            34.24     
==================================================
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

No acc drop.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

PR:
```
$python3 -m lmms_eval --model openai_compatible --model_args model_version=Qwen/Qwen3-VL-235B-A22B-Instruct-FP8   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-12-14 16:24:29 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-12-14 16:24:32 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-12-14 16:24:32 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-12-14 16:24:32 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-12-14 16:24:35 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-12-14 16:24:35 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 14312.10it/s]
2025-12-14 16:24:35 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:38<00:00,  2.87s/it]2025-12-14 16:28:14 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1594.519s, Total tokens: 3234, Avg speed: 2.0 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:38<00:00,  3.84s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11242.81it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.78333}, 'Art': {'num': 30, 'acc': 0.8}, 'Art_Theory': {'num': 30, 'acc': 0.93333}, 'Design': {'num': 30, 'acc': 0.9}, 'Music': {'num': 30, 'acc': 0.5}, 'Overall-Business': {'num': 150, 'acc': 0.63333}, 'Accounting': {'num': 30, 'acc': 0.6}, 'Economics': {'num': 30, 'acc': 0.86667}, 'Finance': {'num': 30, 'acc': 0.36667}, 'Manage': {'num': 30, 'acc': 0.53333}, 'Marketing': {'num': 30, 'acc': 0.8}, 'Overall-Science': {'num': 150, 'acc': 0.56667}, 'Biology': {'num': 30, 'acc': 0.66667}, 'Chemistry': {'num': 30, 'acc': 0.46667}, 'Geography': {'num': 30, 'acc': 0.6}, 'Math': {'num': 30, 'acc': 0.46667}, 'Physics': {'num': 30, 'acc': 0.63333}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.7}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.7}, 'Clinical_Medicine': {'num': 30, 'acc': 0.8}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.4}, 'Pharmacy': {'num': 30, 'acc': 0.73333}, 'Public_Health': {'num': 30, 'acc': 0.86667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.80833}, 'History': {'num': 30, 'acc': 0.86667}, 'Literature': {'num': 30, 'acc': 0.93333}, 'Sociology': {'num': 30, 'acc': 0.7}, 'Psychology': {'num': 30, 'acc': 0.73333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.46667}, 'Agriculture': {'num': 30, 'acc': 0.6}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.33333}, 'Computer_Science': {'num': 30, 'acc': 0.56667}, 'Electronics': {'num': 30, 'acc': 0.43333}, 'Energy_and_Power': {'num': 30, 'acc': 0.56667}, 'Materials': {'num': 30, 'acc': 0.46667}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.3}, 'Overall': {'num': 900, 'acc': 0.63778}}
fatal: not a git repository (or any of the parent directories): .git
2025-12-14 16:28:14 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-235B-A22B-Instruct-FP8), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.6378|±  |   N/A|

$bash bench_one_video.sh 
{"id":"15ecac03ba5e4bb4afc00ed6bb2fcf24","object":"chat.completion","created":1765699698,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频里的招牌上写着：\n\n**小鞋匠洗鞋**\n\n旁边还有小字：\n\n**修复 上色 保养  手机号码：15295211190**\n\n这个招牌表明这是一家提供洗鞋、修复、上色和保养服务的店铺。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":12009,"total_tokens":12071,"completion_tokens":62,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m14.021s
user    0m0.001s
sys     0m0.003s
```

Main:
```
$python3 -m lmms_eval --model openai_compatible --model_args model_version=Qwen/Qwen3-VL-235B-A22B-Instruct-FP8   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-12-14 16:16:27 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-12-14 16:16:29 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-12-14 16:16:29 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-12-14 16:16:29 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-12-14 16:16:33 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-12-14 16:16:33 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 13954.09it/s]
2025-12-14 16:16:33 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:37<00:00,  2.89s/it]2025-12-14 16:20:11 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1557.292s, Total tokens: 3208, Avg speed: 2.1 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:37<00:00,  3.81s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 10912.69it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.78333}, 'Art': {'num': 30, 'acc': 0.8}, 'Art_Theory': {'num': 30, 'acc': 0.93333}, 'Design': {'num': 30, 'acc': 0.9}, 'Music': {'num': 30, 'acc': 0.5}, 'Overall-Business': {'num': 150, 'acc': 0.60667}, 'Accounting': {'num': 30, 'acc': 0.56667}, 'Economics': {'num': 30, 'acc': 0.86667}, 'Finance': {'num': 30, 'acc': 0.36667}, 'Manage': {'num': 30, 'acc': 0.53333}, 'Marketing': {'num': 30, 'acc': 0.7}, 'Overall-Science': {'num': 150, 'acc': 0.57333}, 'Biology': {'num': 30, 'acc': 0.66667}, 'Chemistry': {'num': 30, 'acc': 0.46667}, 'Geography': {'num': 30, 'acc': 0.56667}, 'Math': {'num': 30, 'acc': 0.46667}, 'Physics': {'num': 30, 'acc': 0.7}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.70667}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.73333}, 'Clinical_Medicine': {'num': 30, 'acc': 0.8}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.43333}, 'Pharmacy': {'num': 30, 'acc': 0.7}, 'Public_Health': {'num': 30, 'acc': 0.86667}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.80833}, 'History': {'num': 30, 'acc': 0.86667}, 'Literature': {'num': 30, 'acc': 0.93333}, 'Sociology': {'num': 30, 'acc': 0.7}, 'Psychology': {'num': 30, 'acc': 0.73333}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.44762}, 'Agriculture': {'num': 30, 'acc': 0.6}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.36667}, 'Computer_Science': {'num': 30, 'acc': 0.5}, 'Electronics': {'num': 30, 'acc': 0.36667}, 'Energy_and_Power': {'num': 30, 'acc': 0.56667}, 'Materials': {'num': 30, 'acc': 0.5}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.23333}, 'Overall': {'num': 900, 'acc': 0.63111}}
fatal: not a git repository (or any of the parent directories): .git
2025-12-14 16:20:11 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=Qwen/Qwen3-VL-235B-A22B-Instruct-FP8), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.6311|±  |   N/A|

$bash bench_one_video.sh 
{"id":"3fb8e99d6b244960bbc1824dc3dcaa4a","object":"chat.completion","created":1765700127,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"视频里的招牌上写着：\n\n**小鞋匠洗鞋**\n\n旁边还有小字：\n\n**修复 上色 保养  手机号码：15295211190**\n\n这个招牌是一个洗鞋店的广告，提供鞋子的修复、上色和保养服务，并附上了联系电话。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":12009,"total_tokens":12076,"completion_tokens":67,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m14.619s
user    0m0.000s
sys     0m0.004s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
