### PR TITLE
Optimize confidential compute performance by manual async copy

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -70,7 +70,11 @@ class SchedulerOutputProcessorMixin:
         skip_stream_req = None
 
         if self.is_generation:
-            if result.copy_done is not None:
+            # Handle synchronization for overlap scheduling
+            if result.use_confidential_compute:
+                # Confidential compute mode: resolve Future objects from worker thread
+                result.resolve_confidential_futures()
+            elif result.copy_done is not None:
                 result.copy_done.synchronize()
 
             (
@@ -288,7 +292,10 @@ class SchedulerOutputProcessorMixin:
         batch: ScheduleBatch,
         result: GenerationBatchResult,
     ):
-        if result.copy_done is not None:
+        # Handle synchronization for overlap scheduling
+        if result.use_confidential_compute:
+            result.resolve_confidential_futures()
+        elif result.copy_done is not None:
             result.copy_done.synchronize()
 
         next_token_ids = result.next_token_ids.tolist()
@@ -318,7 +325,10 @@ class SchedulerOutputProcessorMixin:
         batch: ScheduleBatch,
         result: GenerationBatchResult,
     ):
-        if result.copy_done is not None:
+        # Handle synchronization for overlap scheduling
+        if result.use_confidential_compute:
+            result.resolve_confidential_futures()
+        elif result.copy_done is not None:
             result.copy_done.synchronize()
 
         logits_output, next_token_ids, can_run_cuda_graph = (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -333,6 +333,7 @@ class ServerArgs:
     base_gpu_id: int = 0
     gpu_id_step: int = 1
     sleep_on_idle: bool = False
+    enable_confidential_compute_optimize: bool = False
     custom_sigquit_handler: Optional[Callable] = None
 
     # Logging
@@ -2861,6 +2862,12 @@ class ServerArgs:
             "--sleep-on-idle",
             action="store_true",
             help="Reduce CPU usage when sglang is idle.",
+        )
+        parser.add_argument(
+            "--enable-cc-optimize",
+            action="store_true",
+            dest="enable_confidential_compute_optimize",
+            help="Enable confidential compute optimization. Uses blocking D2H copy in worker thread for enhanced performance in confidential computing environments.",
         )
         parser.add_argument(
             "--custom-sigquit-handler",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This pr is for optimizing confidential compute performance. When using confidential computing (hereinafter referred to as "CC"), the cudaMemcpyAsync function has become synchronous. Because there is a decryption process after copying, and this decryption process is synchronous. This change diable the overlap between cpu and gpu in scheduler because the next batch should wait util the last batch's result return, which slowed down the e2e performance finally. 

| concurrency | Output throughput（w/o CC） | Output token throughput (w/ CC） | loss ratio|
|:-----:|---------------:|---------------:|------:|
| 1     | 172.896        | 141.088        | 18.40% |
| 4     | 588.373        | 489.87         | 16.74% |
| 8     | 1058.711       | 898.424        | 15.14% |
| 16    | 1758.951       | 1515.35        | 13.85% |
| 32    | 2547.794       | 2297.031       | 9.84% |
| 64    | 2980.74        | 2761.412       | 7.36% |
| 128   | 3246.715       | 3090.795       | 4.80% |
| 256   | 3309.584       | 3215.861       | 2.83% |

We optimze the h2d step by manual async with an another copy thread, which can restore full performance to non-CC scene.

## Modifications

1. Add server arguments (--enable-cc-optimize) to enable our optimization for CC.
2. Add a copy thread in scheduler to perform async copy_to_cpu procedure.
3. Replace copy_to_cpu function with async version.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
There is no impact in accuracy.

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Qwen2.5-7B-Instruct, TP1
| Concurrency | Throughput (w/o CC) | Throughput (w/ CC, no Opt.) | Throughput (w/ CC, Opt.) | Speedup (vs. w/ CC, no Opt.) |
|:-----------:|------------------------:|------------------------------:|-----------------------------:|-------------------------------:|
| 1           | 172.896                 | 141.088                       | 172.971                      | +22.6% |
| 4           | 588.373                 | 489.87                        | 589.49                       | +20.3% |
| 8           | 1058.711                | 898.424                       | 1056.073                     | +17.5% |
| 16          | 1758.951                | 1515.35                       | 1765.767                     | +16.5% |
| 32          | 2547.794                | 2297.031                      | 2564.844                     | +11.7% |
| 64          | 2980.74                 | 2761.412                      | 2965.177                     | +7.4% |
| 128         | 3246.715                | 3090.795                      | 3233.045                     | +4.6% |
| 256         | 3309.584                | 3215.861                      | 3303.094                     | +2.7% |


DeepSeek-V3.1-Terminus-W4AFP8, TP8
| Concurrency | Throughput (w/o CC) | Throughput (w/ CC, no Opt.) | Throughput (w/ CC, Opt.) | Speedup (vs. w/ CC, no Opt.) |
|:-----------:|--------------------:|----------------------------:|--------------------------:|-------------------------------:|
| 1           | 67.822              | 60.189                      | 67.858                    | +12.74% |
| 8           | 306.653             | 282.054                     | 307.784                   | +9.12%  |
| 16          | 488.766             | 452.879                     | 489.775                   | +8.15%  |
| 24          | 579.51              | 552.357                     | 589.447                   | +6.71%  |
| 32          | 682.756             | 643.174                     | 681.993                   | +6.04%  |
| 48          | 813.519             | 782.101                     | 828.047                   | +5.88%  |
| 64          | 1064.175            | 1002.979                    | 1065.684                  | +6.25%  |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
