### PR TITLE
dsv32 support o_proj tp

### DIFF
--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Union
 import torch
 import torch.distributed
 
-from .parallel_state import get_tp_group
+from .parallel_state import get_o_proj_dp_group, get_o_proj_tp_group, get_tp_group
 
 
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
@@ -33,3 +33,22 @@ def broadcast_tensor_dict(
     if not torch.distributed.is_initialized():
         return tensor_dict
     return get_tp_group().broadcast_tensor_dict(tensor_dict, src)
+
+
+def o_proj_tensor_model_parallel_reduce_scatter_tensor(
+    output: torch.Tensor, input_: torch.Tensor
+) -> torch.Tensor:
+    """Reduce-scatter the input tensor across o_proj tp group."""
+    return get_o_proj_tp_group().reduce_scatter_tensor(output, input_)
+
+
+def o_proj_tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce the input tensor across o_proj tp group."""
+    return get_o_proj_tp_group().all_reduce(input_)
+
+
+def o_proj_data_model_parallel_all_gather(
+    input_: torch.Tensor, dim: int = -1
+) -> torch.Tensor:
+    """All-gather the input tensor across o_proj dp group."""
+    return get_o_proj_dp_group().all_gather(input_, dim)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -241,6 +241,7 @@ class Envs:
     # NPU
     SGLANG_NPU_DISABLE_ACL_FORMAT_WEIGHT = EnvBool(False)
     SGLANG_NPU_USE_MULTI_STREAM = EnvBool(False)
+    SGLANG_O_PROJ_TP_SIZE = EnvInt(0)
 
     # Quantization
     SGLANG_INT4_WEIGHT = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -411,8 +411,7 @@ def forward_dsa_core_npu(
         attn_output = attn_output.contiguous()
         torch.ops.npu.batch_matmul_transpose(attn_output, m.w_vc, attn_bmm_output)
 
-    attn_bmm_output = attn_bmm_output.reshape(-1, m.num_local_heads * m.v_head_dim)
-
+    attn_bmm_output = m.before_o_proj.prepare_o_proj(attn_bmm_output, forward_batch)
     output, _ = m.o_proj(attn_bmm_output)
     return output
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -30,6 +30,8 @@ from typing import (
 
 import torch
 
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
 try:
     from triton_kernels.routing import GatherIndx, RoutingData, ScatterIndx, routing
 except ImportError:
@@ -333,6 +335,7 @@ class TopK(CustomOp):
         self,
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
+        forward_batch: ForwardBatch,
         *,
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
@@ -346,6 +349,7 @@ class TopK(CustomOp):
             topk_config=self.topk_config,
             num_token_non_padded=num_token_non_padded,
             expert_location_dispatch_info=expert_location_dispatch_info,
+            forward_batch=forward_batch,
         )
 
     def empty_topk_output(self, device: torch.device) -> TopKOutput:

--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -949,6 +949,14 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
 
         cos, sin = self.get_cos_sin_cache(positions, query.dtype, offsets)
 
+        if cos.shape[0] == 0 or sin.shape[0] == 0:
+            sin = torch.empty(
+                [num_tokens, 1, 1, self.rotary_dim], device=sin.device, dtype=sin.dtype
+            )
+            cos = torch.empty(
+                [num_tokens, 1, 1, self.rotary_dim], device=cos.device, dtype=cos.dtype
+            )
+
         query_rot = query[..., : self.rotary_dim]
         key_rot = key[..., : self.rotary_dim]
         if self.rotary_dim < self.head_size:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2279,6 +2279,8 @@ class ModelWorkerBatch:
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
+    batch_size_max_across_dp: int = 0
+
     # For mamba state tracking
     mamba_track_indices: Optional[torch.Tensor] = None  # shape: [b], int64
     mamba_track_mask: Optional[torch.Tensor] = None  # shape: [b], bool

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -34,6 +34,7 @@ from torch.cuda import Stream as CudaStream
 from torch.cuda import StreamContext as CudaStreamContext
 from torch.distributed import barrier
 
+from python.sglang.srt.layers.communicator import get_max_bs_across_dp
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.constrained.base_grammar_backend import (
     INVALID_GRAMMAR_OBJ,
@@ -2195,6 +2196,7 @@ class Scheduler(
                     model_worker_batch.sampling_info.copy_for_forward()
                 )
 
+                get_max_bs_across_dp(model_worker_batch)
                 bs = len(model_worker_batch.seq_lens)
                 future_indices = self.future_map.alloc_future_indices(bs)
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -395,6 +395,8 @@ class ForwardBatch:
     # For hidden states before normal
     return_hidden_states_before_norm: bool = False
 
+    batch_size_max_across_dp: Optional[int] = None
+
     @classmethod
     def init_new(
         cls,
@@ -441,6 +443,9 @@ class ForwardBatch:
             return_hidden_states_before_norm=batch.return_hidden_states_before_norm,
         )
         device = model_runner.device
+
+        if batch.batch_size_max_across_dp is not None:
+            ret_batch_size_max_across_dp = batch.batch_size_max_across_dp
 
         if batch.extend_input_logprob_token_ids is not None:
             ret.extend_input_logprob_token_ids_gpu = (

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -45,6 +45,9 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.distributed import (
     divide,
     get_moe_expert_parallel_world_size,
+    get_o_proj_data_parallel_world_size,
+    get_o_proj_tensor_parallel_rank,
+    get_o_proj_tensor_parallel_world_size,
     get_pp_group,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
@@ -70,6 +73,7 @@ from sglang.srt.layers.attention.nsa.utils import (
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.attention.utils import concat_and_cast_mha_k_triton
 from sglang.srt.layers.communicator import (
+    BeforeOproj,
     LayerCommunicator,
     LayerScatterModes,
     enable_moe_dense_fully_dp,
@@ -87,6 +91,7 @@ from sglang.srt.layers.linear import (
     MergedColumnParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    TP2DPandTPRowParallelLinear,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import (
@@ -1015,6 +1020,7 @@ class DeepseekV2MoE(nn.Module):
             topk_output = self.topk(
                 hidden_states,
                 router_logits,
+                forward_batch=forward_batch,
                 num_token_non_padded=forward_batch.num_token_non_padded,
                 expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
                     layer_id=self.layer_id,
@@ -1297,6 +1303,12 @@ class DeepseekV2AttentionMLA(nn.Module):
         self.quant_config = quant_config
         attn_tp_rank = get_attention_tp_rank()
         attn_tp_size = get_attention_tp_size()
+        o_proj_tp_size = get_o_proj_tensor_parallel_world_size()
+        o_proj_dp_size = get_o_proj_data_parallel_world_size()
+        self.attn_tp_rank = attn_tp_rank
+        self.attn_tp_size = attn_tp_size
+        self.o_proj_tp_size = o_proj_tp_size
+        self.o_proj_dp_size = o_proj_dp_size
         self.use_nsa = is_deepseek_nsa(config)
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
@@ -1384,16 +1396,29 @@ class DeepseekV2AttentionMLA(nn.Module):
             tp_size=attn_tp_size,
         )
         # O projection.
-        self.o_proj = RowParallelLinear(
-            self.num_heads * self.v_head_dim,
-            self.hidden_size,
-            bias=False,
-            quant_config=quant_config,
-            reduce_results=reduce_results,
-            prefix=add_prefix("o_proj", prefix),
-            tp_rank=attn_tp_rank,
-            tp_size=attn_tp_size,
-        )
+        if envs.SGLANG_O_PROJ_TP_SIZE.get() > 0:
+            self.o_rpoj = TP2DPandTPRowParallelLinear(
+                self.num_heads * self.v_head_dim,
+                self.hidden_size,
+                bias=False,
+                quant_config=quant_config,
+                reduce_results=reduce_results,
+                prefix=add_prefix("o_proj", prefix),
+                tp_rank=get_o_proj_tensor_parallel_rank(),
+                tp_size=o_proj_tp_size,
+                attn_tp_size=attn_tp_size,
+            )
+        else:
+            self.o_proj = RowParallelLinear(
+                self.num_heads * self.v_head_dim,
+                self.hidden_size,
+                bias=False,
+                quant_config=quant_config,
+                reduce_results=reduce_results,
+                prefix=add_prefix("o_proj", prefix),
+                tp_rank=attn_tp_rank,
+                tp_size=attn_tp_size,
+            )
         self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
 
         if not skip_rope:
@@ -1522,6 +1547,14 @@ class DeepseekV2AttentionMLA(nn.Module):
                 self.weight_block_size = (
                     self.fused_qkv_a_proj_with_mqa.quant_method.quant_config.weight_block_size
                 )
+        self.before_o_proj = BeforeOproj(
+            self.num_heads,
+            self.v_head_dim,
+            attn_tp_size,
+            o_proj_tp_size,
+            o_proj_dp_size,
+            attn_tp_rank,
+        )
 
     def dispatch_attn_forward_method(
         self, forward_batch: ForwardBatch
@@ -1557,6 +1590,28 @@ class DeepseekV2AttentionMLA(nn.Module):
         state.hidden_states_after_attn = self.forward_core(
             state.pop("attn_intermediate_state")
         )
+
+    def process_idle(self, hidden_states, forward_batch: ForwardBatch):
+        forward_batch.attn_backend.init_forward_metadata(forward_batch)
+        bs = forward_batch.batch_size_max_across_dp
+        hidden_states = torch.empty(
+            (bs, self.hidden_states.shape[1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        forward_batch.attn_backend.forward_metadata.seq_lens_cpu_int = torch.full(
+            (bs,), 1, dtype=torch.int32
+        )
+        positions = torch.clamp(
+            forward_batch.attn_backend.forward_metadata.seq_lens_cpu_int - 1,
+            min=0,
+            dtype=torch.int64,
+            device=hidden_states.device,
+        )
+        forward_batch.attn_backend.forward_metadata.block_tables = torch.arange(
+            1, bs + 1, dtype=torch.int32, device=hidden_states.device
+        ).reshape(bs, -1)
+        return hidden_states, positions
 
     def forward(
         self,
@@ -1601,10 +1656,15 @@ class DeepseekV2AttentionMLA(nn.Module):
                 not get_attn_tp_context().input_scattered
                 and hidden_states.shape[0] == 0
             ):
-                assert (
-                    not self.o_proj.reduce_results
-                ), "short-circuiting allreduce will lead to hangs"
-                return hidden_states, None, forward_batch, None
+                if self.attn_tp_size == 1 and self.o_proj_tp_size > 1:
+                    hidden_states, positions, forward_batch = self.process_idle(
+                        hidden_states, forward_batch
+                    )
+                else:
+                    assert (
+                        not self.o_proj.reduce_results
+                    ), "short-circuiting allreduce will lead to hangs"
+                    return hidden_states, None, forward_batch, None
 
         attn_forward_method = self.dispatch_attn_forward_method(forward_batch)
         if attn_forward_method == AttnForwardMethod.MHA:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In order to improve the performance of DeepSeek-V3.2,  we enabled the `o_proj` layers to support tensor parallel and tensor parallel independently of `attn_tp`.

## Modifications

-  O_Proj Tensor Parallelism: Introduced tensor parallel and data parallel support for the` o_proj` layers, allowing them to operate independently of the attention tensor parallelism (`attn_tp`). This is controlled by the `O_PROJ_TP_SIZE` environment variable.
-  Distributed Communication Operations: Added new communication primitives  and corresponding parallel state groups (`_O_PROJ_TP`, `_OPROJ_DP`) to manage `o_proj` specific distributed communication.
-  New `BeforeOproj`  class:  The `BeforeOproj` class is to handle the reshaping and all-to-all communication before the `o_proj` layer, adapting behavior for both decode and prefill phases. The followling pictures show this process.
-  Synchronizing Batch Size : Implemented `batch_size_max_across_dp` in `ModelWorkerBatch` and `ForwardBatch` to synchronize the maximum batch size across data parallel groups
- Linear Layer Weight Loading: Updated the Linear layer's weight loading logic to correctly shard `o_proj` weights according to the new `o_proj` tensor and data parallel configurations.

**DP to DP+TP**
<img width="710" height="448" alt="p1" src="https://github.com/user-attachments/assets/cb39df5b-1923-4c08-ab6a-b47ba98d6964" />
**TP to DP**
<img width="793" height="721" alt="p2" src="https://github.com/user-attachments/assets/f262a1ea-cc2e-450e-88e1-1c1a1b1d4c5e" />
**TP to DP+TP**
<img width="789" height="740" alt="p3" src="https://github.com/user-attachments/assets/1d1d8772-088c-4c94-9303-6f00b6e2f4ed" />

## Accuracy Tests
We test on the GMS8K dataset. The accuracy is 0.965.
<img width="2302" height="99" alt="p4" src="https://github.com/user-attachments/assets/75fe9104-e15e-4499-be45-f93d867a7ee5" />


## Benchmarking and Profiling

### Benchmarking
Before(**prefill** TP, **decode** DP)
<img width="1640" height="944" alt="p5" src="https://github.com/user-attachments/assets/c449bcd7-a466-459a-8731-9a576e2dfde2" />
After (**prefill** TP -> o_proj TP16 + DP2, **decode** DP -> o_proj TP16 + DP2)
<img width="1653" height="972" alt="p6" src="https://github.com/user-attachments/assets/9817ad5b-bf0d-4d34-9b27-60f0e873932f" />
After (**prefill** TP -> o_proj TP8 + DP4, **decode** DP -> o_proj TP8 + DP4)
<img width="1622" height="918" alt="p7" src="https://github.com/user-attachments/assets/559ed447-36c9-4221-8fed-8900e90a201f" />
After (**prefill** TP -> o_proj TP4 + DP8, **decode** DP -> o_proj TP4 + DP8)
<img width="1619" height="916" alt="p8" src="https://github.com/user-attachments/assets/2f03cfa7-00ec-4049-bb4c-6c05c6ac5e49" />


**The benchmarking data comparing only the prefill phase are as follows:**
TP16：1033 ms
TP8 DP2： 1196 ms
TP4 DP4：1069 ms
Oproj TP8： 1038 ms
Oproj TP4： 1017 ms

### profilling
Before
<img width="840" height="330" alt="p9" src="https://github.com/user-attachments/assets/bd3e2bf7-27c1-46c0-8368-e1616799352c" />
After
<img width="1385" height="350" alt="p10" src="https://github.com/user-attachments/assets/dc1afc80-4fa5-4e84-bd47-a78f685596de" />
<img width="1271" height="246" alt="p11" src="https://github.com/user-attachments/assets/760d7382-d847-4df8-b011-0e70e9c094aa" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
