### PR TITLE
fix(lora_manager): skip false positive matches in target modules

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -505,6 +505,12 @@ class LoRAManager:
             # The module should be converted if it is included in target_names
             if module_name.split(".")[-1] in self.target_modules:
                 layer_id = get_layer_id(module_name)
+
+                # Skip false positives e.g. visual.blocks.0.attn.qkv_proj
+                # in Qwen 2.5 VL 3B.
+                if layer_id is None:
+                    continue
+
                 self.lora_modules[layer_id][module_name] = self.set_lora_module(
                     module_name, module
                 )


### PR DESCRIPTION
## Motivation

This PR fixes a minor bug in the LoRA manager to skip false positive matches while loading LoRA adapters.

Fixes #14954.

## Modifications

In `python/sglang/srt/lora/lora_manager.py`, in `init_lora_modules`, when `get_layer_id` returns `None`, continue the loop instead of proceeding to assign the LoRA module layers.

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
