### PR TITLE
fix(DeepSeek-V3.2 function_call): fix streaming content loss in DeepSeekV32Detector

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -196,9 +196,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
         if not has_tool_call and not potentially_dsml and not ends_with_prefix:
             self._buffer = ""
             for e_token in [self.eot_token, self.invoke_end_token]:
-                if e_token in new_text:
-                    new_text = new_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=new_text)
+                if e_token in current_text:
+                    current_text = current_text.replace(e_token, "")
+            return StreamingParseResult(normal_text=current_text)
 
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)


### PR DESCRIPTION
## Motivation

When the buffer contains accumulated content from previous chunks (e.g., when a chunk ends with "<"), the code was returning `new_text` instead of `current_text` when determining the content is not DSML. This caused previously buffered content to be discarded.

For example, when streaming text containing `<user_maybe_say>`:
- Chunk 1: "...<" (buffered, returns empty)
- Chunk 2: "user_maybe_say>..." (returns only new_text, discards "<")

This resulted in `<user_maybe_say>` being output as `user_maybe_say>` with the leading "<" lost.

The fix changes to return `current_text` (buffer content) instead of `new_text` (current chunk only), ensuring no content is lost when the buffer is cleared.

```
{
  "model": "DeepSeek-V3.2",
  "messages": [
    {
      "role": "user",
      "content": "请原样输出下面这段话：--start--\n\n米饭仙人是日本知名演员**村方�的彩（村方乃々佳）**的别称，她因在综艺节目中展现出对米饭的极度热爱而走红。\n\n<br>\n\n不过更常见的\"米饭仙人\"指的是日本料理人**村嶋孟**，一位专注煮饭超过50年的匠人，被誉为\"煮饭仙人\"。他对米饭的执着追求让他成为日本饮食文化的传奇人物。\n\n<br>\n\n你想了解的是哪一位？\n\n<user_maybe_say>\n村嶋孟煮饭有什么特别的技巧？\n他在中国有开店吗？\n最近有什么好吃的日料推荐？\n</user_maybe_say>\n\n--end--"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "获取指定城市的天气信息",
        "parameters": {
          "type": "object",
          "properties": {
            "city": {
              "type": "string",
              "description": "城市名称，例如：北京、上海、深圳"
            }
          },
          "required": ["city"]
        }
      }
    }
  ],
  "stream": true,
  "max_tokens": 8192,
  "top_p": 0.3
}


🌊 检测到 stream=true，使用流式模式...
Status code: 200

=== 流式响应开始 ===

📝 Reasoning Content:
----------------------------------------
(无 reasoning_content)
----------------------------------------

💬 Content:
----------------------------------------
--start--

米饭仙人是日本知名演员**村方�的彩（村方乃々佳）**的别称，她因在综艺节目中展现出对米饭的极度热爱而走红。

<br>

不过更常见的"米饭仙人"指的是日本料理人**村嶋孟**，一位专注煮饭超过50年的匠人，被誉为"煮饭仙人"。他对米饭的执着追求让他成为日本饮食文化的传奇人物。

<br>

你想了解的是哪一位？

ay>
村嶋孟煮饭有什么特别的技巧？
他在中国有开店吗？
最近有什么好吃的日料推荐ay>

--end--
```

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Modifications
- Changed parse_streaming_increment() in DeepSeekV32Detector to return current_text instead of new_text when the content is determined to not be DSML format
- Updated the end-of-token replacement to also operate on current_text instead of new_text for consistency
Before：
```
if not has_tool_call and not potentially_dsml and not ends_with_prefix:
    self._buffer = ""
    for e_token in [self.eot_token, self.invoke_end_token]:
        if e_token in new_text:
            new_text = new_text.replace(e_token, "")
    return StreamingParseResult(normal_text=new_text)
```
After: 
```
if not has_tool_call and not potentially_dsml and not ends_with_prefix:
    self._buffer = ""
    for e_token in [self.eot_token, self.invoke_end_token]:
        if e_token in current_text:
            current_text = current_text.replace(e_token, "")
    return StreamingParseResult(normal_text=current_text)
```

After Fix: 
```
{
  "model": "DeepSeek-V3.2",
  "messages": [
    {
      "role": "user",
      "content": "请原样输出下面这段话：--start--\n\n米饭仙人是日本知名演员**村方�的彩（村方乃々佳）**的别称，她因在综艺节目中展现出对米饭的极度热爱而走红。\n\n<br>\n\n不过更常见的\"米饭仙人\"指的是日本料理人**村嶋孟**，一位专注煮饭超过50年的匠人，被誉为\"煮饭仙人\"。他对米饭的执着追求让他成为日本饮食文化的传奇人物。\n\n<br>\n\n你想了解的是哪一位？\n\n<user_maybe_say>\n村嶋孟煮饭有什么特别的技巧？\n他在中国有开店吗？\n最近有什么好吃的日料推荐？\n</user_maybe_say>\n\n--end--"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "获取指定城市的天气信息",
        "parameters": {
          "type": "object",
          "properties": {
            "city": {
              "type": "string",
              "description": "城市名称，例如：北京、上海、深圳"
            }
          },
          "required": ["city"]
        }
      }
    }
  ],
  "stream": true,
  "max_tokens": 8192,
  "top_p": 0.3
}



我这个请求， stream 的情况返回的时候有问题：

🌊 检测到 stream=true，使用流式模式...
Status code: 200

=== 流式响应开始 ===

📝 Reasoning Content:
----------------------------------------
(无 reasoning_content)
----------------------------------------

💬 Content:
----------------------------------------
--start--

米饭仙人是日本知名演员**村方乃々佳（村方乃々佳）**的别称，她因在综艺节目中展现出对米饭的极度热爱而走红。

<br>

不过更常见的"米饭仙人"指的是日本料理人**村嶋孟**，一位专注煮饭超过50年的匠人，被誉为"煮饭仙人"。他对米饭的执着追求让他成为日本饮食文化的传奇人物。

<br>

你想了解的是哪一位？

<user_maybe_say>
村嶋孟煮饭有什么特别的技巧？
他在中国有开店吗？
最近有什么好吃的日料推荐？
</user_maybe_say>

--end--
```

## Accuracy Tests
This change does not affect model outputs. It only fixes the streaming output logic to correctly return buffered content.

## Benchmarking and Profiling
This change does not impact inference speed. It only affects the string returned in streaming mode.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
