### PR TITLE
fix: adding schedule for nightly wheel

### DIFF
--- a/.github/workflows/release-pypi-nightly.yml
+++ b/.github/workflows/release-pypi-nightly.yml
@@ -1,6 +1,9 @@
 name: Release PyPI Nightly Wheels
 
 on:
+  # Run daily at 2 AM UTC
+  schedule:
+    - cron: '0 2 * * *'
   # Triggered by nightly Docker workflow to use same commit
   repository_dispatch:
     types: [nightly-release]


### PR DESCRIPTION
## Motivation

Adding schedule to run nightly wheel at 2am daily.

## Modifications

Added schudule to release-pypi-nightly.yml

## Accuracy Tests

N/A

## Benchmarking and Profiling

N/A

## Checklist

- [ Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
