### PR TITLE
Fix FP4 KV cache with EAGLE speculative decoding

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1018,7 +1018,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 max_seq_len = metadata.max_seq_len_k + metadata.max_seq_len_q
             q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
             # FP4 KV cache is dequantized, so skip dtype assertion for FP4
-            if not (float4_dtype is not None and self.data_type == float4_dtype):
+            if not is_fp4_kv_cache:
                 assert kv_cache.dtype == self.data_type
 
             raw_out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1005,8 +1005,8 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             )
             # FP4 KV cache is stored as FP4 but accessed as dequantized (bfloat16),
             # so don't convert q to FP4
-            float4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
-            if not (float4_dtype is not None and self.data_type == float4_dtype):
+            is_fp4_kv_cache = float4_dtype is not None and self.data_type == float4_dtype
+            if not is_fp4_kv_cache:
                 q = q.to(self.data_type)
 
             bmm1_scale = q_scale * k_scale * layer.scaling


### PR DESCRIPTION
Fixes the "copy_" not implemented for 'Float4_e2m1fn_x2' error when using EAGLE speculative decoding with FP4 KV cache.

Issue:
- EAGLE's TARGET_VERIFY mode attempted to convert query tensors to FP4 dtype using .to(), which internally uses copy_() operation
- PyTorch doesn't implement copy_() for float4_e2m1fn_x2 dtype
- This only affected EAGLE mode because regular decode doesn't enter the TARGET_VERIFY/DRAFT_EXTEND code path

Solution:
- Skip dtype conversion when using FP4 KV cache, since FP4 buffers are automatically dequantized to bfloat16 when accessed via get_key_buffer()
- Skip dtype assertion for FP4 since kv_cache is in compute dtype after dequantization
- Follows the same pattern as FP8 KV cache handling

Tested with:
  -e SGLANG_ENABLE_SPEC_V2=1 
  -e SGLANG_DISABLE_CONSECUTIVE_PREFILL_OVERLAP=1 
  -e SGLANG_SCHEDULER_DONT_INTERRUPT_CURRENT_DECODE=1 
  -e ENGINE_TYPE=sglang 
  cd sglang/python && pip install -e .[all] && python3 -m sglang.launch_server \
    --model-path /scratch/huggingface/dsv31-agent-1003-bt-rl-1026-mtp-2-force-thinkFP4 \
    --trust-remote-code \
    --quantization modelopt_fp4 \
    --tp 4 \
    --port 30001 \
     --enable-metrics \
    --enable-flashinfer-allreduce-fusion \
    --kv-cache-dtype fp4_e2m1 \
    --page-size 64 \
    --max-running-requests 32 \
    --chunked-prefill-size 32768 \
    --log-requests \
    --log-requests-level 0 \
    --speculative-algorithm EAGLE \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --attention-backend trtllm_mla \
    --moe-runner-backend flashinfer_trtllm \
    --cuda-graph-bs \