### PR TITLE
[model-gateway] Add streaming metrics for harmony gRPC router

### DIFF
--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -756,6 +756,7 @@ pub mod smg_labels {
     pub const BACKEND_REGULAR: &str = "regular";
     pub const BACKEND_PD: &str = "pd";
     pub const BACKEND_EXTERNAL: &str = "external";
+    pub const BACKEND_HARMONY: &str = "harmony";
 
     // Connection modes
     pub const CONNECTION_HTTP: &str = "http";

--- a/sgl-model-gateway/src/routers/grpc/harmony/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/streaming.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{hash_map::Entry::Vacant, HashMap},
     io,
     sync::Arc,
+    time::Instant,
 };
 
 use axum::{body::Body, http::StatusCode, response::Response};
@@ -19,6 +20,7 @@ use super::{
 };
 use crate::{
     grpc_client::sglang_proto::generate_complete::MatchedStop::{MatchedStopStr, MatchedTokenId},
+    observability::metrics::{smg_labels, SmgMetrics, StreamingMetricsParams},
     protocols::{
         chat::{
             ChatCompletionRequest, ChatCompletionStreamResponse, ChatMessageDelta, ChatStreamChoice,
@@ -183,6 +185,10 @@ impl HarmonyStreamingProcessor {
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
+        // Timing for metrics
+        let start_time = Instant::now();
+        let mut first_token_time: Option<Instant> = None;
+
         // Per-index state management (for n>1 support)
         let mut parsers: HashMap<u32, HarmonyParserAdapter> = HashMap::new();
         let mut is_firsts: HashMap<u32, bool> = HashMap::new();
@@ -201,6 +207,11 @@ impl HarmonyStreamingProcessor {
                 ProtoResponseVariant::Chunk(chunk_wrapper) => {
                     let chunk = chunk_wrapper.as_sglang();
                     let index = chunk.index;
+
+                    // Track first token time for TTFT metric
+                    if first_token_time.is_none() {
+                        first_token_time = Some(Instant::now());
+                    }
 
                     // Initialize parser for this index if needed
                     if let Vacant(e) = parsers.entry(index) {
@@ -285,11 +296,12 @@ impl HarmonyStreamingProcessor {
             }
         }
 
+        // Compute totals once for both usage chunk and metrics
+        let total_prompt: u32 = prompt_tokens.values().sum();
+        let total_completion: u32 = completion_tokens.values().sum();
+
         // Emit final usage if requested
         if let Some(true) = stream_options.as_ref().and_then(|so| so.include_usage) {
-            let total_prompt: u32 = prompt_tokens.values().sum();
-            let total_completion: u32 = completion_tokens.values().sum();
-
             Self::emit_usage_chunk(
                 total_prompt,
                 total_completion,
@@ -302,6 +314,18 @@ impl HarmonyStreamingProcessor {
         // Mark stream as completed successfully to prevent abort on drop
         grpc_stream.mark_completed();
 
+        // Record streaming metrics
+        SmgMetrics::record_streaming_metrics(StreamingMetricsParams {
+            router_type: smg_labels::ROUTER_GRPC,
+            backend_type: smg_labels::BACKEND_HARMONY,
+            model_id: &original_request.model,
+            endpoint: smg_labels::ENDPOINT_CHAT,
+            ttft: first_token_time.map(|t| t.duration_since(start_time)),
+            generation_duration: start_time.elapsed(),
+            input_tokens: Some(total_prompt as u64),
+            output_tokens: total_completion as u64,
+        });
+
         Ok(())
     }
 
@@ -313,6 +337,10 @@ impl HarmonyStreamingProcessor {
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
+        // Timing for metrics
+        let start_time = Instant::now();
+        let mut first_token_time: Option<Instant> = None;
+
         // Phase 1: Process prefill stream (collect metadata)
         let mut prompt_tokens: HashMap<u32, u32> = HashMap::new();
 
@@ -341,6 +369,11 @@ impl HarmonyStreamingProcessor {
                 ProtoResponseVariant::Chunk(chunk_wrapper) => {
                     let chunk = chunk_wrapper.as_sglang();
                     let index = chunk.index;
+
+                    // Track first token time for TTFT metric
+                    if first_token_time.is_none() {
+                        first_token_time = Some(Instant::now());
+                    }
 
                     // Initialize parser for this index if needed
                     if let Vacant(e) = parsers.entry(index) {
@@ -425,11 +458,12 @@ impl HarmonyStreamingProcessor {
         // This ensures that if client disconnects during decode, BOTH streams send abort
         prefill_stream.mark_completed();
 
+        // Compute totals once for both usage chunk and metrics
+        let total_prompt: u32 = prompt_tokens.values().sum();
+        let total_completion: u32 = completion_tokens.values().sum();
+
         // Emit final usage if requested
         if let Some(true) = stream_options.as_ref().and_then(|so| so.include_usage) {
-            let total_prompt: u32 = prompt_tokens.values().sum();
-            let total_completion: u32 = completion_tokens.values().sum();
-
             Self::emit_usage_chunk(
                 total_prompt,
                 total_completion,
@@ -438,6 +472,18 @@ impl HarmonyStreamingProcessor {
                 tx,
             )?;
         }
+
+        // Record streaming metrics
+        SmgMetrics::record_streaming_metrics(StreamingMetricsParams {
+            router_type: smg_labels::ROUTER_GRPC,
+            backend_type: smg_labels::BACKEND_HARMONY,
+            model_id: &original_request.model,
+            endpoint: smg_labels::ENDPOINT_CHAT,
+            ttft: first_token_time.map(|t| t.duration_since(start_time)),
+            generation_duration: start_time.elapsed(),
+            input_tokens: Some(total_prompt as u64),
+            output_tokens: total_completion as u64,
+        });
 
         Ok(())
     }


### PR DESCRIPTION
Add TTFT, TPOT, generation duration, and token count metrics to the harmony streaming processor, matching the metrics added to the regular gRPC streaming router.

Changes:
- Add BACKEND_HARMONY constant to smg_labels
- Add timing and first_token_time tracking to process_single_stream
- Add timing and first_token_time tracking to process_dual_stream
- Record SmgMetrics at end of both stream processors
- Optimize: compute token totals once for both usage chunk and metrics


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
