### PR TITLE
[Fix] suppress remote weight loading engine w/o mooncake installed

### DIFF
--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -33,7 +33,7 @@ dependencies = [
   "interegular",
   "llguidance>=0.7.11,<0.8.0",
   "modelscope",
-  "mooncake",
+  "mooncake-transfer-engine-non-cuda",
   "msgspec",
   "ninja",
   "numpy",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -33,7 +33,6 @@ dependencies = [
   "interegular",
   "llguidance>=0.7.11,<0.8.0",
   "modelscope",
-  "mooncake-transfer-engine-non-cuda",
   "msgspec",
   "ninja",
   "numpy",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -33,6 +33,7 @@ dependencies = [
   "interegular",
   "llguidance>=0.7.11,<0.8.0",
   "modelscope",
+  "mooncake",
   "msgspec",
   "ninja",
   "numpy",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2144,18 +2144,25 @@ class ServerArgs:
             self.skip_server_warmup = True
 
     def _handle_remote_instance_weight_loader_support_transfer_engine(self):
-        if importlib.util.find_spec("mooncake.engine") is None:
+        try:
+            importlib.import_module("mooncake")
+            if importlib.util.find_spec("mooncake.engine") is None:
+                logger.warning(
+                    f"Failed to import mooncake.engine. Does not support using TransferEngine as remote instance weight loader backend."
+                )
+                self.remote_instance_weight_loader_support_transfer_engine = False
+            elif self.enable_memory_saver:
+                logger.warning(
+                    "Memory saver is enabled, which is not compatible with TransferEngine. Does not support using TransferEngine as remote instance weight loader backend."
+                )
+                self.remote_instance_weight_loader_support_transfer_engine = False
+            else:
+                self.remote_instance_weight_loader_support_transfer_engine = True
+        except ImportError:
             logger.warning(
-                f"Failed to import mooncake.engine. Does not support using TransferEngine as remote instance weight loader backend."
+                f"Failed to import mooncake. Does not support using TransferEngine as remote instance weight loader backend."
             )
             self.remote_instance_weight_loader_support_transfer_engine = False
-        elif self.enable_memory_saver:
-            logger.warning(
-                "Memory saver is enabled, which is not compatible with TransferEngine. Does not support using TransferEngine as remote instance weight loader backend."
-            )
-            self.remote_instance_weight_loader_support_transfer_engine = False
-        else:
-            self.remote_instance_weight_loader_support_transfer_engine = True
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):


### PR DESCRIPTION
## Motivation

Fix the `ModuleNotFoundError: No module named 'mooncake'` in non-cuda CI cases introduced by #13125 

## Modifications

Add `mooncake` package check with `try...except` syntax. Set `server_args.remote_instance_weight_loader_support_transfer_engine` as `False` if `mooncake` package was not installed.


Adding `mooncake` installation does not work on non-CUDA platforms. Such error would be raised:

```
  File "/opt/.venv/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 2683, in run_scheduler_process
    scheduler = Scheduler(
                ^^^^^^^^^^
  File "/opt/.venv/lib/python3.12/site-packages/sglang/srt/managers/scheduler.py", line 320, in __init__
    self.tp_worker = TpModelWorker(
                     ^^^^^^^^^^^^^^
  File "/opt/.venv/lib/python3.12/site-packages/sglang/srt/managers/tp_worker.py", line 248, in __init__
    self._model_runner = ModelRunner(
                         ^^^^^^^^^^^^
  File "/opt/.venv/lib/python3.12/site-packages/sglang/srt/model_executor/model_runner.py", line 366, in __init__
    self.initialize(min_per_gpu_memory)
  File "/opt/.venv/lib/python3.12/site-packages/sglang/srt/model_executor/model_runner.py", line 451, in initialize
    register_memory_region_v2(
  File "/opt/.venv/lib/python3.12/site-packages/sglang/srt/model_loader/remote_instance_weight_loader_utils.py", line 144, in register_memory_region_v2
    memory_snapshot = torch.cuda.memory.memory_snapshot()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/.venv/lib/python3.12/site-packages/torch/cuda/memory.py", line 627, in memory_snapshot
    return torch._C._cuda_memorySnapshot(mempool_id)["segments"]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch._C' has no attribute '_cuda_memorySnapshot'
```

