### PR TITLE
fix: config change after transformers upgrade results in dummy mode failure

### DIFF
--- a/python/sglang/srt/models/grok.py
+++ b/python/sglang/srt/models/grok.py
@@ -177,6 +177,10 @@ def _yarn_linear_ramp_mask(
 
 
 def get_rope_scaling(config):
+    params = getattr(config, "rope_parameters", None)
+    if params and set(params.keys()) <= {"rope_theta", "rope_type"}:
+        return None
+
     rope_type = getattr(config, "rope_type", None)
     if rope_type:
         original_max_position_embeddings = getattr(

--- a/python/sglang/srt/models/grok.py
+++ b/python/sglang/srt/models/grok.py
@@ -178,7 +178,7 @@ def _yarn_linear_ramp_mask(
 
 def get_rope_scaling(config):
     params = getattr(config, "rope_parameters", None)
-    if params and set(params.keys()) <= {"rope_theta", "rope_type"}:
+    if isinstance(params, dict) and set(params.keys()).issubset({"rope_theta", "rope_type"}):
         return None
 
     rope_type = getattr(config, "rope_type", None)

--- a/python/sglang/srt/models/grok.py
+++ b/python/sglang/srt/models/grok.py
@@ -178,7 +178,9 @@ def _yarn_linear_ramp_mask(
 
 def get_rope_scaling(config):
     params = getattr(config, "rope_parameters", None)
-    if isinstance(params, dict) and set(params.keys()).issubset({"rope_theta", "rope_type"}):
+    if isinstance(params, dict) and set(params.keys()).issubset(
+        {"rope_theta", "rope_type"}
+    ):
         return None
 
     rope_type = getattr(config, "rope_type", None)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.ai to discuss further. -->

## Motivation

To run dummy test for grok, hit an issue related to transformers revision. The root cause is 5.0.0rc0 changes the parameters in PretrainedConfig, which is used by dummy test to set up its rope scaling related parameters.

## Modifications

If "rope_parameters" is just a small dict, no real need to prepare rope scaling parameters for later rotary emb.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
