### PR TITLE
fix: adjusting frequency for ci failure monitor

### DIFF
--- a/.github/workflows/ci-failure-monitor.yml
+++ b/.github/workflows/ci-failure-monitor.yml
@@ -2,7 +2,7 @@ name: CI Failure Monitor
 
 on:
   schedule:
-    - cron: '0 * * * *' # Every hour
+    - cron: '0 */3 * * *' # Every 3 hour
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Motivation

Making ci failure monitor run every 3 hours instead of every hour.

## Modifications

Adjust the schedule in ci-failure-monitor.yml

## Accuracy Tests

n/a

## Benchmarking and Profiling

n/a

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [n/a] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [n/a] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
