### PR TITLE
[Diffusion] Fix default resolution 720p width from 1080 to 1280

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/input_validation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/input_validation.py
@@ -221,7 +221,7 @@ class InputValidationStage(PipelineStage):
 
         # if height or width is not specified at this point, set default to 720p
         default_height = 720
-        default_width = 1080
+        default_width = 1280
         if batch.height is None and batch.width is None:
             batch.height = default_height
             batch.width = default_width


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When running Wan T2V models without specifying height and width parameters, the generation fails with error: `RuntimeError: The size of tensor a (135) must match the size of tensor b (134) at non-singleton dimension 4`. This error occurs in the denoising stage when the scheduler tries to compute `x0_pred = sample - sigma_t * model_output`.

Run the following command without explicit height/width parameters:

```bash
sglang generate \
  --model-path /path/to/Wan2.2-T2V-A14B-Diffusers \
  --text-encoder-cpu-offload \
  --pin-cpu-memory \
  --num-gpus 4 \
  --ulysses-degree 2 \
  --ring-degree 2 \
  --prompt "A cat walks on the grass, realistic"
```

The error appears during the denoising stage. As a workaround, adding `--height=720 --width=1280` makes it work correctly.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
