### PR TITLE
[PD][model-gateway][1/2] Expose decode KV cache availability in /get_load API

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1616,6 +1616,9 @@ class GetLoadReqOutput(BaseReq):
     num_reqs: int
     num_waiting_reqs: int
     num_tokens: int
+    # KV cache available tokens for decode capacity-aware routing
+    kv_available_tokens: int = -1
+    kv_total_tokens: int = -1
 
 
 @dataclass

--- a/sgl-model-gateway/src/protocols/worker_spec.rs
+++ b/sgl-model-gateway/src/protocols/worker_spec.rs
@@ -312,4 +312,10 @@ pub struct WorkerLoadInfo {
     pub worker_type: Option<String>,
     /// Current load (-1 indicates failure to fetch)
     pub load: isize,
+    /// KV cache available tokens (-1 indicates not available or failure to fetch)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_available_tokens: Option<isize>,
+    /// KV cache total capacity (-1 indicates not available or failure to fetch)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_total_tokens: Option<isize>,
 }


### PR DESCRIPTION
## Motivation

In PD disaggregation deployments, the router assigns decode workers **without knowing their KV cache capacity**. This causes KV cache eviction on long-text workloads when multiple requests land on a decode worker that doesn't have enough space.

**Goal**: Let the router filter out decode workers with insufficient KV capacity before selection.

## Two-Phase Plan

| Phase | Description | Status |
|-------|-------------|--------|
| **Phase 1 (this PR)** | Expose `kv_available_tokens` and `kv_total_tokens` in `/get_load` API | 🚧 |
| **Phase 2** | Add capacity filter before decode worker selection | TODO |

## Modifications

### Backend (SGLang Scheduler)
- `io_struct.py`: Add `kv_available_tokens`, `kv_total_tokens` to `GetLoadReqOutput`
- `scheduler_metrics_mixin.py`: Calculate KV availability in `get_load()`
  - Standard models: `available_size + evictable_size`
  - Hybrid SWA: `full_available_size`
  - SSM (Mamba): `allocator.available_size`

### Router (sgl-model-gateway)
- `worker_spec.rs`: Add KV fields to `WorkerLoadInfo`
- `worker_manager.rs`: Parse KV fields in `get_worker_load_extended()`

## Phase 2 Preview

```rust
// Filter before existing selection policy
let viable = decode_workers.filter(|w|
    w.kv_available_tokens.map_or(true, |avail| avail >= prompt_len)
);
existing_policy_select(viable)
```

## Accuracy Tests

N/A - This PR only adds monitoring/metrics fields, no changes to model forward code.

## Benchmarking and Profiling

N/A - This PR adds minimal overhead (~100ms intervals for `/get_load` calls), no impact on inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
