### PR TITLE
[Metric] add output throughput per request in Prometheus.

### DIFF
--- a/docs/references/production_metrics.md
+++ b/docs/references/production_metrics.md
@@ -123,6 +123,15 @@ sglang:gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct"} 86.50814177
 # HELP sglang:num_queue_reqs The number of requests in the waiting queue
 # TYPE sglang:num_queue_reqs gauge
 sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 2826.0
+# HELP sglang:request_output_throughput_tokens_per_second Histogram of per-request output throughput in tokens per second.
+# TYPE sglang:request_output_throughput_tokens_per_second histogram
+sglang:request_output_throughput_tokens_per_second_sum{model_name="meta-llama/Llama-3.1-8B-Instruct"} 495230.5
+sglang:request_output_throughput_tokens_per_second_bucket{le="10",model_name="meta-llama/Llama-3.1-8B-Instruct"} 120.0
+sglang:request_output_throughput_tokens_per_second_bucket{le="20",model_name="meta-llama/Llama-3.1-8B-Instruct"} 580.0
+sglang:request_output_throughput_tokens_per_second_bucket{le="50",model_name="meta-llama/Llama-3.1-8B-Instruct"} 4500.0
+sglang:request_output_throughput_tokens_per_second_bucket{le="100",model_name="meta-llama/Llama-3.1-8B-Instruct"} 8200.0
+sglang:request_output_throughput_tokens_per_second_bucket{le="+Inf",model_name="meta-llama/Llama-3.1-8B-Instruct"} 11008.0
+sglang:request_output_throughput_tokens_per_second_count{model_name="meta-llama/Llama-3.1-8B-Instruct"} 11008.0
 ```
 
 ## Setup Guide

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1931,7 +1931,6 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 decode_time = state.finished_time_perf - state.first_token_time_perf
                 output_throughput = completion_tokens / decode_time
 
-
             self.metrics_collector.observe_one_finished_request(
                 labels,
                 recv_obj.prompt_tokens[i],

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1921,6 +1921,17 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 else 0
             )
 
+            # Calculate per-request output throughput (tokens/second)
+            output_throughput = None
+            if (
+                state.first_token_time_perf > 0.0
+                and state.finished_time_perf > 0.0
+                and completion_tokens > 0
+            ):
+                decode_time = state.finished_time_perf - state.first_token_time_perf
+                if decode_time > 0:
+                    output_throughput = completion_tokens / decode_time
+
             self.metrics_collector.observe_one_finished_request(
                 labels,
                 recv_obj.prompt_tokens[i],
@@ -1929,6 +1940,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 state.finished_time - state.created_time,
                 has_grammar,
                 retraction_count,
+                output_throughput,
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1925,12 +1925,12 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
             output_throughput = None
             if (
                 state.first_token_time_perf > 0.0
-                and state.finished_time_perf > 0.0
+                and state.finished_time_perf > state.first_token_time_perf
                 and completion_tokens > 0
             ):
                 decode_time = state.finished_time_perf - state.first_token_time_perf
-                if decode_time > 0:
-                    output_throughput = completion_tokens / decode_time
+                output_throughput = completion_tokens / decode_time
+
 
             self.metrics_collector.observe_one_finished_request(
                 labels,

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -1015,7 +1015,7 @@ class TokenizerMetricsCollector:
             )
         self.num_retractions.labels(**labels).observe(retraction_count)
         # Per-request output throughput (tokens/second)
-        if output_throughput is not None and output_throughput > 0:
+        if output_throughput is not None:
             self.histogram_request_output_throughput.labels(**labels).observe(
                 output_throughput
             )

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -959,6 +959,36 @@ class TokenizerMetricsCollector:
             ],
         )
 
+        # Per-request output throughput histogram (tokens/second)
+        self.histogram_request_output_throughput = Histogram(
+            name="sglang:request_output_throughput_tokens_per_second",
+            documentation="Histogram of per-request output throughput in tokens per second.",
+            labelnames=labels.keys(),
+            buckets=[
+                1,
+                2,
+                5,
+                10,
+                20,
+                30,
+                40,
+                50,
+                75,
+                100,
+                150,
+                200,
+                300,
+                400,
+                500,
+                750,
+                1000,
+                1500,
+                2000,
+                3000,
+                5000,
+            ],
+        )
+
     def observe_one_finished_request(
         self,
         labels: Dict[str, str],
@@ -968,6 +998,7 @@ class TokenizerMetricsCollector:
         e2e_latency: float,
         has_grammar: bool,
         retraction_count: int,
+        output_throughput: Optional[float] = None,
     ):
         self.prompt_tokens_total.labels(**labels).inc(prompt_tokens)
         self.generation_tokens_total.labels(**labels).inc(generation_tokens)
@@ -983,6 +1014,11 @@ class TokenizerMetricsCollector:
                 float(generation_tokens)
             )
         self.num_retractions.labels(**labels).observe(retraction_count)
+        # Per-request output throughput (tokens/second)
+        if output_throughput is not None and output_throughput > 0:
+            self.histogram_request_output_throughput.labels(**labels).observe(
+                output_throughput
+            )
 
     def observe_time_to_first_token(self, labels: Dict[str, str], value: float):
         self.histogram_time_to_first_token.labels(**labels).observe(value)

--- a/test/srt/test_metrics.py
+++ b/test/srt/test_metrics.py
@@ -66,6 +66,7 @@ class TestEnableMetrics(CustomTestCase):
                 "sglang:time_to_first_token_seconds",
                 "sglang:inter_token_latency_seconds",
                 "sglang:e2e_request_latency_seconds",
+                "sglang:request_output_throughput_tokens_per_second",
             ]
 
             for metric in essential_metrics:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When monitoring LLM inference performance, per-request output throughput is a critical metric for understanding individual request performance.

Currently, **vLLM** exposes `vllm:request_time_per_output_token_seconds` as a per-request histogram in Prometheus, allowing users to calculate metrics like:
- Average per-request throughput over the last N minutes
- P50/P90/P99 percentiles of per-request throughput

**SGLang** only provides `decode_throughput` in the API response's `meta_info` field, but does not expose it as a Prometheus metric. This makes it impossible to:
1. Calculate the average per-request output throughput over a time window using PromQL
2. Monitor per-request throughput percentiles in Grafana dashboards
3. Set up alerts based on per-request throughput degradation

This PR adds a new Prometheus histogram metric `sglang:request_output_throughput_tokens_per_second` to address this gap.

## Modifications

1. **`python/sglang/srt/metrics/collector.py`**
   - Added `histogram_request_output_throughput` Histogram in `TokenizerMetricsCollector`
   - Modified `observe_one_finished_request()` to accept optional `output_throughput` parameter and record it

2. **`python/sglang/srt/managers/tokenizer_manager.py`**
   - Calculate per-request output throughput (`completion_tokens / decode_time`) in `collect_metrics()`
   - Pass `output_throughput` to `observe_one_finished_request()`

3. **`docs/references/production_metrics.md`**
   - Added documentation and example output for the new metric

## Tests

1. **`test/srt/test_metrics.py`**
   - Added `sglang:request_output_throughput_tokens_per_second` to essential metrics verification list
