### PR TITLE
EAGLE v2 overlap Tree Compaction: fix tree mode (topk > 1) 

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1566,7 +1566,7 @@ class FlashInferMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.cuda_graph_kv_indices = torch.zeros(
-            (self.speculative_num_steps, max_bs * self.topk * self.max_context_len),
+            (self.speculative_num_steps, max_num_tokens * self.max_context_len),
             dtype=torch.int32,
             device="cuda",
         )

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1566,7 +1566,7 @@ class FlashInferMultiStepDraftBackend:
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         self.cuda_graph_kv_indices = torch.zeros(
-            (self.speculative_num_steps, max_bs * self.max_context_len),
+            (self.speculative_num_steps, max_bs * self.topk * self.max_context_len),
             dtype=torch.int32,
             device="cuda",
         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2095,13 +2095,6 @@ class ServerArgs:
                 logger.warning(
                     "Spec v2 is enabled for eagle/eagle3 speculative decoding and overlap schedule is turned on."
                 )
-                if (
-                    self.speculative_eagle_topk is not None
-                    and self.speculative_eagle_topk > 1
-                ):
-                    raise ValueError(
-                        "Spec v2 currently only supports topk = 1 for speculative decoding."
-                    )
             else:
                 self.disable_overlap_schedule = True
                 logger.warning(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -768,9 +768,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
             accept_length,
             accept_index,
         ) = verify_input.sample(batch, logits_output, vocab_mask)
-        new_seq_lens = batch.seq_lens + accept_length
-        verify_done = torch.get_device_module(self.device).Event()
-        verify_done.record()
 
         if not batch.forward_mode.is_idle():
             all_verified_id = predict[accept_index]
@@ -816,6 +813,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
         else:
             verified_id = torch.empty((0,), device=self.device, dtype=torch.int32)
             output_predict = predict
+
+        new_seq_lens = batch.seq_lens + accept_length
+        verify_done = torch.get_device_module(self.device).Event()
+        verify_done.record()
 
         next_draft_input = EagleDraftInput(
             verified_id=verified_id,


### PR DESCRIPTION
Tree mode accepts scattered positions. Overlap v2 assumes a dense prefix. This mismatch caused gibberish for `topk > 1`.

This PR compacts the verified window in tree mode so the rest of the pipeline can keep using the dense layout.

## Changes
- Pack `predict`, `hidden_states`, and `out_cache_loc` into `[bs * tree_size]` using a fused Triton kernel (`compact_data_tensors_kernel`).
- In `EAGLEWorkerV2.verify()`, compact data tensors and the `req_to_token` verify window when `topk > 1`.
- Fix `fill_new_verified_id` stride: use `self.speculative_num_steps + 1` (width of `accept_index`), not `self.speculative_num_draft_tokens`.

## Context
- Roadmap: [sgl-project/sglang#11762](https://github.com/sgl-project/sglang/issues/11762)
- Overlap spec skeleton: [PR #11398](https://github.com/sgl-project/sglang/pull/11398)
- Prior topk>1 attempt (abandoned?): [PR #11839](https://github.com/sgl-project/sglang/pull/11839)

## Testing
```
export SGLANG_ENABLE_SPEC_V2=1
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3-8B \
  --attention-backend flashinfer \
  --dtype bfloat16 \
  --speculative-algorithm EAGLE3 \
  --speculative-draft-model-path Tengyunw/qwen3_8b_eagle3 \
  --speculative-num-steps 5 \
  --speculative-eagle-topk 10 \
  --speculative-num-draft-tokens 32 \
  --disable-radix-cache \
  --disable-cuda-graph \
  --port 30001
```
```
python3 -m sglang.bench_serving \
  --port 30001 \
  --dataset-name sharegpt \
  --request-rate 15 \
  --num-prompts 1000 \
  --random-input-len 128 \
  --random-output-len 128
  ```

## Notes
- Spec v2 is enabled via `SGLANG_ENABLE_SPEC_V2=1` (replaces `--enable-beta-spec`).
- This does **not** enable `SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1` yet.
