### PR TITLE
[model-gateway] optimize worker registry and reduce lock contention in grpc client fetch

### DIFF
--- a/sgl-model-gateway/src/core/circuit_breaker.rs
+++ b/sgl-model-gateway/src/core/circuit_breaker.rs
@@ -374,8 +374,14 @@ impl CircuitBreaker {
     }
 
     fn publish_gauge_metrics(&self) {
-        Metrics::set_worker_cb_consecutive_failures(&self.metric_label, self.failure_count());
-        Metrics::set_worker_cb_consecutive_successes(&self.metric_label, self.success_count());
+        Metrics::set_worker_cb_consecutive_failures(
+            &self.metric_label,
+            self.consecutive_failures(),
+        );
+        Metrics::set_worker_cb_consecutive_successes(
+            &self.metric_label,
+            self.consecutive_successes(),
+        );
     }
 }
 

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -705,8 +705,9 @@ impl PDRouter {
         let prefill_workers = if let Some(model) = effective_model_id {
             self.worker_registry
                 .get_by_model_fast(model)
-                .into_iter()
+                .iter()
                 .filter(|w| matches!(w.worker_type(), WorkerType::Prefill { .. }))
+                .cloned()
                 .collect()
         } else {
             self.worker_registry.get_prefill_workers()
@@ -715,8 +716,9 @@ impl PDRouter {
         let decode_workers = if let Some(model) = effective_model_id {
             self.worker_registry
                 .get_by_model_fast(model)
-                .into_iter()
+                .iter()
                 .filter(|w| matches!(w.worker_type(), WorkerType::Decode))
+                .cloned()
                 .collect()
         } else {
             self.worker_registry.get_decode_workers()


### PR DESCRIPTION
## Replace gRPC client RwLock with OnceCell for lock-free access

The grpc_client field was using `Arc<RwLock<Option<Arc<GrpcClient>>>>` which required acquiring a tokio RwLock on every single request just to get the cached client reference.

Changed to `Arc<OnceCell<Arc<GrpcClient>>>`:
- First request initializes the client (one-time lock)
- All subsequent requests are completely lock-free
- `OnceCell::get()` is just a pointer read after initialization

This eliminates the main source of contention under high concurrency for the gRPC router path where get_grpc_client() is called per-request.

## Change `get_by_model` to return `Arc<[Arc<dyn Worker>]>` for true O(1) reads

Previously get_by_model returned Vec<Arc<dyn Worker>> which required calling .to_vec() on the immutable snapshot - O(n) Arc clones on every call.

Now returns Arc<[Arc<dyn Worker>]> directly - just an atomic refcount bump.
This is the fastest possible read path with zero contention:
- No locks acquired
- No memory allocation
- No cloning of worker references
- Single atomic increment

Callers that just iterate (.iter(), .is_empty(), .len()) work unchanged via Deref. Only callers that need owned Vec call .to_vec() explicitly.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
