### PR TITLE
fix: skipping TestEPDDisaggregationOneEncoder test

### DIFF
--- a/test/srt/test_epd_disaggregation.py
+++ b/test/srt/test_epd_disaggregation.py
@@ -177,6 +177,7 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
 
         subprocess.run(cmd, check=True, timeout=3600)
 
+    @unittest.skip("Skipping because multi-encoder test already covers functionality.")
     def test_mmmu(self):
         """Test MMMU evaluation with EPD disaggregation"""
         import glob

--- a/test/srt/test_epd_disaggregation.py
+++ b/test/srt/test_epd_disaggregation.py
@@ -10,6 +10,7 @@ from sglang.test.server_fixtures.disaggregation_fixture import (
 from sglang.test.test_utils import (
     DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    is_in_ci,
     popen_launch_server,
 )
 
@@ -177,7 +178,7 @@ class TestEPDDisaggregationOneEncoder(PDDisaggregationServerBase):
 
         subprocess.run(cmd, check=True, timeout=3600)
 
-    @unittest.skip("Skipping because multi-encoder test already covers functionality.")
+    @unittest.skipIf(is_in_ci(), "Skipping in CI to reduce multi-GPU runtime")
     def test_mmmu(self):
         """Test MMMU evaluation with EPD disaggregation"""
         import glob


### PR DESCRIPTION
## Motivation

To conserve 4 gpu runner resource by skipping a redundant test.

## Modifications

Added the skip decorator.

## Accuracy Tests

https://github.com/sgl-project/sglang/actions/runs/20286435445

## Benchmarking and Profiling

n/a

## Checklist

- [Done] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [Done ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ Done] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ Done] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
