### PR TITLE
Add a special label for b200 CI runner that can run kernel tests

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,6 +38,7 @@ jobs:
       sgl_kernel: ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }}
       multimodal_gen: ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen }}
       max_parallel: ${{ steps.set-parallel.outputs.max_parallel }}
+      b200_runner: ${{ steps.set-runner.outputs.b200_runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -81,6 +82,16 @@ jobs:
             echo "Using default max_parallel of 8"
           fi
 
+      - name: Set B200 runner tag
+        id: set-runner
+        run: |
+          sgl_kernel="${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }}"
+          if [[ "$sgl_kernel" == "true" ]]; then
+            echo "b200_runner=4-gpu-b200-kernel" >> $GITHUB_OUTPUT
+          else
+            echo "b200_runner=4-gpu-b200" >> $GITHUB_OUTPUT
+          fi
+
       - name: Show filter results in summary (table)
         run: |
           {
@@ -92,6 +103,7 @@ jobs:
             echo "| sgl_kernel     | ${{ steps.filter.outputs.sgl_kernel || steps.scheduled.outputs.sgl_kernel }} |"
             echo "| multimodal_gen | ${{ steps.filter.outputs.multimodal_gen || steps.scheduled.outputs.multimodal_gen }} |"
             echo "| max_parallel   | ${{ steps.set-parallel.outputs.max_parallel }} |"
+            echo "| b200_runner    | ${{ steps.set-runner.outputs.b200_runner }} |"
           } >> $GITHUB_STEP_SUMMARY
 
   # =============================================== PR Gate ====================================================
@@ -296,9 +308,9 @@ jobs:
   sgl-kernel-b200-test:
     needs: [check-changes, sgl-kernel-build-wheels]
     if: needs.check-changes.outputs.sgl_kernel == 'true'
-    runs-on: 4-gpu-b200
+    runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     env:
-      RUNNER_LABELS: 4-gpu-b200
+      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -1191,9 +1203,9 @@ jobs:
           ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
         )
       )
-    runs-on: 4-gpu-b200
+    runs-on: ${{ needs.check-changes.outputs.b200_runner }}
     env:
-      RUNNER_LABELS: 4-gpu-b200
+      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/sgl-kernel/build.sh
+++ b/sgl-kernel/build.sh
@@ -233,7 +233,6 @@ docker run --rm \
       echo \"\"
       echo \"==================================\"
       echo \"ccache Statistics\"
-      echo \"ccache Statistics\"
       echo \"==================================\"
       ccache -s
       echo \"\"

--- a/sgl-kernel/build.sh
+++ b/sgl-kernel/build.sh
@@ -233,6 +233,7 @@ docker run --rm \
       echo \"\"
       echo \"==================================\"
       echo \"ccache Statistics\"
+      echo \"ccache Statistics\"
       echo \"==================================\"
       ccache -s
       echo \"\"


### PR DESCRIPTION
Some runners cannot download kernel package, thus adding a new tag 4-gpu-b200-kernel to differentiate

<img width="1694" height="436" alt="image" src="https://github.com/user-attachments/assets/77244946-61d1-4e4b-9ea6-054912f6b9e1" />
