### PR TITLE
fix: adjust time for test_epd_disaggregation.py

### DIFF
--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -146,7 +146,7 @@ suites = {
         TestFile("test_multi_instance_release_memory_occupation.py", 64),
         TestFile("test_pp_single_node.py", 500),
         TestFile("test_piecewise_cuda_graph.py", 1260),
-        TestFile("test_epd_disaggregation.py", 400),
+        TestFile("test_epd_disaggregation.py", 150),
     ],
     "per-commit-8-gpu-h200": [
         TestFile("test_deepseek_v3_basic.py", 275),


### PR DESCRIPTION
## Motivation

Adjust time in run_suite.py for test_epd_disaggregation.py.

## Modifications

Same as motivation.

## Accuracy Tests

Verified approx time to be 117 seconds, so setting 150 seconds for a bit of buffer room: https://github.com/sgl-project/sglang/actions/runs/20319634101/job/58372560609#step:5:5252

## Benchmarking and Profiling

n/a

## Checklist

- [Done ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ Done] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [Done ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [Done ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [Done ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
