### PR TITLE
[AMD] Fix and add accuracy-test-2-gpu-amd back

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -464,7 +464,6 @@ jobs:
     needs: [check-changes, accuracy-test-1-gpu-amd]
     # Temporarily disabled - uncomment when ready to re-enable (tracked here: https://github.com/sgl-project/sglang/issues/13107)
     if: |
-      false &&
       always() &&
       (
         (inputs.target_stage == 'accuracy-test-2-gpu-amd') ||
@@ -497,7 +496,7 @@ jobs:
       - name: Evaluate accuracy (TP=2)
         timeout-minutes: 30
         run: |
-          bash scripts/ci/amd_ci_exec.sh -e SGLANG_USE_AITER=0 -e HF_HUB_ENABLE_HF_TRANSFER=0 python3 test_moe_eval_accuracy_large.py
+          bash scripts/ci/amd_ci_exec.sh -e SGLANG_USE_AITER_AR=0 -e SGLANG_USE_AITER=0 -e HF_HUB_ENABLE_HF_TRANSFER=0 python3 test_moe_eval_accuracy_large.py
 
   pr-test-amd-finish:
     needs:
@@ -515,7 +514,7 @@ jobs:
         performance-test-1-gpu-part-2-amd,
         performance-test-2-gpu-amd,
         accuracy-test-1-gpu-amd,
-        # accuracy-test-2-gpu-amd, # Temporarily disabled
+        accuracy-test-2-gpu-amd, # Temporarily disabled
       ]
     if: always()
     runs-on: ubuntu-latest

--- a/test/srt/test_moe_eval_accuracy_large.py
+++ b/test/srt/test_moe_eval_accuracy_large.py
@@ -61,7 +61,7 @@ class TestMoEEvalAccuracyLarge(CustomTestCase):
             model=self.model,
             eval_name="humaneval",
             num_examples=None,
-            num_threads=1,
+            num_threads=1024,
         )
 
         metrics = run_eval(args)

--- a/test/srt/test_moe_eval_accuracy_large.py
+++ b/test/srt/test_moe_eval_accuracy_large.py
@@ -61,7 +61,7 @@ class TestMoEEvalAccuracyLarge(CustomTestCase):
             model=self.model,
             eval_name="humaneval",
             num_examples=None,
-            num_threads=1024,
+            num_threads=1,
         )
 
         metrics = run_eval(args)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Co-author : @bingxche 
## Motivation

<!-- Describe the purpose and goals of this pull request. -->
 To add accuracy-test-2-gpu-amd(test_moe_eval_accuracy_large.py) back, we add SGLANG_USE_AITER_AR=0 into the command, disabling the aiter custom_allreduce in this test.
 
## Modifications

<!-- Detail the changes made in this pull request. -->
.github/workflows/pr-test-amd.yml

## Accuracy Tests
Device - MI-325
Settings - SGLANG_USE_AITER_AR=0, num_threads=1024
Before - 0.268
After - **0.422**
Ran 3 tests in **406.697s**
```
Score: **0.422**
Writing report to /tmp/humaneval_mistralai_Mixtral-8x7B-Instruct-v0.1.html
{'pass@1': 0.42195121951219516, 'pass@1:std': 0.47524689096990586, 'pass@2': 0.4445121951219513, 'pass@2:std': 0.4832881593555032, 'pass@5': 0.4695121951219512, 'pass@5:std': 0.499069628161961, 'score:std': 0.47524689096990586, 'score': 0.42195121951219516}
```
```
[2025-12-18 17:51:32 TP0] Decode batch, #running-req: 2, #token: 3282, token usage: 0.00, cuda graph: True, gen throughput (token/s): 204.54, #queue-req: 0, 
[2025-12-18 17:51:32 TP0] Decode batch, #running-req: 1, #token: 1733, token usage: 0.00, cuda graph: True, gen throughput (token/s): 169.94, #queue-req: 0, 
[2025-12-18 17:51:32 TP0] Decode batch, #running-req: 1, #token: 1773, token usage: 0.00, cuda graph: True, gen throughput (token/s): 123.76, #queue-req: 0, 
100%|█████████████████████████████████████████████████████████████████████████████████████████| 5000/5000 [02:59<00:00, 27.92it/s]
Total latency: 179.171 s
Score: 0.633
Writing report to /tmp/mmlu_mistralai_Mixtral-8x7B-Instruct-v0.1.html
{'other': 0.7285223367697594, 'other:std': 0.4447218699336571, 'score:std': 0.4820967122891422, 'stem': 0.6374321880650995, 'stem:std': 0.48074150401607635, 'humanities': 0.5173237753882916, 'humanities:std': 0.49969979668426523, 'social_sciences': 0.7045454545454546, 'social_sciences:std': 0.45624681590647115, 'score': 0.6326}
Writing results to /tmp/mmlu_mistralai_Mixtral-8x7B-Instruct-v0.1.json
WARNING:root:GITHUB_STEP_SUMMARY environment variable not set
.
----------------------------------------------------------------------
Ran 3 tests in 406.697s

OK
```

Settings - SGLANG_USE_AITER_AR=1(default), num_threads=1
Before - 0.268
After - **0.421**
Ran 3 tests in **1096.271s**
```
Total latency: 848.003 s
Score: **0.421**
Writing report to /tmp/humaneval_mistralai_Mixtral-8x7B-Instruct-v0.1.html
{'pass@1': 0.42073170731707316, 'pass@1:std': 0.4867106630046756, 'pass@2': 0.4292682926829269, 'pass@2:std': 0.493491247081309, 'pass@5': 0.4329268292682927, 'pass@5:std': 0.49548076629471227, 'score:std': 0.4867106630046756, 'score': 0.42073170731707316}
Writing results to /tmp/humaneval_mistralai_Mixtral-8x7B-Instruct-v0.1.json
WARNING:root:GITHUB_STEP_SUMMARY environment variable not set
```
```
Total latency: 183.573 s
Score: 0.640
Writing report to /tmp/mmlu_mistralai_Mixtral-8x7B-Instruct-v0.1.html
{'other': 0.7285223367697594, 'other:std': 0.4447218699336571, 'score:std': 0.4801164858656699, 'stem': 0.6482820976491862, 'stem:std': 0.4775064601832704, 'humanities': 0.5286738351254481, 'humanities:std': 0.4991771340708613, 'social_sciences': 0.7083333333333334, 'social_sciences:std': 0.45452967144315476, 'score': 0.6396}
Writing results to /tmp/mmlu_mistralai_Mixtral-8x7B-Instruct-v0.1.json
WARNING:root:GITHUB_STEP_SUMMARY environment variable not set
.
----------------------------------------------------------------------
Ran 3 tests in 1096.271s

OK
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
