### PR TITLE
Remove incorrect BlockRemoved event emission during node splits

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -649,7 +649,6 @@ class RadixCache(BasePrefixCache):
     def _split_node(self, key: RadixKey, child: TreeNode, split_len: int):
         # new_node -> child
         # New node inherits child's priority (represents shared prefix)
-        self._record_remove_event(child)
         new_node = TreeNode(priority=child.priority)
         new_node.children = {self.get_child_key_fn(key[split_len:]): child}
         new_node.parent = child.parent


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When using the KV-aware router with disaggregated inference, `_split_node` incorrectly emits `BlockRemoved` events for all blocks in a node before splitting. Since no corresponding `BlockStored` events are emitted for the reorganized nodes afterward, the router permanently loses track of cached blocks on the worker.

This causes suboptimal routing: requests with shared prefixes (e.g., common system prompts) are not preferentially routed to workers that already have those prefixes cached, even though the KV cache data remains on the GPU.

**Example scenario:**
1. Request A caches `[system_prompt + user_A]` → blocks H1, H2, H3 stored on Worker1
2. Request B with same system prompt triggers a node split
3. `_split_node` emits `BlockRemoved` for H1, H2, H3, but only `BlockStored` for H4 (user_B's new block)
4. Router now thinks Worker1 only has H4; system prompt blocks H1, H2 become permanently invisible
5. Future requests with same system prompt are not routed to Worker1

Related to https://github.com/sgl-project/sglang/pull/13488

## Modifications

Remove the `_record_remove_event(child)` call from `_split_node` in `radix_cache.py`.

This is correct because node splitting is a tree restructuring operation, not a cache eviction. The underlying KV cache data and block hashes remain unchanged—only the tree structure is reorganized. The router only needs to know which blocks exist on which workers, not the internal tree structure.

## Accuracy Tests

N/A - This change only affects KV cache event emission for the disaggregated router, not model outputs.

## Benchmarking and Profiling

N/A - This change removes an unnecessary function call, so no performance regression expected. It should improve routing efficiency when using the KV-aware router with workloads that share common prefixes.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
