### PR TITLE
fix(managers): correct typos and type hints

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -250,8 +250,8 @@ class GenerateReqInput(BaseReq, APIServingTimingMixin):
     return_entropy: bool = False
 
     need_wait_for_image: Optional[bool] = None
-    num_items_assigned: Optional[List] = None
-    embedding_ports: Optional[List] = None
+    num_items_assigned: Optional[List[Any]] = None
+    embedding_ports: Optional[List[Any]] = None
 
     def contains_mm_input(self) -> bool:
         return (
@@ -733,8 +733,8 @@ class TokenizedGenerateReqInput(BaseReq):
     return_entropy: bool = False
 
     need_wait_for_image: bool = False
-    num_items_assigned: Optional[List] = None
-    embedding_ports: Optional[List] = None
+    num_items_assigned: Optional[List[Any]] = None
+    embedding_ports: Optional[List[Any]] = None
 
 
 @dataclass
@@ -963,7 +963,7 @@ class BatchTokenIDOutput(
     retraction_counts: List[int]
 
     # The trainer step id. Used to know which step's weights are used for sampling.
-    token_steps: List[List[int]] = None
+    token_steps: Optional[List[List[int]]] = None
 
 
 @dataclass
@@ -995,7 +995,7 @@ class BatchMultimodalDecodeReq(BaseBatchReq):
     return_bytes: List[bool]
 
     # The trainer step id. Used to know which step's weights are used for sampling.
-    token_steps: List[List[int]] = None
+    token_steps: Optional[List[List[int]]] = None
 
 
 @dataclass
@@ -1042,7 +1042,7 @@ class BatchStrOutput(
     retraction_counts: List[int]
 
     # The trainer step id. Used to know which step's weights are used for sampling.
-    token_steps: List[List[int]] = None
+    token_steps: Optional[List[List[int]]] = None
 
 
 @dataclass

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -510,7 +510,7 @@ class Req:
         self.kv_committed_freed = False
         self.kv_overallocated_freed = False
 
-        # for corss-endoder model
+        # for cross-encoder model
         self.token_type_ids = token_type_ids
 
         # The length of KV that have been removed in local attention chunked prefill
@@ -1784,7 +1784,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         return retracted_reqs, new_estimate_ratio, []
 
-    def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
+    def release_req(self, idx: int, remaining_req_count: int, server_args: ServerArgs):
         req = self.reqs[idx]
 
         if server_args.disaggregation_mode == "decode":
@@ -1794,7 +1794,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # TODO (csy): for preempted requests, we may want to insert into the tree
         release_kv_cache(req, self.tree_cache, is_insert=False)
         # NOTE(lsyin): we should use the newly evictable memory instantly.
-        num_tokens = remaing_req_count * envs.SGLANG_RETRACT_DECODE_STEPS.get()
+        num_tokens = remaining_req_count * envs.SGLANG_RETRACT_DECODE_STEPS.get()
         evict_from_tree_cache(self.tree_cache, num_tokens)
 
         req.reset_for_retract()


### PR DESCRIPTION
## Summary
Code quality improvements: typo corrections and type hint fixes in managers module.

## Changes

### Typo Fixes (schedule_batch.py)
- `remaing_req_count` → `remaining_req_count` (parameter name and usage)
- `corss-endoder` → `cross-encoder` (comment)

### Type Hint Fixes (io_struct.py)
- Added `Optional` wrapper for `token_steps: List[List[int]] = None` (3 occurrences)
- Added type parameter to `Optional[List]` → `Optional[List[Any]]` (4 occurrences)

## Rationale
- Improves code readability and maintainability
- Fixes type checker warnings (mypy/pyright)
- Enables proper IDE type inference for optional fields

## Test Plan
- No functional changes - typos and type annotations only
- Existing tests should pass unchanged
