### PR TITLE
[model-gateway] Avoid MCP Server Initialization Issue

### DIFF
--- a/sgl-model-gateway/src/mcp/manager.rs
+++ b/sgl-model-gateway/src/mcp/manager.rs
@@ -660,9 +660,8 @@ impl McpManager {
 
                 // Create HTTP client with proxy support
                 let client = if token.is_some() {
-                    let mut builder = reqwest::Client::builder()
-                        .timeout(Duration::from_secs(30))
-                        .connect_timeout(Duration::from_secs(10));
+                    let mut builder =
+                        reqwest::Client::builder().connect_timeout(Duration::from_secs(10));
 
                     // Apply proxy configuration using proxy.rs helper
                     if let Some(proxy_cfg) = proxy_config {

--- a/sgl-model-gateway/src/mcp/proxy.rs
+++ b/sgl-model-gateway/src/mcp/proxy.rs
@@ -96,7 +96,7 @@ pub fn apply_proxy_to_builder(
 /// A configured reqwest::Client or error
 pub fn create_http_client(proxy_config: Option<&McpProxyConfig>) -> McpResult<reqwest::Client> {
     let mut builder = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(3000))
         .connect_timeout(Duration::from_secs(10));
 
     // Apply MCP-specific proxy if configured

--- a/sgl-model-gateway/src/mcp/proxy.rs
+++ b/sgl-model-gateway/src/mcp/proxy.rs
@@ -95,8 +95,7 @@ pub fn apply_proxy_to_builder(
 /// # Returns
 /// A configured reqwest::Client or error
 pub fn create_http_client(proxy_config: Option<&McpProxyConfig>) -> McpResult<reqwest::Client> {
-    let mut builder = reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(10));
+    let mut builder = reqwest::Client::builder().connect_timeout(Duration::from_secs(10));
 
     // Apply MCP-specific proxy if configured
     if let Some(proxy_cfg) = proxy_config {

--- a/sgl-model-gateway/src/mcp/proxy.rs
+++ b/sgl-model-gateway/src/mcp/proxy.rs
@@ -96,7 +96,6 @@ pub fn apply_proxy_to_builder(
 /// A configured reqwest::Client or error
 pub fn create_http_client(proxy_config: Option<&McpProxyConfig>) -> McpResult<reqwest::Client> {
     let mut builder = reqwest::Client::builder()
-        .timeout(Duration::from_secs(3000))
         .connect_timeout(Duration::from_secs(10));
 
     // Apply MCP-specific proxy if configured


### PR DESCRIPTION
## Motivation
With the MCP sse client configured with 30 sec timeout, the session between client & mcp server will disconnect & re-connect every 30 sec, without having the initialization phase done correctly, causing issues during tool calling.

**MCP server log**
_Frequent Disconnect & Handshake While Missing the Initilization_ 

```
INFO:     127.0.0.1:51424 - "POST /messages/?session_id=48a4c6068b2c4be788940c093938ee5c HTTP/1.1" 202 Accepted
WARNING:root:Failed to validate request: Received request before initialization was complete
DEBUG:root:Message that failed validation: method='resources/list' params={'_meta': {'progressToken': 24}} jsonrpc='2.0' id=25
DEBUG:mcp.server.sse:Sending message via SSE: SessionMessage(message=JSONRPCMessage(root=JSONRPCError(jsonrpc='2.0', id=25, error=ErrorData(code=-32602, message='Invalid request parameters', data=''))), metadata=None)
DEBUG:sse_starlette.sse:chunk: b'event: message\r\ndata: {"jsonrpc":"2.0","id":25,"error":{"code":-32602,"message":"Invalid request parameters","data":""}}\r\n\r\n'
DEBUG:mcp.server.sse:Setting up SSE connection
DEBUG:mcp.server.sse:Created new session with ID: 9c65df00-509e-42d4-ad8b-a4636947d805
DEBUG:mcp.server.sse:Starting SSE response task
DEBUG:mcp.server.sse:Yielding read and write streams
DEBUG:sse_starlette.sse:Got event: http.disconnect. Stop streaming.
INFO:     127.0.0.1:51424 - "GET /sse HTTP/1.1" 200 OK
DEBUG:mcp.server.sse:Starting SSE writer
DEBUG:mcp.server.sse:Sent endpoint event: /messages/?session_id=9c65df00509e42d4ad8ba4636947d805
DEBUG:sse_starlette.sse:chunk: b'event: endpoint\r\ndata: /messages/?session_id=9c65df00509e42d4ad8ba4636947d805\r\n\r\n'
DEBUG:root:Client session disconnected 48a4c606-8b2c-4be7-8894-0c093938ee5c
DEBUG:sse_starlette.sse:ping: b': ping - 2025-12-13 11:35:53.423372+00:00\r\n\r\n'
DEBUG:sse_starlette.sse:Got event: http.disconnect. Stop streaming.
DEBUG:root:Client session disconnected 9c65df00-509e-42d4-ad8b-a4636947d805
DEBUG:mcp.server.sse:Setting up SSE connection
DEBUG:mcp.server.sse:Created new session with ID: f43f9151-4ce7-43a1-a3a8-aa387caedbbf
DEBUG:mcp.server.sse:Starting SSE response task
DEBUG:mcp.server.sse:Yielding read and write streams
```

Errors
```
INFO:     127.0.0.1:55664 - "POST /messages/?session_id=7b1522f1efa944e48d2a7e8ec1036623 HTTP/1.1" 202 Accepted
[12/08/25 22:16:19] WARNING  Failed to validate request: Received request before initialization was complete     
```

**SMG log**
- The `Invalid request parameters` is a bit misleading
```
2025-12-13 10:58:07  WARN http_request{method=POST uri=/v1/responses version=HTTP/1.1 module="sglang::router_rs" request_id="resp-pP47n5D4fLqNITYO9McHdOCq"}: sgl_model_gateway::routers::grpc::regular::responses::tool_loop: /home/wenyixu/sglang/sgl-model-gateway/src/routers/grpc/regular/responses/tool_loop.rs:397: Tool execution failed: tool call failed: Tool execution failed: Failed to call tool: Mcp error: -32602: Invalid request parameters("")
```

## Modifications
Removed the timeout config, it should be OK considering that sse should be long-living.

## Accuracy Tests
The SSE connection will not get periodically disconnected, and the `Mcp error: -32602` is gone now.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
