### PR TITLE
[diffusion] fix: Fixed pytorch non-writable array warning

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/distributed.py
+++ b/python/sglang/multimodal_gen/runtime/utils/distributed.py
@@ -32,7 +32,7 @@ def broadcast_pyobj(
             size = len(serialized_data)
 
             tensor_data = torch.ByteTensor(
-                np.frombuffer(serialized_data, dtype=np.uint8)
+                np.frombuffer(serialized_data, dtype=np.uint8).copy()
             ).to(device)
             tensor_size = torch.tensor([size], dtype=torch.long, device=device)
 


### PR DESCRIPTION

## Motivation
<img width="1556" height="107" alt="截屏2025-12-13 07 26 38" src="https://github.com/user-attachments/assets/206ba1a1-418b-44a2-afc6-b306446b86fd" />

`np.frombuffer()` creates a read-only view of the buffer data, which PyTorch cannot directly convert to a writable tensor without warnings.

## Modifications

Added `.copy()` to create a writable NumPy array before PyTorch tensor conversion

## Accuracy Tests
<img width="722" height="60" alt="截屏2025-12-13 07 26 51" src="https://github.com/user-attachments/assets/98e48b2f-e499-4704-b560-3f1f886f3b48" />



## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
