### PR TITLE
[Diffusion] Fix `sglang generate --perf-dump-path` to include per-denoising-step timings

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/cli/generate.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/cli/generate.py
@@ -71,6 +71,7 @@ def maybe_dump_performance(args: argparse.Namespace, server_args, prompt: str, r
 
     timings = RequestTimings(request_id=timings_dict.get("request_id"))
     timings.stages = timings_dict.get("stages", {})
+    timings.steps = timings_dict.get("steps", [])
     timings.total_duration_ms = timings_dict.get("total_duration_ms", 0)
 
     PerformanceLogger.dump_benchmark_report(

--- a/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
+++ b/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
@@ -207,6 +207,12 @@ class PerformanceLogger:
             for name, duration_ms in timings.stages.items()
         ]
 
+        denoise_steps_ms = list(timings.steps)
+        denoise_steps = [
+            {"index": idx, "duration_ms": duration_ms}
+            for idx, duration_ms in enumerate(denoise_steps_ms)
+        ]
+
         report = {
             "timestamp": datetime.now(UTC).isoformat(),
             "request_id": timings.request_id,
@@ -214,6 +220,8 @@ class PerformanceLogger:
             "tag": tag,
             "total_duration_ms": timings.total_duration_ms,
             "steps": formatted_steps,
+            "denoise_steps_ms": denoise_steps_ms,
+            "denoise_steps": denoise_steps,
             "meta": meta or {},
         }
 


### PR DESCRIPTION
…mings

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`--perf-dump-path` previously only reported stage-level timings; denoising step timings were recorded internally but not exported, making step-level performance analysis difficult.

```shell
sglang generate   --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 8   --ulysses-degree 4 --attention-backend sage_attn  --enable-torch-compile --prompt "A cat walks on the grass, realistic" --num-frames 81 --height 720 --width 1280 --num-inference-steps 27 --guidance-scale 3.5 --guidance-scale-2 4.0 --perf-dump-path /home/sglang/bbuf/dump/wan_step_profile_cp4.json
```

main:

```shell
{
  "timestamp": "2025-12-18T09:54:57.458009+00:00",
  "request_id": "mocked_fake_id_for_offline_generate",
  "commit_hash": "N/A",
  "tag": "cli_generate",
  "total_duration_ms": 258634.50716499938,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 0.02987999323522672
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 4367.844829001115
    },
    {
      "name": "ConditioningStage",
      "duration_ms": 0.02050100010819733
    },
    {
      "name": "TimestepPreparationStage",
      "duration_ms": 2.1379899990279227
    },
    {
      "name": "LatentPreparationStage",
      "duration_ms": 1.3523620000341907
    },
    {
      "name": "DenoisingStage",
      "duration_ms": 246093.7836929952
    },
    {
      "name": "DecodingStage",
      "duration_ms": 8154.947353999887
    }
  ],
  "meta": {
    "prompt": "A cat walks on the grass, realistic",
    "model": "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
  }
}
```

pr:

```shell
{
  "timestamp": "2025-12-18T10:28:21.066035+00:00",
  "request_id": "mocked_fake_id_for_offline_generate",
  "commit_hash": "N/A",
  "tag": "cli_generate",
  "total_duration_ms": 210525.15494499676,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 0.03347200254211202
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 3120.2044490055414
    },
    {
      "name": "ConditioningStage",
      "duration_ms": 0.01699299900792539
    },
    {
      "name": "TimestepPreparationStage",
      "duration_ms": 1.414112004567869
    },
    {
      "name": "LatentPreparationStage",
      "duration_ms": 1.3658340030815452
    },
    {
      "name": "DenoisingStage",
      "duration_ms": 199231.02747400117
    },
    {
      "name": "DecodingStage",
      "duration_ms": 8155.960589996539
    }
  ],
  "denoise_steps_ms": [
    22829.026314997463,
    6259.82964499417,
    6281.114571997023,
    6233.437529001094,
    6267.051975002687,
    6281.4354069996625,
    6284.808896001778,
    6283.654501996352,
    6281.060893998074,
    6287.088049000886,
    6284.198787994683,
    6283.992575001321,
    6282.133450004039,
    6290.5464170034975,
    6284.620095000719,
    6284.751753999444,
    6286.800633999519,
    6287.583174998872,
    19135.74015100312,
    6218.878407002194,
    6239.349215997208,
    6272.819425998023,
    6289.981137000723,
    6285.385734998272,
    6286.325935994682,
    6287.876952999795,
    6285.685472998011
  ],
  "denoise_steps": [
    {
      "index": 0,
      "duration_ms": 22829.026314997463
    },
    {
      "index": 1,
      "duration_ms": 6259.82964499417
    },
...
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
