### PR TITLE
fix(speculative): use target worker pp_rank instead of hardcoded 0

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -142,7 +142,7 @@ class EAGLEWorker(TpModelWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=target_worker.pp_rank,
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 nccl_port=nccl_port,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -121,7 +121,7 @@ class EagleDraftWorker(BaseDraftWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=target_worker.pp_rank,
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 nccl_port=nccl_port,

--- a/python/sglang/srt/speculative/standalone_worker.py
+++ b/python/sglang/srt/speculative/standalone_worker.py
@@ -76,7 +76,7 @@ class StandaloneWorker(EAGLEWorker):
                 server_args=server_args,
                 gpu_id=gpu_id,
                 tp_rank=tp_rank,
-                pp_rank=0,  # FIXME
+                pp_rank=target_worker.pp_rank,
                 dp_rank=dp_rank,
                 moe_ep_rank=moe_ep_rank,
                 nccl_port=nccl_port,


### PR DESCRIPTION
## Summary
- Fixes hardcoded `pp_rank=0` in speculative decoding draft workers
- Enables proper pipeline parallelism support for EAGLE/EAGLE3 speculative decoding

## Problem
The speculative decoding workers (`EagleWorker`, `EagleWorkerV2`, `StandaloneWorker`) had hardcoded `pp_rank=0` when creating draft model workers, marked with `# FIXME` comments:

```python
pp_rank=0,  # FIXME
```

This prevents proper pipeline parallelism support when the model is distributed across multiple GPUs using PP (pipeline parallelism).

## Solution
Changed all three files to use the target worker's actual `pp_rank`:

```python
# Before
pp_rank=0,  # FIXME

# After
pp_rank=target_worker.pp_rank,
```

## Files Changed
- `python/sglang/srt/speculative/eagle_worker.py`
- `python/sglang/srt/speculative/eagle_worker_v2.py`
- `python/sglang/srt/speculative/standalone_worker.py`

## Test Plan
- The change is straightforward attribute access that mirrors how `tp_rank` is already handled
- Draft workers will now correctly inherit pipeline parallelism configuration from target workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>