### PR TITLE
[model-gateway] reduce CPU overhead in metrics system

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{
     core::WorkerRegistry,
-    observability::metrics::{metrics_labels, Metrics},
+    observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     policies::PolicyRegistry,
     protocols::{
         chat::{ChatCompletionRequest, ChatCompletionResponse},
@@ -215,7 +215,7 @@ impl RequestPipeline {
             metrics_labels::CONNECTION_GRPC,
             &request_for_metrics.model,
             metrics_labels::ENDPOINT_CHAT,
-            streaming,
+            bool_to_static_str(streaming),
         );
 
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
@@ -320,7 +320,7 @@ impl RequestPipeline {
             metrics_labels::CONNECTION_GRPC,
             model_for_metrics.as_deref().unwrap_or("unknown"),
             metrics_labels::ENDPOINT_GENERATE,
-            streaming,
+            bool_to_static_str(streaming),
         );
 
         let mut ctx = RequestContext::for_generate(request, headers, model_id, components);

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     observability::{
         events::{self, Event},
-        metrics::{metrics_labels, Metrics},
+        metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
     policies::{LoadBalancingPolicy, PolicyRegistry},
@@ -288,7 +288,7 @@ impl PDRouter {
             metrics_labels::CONNECTION_HTTP,
             model,
             endpoint,
-            context.is_stream,
+            bool_to_static_str(context.is_stream),
         );
         // Clone request once outside the retry loop, then use Arc to share across attempts
         // This avoids O(retries) clones by sharing the same data

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     observability::{
         events::{self, Event},
-        metrics::{metrics_labels, Metrics},
+        metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
     policies::PolicyRegistry,
@@ -189,7 +189,7 @@ impl Router {
             metrics_labels::CONNECTION_HTTP,
             model,
             endpoint,
-            is_stream,
+            bool_to_static_str(is_stream),
         );
 
         let response = RetryExecutor::execute_response_with_retry(

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -36,7 +36,7 @@ use crate::{
     app_context::AppContext,
     core::{model_type::Endpoint, ModelCard, ProviderType, RuntimeType, Worker, WorkerRegistry},
     data_connector::{ConversationId, ListParams, ResponseId, SortOrder},
-    observability::metrics::{metrics_labels, Metrics},
+    observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     protocols::{
         chat::ChatCompletionRequest,
         responses::{
@@ -589,7 +589,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             metrics_labels::CONNECTION_HTTP,
             model,
             metrics_labels::ENDPOINT_CHAT,
-            streaming,
+            bool_to_static_str(streaming),
         );
 
         let auth_header = extract_auth_header(headers, &None);
@@ -782,7 +782,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             metrics_labels::CONNECTION_HTTP,
             model,
             metrics_labels::ENDPOINT_RESPONSES,
-            streaming,
+            bool_to_static_str(streaming),
         );
 
         let auth_header = extract_auth_header(headers, &None);


### PR DESCRIPTION
Key optimizations:
- Add bool_to_static_str() for zero-cost bool-to-string conversion
- Add status_code_to_static_str() lookup table for common HTTP codes
- Change record_router_request() streaming param from bool to &'static str
- Optimize record_streaming_metrics() to minimize string clones
- Update all router call sites to use static strings

This eliminates allocations for the streaming label (was bool.to_string()) and reduces allocations in record_streaming_metrics from 5 clones to max 3. Common HTTP status codes (200, 400, 500, etc.) now use static strings.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
