### PR TITLE
Support TP overlap on Blackwell

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/nvshmem_communicator.py
+++ b/python/sglang/srt/distributed/device_communicators/nvshmem_communicator.py
@@ -1,0 +1,128 @@
+"""
+NVSHMEM Communicator for symmetric memory operations.
+Simple, efficient implementation following torchrun initialization pattern.
+"""
+
+import logging
+import os
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+logger = logging.getLogger(__name__)
+
+# Check NVSHMEM availability
+nvshmem_is_available = False
+if torch.cuda.is_available():
+    try:
+        from cuda.core.experimental import Device
+        import nvshmem.core
+        import nvshmem.bindings
+        import numpy as np
+        nvshmem_is_available = True
+    except ImportError:
+        nvshmem_is_available = False
+
+def get_nvshmem_comm():
+    """Get NVSHMEM communicator from world group if available"""
+    try:
+        from sglang.srt.distributed import get_world_group
+        world_group = get_world_group()
+        nvshmem_comm = getattr(world_group, 'nvshmem_comm', None)
+        return nvshmem_comm if (nvshmem_comm and not nvshmem_comm.disabled) else None
+    except Exception:
+        return None
+
+
+class NvshmemCommunicator:
+    """Simple NVSHMEM communicator following torchrun pattern"""
+    
+    def __init__(self, group: ProcessGroup, device: Union[int, str, torch.device]):
+        self.disabled = not nvshmem_is_available
+        if self.disabled:
+            logger.warning("NVSHMEM not available")
+            return
+            
+        self.group = group
+        self.world_size = dist.get_world_size(self.group)
+        self.rank = dist.get_rank(self.group)
+        self.local_rank = self.rank % 8
+        
+        # Track created tensors for unified cleanup
+        self._created_tensors = []
+        
+        self._init_nvshmem()
+        
+    
+    def _init_nvshmem(self):
+        """Initialize NVSHMEM using UniqueID broadcast pattern"""
+        # Set CUDA device
+        torch.cuda.set_device(self.local_rank)
+        
+        # Create cuda.core Device
+        dev = Device(self.local_rank)
+        dev.set_current()
+        # Create and broadcast unique ID
+        uid = nvshmem.core.get_unique_id(empty=(self.rank != 0))
+        uid_bytes = uid._data.view(np.uint8).copy()
+        uid_tensor = torch.from_numpy(uid_bytes).cuda()
+        dist.broadcast(uid_tensor, src=0, group=self.group)
+        dist.barrier(group=self.group)
+        uid._data[:] = uid_tensor.cpu().numpy().view(uid._data.dtype)
+        
+        # Initialize NVSHMEM
+        nvshmem.core.init(
+            device=dev, 
+            uid=uid, 
+            rank=self.rank, 
+            nranks=self.world_size, 
+            initializer_method="uid"
+        )
+        
+        logger.info(f"NVSHMEM initialized: rank={self.rank}, world_size={self.world_size}")
+    
+    def create_symmetric_tensor(self, shape, dtype=torch.float32):
+        """Create symmetric tensor and track for cleanup"""
+        if self.disabled:
+            return torch.zeros(shape, dtype=dtype, device=f"cuda:{self.local_rank}")
+        
+        tensor = nvshmem.core.tensor(shape, dtype=dtype)
+        self._created_tensors.append(tensor)
+        return tensor
+    
+    def create_multicast_pointer(self, tensor):
+        """Create multicast pointer"""
+        if self.disabled:
+            return None
+        local_ptr = tensor.data_ptr()
+        return nvshmem.bindings.mc_ptr(nvshmem.core.Teams.TEAM_NODE, local_ptr)
+    
+    def cleanup(self):
+        """Cleanup NVSHMEM tensors and finalize"""
+        if not self.disabled:
+            try:
+                # Free all tracked tensors
+                for tensor in self._created_tensors:
+                    try:
+                        nvshmem.core.free_tensor(tensor)
+                    except Exception as e:
+                        logger.warning(f"Failed to free NVSHMEM tensor: {e}")
+                
+                self._created_tensors.clear()
+                
+                # Synchronization barrier before finalization
+                if dist.is_initialized():
+                    dist.barrier(device_ids=[self.local_rank], group=self.group)
+                
+                # Finalize NVSHMEM
+                nvshmem.core.finalize()
+                logger.info("NVSHMEM tensors freed and finalized")
+                
+            except Exception as e:
+                logger.warning(f"NVSHMEM cleanup failed: {e}")
+    
+    def get_tensor_count(self):
+        """Get number of tracked tensors for debugging"""
+        return len(self._created_tensors) if not self.disabled else 0

--- a/python/sglang/srt/distributed/device_communicators/nvshmem_communicator.py
+++ b/python/sglang/srt/distributed/device_communicators/nvshmem_communicator.py
@@ -4,8 +4,7 @@ Simple, efficient implementation following torchrun initialization pattern.
 """
 
 import logging
-import os
-from typing import Optional, Union
+from typing import Union
 
 import torch
 import torch.distributed as dist
@@ -17,20 +16,23 @@ logger = logging.getLogger(__name__)
 nvshmem_is_available = False
 if torch.cuda.is_available():
     try:
-        from cuda.core.experimental import Device
-        import nvshmem.core
-        import nvshmem.bindings
         import numpy as np
+        import nvshmem.bindings
+        import nvshmem.core
+        from cuda.core.experimental import Device
+
         nvshmem_is_available = True
     except ImportError:
         nvshmem_is_available = False
+
 
 def get_nvshmem_comm():
     """Get NVSHMEM communicator from world group if available"""
     try:
         from sglang.srt.distributed import get_world_group
+
         world_group = get_world_group()
-        nvshmem_comm = getattr(world_group, 'nvshmem_comm', None)
+        nvshmem_comm = getattr(world_group, "nvshmem_comm", None)
         return nvshmem_comm if (nvshmem_comm and not nvshmem_comm.disabled) else None
     except Exception:
         return None
@@ -38,29 +40,28 @@ def get_nvshmem_comm():
 
 class NvshmemCommunicator:
     """Simple NVSHMEM communicator following torchrun pattern"""
-    
+
     def __init__(self, group: ProcessGroup, device: Union[int, str, torch.device]):
         self.disabled = not nvshmem_is_available
         if self.disabled:
             logger.warning("NVSHMEM not available")
             return
-            
+
         self.group = group
         self.world_size = dist.get_world_size(self.group)
         self.rank = dist.get_rank(self.group)
         self.local_rank = self.rank % 8
-        
+
         # Track created tensors for unified cleanup
         self._created_tensors = []
-        
+
         self._init_nvshmem()
-        
-    
+
     def _init_nvshmem(self):
         """Initialize NVSHMEM using UniqueID broadcast pattern"""
         # Set CUDA device
         torch.cuda.set_device(self.local_rank)
-        
+
         # Create cuda.core Device
         dev = Device(self.local_rank)
         dev.set_current()
@@ -71,34 +72,36 @@ class NvshmemCommunicator:
         dist.broadcast(uid_tensor, src=0, group=self.group)
         dist.barrier(group=self.group)
         uid._data[:] = uid_tensor.cpu().numpy().view(uid._data.dtype)
-        
+
         # Initialize NVSHMEM
         nvshmem.core.init(
-            device=dev, 
-            uid=uid, 
-            rank=self.rank, 
-            nranks=self.world_size, 
-            initializer_method="uid"
+            device=dev,
+            uid=uid,
+            rank=self.rank,
+            nranks=self.world_size,
+            initializer_method="uid",
         )
-        
-        logger.info(f"NVSHMEM initialized: rank={self.rank}, world_size={self.world_size}")
-    
+
+        logger.info(
+            f"NVSHMEM initialized: rank={self.rank}, world_size={self.world_size}"
+        )
+
     def create_symmetric_tensor(self, shape, dtype=torch.float32):
         """Create symmetric tensor and track for cleanup"""
         if self.disabled:
             return torch.zeros(shape, dtype=dtype, device=f"cuda:{self.local_rank}")
-        
+
         tensor = nvshmem.core.tensor(shape, dtype=dtype)
         self._created_tensors.append(tensor)
         return tensor
-    
+
     def create_multicast_pointer(self, tensor):
         """Create multicast pointer"""
         if self.disabled:
             return None
         local_ptr = tensor.data_ptr()
         return nvshmem.bindings.mc_ptr(nvshmem.core.Teams.TEAM_NODE, local_ptr)
-    
+
     def cleanup(self):
         """Cleanup NVSHMEM tensors and finalize"""
         if not self.disabled:
@@ -109,20 +112,20 @@ class NvshmemCommunicator:
                         nvshmem.core.free_tensor(tensor)
                     except Exception as e:
                         logger.warning(f"Failed to free NVSHMEM tensor: {e}")
-                
+
                 self._created_tensors.clear()
-                
+
                 # Synchronization barrier before finalization
                 if dist.is_initialized():
                     dist.barrier(device_ids=[self.local_rank], group=self.group)
-                
+
                 # Finalize NVSHMEM
                 nvshmem.core.finalize()
                 logger.info("NVSHMEM tensors freed and finalized")
-                
+
             except Exception as e:
                 logger.warning(f"NVSHMEM cleanup failed: {e}")
-    
+
     def get_tensor_count(self):
         """Get number of tracked tensors for debugging"""
         return len(self._created_tensors) if not self.disabled else 0

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -245,7 +245,9 @@ class GroupCoordinator:
     )
 
     use_torch_symm_mem: bool  # a hint of whether to use SymmMemAllReduce
-    use_nvshmem_mem: bool  # a hint of whether to use NvshmemMem for symmetric memory operations
+    use_nvshmem_mem: (
+        bool  # a hint of whether to use NvshmemMem for symmetric memory operations
+    )
 
     use_message_queue_broadcaster: (
         bool  # a hint of whether to use message queue broadcaster
@@ -1349,6 +1351,7 @@ class GroupCoordinator:
             self.nvshmem_comm.cleanup()
             self.nvshmem_comm = None
 
+
 _WORLD: Optional[GroupCoordinator] = None
 
 
@@ -1371,7 +1374,7 @@ def init_world_group(
         use_hpu_communicator=False,
         use_xpu_communicator=False,
         use_npu_communicator=False,
-        use_nvshmem_communicator=(os.environ.get('SGLANG_USE_NVSHMEM', '0') == '1'),
+        use_nvshmem_communicator=(os.environ.get("SGLANG_USE_NVSHMEM", "0") == "1"),
         group_name="world",
     )
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -244,7 +244,6 @@ class GroupCoordinator:
         bool  # a hint of whether to use TorchSymmMemAllReduce
     )
 
-    use_torch_symm_mem: bool  # a hint of whether to use SymmMemAllReduce
     use_nvshmem_mem: (
         bool  # a hint of whether to use NvshmemMem for symmetric memory operations
     )

--- a/python/sglang/srt/layers/gemm_allreduce.py
+++ b/python/sglang/srt/layers/gemm_allreduce.py
@@ -1,0 +1,2152 @@
+import argparse
+import ctypes
+import os
+import time
+from functools import partial
+from math import prod
+from typing import Optional, Tuple, Type, Union
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.testing as testing
+import cutlass.torch as cutlass_torch
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.distributed_helpers as distributed_helpers
+import cutlass._mlir.ir as ir
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cute.typing import Pointer, Int32, Float16, BFloat16, Float32
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass._mlir.dialects import llvm
+
+class PersistentDenseGemmKernel:
+    """This class implements batched matrix multiplication (C = A x B) with support for various data types
+    and architectural features specific to Blackwell GPUs with persistent tile scheduling and warp specialization.
+
+    :param acc_dtype: Data type for accumulation during computation
+    :type acc_dtype: type[cutlass.Numeric]
+    :param use_2cta_instrs: Whether to use CTA group 2 for advanced thread cooperation
+    :type use_2cta_instrs: bool
+    :param mma_tiler_mn: Shape of the Matrix Multiply-Accumulate (MMA) tile (M,N)
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster dimensions (M,N) for parallel processing
+    :type cluster_shape_mn: Tuple[int, int]
+    :param use_tma_store: Whether to use Tensor Memory Access (TMA) for storing results
+    :type use_tma_store: bool
+    :param all_reduce: All-reduce mode, can be "none", "two_shot"
+    :type all_reduce: str
+
+    :note: In current version, A and B tensor must have the same data type
+        - i.e., Float8E4M3FN for A and Float8E5M2 for B is not supported
+
+    :note: Supported A/B data types:
+        - TFloat32
+        - Float16/BFloat16
+        - Int8/Uint8
+        - Float8E4M3FN/Float8E5M2
+
+    :note: Supported accumulator data types:
+        - Float32 (for all floating point A/B data types)
+        - Float16 (only for fp16 and fp8 A/B data types)
+        - Int32 (only for uint8/int8 A/B data types)
+
+    :note: Supported C data types:
+        - Float32 (for float32 and int32 accumulator data types)
+        - Int32 (for float32 and int32 accumulator data types)
+        - Float16/BFloat16 (for fp16 and fp8 accumulator data types)
+        - Int8/Uint8 (for uint8/int8 accumulator data types)
+        - Float8E4M3FN/Float8E5M2 (for float32 accumulator data types)
+
+    :note: Constraints:
+        - MMA tiler M must be 64/128 (use_2cta_instrs=False) or 128/256 (use_2cta_instrs=True)
+        - MMA tiler N must be 32-256, step 32
+        - Cluster shape M must be multiple of 2 if use_2cta_instrs=True
+        - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+
+    Example:
+        >>> gemm = PersistentDenseGemmKernel(
+        ...     acc_dtype=cutlass.Float32,
+        ...     use_2cta_instrs=True,
+        ...     mma_tiler_mn=(128, 128),
+        ...     cluster_shape_mn=(2, 2)
+        ... )
+        >>> gemm(a_tensor, b_tensor, c_tensor, max_active_clusters, stream)
+    """
+
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_tma_store: bool,
+        all_reduce="none",
+    ):
+        """Initializes the configuration for a Blackwell dense GEMM kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+            - use_2cta_instrs: Boolean indicating if the tcgen05 MMA variant
+              with cta_group=2 should be used.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        3. Output C tensor store mode:
+            - use_tma_store: Boolean indicating whether to use Tensor Memory Access (TMA) for storing results.
+
+        :param acc_dtype: Data type of the accumulator.
+        :type acc_dtype: type[cutlass.Numeric]
+        :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
+        :type mma_tiler_mn: Tuple[int, int]
+        :param use_2cta_instrs: Boolean, True to use cta_group=2 MMA variant.
+        :type use_2cta_instrs: bool
+        :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
+        :type cluster_shape_mn: Tuple[int, int]
+        :param use_tma_store: Use Tensor Memory Access (TMA) or normal store for output C tensor.
+        :type use_tma_store: bool
+        :param all_reduce: All-reduce mode, can be "none", "two_shot"
+        :type all_reduce: str
+        """
+
+        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler_mn = mma_tiler_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.use_tma_store = use_tma_store
+
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        self.all_reduce = all_reduce
+
+        self.occupancy = 1
+        # Set specialized warp ids
+        self.epilog_warp_id = (
+            0,
+            1,
+            2,
+            3,
+        )
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.all_reduce_warp_id = ()
+        self.all_reduce = "none"
+        if all_reduce != "none":
+            self.all_reduce = all_reduce
+            self.all_reduce_warp_id = (6, 7, 8, 9)
+        self.threads_per_cta = 32 * len(
+            (
+                self.mma_warp_id,
+                self.tma_warp_id,
+                *self.epilog_warp_id,
+                *self.all_reduce_warp_id,
+            )
+        )
+        # Set barrier id for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_bar_id = 0
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.all_reduce_sync_bar_id = 3
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+
+        self.num_ranks = 1
+        self.rank_id = 0
+        if all_reduce != "none":
+            self.num_ranks = torch.distributed.get_world_size()
+            self.rank_id = torch.distributed.get_rank()
+
+    def is_valid(self):
+        mma_m, mma_n = self.mma_tiler_mn
+        if (mma_m // (2 if self.use_2cta_instrs else 1)) not in [64, 128]:
+            return False
+        if self.cluster_shape_mn[0] % (2 if self.use_2cta_instrs else 1) != 0:
+            return False
+        if self.cluster_shape_mn[0] == 4 and self.cluster_shape_mn[1] == 4:
+            return False
+        return True
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B
+        - Computing epilogue subtile
+        - Setting up A/B/C stage counts in shared memory
+        - Computing A/B/C shared memory layout
+        - Computing tensor memory allocation columns
+        """
+        # Configure tiled mma
+        tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler[:2],
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        # Compute epilogue subtile
+        if cutlass.const_expr(self.use_tma_store):
+            self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+                self.cta_tile_shape_mnk,
+                self.use_2cta_instrs,
+                self.c_layout,
+                self.c_dtype,
+            )
+        else:
+            self.epi_tile = self.cta_tile_shape_mnk[:2]
+
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.smem_capacity,
+            self.occupancy,
+            self.use_tma_store,
+        )
+
+        # Compute A/B/C shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = (
+            sm100_utils.make_smem_layout_epi(
+                self.c_dtype,
+                self.c_layout,
+                self.epi_tile,
+                self.num_c_stage,
+            )
+            if self.use_tma_store
+            else None
+        )
+
+        # Compute the number of tensor memory allocation columns
+        self.num_tmem_alloc_cols = self._compute_num_tmem_alloc_cols(
+            tiled_mma, self.mma_tiler, self.num_acc_stage
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+        c_mc: cute.Tensor = None,
+        barrier_flag: cute.Tensor = None,
+        barrier_flag_mc: cute.Tensor = None,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a: Input tensor A
+        :type a: cute.Tensor
+        :param b: Input tensor B
+        :type b: cute.Tensor
+        :param c: Output tensor C
+        :type c: cute.Tensor
+        :param c_mc: Output symmetric tensor C_mc, any write or read to a multicast tensor will be broadcasted to all GPUs
+        :type c_mc: cute.Tensor
+        :param max_active_clusters: Maximum number of active clusters
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        :param epilogue_op: Optional elementwise lambda function to apply to the output tensor
+        :type epilogue_op: cutlass.Constexpr
+        :raises TypeError: If input data types are incompatible with the MMA instruction.
+        :raises AssertionError: If OOB (Out-Of-Bounds) tiles are present when TMA store is disabled.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler[:2],
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.TFloat32 if a.element_type is cutlass.Float32 else None
+            ),
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.TFloat32 if b.element_type is cutlass.Float32 else None
+            ),
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size) * atom_thr_size
+
+        # Setup TMA store for C
+        tma_atom_c = None
+        tma_tensor_c = None
+        if cutlass.const_expr(self.use_tma_store):
+            epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+            tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                c,
+                epi_smem_layout,
+                self.epi_tile,
+            )
+
+        # Compute grid size
+        self.tile_sched_params, grid = self._compute_grid(
+            c, self.cta_tile_shape_mnk, self.cluster_shape_mn, max_active_clusters
+        )
+
+        self.buffer_align_bytes = 1024
+
+        c_smem_size = (
+            cute.cosize(self.c_smem_layout_staged.outer) if self.use_tma_store else 0
+        )
+
+        # Define shared storage for kernel
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    c_smem_size,
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c if self.use_tma_store else c,
+            self.cluster_layout_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+            c_mc,
+            barrier_flag,
+            barrier_flag_mc,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: Optional[cute.CopyAtom],
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        c_mc: cute.Tensor,
+        barrier_flag: cute.Tensor,
+        barrier_flag_mc: cute.Tensor,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            if cutlass.const_expr(self.use_tma_store):
+                cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilog_warp_id) * (
+            2 if use_2cta_instrs else 1
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilog_warp_id)),
+        )
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed()
+
+        #
+        # Setup smem tensor A/B/C
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = (
+            storage.sC.get_tensor(
+                c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner
+            )
+            if self.use_tma_store
+            else None
+        )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+
+        #
+        # Compute multicast mask for A/B buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bN, RestM, RestN, RestL)
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        tCtAcc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.barrier(
+                barrier_id=self.cta_sync_bar_id, number_of_threads=self.threads_per_cta
+            )
+
+        #
+        # Specialized TMA load warp
+        #
+
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_ab_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_tile_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                        ab_producer_state
+                    )
+                #
+                # Tma load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(
+                        ab_producer_state, peek_ab_empty_status
+                    )
+
+                    # TMA load A/B
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAsA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBsB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+
+                    # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_tile_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                            ab_producer_state
+                        )
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_ab_stage
+            )
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                # Set tensor memory buffer for current tile
+                # (MMA, MMA_M, MMA_N)
+                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                        ab_consumer_state
+                    )
+
+                #
+                # Wait for accumulator buffer empty
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                #
+                # Reset the ACCUMULATE field for each tile
+                #
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                #
+                # Mma mainloop
+                #
+                for k_tile in range(k_tile_cnt):
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(
+                            ab_consumer_state, peek_ab_full_status
+                        )
+
+                        # tCtAcc += tCrA * tCrB
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblock_coord = (
+                                None,
+                                None,
+                                kblock_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblock_coord],
+                                tCrB[kblock_coord],
+                                tCtAcc,
+                            )
+                            # Enable accumulate on tCtAcc after first kblock
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+
+                    # Peek (try_wait) AB buffer full for k_tile = k_tile + 1
+                    ab_consumer_state.advance()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if ab_consumer_state.count < k_tile_cnt:
+                        if is_leader_cta:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                                ab_consumer_state
+                            )
+
+                #
+                # Async arrive accumulator buffer full
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue
+            #
+            epi_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs
+            )
+
+            tTR_rC = None
+            tiled_copy_r2s = None
+            simt_atom = None
+            tRS_rC = None
+            tRS_sC = None
+            bSG_sC = None
+            bSG_gC_partitioned = None
+            tTR_gC_partitioned = None
+            if cutlass.const_expr(self.use_tma_store):
+                tTR_rC = cute.make_fragment(tTR_rAcc.shape, self.c_dtype)
+                tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                    tiled_copy_t2r, tTR_rC, epi_tidx, sC
+                )
+                (
+                    tma_atom_c,
+                    bSG_sC,
+                    bSG_gC_partitioned,
+                ) = self.epilog_gmem_copy_and_partition(
+                    epi_tidx, tma_atom_c, tCgC, epi_tile, sC
+                )
+            else:
+                (
+                    simt_atom,
+                    tTR_rC,
+                    tTR_gC_partitioned,
+                ) = self.epilog_gmem_copy_and_partition(
+                    epi_tidx, tiled_copy_t2r, tCgC, epi_tile, sC
+                )
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            c_pipeline = None
+            if cutlass.const_expr(self.use_tma_store):
+                # Threads/warps participating in tma store pipeline
+                c_producer_group = pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    32 * len(self.epilog_warp_id),
+                    32 * len(self.epilog_warp_id),
+                )
+                c_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=self.num_c_stage,
+                    producer_group=c_producer_group,
+                )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                bSG_gC = None
+                tTR_gC = None
+                if cutlass.const_expr(self.use_tma_store):
+                    # ((ATOM_V, REST_V), EPI_M, EPI_N)
+                    bSG_gC = bSG_gC_partitioned[
+                        (
+                            None,
+                            None,
+                            None,
+                            *mma_tile_coord_mnl,
+                        )
+                    ]
+                else:
+                    # (T2R, T2R_M, T2R_N, EPI_M, EPI_N)
+                    tTR_gC = tTR_gC_partitioned[
+                        (
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            *mma_tile_coord_mnl,
+                        )
+                    ]
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[
+                    (None, None, None, None, None, acc_consumer_state.index)
+                ]
+
+                #
+                # Wait for accumulator buffer full
+                #
+                acc_pipeline.consumer_wait(acc_consumer_state)
+
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                if cutlass.const_expr(self.use_tma_store):
+                    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+                else:
+                    tTR_gC = cute.group_modes(tTR_gC, 3, cute.rank(tTR_gC))
+
+                #
+                # Store accumulator to global memory in subtiles
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                for subtile_idx in cutlass.range(subtile_cnt):
+                    #
+                    # Load accumulator from tensor memory buffer to register
+                    #
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                    if cutlass.const_expr(self.use_tma_store):
+                        #
+                        # Convert to C type
+                        #
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+
+                        #
+                        # Store C to shared memory
+                        #
+                        c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, None, c_buffer)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        cute.arch.fence_proxy(
+                            cute.arch.ProxyKind.async_shared,
+                            space=cute.arch.SharedSpace.shared_cta,
+                        )
+                        epilog_threads = 32 * len(self.epilog_warp_id)
+                        cute.arch.barrier(
+                            barrier_id=self.epilog_sync_bar_id,
+                            number_of_threads=epilog_threads,
+                        )
+
+                        #
+                        # TMA store C to global memory
+                        #
+                        if warp_idx == self.epilog_warp_id[0]:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sC[(None, c_buffer)],
+                                bSG_gC[(None, subtile_idx)],
+                            )
+                            # Fence and barrier to make sure shared memory store is visible to TMA store
+                            c_pipeline.producer_commit()
+                            c_pipeline.producer_acquire()
+                        cute.arch.barrier(
+                            barrier_id=self.epilog_sync_bar_id,
+                            number_of_threads=epilog_threads,
+                        )
+                    else:
+                        #
+                        # Convert to C type
+                        #
+                        acc_vec = tTR_rAcc.load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                        tTR_rC.store(acc_vec)
+
+                        #
+                        # Store C to global memory
+                        #
+                        cute.copy(
+                            simt_atom, tTR_rC, tTR_gC[(None, None, None, subtile_idx)]
+                        )
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                with cute.arch.elect_one():
+                    acc_pipeline.consumer_release(acc_consumer_state)
+                acc_consumer_state.advance()
+
+                # Allreduce
+                if cutlass.const_expr(self.all_reduce == "two_shot"):
+                    tile_id = Int32(
+                        tile_sched._current_work_linear_idx
+                        * cute.size(self.cluster_shape_mn)
+                        + cute.arch.block_idx_in_cluster()
+                    )
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.arch.cp_async_bulk_wait_group(0, read=False)
+                        # System barrier to make sure that data from each GPU is in memory before allreduce
+                        with cute.arch.elect_one():
+                            flag = barrier_flag_mc.iterator + tile_id
+                            cute.arch.fence_acq_rel_gpu()
+                            distributed_helpers.spin_lock_multimem_arrive(flag)
+                            cute.arch.fence_proxy(cute.arch.ProxyKind.alias)
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            epilog_threads = 32 * len(self.epilog_warp_id)
+            cute.arch.barrier(
+                barrier_id=self.epilog_sync_bar_id, number_of_threads=epilog_threads
+            )
+            tmem.free(tmem_ptr)
+
+            #
+            # Wait for C store complete
+            #
+            if cutlass.const_expr(self.use_tma_store):
+                c_pipeline.producer_tail()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Allreduce warps
+        # ///////////////////////////////////////////////////////////////////////////////
+        if cutlass.const_expr(self.all_reduce == "two_shot"):
+            if warp_idx >= self.all_reduce_warp_id[0]:
+                # ///////////////////////////////////////////////////////////////////////////////
+                # Add persistent tile loop
+                # ///////////////////////////////////////////////////////////////////////////////
+
+                rank_id = self.rank_id
+                num_ranks = Int32(self.num_ranks)
+                lane_id = cute.arch.lane_idx()
+
+                tile_sched = utils.StaticPersistentTileScheduler.create(
+                    tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+                )
+                work_tile = tile_sched.initial_work_tile_info()
+
+                # we want 128bit ld/st for better performance
+                atom_val = 128 // c_mc.element_type.width
+                atom_thr_n = self.mma_tiler[1] // atom_val
+                atom_thr_m = len(self.all_reduce_warp_id) * (
+                    cute.arch.WARP_SIZE // atom_thr_n
+                )
+                thr_layout = cute.make_layout(
+                    (atom_thr_m, atom_thr_n), stride=(atom_thr_n, 1)
+                )
+                val_layout = cute.make_layout((1, atom_val), stride=(atom_val, 1))
+
+                copy_atom_load = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), c_mc.element_type
+                )
+                tiled_copy_fake = cute.make_tiled_copy_tv(
+                    copy_atom_load, thr_layout, val_layout
+                )
+                thr_copy_fake = tiled_copy_fake.get_slice(
+                    tidx - self.all_reduce_warp_id[0] * 32
+                )
+
+                while work_tile.is_valid_tile:
+                    cur_tile_coord = work_tile.tile_idx
+                    tile_id = Int32(
+                        tile_sched._current_work_linear_idx
+                        * cute.size(self.cluster_shape_mn)
+                        + cute.arch.block_idx_in_cluster()
+                    )
+                    mma_tile_coord_mnl = (
+                        cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                        cur_tile_coord[1],
+                        cur_tile_coord[2],
+                    )
+
+                    # System barrier to make sure that data from each GPU is in memory before allreduce
+                    if warp_idx == self.all_reduce_warp_id[0]:
+                        with cute.arch.elect_one():
+                            flag = barrier_flag.iterator + tile_id
+                            # TODO: we may use LDG+STG for spin lock instead of ATOMIC_CAS for better performance.
+                            distributed_helpers.spin_lock_wait(flag, num_ranks)
+
+                    cute.arch.barrier(
+                        barrier_id=self.all_reduce_sync_bar_id,
+                        number_of_threads=32 * len(self.all_reduce_warp_id),
+                    )
+                    # partition and slice at tile level
+                    gC_mc = cute.local_tile(
+                        c_mc,
+                        cute.slice_(self.mma_tiler, (None, None, 0)),
+                        (None, None, None),
+                    )
+                    tCgC_mc = thr_mma.partition_C(gC_mc)
+                    tCgC_mc_slice = tCgC_mc[((None, None), 0, 0, *mma_tile_coord_mnl)]
+
+                    # partition based on the number of GPUs
+                    cta_mma_tile_m = self.mma_tiler[0] // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    m_local_rank = int(cta_mma_tile_m / self.num_ranks)
+                    tCgC_mc_slice_partitioned = cute.zipped_divide(
+                        tCgC_mc_slice, (m_local_rank, self.mma_tiler[1])
+                    )
+                    tCgC_mc_local_rank = cute.slice_(
+                        tCgC_mc_slice_partitioned, ((None, None), (rank_id, 0))
+                    )
+
+                    # partition at thread level
+                    frgC_mc = thr_copy_fake.partition_S(tCgC_mc_local_rank)
+                    atom, loop_m, loop_n = frgC_mc.shape
+                    for i in cutlass.range_constexpr(loop_m):
+                        for j in cutlass.range_constexpr(loop_n):
+                            mc_ptr = frgC_mc[None, i, j].iterator
+                            x, y, z, w = 0, 0, 0, 0
+                            if cutlass.const_expr(self.c_dtype == Float16):
+                                x, y, z, w = distributed_helpers.multimem_ld_reduce_8xf16(mc_ptr)
+                            elif cutlass.const_expr(self.c_dtype == Float32):
+                                x, y, z, w = distributed_helpers.multimem_ld_reduce_4xf32(mc_ptr)
+                            elif cutlass.const_expr(self.c_dtype == BFloat16):
+                                x, y, z, w = distributed_helpers.multimem_ld_reduce_8xbf16(mc_ptr)
+                            elif cutlass.const_expr(self.c_dtype == Float8E4M3FN):
+                                x, y, z, w = distributed_helpers.multimem_ld_reduce_16xe4m3(mc_ptr)
+                            elif cutlass.const_expr(self.c_dtype == Float8E5M2):
+                                x, y, z, w = distributed_helpers.multimem_ld_reduce_16xe5m2(mc_ptr)
+                            distributed_helpers.multimem_st_4xb32(mc_ptr, x, y, z, w)
+                    # Advance to next tile
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
+
+                cute.arch.barrier(
+                    barrier_id=self.all_reduce_sync_bar_id,
+                    number_of_threads=32 * len(self.all_reduce_warp_id),
+                )
+                # System barrier to make sure all the peer memory transfers are completed.
+                last_flag_idx = cute.size(
+                    tile_sched.params.problem_layout_ncluster_mnl
+                ) * cute.size(self.cluster_shape_mn)
+                if warp_idx == self.all_reduce_warp_id[0]:
+                    with cute.arch.elect_one():
+                        distributed_helpers.sm_wise_inter_gpu_multimem_barrier(
+                            barrier_flag.iterator + last_flag_idx,
+                            barrier_flag_mc.iterator + last_flag_idx,
+                            self.num_ranks,
+                        )
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory (source) and register array (destination).
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param tAcc: The accumulator tensor to be copied and partitioned
+        :type tAcc: cute.Tensor
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :type use_2cta_instrs: bool
+
+        :return: A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+            - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+            - tTR_tAcc: The partitioned accumulator tensor
+            - tTR_rAcc: The accumulated tensor in register used to hold t2r results
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # Make tiledCopy for tensor memory load
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(
+            copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)]
+        )
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_M, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_mnl_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        # (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_fragment(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition register array (source) and shared memory (destination).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rC: The partitioned accumulator tensor
+        :type tTR_rC: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+        :type sepi: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_r2s, tRS_rC, tRS_sC) where:
+            - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+            - tRS_rC: The partitioned tensor C (register source)
+            - tRS_sC: The partitioned tensor C (smem destination)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(
+            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+        )
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Make tiledCopy for global memory store, then use it to:
+        - partition register array (source) and global memory (destination) for none TMA store version;
+        - partition shared memory (source) and global memory (destination) for TMA store version.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param atom: The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+        :type atom: cute.CopyAtom or cute.TiledCopy
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+
+        :return: A tuple containing either:
+            - For TMA store: (tma_atom_c, bSG_sC, bSG_gC) where:
+                - tma_atom_c: The TMA copy atom
+                - bSG_sC: The partitioned shared memory tensor C
+                - bSG_gC: The partitioned global tensor C
+            - For non-TMA store: (simt_atom, tTR_rC, tTR_gC) where:
+                - simt_atom: The SIMT copy atom
+                - tTR_rC: The register tensor C
+                - tTR_gC: The partitioned global tensor C
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+        if cutlass.const_expr(self.use_tma_store):
+            tma_atom_c = atom
+            sC_for_tma_partition = cute.group_modes(sC, 0, 2)
+            gC_for_tma_partition = cute.group_modes(gC_epi, 0, 2)
+            # ((ATOM_V, REST_V), EPI_M, EPI_N)
+            # ((ATOM_V, REST_V), EPI_M, EPI_N, RestM, RestN, RestL)
+            bSG_sC, bSG_gC = cpasync.tma_partition(
+                tma_atom_c,
+                0,
+                cute.make_layout(1),
+                sC_for_tma_partition,
+                gC_for_tma_partition,
+            )
+            return tma_atom_c, bSG_sC, bSG_gC
+        else:
+            tiled_copy_t2r = atom
+            # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+            thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+            tTR_gC = thr_copy_t2r.partition_D(gC_epi)
+            # (T2R, T2R_M, T2R_N)
+            tTR_rC = cute.make_fragment(
+                tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.c_dtype
+            )
+            simt_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.c_dtype)
+            return simt_atom, tTR_rC, tTR_gC
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        smem_capacity: int,
+        occupancy: int,
+        use_tma_store: bool,
+    ) -> Tuple[int, int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: Layout enum of operand C.
+        :type c_layout: utils.LayoutEnum
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+        :param use_tma_store: Whether TMA store is enabled.
+        :type use_tma_store: bool
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, C stages)
+        :rtype: tuple[int, int, int]
+        """
+        # Default ACC stages
+        num_acc_stage = 2
+
+        # Default C stages
+        num_c_stage = 2 if use_tma_store else 0
+
+        # Calculate smem layout and size for one stage of A, B, and C
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        c_smem_layout_staged_one = (
+            sm100_utils.make_smem_layout_epi(
+                c_dtype,
+                c_layout,
+                epi_tile,
+                1,
+            )
+            if use_tma_store
+            else None
+        )
+        ab_bytes_per_stage = cute.size_in_bytes(
+            a_dtype, a_smem_layout_stage_one
+        ) + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+        mbar_helpers_bytes = 1024
+        c_bytes_per_stage = (
+            cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+            if use_tma_store
+            else 0
+        )
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        # Calculate A/B stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes and initial C stages bytes
+        # Divide remaining by bytes needed per A/B stage
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        if use_tma_store:
+            num_c_stage += (
+                smem_capacity
+                - occupancy * ab_bytes_per_stage * num_ab_stage
+                - occupancy * (mbar_helpers_bytes + c_bytes)
+            ) // (occupancy * c_bytes_per_stage)
+        return num_acc_stage, num_ab_stage, num_c_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Use persistent tile scheduler to compute the grid size for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param cta_tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type cta_tile_shape_mnk: tuple[int, int, int]
+        :param cluster_shape_mn: Shape of each cluster in M, N dimensions.
+        :type cluster_shape_mn: tuple[int, int]
+        :param max_active_clusters: Maximum number of active clusters.
+        :type max_active_clusters: cutlass.Constexpr
+
+        :return: A tuple containing:
+            - tile_sched_params: Parameters for the persistent tile scheduler.
+            - grid: Grid shape for kernel launch.
+        :rtype: Tuple[utils.PersistentTileSchedulerParams, tuple[int, int, int]]
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def _compute_num_tmem_alloc_cols(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: Tuple[int, int, int],
+        num_acc_stage: int,
+    ) -> int:
+        """
+        Compute the number of tensor memory allocation columns.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler: The shape (M, N, K) of the MMA tile.
+        :type mma_tiler: tuple[int, int, int]
+        :param num_acc_stage: The stage of the accumulator tensor.
+        :type num_acc_stage: int
+
+        :return: The number of tensor memory allocation columns.
+        :rtype: int
+        """
+        acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
+        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake)
+
+        return num_tmem_alloc_cols
+
+    def is_valid_dtypes(
+        self,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the dtypes are valid
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param acc_dtype: The data type of the accumulator
+        :type acc_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+
+        :return: True if the dtypes are valid, False otherwise
+        :rtype: bool
+        """
+        valid_ab_dtypes = {
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.TFloat32,
+            cutlass.Uint8,
+            cutlass.Int8,
+            cutlass.Float8E4M3FN,
+            cutlass.Float8E5M2,
+        }
+        if ab_dtype not in valid_ab_dtypes:
+            return False
+
+        if self.acc_dtype not in {cutlass.Float32, cutlass.Float16, cutlass.Int32}:
+            return False
+
+        # Define compatibility mapping between accumulator type and AB type
+        acc_ab_compatibility = {
+            cutlass.Float32: {
+                cutlass.Float16,
+                cutlass.BFloat16,
+                cutlass.TFloat32,
+                cutlass.Float8E4M3FN,
+                cutlass.Float8E5M2,
+            },  # Float32 accumulator supports floating point AB types only
+            cutlass.Float16: {
+                cutlass.Float16,
+                cutlass.Float8E4M3FN,
+                cutlass.Float8E5M2,
+            },
+            cutlass.Int32: {cutlass.Uint8, cutlass.Int8},
+        }
+        # Check compatibility between accumulator type and AB type
+        if ab_dtype not in acc_ab_compatibility[self.acc_dtype]:
+            return False
+
+        # Define compatibility mapping between accumulator type and C type
+        acc_c_compatibility = {
+            cutlass.Float32: {
+                cutlass.Float32,
+                cutlass.Float16,
+                cutlass.BFloat16,
+                cutlass.Float8E4M3FN,
+                cutlass.Float8E5M2,
+                cutlass.Int32,
+                cutlass.Int8,
+                cutlass.Uint8,
+            },
+            cutlass.Float16: {
+                cutlass.BFloat16,
+                cutlass.Float16,
+            },
+            cutlass.Int32: {
+                cutlass.BFloat16,
+                cutlass.Float16,
+                cutlass.Float32,
+                cutlass.Int32,
+                cutlass.Int8,
+                cutlass.Uint8,
+            },
+        }
+        # Check compatibility between accumulator type and C type
+        if c_dtype not in acc_c_compatibility[self.acc_dtype]:
+            return False
+
+        # check if c_dtype is supported by multimem all-reduce
+        if cutlass.const_expr(self.all_reduce != "none" and c_dtype not in {cutlass.Float16, cutlass.Float32, cutlass.BFloat16, cutlass.Float8E4M3FN, cutlass.Float8E5M2}):
+            return False
+
+        return True
+
+    def is_valid_mma_tiler_and_cluster_shape(self) -> bool:
+        """Check if the mma tiler and cluster shape are valid.
+
+        :return: True if the mma tiler and cluster shape are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+        
+        # Skip invalid mma tile shape
+        mma_m_valid = (
+            (not self.use_2cta_instrs and self.mma_tiler_mn[0] in [64, 128])
+            or (self.use_2cta_instrs and self.mma_tiler_mn[0] in [128, 256])
+        )
+        if not mma_m_valid:
+            is_valid = False
+            
+        mma_n_valid = self.mma_tiler_mn[1] in range(32, 257, 32)
+        if not mma_n_valid:
+            is_valid = False
+            
+        # Skip illegal cluster shape
+        cluster_m_alignment = self.cluster_shape_mn[0] % (2 if self.use_2cta_instrs else 1) == 0
+        if not cluster_m_alignment:
+            is_valid = False
+            
+        # Skip invalid cluster shape
+        is_power_of_2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        cluster_size_valid = self.cluster_shape_mn[0] * self.cluster_shape_mn[1] <= 16
+        cluster_m_positive = self.cluster_shape_mn[0] > 0
+        cluster_n_positive = self.cluster_shape_mn[1] > 0
+        cluster_m_power_of_2 = is_power_of_2(self.cluster_shape_mn[0])
+        cluster_n_power_of_2 = is_power_of_2(self.cluster_shape_mn[1])
+        
+        if not cluster_size_valid:
+            is_valid = False
+        if not cluster_m_positive:
+            is_valid = False
+        if not cluster_n_positive:
+            is_valid = False
+        if not cluster_m_power_of_2:
+            is_valid = False
+        if not cluster_n_power_of_2:
+            is_valid = False
+            
+        return is_valid
+
+    def is_valid_tensor_alignment(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        a_aligned = check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+        b_aligned = check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+        c_aligned = check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        
+        if not (a_aligned and b_aligned and c_aligned):
+            is_valid = False
+        
+        # Check all-reduce alignment
+        all_reduce_aligned = True
+        if self.all_reduce != "none":
+            all_reduce_aligned = m % 128 == 0 or n % 128 == 0
+            if not all_reduce_aligned:
+                is_valid = False
+
+        return is_valid
+
+    def is_valid_epilog_store_option(
+        self,
+        m: int,
+        n: int,
+    ) -> bool:
+        """
+        Check if the epilogue store option is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+
+        :return: True if the epilogue store option is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+        # None TMA store version does not have predication, can not support OOB tiles
+        cta_tile_shape_mn = (
+            self.mma_tiler_mn[0] // (2 if self.use_2cta_instrs else 1),
+            self.mma_tiler_mn[1],
+        )
+        
+        if not self.use_tma_store:
+            m_aligned = m % cta_tile_shape_mn[0] == 0
+            n_aligned = n % cta_tile_shape_mn[1] == 0
+            if not (m_aligned and n_aligned):
+                is_valid = False
+        
+        return is_valid
+
+    def can_implement(self, a: cute.Tensor, b: cute.Tensor, c: cute.Tensor) -> bool:
+        """Check if the given tensors can be implemented by this kernel.
+
+        :param a: Input tensor A
+        :type a: cute.Tensor
+        :param b: Input tensor B
+        :type b: cute.Tensor
+        :param c: Output tensor C
+        :type c: cute.Tensor
+
+        :return: True if the gemm supports the given config, False otherwise
+        :rtype: bool
+        """
+        # Get tensor dimensions following distributed version pattern
+        # a.shape should be (M, K, L), b.shape should be (N, K, L), c.shape should be (M, N, L)
+        m, k, l = a.shape[0], a.shape[1], a.shape[2]
+        n = b.shape[0]
+
+        # infer a_major, b_major, c_major
+        is_m_major_a = utils.LayoutEnum.from_tensor(a).is_m_major_a()
+        is_n_major_b = utils.LayoutEnum.from_tensor(b).is_n_major_b()
+        is_m_major_c = utils.LayoutEnum.from_tensor(c).is_m_major_c()
+        a_major = "m" if is_m_major_a else "k"
+        b_major = "n" if is_n_major_b else "k"
+        c_major = "m" if is_m_major_c else "n"
+
+        can_implement = True
+        
+        # Skip unsupported types
+        dtypes_valid = self.is_valid_dtypes(a.element_type, c.element_type)
+        if not dtypes_valid:
+            can_implement = False
+            
+        # Skip invalid mma tile shape and cluster shape
+        mma_tiler_valid = self.is_valid_mma_tiler_and_cluster_shape()
+        if not mma_tiler_valid:
+            can_implement = False
+            
+        # Skip illegal problem shape for load/store alignment
+        alignment_valid = self.is_valid_tensor_alignment(
+            m, n, k, l, a.element_type, c.element_type, a_major, b_major, c_major
+        )
+        if not alignment_valid:
+            can_implement = False
+            
+        # Skip invalid epilogue store option
+        epilog_valid = self.is_valid_epilog_store_option(m, n)
+        if not epilog_valid:
+            can_implement = False
+            
+        # Check world size for all-reduce
+        world_size = dist.get_world_size() if dist.is_initialized() else 1
+        world_size_valid = world_size in [2, 4, 8] or self.all_reduce == "none"
+        if not world_size_valid:
+            can_implement = False
+            
+        return can_implement
+
+class GemmARLayer:
+    """A high-performance GEMM+AllReduce layer based on CUTLASS PersistentDenseGemmKernel.
+    
+    This layer combines matrix multiplication with all-reduce communication in a single
+    fused operation, optimized for distributed training on Blackwell GPUs.
+    """
+    
+    def __init__(
+        self,
+        tp_group,
+        max_M: int,
+        N: int, 
+        K: int,
+        input_dtype: torch.dtype,
+        output_dtype: torch.dtype,
+        local_world_size: int,
+        c_tensor_mc: cute.Tensor,
+        torch_symm_tensor: torch.Tensor,
+        mma_tiler_mn: Tuple[int, int] = (256, 256),
+        cluster_shape_mn: Tuple[int, int] = (2, 1),
+        use_2cta_instrs: bool = True,
+        use_tma_store: bool = True,
+        all_reduce: str = "none"
+    ):
+        self.tp_group = tp_group
+        self.max_M = max_M
+        self.N = N
+        self.K = K
+        
+        self.input_torch_dtype = input_dtype
+        self.output_torch_dtype = output_dtype
+        self.input_dtype = self._torch_dtype_to_cutlass_dtype(input_dtype)
+        self.output_dtype = self._torch_dtype_to_cutlass_dtype(output_dtype)
+        # Set accumulator dtype - usually Float32 for better precision
+        self.acc_dtype = cutlass.Float32
+        self.c_tensor_mc = c_tensor_mc
+        self.torch_symm_tensor = torch_symm_tensor
+        self.local_world_size = local_world_size
+
+        self.mma_tiler_mn = mma_tiler_mn
+        self.cluster_shape_mn = cluster_shape_mn
+        self.use_2cta_instrs = use_2cta_instrs
+        self.use_tma_store = use_tma_store
+        self.all_reduce = all_reduce
+
+        if all_reduce != "none" and local_world_size not in [2, 4, 8]:
+            raise ValueError(f"AllReduce only supports world_size of 2, 4, 8, got {local_world_size}")
+        
+        self._init_gemm_allreduce()
+    
+    def _torch_dtype_to_cutlass_dtype(self, torch_dtype):
+        """Convert PyTorch dtype to CUTLASS dtype"""
+        dtype_map = {
+            torch.float16: cutlass.Float16,
+            torch.bfloat16: cutlass.BFloat16,
+            torch.float32: cutlass.Float32,
+            torch.int8: cutlass.Int8,
+            torch.uint8: cutlass.Uint8,
+        }
+        if hasattr(torch, 'float8_e4m3fn'):
+            dtype_map[torch.float8_e4m3fn] = cutlass.Float8E4M3FN
+        if hasattr(torch, 'float8_e5m2'):
+            dtype_map[torch.float8_e5m2] = cutlass.Float8E5M2
+        
+        if torch_dtype not in dtype_map:
+            raise ValueError(f"Unsupported PyTorch dtype: {torch_dtype}")
+        return dtype_map[torch_dtype]
+    
+    def _init_gemm_allreduce(self):
+        """Initialize the CUTLASS GEMM+AllReduce kernel."""
+
+        self.gemm_kernel = PersistentDenseGemmKernel(
+            acc_dtype=self.acc_dtype,
+            use_2cta_instrs=self.use_2cta_instrs,
+            mma_tiler_mn=self.mma_tiler_mn,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_tma_store=self.use_tma_store,
+            all_reduce=self.all_reduce,
+        )
+        
+        # Get hardware info for max active clusters
+        self.max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+            self.cluster_shape_mn[0] * self.cluster_shape_mn[1]
+        )
+        
+        # Pre-compile kernel with template tensors
+        self._precompile_kernel()
+     
+    def _create_template_tensors(self):
+        """Create template tensors for kernel compilation following distributed version exactly."""
+        l = 1  # Batch dimension
+        
+        a_major = "k"
+        b_major = "k"
+        c_major = "n"
+        a_torch_cpu = cutlass_torch.matrix(l, self.max_M, self.K, a_major == "m", self.input_dtype)
+        b_torch_cpu = cutlass_torch.matrix(l, self.N, self.K, b_major == "n", self.input_dtype)
+        c_torch_cpu = cutlass_torch.matrix(l, self.max_M, self.N, c_major == "m", self.output_dtype)
+        # print(f"a_torch_cpu: {a_torch_cpu.shape, a_torch_cpu.stride(), a_torch_cpu.dtype}, ")
+        # print(f"b_torch_cpu: {b_torch_cpu.shape, b_torch_cpu.stride(), b_torch_cpu.dtype}, ")
+        # print(f"c_torch_cpu: {c_torch_cpu.shape, c_torch_cpu.stride(), c_torch_cpu.dtype}, ")
+
+        a_tensor, _ = cutlass_torch.cute_tensor_like(
+            a_torch_cpu, self.input_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        b_tensor, _ = cutlass_torch.cute_tensor_like(
+            b_torch_cpu, self.input_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        c_tensor, c_torch_gpu = cutlass_torch.cute_tensor_like(
+            c_torch_cpu, self.output_dtype, is_dynamic_layout=True, assumed_align=16
+        )
+        # print(f"a_tensor: {a_tensor.shape, a_tensor._dtype}")
+        # print(f"b_tensor: {b_tensor.shape, b_tensor._dtype}")
+        # print(f"c_tensor: {c_tensor.shape, c_tensor._dtype}")
+        if self.all_reduce != "none":
+            # c_tensor, c_tensor_mc, c_torch_gpu = create_mc_tensor(
+            #     c_torch_cpu, self.output_dtype, (1 if c_major == "n" else 0), is_dynamic_layout=True
+            # )
+            torch_tensor_gpu = self.torch_symm_tensor
+            cute_tensor = from_dlpack(torch_tensor_gpu, assumed_align=16)
+            cute_tensor.element_type = self.output_dtype
+            cute_tensor = cute_tensor.mark_layout_dynamic(leading_dim=1) # if is_dynamic_layout 
+            cute_tensor = cutlass_torch.convert_cute_tensor(
+                torch_tensor_gpu,
+                cute_tensor,
+                self.output_dtype,
+                is_dynamic_layout=True,
+            )
+
+            c_tensor = cute_tensor
+            c_torch_gpu = torch_tensor_gpu
+        return a_tensor, b_tensor, c_tensor, c_torch_gpu
+    
+    def _precompile_kernel(self):
+        """Pre-compile the GEMM kernel with template tensors."""
+        torch_stream = torch.cuda.current_stream()
+        current_stream = cuda.CUstream(torch_stream.cuda_stream)
+        
+        a_tensor, b_tensor, c_tensor, c_torch_gpu = self._create_template_tensors()
+        # c_torch_gpu is used in compare of verity
+        # self.c_tensor = c_tensor
+        self.c_torch_gpu = c_torch_gpu
+
+        if not self.gemm_kernel.can_implement(a_tensor, b_tensor, c_tensor):
+            raise RuntimeError(f"GEMM kernel cannot implement configuration")
+        
+        
+        if self.all_reduce == "none":
+            # print("[GEMM_ALLREDUCE] Starting compilation (all_reduce=none)...")
+            # compile_start_time = time.time()
+            self.compiled_gemm = cute.compile(
+                self.gemm_kernel, a_tensor, b_tensor, c_tensor, 
+                self.max_active_clusters, current_stream
+            )
+            # compile_end_time = time.time()
+            # compile_duration = compile_end_time - compile_start_time
+            # print(f"[GEMM_ALLREDUCE] Compilation completed in {compile_duration:.4f} seconds")
+        else:
+            self.barrier_flag_memref, self.barrier_flag_mc_memref = self._create_barrier_flags(self.max_M)
+            # print(f"[GEMM_ALLREDUCE] Starting compilation (all_reduce={self.all_reduce})...")
+            # compile_start_time = time.time()
+            self.compiled_gemm = cute.compile(
+                self.gemm_kernel,
+                a_tensor, b_tensor, c_tensor,
+                self.max_active_clusters, current_stream,
+                c_mc=self.c_tensor_mc,
+                barrier_flag=self.barrier_flag_memref,
+                barrier_flag_mc=self.barrier_flag_mc_memref,
+            )
+            # compile_end_time = time.time()
+            # compile_duration = compile_end_time - compile_start_time
+            # print(f"[GEMM_ALLREDUCE] Compilation completed in {compile_duration:.4f} seconds")
+    
+    def _create_barrier_flags(self, m: int):
+        """Create barrier flags for synchronization in all-reduce."""
+        cta_tile_shape_mn = (
+            self.mma_tiler_mn[0] // (2 if self.use_2cta_instrs else 1),
+            self.mma_tiler_mn[1],
+        )
+        problem_shape_ntile_mn = (m // cta_tile_shape_mn[0], self.N // cta_tile_shape_mn[1])
+        num_tiles = problem_shape_ntile_mn[0] * problem_shape_ntile_mn[1]
+        num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+    
+        barrier_flag = symm_mem.empty(
+            (num_tiles + num_sms,), 
+            device=f"cuda", 
+            dtype=torch.int32
+        )
+        barrier_flag.fill_(0)
+        # symm = symm_mem.rendezvous(barrier_flag, group=self.tp_group.group_name)
+        symm = symm_mem.rendezvous(barrier_flag, group=dist.group.WORLD.group_name)        
+        barrier_flag_mc = symm.multicast_ptr
+            
+        barrier_flag_memref = from_dlpack(barrier_flag)
+        barrier_flag_memref = barrier_flag_memref.mark_layout_dynamic()
+        barrier_flag_mc_memref = from_dlpack(
+            cutlass_torch.as_tensor(
+                barrier_flag_mc, barrier_flag.shape, barrier_flag.dtype
+            ),
+        )
+        barrier_flag_mc_memref = barrier_flag_mc_memref.mark_layout_dynamic()
+        
+        return barrier_flag_memref, barrier_flag_mc_memref
+    
+    def forward(self, input_tensor: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """
+        Args:
+            input_tensor: Input tensor of shape [M, K] 
+            weight: Weight tensor of shape [N, K]
+        Returns:
+            Output tensor of shape [M, N] with all-reduce applied
+        """
+        assert input_tensor.shape[1] == self.K, f"Input K dim mismatch: {input_tensor.shape[1]} vs {self.K}"
+        assert weight.shape[0] == self.N, f"Weight N dim mismatch: {weight.shape[0]} vs {self.N}"
+        assert weight.shape[1] == self.K, f"Weight K dim mismatch: {weight.shape[1]} vs {self.K}"
+        assert bias is None, f"Bias is not supported yet"
+        
+        torch_stream = torch.cuda.current_stream()
+        current_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+        actual_m = input_tensor.shape[0]
+
+        input_tensor_3d = input_tensor.unsqueeze(-1)
+        weight_3d = weight.unsqueeze(-1)
+
+        # a_tensor, _ = cutlass_torch.cute_tensor_like(
+        #     input_tensor_3d, self.input_dtype, is_dynamic_layout=True, assumed_align=16
+        # )
+        # b_tensor, _ = cutlass_torch.cute_tensor_like(
+        #     weight_3d, self.input_dtype, is_dynamic_layout=True, assumed_align=16
+        # )
+        a_tensor = from_dlpack(input_tensor_3d, assumed_align=16)
+        a_tensor.element_type = self.input_dtype
+        a_tensor = a_tensor.mark_layout_dynamic(leading_dim=1)
+        b_tensor = from_dlpack(weight_3d, assumed_align=16)
+        b_tensor.element_type = self.input_dtype
+        b_tensor = b_tensor.mark_layout_dynamic(leading_dim=1)            
+
+        c_tensor = from_dlpack(self.c_torch_gpu[:actual_m, :], assumed_align=16)
+        c_tensor.element_type = self.output_dtype
+        c_tensor = c_tensor.mark_layout_dynamic(leading_dim=1)
+        
+        # print(f"a_tensor: {a_tensor.shape, a_tensor._dtype}")
+        # print(f"b_tensor: {b_tensor.shape, b_tensor._dtype}")
+        # print(f"c_tensor: {c_tensor.shape, c_tensor._dtype}")
+        # dist.barrier(group=self.tp_group)
+        if self.all_reduce == "none":
+            self.compiled_gemm(a_tensor, b_tensor, c_tensor, current_stream)
+        else:
+            self.compiled_gemm(
+                a_tensor, b_tensor, c_tensor, current_stream,
+                c_mc=self.c_tensor_mc,
+                barrier_flag=self.barrier_flag_memref,
+                barrier_flag_mc=self.barrier_flag_mc_memref,
+            )
+        
+        result = self.c_torch_gpu.squeeze(-1)
+        return result[:actual_m, :]
+    

--- a/python/sglang/srt/layers/gemm_allreduce.py
+++ b/python/sglang/srt/layers/gemm_allreduce.py
@@ -2080,8 +2080,8 @@ class GemmARLayer:
             dtype=torch.int32
         )
         barrier_flag.fill_(0)
-        # symm = symm_mem.rendezvous(barrier_flag, group=self.tp_group.group_name)
-        symm = symm_mem.rendezvous(barrier_flag, group=dist.group.WORLD.group_name)        
+        symm = symm_mem.rendezvous(barrier_flag, group=self.tp_group.group_name)
+        # symm = symm_mem.rendezvous(barrier_flag, group=dist.group.WORLD.group_name)        
         barrier_flag_mc = symm.multicast_ptr
             
         barrier_flag_memref = from_dlpack(barrier_flag)
@@ -2133,9 +2133,9 @@ class GemmARLayer:
         c_tensor.element_type = self.output_dtype
         c_tensor = c_tensor.mark_layout_dynamic(leading_dim=1)
         
-        # print(f"a_tensor: {a_tensor.shape, a_tensor._dtype}")
-        # print(f"b_tensor: {b_tensor.shape, b_tensor._dtype}")
-        # print(f"c_tensor: {c_tensor.shape, c_tensor._dtype}")
+        print(f"a_tensor: {a_tensor.shape, a_tensor._dtype}")
+        print(f"b_tensor: {b_tensor.shape, b_tensor._dtype}")
+        print(f"c_tensor: {c_tensor.shape, c_tensor._dtype}, actual_m: {actual_m}")
         # dist.barrier(group=self.tp_group)
         if self.all_reduce == "none":
             self.compiled_gemm(a_tensor, b_tensor, c_tensor, current_stream)
@@ -2148,5 +2148,6 @@ class GemmARLayer:
             )
         
         result = self.c_torch_gpu.squeeze(-1)
+        print(f"result: {result.shape}")
         return result[:actual_m, :]
     

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1397,6 +1397,7 @@ class RowParallelLinear(LinearBase):
         if input_.shape[0] >= 128 and get_int_env_var("SGL_USE_TP_OVERLAP", 0) == 1:
             if self.gemm_ar_attn_op:
                 output = self.gemm_ar_attn_op.forward(input_, self.weight, self.bias)
+                print(f"gemm_ar_attn_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
 
                 # m = input_.shape[0]
                 # k = input_.shape[1] 
@@ -1420,6 +1421,8 @@ class RowParallelLinear(LinearBase):
                 # self.bias: None
             else:
                 output = self.gemm_ar_mlp_op.forward(input_, self.weight, self.bias)
+                print(f"gemm_ar_mlp_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
+
                 # m = input_.shape[0]
                 # k = input_.shape[1]
                 # n = self.weight.shape[0]

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1397,52 +1397,14 @@ class RowParallelLinear(LinearBase):
         if input_.shape[0] >= 128 and get_int_env_var("SGL_USE_TP_OVERLAP", 0) == 1:
             if self.gemm_ar_attn_op:
                 output = self.gemm_ar_attn_op.forward(input_, self.weight, self.bias)
-                print(f"gemm_ar_attn_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
-
-                # m = input_.shape[0]
-                # k = input_.shape[1] 
-                # n = self.weight.shape[0]
-                # if self.tp_rank == 0:
-                #     start_event = torch.cuda.Event(enable_timing=True)
-                #     end_event = torch.cuda.Event(enable_timing=True)
-                #     start_event.record()
-                #     output = self.gemm_ar_attn_op.forward(input_, self.weight, self.bias)
-                #     end_event.record()
-                #     end_event.synchronize()
-                #     execution_time = start_event.elapsed_time(end_event)
-                #     print(f"gemm_ar_attn_op: m={m}, n={n}, k={k}, forward execution time: {execution_time:.3f} ms")
-                # else:
-                #     output = self.gemm_ar_attn_op.forward(input_, self.weight, self.bias)
-                
-                # output = self.gemm_ar_attn_op.forward(input_, self.weight, self.bias)
-                #print(f"gemm_ar_attn_op: input_.shape: {input_.shape}, input_.stride(): {input_.stride()}, input_.dtype: {input_.dtype}; self.weight.shape: {self.weight.shape}, self.weight.stride(): {self.weight.stride()}, self.weight.dtype: {self.weight.dtype}; self.bias: {self.bias}")
+                # print(f"gemm_ar_attn_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
                 # input_.shape: torch.Size([256, 2048]), input_.stride(): (2048, 1)
                 # self.weight.shape: torch.Size([8192, 2048]), self.weight.stride(): (2048, 1)
                 # self.bias: None
             else:
                 output = self.gemm_ar_mlp_op.forward(input_, self.weight, self.bias)
-                print(f"gemm_ar_mlp_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
+                # print(f"gemm_ar_mlp_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
 
-                # m = input_.shape[0]
-                # k = input_.shape[1]
-                # n = self.weight.shape[0]
-                # if self.tp_rank == 0:
-                #     start_event = torch.cuda.Event(enable_timing=True)
-                #     end_event = torch.cuda.Event(enable_timing=True)
-                #     start_event.record()
-                #     output = self.gemm_ar_mlp_op.forward(input_, self.weight, self.bias)
-                #     end_event.record()
-                #     end_event.synchronize()
-                #     execution_time = start_event.elapsed_time(end_event)
-                #     print(f"gemm_ar_mlp_op: m={m}, n={n}, k={k}, forward execution time: {execution_time:.3f} ms")
-                # else:
-                #     output = self.gemm_ar_mlp_op.forward(input_, self.weight, self.bias)
-                
-                # print(f"gemm_ar_mlp_op forward: input_.shape: {input_.shape}, input_.stride(): {input_.stride()}, input_.dtype: {input_.dtype}; self.weight.shape: {self.weight.shape}, self.weight.stride(): {self.weight.stride()}, self.weight.dtype: {self.weight.dtype}; self.bias: {self.bias}")
-                # output = self.gemm_ar_mlp_op.forward(input_, self.weight, self.bias)
-                # 没打
-                # print(f"forward else, original output.shape: {output.shape}, original output.stride(): {output.stride()}")
-                
             output_bias = self.bias if self.skip_bias_add else None
             return output, output_bias
                     

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -33,7 +33,14 @@ from sglang.srt.layers.parameter import (
 )
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.utils import pad_or_narrow_weight
-from sglang.srt.utils import get_int_env_var, get_bool_env_var, is_cpu, is_hip, is_npu, set_weight_attrs
+from sglang.srt.utils import (
+    get_bool_env_var,
+    get_int_env_var,
+    is_cpu,
+    is_hip,
+    is_npu,
+    set_weight_attrs,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import (
@@ -1300,7 +1307,7 @@ class RowParallelLinear(LinearBase):
             self.register_parameter("bias", None)
 
         self.gemm_ar_attn_op = None
-        self.gemm_ar_mlp_op = None            
+        self.gemm_ar_mlp_op = None
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
         input_dim = getattr(param, "input_dim", None)
@@ -1407,7 +1414,7 @@ class RowParallelLinear(LinearBase):
 
             output_bias = self.bias if self.skip_bias_add else None
             return output, output_bias
-                    
+
         if self.input_is_parallel:
             input_parallel = input_
         else:
@@ -1440,7 +1447,7 @@ class RowParallelLinear(LinearBase):
         #     n = output_parallel.shape[1]
         #     print(f"SGLang original gemm_ar_op: m={m}, n={n}, k={k}, forward execution time: {execution_time:.3f} ms")
         #     # print(f"input_parallel shape: {input_parallel.shape}, output_parallel shape: {output_parallel.shape}, output shape: {output.shape}, forward execution time: {execution_time:.3f} ms")
-    
+
         output_bias = self.bias if self.skip_bias_add else None
 
         return output, output_bias

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -1404,13 +1404,8 @@ class RowParallelLinear(LinearBase):
         if input_.shape[0] >= 128 and get_int_env_var("SGL_USE_TP_OVERLAP", 0) == 1:
             if self.gemm_ar_attn_op:
                 output = self.gemm_ar_attn_op.forward(input_, self.weight, self.bias)
-                # print(f"gemm_ar_attn_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
-                # input_.shape: torch.Size([256, 2048]), input_.stride(): (2048, 1)
-                # self.weight.shape: torch.Size([8192, 2048]), self.weight.stride(): (2048, 1)
-                # self.bias: None
             else:
                 output = self.gemm_ar_mlp_op.forward(input_, self.weight, self.bias)
-                # print(f"gemm_ar_mlp_op: input_.shape: {input_.shape}; self.weight.shape: {self.weight.shape}; output.shape: {output.shape}")
 
             output_bias = self.bias if self.skip_bias_add else None
             return output, output_bias
@@ -1438,15 +1433,6 @@ class RowParallelLinear(LinearBase):
             output = tensor_model_parallel_all_reduce(output_parallel)
         else:
             output = output_parallel
-        # end_event.record()
-        # end_event.synchronize()
-        # execution_time = start_event.elapsed_time(end_event)
-        # if self.tp_rank == 0:
-        #     m = input_parallel.shape[0]
-        #     k = input_parallel.shape[1]
-        #     n = output_parallel.shape[1]
-        #     print(f"SGLang original gemm_ar_op: m={m}, n={n}, k={k}, forward execution time: {execution_time:.3f} ms")
-        #     # print(f"input_parallel shape: {input_parallel.shape}, output_parallel shape: {output_parallel.shape}, output shape: {output.shape}, forward execution time: {execution_time:.3f} ms")
 
         output_bias = self.bias if self.skip_bias_add else None
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -158,8 +158,8 @@ from sglang.srt.utils import (
     get_available_gpu_memory,
     get_bool_env_var,
     get_cpu_ids_by_node,
-    get_local_ip_auto,
     get_int_env_var,
+    get_local_ip_auto,
     init_custom_process_group,
     is_cuda,
     is_float4_e2m1fn_x2,
@@ -317,7 +317,7 @@ class ModelRunner:
         self.use_mla_backend = self.model_config.attention_arch == AttentionArch.MLA
         self.attention_chunk_size = model_config.attention_chunk_size
         self.gemm_ar_attn_op = None
-        self.gemm_ar_mlp_op = None        
+        self.gemm_ar_mlp_op = None
         self.forward_pass_id = 0
         self.init_new_workspace = False
 
@@ -435,7 +435,6 @@ class ModelRunner:
         self.sampler = Sampler()
         self.load_model()
 
-
         if (
             self.server_args.remote_instance_weight_loader_support_transfer_engine
             and self.remote_instance_transfer_engine_weight_info is None
@@ -449,7 +448,7 @@ class ModelRunner:
         if self.device == "cuda" and get_int_env_var("SGL_USE_TP_OVERLAP", 0) == 1:
             logger.info(f"Initialize Gemm-AllReduce Overlap Operator...")
             self.init_overlap_gemm_allreduce_operator()
-            
+
         # Check if the model is using hybrid SWA
         if (
             not self.server_args.disable_hybrid_swa_memory
@@ -2068,21 +2067,26 @@ class ModelRunner:
             ranks=self.tp_group.ranks, backend="gloo"
         )
         torch.distributed.barrier(_TP_OVERLAP_GROUP)
-    
+
         # Init symm memory, init mc tensor
-        import torch.distributed._symmetric_memory as symm_mem
         import cutlass
         import cutlass.torch as cutlass_torch
+        import torch.distributed._symmetric_memory as symm_mem
         from cutlass.cute.runtime import from_dlpack
-        
+
         def create_c_tensor_mc(torch_tensor_cpu):
-            # Try NVSHMEM first, fallback to torch symm_mem  
-            from sglang.srt.distributed.device_communicators.nvshmem_communicator import get_nvshmem_comm
+            # Try NVSHMEM first, fallback to torch symm_mem
+            from sglang.srt.distributed.device_communicators.nvshmem_communicator import (
+                get_nvshmem_comm,
+            )
+
             nvshmem_comm = get_nvshmem_comm()
-        
+
             if nvshmem_comm:
                 # Use NVSHMEM_SYMM_MEM
-                symm_tensor = nvshmem_comm.create_symmetric_tensor(torch_tensor_cpu.shape, dtype=torch_tensor_cpu.dtype)
+                symm_tensor = nvshmem_comm.create_symmetric_tensor(
+                    torch_tensor_cpu.shape, dtype=torch_tensor_cpu.dtype
+                )
                 mc_ptr = nvshmem_comm.create_multicast_pointer(symm_tensor)
             else:
                 # Use TORCH_SYMM_MEM
@@ -2090,14 +2094,20 @@ class ModelRunner:
                     torch_tensor_cpu.shape, device="cuda", dtype=torch_tensor_cpu.dtype
                 )
                 symm_tensor.copy_(torch_tensor_cpu)
-                symm = symm_mem.rendezvous(symm_tensor, group=dist.group.WORLD.group_name)
+                symm = symm_mem.rendezvous(
+                    symm_tensor, group=dist.group.WORLD.group_name
+                )
                 mc_ptr = symm.multicast_ptr
 
             cute_tensor_mc = from_dlpack(
-                cutlass_torch.as_tensor(mc_ptr, torch_tensor_cpu.shape, torch_tensor_cpu.dtype),
+                cutlass_torch.as_tensor(
+                    mc_ptr, torch_tensor_cpu.shape, torch_tensor_cpu.dtype
+                ),
                 assumed_align=16,
             )
-            cute_tensor_mc = cute_tensor_mc.mark_layout_dynamic(leading_dim=1)  # is_dynamic_layout=True
+            cute_tensor_mc = cute_tensor_mc.mark_layout_dynamic(
+                leading_dim=1
+            )  # is_dynamic_layout=True
             return symm_tensor, cute_tensor_mc
 
         dtype_map = {
@@ -2107,10 +2117,13 @@ class ModelRunner:
         }
         max_M = self.model_config.hf_config.max_position_embeddings
         N = self.model_config.hf_config.hidden_size
-        _c_torch_cpu = cutlass_torch.matrix(1, max_M, N, False, dtype_map.get(self.model_config.dtype, cutlass.BFloat16))  # l = 1, c_major == "m"
+        _c_torch_cpu = cutlass_torch.matrix(
+            1, max_M, N, False, dtype_map.get(self.model_config.dtype, cutlass.BFloat16)
+        )  # l = 1, c_major == "m"
         torch_symm_tensor, c_tensor_mc = create_c_tensor_mc(_c_torch_cpu)
 
         from sglang.srt.layers.gemm_allreduce import GemmARLayer
+
         self.gemm_ar_attn_op = GemmARLayer(
             tp_group=_TP_OVERLAP_GROUP,
             max_M=max_M,
@@ -2121,11 +2134,11 @@ class ModelRunner:
             local_world_size=self.tp_size,
             c_tensor_mc=c_tensor_mc,
             torch_symm_tensor=torch_symm_tensor,
-            mma_tiler_mn=(256, 256),  # Larger tiler for better performance  
+            mma_tiler_mn=(256, 256),  # Larger tiler for better performance
             cluster_shape_mn=(2, 1),  # Better cluster shape for TP
-            use_2cta_instrs=True,     # Enable for better performance
+            use_2cta_instrs=True,  # Enable for better performance
             use_tma_store=True,
-            all_reduce="LDMCxSTMC",    
+            all_reduce="LDMCxSTMC",
         )
 
         self.gemm_ar_mlp_op = GemmARLayer(
@@ -2142,15 +2155,14 @@ class ModelRunner:
             cluster_shape_mn=(2, 2),
             use_2cta_instrs=True,
             use_tma_store=True,
-            all_reduce="LDMCxSTMC",    
+            all_reduce="LDMCxSTMC",
         )
-        
+
         for each in self.model.model.layers:
             if each.self_attn.o_proj:
                 each.self_attn.o_proj.gemm_ar_attn_op = self.gemm_ar_attn_op
             if each.mlp.down_proj:
                 each.mlp.down_proj.gemm_ar_mlp_op = self.gemm_ar_mlp_op
-
 
     def init_cublas(self):
         """We need to run a small matmul to init cublas. Otherwise, it will raise some errors later."""

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -434,16 +434,6 @@ class ModelRunner:
         self.sampler = Sampler()
         self.load_model()
 
-        if (
-            self.server_args.remote_instance_weight_loader_support_transfer_engine
-            and self.remote_instance_transfer_engine_weight_info is None
-        ):
-            self.remote_instance_transfer_engine_weight_info = (
-                register_memory_region_v2(
-                    self.model, self.remote_instance_transfer_engine
-                )
-            )
-
         if self.device == "cuda" and get_int_env_var("SGL_USE_TP_OVERLAP", 0) == 1:
             logger.info(f"Initialize Gemm-AllReduce Overlap Operator...")
             self.init_overlap_gemm_allreduce_operator()

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -159,7 +159,6 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_cpu_ids_by_node,
     get_int_env_var,
-    get_local_ip_auto,
     init_custom_process_group,
     is_cuda,
     is_float4_e2m1fn_x2,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2125,7 +2125,7 @@ class ModelRunner:
             cluster_shape_mn=(2, 1),  # Better cluster shape for TP
             use_2cta_instrs=True,     # Enable for better performance
             use_tma_store=True,
-            all_reduce="two_shot",    
+            all_reduce="LDMCxSTMC",    
         )
 
         self.gemm_ar_mlp_op = GemmARLayer(
@@ -2142,7 +2142,7 @@ class ModelRunner:
             cluster_shape_mn=(2, 2),
             use_2cta_instrs=True,
             use_tma_store=True,
-            all_reduce="two_shot",    
+            all_reduce="LDMCxSTMC",    
         )
         
         for each in self.model.model.layers:

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -252,10 +252,8 @@ class Qwen2DecoderLayer(nn.Module):
         )
 
         # Fully Connected
-        # print(f"Qwen2DecoderLayer: hidden_states.shape: {hidden_states.shape}, residual.shape: {residual.shape}")
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
-        # print(f"Qwen2DecoderLayer: hidden_states.shape: {hidden_states.shape}, residual.shape: {residual.shape}")
         return hidden_states, residual
 
 

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -252,8 +252,10 @@ class Qwen2DecoderLayer(nn.Module):
         )
 
         # Fully Connected
+        # print(f"Qwen2DecoderLayer: hidden_states.shape: {hidden_states.shape}, residual.shape: {residual.shape}")
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
         hidden_states = self.mlp(hidden_states)
+        # print(f"Qwen2DecoderLayer: hidden_states.shape: {hidden_states.shape}, residual.shape: {residual.shape}")
         return hidden_states, residual
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

We do GEMM+AllReduce overlap during TensorParallel via cutlass based fused kernel on B200.
Co-auther @zhou9402 

## Modifications

Add two GEMM+AR op in ModelRunner, one for ATTN and the other for MLP.
Add PersistentDenseGemmKernel and GemmARLayer.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
<img width="790" height="89" alt="image" src="https://github.com/user-attachments/assets/188bac2a-028f-4470-98c1-54f56d58c434" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Results of bench_serving on 8*B200 Qwen2.5-72B-Instruct: throuput +6.42%

Prefill: 
| GPU | model                 | TP | in/out  | latency/ms | throuput | sglang version |
| --- | --------------------- | -- | ------ | ---------- | -------- | -------------- |
| B200 | Qwen2.5-72B-Instruct | 4  | 4096/1 | 5195.9       | 21947    | origin         |
| B200 | Qwen2.5-72B-Instruct | 4  | 4096/1 | 4902.7       | 23356    | origin+overlap |


Decode: 
| GPU | model                 | TP | in/out   | latency/ms | throuput | sglang version |
| --- | --------------------- | -- | ------- | ---------- | -------- | -------------- |
| B200 | Qwen2.5-72B-Instruct | 4  | 4096/128 | 52.8     | 685     | origin         |
| B200 | Qwen2.5-72B-Instruct | 4  | 4096/126 | 50.5     | 729     | origin+overlap |



* Original:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 64
Successful requests:                     512
Benchmark duration (s):                  95.55
Total input tokens:                      2097152
Total input text tokens:                 2097152
Total input vision tokens:               0
Total generated tokens:                  65536
Total generated tokens (retokenized):    65514
Request throughput (req/s):              5.36
Input token throughput (tok/s):          21947.55
Output token throughput (tok/s):         685.86
Peak output token throughput (tok/s):    4096.00
Peak concurrent requests:                128
Total token throughput (tok/s):          22633.41
Concurrency:                             63.93
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11931.70
Median E2E Latency (ms):                 11948.05
---------------Time to First Token----------------
Mean TTFT (ms):                          5390.79
Median TTFT (ms):                        5195.96
P99 TTFT (ms):                           9950.64
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.50
Median TPOT (ms):                        52.82
P99 TPOT (ms):                           90.43
---------------Inter-Token Latency----------------
Mean ITL (ms):                           51.49
Median ITL (ms):                         15.76
P95 ITL (ms):                            16.62
P99 ITL (ms):                            19.53
Max ITL (ms):                            9581.36
==================================================
```

* Overlap:
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 64
Successful requests:                     512
Benchmark duration (s):                  89.79
Total input tokens:                      2097152
Total input text tokens:                 2097152
Total input vision tokens:               0
Total generated tokens:                  65536
Total generated tokens (retokenized):    65510
Request throughput (req/s):              5.70
Input token throughput (tok/s):          23356.35
Output token throughput (tok/s):         729.89
Peak output token throughput (tok/s):    4288.00
Peak concurrent requests:                128
Total token throughput (tok/s):          24086.24
Concurrency:                             63.93
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   11211.35
Median E2E Latency (ms):                 11199.54
---------------Time to First Token----------------
Mean TTFT (ms):                          4961.45
Median TTFT (ms):                        4902.74
P99 TTFT (ms):                           9240.62
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          49.21
Median TPOT (ms):                        50.54
P99 TPOT (ms):                           84.71
---------------Inter-Token Latency----------------
Mean ITL (ms):                           49.20
Median ITL (ms):                         15.77
P95 ITL (ms):                            16.72
P99 ITL (ms):                            20.42
Max ITL (ms):                            8848.02
==================================================
```

Timeline in profile: GEMM+AR 552us -> 423us

Original GEMM + AllReduce:
<img width="694" height="224" alt="image" src="https://github.com/user-attachments/assets/cc75c917-a129-4e7a-a047-fd943a323ab4" />

Overlap Fused kernel:
<img width="517" height="209" alt="image" src="https://github.com/user-attachments/assets/6acdce1b-64e0-45a2-bb92-9cfc8bb923cd" />



Command:
* Original:
```
python -m sglang.launch_server --model /workspace/qwen-72b --trust-remote-code --tp 4 --host 0.0.0.0 --port 30000 --mem-fraction-static 0.7 --chunked-prefill-size 16384 --max-running-requests 256 --enable-metrics --disable-radix-cache
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompt 512 --random-input 4096 --random-output 128 --random-range-ratio 1 --host 127.0.0.1 --port 30000 --max-concurrency 64
```

* Overlap:
```
SGL_USE_TP_OVERLAP=1 python -m sglang.launch_server --model /workspace/qwen-72b --trust-remote-code --tp 4 --host 0.0.0.0 --port 30000 --mem-fraction-static 0.7 --chunked-prefill-size 16384 --max-running-requests 256 --enable-metrics --disable-radix-cache
python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompt 512 --random-input 4096 --random-output 128 --random-range-ratio 1 --host 127.0.0.1 --port 30000 --max-concurrency 64
```



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
