### PR TITLE
Fix test_pp_single_node.py estimated time from 800s to 500s

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -150,7 +150,7 @@ suites = {
         TestFile("test_gpt_oss_4gpu.py", 300),
         TestFile("test_local_attn.py", 411),
         TestFile("test_multi_instance_release_memory_occupation.py", 64),
-        TestFile("test_pp_single_node.py", 800),
+        TestFile("test_pp_single_node.py", 500),
         TestFile("test_piecewise_cuda_graph.py", 1200),
         TestFile("test_epd_disaggregation.py", 400),
     ],


### PR DESCRIPTION
## Summary
- Reduce estimated time for `test_pp_single_node.py` from 800s to 500s

The test has 2 skipped tests in CI:
- `TestQwenPPAccuracy.test_pp_consistency` (skipped via `is_in_ci()`)
- `TestGLM41VPPAccuracy` (entire class skipped via `is_in_ci()`)

The actual runtime should be around 470s.

## Test plan
- [ ] Monitor CI runtime to confirm the new estimate is accurate