### PR TITLE
[MoE Hot bug] Fix EP expert ID handling in moe_align_kernel

### DIFF
--- a/sgl-kernel/csrc/moe/moe_align_kernel.cu
+++ b/sgl-kernel/csrc/moe/moe_align_kernel.cu
@@ -36,7 +36,7 @@ __global__ void count_and_sort_expert_tokens_kernel(
 
   for (size_t i = tid; i < numel; i += stride) {
     int32_t expert_id = topk_ids[i];
-    if(expert_id >= 0 && expert_id < num_experts) {
+    if (expert_id >= 0 && expert_id < num_experts) {
       int32_t rank_post_pad = atomicAdd(&cumsum_buffer[expert_id], 1);
       sorted_token_ids[rank_post_pad] = i;
     }
@@ -281,7 +281,7 @@ __global__ void moe_align_block_size_small_batch_expert_kernel(
 
   for (size_t i = tid; i < numel; i += stride) {
     int32_t expert_id = topk_ids[i];
-    if(expert_id >= 0 && expert_id < num_experts) {
+    if (expert_id >= 0 && expert_id < num_experts) {
       ++tokens_cnts[(tid + 1) * num_experts + expert_id];
     }
   }

--- a/sgl-kernel/csrc/moe/moe_align_kernel.cu
+++ b/sgl-kernel/csrc/moe/moe_align_kernel.cu
@@ -29,14 +29,17 @@ __global__ void count_and_sort_expert_tokens_kernel(
     const scalar_t* __restrict__ topk_ids,
     int32_t* __restrict__ sorted_token_ids,
     int32_t* __restrict__ cumsum_buffer,
+    int32_t num_experts,
     size_t numel) {
   const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
   const size_t stride = blockDim.x * gridDim.x;
 
   for (size_t i = tid; i < numel; i += stride) {
-    int32_t expert_id = topk_ids[i] + 1;
-    int32_t rank_post_pad = atomicAdd(&cumsum_buffer[expert_id], 1);
-    sorted_token_ids[rank_post_pad] = i;
+    int32_t expert_id = topk_ids[i];
+    if(expert_id >= 0 && expert_id < num_experts) {
+      int32_t rank_post_pad = atomicAdd(&cumsum_buffer[expert_id], 1);
+      sorted_token_ids[rank_post_pad] = i;
+    }
   }
 }
 
@@ -95,8 +98,10 @@ __global__ void moe_align_block_size_kernel(
   __syncthreads();
 
   for (size_t i = tid; i < numel; i += stride) {
-    int expert_id = topk_ids[i] + 1;
-    atomicAdd(&shared_counts[expert_id], 1);
+    int expert_id = topk_ids[i];
+    if (expert_id >= 0 && expert_id < num_experts) {
+      atomicAdd(&shared_counts[expert_id], 1);
+    }
   }
 
   __syncthreads();
@@ -228,7 +233,7 @@ __global__ void moe_align_block_size_kernel(
         right = mid;
       }
     }
-    expert_ids[i] = left - 2;
+    expert_ids[i] = left - 1;
   }
 }
 
@@ -275,8 +280,10 @@ __global__ void moe_align_block_size_small_batch_expert_kernel(
   }
 
   for (size_t i = tid; i < numel; i += stride) {
-    int32_t expert_id = topk_ids[i] + 1;
-    ++tokens_cnts[(tid + 1) * num_experts + expert_id];
+    int32_t expert_id = topk_ids[i];
+    if(expert_id >= 0 && expert_id < num_experts) {
+      ++tokens_cnts[(tid + 1) * num_experts + expert_id];
+    }
   }
 
   __syncthreads();
@@ -302,15 +309,17 @@ __global__ void moe_align_block_size_small_batch_expert_kernel(
 
   if (tid < num_experts) {
     for (int i = cumsum[tid]; i < cumsum[tid + 1]; i += block_size) {
-      expert_ids[i / block_size] = tid - 1;
+      expert_ids[i / block_size] = tid;
     }
   }
 
   for (size_t i = tid; i < numel; i += stride) {
-    int32_t expert_id = topk_ids[i] + 1;
-    int32_t rank_post_pad = tokens_cnts[tid * num_experts + expert_id] + cumsum[expert_id];
-    sorted_token_ids[rank_post_pad] = i;
-    ++tokens_cnts[tid * num_experts + expert_id];
+    int32_t expert_id = topk_ids[i];
+    if (expert_id >= 0 && expert_id < num_experts) {
+      int32_t rank_post_pad = tokens_cnts[tid * num_experts + expert_id] + cumsum[expert_id];
+      sorted_token_ids[rank_post_pad] = i;
+      ++tokens_cnts[tid * num_experts + expert_id];
+    }
   }
 }
 
@@ -377,6 +386,7 @@ void moe_align_block_size(
           topk_ids.data_ptr<scalar_t>(),
           sorted_token_ids.data_ptr<int32_t>(),
           cumsum_buffer.data_ptr<int32_t>(),
+          num_experts,
           topk_ids.numel());
     }
   });


### PR DESCRIPTION
## Motivation

Fix https://github.com/sgl-project/sglang/pull/8514 bug

It will cause Warp Illegal Instruction when serving kimi_k2 with piece-wise-cuda-graph

It also causes the last expert to consistently remain unaccounted for in both statistics and output position calculations under non-EP conditions.

cc @ch-wan 

We can now filter EP experts by checking `expert_id >= 0 && expert_id < num_experts`, instead of doing `expert_id + 1` .

Or we can filter it by checking `experd_id==1` like vLLM: https://github.com/vllm-project/vllm/blob/main/csrc/moe/moe_align_sum_kernels.cu#L132 

## Kimi K2 Thinking Acc

### Kimi K2 Thinking piecewise cuda graph

```shell
python3 -m sglang.launch_server --model-path moonshotai/Kimi-K2-Thinking --tp 8 --trust-remote-code  --tool-call-parser kimi_k2 --reasoning-parser kimi_k2 --model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}' --enable-piecewise-cuda-graph
```

```shell
➜  sglang git:(pcg-marlin-moe) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 1400 --parallel 1400
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:24<00:00, 53.88it/s]
Accuracy: 0.938
Invalid: 0.001
Latency: 24.583 s
Output throughput: 5294.458 token/s
```

### Kimi K2 Thinking without piecewise cuda graph

```shell
python3 -m sglang.launch_server --model-path moonshotai/Kimi-K2-Thinking --tp 8 --trust-remote-code  --tool-call-parser kimi_k2 --reasoning-parser kimi_k2 --model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}' 
```

```shell
➜  sglang git:(pcg-marlin-moe) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 1400 --parallel 1400
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:24<00:00, 54.09it/s]
Accuracy: 0.941
Invalid: 0.001
Latency: 24.558 s
Output throughput: 5289.763 token/s
```

### Kimi K2 Thinking EP


```shell
python3 -m sglang.launch_server --model-path moonshotai/Kimi-K2-Thinking --tp 8 --ep 4 --trust-remote-code  --tool-call-parser kimi_k2 --reasoning-parser kimi_k2 --model-loader-extra-config='{"enable_multithread_load": "true","num_threads": 64}'
```

```shell
➜  sglang git:(pcg-marlin-moe) ✗ python3 benchmark/gsm8k/bench_sglang.py --num-questions 1400 --parallel 1400
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:23<00:00, 55.14it/s]
Accuracy: 0.939
Invalid: 0.000
Latency: 24.119 s
Output throughput: 5519.985 token/s
```


