### PR TITLE
[FIX] add lora draining to prevent edge case of a request never scheduling

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1849,11 +1849,11 @@ class Scheduler(
                 if not self.tp_worker.can_run_lora_batch(
                     next_batch_loras | {req.lora_id}
                 ):
-                    draining_loras.update(
+                    draining_loras = {
                         lora_id
                         for lora_id in running_batch_loras
                         if lora_id is not None
-                    )
+                    }
 
                     continue
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

#14795 optimizes LoRA scheduling by allowing non-LoRA requests to be mixed with LoRA requests in a batch. However, there now is an edge case where a request can be prevented from scheduling because the `Scheduler` greedily seeks to schedule requests whose adapters are already loaded.

For example, consider if `max_loras_per_batch = 1` and we have two adapters, `A` and `B`. Then, suppose the waiting queue is: `A, B, A, A, ...., A`. Then, as long `A` is in the running batch of LoRA adapters, `B` will never be scheduled.

## Modifications

- Add a `draining_loras` set which contains adapters in the current running batch. Requests which have adapters in this set should not be scheduled in order to allow requests that use other adapters to be scheduled.
- Small comment and code cleanups

## Accuracy Tests

To demonstrate the above example in more detail, add a print statement right before returning `new_batch` in `get_new_batch_prefill` with all LoRAs being used for that batch. Then, follow these steps:

Start the server:
```
python3 -m sglang.launch_server \
    --model-path meta-llama/Llama-3.1-8B-Instruct \
    --max-loaded-loras 2 \
    --max-loras-per-batch 1 \
    --max-running-requests 8 \
    --lora-paths \
        adapter0=mkopecki/chess-lora-adapter-llama-3.1-8b \
        adapter1=mkopecki/chess-lora-adapter-llama-3.1-8b
```

Send 100 requests, where we schedule `adapter0` first, then `adapter1` next, then all other requests use `adapter0`.

```
import json
import requests

PORT = 30000
URL = f"http://localhost:{PORT}"

num_reqs = 100

all_sampling_params = [{"max_new_tokens": 32}]
all_sampling_params += [{"max_new_tokens": 256}] * (num_reqs - 1)

adapters = ["adapter0", "adapter1"]
adapters += ["adapter0"] * (num_reqs - 2)

payload = {
    "text": ["Write a story about literally whatever you want"] * num_reqs,
    "sampling_params": all_sampling_params,
    "lora_path": adapters,
}

response = requests.post(
    URL + "/generate",
    json=payload,
)
```

Current results:

```
[2025-12-14 17:11:30] INFO:     127.0.0.1:56426 - "POST /generate HTTP/1.1" 200 OK
[2025-12-14 17:11:30] The server is fired up and ready to roll!
[2025-12-14 17:11:32] Prefill batch, #new-seq: 8, #new-token: 72, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 92,
req rid: 19013aab962d4f608c18c3797c578164, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: 6309ac90eaea4e64911f8d8e9fb0bb78, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: b5f2e84c56e64f7eaca497390b8e46c7, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: df42ec586235466db1b0ab2809db6c48, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: 9e7a536043944d21b99e942d75e6e8ed, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: 4a6fe7b9337e47e89a4b120e8bd44a87, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: e2c81298baa94a0bab85982c2faf5b40, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
req rid: bee4456b55574840b78b2317c1dd1537, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
[2025-12-14 17:11:33] Decode batch, #running-req: 8, #token: 240, token usage: 0.00, cuda graph: True, gen throughput (token/s): 14.79, #queue-req: 92,
[2025-12-14 17:11:33] Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 8, token usage: 0.00, #running-req: 7, #queue-req: 91,
req rid: 3628b909326545ab8da715a368941bdc, req lora id: da5b421f7a2a4640a704bb82b5bc6b77
[2025-12-14 17:11:33] Decode batch, #running-req: 8, #token: 560, token usage: 0.00, cuda graph: True, gen throughput (token/s): 750.08, #queue-req: 91,
[2025-12-14 17:11:34] Decode batch, #running-req: 8, #token: 880, token usage: 0.00, cuda graph: True, gen throughput (token/s): 881.06, #queue-req: 91,
[2025-12-14 17:11:34] Decode batch, #running-req: 8, #token: 1200, token usage: 0.00, cuda graph: True, gen throughput (token/s): 876.44, #queue-req: 91,
...
[2025-12-14 17:12:03] Decode batch, #running-req: 1, #token: 238, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.43, #queue-req: 1,
[2025-12-14 17:12:03] Prefill batch, #new-seq: 1, #new-token: 9, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
req rid: 1e1df6deac904791afbccc04f6405477, req lora id: b5e11ba06d7a429f91dd305af6b4ca59
[2025-12-14 17:12:04] Decode batch, #running-req: 1, #token: 22, token usage: 0.00, cuda graph: True, gen throughput (token/s): 72.34, #queue-req: 0,
[2025-12-14 17:12:04] Decode batch, #running-req: 1, #token: 62, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.82, #queue-req: 0,
[2025-12-14 17:12:04] Decode batch, #running-req: 1, #token: 102, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.82, #queue-req: 0,
```

Results after these modifications:

```
[2025-12-14 17:07:16] The server is fired up and ready to roll!
[2025-12-14 17:07:27] Prefill batch, #new-seq: 1, #new-token: 9, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 1,
req rid: cb9c0fde619e40fabbdf2796d73a3d5b, req lora id: 0c117d90d1eb4ea5972eb32d628e60f2
[2025-12-14 17:07:28] Decode batch, #running-req: 1, #token: 0, token usage: 0.00, cuda graph: True, gen throughput (token/s): 1.57, #queue-req: 99,
[2025-12-14 17:07:28] Prefill batch, #new-seq: 1, #new-token: 9, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 98,
req rid: d5d9203068c7415caa4970d46e1d2d8d, req lora id: 95c3de11762e41968987542494c141ec
[2025-12-14 17:07:28] Decode batch, #running-req: 1, #token: 50, token usage: 0.00, cuda graph: True, gen throughput (token/s): 81.12, #queue-req: 98,
[2025-12-14 17:07:28] Decode batch, #running-req: 1, #token: 90, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.85, #queue-req: 98,
[2025-12-14 17:07:29] Decode batch, #running-req: 1, #token: 130, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.80, #queue-req: 98,
[2025-12-14 17:07:29] Decode batch, #running-req: 1, #token: 170, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.42, #queue-req: 98,
[2025-12-14 17:07:29] Decode batch, #running-req: 1, #token: 210, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.36, #queue-req: 98,
[2025-12-14 17:07:30] Decode batch, #running-req: 1, #token: 250, token usage: 0.00, cuda graph: True, gen throughput (token/s): 113.35, #queue-req: 98,
[2025-12-14 17:07:30] Prefill batch, #new-seq: 8, #new-token: 8, #cached-token: 64, token usage: 0.00, #running-req: 0, #queue-req: 90,
req rid: 63a099685a4a4d3f94fd95a1bbd260c3, req lora id: 0c117d90d1eb4ea5972eb32d628e60f2
req rid: 6250c8c7f873442e8b59d2fca9083180, req lora id: 0c117d90d1eb4ea5972eb32d628e60f2
req rid: e9a795d403a945b888961b6d2321892f, req lora id: 0c117d90d1eb4ea5972eb32d628e60f2
```

You can see that currently, the request using `adapter1` is only scheduled at the very end, despite it being loaded as second in the waiting queue. However, with these modifications, it is scheduled in the second prefill batch.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
