### PR TITLE
[Diffusion] Cache dit support parallel

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -219,18 +219,11 @@ class DenoisingStage(PipelineStage):
             has_sp = sp_world_size > 1
             has_tp = tp_world_size > 1
 
-            if has_sp and has_tp:
-                raise ValueError(
-                    "cache-dit does not support hybrid parallelism (SP + TP). "
-                    "Please use either sequence parallelism or tensor parallelism, not both."
-                )
-
             sp_group = sp_group_candidate.device_group if has_sp else None
             tp_group = tp_group_candidate.device_group if has_tp else None
 
             logger.info(
-                "cache-dit enabled in distributed environment (world_size=%d, "
-                "sp_group=%s, tp_group=%s)",
+                "cache-dit enabled in distributed environment (world_size=%d, has_sp=%s, has_tp=%s)",
                 world_size,
                 has_sp,
                 has_tp,

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -956,6 +956,17 @@ class ServerArgs:
                     "CFG Parallelism is enabled via `--enable-cfg-parallel`, while -num-gpus==1"
                 )
 
+        from sglang.multimodal_gen.runtime.utils import envs
+
+        if envs.SGLANG_CACHE_DIT_ENABLED:
+            has_sp = self.sp_degree > 1
+            has_tp = self.tp_size > 1
+            if has_sp and has_tp:
+                raise ValueError(
+                    "cache-dit does not support hybrid parallelism (SP + TP). "
+                    "Please use either sequence parallelism or tensor parallelism, not both."
+                )
+
 
 @dataclasses.dataclass
 class PortArgs:

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -8,6 +8,7 @@ import argparse
 import dataclasses
 import inspect
 import json
+import os
 import random
 import sys
 import tempfile
@@ -956,9 +957,7 @@ class ServerArgs:
                     "CFG Parallelism is enabled via `--enable-cfg-parallel`, while -num-gpus==1"
                 )
 
-        from sglang.multimodal_gen.runtime.utils import envs
-
-        if envs.SGLANG_CACHE_DIT_ENABLED:
+        if os.getenv("SGLANG_CACHE_DIT_ENABLED", "").lower() == "true":
             has_sp = self.sp_degree > 1
             has_tp = self.tp_size > 1
             if has_sp and has_tp:

--- a/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
@@ -38,16 +38,30 @@ def _patch_cache_dit_similarity():
     if _original_similarity is None:
         _original_similarity = cache_manager.CachedContextManager.similarity
 
-    def patched_similarity(self, t1, t2, threshold, parallelized, prefix=""):
+    def patched_similarity(self, t1, t2, *, threshold, parallelized=False, prefix="Fn"):
         if not parallelized:
-            return _original_similarity(self, t1, t2, threshold, parallelized, prefix)
+            return _original_similarity(
+                self,
+                t1,
+                t2,
+                threshold=threshold,
+                parallelized=parallelized,
+                prefix=prefix,
+            )
 
         sp_group = getattr(self, "_sglang_sp_group", None)
         tp_group = getattr(self, "_sglang_tp_group", None)
         target_group = sp_group or tp_group
 
         if target_group is None:
-            return _original_similarity(self, t1, t2, threshold, parallelized, prefix)
+            return _original_similarity(
+                self,
+                t1,
+                t2,
+                threshold=threshold,
+                parallelized=parallelized,
+                prefix=prefix,
+            )
 
         condition_thresh = self.get_important_condition_threshold()
         if condition_thresh > 0.0:

--- a/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
@@ -63,6 +63,7 @@ def _patch_cache_dit_similarity():
                 prefix=prefix,
             )
 
+        # Adapted from https://github.com/vipshop/cache-dit/blob/main/src/cache_dit/caching/cache_contexts/cache_manager.py#L495-L523
         condition_thresh = self.get_important_condition_threshold()
         if condition_thresh > 0.0:
             raw_diff = (t1 - t2).abs()

--- a/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/utils/cache_dit_integration.py
@@ -35,8 +35,10 @@ def _patch_cache_dit_similarity():
     from cache_dit.caching.cache_contexts import cache_manager
 
     global _original_similarity
-    if _original_similarity is None:
-        _original_similarity = cache_manager.CachedContextManager.similarity
+    if _original_similarity is not None:
+        return
+
+    _original_similarity = cache_manager.CachedContextManager.similarity
 
     def patched_similarity(self, t1, t2, *, threshold, parallelized=False, prefix="Fn"):
         if not parallelized:


### PR DESCRIPTION
```markdown
main:

 sglang generate   --model-path /nas/bbuf/Wan2.2-T2V-A14B-Diffusers   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 4   --ulysses-degree 4 --attention-backend sage_attn  --prompt "A cat walks on the grass, realistic" --num-frames 81 --height 720 --width 1280

[12-15 05:42:55] [InputValidationStage] started...
[12-15 05:42:55] [InputValidationStage] finished in 0.0008 seconds
[12-15 05:42:55] [TextEncodingStage] started...
[12-15 05:42:58] [TextEncodingStage] finished in 2.9263 seconds
[12-15 05:42:58] [ConditioningStage] started...
[12-15 05:42:58] [ConditioningStage] finished in 0.0001 seconds
[12-15 05:42:58] [TimestepPreparationStage] started...
[12-15 05:42:58] [TimestepPreparationStage] finished in 0.0028 seconds
[12-15 05:42:58] [LatentPreparationStage] started...
[12-15 05:42:58] [LatentPreparationStage] finished in 0.0015 seconds
[12-15 05:42:58] [DenoisingStage] started...
100%|██████████████████████████████████████████████████████████████████████████████████████████| 40/40 [05:33<00:00,  8.33s/it]
[12-15 05:48:31] [DenoisingStage] average time per step: 8.3287 seconds
[12-15 05:48:31] [DenoisingStage] finished in 333.6282 seconds
[12-15 05:48:31] [DecodingStage] started...
[12-15 05:48:42] [DecodingStage] finished in 11.0321 seconds
[12-15 05:48:52] Saved output to outputs/A_cat_walks_on_the_grass_realistic_20251215-054255_c162f999.mp4
[12-15 05:48:52] Pixel data generated successfully in 356.66 seconds
[12-15 05:48:52] Completed batch processing. Generated 1 outputs in 356.66 seconds.
```


https://github.com/user-attachments/assets/2012400d-feda-4e23-91cf-676bafea9017


```
pr:


SGLANG_CACHE_DIT_ENABLED=true \
SGLANG_CACHE_DIT_WARMUP=4 \
SGLANG_CACHE_DIT_MC=8 \
SGLANG_CACHE_DIT_RDT=0.24 \
SGLANG_CACHE_DIT_FN=1 \
SGLANG_CACHE_DIT_BN=0 \
SGLANG_CACHE_DIT_TAYLORSEER=true \
SGLANG_CACHE_DIT_SECONDARY_WARMUP=2 \
SGLANG_CACHE_DIT_SECONDARY_MC=20 \
SGLANG_CACHE_DIT_SECONDARY_RDT=0.24 \
SGLANG_CACHE_DIT_SECONDARY_FN=1 \
SGLANG_CACHE_DIT_SECONDARY_BN=0 \
SGLANG_CACHE_DIT_SECONDARY_TAYLORSEER=true \
SGLANG_CACHE_DIT_SCM_PRESET=fast \
SGLANG_CACHE_DIT_SCM_POLICY=dynamic  sglang generate   --model-path /nas/bbuf/Wan2.2-T2V-A14B-Diffusers   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 4   --ulysses-degree 4 --attention-backend sage_attn  --prompt "A cat walks on the grass, realistic" --num-frames 81 --height 720 --width 1280

[12-15 07:29:22] [InputValidationStage] started...
[12-15 07:29:22] [InputValidationStage] finished in 0.0008 seconds
[12-15 07:29:22] [TextEncodingStage] started...
WARNING 12-15 07:29:24 [block_adapters.py:131] pipe is None, use FakeDiffusionPipeline instead.
INFO 12-15 07:29:24 [block_adapters.py:229] Auto fill blocks_name: ['blocks', 'blocks'].
INFO 12-15 07:29:24 [block_adapters.py:162] Found transformer NOT from diffusers: sglang.multimodal_gen.runtime.models.dits.wanvideo disable check_forward_pattern by default.
INFO 12-15 07:29:24 [cache_interface.py:200] cache_config is None, using default DBCacheConfig
INFO 12-15 07:29:24 [cache_adapter.py:77] Adapting Cache Acceleration using custom BlockAdapter!
WARNING 12-15 07:29:24 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
WARNING 12-15 07:29:24 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:24 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-15 07:29:24 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W4I1M0MC8_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
INFO 12-15 07:29:24 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W2I1M0MC20_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
WARNING 12-15 07:29:24 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:24 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140123378760208, context_manager: FakeDiffusionPipeline_140121768562800.
WARNING 12-15 07:29:24 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:24 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140121769868752, context_manager: FakeDiffusionPipeline_140121768562800.
[12-15 07:29:25] [TextEncodingStage] finished in 3.0674 seconds
[12-15 07:29:25] [ConditioningStage] started...
[12-15 07:29:25] [ConditioningStage] finished in 0.0002 seconds
[12-15 07:29:25] [TimestepPreparationStage] started...
[12-15 07:29:25] [TimestepPreparationStage] finished in 0.0040 seconds
[12-15 07:29:25] [LatentPreparationStage] started...
[12-15 07:29:25] [LatentPreparationStage] finished in 0.0022 seconds
[12-15 07:29:25] [DenoisingStage] started...
[12-15 07:29:25] cache-dit enabled in distributed environment (world_size=4, sp_group=True, tp_group=False)
[12-15 07:29:25] SCM: generated mask with 18 compute steps, 22 cache steps (preset=fast)
[12-15 07:29:25] Enabling cache-dit on wan2.2 dual transformers with BlockAdapter
[12-15 07:29:25]   Primary (transformer): Fn=1, Bn=0, W=4, R=0.24, MC=8, TaylorSeer=True
[12-15 07:29:25]   Secondary (transformer_2): Fn=1, Bn=0, W=2, R=0.24, MC=20, TaylorSeer=True
[12-15 07:29:25]   SCM enabled: 18 compute steps, 22 cache steps, policy=dynamic
WARNING 12-15 07:29:25 [block_adapters.py:131] pipe is None, use FakeDiffusionPipeline instead.
INFO 12-15 07:29:25 [block_adapters.py:229] Auto fill blocks_name: ['blocks', 'blocks'].
INFO 12-15 07:29:25 [block_adapters.py:162] Found transformer NOT from diffusers: sglang.multimodal_gen.runtime.models.dits.wanvideo disable check_forward_pattern by default.
INFO 12-15 07:29:25 [cache_interface.py:200] cache_config is None, using default DBCacheConfig
INFO 12-15 07:29:25 [cache_adapter.py:77] Adapting Cache Acceleration using custom BlockAdapter!
WARNING 12-15 07:29:25 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
WARNING 12-15 07:29:25 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-15 07:29:25 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W4I1M0MC8_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
INFO 12-15 07:29:25 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W2I1M0MC20_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
WARNING 12-15 07:29:25 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140089688802704, context_manager: FakeDiffusionPipeline_140089116797520.
WARNING 12-15 07:29:25 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140089119995232, context_manager: FakeDiffusionPipeline_140089116797520.
[12-15 07:29:25] cache-dit enabled on dual transformers (steps=40)
  0%|                                                                                                   | 0/40 [00:00<?, ?it/s]WARNING 12-15 07:29:25 [block_adapters.py:131] pipe is None, use FakeDiffusionPipeline instead.
INFO 12-15 07:29:25 [block_adapters.py:229] Auto fill blocks_name: ['blocks', 'blocks'].
INFO 12-15 07:29:25 [block_adapters.py:162] Found transformer NOT from diffusers: sglang.multimodal_gen.runtime.models.dits.wanvideo disable check_forward_pattern by default.
INFO 12-15 07:29:25 [cache_interface.py:200] cache_config is None, using default DBCacheConfig
INFO 12-15 07:29:25 [cache_adapter.py:77] Adapting Cache Acceleration using custom BlockAdapter!
WARNING 12-15 07:29:25 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
WARNING 12-15 07:29:25 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-15 07:29:25 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W4I1M0MC8_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
INFO 12-15 07:29:25 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W2I1M0MC20_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
WARNING 12-15 07:29:25 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140036139129056, context_manager: FakeDiffusionPipeline_140036140830448.
WARNING 12-15 07:29:25 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140034260318160, context_manager: FakeDiffusionPipeline_140036140830448.
WARNING 12-15 07:29:25 [block_adapters.py:131] pipe is None, use FakeDiffusionPipeline instead.
INFO 12-15 07:29:25 [block_adapters.py:229] Auto fill blocks_name: ['blocks', 'blocks'].
INFO 12-15 07:29:25 [block_adapters.py:162] Found transformer NOT from diffusers: sglang.multimodal_gen.runtime.models.dits.wanvideo disable check_forward_pattern by default.
INFO 12-15 07:29:25 [cache_interface.py:200] cache_config is None, using default DBCacheConfig
INFO 12-15 07:29:25 [cache_adapter.py:77] Adapting Cache Acceleration using custom BlockAdapter!
WARNING 12-15 07:29:25 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
WARNING 12-15 07:29:25 [block_adapters.py:478] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-15 07:29:25 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W4I1M0MC8_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
INFO 12-15 07:29:25 [cache_adapter.py:307] Collected Context Config: DBCache_F1B0_W2I1M0MC20_R0.24_SCM1111111111001100000110000001100000100001_dynamic, Calibrator Config: TaylorSeer_O(1)
WARNING 12-15 07:29:25 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140010297562928, context_manager: FakeDiffusionPipeline_140009561783040.
WARNING 12-15 07:29:25 [pattern_base.py:78] Skipped Forward Pattern Check: ForwardPattern.Pattern_2
INFO 12-15 07:29:25 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for blocks, cache_context: blocks_140009561774112, context_manager: FakeDiffusionPipeline_140009561783040.
100%|██████████████████████████████████████████████████████████████████████████████████████████| 40/40 [04:03<00:00,  6.09s/it]
[12-15 07:33:28] [DenoisingStage] average time per step: 6.0888 seconds
[12-15 07:33:29] [DenoisingStage] finished in 244.2733 seconds
[12-15 07:33:29] [DecodingStage] started...
[12-15 07:33:39] [DecodingStage] finished in 10.0757 seconds
[12-15 07:33:48] Saved output to outputs/A_cat_walks_on_the_grass_realistic_20251215-072921_c162f999.mp4

```

https://github.com/user-attachments/assets/aa2bbfbc-ff54-4cf6-84b6-54cf873090a8


**333.6s->244.27s (36%+)**

