### PR TITLE
[Diffusion] Enhance trace export with gzip and integrity check

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/profiler.py
@@ -119,7 +119,9 @@ class SGLDiffusionProfiler:
         if dump_rank is None:
             dump_rank = self.rank
 
-        current_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        current_rank = (
+            torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        )
         if current_rank != dump_rank:
             return
 
@@ -133,25 +135,25 @@ class SGLDiffusionProfiler:
                 )
             )
             self.profiler.export_chrome_trace(trace_path)
-            
+
             if self._check_trace_integrity(trace_path):
                 logger.info(f"Saved profiler traces to: {CYAN}{trace_path}{RESET}")
             else:
                 logger.warning(f"Trace file may be corrupted: {trace_path}")
         except Exception as e:
             logger.error(f"Failed to save trace: {e}")
-    
+
     def _check_trace_integrity(self, trace_path: str) -> bool:
         try:
             if not os.path.exists(trace_path) or os.path.getsize(trace_path) == 0:
                 return False
-            
-            with gzip.open(trace_path, 'rb') as f:
+
+            with gzip.open(trace_path, "rb") as f:
                 content = f.read()
-                if content.count(b'\x1f\x8b') > 1:
+                if content.count(b"\x1f\x8b") > 1:
                     logger.warning("Multiple gzip headers detected")
                     return False
-            
+
             return True
         except Exception as e:
             logger.warning(f"Trace file integrity check failed: {e}")

--- a/python/sglang/multimodal_gen/runtime/utils/profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/profiler.py
@@ -153,5 +153,6 @@ class SGLDiffusionProfiler:
                     return False
             
             return True
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Trace file integrity check failed: {e}")
             return False

--- a/python/sglang/multimodal_gen/runtime/utils/profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/profiler.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 
 import torch
@@ -118,6 +119,10 @@ class SGLDiffusionProfiler:
         if dump_rank is None:
             dump_rank = self.rank
 
+        current_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        if current_rank != dump_rank:
+            return
+
         try:
             os.makedirs(self.log_dir, exist_ok=True)
             sanitized_profile_mode_id = self.profile_mode_id.replace(" ", "_")
@@ -128,6 +133,25 @@ class SGLDiffusionProfiler:
                 )
             )
             self.profiler.export_chrome_trace(trace_path)
-            logger.info(f"Saved profiler traces to: {CYAN}{trace_path}{RESET}")
+            
+            if self._check_trace_integrity(trace_path):
+                logger.info(f"Saved profiler traces to: {CYAN}{trace_path}{RESET}")
+            else:
+                logger.warning(f"Trace file may be corrupted: {trace_path}")
         except Exception as e:
             logger.error(f"Failed to save trace: {e}")
+    
+    def _check_trace_integrity(self, trace_path: str) -> bool:
+        try:
+            if not os.path.exists(trace_path) or os.path.getsize(trace_path) == 0:
+                return False
+            
+            with gzip.open(trace_path, 'rb') as f:
+                content = f.read()
+                if content.count(b'\x1f\x8b') > 1:
+                    logger.warning("Multiple gzip headers detected")
+                    return False
+            
+            return True
+        except Exception:
+            return False


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes a critical bug where trace files become corrupted when using multi-GPU profiling (e.g., --num-gpus 4 --ulysses-degree 4 --profile). The root cause was that all GPU ranks were simultaneously writing to the same trace file, causing multiple gzip streams to be concatenated, resulting in a corrupted gzip file with hundreds of headers (e.g., 738 headers in a 4-GPU setup) instead of a single valid stream. This made the trace file unopenable in Perfetto UI with error "Error -3 while decompressing data: invalid stored block lengths". The fix adds a distributed rank check in SGLDiffusionProfiler._export_trace() to ensure only the specified rank (default: rank 0) exports the trace file, preventing concurrent writes. Additionally, a `_check_trace_integrity()` method was added to validate the gzip format by detecting multiple gzip headers. Tested with 4-GPU setup: before the fix, trace files were corrupted and unusable; after the fix, a single valid trace file is generated that opens successfully in Perfetto UI. This fix applies to all multi-GPU profiling scenarios while maintaining backward compatibility with single-GPU workflows.


```shell
CUDA_VISIBLE_DEVICES=4,5,6,7 sglang generate --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers  --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 4   --ulysses-degree 4  --enable-torch-compile  --prompt "A cat walks on the grass, realistic" --num-frames 81 --height 720 --width 1280 --profile
```

main:

<img width="837" height="623" alt="图片" src="https://github.com/user-attachments/assets/12a48ee4-5e6d-4dfb-afee-ccb88e81f75d" />

pr:

<img width="1455" height="471" alt="图片" src="https://github.com/user-attachments/assets/56baa76a-53e5-49f5-95fa-132936560e96" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
