### PR TITLE
[model-gateway] Fix metric emission gaps and name mismatch

### DIFF
--- a/sgl-model-gateway/src/core/steps/worker/local/remove_from_worker_registry.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/remove_from_worker_registry.rs
@@ -7,6 +7,7 @@ use tracing::{debug, warn};
 
 use crate::{
     app_context::AppContext,
+    observability::metrics::RouterMetrics,
     workflow::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult},
 };
 
@@ -47,6 +48,9 @@ impl StepExecutor for RemoveFromWorkerRegistryStep {
         } else {
             debug!("Removed {} worker(s) from registry", removed_count);
         }
+
+        // Update active workers metric
+        RouterMetrics::set_active_workers(app_context.worker_registry.len());
 
         Ok(StepResult::Success)
     }

--- a/sgl-model-gateway/src/core/steps/worker/shared/register.rs
+++ b/sgl-model-gateway/src/core/steps/worker/shared/register.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 use crate::{
     app_context::AppContext,
     core::Worker,
+    observability::metrics::RouterMetrics,
     workflow::{StepExecutor, StepResult, WorkflowContext, WorkflowResult},
 };
 
@@ -35,6 +36,9 @@ impl StepExecutor for RegisterWorkersStep {
             );
             worker_ids.push(worker_id);
         }
+
+        // Update active workers metric
+        RouterMetrics::set_active_workers(app_context.worker_registry.len());
 
         context.set("worker_ids", worker_ids);
         Ok(StepResult::Success)

--- a/sgl-model-gateway/src/core/worker_registry.rs
+++ b/sgl-model-gateway/src/core/worker_registry.rs
@@ -224,6 +224,16 @@ impl WorkerRegistry {
             .unwrap_or_default()
     }
 
+    /// Get the number of workers in the registry
+    pub fn len(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Check if the registry is empty
+    pub fn is_empty(&self) -> bool {
+        self.workers.is_empty()
+    }
+
     /// Get all workers
     pub fn get_all(&self) -> Vec<Arc<dyn Worker>> {
         self.workers

--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -37,7 +37,7 @@ pub fn init_metrics() {
         "Total number of request errors by route and error type"
     );
     describe_counter!(
-        "sgl_router_upstream_http_responses_total",
+        "sgl_router_attempt_http_responses_total",
         "Total number of upstream engine HTTP responses by status code"
     );
     describe_counter!(
@@ -279,6 +279,10 @@ impl RouterMetrics {
             "worker" => worker_url.to_string()
         )
         .set(if healthy { 1.0 } else { 0.0 });
+    }
+
+    pub fn set_active_workers(count: usize) {
+        gauge!("sgl_router_active_workers").set(count as f64);
     }
 
     pub fn record_processed_request(worker_url: &str) {

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -134,6 +134,12 @@ impl CacheAwarePolicy {
                         let model_id = tree_ref.key();
                         let tree = tree_ref.value();
                         tree.evict_tenant_by_size(max_tree_size);
+
+                        // Update tree size metrics per worker (tenant)
+                        for entry in tree.tenant_char_count.iter() {
+                            RouterMetrics::set_tree_size(entry.key(), *entry.value());
+                        }
+
                         debug!(
                             "Cache eviction completed for model {}, max_size: {}",
                             model_id, max_tree_size

--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -18,7 +18,10 @@ use rustls;
 use tokio::{task, time};
 use tracing::{debug, error, info, warn};
 
-use crate::{app_context::AppContext, core::Job, protocols::worker_spec::WorkerConfigRequest};
+use crate::{
+    app_context::AppContext, core::Job, observability::metrics::RouterMetrics,
+    protocols::worker_spec::WorkerConfigRequest,
+};
 
 #[derive(Debug, Clone)]
 pub struct ServiceDiscoveryConfig {
@@ -404,6 +407,7 @@ async fn handle_pod_event(
                 match job_queue.submit(job).await {
                     Ok(_) => {
                         debug!("Worker addition job submitted for: {}", worker_url);
+                        RouterMetrics::record_discovery_update(1, 0);
                     }
                     Err(e) => {
                         error!(
@@ -462,6 +466,7 @@ async fn handle_pod_deletion(
                 );
             } else {
                 debug!("Submitted worker removal job for {}", worker_url);
+                RouterMetrics::record_discovery_update(0, 1);
             }
         } else {
             error!(


### PR DESCRIPTION
- Fix describe/emit name mismatch: sgl_router_upstream_http_responses_total was described but sgl_router_attempt_http_responses_total was emitted. Changed describe to match the emit.
- Add set_active_workers helper method to RouterMetrics
- Emit sgl_router_active_workers in RegisterWorkersStep and RemoveFromWorkerRegistryStep via workflow system
- Add len() and is_empty() methods to WorkerRegistry for metric emission
- Emit sgl_router_discovery_updates_total in service_discovery.rs on pod addition and deletion events
- Emit sgl_router_tree_size gauge in cache_aware.rs eviction thread per worker/tenant

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
