### PR TITLE
Fix exception handling in run_with_timeout

### DIFF
--- a/python/sglang/test/ci/ci_utils.py
+++ b/python/sglang/test/ci/ci_utils.py
@@ -22,9 +22,13 @@ def run_with_timeout(
 ):
     """Run a function with timeout."""
     ret_value = []
+    exception_info = [None]
 
     def _target_func():
-        ret_value.append(func(*args, **(kwargs or {})))
+        try:
+            ret_value.append(func(*args, **(kwargs or {})))
+        except Exception as e:
+            exception_info[0] = e
 
     t = threading.Thread(target=_target_func)
     t.start()
@@ -32,8 +36,11 @@ def run_with_timeout(
     if t.is_alive():
         raise TimeoutError()
 
+    if exception_info[0] is not None:
+        raise exception_info[0]
+
     if not ret_value:
-        raise RuntimeError()
+        raise RuntimeError("Thread completed but returned no value")
 
     return ret_value[0]
 


### PR DESCRIPTION
## Summary
- Capture and re-raise exceptions from threads instead of losing them

## Motivation
When an exception occurs inside the thread in `run_with_timeout`, it was silently lost. The main thread only saw an empty `ret_value` and raised a bare `RuntimeError()` with no information about what actually went wrong.

For example, a `UnicodeDecodeError` in the thread would show up only in stderr as "Exception in thread Thread-3", while the main code would raise an unhelpful `RuntimeError` making debugging difficult.

## Changes
- Wrap the thread function in try/except to capture any exceptions
- Re-raise the captured exception in the main thread
- Add descriptive message to RuntimeError for edge cases

## Before
```
Exception in thread Thread-3 (_target_func):
...
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 ...
...
RuntimeError   # <- unhelpful, no context
```

## After
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 ...  # <- actual error is raised
```