### PR TITLE
[NSA] Fix NSA backend assertion error when running DeepSeek-V3.2 PP with radix-cache

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/dequant_k_cache.py
+++ b/python/sglang/srt/layers/attention/nsa/dequant_k_cache.py
@@ -189,10 +189,9 @@ def dequantize_k_cache_paged(
     ), f"dim_quant: {dim_quant} != 656 detected in dequantize_k_cache_paged"
     quant_k_cache = quant_k_cache.view((-1, dim_quant))
 
-    total_num_tokens, _ = quant_k_cache.shape
+    # num_tokens can exceed kv_cache_size due to prefix sharing (multiple seqs share same KV slots)
+    # Index bounds validated in nsa_backend.init_forward_metadata
     num_tokens = page_table_1_flattened.shape[0]
-    assert num_tokens <= total_num_tokens
-
     assert quant_k_cache.dtype == torch.float8_e4m3fn
     dim_nope = 512
     dim_rope = 64

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -486,6 +486,14 @@ class NativeSparseAttnBackend(AttentionBackend):
                     page_table_1_flattened.shape[0] == forward_batch.seq_lens_sum
                 ), f"{page_table_1_flattened.shape[0] = } must be the same as {forward_batch.seq_lens_sum = }"
 
+                # Validate page table indices (once per batch)
+                kv_cache_size = forward_batch.token_to_kv_pool.size
+                if page_table_1_flattened.numel() > 0:
+                    max_idx = page_table_1_flattened.max().item()
+                    assert (
+                        max_idx < kv_cache_size
+                    ), f"Invalid page table index: max={max_idx}, kv_cache_size={kv_cache_size}"
+
             if topk_transform_method == TopkTransformMethod.RAGGED:
                 topk_indices_offset = torch.repeat_interleave(
                     cu_seqlens_k[:-1],

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -489,6 +489,7 @@ class NativeSparseAttnBackend(AttentionBackend):
                 ), f"{page_table_1_flattened.shape[0] = } must be the same as {forward_batch.seq_lens_sum = }"
 
                 # Validate indices when logical tokens exceed physical capacity
+                # This is likely to be triggered by PP with high kv reuse & parallelism
                 kv_cache_capacity = (
                     forward_batch.token_to_kv_pool.size
                     + forward_batch.token_to_kv_pool.page_size

--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -463,14 +463,16 @@ class NativeSparseAttnBackend(AttentionBackend):
                 ]
             )
 
-            # Check if MHA with FP8 needs page_table_1_flattened for dequantization
+            # Check if MHA FP8 dequantization is needed
             mha_dequantize_needed = (
                 self.use_mha
                 and forward_batch.token_to_kv_pool.dtype == torch.float8_e4m3fn
             )
             forward_batch.using_mha_one_shot_fp8_dequant = mha_dequantize_needed
 
-            if (
+            # page_table_1_flattened is only used when prefix sharing is enabled:
+            has_prefix_sharing = any(forward_batch.extend_prefix_lens_cpu)
+            if has_prefix_sharing and (
                 topk_transform_method == TopkTransformMethod.RAGGED
                 or mha_dequantize_needed
             ):
@@ -486,13 +488,17 @@ class NativeSparseAttnBackend(AttentionBackend):
                     page_table_1_flattened.shape[0] == forward_batch.seq_lens_sum
                 ), f"{page_table_1_flattened.shape[0] = } must be the same as {forward_batch.seq_lens_sum = }"
 
-                # Validate page table indices (once per batch)
-                kv_cache_size = forward_batch.token_to_kv_pool.size
-                if page_table_1_flattened.numel() > 0:
+                # Validate indices when logical tokens exceed physical capacity
+                kv_cache_capacity = (
+                    forward_batch.token_to_kv_pool.size
+                    + forward_batch.token_to_kv_pool.page_size
+                )
+                if forward_batch.seq_lens_sum > kv_cache_capacity:
                     max_idx = page_table_1_flattened.max().item()
-                    assert (
-                        max_idx < kv_cache_size
-                    ), f"Invalid page table index: max={max_idx}, kv_cache_size={kv_cache_size}"
+                    assert max_idx < kv_cache_capacity, (
+                        f"Invalid page table index: max={max_idx}, "
+                        f"kv_cache_capacity={kv_cache_capacity}"
+                    )
 
             if topk_transform_method == TopkTransformMethod.RAGGED:
                 topk_indices_offset = torch.repeat_interleave(


### PR DESCRIPTION
## Motivation

Fix NSA backend assertion error when running DeepSeek-V3.2 triggered when running DeepSeek-V3.2 PP with radix-cache.

The assertion `num_tokens <= total_num_tokens` in `dequant_k_cache.py` assumes that logical token count cannot exceed physical KV cache size. However, prefix sharing allows multiple sequences to share the same KV cache slots, making `seq_lens_sum` larger than `kv_cache_size`.

**Reproduction:**
```
python3 -m sglang.launch_server \
    --model-path deepseek-ai/DeepSeek-V3.2-Exp \
    --tp-size 2 \
    --pp-size 4 \
    --max-running-requests 128 \
    --max-total-tokens 100000 \
    --chunked-prefill-size 8192 \
    --mem-fraction-static 0.80
```
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 20 --num-questions 1319 --parallel 1319
```

**Error:**:
```
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/nsa_backend.py", line 983, in forward_extend
    kv_cache = dequantize_k_cache_paged(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/nsa/dequant_k_cache.py", line 194, in dequantize_k_cache_paged
    assert num_tokens <= total_num_tokens
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

## Modifications

1. **`nsa_backend.py`**: Add page table index bounds validation in `init_forward_metadata()` (once per batch) to ensure all indices are within valid KV cache range.

2. **`dequant_k_cache.py`**: Remove incorrect assertion and add clarifying comments.

## Accuracy Tests
After fix:
```
python3 -m sglang.launch_server \
    --model-path deepseek-ai/DeepSeek-V3.2-Exp \
    --tp-size 2 \
    --pp-size 4 \
    --max-running-requests 128 \
    --max-total-tokens 100000 \
    --chunked-prefill-size 8192 \
    --mem-fraction-static 0.80
```
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 20 --num-questions 1319 --parallel 1319
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [03:10<00:00,  6.91it/s]
Accuracy: 0.958
Invalid: 0.000
Latency: 192.569 s
Output throughput: 678.099 token/s
```

## Benchmarking and Profiling


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)