### PR TITLE
[NVIDIA] Fixes for NVFP4 all-gather with spec decoding

### DIFF
--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from enum import Enum, IntEnum
-from functools import lru_cache
 from typing import TYPE_CHECKING, Optional
 
 from sglang.srt.distributed.parallel_state import get_moe_expert_parallel_world_size
@@ -250,7 +249,6 @@ def get_tbo_token_distribution_threshold() -> float:
     return TBO_TOKEN_DISTRIBUTION_THRESHOLD
 
 
-@lru_cache(maxsize=1)
 def should_use_flashinfer_cutlass_moe_fp4_allgather():
     """
     Perform FP4 quantize before all-gather for flashinfer cutlass moe to reduce communication cost for high-throughput serving.
@@ -286,12 +284,16 @@ def speculative_moe_a2a_backend_context():
     This ensures that draft models in speculative decoding use the configured speculative A2A backend.
     """
     global MOE_A2A_BACKEND
+    global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     original_backend = MOE_A2A_BACKEND
     try:
         MOE_A2A_BACKEND = get_speculative_moe_a2a_backend()
+        # Disable FP4 allgather for spec decode since MTP layers are unquantized
+        DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = True
         yield
     finally:
         MOE_A2A_BACKEND = original_backend
+        DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = False
 
 
 # The type of method in top-K routing, for use in torch custom op

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -286,6 +286,9 @@ def speculative_moe_a2a_backend_context():
     global MOE_A2A_BACKEND
     global DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
     original_backend = MOE_A2A_BACKEND
+    original_disable_flashinfer_cutlass_moe_fp4_allgather = (
+        DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER
+    )
     try:
         MOE_A2A_BACKEND = get_speculative_moe_a2a_backend()
         # Disable FP4 allgather for spec decode since MTP layers are unquantized
@@ -293,7 +296,9 @@ def speculative_moe_a2a_backend_context():
         yield
     finally:
         MOE_A2A_BACKEND = original_backend
-        DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = False
+        DISABLE_FLASHINFER_CUTLASS_MOE_FP4_ALLGATHER = (
+            original_disable_flashinfer_cutlass_moe_fp4_allgather
+        )
 
 
 # The type of method in top-K routing, for use in torch custom op

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -22,6 +22,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.cutlass_moe_params import CutlassMoEParams, CutlassMoEType
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
+from sglang.srt.layers.moe.utils import should_use_flashinfer_cutlass_moe_fp4_allgather
 from sglang.srt.layers.parameter import ModelWeightParameter, PerTensorScaleParameter
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
@@ -1606,7 +1607,10 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         layer.dispatcher.set_quant_config(
             {
                 "input_global_scale": (
-                    layer.w13_input_scale_quant if MOE_NVFP4_DISPATCH else None
+                    layer.w13_input_scale_quant
+                    if MOE_NVFP4_DISPATCH
+                    or should_use_flashinfer_cutlass_moe_fp4_allgather()
+                    else None
                 )
             }
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

This PR fixes two issues with the FP4-allgather path.
1. Since https://github.com/sgl-project/sglang/pull/13327 it became necessary to set `SGLANG_MOE_NVFP4_DISPATCH=1` for the fp4 allgather to work, otherwise the input global scale would not be set for the dispatcher. Now, you won't need to set this environment variable.

Previously seen error message:
```
  File "/trevor/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 887, in forward
    dispatch_output = self.dispatcher.dispatch(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/moe/token_dispatcher/standard.py", line 106, in dispatch
    assert global_scale is not None, "input_global_scale is not set"
           ^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: input_global_scale is not set
```

2. With speculative decoding, the MTP layers in DeepSeek don't use quantization, so the FP4 all gather code path would cause an error. Now, we disable it in the speculative context. Note: A cleaner way to handle this would be to create a separate dispatcher and moe-a2a-backend for fp4 allgather - let me know if that would be preffered.

Previously seen error message:
```
  File "/trevor/sglang/python/sglang/srt/speculative/eagle_worker.py", line 285, in forward_batch_generation
    self.forward_draft_extend(
  File "/trevor/sglang/python/sglang/srt/speculative/eagle_worker.py", line 949, in forward_draft_extend
    logits_output, _ = self.draft_model_runner.forward(forward_batch)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/model_executor/model_runner.py", line 2731, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/model_executor/model_runner.py", line 2801, in _forward_raw
    ret = self.forward_extend(
          ^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/model_executor/model_runner.py", line 2676, in forward_extend
    return self.model.forward(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_nextn.py", line 246, in forward
    hidden_states = self.model(input_ids, positions, forward_batch)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_nextn.py", line 167, in forward
    hidden_states, residual = self.decoder(
                              ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 2918, in forward
    hidden_states = self.mlp(
                    ^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 809, in forward
    return self.forward_normal(
           ^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/models/deepseek_v2.py", line 907, in forward_normal
    final_hidden_states = self.experts(
                          ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 887, in forward
    dispatch_output = self.dispatcher.dispatch(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/trevor/sglang/python/sglang/srt/layers/moe/token_dispatcher/standard.py", line 105, in dispatch
    global_scale = self.quant_config.get("input_global_scale", None)
                   ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

## Accuracy

```
python -m sglang.launch_server   --model-path nvidia/DeepSeek-R1-0528-FP4-v2   --trust-remote-code   --kv-cache-dtype "fp8_e4m3"   --attention-backend flashinfer   --quantization "modelopt_fp4"   --moe-runner-backend "flashinfer_cutlass"   --disable-radix-cache   --disable-chunked-prefix-cache   --stream-interval 50   --decode-log-interval 1000   --watchdog-timeout 1000000   --context-length 2176   --disable-shared-experts-fusion   --eplb-algorithm "deepseek"   --mem-fraction-static 0.84   --max-total-tokens 131072   --max-prefill-tokens 32768   --chunked-prefill-size 65536   --max-running-requests 30000   --disable-cuda-graph   --enable-dp-attention   --tp-size 4   --dp-size 4   --ep-size 4   --speculative-algorithm "EAGLE"   --speculative-num-steps 1   --speculative-eagle-topk 1   --speculative-num-draft-tokens 2

python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319 --port=30000

Accuracy: 0.958
Invalid: 0.000
Latency: 116.420 s
Output throughput: 1245.663 token/s
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
