### PR TITLE
fix: making the publish trace error check broader

### DIFF
--- a/scripts/ci/publish_traces.py
+++ b/scripts/ci/publish_traces.py
@@ -14,12 +14,8 @@ from urllib.request import Request, urlopen
 
 
 def is_rate_limit_error(e):
-    """Check if an exception is a rate limit error"""
-    return (
-        isinstance(e, HTTPError)
-        and e.code in [403, 429]
-        and "rate limit exceeded" in getattr(e, "error_body", "").lower()
-    )
+    """Check if an exception is a GitHub permission/quota error that should not be retried"""
+    return isinstance(e, HTTPError) and e.code in [403, 429]
 
 
 def make_github_request(url, token, method="GET", data=None):


### PR DESCRIPTION
## Motivation

Currently, we're getting a new kind of 403 error in `{"message":"Repository is above its size quota.","documentation_url":"https://docs.github.com/rest/git/blobs#create-a-blob","status":"403"}`

## Modifications

Removed condition to see if "rate limit exceeded" is in the error message.

## Accuracy Tests

pending.

## Benchmarking and Profiling

N/A

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
