### PR TITLE
Fix negative duration panic in token bucket wait time calculation

### DIFF
--- a/sgl-model-gateway/src/core/token_bucket.rs
+++ b/sgl-model-gateway/src/core/token_bucket.rs
@@ -105,7 +105,7 @@ impl TokenBucket {
         let wait_time = {
             let inner = self.inner.lock().await;
             let tokens_needed = tokens - inner.tokens;
-            let wait_secs = tokens_needed / self.refill_rate;
+            let wait_secs = (tokens_needed / self.refill_rate).max(0.0);
             Duration::from_secs_f64(wait_secs)
         };
 


### PR DESCRIPTION
## Summary
- Clamp `wait_secs` to non-negative value using `.max(0.0)` before passing to `Duration::from_secs_f64()`
- Prevents panic when `tokens_needed` becomes negative due to concurrent token refills

## Test plan
- Existing unit tests pass
- The fix is defensive; prevents edge case panic in concurrent scenarios

related https://github.com/vllm-project/router/pull/28
🤖 Generated with [Claude Code](https://claude.com/claude-code)