### PR TITLE
[Feature] Add DCP support for GQA with flashinfer

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -702,10 +702,10 @@ class GroupCoordinator:
 
         chunk_size = input_tensor.shape[0] // world_size
         output_shape = (chunk_size,) + input_tensor.shape[1:]
-
-        output_tensor = torch.empty(
-            output_shape, dtype=input_tensor.dtype, device=input_tensor.device
-        )
+        with self.use_symmetric_memory(self):
+            output_tensor = torch.empty(
+                output_shape, dtype=input_tensor.dtype, device=input_tensor.device
+            )
 
         # Perform reduce-scatter operation
         self.reduce_scatter_tensor(output_tensor, input_tensor)
@@ -1481,7 +1481,9 @@ def graph_capture(stream: Optional[torch.cuda.Stream] = None):
     """
     with get_tp_group().graph_capture(
         stream=stream
-    ) as context, get_pp_group().graph_capture(context):
+    ) as context, get_pp_group().graph_capture(context), get_dcp_group().graph_capture(
+        context
+    ):
         yield context
 
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -710,9 +710,7 @@ class GroupCoordinator:
         )
 
         # Perform reduce-scatter operation
-        torch.distributed.reduce_scatter_tensor(
-            output_tensor, input_tensor, group=self.device_group
-        )
+        self.reduce_scatter_tensor(output_tensor, input_tensor)
 
         # Reshape before returning
         return output_tensor.movedim(0, dim).contiguous()

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -697,8 +697,6 @@ class GroupCoordinator:
             # Convert negative dim to positive.
             dim += input_.dim()
 
-        # Note: This will produce an incorrect answer if we don't make
-        # the input_tensor contiguous. Possible bug in reduce_scatter_tensor?
         input_tensor = input_.movedim(0, dim).contiguous()
         assert input_tensor.shape[0] % world_size == 0
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -697,7 +697,8 @@ class GroupCoordinator:
             # Convert negative dim to positive.
             dim += input_.dim()
 
-        input_tensor = input_.movedim(0, dim).contiguous()
+        with self.use_symmetric_memory(self):
+            input_tensor = input_.movedim(0, dim).contiguous()
         assert input_tensor.shape[0] % world_size == 0
 
         chunk_size = input_tensor.shape[0] // world_size

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -768,6 +768,11 @@ def _set_envs_and_config(server_args: ServerArgs):
         os.environ["NCCL_NVLS_ENABLE"] = str(
             int(server_args.enable_nccl_nvls or server_args.enable_symm_mem)
         )
+    if "NCCL_GRAPH_MIXING_SUPPORT" not in os.environ and server_args.dcp_size > 1:
+        # NCCL_GRAPH_MIXING_SUPPORT=0 can avoid the unnecessary EVENT_WAIT and EVENT_RECORD in cuda graph.
+        # This is helpful for improving DCP performance because it reduces bubbles.
+        # https://discuss.pytorch.org/t/unexplained-gaps-in-execution-before-nccl-operations-when-using-cuda-graphs/197818/15
+        os.environ["NCCL_GRAPH_MIXING_SUPPORT"] = "0"
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "8"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -870,6 +870,11 @@ class FlashInferAttnBackend(AttentionBackend):
                 o, _ = merge_state(o1, s1, o2, s2)
 
             if save_kv_cache:
+                if self.dcp_size > 1:
+                    assert forward_batch.dcp_kv_mask is not None
+                    k = k[forward_batch.dcp_kv_mask]
+                    v = v[forward_batch.dcp_kv_mask]
+                    cache_loc = cache_loc[forward_batch.dcp_kv_mask]
                 forward_batch.token_to_kv_pool.set_kv_buffer(
                     layer, cache_loc, k, v, layer.k_scale, layer.v_scale
                 )
@@ -897,6 +902,11 @@ class FlashInferAttnBackend(AttentionBackend):
         if k is not None:
             assert v is not None
             if save_kv_cache:
+                if self.dcp_size > 1:
+                    assert forward_batch.dcp_kv_mask is not None
+                    k = k[forward_batch.dcp_kv_mask]
+                    v = v[forward_batch.dcp_kv_mask]
+                    cache_loc = cache_loc[forward_batch.dcp_kv_mask]
                 forward_batch.token_to_kv_pool.set_kv_buffer(
                     layer, cache_loc, k, v, layer.k_scale, layer.v_scale
                 )

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -146,7 +146,8 @@ class FlashInferAttnBackend(AttentionBackend):
         self.decode_use_tensor_cores = should_use_tensor_core(
             kv_cache_dtype=model_runner.kv_cache_dtype,
             num_attention_heads=model_runner.model_config.num_attention_heads
-            // get_attention_tp_size(),
+            // get_attention_tp_size()
+            * self.dcp_size,
             num_kv_heads=model_runner.model_config.get_num_kv_heads(
                 get_attention_tp_size()
             ),

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 import torch
 
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
-    SymmetricMemoryContext,
     use_symmetric_memory,
 )
 from sglang.srt.distributed.parallel_state import get_dcp_group
@@ -913,9 +912,8 @@ class FlashInferAttnBackend(AttentionBackend):
         )
 
         if self.dcp_size > 1:
-            with use_symmetric_memory(get_dcp_group()) as sm_context:
-                if isinstance(sm_context, SymmetricMemoryContext):
-                    q = q.clone(memory_format=torch.contiguous_format)
+            with use_symmetric_memory(get_dcp_group()):
+                q = q.clone(memory_format=torch.contiguous_format)
             q = get_dcp_group().all_gather(q, dim=1)
         else:
             q = q.contiguous()

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -878,15 +878,18 @@ class FlashInferAttnBackend(AttentionBackend):
                 o, _ = merge_state(o1, s1, o2, s2)
 
             if save_kv_cache:
-                forward_batch.token_to_kv_pool.set_kv_buffer(
+                args = (
                     layer,
                     cache_loc,
                     k,
                     v,
                     layer.k_scale,
                     layer.v_scale,
-                    dcp_kv_mask=forward_batch.dcp_kv_mask,
                 )
+                kwargs = {}
+                if self.dcp_size > 1:
+                    kwargs["dcp_kv_mask"] = forward_batch.dcp_kv_mask
+                forward_batch.token_to_kv_pool.set_kv_buffer(*args, **kwargs)
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
@@ -918,15 +921,18 @@ class FlashInferAttnBackend(AttentionBackend):
         if k is not None:
             assert v is not None
             if save_kv_cache:
-                forward_batch.token_to_kv_pool.set_kv_buffer(
+                args = (
                     layer,
                     cache_loc,
                     k,
                     v,
                     layer.k_scale,
                     layer.v_scale,
-                    dcp_kv_mask=forward_batch.dcp_kv_mask,
                 )
+                kwargs = {}
+                if self.dcp_size > 1:
+                    kwargs["dcp_kv_mask"] = forward_batch.dcp_kv_mask
+                forward_batch.token_to_kv_pool.set_kv_buffer(*args, **kwargs)
 
         # Call the wrapped function
         o, s = decode_wrapper.forward_return_lse(

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -18,9 +18,7 @@ import torch
 from sglang.srt.compilation.piecewise_context_manager import is_in_piecewise_cuda_graph
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-from sglang.srt.layers.attention.flashinfer_backend import (
-    create_flashinfer_kv_indices_triton,
-)
+from sglang.srt.layers.attention.utils import create_flashinfer_kv_indices_triton
 from sglang.srt.layers.dp_attention import get_attention_tp_size
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -321,6 +321,7 @@ def pad_sequence_with_mask(
     return B, output, attn_mask
 
 
+# Adapted from vllm: https://github.com/vllm-project/vllm/blob/v0.12.0/vllm/attention/ops/common.py
 @triton.jit
 def _correct_attn_cp_out_kernel(
     outputs_ptr,

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -455,20 +455,13 @@ def cp_lse_ag_out_rs(
     cp_attn_out: [ B, H, D ]
     cp_attn_lse: [ B, H ]
     """
-    if cp_group.world_size == 1:
-        return cp_attn_out
-
     if ctx is None:
         ctx = CPTritonContext()
 
-    lses = torch.empty(
-        (cp_group.world_size,) + cp_attn_lse.shape,
-        dtype=cp_attn_lse.dtype,
-        device=cp_attn_lse.device,
-    )
-
     cp_attn_lse = cp_attn_lse.contiguous()
-    lses = cp_group.all_gather(cp_attn_lse, dim=0).view_as(lses)
+    lses = cp_group.all_gather(cp_attn_lse, dim=0).view(
+        (cp_group.world_size,) + cp_attn_lse.shape
+    )
     out, lse = correct_attn_out(cp_attn_out, lses, cp_group.rank_in_group, ctx)
     assert out.is_contiguous()
     out = cp_group.reduce_scatter_along_dim(out, dim=1)

--- a/python/sglang/srt/layers/attention/utils.py
+++ b/python/sglang/srt/layers/attention/utils.py
@@ -2,6 +2,8 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.distributed.parallel_state import GroupCoordinator
+
 _FLASHMLA_CREATE_KV_BLOCK_SIZE = 4096
 FLASHMLA_CREATE_KV_BLOCK_SIZE_TRITON = tl.constexpr(_FLASHMLA_CREATE_KV_BLOCK_SIZE)
 
@@ -277,3 +279,202 @@ def pad_sequence_with_mask(
     )
 
     return B, output, attn_mask
+
+
+@triton.jit
+def _correct_attn_cp_out_kernel(
+    outputs_ptr,
+    new_output_ptr,
+    lses_ptr,
+    vlse_ptr,
+    outputs_stride_B,
+    outputs_stride_H,
+    outputs_stride_D,
+    lses_stride_N,
+    lses_stride_B,
+    lses_stride_H,
+    lse_idx,
+    HEAD_DIM: tl.constexpr,
+    N_ROUNDED: tl.constexpr,
+):
+    """
+    Apply the all-gathered lses to correct each local rank's attention
+    output. we still need perform a cross-rank reduction to obtain the
+    final attention output.
+
+    Args:
+        outputs_ptr (triton.PointerType):
+            Pointer to input tensor of shape [ B, H, D ]
+        lses_ptr (triton.PointerType):
+            Pointer to input tensor of shape [ N, B, H ]
+        new_output_ptr (triton.PointerType):
+            Pointer to output tensor of shape [ B, H, D ]
+        vlse_ptr (triton.PointerType):
+            Pointer to output tensor of shape [ B, H ]
+    """
+    batch_idx = tl.program_id(axis=0).to(tl.int64)
+    head_idx = tl.program_id(axis=1).to(tl.int64)
+    d_offsets = tl.arange(0, HEAD_DIM)
+    num_n_offsets = tl.arange(0, N_ROUNDED)
+
+    # shape = [N]
+    lse_offsets = (
+        num_n_offsets * lses_stride_N
+        + batch_idx * lses_stride_B
+        + head_idx * lses_stride_H
+    )
+
+    # calc final lse
+    lse = tl.load(lses_ptr + lse_offsets)
+    lse = tl.where((lse != lse) | (lse == float("inf")), -float("inf"), lse)
+    lse_max = tl.max(lse, axis=0)
+    lse_max = tl.where(lse_max == -float("inf"), 0, lse_max)
+    lse -= lse_max
+    lse_exp = tl.exp2(lse)
+    lse_acc = tl.sum(lse_exp, axis=0)
+    lse = tl.log2(lse_acc)
+    lse += lse_max
+
+    lse_offsets = batch_idx * lses_stride_B + head_idx * lses_stride_H
+    tl.store(vlse_ptr + lse_offsets, lse)
+
+    # shape = [D]
+    output_offsets = (
+        batch_idx * outputs_stride_B
+        + head_idx * outputs_stride_H
+        + d_offsets * outputs_stride_D
+    )
+
+    # correct output
+    lse_offset = (
+        lse_idx * lses_stride_N + batch_idx * lses_stride_B + head_idx * lses_stride_H
+    )
+    lse_tmp = tl.load(lses_ptr + lse_offset)
+    lse_finally = lse_tmp - lse
+    lse_finally = tl.where(
+        (lse_finally != lse_finally) | (lse_finally == float("inf")),
+        -float("inf"),
+        lse_finally,
+    )
+    factor = tl.exp2(lse_finally)
+    output = tl.load(outputs_ptr + output_offsets)
+    output = output * factor
+
+    tl.store(new_output_ptr + output_offsets, output)
+
+
+class CPTritonContext:
+    """The CPTritonContext is used to avoid recompilation of the Triton JIT."""
+
+    def __init__(self):
+        self.inner_kernel = None
+
+    def call_kernel(self, kernel, grid, *regular_args, **const_args):
+        if self.inner_kernel is None:
+            self.inner_kernel = kernel[grid](*regular_args, **const_args)
+        else:
+            self.inner_kernel[grid](*regular_args)
+
+
+def correct_attn_out(
+    out: torch.Tensor, lses: torch.Tensor, cp_rank: int, ctx: CPTritonContext
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Correct the attention output using the all-gathered lses.
+
+    Args:
+        out: Tensor of shape [ B, H, D ]
+        lses: Tensor of shape [ N, B, H ]
+        cp_rank: Current rank in the context-parallel group
+        ctx: Triton context to avoid recompilation
+
+    Returns:
+        Tuple of (out, lse) with corrected attention and final log-sum-exp.
+    """
+    if ctx is None:
+        ctx = CPTritonContext()
+
+    # --- Normalize to 3D views ---
+    if out.ndim == 4 and out.shape[1] == 1:
+        out = out.squeeze(1)
+    assert out.ndim == 3, f"expected out [B,H,D] or [B,1,H,D], got {tuple(out.shape)}"
+
+    if lses.ndim == 4 and lses.shape[-1] == 1:
+        lses = lses.squeeze(-1)
+    if lses.ndim == 4 and lses.shape[1] == 1:
+        lses = lses.squeeze(1)
+    assert lses.ndim == 3, (
+        f"expected lses [N,B,H] (optionally with a 1-sized extra dim), "
+        f"got {tuple(lses.shape)}"
+    )
+
+    B, H, D = out.shape
+    N = lses.shape[0]
+
+    # Strides after we normalized shapes to 3-D views.  The kernel computes
+    # offsets for `vlse_ptr` using lses_stride_B/H, so the output buffer must
+    # have the same B/H stride layout as a slice of `lses`.
+    o_sB, o_sH, o_sD = out.stride()
+    l_sN, l_sB, l_sH = lses.stride()
+
+    # Allocate LSE with the same B/H strides as `lses` so writes land correctly
+    # even when `lses` is a non-contiguous view (e.g., 4-D to 3-D squeeze).
+    lse = torch.empty_strided(
+        (B, H), (l_sB, l_sH), device=lses.device, dtype=lses.dtype
+    )
+
+    # Kernel launch config
+    grid = (B, H, 1)
+
+    regular_args = (
+        out,
+        out,
+        lses,
+        lse,
+        o_sB,
+        o_sH,
+        o_sD,
+        l_sN,
+        l_sB,
+        l_sH,
+        cp_rank,
+    )
+    const_args = {"HEAD_DIM": D, "N_ROUNDED": N}
+
+    ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args, **const_args)
+    return out, lse
+
+
+def cp_lse_ag_out_rs(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    ctx: CPTritonContext = None,
+    return_lse: bool = False,
+):
+    """
+    cp_attn_out: [ B, H, D ]
+    cp_attn_lse: [ B, H ]
+    """
+    if cp_group.world_size == 1:
+        return cp_attn_out
+
+    if ctx is None:
+        ctx = CPTritonContext()
+
+    lses = torch.empty(
+        (cp_group.world_size,) + cp_attn_lse.shape,
+        dtype=cp_attn_lse.dtype,
+        device=cp_attn_lse.device,
+    )
+
+    cp_attn_lse = cp_attn_lse.contiguous()
+    lses = cp_group.all_gather(cp_attn_lse, dim=0).view_as(lses)
+    out, lse = correct_attn_out(cp_attn_out, lses, cp_group.rank_in_group, ctx)
+    assert out.is_contiguous()
+    out = cp_group.reduce_scatter_along_dim(out, dim=1)
+    if return_lse:
+        cp_num_heads = lse.shape[1] // cp_group.world_size
+        cp_rank = cp_group.rank_in_group
+        lse = lse[:, cp_num_heads * cp_rank : cp_num_heads * (cp_rank + 1)]
+        return out, lse
+    return out

--- a/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
+++ b/python/sglang/srt/managers/scheduler_runtime_checker_mixin.py
@@ -20,8 +20,10 @@ logger = logging.getLogger(__name__)
 
 class SchedulerRuntimeCheckerMixin:
     def _get_token_info(self: Scheduler):
-        available_size = self.token_to_kv_pool_allocator.available_size()
-        evictable_size = self.tree_cache.evictable_size()
+        available_size = (
+            self.token_to_kv_pool_allocator.available_size() // self.dcp_size
+        )
+        evictable_size = self.tree_cache.evictable_size() // self.dcp_size
         num_used = self.max_total_num_tokens - (available_size + evictable_size)
         token_usage = num_used / self.max_total_num_tokens
         return num_used, token_usage, available_size, evictable_size

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -39,7 +39,6 @@ import triton.language as tl
 from sglang.jit_kernel.kvcache import can_use_store_cache, store_cache
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
-from sglang.srt.distributed.parallel_state import get_dcp_group
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.nsa import index_buf_accessor
 from sglang.srt.layers.attention.nsa.quant_k_cache import (
@@ -946,15 +945,6 @@ class MHATokenToKVPool(KVCache):
             layer_id = layer_id_override
         else:
             layer_id = layer.layer_id
-
-        dcp_size = get_dcp_group().world_size
-        dcp_rank = get_dcp_group().rank_in_group
-        if dcp_size > 1:
-            valid_mask = loc % dcp_size == dcp_rank
-            loc = loc[valid_mask] // dcp_size
-            cache_k = cache_k[valid_mask]
-            cache_v = cache_v[valid_mask]
-
         if cache_k.dtype != self.dtype:
             if k_scale is not None:
                 cache_k.div_(k_scale)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -289,6 +289,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.gpu_id = gpu_id
         self.tp_rank = tp_rank
         self.tp_size = tp_size
+        self.dcp_size = server_args.dcp_size
         self.moe_ep_rank = moe_ep_rank
         self.moe_ep_size = moe_ep_size
         self.dp_size = server_args.dp_size
@@ -777,6 +778,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                 tensor_model_parallel_size=self.tp_size,
                 pipeline_model_parallel_size=self.pp_size,
                 expert_model_parallel_size=self.moe_ep_size,
+                decode_context_parallel_size=self.dcp_size,
                 duplicate_tp_group=self.server_args.enable_pdmux,
             )
             initialize_dp_attention(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1800,6 +1800,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             dtype=self.model_config.dtype,
             dp_size=self.server_args.dp_size,
             pp_size=self.server_args.pp_size,
+            dcp_size=self.server_args.dcp_size,
             is_encoder_decoder=self.model_config.is_encoder_decoder,
             require_mlp_tp_gather=require_mlp_tp_gather_,
             seq_len_fill_value=seq_len_fill_value,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -290,6 +290,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.tp_rank = tp_rank
         self.tp_size = tp_size
         self.dcp_size = server_args.dcp_size
+        self.dcp_rank = self.tp_rank % self.dcp_size
         self.moe_ep_rank = moe_ep_rank
         self.moe_ep_size = moe_ep_size
         self.dp_size = server_args.dp_size

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -621,7 +621,7 @@ class ModelRunnerKVCacheMixin:
                         need_sort=need_sort,
                     )
                 else:
-                    if self.page_size == 1:
+                    if self.page_size == 1 and self.dcp_size == 1:
                         self.token_to_kv_pool_allocator = TokenToKVPoolAllocator(
                             self.max_total_num_tokens,
                             dtype=self.kv_cache_dtype,
@@ -631,8 +631,8 @@ class ModelRunnerKVCacheMixin:
                         )
                     else:
                         self.token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
-                            self.max_total_num_tokens,
-                            page_size=self.page_size,
+                            self.max_total_num_tokens * self.dcp_size,
+                            page_size=self.page_size * self.dcp_size,
                             dtype=self.kv_cache_dtype,
                             device=self.device,
                             kvcache=self.token_to_kv_pool,

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 import numpy as np
 import torch
 
+from sglang.srt.distributed.parallel_state import get_dcp_group
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
 from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
@@ -111,6 +112,7 @@ def enable_fused_set_kv_buffer(forward_batch: ForwardBatch):
         and hasattr(forward_batch.token_to_kv_pool, "dtype")
         and forward_batch.token_to_kv_pool.dtype == torch.bfloat16
         and not isinstance(forward_batch.token_to_kv_pool, SWAKVPool)
+        and get_dcp_group().world_size == 1
     )
 
 

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -21,8 +21,8 @@ from typing import TYPE_CHECKING, Any, Optional, Tuple
 import numpy as np
 import torch
 
-from sglang.srt.distributed.parallel_state import get_dcp_group
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
+from sglang.srt.distributed.parallel_state import get_dcp_group
 from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -335,6 +335,7 @@ class ServerArgs:
     # Runtime options
     device: Optional[str] = None
     tp_size: int = 1
+    dcp_size: int = 1
     pp_size: int = 1
     pp_max_micro_batch_size: Optional[int] = None
     pp_async_batch_depth: int = 0
@@ -3078,6 +3079,13 @@ class ServerArgs:
             help="The tensor parallelism size.",
         )
         parser.add_argument(
+            "--decode-context-parallel-size",
+            "--dcp-size",
+            type=int,
+            default=ServerArgs.dcp_size,
+            help="The decode context parallel size.",
+        )
+        parser.add_argument(
             "--pipeline-parallel-size",
             "--pp-size",
             type=int,
@@ -4815,6 +4823,7 @@ class ServerArgs:
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace):
         args.tp_size = args.tensor_parallel_size
+        args.dcp_size = args.decode_context_parallel_size
         args.pp_size = args.pipeline_parallel_size
         args.dp_size = args.data_parallel_size
         args.ep_size = args.expert_parallel_size

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -55,6 +55,7 @@ suites = {
     "__not_in_ci__": [
         TestFile("test_release_memory_occupation.py", 200),  # Temporarily disabled
         TestFile("models/test_dummy_grok_models.py"),
+        TestFile("test_dcp.py"),
         TestFile("test_profile_v2.py"),
         TestFile("models/test_ministral3_models.py"),
         TestFile("test_mistral_large3_basic.py"),

--- a/test/srt/test_dcp.py
+++ b/test/srt/test_dcp.py
@@ -1,0 +1,77 @@
+"""
+Usage:
+cd test/srt
+python3 -m unittest test_dcp.TestGQADCP2TP4.test_a_gsm8k
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+
+class TestGQADCP2TP4(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "Qwen/Qwen2.5-1.5B"
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--dcp",
+                "2",
+                "--enable-torch-compile",
+                "--torch-compile-max-bs",
+                "2",
+                "--attention-backend",
+                "flashinfer",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_a_gsm8k(
+        self,
+    ):
+        requests.get(self.base_url + "/flush_cache")
+
+        args = SimpleNamespace(
+            num_shots=5,
+            data_path=None,
+            num_questions=200,
+            max_new_tokens=512,
+            parallel=128,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"{metrics=}")
+
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_gsm8k (Qwen2.5-1.5B-DCP2TP4)\n"
+                f'{metrics["accuracy"]=:.3f}\n'
+            )
+            self.assertGreater(metrics["accuracy"], 0.59)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Following RFC https://github.com/sgl-project/sglang/issues/12196, this PR adds decode context parallel (DCP) support for GQA models, aimed at reducing KV redundancy when the TP size exceeds the number of key-value heads. A similar work has already been adopted by vLLM (https://github.com/vllm-project/vllm/pull/24864).

### Difference between DCP and DP Attention
Although both DCP and DP Attention can reduce KV cache memory redundancy, their implementation approaches and effects are entirely different.
- DP Attention applies data parallelism to the attention, where each DP worker independently processes a distinct subset of the batch. This means DP Attention splitting along the **sequence dimension**, placing different sequences on different GPUs to avoid KV cache redundancy.
- DCP is built on top of tensor parallelism (TP) and stores tokens (KV Cache) of a sequence across different DCP workers in an interleaved manner. This means DCP splitting along the **token dimension**, placing tokens from the same sequence across different GPUs to avoid KV cache redundancy.

In comparison, DCP offers the following advantages that DP Attention does not have.
1. The KV cache for a single sequence can be distributed across all GPUs, which is highly beneficial for handling extremely long contexts. In contrast, DP Attention can only store the KV cache of a single sequence on a subset of GPUs (determined by `attn_tp_size`).
2. The attention computation for each sequence can leverage all GPUs. In contrast, DP Attention can only utilize a subset of GPUs (determined by `attn_tp_size`). This means DCP has the potential to avoid KV redundancy while maintaining low latency (close to that of tensor parallelism). We need to further optimize the overhead of DCP, especially its communication overhead, to achieve this benefit.
3. Avoids the redundant Q, K, V, and O weight storage additionally introduced by data parallelism.

## Modifications

- Add DCP args (`--dcp-size`)
- Add DCP communication group
- Modify KV cache management and allocation. 
    - In the logical view (Radix cache and TokenToKVPoolAllocator), the page size is scaled up by a factor of dcp-size compared to the base page size.
    - For the actual KV buffer (TokenToKVPool), the page size remains unchanged.
    - KV are stored in an interleaved style across the KV Pool of the corresponding DCP rank.
- Modify flashinfer backend. Each dcp rank only stores a partial segment of the KV cache, so we must compute attention output using online softmax to ensure correct. 


<!-- Detail the changes made in this pull request. -->

## Usage
```shell
# TP8 (Baseline)
python -m sglang.launch_server --model-path Qwen/Qwen3-235B-A22B-Instruct-2507 --tp 8 --attention-backend flashinfer  --enable-symm-mem

# DCP2TP8
python -m sglang.launch_server --model-path Qwen/Qwen3-235B-A22B-Instruct-2507 --tp 8 --dcp 2 --attention-backend flashinfer  --enable-symm-mem
```

## Accuracy Tests
Qwen3-235B-A22B-Instruct-2507 test results.
- TP8 (Baseline)
```
$python3 -m sglang.test.few_shot_gsm8k  --parallel 128 --max-new-tokens 512
100%|███████████████████| 200/200 [00:16<00:00, 12.42it/s]
Accuracy: 0.975
Invalid: 0.000
Latency: 17.437 s
Output throughput: 1586.356 token/s
```

- DCP2TP8
```
python3 -m sglang.test.few_shot_gsm8k  --parallel 128 --max-new-tokens 512
100%|███████████████████| 200/200 [00:20<00:00,  9.76it/s]
Accuracy: 0.965
Invalid: 0.000
Latency: 22.336 s
Output throughput: 1272.156 token/s
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->


## Benchmarking and Profiling
DCP can expand the KV Cache memory by reducing KV redundancy  thereby allowing for a larger batch size or more prefix cache. We tested Qwen3-235B-A22B-Instruct-2507 on H20 with 32k/4k.
1. We first compare on bs=1 to evaluate the impact of DCP overhead on TPOT. The results show that DCP's impact on TPOT is within 10% (< 1ms).
- TP8
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     10        
Benchmark duration (s):                  217.32    
Total input tokens:                      124262    
Total input text tokens:                 124262    
Total input vision tokens:               0         
Total generated tokens:                  20099     
Total generated tokens (retokenized):    20097     
Request throughput (req/s):              0.05      
Input token throughput (tok/s):          571.81    
Output token throughput (tok/s):         92.49     
Peak output token throughput (tok/s):    103.00    
Peak concurrent requests:                2         
Total token throughput (tok/s):          664.29    
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   21729.72  
Median E2E Latency (ms):                 20860.90  
P90 E2E Latency (ms):                    36148.13  
P99 E2E Latency (ms):                    37502.47  
---------------Time to First Token----------------
Mean TTFT (ms):                          1366.96   
Median TTFT (ms):                        1065.90   
P99 TTFT (ms):                           3954.15   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.18     
Median TPOT (ms):                        10.15     
P99 TPOT (ms):                           10.59     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           10.14     
Median ITL (ms):                         10.13     
P95 ITL (ms):                            10.55     
P99 ITL (ms):                            10.95     
Max ITL (ms):                            15.91     
==================================================
```
- DCP2TP8
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     10        
Benchmark duration (s):                  231.46    
Total input tokens:                      124262    
Total input text tokens:                 124262    
Total input vision tokens:               0         
Total generated tokens:                  20099     
Total generated tokens (retokenized):    20033     
Request throughput (req/s):              0.04      
Input token throughput (tok/s):          536.85    
Output token throughput (tok/s):         86.83     
Peak output token throughput (tok/s):    95.00     
Peak concurrent requests:                2         
Total token throughput (tok/s):          623.69    
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   23144.42  
Median E2E Latency (ms):                 22191.90  
P90 E2E Latency (ms):                    38961.84  
P99 E2E Latency (ms):                    40010.64  
---------------Time to First Token----------------
Mean TTFT (ms):                          1402.02   
Median TTFT (ms):                        1091.36   
P99 TTFT (ms):                           4025.15   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.86     
Median TPOT (ms):                        10.81     
P99 TPOT (ms):                           11.24     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           10.82     
Median ITL (ms):                         10.76     
P95 ITL (ms):                            11.16     
P99 ITL (ms):                            11.74     
Max ITL (ms):                            17.22     
==================================================
```

2. We compared the throughput gains from DCP under large batch sizes. Compared to TP8, DCP2TP8 can double the KV Cache memory, increasing TPS by 16%. 

| bs | TP8 (TPS) | DCP2TP8 (TPS) | Throughput gain |
|:----:|:----:|:-----:|:------:|
|   32  | 4626     | 4635        | 0.2%                  |
|   48  |   4891    |   5165          | 5.6%              |
|  64  |     4916    |     5386      | 9.6%              |
|  80  |    4950    |     5540       | 12.0%            |
|  96  |    4897    |     5679       |   16.0%          |

The performance gain will be even more significant with longer contexts or on devices with less GPU memory. The test results for 32K/8K are as follows:
| bs | TP8 (TPS) | DCP2TP8 (TPS) | Throughput gain |
|:----:|:----:|:-----:|:------:|
|   32  |  3376     |    3511     | 4.0%                  |
|   48  |   3589    |    3978   | 10.8%              |
|  64  |     3620   |    4191       | 15.7%              |
|  80  |   3541     |       4415     | 24.7%            |


## Limitations
1. DCP requires inter-rank communication to correct the attention output, which introduces additional communication overhead. This results in a ~10% (Test Qwen3-235B-A22B on H20) increase in TPOT for small batch sizes.
**Some optimization efforts are currently underway**.
    - [x] Reduce communication overhead through NCCL symmetric memory.
    - [ ] Avoiding all-gather Q by using replicated QKVO linear layers.
2. DCP cannot infinitely increase the KV Cache memory capacity. Its maximum value is limited by the ratio of TP size to the number of KV heads.

## TODOs
- [ ] Modify apply_rope_pos_ids_cos_sin_cache kernel enable DCP support for fused_set_kv_buffer

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
