### PR TITLE
extend timeout for b200 test

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1214,7 +1214,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd test/srt
-          python3 run_suite.py --suite per-commit-4-gpu-b200 --auto-partition-id ${{ matrix.part }}  --auto-partition-size 3 --timeout-per-file 1800
+          IS_BLACKWELL=1 python3 run_suite.py --suite per-commit-4-gpu-b200 --auto-partition-id ${{ matrix.part }}  --auto-partition-size 3 --timeout-per-file 1800
 
   # TODO: Add gb200 tests back after the ci runner is fixed
   # unit-test-backend-4-gpu-gb200:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -151,6 +151,7 @@ class Envs:
     # Test & Debug
     SGLANG_IS_IN_CI = EnvBool(False)
     SGLANG_IS_IN_CI_AMD = EnvBool(False)
+    IS_BLACKWELL = EnvBool(False)
     SGLANG_SET_CPU_AFFINITY = EnvBool(False)
     SGLANG_PROFILE_WITH_STACK = EnvBool(True)
     SGLANG_PROFILE_RECORD_SHAPES = EnvBool(True)

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -30,6 +30,7 @@ from PIL import Image
 
 from sglang.bench_serving import run_benchmark
 from sglang.global_config import global_config
+from sglang.srt.environ import envs
 from sglang.srt.utils import (
     get_bool_env_var,
     get_device,
@@ -162,7 +163,7 @@ def is_in_amd_ci():
 
 def is_blackwell_system():
     """Return whether it is running on a Blackwell (B200) system."""
-    return get_bool_env_var("IS_BLACKWELL")
+    return envs.IS_BLACKWELL.get()
 
 
 def _use_cached_default_models(model_repo: str):


### PR DESCRIPTION
Keeps on failing due to timeout (from trt allreduce fusion, flashinfer autotune), like

https://github.com/sgl-project/sglang/actions/runs/20119197436/job/57802226526?pr=14357
https://github.com/sgl-project/sglang/actions/runs/20118348681/job/57804217560?pr=13798

This env var increases to 50 min (already used elsewhere)