### PR TITLE
fix: removing latest-sglang=1

### DIFF
--- a/.github/workflows/release-docker-dev-pr.yml
+++ b/.github/workflows/release-docker-dev-pr.yml
@@ -78,7 +78,7 @@ jobs:
             --build-arg BUILD_TYPE=${{ matrix.build_type }} \
             --build-arg CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) \
             --build-arg GRACE_BLACKWELL=${{ matrix.grace_blackwell }} \
-            --build-arg USE_LATEST_SGLANG=1 \
+            --build-arg BRANCH_TYPE=local \
             --build-arg INSTALL_FLASHINFER_JIT_CACHE=1 \
             -t lmsysorg/sglang:${tag} \
             --no-cache \


### PR DESCRIPTION
## Motivation

Resolves a critical bug where the actual code content in the pr branch of the docker image gets overwritten by `latest-sglang=1`

## Modifications

Remove latest-sglang=1 and add branch-type=local.

## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/20252525153

https://hub.docker.com/layers/lmsysorg/sglang/dev-pr-15207/images/sha256-1430f40780d9fa316ee244b0b516aa139d048c422ca2db8d86e71cba80c28085

## Benchmarking and Profiling

n/a

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
