### PR TITLE
Fix black formatting in ci_utils.py

### DIFF
--- a/python/sglang/test/ci/ci_utils.py
+++ b/python/sglang/test/ci/ci_utils.py
@@ -209,9 +209,7 @@ def run_unittest_files(
                         is_retriable, reason = is_retriable_failure(output)
 
                         if is_retriable:
-                            logger.info(
-                                f"\n[CI Retry] {filename} failed with {reason}"
-                            )
+                            logger.info(f"\n[CI Retry] {filename} failed with {reason}")
                             logger.info(
                                 f"[CI Retry] Waiting {retry_wait_seconds}s before retry...\n"
                             )


### PR DESCRIPTION
## Summary

Fix black formatting issue in `python/sglang/test/ci/ci_utils.py`.

The logger.info call didn't pass lint

## Test Plan

- [x] Lint passes