### PR TITLE
[Deepseek V3.2] Support Overlap Spec + NSA

### DIFF
--- a/docs/basic_usage/deepseek_v32.md
+++ b/docs/basic_usage/deepseek_v32.md
@@ -71,6 +71,10 @@ python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --dp
 - The best configuration for `--speculative-num-steps`, `--speculative-eagle-topk` and `--speculative-num-draft-tokens` can be searched with [bench_speculative.py](https://github.com/sgl-project/sglang/blob/main/scripts/playground/bench_speculative.py) script for given batch size. The minimum configuration is `--speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2`, which can achieve speedup for larger batch sizes.
 - The default value of  `--max-running-requests` is set to `48` for MTP. For larger batch sizes, this value should be increased beyond the default value.
 
+```{tip}
+To enable the experimental overlap scheduler for EAGLE speculative decoding, set the environment variable `SGLANG_ENABLE_SPEC_V2=1`. This can improve performance by enabling overlap scheduling between draft and verification stages.
+```
+
 
 ## Function Calling and Reasoning Parser
 The usage of function calling and reasoning parser is the same as DeepSeek V3.1. Please refer to [Reasoning Parser](https://docs.sglang.io/advanced_features/separate_reasoning.html) and [Tool Parser](https://docs.sglang.io/advanced_features/tool_parser.html) documents.

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -295,7 +295,7 @@ class Indexer(CustomOp):
         blocksize = page_size
         if (
             forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend()
+            or forward_batch.forward_mode.is_draft_extend(include_v2=True)
         ):
             seqlens_32 = metadata.get_seqlens_expanded()
         else:
@@ -900,7 +900,7 @@ class Indexer(CustomOp):
             if (
                 forward_batch.forward_mode.is_decode_or_idle()
                 or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend()
+                or forward_batch.forward_mode.is_draft_extend(include_v2=True)
             ):
                 topk_result = self._get_topk_paged(
                     forward_batch, layer_id, q_fp8, weights, metadata


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Part of V3.2 Roadmap https://github.com/sgl-project/sglang/issues/15025

Enable overlap spec and EAGLE + NSA backend.

```
SGLANG_ENABLE_SPEC_V2=1 python3 -m sglang.launch_server --model-path deepseek-ai/DeepSeek-V3.2 --trust-remote-code --tp 8 --speculative-algorithm EAGLE
```

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

In EAGLE V1, we had (with `python3 -m sglang.test.send_one --stream --max-new-tokens 1024`)

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    7.922    |  1024  |   2.960    |     129.26      |
+-------------+--------+------------+-----------------+
```

After simply adding in the guards for `include_v2=True`, we had a slowdown to:

```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    9.015    |  1024  |   2.960    |     113.59      |
+-------------+--------+------------+-----------------+
```

After profiling, we were able to find the root cause:
### EAGLE V1
<img width="780" height="491" alt="Screenshot 2025-12-16 at 9 43 56 PM" src="https://github.com/user-attachments/assets/3d5308c8-01a2-4158-abea-dfb766dc6e51" />

### EAGLE V2 (before code change)
<img width="680" height="802" alt="Screenshot 2025-12-16 at 9 45 11 PM" src="https://github.com/user-attachments/assets/58b2ad35-4c77-4717-a555-90a1cc8a0309" />

When we use `extend_seq_lens_cpu`, it will cause an unneeded sync. 

### EAGLE V2 (after code change)
<img width="867" height="804" alt="Screenshot 2025-12-16 at 9 52 52 PM" src="https://github.com/user-attachments/assets/a03eeafb-1238-4936-8469-07193e740159" />

It will increase to:
```
+-------------+--------+------------+-----------------+
| Latency (s) | Tokens | Acc Length | Speed (token/s) |
+-------------+--------+------------+-----------------+
|    7.306    |  1024  |   2.960    |     140.17      |
+-------------+--------+------------+-----------------+
```

So it is around 8%.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

`python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319`

Before:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:35<00:00,  8.46it/s]
Accuracy: 0.946
Invalid: 0.000
Latency: 156.114 s
Output throughput: 817.299 token/s
```

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 20 --num-questions 1319 --parallel 1319
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [02:23<00:00,  9.20it/s]
Accuracy: 0.955
Invalid: 0.000
Latency: 147.938 s
Output throughput: 868.237 token/s
```

After:
```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 8 --num-questions 1319 --parallel 1319
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:56<00:00, 11.31it/s]
Accuracy: 0.948
Invalid: 0.000
Latency: 116.809 s
Output throughput: 1112.259 token/s
```

```
python3 benchmark/gsm8k/bench_sglang.py --num-shots 20 --num-questions 1319 --parallel 1319
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:33<00:00, 14.16it/s]
Accuracy: 0.954
Invalid: 0.000
Latency: 93.615 s
Output throughput: 1390.591 token/s
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
