### PR TITLE
fix(quantization): correct int8 scaling range on HIP

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_kernel.py
+++ b/python/sglang/srt/layers/quantization/fp8_kernel.py
@@ -243,9 +243,10 @@ def _per_token_group_quant_8bit_raw(
     if _is_hip:
         if dtype == torch.int8:
             bit8_max = 127.0
+            bit8_min = -128.0
         else:
             bit8_max = 224.0
-        bit8_min = -bit8_max  # TODO incorrect for int8
+            bit8_min = -bit8_max
     else:
         if dtype == torch.int8:
             info = torch.iinfo(dtype)


### PR DESCRIPTION
## Summary
- Fix incorrect int8 scaling range on HIP (AMD GPUs)
- The int8 type has an asymmetric range of [-128, 127], but the HIP path was computing `bit8_min = -bit8_max` which gives -127.0 instead of -128.0
- This addresses the TODO comment in fp8_kernel.py

## Technical Details
For signed 8-bit integers:
- Maximum value: 127 (2^7 - 1)
- Minimum value: -128 (-2^7)

The CUDA path correctly uses `torch.iinfo(dtype).min` to get -128, but the HIP path was manually computing `-bit8_max` which incorrectly gave -127.

## Test plan
- [x] Code review for correctness
- [ ] Run existing quantization tests on AMD GPU