### PR TITLE
[diffusion] platform: support ROCM sglang diffusion with TORCH_SDPA/FA backend

### DIFF
--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -68,6 +68,22 @@ runtime_common = [
   "grpcio-reflection==1.75.1", # required by srt/entrypoints/grpc_server.py
 ]
 
+diffusion = [
+  "PyYAML==6.0.1",
+  "cloudpickle",
+  "diffusers==0.36.0",
+  "imageio==2.36.0",
+  "imageio-ffmpeg==0.5.1",
+  "moviepy>=2.0.0",
+  "opencv-python==4.10.0.84",
+  "remote-pdb",
+  "st_attn ==0.0.7",
+  "vsa==0.0.4",
+  "yunchang@git+https://github.com/feifeibear/long-context-attention.git@b192e97", # fix torch_cpp_ext._get_cuda_arch_flags() https://github.com/feifeibear/long-context-attention/pull/148,
+  "runai_model_streamer==0.15.3",
+  "cache-dit==1.1.8"
+]
+
 tracing = [
   "opentelemetry-sdk",
   "opentelemetry-api",
@@ -114,6 +130,9 @@ dev_hpu = ["sglang[all_hpu]", "sglang[test]"]
 [project.urls]
 "Homepage" = "https://github.com/sgl-project/sglang"
 "Bug Tracker" = "https://github.com/sgl-project/sglang/issues"
+
+[project.scripts]
+sglang = "sglang.cli.main:main"
 
 [tool.setuptools.package-data]
 "sglang" = [

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -77,7 +77,7 @@ diffusion = [
   "moviepy>=2.0.0",
   "opencv-python==4.10.0.84",
   "remote-pdb",
-  "st_attn ==0.0.7",
+  "st_attn==0.0.7",
   "vsa==0.0.4",
   "yunchang@git+https://github.com/feifeibear/long-context-attention.git@b192e97", # fix torch_cpp_ext._get_cuda_arch_flags() https://github.com/feifeibear/long-context-attention/pull/148,
   "runai_model_streamer==0.15.3",

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -128,7 +128,6 @@ class FlashAttentionImpl(AttentionImpl):
         else:
             max_seqlen_q = query.shape[1]
             max_seqlen_k = key.shape[1]
-
         output = flash_attn_func(
             q=query,  # type: ignore[no-untyped-call]
             k=key,

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -15,8 +15,12 @@ if _is_hip:
     try:
         from flash_attn import flash_attn_func  # Use the flash attention v2 function
     except ImportError:
+
         def _unsupported(*args, **kwargs):
-            raise ImportError("flash-attn is not installed. Please install it, e.g., `pip install flash-attn`.")
+            raise ImportError(
+                "flash-attn is not installed. Please install it, e.g., `pip install flash-attn`."
+            )
+
         flash_attn_func = _unsupported
 else:
     try:

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn_2.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn_2.py
@@ -10,9 +10,18 @@ from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend i
     AttentionMetadata,
     AttentionMetadataBuilder,
 )
-from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
-    flash_attn_func,
-)
+
+try:
+    from flash_attn import flash_attn_func  # Use the flash attention v2 function
+except ImportError:
+
+    def _unsupported(*args, **kwargs):
+        raise ImportError(
+            "flash-attn is not installed. Please install it, e.g., `pip install flash-attn`."
+        )
+
+    flash_attn_func = _unsupported
+
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -39,7 +48,7 @@ class FlashAttention2Backend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls() -> type["AttentionMetadataBuilder"]:
-        raise NotImplementedError
+        return None
 
 
 class FlashAttention2Impl(AttentionImpl):
@@ -68,10 +77,6 @@ class FlashAttention2Impl(AttentionImpl):
             q=query,  # type: ignore[no-untyped-call]
             k=key,
             v=value,
-            cu_seqlens_q=None,
-            cu_seqlens_k=None,
-            max_seqlen_q=None,
-            max_seqlen_k=None,
             softmax_scale=self.softmax_scale,
             causal=self.causal,
         )

--- a/python/sglang/multimodal_gen/runtime/layers/custom_op.py
+++ b/python/sglang/multimodal_gen/runtime/layers/custom_op.py
@@ -50,6 +50,10 @@ class CustomOp(nn.Module):
     def forward_cuda(self, *args, **kwargs) -> Any:
         raise NotImplementedError
 
+    def forward_hip(self, *args, **kwargs) -> Any:
+        # By default, we assume that HIP ops are compatible with CUDA ops.
+        return self.forward_cuda(*args, **kwargs)
+
     def forward_cpu(self, *args, **kwargs) -> Any:
         # By default, we assume that CPU ops are compatible with CUDA ops.
         return self.forward_cuda(*args, **kwargs)

--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -74,6 +74,13 @@ class RMSNorm(CustomOp):
         out = out.view(shape)
         return out
 
+    def forward_hip(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        return self.forward_native(x, residual)
+
     def forward_native(
         self,
         x: torch.Tensor,

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -9,7 +9,6 @@ adjusted to match the structure and interface of `cuda.py`.
 
 import torch
 
-import sglang.multimodal_gen.envs as envs
 from sglang.multimodal_gen.runtime.platforms.interface import (
     AttentionBackendEnum,
     DeviceCapability,
@@ -69,7 +68,9 @@ class RocmPlatform(Platform):
         dtype: torch.dtype,
     ) -> str:
         torch.backends.cudnn.enabled = False  # Seems to improve things a lot on AMD
-        logger.info("Set: torch.backends.cudnn.enabled = False for better AMD performance.")
+        logger.info(
+            "Set: torch.backends.cudnn.enabled = False for better AMD performance."
+        )
 
         if selected_backend == AttentionBackendEnum.TORCH_SDPA:
             logger.info("Using Torch SDPA backend.")

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -68,10 +68,8 @@ class RocmPlatform(Platform):
         head_size: int,
         dtype: torch.dtype,
     ) -> str:
-        logger.info(
-            "Trying SGLANG_DIFFUSION_ATTENTION_BACKEND=%s",
-            envs.SGLANG_DIFFUSION_ATTENTION_BACKEND,
-        )
+        torch.backends.cudnn.enabled = False  # Seems to improve things a lot on AMD
+        logger.info("Set: torch.backends.cudnn.enabled = False for better AMD performance.")
 
         if selected_backend == AttentionBackendEnum.TORCH_SDPA:
             logger.info("Using Torch SDPA backend.")

--- a/python/sglang/multimodal_gen/runtime/platforms/rocm.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/rocm.py
@@ -103,11 +103,11 @@ class RocmPlatform(Platform):
             try:
                 import flash_attn  # noqa: F401
 
-                from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (  # noqa: F401
-                    FlashAttentionBackend,
+                from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2 import (  # noqa: F401
+                    FlashAttention2Backend,
                 )
 
-                supported_sizes = FlashAttentionBackend.get_supported_head_sizes()
+                supported_sizes = FlashAttention2Backend.get_supported_head_sizes()
                 if head_size not in supported_sizes:
                     logger.info(
                         "Cannot use FlashAttention-2 backend for head size %d.",
@@ -130,7 +130,7 @@ class RocmPlatform(Platform):
 
         logger.info("Using Flash Attention backend.")
 
-        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn.FlashAttentionBackend"
+        return "sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn_2.FlashAttention2Backend"
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:


### PR DESCRIPTION
## Motivation

support ROCM sglang diffusion with TORCH_SDPA/FA backend

## Modifications

modify some files releted to ROCM platform.

## AMD SGLANG DIFFUSION STEP
- start a sglang rocm docker
```
docker run -it -v $HOME:$HOME \
               --cap-add=SYS_PTRACE \
               --privileged=true \
               --security-opt seccomp=unconfined \
               --device=/dev/kfd --device=/dev/dri \
               --group-add video \
               --ipc=host \
               --shm-size 128G \
               --network=host \
               --name sglang_rocm_diffusion \
               lmsysorg/sglang:v0.5.6.post1-rocm700-mi30x
```

- install sglang diffusion rocm
```
cd sglang 
cp python/pyproject_other.toml python/pyproject.toml
pip install -e "python[diffusion,srt_hip]"
```

pip will show some version check information
```
vllm 0.9.2rc2.dev2065+g4f43dae12.rocm700 has requirement outlines_core==0.2.10, but you have outlines-core 0.1.26.
vllm 0.9.2rc2.dev2065+g4f43dae12.rocm700 has requirement runai-model-streamer==0.11.0, but you have runai-model-streamer 0.15.3.
vllm 0.9.2rc2.dev2065+g4f43dae12.rocm700 has requirement xgrammar==0.1.21; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64", but you have xgrammar 0.1.27.
```
These version incompatibility messages don't seem to have any noticeable impact.

- run inference scripts
```
sglang generate --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output

sglang generate --model-path=Wan-AI/Wan2.1-I2V-14B-480P-Diffusers     --prompt="Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."     --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true"     --num-gpus 2 --enable-cfg-parallel --save-output

sglang generate --model-path black-forest-labs/FLUX.1-dev     --prompt "A Logo With Bold Large Text: SGL Diffusion"     --save-output

sglang generate --model-path=Qwen/Qwen-Image     --prompt='A curious raccoon'     --width=720 --height=720 --save-output

sglang generate --model-path=Qwen/Qwen-Image-Edit     --prompt="Convert 2D style to 3D style" --image-path="https://github.com/lm-sys/lm-sys.github.io/releases/download/test/TI2I_Qwen_Image_Edit_Input.jpg"     --width=1536 --height=1024 --save-output
```

## Accuracy Tests

```
sglang generate --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output

sglang generate --model-path=Wan-AI/Wan2.1-I2V-14B-480P-Diffusers     --prompt="Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."     --image-path="https://github.com/Wan-Video/Wan2.2/blob/990af50de458c19590c245151197326e208d7191/examples/i2v_input.JPG?raw=true"     --num-gpus 2 --enable-cfg-parallel --save-output

sglang generate --model-path black-forest-labs/FLUX.1-dev     --prompt "A Logo With Bold Large Text: SGL Diffusion"     --save-output

sglang generate --model-path=Qwen/Qwen-Image     --prompt='A curious raccoon'     --width=720 --height=720 --save-output

sglang generate --model-path=Qwen/Qwen-Image-Edit     --prompt="Convert 2D style to 3D style" --image-path="https://github.com/lm-sys/lm-sys.github.io/releases/download/test/TI2I_Qwen_Image_Edit_Input.jpg"     --width=1536 --height=1024 --save-output
```
The output videos and images looks no problems.

## Benchmarking and Profiling

MI300 1 card

- with torch.backends.cudnn.enabled = False
sglang generate --attention-backend torch_sdpa --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output

```
[12-16 08:13:02] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[12-16 08:13:02] [InputValidationStage] started...
[12-16 08:13:02] [InputValidationStage] finished in 0.0001 seconds
[12-16 08:13:02] [TextEncodingStage] started...
[12-16 08:13:07] [TextEncodingStage] finished in 5.6485 seconds
[12-16 08:13:07] [ConditioningStage] started...
[12-16 08:13:07] [ConditioningStage] finished in 0.0000 seconds
[12-16 08:13:07] [TimestepPreparationStage] started...
[12-16 08:13:07] [TimestepPreparationStage] finished in 0.0020 seconds
[12-16 08:13:07] [LatentPreparationStage] started...
[12-16 08:13:07] [LatentPreparationStage] finished in 0.0040 seconds
[12-16 08:13:07] [DenoisingStage] started...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:58<00:00,  2.36s/it]
[12-16 08:15:05] [DenoisingStage] average time per step: 2.3622 seconds
[12-16 08:15:05] [DenoisingStage] finished in 118.1117 seconds
[12-16 08:15:05] [DecodingStage] started...
[12-16 08:15:12] [DecodingStage] finished in 6.7722 seconds
[12-16 08:15:15] Saved output to outputs/A_curious_raccoon_20251216-081302_483bc3b0.mp4
[12-16 08:15:15] Pixel data generated successfully in 133.07 seconds
[12-16 08:15:15] Completed batch processing. Generated 1 outputs in 133.07 seconds.
```

- with torch.backends.cudnn.enabled = False
sglang generate --attention-backend fa --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output
```
[12-16 08:18:36] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[12-16 08:18:36] [InputValidationStage] started...
[12-16 08:18:36] [InputValidationStage] finished in 0.0001 seconds
[12-16 08:18:36] [TextEncodingStage] started...
[12-16 08:18:44] [TextEncodingStage] finished in 7.3111 seconds
[12-16 08:18:44] [ConditioningStage] started...
[12-16 08:18:44] [ConditioningStage] finished in 0.0001 seconds
[12-16 08:18:44] [TimestepPreparationStage] started...
[12-16 08:18:44] [TimestepPreparationStage] finished in 0.0023 seconds
[12-16 08:18:44] [LatentPreparationStage] started...
[12-16 08:18:44] [LatentPreparationStage] finished in 0.0044 seconds
[12-16 08:18:44] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:51<00:00,  2.23s/it]
[12-16 08:20:35] [DenoisingStage] average time per step: 2.2287 seconds
[12-16 08:20:35] [DenoisingStage] finished in 111.4373 seconds
[12-16 08:20:35] [DecodingStage] started...
[12-16 08:20:42] [DecodingStage] finished in 6.7874 seconds
[12-16 08:20:45] Saved output to outputs/A_curious_raccoon_20251216-081836_483bc3b0.mp4
[12-16 08:20:45] Pixel data generated successfully in 128.09 seconds
```

- without torch.backends.cudnn.enabled = False
sglang generate --attention-backend torch_sdpa --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output
```
[12-16 08:52:08] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[12-16 08:52:08] [InputValidationStage] started...
[12-16 08:52:08] [InputValidationStage] finished in 0.0001 seconds
[12-16 08:52:08] [TextEncodingStage] started...
[12-16 08:52:14] [TextEncodingStage] finished in 5.6918 seconds
[12-16 08:52:14] [ConditioningStage] started...
[12-16 08:52:14] [ConditioningStage] finished in 0.0000 seconds
[12-16 08:52:14] [TimestepPreparationStage] started...
[12-16 08:52:14] [TimestepPreparationStage] finished in 0.0020 seconds
[12-16 08:52:14] [LatentPreparationStage] started...
[12-16 08:52:14] [LatentPreparationStage] finished in 0.0039 seconds
[12-16 08:52:14] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:55<00:00,  2.31s/it]
[12-16 08:54:10] [DenoisingStage] average time per step: 2.3141 seconds
[12-16 08:54:10] [DenoisingStage] finished in 115.7071 seconds
[12-16 08:54:10] [DecodingStage] started...
[12-16 08:54:18] [DecodingStage] finished in 8.3042 seconds
[12-16 08:54:21] Saved output to outputs/A_curious_raccoon_20251216-085208_483bc3b0.mp4
[12-16 08:54:21] Pixel data generated successfully in 132.41 seconds
[12-16 08:54:21] Completed batch processing. Generated 1 outputs in 132.41 seconds.
```

- without torch.backends.cudnn.enabled = False
sglang generate --attention-backend fa --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers     --prompt "A curious raccoon"     --save-output
```
[12-16 08:55:21] Running pipeline stages: ['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage']
[12-16 08:55:21] [InputValidationStage] started...
[12-16 08:55:21] [InputValidationStage] finished in 0.0003 seconds
[12-16 08:55:21] [TextEncodingStage] started...
[12-16 08:55:28] [TextEncodingStage] finished in 7.8656 seconds
[12-16 08:55:28] [ConditioningStage] started...
[12-16 08:55:28] [ConditioningStage] finished in 0.0000 seconds
[12-16 08:55:28] [TimestepPreparationStage] started...
[12-16 08:55:28] [TimestepPreparationStage] finished in 0.0020 seconds
[12-16 08:55:28] [LatentPreparationStage] started...
[12-16 08:55:28] [LatentPreparationStage] finished in 0.0039 seconds
[12-16 08:55:28] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [01:56<00:00,  2.34s/it]
[12-16 08:57:25] [DenoisingStage] average time per step: 2.3357 seconds
[12-16 08:57:25] [DenoisingStage] finished in 116.7862 seconds
[12-16 08:57:25] [DecodingStage] started...
[12-16 08:57:34] [DecodingStage] finished in 8.4824 seconds
[12-16 08:57:36] Saved output to outputs/A_curious_raccoon_20251216-085521_483bc3b0.mp4
[12-16 08:57:36] Pixel data generated successfully in 135.66 seconds
[12-16 08:57:36] Completed batch processing. Generated 1 outputs in 135.66 seconds.
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
