### PR TITLE
feature: adding model tag to cuda nightly docker image

### DIFF
--- a/.github/workflows/release-docker-cu13.yml
+++ b/.github/workflows/release-docker-cu13.yml
@@ -50,6 +50,17 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Read model tags
+              run: |
+                  MODEL_TAG=$(cat python/sglang/model_tags.txt | grep -v '^[[:space:]]*$' | tr '\n' '-' | sed 's/-$//')
+                  # Build tag - add model suffix if model tags specified
+                  if [ -n "$MODEL_TAG" ]; then
+                    IMAGE_TAG="${{ matrix.tag }}-${MODEL_TAG}"
+                  else
+                    IMAGE_TAG="${{ matrix.tag }}"
+                  fi
+                  echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
             - name: Build and Push Dev Image
               run: |
                   docker buildx build \
@@ -62,7 +73,7 @@ jobs:
                     --build-arg CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) \
                     --build-arg GRACE_BLACKWELL=${{ matrix.grace_blackwell }} \
                     --build-arg USE_LATEST_SGLANG=1 \
-                    -t lmsysorg/sglang:${{ matrix.tag }} \
+                    -t lmsysorg/sglang:${IMAGE_TAG} \
                     --no-cache \
                     .
 
@@ -86,25 +97,24 @@ jobs:
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
-            - run: |
-                  # Read all model tags and join with dashes
+
+            - name: Read model tags
+              run: |
                   MODEL_TAG=$(cat python/sglang/model_tags.txt | grep -v '^[[:space:]]*$' | tr '\n' '-' | sed 's/-$//')
-
-                  # Build tag list - always preserve 'dev-cu13' as latest
-                  TAGS="-t lmsysorg/sglang:${{ matrix.variant.tag }}"
-                  TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${GITHUB_SHA:0:8}"
-
-                  # Add model-tagged version if model tags are specified
                   if [ -n "$MODEL_TAG" ]; then
-                    TAGS="$TAGS -t lmsysorg/sglang:${{ matrix.variant.tag }}-${MODEL_TAG}"
-                    TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-${MODEL_TAG}-$(date +%Y%m%d)-${GITHUB_SHA:0:8}"
+                    echo "X86_TAG=${{ matrix.variant.x86_tag }}-${MODEL_TAG}" >> $GITHUB_ENV
+                    echo "ARM64_TAG=${{ matrix.variant.arm64_tag }}-${MODEL_TAG}" >> $GITHUB_ENV
+                  else
+                    echo "X86_TAG=${{ matrix.variant.x86_tag }}" >> $GITHUB_ENV
+                    echo "ARM64_TAG=${{ matrix.variant.arm64_tag }}" >> $GITHUB_ENV
                   fi
 
-                  # Create multi-arch manifest
+            - run: |
                   docker buildx imagetools create \
-                    $TAGS \
-                    lmsysorg/sglang:${{ matrix.variant.x86_tag }} \
-                    lmsysorg/sglang:${{ matrix.variant.arm64_tag }}
+                    -t lmsysorg/sglang:${{ matrix.variant.tag }} \
+                    -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${GITHUB_SHA:0:8} \
+                    lmsysorg/sglang:${X86_TAG} \
+                    lmsysorg/sglang:${ARM64_TAG}
 
             - name: Cleanup Old Nightly Builds
               run: |

--- a/.github/workflows/release-docker-cu13.yml
+++ b/.github/workflows/release-docker-cu13.yml
@@ -77,6 +77,9 @@ jobs:
                       x86_tag: dev-x86-cu13
                       arm64_tag: dev-arm64-cu13
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
             - uses: docker/setup-buildx-action@v3
 
             - uses: docker/login-action@v2
@@ -84,9 +87,22 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
             - run: |
+                  # Read all model tags and join with dashes
+                  MODEL_TAG=$(cat python/sglang/model_tags.txt | grep -v '^[[:space:]]*$' | tr '\n' '-' | sed 's/-$//')
+
+                  # Build tag list - always preserve 'dev-cu13' as latest
+                  TAGS="-t lmsysorg/sglang:${{ matrix.variant.tag }}"
+                  TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${GITHUB_SHA:0:8}"
+
+                  # Add model-tagged version if model tags are specified
+                  if [ -n "$MODEL_TAG" ]; then
+                    TAGS="$TAGS -t lmsysorg/sglang:${{ matrix.variant.tag }}-${MODEL_TAG}"
+                    TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-${MODEL_TAG}-$(date +%Y%m%d)-${GITHUB_SHA:0:8}"
+                  fi
+
+                  # Create multi-arch manifest
                   docker buildx imagetools create \
-                    -t lmsysorg/sglang:${{ matrix.variant.tag }} \
-                    -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${GITHUB_SHA:0:8} \
+                    $TAGS \
                     lmsysorg/sglang:${{ matrix.variant.x86_tag }} \
                     lmsysorg/sglang:${{ matrix.variant.arm64_tag }}
 

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -79,6 +79,9 @@ jobs:
             x86_tag: dev-x86
             arm64_tag: dev-arm64
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v2
@@ -87,9 +90,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: |
           SHORT_SHA="${{ github.sha }}"
+          # Read all model tags and join with dashes
+          MODEL_TAG=$(cat python/sglang/model_tags.txt | grep -v '^[[:space:]]*$' | tr '\n' '-' | sed 's/-$//')
+
+          # Build tag list - always preserve 'dev' as latest
+          TAGS="-t lmsysorg/sglang:${{ matrix.variant.tag }}"
+          TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${SHORT_SHA:0:8}"
+
+          # Add model-tagged version if model tags are specified
+          if [ -n "$MODEL_TAG" ]; then
+            TAGS="$TAGS -t lmsysorg/sglang:${{ matrix.variant.tag }}-${MODEL_TAG}"
+            TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-${MODEL_TAG}-$(date +%Y%m%d)-${SHORT_SHA:0:8}"
+          fi
+
+          # Create multi-arch manifest
           docker buildx imagetools create \
-            -t lmsysorg/sglang:${{ matrix.variant.tag }} \
-            -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${SHORT_SHA:0:8} \
+            $TAGS \
             lmsysorg/sglang:${{ matrix.variant.x86_tag }} \
             lmsysorg/sglang:${{ matrix.variant.arm64_tag }}
 

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -51,6 +51,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Read model tags
+        run: |
+          MODEL_TAG=$(cat python/sglang/model_tags.txt | grep -v '^[[:space:]]*$' | tr '\n' '-' | sed 's/-$//')
+          # Build tag - add model suffix if model tags specified
+          if [ -n "$MODEL_TAG" ]; then
+            IMAGE_TAG="${{ matrix.tag }}-${MODEL_TAG}"
+          else
+            IMAGE_TAG="${{ matrix.tag }}"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
       - name: Build and Push Dev Image
         run: |
           docker buildx build \
@@ -64,7 +75,7 @@ jobs:
             --build-arg GRACE_BLACKWELL=${{ matrix.grace_blackwell }} \
             --build-arg USE_LATEST_SGLANG=1 \
             --build-arg INSTALL_FLASHINFER_JIT_CACHE=1 \
-            -t lmsysorg/sglang:${{ matrix.tag }} \
+            -t lmsysorg/sglang:${IMAGE_TAG} \
             --no-cache \
             .
 
@@ -88,26 +99,25 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: |
-          SHORT_SHA="${{ github.sha }}"
-          # Read all model tags and join with dashes
+
+      - name: Read model tags
+        run: |
           MODEL_TAG=$(cat python/sglang/model_tags.txt | grep -v '^[[:space:]]*$' | tr '\n' '-' | sed 's/-$//')
-
-          # Build tag list - always preserve 'dev' as latest
-          TAGS="-t lmsysorg/sglang:${{ matrix.variant.tag }}"
-          TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${SHORT_SHA:0:8}"
-
-          # Add model-tagged version if model tags are specified
           if [ -n "$MODEL_TAG" ]; then
-            TAGS="$TAGS -t lmsysorg/sglang:${{ matrix.variant.tag }}-${MODEL_TAG}"
-            TAGS="$TAGS -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-${MODEL_TAG}-$(date +%Y%m%d)-${SHORT_SHA:0:8}"
+            echo "X86_TAG=${{ matrix.variant.x86_tag }}-${MODEL_TAG}" >> $GITHUB_ENV
+            echo "ARM64_TAG=${{ matrix.variant.arm64_tag }}-${MODEL_TAG}" >> $GITHUB_ENV
+          else
+            echo "X86_TAG=${{ matrix.variant.x86_tag }}" >> $GITHUB_ENV
+            echo "ARM64_TAG=${{ matrix.variant.arm64_tag }}" >> $GITHUB_ENV
           fi
 
-          # Create multi-arch manifest
+      - run: |
+          SHORT_SHA="${{ github.sha }}"
           docker buildx imagetools create \
-            $TAGS \
-            lmsysorg/sglang:${{ matrix.variant.x86_tag }} \
-            lmsysorg/sglang:${{ matrix.variant.arm64_tag }}
+            -t lmsysorg/sglang:${{ matrix.variant.tag }} \
+            -t lmsysorg/sglang:nightly-${{ matrix.variant.tag }}-$(date +%Y%m%d)-${SHORT_SHA:0:8} \
+            lmsysorg/sglang:${X86_TAG} \
+            lmsysorg/sglang:${ARM64_TAG}
 
       - name: Cleanup Old Nightly Builds
         run: |

--- a/python/sglang/model_tags.txt
+++ b/python/sglang/model_tags.txt
@@ -1,0 +1,2 @@
+testModel1
+testModel2


### PR DESCRIPTION
## Motivation

Instead of creating a new post release for a new model that is supported, we add a special model tagging to nightly CUDA docker images; we can specify a list of new models that we support and then the nightly images will be tagged with the model; 

> Normally -> image tags: dev-x86, dev-arm64
> New model supported (glm4.6 for ex.) -> image tags: dev-x86-glm4.6, dev-arm64-glm4.6

## Modifications

Added a models.txt file to add models to, and added a step to release-docker-dev.yml and release-docker-cu13.yml where if there are models are in models.txt, we create a special tag for the nightly image that takes dev-{architecture}-{model}.


## Accuracy Tests

Testing.

## Benchmarking and Profiling

N/A

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
