### PR TITLE
Add NVFP4-style KV Cache

### DIFF
--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -142,7 +142,7 @@ class KVNVFP4QuantizeUtil:
         """
         Quantize tensor to NVFP4 format.
 
-        Mirrors TRTLLM KV-cache behavior: block scales are stored compactly as
+        Block scales are stored compactly as
         (num_heads * head_dim / 16) bytes per token (per K or V), i.e. no padding-to-128
         and no swizzled layout.
         Args:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -895,8 +895,7 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
                 k = self.head_dim
 
                 scale_block_size = 16
-                # Match TRTLLM-style KV-cache block scales:
-                # one FP8 scale per 16 FP4 values (compact, no padding-to-128).
+                # One FP8 scale per 16 FP4 values (compact, no padding-to-128).
                 scale_dim = (n * k) // scale_block_size
 
                 self.store_dtype = torch.uint8


### PR DESCRIPTION
https://github.com/sgl-project/sglang/pull/12612 Introduced FP4 style KV cache. However, it's mostly related to MXFP4-style. 

By supporting NVFP4 KV cache, the key differences are:
1. FP8 E4M3 scaling factor instead of U8EM0
2. Block size of 16 instead of 32 (however, the PR above had a block size of 16 for MXFP4. I believe the OCP specification is 32).
3. Since we want to support both, it can now be specified through `nvfp4_e2m1` or `mxfp4_e2m1`. `fp4_e2m1` will default to mxfp4 for now.
4. TODO: support global k and v scale in fp32. It can be created through ModelOpt and loaded from the checkpoint.

However, the current implementation in this PR is still extremely slow, as we have to dequantize from fp4 to bf16 every time.
Anyway, TRT-LLM can actually take in the pointers to FP4 KV cache (w/ equivalent of TRTLLM’s pagedKvSfCache / kvSfPtr) , but it requires an update to Flashinfer API.

Also, there is currently a weird error with:
```
Error: Failed to initialize the TMA descriptor 700
TMA Desc Addr:   0x7ffff1a59c80
format         13
dim            3
gmem_address   0xa41780000
globalDim      (4096,4096,1,1,1)
globalStrides  (0,2048,0,0,0)
boxDim         (256,64,1,1,1)
elementStrides (1,1,1,1,1)
interleave     0
swizzle        3
l2Promotion    2
oobFill        0
...
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/flashinfer/gemm/gemm_base.py", line 428, in forward
[rank0]:     module.fp4_gemm(
[rank0]:   File "python/tvm_ffi/cython/function.pxi", line 904, in tvm_ffi.core.Function.__call__
[rank0]: RuntimeError: [FP4 gemm Runner] Failed to initialize cutlass FP4 gemm on sm100. Error: Error Internal
```

Reference testing command:
```
python3 -m sglang.bench_one_batch \
  --model-path nvidia/Llama-3.1-8B-Instruct-NVFP4 \
  --quantization modelopt_fp4 \
  --batch-size 1 \
  --input-len 1024 \
  --output-len 1024 \
  --kv-cache-dtype nvfp4_e2m1
```