### PR TITLE
fix(nsa_backend): use Tensor instead of list for repeat_interleave peats

### DIFF
--- a/python/sglang/srt/layers/attention/nsa_backend.py
+++ b/python/sglang/srt/layers/attention/nsa_backend.py
@@ -435,7 +435,7 @@ class NativeSparseAttnBackend(
                 # after verification. Lengths vary per request based on how many tokens
                 # were accepted.
                 page_table = torch.repeat_interleave(
-                    page_table, repeats=extend_seq_lens_cpu, dim=0
+                    page_table, repeats=forward_batch.extend_seq_lens, dim=0
                 )
 
         elif forward_batch.forward_mode.is_extend():


### PR DESCRIPTION

Fix TypeError in torch.repeat_interleave() when using EAGLE speculative decoding with NSA backend. The repeats parameter was incorrectly passed as a Python list (extend_seq_lens_cpu) instead of a Tensor.

torch.repeat_interleave() only accepts int or Tensor for the repeats parameter, not list. Changed to use forward_batch.extend_seq_lens which is the Tensor version containing the same data.

fix https://github.com/sgl-project/sglang/issues/15428