### PR TITLE
fix: address review feedback for cache validation CI gating

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -276,8 +276,17 @@ def _find_local_hf_snapshot_dir_unlocked(
     to prevent race conditions during validation and cleanup.
 
     If the weights are already local, skip downloading and returns the path.
+
+    NOTE: This function only performs cache validation in CI environments.
+    Outside of CI, it returns None to skip the validation overhead and let
+    snapshot_download handle the cache lookup natively.
     """
     if os.path.isdir(model_name_or_path):
+        return None
+
+    # Skip cache validation entirely outside CI to avoid unnecessary overhead
+    # for regular users. Let snapshot_download handle cache lookup natively.
+    if not is_in_ci():
         return None
 
     found_local_snapshot_dir = None
@@ -428,18 +437,8 @@ def _find_local_hf_snapshot_dir_unlocked(
                         return None
 
     if len(local_weight_files) > 0:
-        log_info_on_rank0(
-            logger,
-            f"Found local HF snapshot for {model_name_or_path} at "
-            f"{found_local_snapshot_dir}; skipping download.",
-        )
         return found_local_snapshot_dir
     else:
-        log_info_on_rank0(
-            logger,
-            f"Local HF snapshot at {found_local_snapshot_dir} has no files matching "
-            f"{allow_patterns}; will attempt download.",
-        )
         return None
 
 

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -276,16 +276,11 @@ def _find_local_hf_snapshot_dir_unlocked(
     to prevent race conditions during validation and cleanup.
 
     If the weights are already local, skip downloading and returns the path.
-
-    NOTE: This function only performs cache validation in CI environments.
-    Outside of CI, it returns None to skip the validation overhead and let
-    snapshot_download handle the cache lookup natively.
     """
     if os.path.isdir(model_name_or_path):
         return None
 
     # Skip cache validation entirely outside CI to avoid unnecessary overhead
-    # for regular users. Let snapshot_download handle cache lookup natively.
     if not is_in_ci():
         return None
 


### PR DESCRIPTION
## Summary
Addresses review feedback from @merrymercy on #14849.

## Changes
1. Skip entire function when not in CI. Added early return at the beginning of `_find_local_hf_snapshot_dir_unlocked` so the function exits immediately when not in CI environment. This avoids the lock file issue that users were seeing during downloads.

2. Removed the "Found local HF snapshot for..." log message.