### PR TITLE
[Test] Update LoRA eviction policy tests to match current behavior

### DIFF
--- a/test/nightly/test_lora_eviction_policy.py
+++ b/test/nightly/test_lora_eviction_policy.py
@@ -90,13 +90,13 @@ class TestLoRAEvictionPolicy(unittest.TestCase):
             expected_victim="lora2",
         )
 
-    def test_lru_base_model_priority(self):
-        """Test LRU prioritizes base model for eviction."""
+    def test_lru_base_model_evicted_last(self):
+        """Test LRU evicts LoRA adapters before base model (None)."""
         self._test_eviction_policy(
             "lru",
             access_sequence=["lora1", "lora2", "lora3"],
             candidates={None, "lora1", "lora2", "lora3"},
-            expected_victim=None,
+            expected_victim="lora1",
         )
 
     def test_fifo_basic(self):
@@ -135,13 +135,13 @@ class TestLoRAEvictionPolicy(unittest.TestCase):
             expected_victim="lora2",
         )
 
-    def test_fifo_base_model_priority(self):
-        """Test FIFO prioritizes base model for eviction."""
+    def test_fifo_base_model_evicted_last(self):
+        """Test FIFO evicts LoRA adapters before base model (None)."""
         self._test_eviction_policy(
             "fifo",
             access_sequence=["lora1", "lora2", "lora3"],
             candidates={None, "lora1", "lora2", "lora3"},
-            expected_victim=None,
+            expected_victim="lora1",
         )
 
     def test_policy_remove(self):


### PR DESCRIPTION
## Summary

Followup to #14795 which changed eviction behavior to protect the base model (`None`) from being evicted first, ensuring non-LoRA requests always have a slot available.

This PR updates the test expectations to match the current implementation:
- Rename `test_lru_base_model_priority` to `test_lru_base_model_evicted_last`
- Rename `test_fifo_base_model_priority` to `test_fifo_base_model_evicted_last`
- Update expected victim from `None` to `"lora1"` (the oldest LoRA adapter)

The tests now verify that LoRA adapters are evicted before the base model.

Example failure: https://github.com/sgl-project/sglang/actions/runs/20252286526/job/58146779041

## Test plan

- [x] Verify `test_lru_base_model_evicted_last` passes
- [x] Verify `test_fifo_base_model_evicted_last` passes