### PR TITLE
feat(metrics): implement Layer 2 router metrics (smg_router_*)

### DIFF
--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -765,6 +765,9 @@ pub mod smg_labels {
     pub const ENDPOINT_CHAT: &str = "chat";
     pub const ENDPOINT_GENERATE: &str = "generate";
     pub const ENDPOINT_RESPONSES: &str = "responses";
+    pub const ENDPOINT_COMPLETIONS: &str = "completions";
+    pub const ENDPOINT_RERANK: &str = "rerank";
+    pub const ENDPOINT_EMBEDDINGS: &str = "embeddings";
 
     // Worker types
     pub const WORKER_REGULAR: &str = "regular";
@@ -812,6 +815,22 @@ pub mod smg_labels {
     // Circuit breaker outcomes
     pub const CB_SUCCESS: &str = "success";
     pub const CB_FAILURE: &str = "failure";
+
+    // Router error types
+    pub const ERROR_NO_WORKERS: &str = "no_workers";
+    pub const ERROR_TIMEOUT: &str = "timeout";
+    pub const ERROR_BACKEND: &str = "backend_error";
+    pub const ERROR_VALIDATION: &str = "validation_error";
+    pub const ERROR_INTERNAL: &str = "internal_error";
+
+    // Pipeline stages (gRPC router)
+    pub const STAGE_PREPARATION: &str = "preparation";
+    pub const STAGE_WORKER_SELECTION: &str = "worker_selection";
+    pub const STAGE_CLIENT_ACQUISITION: &str = "client_acquisition";
+    pub const STAGE_REQUEST_BUILDING: &str = "request_building";
+    pub const STAGE_DISPATCH_METADATA: &str = "dispatch_metadata";
+    pub const STAGE_REQUEST_EXECUTION: &str = "request_execution";
+    pub const STAGE_RESPONSE_PROCESSING: &str = "response_processing";
 }
 
 /// SMG Metrics helper struct for the new layered metrics architecture

--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -3,7 +3,7 @@
 //! This module defines the RequestPipeline orchestrator that coordinates
 //! the execution of pipeline stages from request preparation to response delivery.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use axum::response::{IntoResponse, Response};
 use tracing::error;
@@ -13,9 +13,11 @@ use super::{
     context::*,
     harmony,
     regular::{processor, stages::*, streaming},
+    utils::error_type_from_status,
 };
 use crate::{
     core::WorkerRegistry,
+    observability::metrics::{smg_labels, SmgMetrics},
     policies::PolicyRegistry,
     protocols::{
         chat::{ChatCompletionRequest, ChatCompletionResponse},
@@ -34,6 +36,8 @@ use crate::{
 #[derive(Clone)]
 pub struct RequestPipeline {
     stages: Arc<Vec<Box<dyn PipelineStage>>>,
+    /// Backend type for metrics labeling
+    backend_type: &'static str,
 }
 
 impl RequestPipeline {
@@ -79,6 +83,7 @@ impl RequestPipeline {
 
         Self {
             stages: Arc::new(stages),
+            backend_type: smg_labels::BACKEND_REGULAR,
         }
     }
 
@@ -108,6 +113,7 @@ impl RequestPipeline {
 
         Self {
             stages: Arc::new(stages),
+            backend_type: smg_labels::BACKEND_REGULAR,
         }
     }
 
@@ -137,6 +143,7 @@ impl RequestPipeline {
 
         Self {
             stages: Arc::new(stages),
+            backend_type: smg_labels::BACKEND_PD,
         }
     }
 
@@ -182,6 +189,7 @@ impl RequestPipeline {
 
         Self {
             stages: Arc::new(stages),
+            backend_type: smg_labels::BACKEND_PD,
         }
     }
 
@@ -193,22 +201,49 @@ impl RequestPipeline {
         model_id: Option<String>,
         components: Arc<SharedComponents>,
     ) -> Response {
+        let start = Instant::now();
+        // Clone Arc for metrics (cheap atomic increment) to avoid borrow issues
+        let request_for_metrics = Arc::clone(&request);
+        let streaming = request.stream;
+
+        // Record request start
+        SmgMetrics::record_router_request(
+            smg_labels::ROUTER_GRPC,
+            self.backend_type,
+            smg_labels::CONNECTION_GRPC,
+            &request_for_metrics.model,
+            smg_labels::ENDPOINT_CHAT,
+            streaming,
+        );
+
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
 
-        for (idx, stage) in self.stages.iter().enumerate() {
+        for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
                 Ok(Some(response)) => {
-                    // Stage completed successfully with a response (e.g., streaming)
+                    // Stage completed with streaming response - record success and return
+                    SmgMetrics::record_router_duration(
+                        smg_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        smg_labels::CONNECTION_GRPC,
+                        &request_for_metrics.model,
+                        smg_labels::ENDPOINT_CHAT,
+                        start.elapsed(),
+                    );
                     return response;
                 }
-                Ok(None) => {
-                    continue;
-                }
+                Ok(None) => continue,
                 Err(response) => {
-                    // Error occurred
+                    SmgMetrics::record_router_error(
+                        smg_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        smg_labels::CONNECTION_GRPC,
+                        &request_for_metrics.model,
+                        smg_labels::ENDPOINT_CHAT,
+                        error_type_from_status(response.status()),
+                    );
                     error!(
-                        "Stage {} ({}) failed with status {}",
-                        idx + 1,
+                        "Stage {} failed with status {}",
                         stage.name(),
                         response.status()
                     );
@@ -218,11 +253,29 @@ impl RequestPipeline {
         }
 
         match ctx.state.response.final_response {
-            Some(FinalResponse::Chat(response)) => axum::Json(response).into_response(),
+            Some(FinalResponse::Chat(response)) => {
+                SmgMetrics::record_router_duration(
+                    smg_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    smg_labels::CONNECTION_GRPC,
+                    &request_for_metrics.model,
+                    smg_labels::ENDPOINT_CHAT,
+                    start.elapsed(),
+                );
+                axum::Json(response).into_response()
+            }
             Some(FinalResponse::Generate(_)) => {
                 error!(
                     function = "execute_chat",
                     "Wrong response type: expected Chat, got Generate"
+                );
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    smg_labels::CONNECTION_GRPC,
+                    &request_for_metrics.model,
+                    smg_labels::ENDPOINT_CHAT,
+                    smg_labels::ERROR_INTERNAL,
                 );
                 error::internal_error("wrong_response_type", "Internal error: wrong response type")
             }
@@ -230,6 +283,14 @@ impl RequestPipeline {
                 error!(
                     function = "execute_chat",
                     "No response produced by pipeline"
+                );
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    smg_labels::CONNECTION_GRPC,
+                    &request_for_metrics.model,
+                    smg_labels::ENDPOINT_CHAT,
+                    smg_labels::ERROR_INTERNAL,
                 );
                 error::internal_error("no_response_produced", "No response produced")
             }
@@ -244,22 +305,49 @@ impl RequestPipeline {
         model_id: Option<String>,
         components: Arc<SharedComponents>,
     ) -> Response {
+        let start = Instant::now();
+        // Clone model_id for metrics before moving into context
+        // GenerateRequest doesn't have a model field, so we use model_id
+        let model_for_metrics = model_id.clone();
+        let streaming = request.stream;
+
+        // Record request start
+        SmgMetrics::record_router_request(
+            smg_labels::ROUTER_GRPC,
+            self.backend_type,
+            smg_labels::CONNECTION_GRPC,
+            model_for_metrics.as_deref().unwrap_or("unknown"),
+            smg_labels::ENDPOINT_GENERATE,
+            streaming,
+        );
+
         let mut ctx = RequestContext::for_generate(request, headers, model_id, components);
 
-        for (idx, stage) in self.stages.iter().enumerate() {
+        for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
                 Ok(Some(response)) => {
-                    // Stage completed successfully with a response (e.g., streaming)
+                    SmgMetrics::record_router_duration(
+                        smg_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        smg_labels::CONNECTION_GRPC,
+                        model_for_metrics.as_deref().unwrap_or("unknown"),
+                        smg_labels::ENDPOINT_GENERATE,
+                        start.elapsed(),
+                    );
                     return response;
                 }
-                Ok(None) => {
-                    continue;
-                }
+                Ok(None) => continue,
                 Err(response) => {
-                    // Error occurred
+                    SmgMetrics::record_router_error(
+                        smg_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        smg_labels::CONNECTION_GRPC,
+                        model_for_metrics.as_deref().unwrap_or("unknown"),
+                        smg_labels::ENDPOINT_GENERATE,
+                        error_type_from_status(response.status()),
+                    );
                     error!(
-                        "Stage {} ({}) failed with status {}",
-                        idx + 1,
+                        "Stage {} failed with status {}",
                         stage.name(),
                         response.status()
                     );
@@ -269,11 +357,29 @@ impl RequestPipeline {
         }
 
         match ctx.state.response.final_response {
-            Some(FinalResponse::Generate(response)) => axum::Json(response).into_response(),
+            Some(FinalResponse::Generate(response)) => {
+                SmgMetrics::record_router_duration(
+                    smg_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    smg_labels::CONNECTION_GRPC,
+                    model_for_metrics.as_deref().unwrap_or("unknown"),
+                    smg_labels::ENDPOINT_GENERATE,
+                    start.elapsed(),
+                );
+                axum::Json(response).into_response()
+            }
             Some(FinalResponse::Chat(_)) => {
                 error!(
                     function = "execute_generate",
                     "Wrong response type: expected Generate, got Chat"
+                );
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    smg_labels::CONNECTION_GRPC,
+                    model_for_metrics.as_deref().unwrap_or("unknown"),
+                    smg_labels::ENDPOINT_GENERATE,
+                    smg_labels::ERROR_INTERNAL,
                 );
                 error::internal_error("wrong_response_type", "Internal error: wrong response type")
             }
@@ -281,6 +387,14 @@ impl RequestPipeline {
                 error!(
                     function = "execute_generate",
                     "No response produced by pipeline"
+                );
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    smg_labels::CONNECTION_GRPC,
+                    model_for_metrics.as_deref().unwrap_or("unknown"),
+                    smg_labels::ENDPOINT_GENERATE,
+                    smg_labels::ERROR_INTERNAL,
                 );
                 error::internal_error("no_response_produced", "No response produced")
             }

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -2,6 +2,7 @@ use std::{
     any::Any,
     collections::HashSet,
     sync::{atomic::AtomicBool, Arc},
+    time::Instant,
 };
 
 use axum::{
@@ -35,6 +36,7 @@ use crate::{
     app_context::AppContext,
     core::{model_type::Endpoint, ModelCard, ProviderType, RuntimeType, Worker, WorkerRegistry},
     data_connector::{ConversationId, ListParams, ResponseId, SortOrder},
+    observability::metrics::{smg_labels, SmgMetrics},
     protocols::{
         chat::ChatCompletionRequest,
         responses::{
@@ -576,6 +578,20 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         body: &ChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
+        let start = Instant::now();
+        let model = model_id.unwrap_or(body.model.as_str());
+        let streaming = body.stream;
+
+        // Record request start
+        SmgMetrics::record_router_request(
+            smg_labels::ROUTER_OPENAI,
+            smg_labels::BACKEND_EXTERNAL,
+            smg_labels::CONNECTION_HTTP,
+            model,
+            smg_labels::ENDPOINT_CHAT,
+            streaming,
+        );
+
         let auth_header = extract_auth_header(headers, &None);
 
         let worker = match self
@@ -583,18 +599,44 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             .await
         {
             Ok(w) => w,
-            Err(response) => return response,
+            Err(response) => {
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_OPENAI,
+                    smg_labels::BACKEND_EXTERNAL,
+                    smg_labels::CONNECTION_HTTP,
+                    model,
+                    smg_labels::ENDPOINT_CHAT,
+                    smg_labels::ERROR_NO_WORKERS,
+                );
+                return response;
+            }
         };
 
         let mut payload = match to_value(body) {
             Ok(v) => v,
             Err(e) => {
-                return error_responses::bad_request(format!("Failed to serialize request: {}", e))
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_OPENAI,
+                    smg_labels::BACKEND_EXTERNAL,
+                    smg_labels::CONNECTION_HTTP,
+                    model,
+                    smg_labels::ENDPOINT_CHAT,
+                    smg_labels::ERROR_VALIDATION,
+                );
+                return error_responses::bad_request(format!("Failed to serialize request: {}", e));
             }
         };
 
         let provider = self.get_provider_arc_for_worker(worker.as_ref(), model_id);
         if let Err(e) = provider.transform_request(&mut payload, Endpoint::Chat) {
+            SmgMetrics::record_router_error(
+                smg_labels::ROUTER_OPENAI,
+                smg_labels::BACKEND_EXTERNAL,
+                smg_labels::CONNECTION_HTTP,
+                model,
+                smg_labels::ENDPOINT_CHAT,
+                smg_labels::ERROR_VALIDATION,
+            );
             return error_responses::bad_request(format!("Provider transform error: {}", e));
         }
 
@@ -630,6 +672,14 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             Ok(r) => r,
             Err(e) => {
                 worker.circuit_breaker().record_failure();
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_OPENAI,
+                    smg_labels::BACKEND_EXTERNAL,
+                    smg_labels::CONNECTION_HTTP,
+                    model,
+                    smg_labels::ENDPOINT_CHAT,
+                    smg_labels::ERROR_BACKEND,
+                );
                 return (
                     StatusCode::SERVICE_UNAVAILABLE,
                     format!("Failed to contact upstream: {}", e),
@@ -646,6 +696,14 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             match resp.bytes().await {
                 Ok(body) => {
                     worker.circuit_breaker().record_success();
+                    SmgMetrics::record_router_duration(
+                        smg_labels::ROUTER_OPENAI,
+                        smg_labels::BACKEND_EXTERNAL,
+                        smg_labels::CONNECTION_HTTP,
+                        model,
+                        smg_labels::ENDPOINT_CHAT,
+                        start.elapsed(),
+                    );
                     let mut response = Response::new(Body::from(body));
                     *response.status_mut() = status;
                     if let Some(ct) = content_type {
@@ -655,6 +713,14 @@ impl crate::routers::RouterTrait for OpenAIRouter {
                 }
                 Err(e) => {
                     worker.circuit_breaker().record_failure();
+                    SmgMetrics::record_router_error(
+                        smg_labels::ROUTER_OPENAI,
+                        smg_labels::BACKEND_EXTERNAL,
+                        smg_labels::CONNECTION_HTTP,
+                        model,
+                        smg_labels::ENDPOINT_CHAT,
+                        smg_labels::ERROR_BACKEND,
+                    );
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         format!("Failed to read response: {}", e),
@@ -663,6 +729,15 @@ impl crate::routers::RouterTrait for OpenAIRouter {
                 }
             }
         } else {
+            // For streaming, record duration at start since we can't track completion
+            SmgMetrics::record_router_duration(
+                smg_labels::ROUTER_OPENAI,
+                smg_labels::BACKEND_EXTERNAL,
+                smg_labels::CONNECTION_HTTP,
+                model,
+                smg_labels::ENDPOINT_CHAT,
+                start.elapsed(),
+            );
             let stream = resp.bytes_stream();
             let (tx, rx) = mpsc::unbounded_channel();
             tokio::spawn(async move {
@@ -696,15 +771,38 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         body: &ResponsesRequest,
         model_id: Option<&str>,
     ) -> Response {
+        let start = Instant::now();
+        let model = model_id.unwrap_or(body.model.as_str());
+        let streaming = body.stream.unwrap_or(false);
+
+        // Record request start
+        SmgMetrics::record_router_request(
+            smg_labels::ROUTER_OPENAI,
+            smg_labels::BACKEND_EXTERNAL,
+            smg_labels::CONNECTION_HTTP,
+            model,
+            smg_labels::ENDPOINT_RESPONSES,
+            streaming,
+        );
+
         let auth_header = extract_auth_header(headers, &None);
 
-        let model = model_id.unwrap_or(body.model.as_str());
         let worker = match self
             .select_worker_for_model(model, auth_header.as_ref())
             .await
         {
             Ok(w) => w,
-            Err(response) => return response,
+            Err(response) => {
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_OPENAI,
+                    smg_labels::BACKEND_EXTERNAL,
+                    smg_labels::CONNECTION_HTTP,
+                    model,
+                    smg_labels::ENDPOINT_RESPONSES,
+                    smg_labels::ERROR_NO_WORKERS,
+                );
+                return response;
+            }
         };
 
         let mut request_body = body.clone();
@@ -755,6 +853,14 @@ impl crate::routers::RouterTrait for OpenAIRouter {
                 .get_conversation(&conv_id)
                 .await
             {
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_OPENAI,
+                    smg_labels::BACKEND_EXTERNAL,
+                    smg_labels::CONNECTION_HTTP,
+                    model,
+                    smg_labels::ENDPOINT_RESPONSES,
+                    smg_labels::ERROR_VALIDATION,
+                );
                 return error_responses::not_found("conversation", &conv_id.0);
             }
 
@@ -864,12 +970,28 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let mut payload = match to_value(&request_body) {
             Ok(v) => v,
             Err(e) => {
-                return error_responses::bad_request(format!("Failed to serialize request: {}", e))
+                SmgMetrics::record_router_error(
+                    smg_labels::ROUTER_OPENAI,
+                    smg_labels::BACKEND_EXTERNAL,
+                    smg_labels::CONNECTION_HTTP,
+                    model,
+                    smg_labels::ENDPOINT_RESPONSES,
+                    smg_labels::ERROR_VALIDATION,
+                );
+                return error_responses::bad_request(format!("Failed to serialize request: {}", e));
             }
         };
 
         let provider = self.get_provider_arc_for_worker(worker.as_ref(), model_id);
         if let Err(e) = provider.transform_request(&mut payload, Endpoint::Responses) {
+            SmgMetrics::record_router_error(
+                smg_labels::ROUTER_OPENAI,
+                smg_labels::BACKEND_EXTERNAL,
+                smg_labels::CONNECTION_HTTP,
+                model,
+                smg_labels::ENDPOINT_RESPONSES,
+                smg_labels::ERROR_VALIDATION,
+            );
             return error_responses::bad_request(format!("Provider transform error: {}", e));
         }
 
@@ -891,11 +1013,25 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             previous_response_id: original_previous_response_id,
         });
 
-        if ctx.is_streaming() {
+        let response = if ctx.is_streaming() {
             handle_streaming_response(ctx).await
         } else {
             self.handle_non_streaming_response(ctx).await
+        };
+
+        // Record duration only for successful requests (errors tracked inside handlers)
+        if response.status().is_success() {
+            SmgMetrics::record_router_duration(
+                smg_labels::ROUTER_OPENAI,
+                smg_labels::BACKEND_EXTERNAL,
+                smg_labels::CONNECTION_HTTP,
+                model,
+                smg_labels::ENDPOINT_RESPONSES,
+                start.elapsed(),
+            );
         }
+
+        response
     }
 
     async fn get_response(


### PR DESCRIPTION
Add unified router metrics instrumentation across all router types:
- `smg_router_requests_total`: Counter for request starts
- `smg_router_request_duration_seconds`: Histogram for request latency
- `smg_router_request_errors_total`: Counter for request errors

Routers instrumented:
- gRPC pipeline (chat/generate endpoints)
- HTTP router (regular backend)
- HTTP PD router (prefill-decode backend)
- OpenAI router (external backend)

Implementation details:
- Use `&'static str` labels via `smg_labels` constants (zero allocation)
- `Arc::clone` for request sharing in gRPC (cheap atomic increment)
- Shared helpers in `grpc/utils.rs` (`route_to_endpoint`, `error_type_from_status`)

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
