### PR TITLE
[model-gateway] tokenizer: add async encoding to avoid blocking async runtime

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -58,8 +58,14 @@ impl ChatPreparationStage {
             }
         };
 
-        // Step 3: Tokenize the processed text
-        let encoding = match ctx.components.tokenizer.encode(&processed_messages.text) {
+        // Step 3: Tokenize the processed text (async to avoid blocking runtime for large prompts)
+        let encoding = match ctx
+            .components
+            .tokenizer
+            .clone()
+            .encode_async(&processed_messages.text)
+            .await
+        {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "ChatPreparationStage::execute", error = %e, "Tokenization failed");

--- a/sgl-model-gateway/src/tokenizer/mod.rs
+++ b/sgl-model-gateway/src/tokenizer/mod.rs
@@ -71,12 +71,21 @@ impl Tokenizer {
         DecodeStream::new(self.0.clone(), prompt_token_ids, skip_special_tokens)
     }
 
-    /// Direct encode method
+    /// Direct encode method (sync)
     pub fn encode(&self, input: &str) -> Result<Encoding> {
         self.0.encode(input)
     }
 
-    /// Direct batch encode method
+    /// Async encode with adaptive offloading.
+    ///
+    /// - Small inputs (<4KB): inline execution, no overhead
+    /// - Large inputs (>=4KB): offloaded to blocking thread pool to avoid
+    ///   blocking the async runtime (large prompts can take 50-200ms+)
+    pub async fn encode_async(&self, input: &str) -> Result<Encoding> {
+        self.0.clone().encode_async(input).await
+    }
+
+    /// Direct batch encode method (sync)
     pub fn encode_batch(&self, inputs: &[&str]) -> Result<Vec<Encoding>> {
         self.0.encode_batch(inputs)
     }


### PR DESCRIPTION
Add `encode_async` trait method to `Encoder` trait with adaptive offloading to prevent CPU-intensive tokenization from blocking the Tokio async runtime.

- Small inputs (<4KB): inline execution, no overhead
- Large inputs (>=4KB): offloaded to spawn_blocking thread pool

Implemented for: HuggingFaceTokenizer, TiktokenTokenizer, MockTokenizer, CachedTokenizer

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
