### PR TITLE
perf(import): move LazyImport to dedicated lightweight module

### DIFF
--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -34,7 +34,7 @@ from sglang.lang.choices import (
 )
 
 # Lazy import some libraries
-from sglang.utils import LazyImport
+from sglang.lazy import LazyImport
 from sglang.version import __version__
 
 Anthropic = LazyImport("sglang.lang.backend.anthropic", "Anthropic")

--- a/python/sglang/lazy.py
+++ b/python/sglang/lazy.py
@@ -1,0 +1,52 @@
+"""Lightweight lazy import utilities.
+
+This module is intentionally minimal to avoid importing heavy dependencies
+when only the LazyImport class is needed.
+"""
+
+import importlib
+
+
+class LazyImport:
+    """Lazy import to make `import sglang` run faster.
+
+    This class delays the actual import of a module until it's first accessed,
+    which helps reduce the initial import time of the sglang package.
+
+    Parameters
+    ----------
+    module_name : str
+        The full module path to import (e.g., "sglang.lang.backend.openai")
+    class_name : str
+        The name of the class/object to import from the module
+
+    Examples
+    --------
+    >>> OpenAI = LazyImport("sglang.lang.backend.openai", "OpenAI")
+    >>> # OpenAI module is not loaded yet
+    >>> client = OpenAI()  # Now the module is loaded
+    """
+
+    def __init__(self, module_name: str, class_name: str):
+        self.module_name = module_name
+        self.class_name = class_name
+        self._module = None
+
+    def _load(self):
+        if self._module is None:
+            module = importlib.import_module(self.module_name)
+            self._module = getattr(module, self.class_name)
+        return self._module
+
+    def __getattr__(self, name: str):
+        module = self._load()
+        return getattr(module, name)
+
+    def __call__(self, *args, **kwargs):
+        module = self._load()
+        return module(*args, **kwargs)
+
+    def __repr__(self):
+        if self._module is None:
+            return f"<LazyImport {self.module_name}.{self.class_name} (not loaded)>"
+        return repr(self._module)

--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -302,27 +302,9 @@ def find_printable_text(text: str):
         return text[: text.rfind(" ") + 1]
 
 
-class LazyImport:
-    """Lazy import to make `import sglang` run faster."""
-
-    def __init__(self, module_name: str, class_name: str):
-        self.module_name = module_name
-        self.class_name = class_name
-        self._module = None
-
-    def _load(self):
-        if self._module is None:
-            module = importlib.import_module(self.module_name)
-            self._module = getattr(module, self.class_name)
-        return self._module
-
-    def __getattr__(self, name: str):
-        module = self._load()
-        return getattr(module, name)
-
-    def __call__(self, *args, **kwargs):
-        module = self._load()
-        return module(*args, **kwargs)
+# Re-export LazyImport for backward compatibility
+# The actual implementation is in sglang.lazy to avoid loading heavy dependencies
+from sglang.lazy import LazyImport
 
 
 def download_and_cache_file(url: str, filename: Optional[str] = None):

--- a/test/test_lazy_import.py
+++ b/test/test_lazy_import.py
@@ -13,11 +13,14 @@ class TestLazyImport(unittest.TestCase):
 
     def test_lazy_import_module_is_lightweight(self):
         """Test that sglang.lazy doesn't import heavy dependencies."""
-        # Clear any cached imports
+        # Unload the module if it was already imported by another test
+        if "sglang.lazy" in sys.modules:
+            del sys.modules["sglang.lazy"]
+
         modules_before = set(sys.modules.keys())
 
         # Import the lazy module
-        from sglang.lazy import LazyImport
+        from sglang.lazy import LazyImport  # noqa: F401
 
         modules_after = set(sys.modules.keys())
         new_modules = modules_after - modules_before
@@ -36,40 +39,63 @@ class TestLazyImport(unittest.TestCase):
         """Test that LazyImport doesn't load the module until accessed."""
         from sglang.lazy import LazyImport
 
-        # Create a lazy import
-        lazy_obj = LazyImport("json", "dumps")
+        # Create a lazy import for a module that's unlikely to be pre-loaded
+        lazy_obj = LazyImport("decimal", "Decimal")
 
         # The module should not be loaded yet
         self.assertIsNone(lazy_obj._module)
 
         # Access the module
-        result = lazy_obj({"key": "value"})
+        result = lazy_obj("3.14")
 
         # Now it should be loaded
         self.assertIsNotNone(lazy_obj._module)
-        self.assertEqual(result, '{"key": "value"}')
+        self.assertEqual(str(result), "3.14")
 
     def test_lazy_import_getattr(self):
         """Test that LazyImport properly delegates attribute access."""
         from sglang.lazy import LazyImport
 
-        # Use a standard library module for testing
-        lazy_path = LazyImport("os.path", "join")
+        # Lazy import the datetime class
+        lazy_datetime = LazyImport("datetime", "datetime")
 
-        # __name__ should trigger loading and attribute access
-        result = lazy_path("a", "b", "c")
-        self.assertIn("b", result)
+        # Accessing a class method should trigger __getattr__ and load the module
+        now = lazy_datetime.now()
+        self.assertIsNotNone(now)
+
+        # Verify the module was loaded
+        self.assertIsNotNone(lazy_datetime._module)
+
+        # Check that we got a datetime object
+        import datetime
+
+        self.assertIsInstance(now, datetime.datetime)
 
     def test_lazy_import_repr_before_load(self):
         """Test repr before module is loaded."""
         from sglang.lazy import LazyImport
 
-        lazy_obj = LazyImport("json", "dumps")
+        # Use a module unlikely to be pre-loaded
+        lazy_obj = LazyImport("fractions", "Fraction")
+
         repr_str = repr(lazy_obj)
 
         self.assertIn("LazyImport", repr_str)
         self.assertIn("not loaded", repr_str)
-        self.assertIn("json", repr_str)
+        self.assertIn("fractions", repr_str)
+
+    def test_lazy_import_repr_after_load(self):
+        """Test repr after module is loaded."""
+        from sglang.lazy import LazyImport
+
+        lazy_obj = LazyImport("json", "dumps")
+
+        # Trigger loading
+        lazy_obj({"test": 1})
+
+        # After loading, repr should show the actual module
+        repr_str = repr(lazy_obj)
+        self.assertNotIn("not loaded", repr_str)
 
     def test_backward_compatibility_utils_import(self):
         """Test that LazyImport can still be imported from utils."""
@@ -79,6 +105,42 @@ class TestLazyImport(unittest.TestCase):
 
         # They should be the same class
         self.assertIs(LazyImportFromUtils, LazyImportFromLazy)
+
+    def test_thread_safety(self):
+        """Test that LazyImport is thread-safe."""
+        import threading
+        from sglang.lazy import LazyImport
+
+        lazy_obj = LazyImport("collections", "OrderedDict")
+        results = []
+        errors = []
+
+        def load_module():
+            try:
+                # Access the lazy import from multiple threads
+                obj = lazy_obj()
+                obj["key"] = "value"
+                results.append(obj["key"])
+            except Exception as e:
+                errors.append(e)
+
+        # Create multiple threads
+        threads = [threading.Thread(target=load_module) for _ in range(10)]
+
+        # Start all threads
+        for t in threads:
+            t.start()
+
+        # Wait for all threads to complete
+        for t in threads:
+            t.join()
+
+        # Verify no errors occurred
+        self.assertEqual(len(errors), 0, f"Thread errors: {errors}")
+
+        # Verify all threads got the correct result
+        self.assertEqual(len(results), 10)
+        self.assertTrue(all(r == "value" for r in results))
 
 
 if __name__ == "__main__":

--- a/test/test_lazy_import.py
+++ b/test/test_lazy_import.py
@@ -1,0 +1,85 @@
+"""Tests for lazy import optimization.
+
+This test verifies that the LazyImport class works correctly and
+that importing it doesn't load heavy dependencies.
+"""
+
+import sys
+import unittest
+
+
+class TestLazyImport(unittest.TestCase):
+    """Test suite for LazyImport functionality."""
+
+    def test_lazy_import_module_is_lightweight(self):
+        """Test that sglang.lazy doesn't import heavy dependencies."""
+        # Clear any cached imports
+        modules_before = set(sys.modules.keys())
+
+        # Import the lazy module
+        from sglang.lazy import LazyImport
+
+        modules_after = set(sys.modules.keys())
+        new_modules = modules_after - modules_before
+
+        # These heavy modules should NOT be loaded
+        heavy_modules = ["numpy", "torch", "requests", "IPython", "pydantic", "tqdm"]
+        for heavy in heavy_modules:
+            loaded_heavy = [m for m in new_modules if m.startswith(heavy)]
+            self.assertEqual(
+                len(loaded_heavy),
+                0,
+                f"Heavy module '{heavy}' was loaded when importing LazyImport: {loaded_heavy}",
+            )
+
+    def test_lazy_import_delays_loading(self):
+        """Test that LazyImport doesn't load the module until accessed."""
+        from sglang.lazy import LazyImport
+
+        # Create a lazy import
+        lazy_obj = LazyImport("json", "dumps")
+
+        # The module should not be loaded yet
+        self.assertIsNone(lazy_obj._module)
+
+        # Access the module
+        result = lazy_obj({"key": "value"})
+
+        # Now it should be loaded
+        self.assertIsNotNone(lazy_obj._module)
+        self.assertEqual(result, '{"key": "value"}')
+
+    def test_lazy_import_getattr(self):
+        """Test that LazyImport properly delegates attribute access."""
+        from sglang.lazy import LazyImport
+
+        # Use a standard library module for testing
+        lazy_path = LazyImport("os.path", "join")
+
+        # __name__ should trigger loading and attribute access
+        result = lazy_path("a", "b", "c")
+        self.assertIn("b", result)
+
+    def test_lazy_import_repr_before_load(self):
+        """Test repr before module is loaded."""
+        from sglang.lazy import LazyImport
+
+        lazy_obj = LazyImport("json", "dumps")
+        repr_str = repr(lazy_obj)
+
+        self.assertIn("LazyImport", repr_str)
+        self.assertIn("not loaded", repr_str)
+        self.assertIn("json", repr_str)
+
+    def test_backward_compatibility_utils_import(self):
+        """Test that LazyImport can still be imported from utils."""
+        # This import should work for backward compatibility
+        from sglang.utils import LazyImport as LazyImportFromUtils
+        from sglang.lazy import LazyImport as LazyImportFromLazy
+
+        # They should be the same class
+        self.assertIs(LazyImportFromUtils, LazyImportFromLazy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Move `LazyImport` class from `sglang/utils.py` to a new dedicated `sglang/lazy.py` module to help reduce import time.

## Problem

As reported in #10492, `import sglang` takes ~12 seconds. One contributing factor is that `utils.py` imports many heavy dependencies at module level:

```python
# utils.py top-level imports
import numpy as np
import pybase64
import requests
from IPython.display import HTML, display
from pydantic import BaseModel
from tqdm import tqdm
# ... and more
```

When `sglang/__init__.py` imported `LazyImport` from `utils.py`, it triggered all these heavy imports.

## Solution

Create a new lightweight `sglang/lazy.py` module that only imports `importlib`:

```python
# lazy.py - only depends on importlib
import importlib

class LazyImport:
    ...
```

## Changes

| File | Change |
|------|--------|
| `python/sglang/lazy.py` | New lightweight module with LazyImport class |
| `python/sglang/__init__.py` | Import LazyImport from lazy module |
| `python/sglang/utils.py` | Re-export LazyImport for backward compatibility |
| `test/test_lazy_import.py` | Tests for LazyImport functionality |

## Note

This is a **partial fix** for #10492. The full optimization would require making `sglang.lang.api` imports lazy as well, which is a larger change.

## Test Plan

```python
# Verify lazy.py is lightweight
import importlib.util
spec = importlib.util.spec_from_file_location('lazy', 'python/sglang/lazy.py')
lazy_module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(lazy_module)

LazyImport = lazy_module.LazyImport
lazy_json = LazyImport('json', 'dumps')
assert lazy_json._module is None  # Not loaded yet
result = lazy_json({'test': 123})
assert result == '{"test": 123}'
```

Partial fix for #10492

🤖 Generated with [Claude Code](https://claude.com/claude-code)