### PR TITLE
[model-gateway] Add Layer 3 worker metrics (smg_worker_*)

### DIFF
--- a/sgl-model-gateway/src/core/circuit_breaker.rs
+++ b/sgl-model-gateway/src/core/circuit_breaker.rs
@@ -8,7 +8,7 @@ use std::{
 
 use tracing::info;
 
-use crate::observability::metrics::RouterMetrics;
+use crate::observability::metrics::{RouterMetrics, SmgMetrics};
 
 /// Circuit breaker configuration
 #[derive(Debug, Clone)]
@@ -96,6 +96,9 @@ impl CircuitBreaker {
     /// Create a new circuit breaker with custom configuration and metric label
     pub fn with_config_and_label(config: CircuitBreakerConfig, metric_label: String) -> Self {
         let init_state = CircuitState::Closed;
+        // New metrics
+        SmgMetrics::set_worker_cb_state(&metric_label, init_state.to_int());
+        // Legacy metrics
         RouterMetrics::set_cb_state(&metric_label, init_state.to_int());
         Self {
             state: Arc::new(RwLock::new(init_state)),
@@ -153,6 +156,9 @@ impl CircuitBreaker {
         }
 
         let outcome_str = if success { "success" } else { "failure" };
+        // New metrics
+        SmgMetrics::record_worker_cb_outcome(&self.metric_label, outcome_str);
+        // Legacy metrics
         RouterMetrics::record_cb_outcome(&self.metric_label, outcome_str);
         self.publish_gauge_metrics();
     }
@@ -232,6 +238,10 @@ impl CircuitBreaker {
             let from = old_state.as_str();
             let to = new_state.as_str();
             info!("Circuit breaker state transition: {} -> {}", from, to);
+            // New metrics
+            SmgMetrics::record_worker_cb_transition(&self.metric_label, from, to);
+            SmgMetrics::set_worker_cb_state(&self.metric_label, new_state.to_int());
+            // Legacy metrics
             RouterMetrics::record_cb_state_transition(&self.metric_label, from, to);
             RouterMetrics::set_cb_state(&self.metric_label, new_state.to_int());
             self.publish_gauge_metrics();
@@ -315,6 +325,10 @@ impl CircuitBreaker {
 
     // TODO maybe publish whenever the variable is changed
     fn publish_gauge_metrics(&self) {
+        // New metrics
+        SmgMetrics::set_worker_cb_consecutive_failures(&self.metric_label, self.failure_count());
+        SmgMetrics::set_worker_cb_consecutive_successes(&self.metric_label, self.success_count());
+        // Legacy metrics
         RouterMetrics::set_cb_consecutive_failures(&self.metric_label, self.failure_count());
         RouterMetrics::set_cb_consecutive_successes(&self.metric_label, self.success_count());
     }

--- a/sgl-model-gateway/src/core/steps/worker/local/remove_from_worker_registry.rs
+++ b/sgl-model-gateway/src/core/steps/worker/local/remove_from_worker_registry.rs
@@ -1,13 +1,13 @@
 //! Step to remove workers from worker registry.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use tracing::{debug, warn};
 
 use crate::{
     app_context::AppContext,
-    observability::metrics::RouterMetrics,
+    observability::metrics::{RouterMetrics, SmgMetrics},
     workflow::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult},
 };
 
@@ -26,6 +26,20 @@ impl StepExecutor for RemoveFromWorkerRegistryStep {
             "Removing {} worker(s) from worker registry",
             worker_urls.len()
         );
+
+        // Collect unique worker configurations before removal for pool size updates
+        let unique_configs: HashSet<_> = worker_urls
+            .iter()
+            .filter_map(|url| app_context.worker_registry.get_by_url(url))
+            .map(|w| {
+                let meta = w.metadata();
+                (
+                    meta.worker_type.clone(),
+                    meta.connection_mode.clone(),
+                    w.model_id().to_string(),
+                )
+            })
+            .collect();
 
         let mut removed_count = 0;
         for worker_url in worker_urls.iter() {
@@ -49,8 +63,33 @@ impl StepExecutor for RemoveFromWorkerRegistryStep {
             debug!("Removed {} worker(s) from registry", removed_count);
         }
 
-        // Update active workers metric
+        // Update active workers metric (legacy)
         RouterMetrics::set_active_workers(app_context.worker_registry.len());
+
+        // Update Layer 3 worker pool size metrics for unique configurations
+        for (worker_type, connection_mode, model_id) in unique_configs {
+            // Get labels before moving values into get_workers_filtered
+            let worker_type_label = worker_type.as_metric_label();
+            let connection_mode_label = connection_mode.as_metric_label();
+
+            let pool_size = app_context
+                .worker_registry
+                .get_workers_filtered(
+                    Some(&model_id),
+                    Some(worker_type),
+                    Some(connection_mode),
+                    None,
+                    false,
+                )
+                .len();
+
+            SmgMetrics::set_worker_pool_size(
+                worker_type_label,
+                connection_mode_label,
+                &model_id,
+                pool_size,
+            );
+        }
 
         Ok(StepResult::Success)
     }

--- a/sgl-model-gateway/src/core/steps/worker/shared/register.rs
+++ b/sgl-model-gateway/src/core/steps/worker/shared/register.rs
@@ -1,6 +1,6 @@
 //! Unified worker registration step.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_trait::async_trait;
 use tracing::debug;
@@ -8,7 +8,7 @@ use tracing::debug;
 use crate::{
     app_context::AppContext,
     core::Worker,
-    observability::metrics::RouterMetrics,
+    observability::metrics::{RouterMetrics, SmgMetrics},
     workflow::{StepExecutor, StepResult, WorkflowContext, WorkflowResult},
 };
 
@@ -37,8 +37,46 @@ impl StepExecutor for RegisterWorkersStep {
             worker_ids.push(worker_id);
         }
 
-        // Update active workers metric
+        // Update active workers metric (legacy)
         RouterMetrics::set_active_workers(app_context.worker_registry.len());
+
+        // Collect unique worker configurations to avoid redundant metric updates
+        let unique_configs: HashSet<_> = workers
+            .iter()
+            .map(|w| {
+                let meta = w.metadata();
+                (
+                    meta.worker_type.clone(),
+                    meta.connection_mode.clone(),
+                    w.model_id().to_string(),
+                )
+            })
+            .collect();
+
+        // Update Layer 3 worker pool size metrics per unique type/connection/model
+        for (worker_type, connection_mode, model_id) in unique_configs {
+            // Get labels before moving values into get_workers_filtered
+            let worker_type_label = worker_type.as_metric_label();
+            let connection_mode_label = connection_mode.as_metric_label();
+
+            let pool_size = app_context
+                .worker_registry
+                .get_workers_filtered(
+                    Some(&model_id),
+                    Some(worker_type),
+                    Some(connection_mode),
+                    None,
+                    false,
+                )
+                .len();
+
+            SmgMetrics::set_worker_pool_size(
+                worker_type_label,
+                connection_mode_label,
+                &model_id,
+                pool_size,
+            );
+        }
 
         context.set("worker_ids", worker_ids);
         Ok(StepResult::Success)

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{
     core::{BasicWorkerBuilder, DPAwareWorkerBuilder},
-    observability::metrics::RouterMetrics,
+    observability::metrics::{smg_labels, RouterMetrics, SmgMetrics},
     protocols::worker_spec::WorkerInfo,
     routers::grpc::client::GrpcClient,
 };
@@ -310,6 +310,14 @@ impl ConnectionMode {
             _ => false,
         }
     }
+
+    /// Get the metric label for this connection mode
+    pub fn as_metric_label(&self) -> &'static str {
+        match self {
+            ConnectionMode::Http => smg_labels::CONNECTION_HTTP,
+            ConnectionMode::Grpc { .. } => smg_labels::CONNECTION_GRPC,
+        }
+    }
 }
 
 impl fmt::Display for ConnectionMode {
@@ -388,6 +396,17 @@ impl fmt::Display for WorkerType {
                 None => write!(f, "Prefill"),
             },
             WorkerType::Decode => write!(f, "Decode"),
+        }
+    }
+}
+
+impl WorkerType {
+    /// Get the metric label for this worker type
+    pub fn as_metric_label(&self) -> &'static str {
+        match self {
+            WorkerType::Regular => smg_labels::WORKER_REGULAR,
+            WorkerType::Prefill { .. } => smg_labels::WORKER_PREFILL,
+            WorkerType::Decode => smg_labels::WORKER_DECODE,
         }
     }
 }
@@ -537,7 +556,9 @@ impl BasicWorker {
     }
 
     fn update_running_requests_metrics(&self) {
-        RouterMetrics::set_running_requests(self.url(), self.load());
+        let load = self.load();
+        RouterMetrics::set_running_requests(self.url(), load);
+        SmgMetrics::set_worker_requests_active(self.url(), load);
     }
 }
 
@@ -574,9 +595,15 @@ impl Worker for BasicWorker {
             ConnectionMode::Grpc { .. } => self.grpc_health_check().await?,
         };
 
+        // Get worker type label for metrics
+        let worker_type_str = self.metadata.worker_type.as_metric_label();
+
         if health_result {
             self.consecutive_failures.store(0, Ordering::Release);
             let successes = self.consecutive_successes.fetch_add(1, Ordering::AcqRel) + 1;
+
+            // Record health check success metric
+            SmgMetrics::record_worker_health_check(worker_type_str, smg_labels::CB_SUCCESS);
 
             if !self.is_healthy()
                 && successes >= self.metadata.health_config.success_threshold as usize
@@ -588,6 +615,9 @@ impl Worker for BasicWorker {
         } else {
             self.consecutive_successes.store(0, Ordering::Release);
             let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
+
+            // Record health check failure metric
+            SmgMetrics::record_worker_health_check(worker_type_str, smg_labels::CB_FAILURE);
 
             if self.is_healthy()
                 && failures >= self.metadata.health_config.failure_threshold as usize


### PR DESCRIPTION
Implement smg_worker_* metrics for worker-level observability:

- Circuit breaker: outcomes, state, transitions, consecutive counts
- Health checks: success/failure by worker type
- Worker selection: by type, connection mode, model, policy
- Retries: count, backoff duration, exhausted
- Pool size: by worker type, connection mode, model

All metrics use smg_labels constants for consistency. Dual-emit with legacy RouterMetrics for backward compatibility.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
