### PR TITLE
Feature/lora filesystem resolver #15417

### DIFF
--- a/docs/advanced_features/lora.ipynb
+++ b/docs/advanced_features/lora.ipynb
@@ -45,9 +45,7 @@
     "\n",
     "* `--max-lora-chunk-size`: Maximum chunk size for the ChunkedSGMV LoRA backend. Only used when --lora-backend is 'csgmv'. Choosing a larger value might improve performance. Please tune this value based on your hardware and workload as needed. Defaults to 16.\n",
     "\n",
-    "* `--lora-cache-dir`: Root directory for LoRA adapters. When a request specifies an adapter that isn't loaded, the system will automatically check this directory and load it if found. Similar to vLLM's `lora_filesystem_resolver`. Can also be set via `SGLANG_LORA_CACHE_DIR` environment variable.\n",
-    "\n",
-    "* `--allow-runtime-lora-updating`: Allow automatic discovery and loading of LoRA adapters from `--lora-cache-dir` at runtime. Similar to `VLLM_ALLOW_RUNTIME_LORA_UPDATING` in vLLM. When enabled, adapters will be automatically reloaded if their weights are updated (useful for RL training scenarios). Can also be set via `SGLANG_ALLOW_RUNTIME_LORA_UPDATING` environment variable.\n",
+    "* `--runtime-lora-cache-dir`: Root directory for LoRA adapters. When set, enables automatic discovery and loading of adapters from this directory at runtime. When a request specifies an adapter that isn't loaded, the system will automatically check this directory and load it if found. Adapters will also be automatically reloaded if their weights are updated (useful for RL training scenarios). Can also be set via `SGLANG_RUNTIME_LORA_CACHE_DIR` environment variable.\n",
     "\n",
     "* `tp_size`: LoRA serving along with Tensor Parallelism is supported by SGLang. `tp_size` controls the number of GPUs for tensor parallelism. More details on the tensor sharding strategy can be found in [S-Lora](https://arxiv.org/pdf/2311.03285) paper.\n",
     "\n",
@@ -401,17 +399,14 @@
    "source": [
     "### Filesystem Resolver (Auto-Discovery)\n",
     "\n",
-    "SGLang supports automatic discovery and loading of LoRA adapters from a filesystem directory, similar to vLLM's `lora_filesystem_resolver`. This feature is particularly useful for:\n",
+    "SGLang supports automatic discovery and loading of LoRA adapters from a filesystem directory. This feature is particularly useful for:\n",
     "\n",
     "* **Multi-tenant environments**: Different users can have their own adapters without requiring server restarts\n",
     "* **RL training scenarios**: Automatically reload adapters when weights are updated during training\n",
     "\n",
-    "To enable this feature:\n",
+    "To enable this feature, set `--runtime-lora-cache-dir` to specify the root directory for LoRA adapters.\n",
     "\n",
-    "1. Set `--lora-cache-dir` to specify the root directory for LoRA adapters\n",
-    "2. Enable `--allow-runtime-lora-updating` to allow automatic discovery and reloading\n",
-    "\n",
-    "When a request specifies an adapter that isn't currently loaded, the system will automatically check the `--lora-cache-dir` directory and load it if found. If the adapter is already loaded and `--allow-runtime-lora-updating` is enabled, the system will automatically reload it to pick up any weight updates.\n"
+    "When a request specifies an adapter that isn't currently loaded, the system will automatically check the `--runtime-lora-cache-dir` directory and load it if found. If the adapter is already loaded, the system will automatically reload it to pick up any weight updates.\n"
    ]
   },
   {
@@ -424,8 +419,7 @@
     "    \"\"\"\n",
     "python3 -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \\\n",
     "    --enable-lora \\\n",
-    "    --lora-cache-dir /tmp/sglang_lora_cache \\\n",
-    "    --allow-runtime-lora-updating \\\n",
+    "    --runtime-lora-cache-dir /tmp/sglang_lora_cache \\\n",
     "    --max-lora-rank 256 \\\n",
     "    --lora-target-modules all \\\n",
     "    --max-loras-per-batch 2 \\\n",
@@ -465,7 +459,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**RL Training Scenario**: When adapter weights are updated (e.g., during RL training), the system will automatically reload them on the next request if `--allow-runtime-lora-updating` is enabled. This allows seamless integration with training pipelines without manual intervention.\n"
+    "**RL Training Scenario**: When adapter weights are updated (e.g., during RL training), the system will automatically reload them on the next request if `--runtime-lora-cache-dir` is set. This allows seamless integration with training pipelines without manual intervention.\n"
    ]
   },
   {

--- a/docs/advanced_features/lora.ipynb
+++ b/docs/advanced_features/lora.ipynb
@@ -45,6 +45,10 @@
     "\n",
     "* `--max-lora-chunk-size`: Maximum chunk size for the ChunkedSGMV LoRA backend. Only used when --lora-backend is 'csgmv'. Choosing a larger value might improve performance. Please tune this value based on your hardware and workload as needed. Defaults to 16.\n",
     "\n",
+    "* `--lora-cache-dir`: Root directory for LoRA adapters. When a request specifies an adapter that isn't loaded, the system will automatically check this directory and load it if found. Similar to vLLM's `lora_filesystem_resolver`. Can also be set via `SGLANG_LORA_CACHE_DIR` environment variable.\n",
+    "\n",
+    "* `--allow-runtime-lora-updating`: Allow automatic discovery and loading of LoRA adapters from `--lora-cache-dir` at runtime. Similar to `VLLM_ALLOW_RUNTIME_LORA_UPDATING` in vLLM. When enabled, adapters will be automatically reloaded if their weights are updated (useful for RL training scenarios). Can also be set via `SGLANG_ALLOW_RUNTIME_LORA_UPDATING` environment variable.\n",
+    "\n",
     "* `tp_size`: LoRA serving along with Tensor Parallelism is supported by SGLang. `tp_size` controls the number of GPUs for tensor parallelism. More details on the tensor sharding strategy can be found in [S-Lora](https://arxiv.org/pdf/2311.03285) paper.\n",
     "\n",
     "From client side, the user needs to provide a list of strings as input batch, and a list of adaptor names that each input sequence corresponds to."
@@ -389,6 +393,88 @@
     ")\n",
     "print(f\"Output from lora0: \\n{response.json()[0]['text']}\\n\")\n",
     "print(f\"Output from lora1 (updated): \\n{response.json()[1]['text']}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filesystem Resolver (Auto-Discovery)\n",
+    "\n",
+    "SGLang supports automatic discovery and loading of LoRA adapters from a filesystem directory, similar to vLLM's `lora_filesystem_resolver`. This feature is particularly useful for:\n",
+    "\n",
+    "* **Multi-tenant environments**: Different users can have their own adapters without requiring server restarts\n",
+    "* **RL training scenarios**: Automatically reload adapters when weights are updated during training\n",
+    "\n",
+    "To enable this feature:\n",
+    "\n",
+    "1. Set `--lora-cache-dir` to specify the root directory for LoRA adapters\n",
+    "2. Enable `--allow-runtime-lora-updating` to allow automatic discovery and reloading\n",
+    "\n",
+    "When a request specifies an adapter that isn't currently loaded, the system will automatically check the `--lora-cache-dir` directory and load it if found. If the adapter is already loaded and `--allow-runtime-lora-updating` is enabled, the system will automatically reload it to pick up any weight updates.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "server_process, port = launch_server_cmd(\n",
+    "    \"\"\"\n",
+    "python3 -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \\\n",
+    "    --enable-lora \\\n",
+    "    --lora-cache-dir /tmp/sglang_lora_cache \\\n",
+    "    --allow-runtime-lora-updating \\\n",
+    "    --max-lora-rank 256 \\\n",
+    "    --lora-target-modules all \\\n",
+    "    --max-loras-per-batch 2 \\\n",
+    "    --log-level warning\n",
+    "\"\"\"\n",
+    ")\n",
+    "\n",
+    "wait_for_server(f\"http://localhost:{port}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you can use adapters directly without pre-loading them. The system will automatically discover and load them from the filesystem:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = f\"http://127.0.0.1:{port}\"\n",
+    "response = requests.post(\n",
+    "    url + \"/v1/chat/completions\",\n",
+    "    json={\n",
+    "        \"model\": \"meta-llama/Meta-Llama-3.1-8B-Instruct:test_adapter\",\n",
+    "        \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}],\n",
+    "        \"max_tokens\": 10,\n",
+    "    },\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**RL Training Scenario**: When adapter weights are updated (e.g., during RL training), the system will automatically reload them on the next request if `--allow-runtime-lora-updating` is enabled. This allows seamless integration with training pipelines without manual intervention.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "terminate_process(server_process)"
    ]
   },
   {

--- a/docs/advanced_features/lora.ipynb
+++ b/docs/advanced_features/lora.ipynb
@@ -401,6 +401,48 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -233,8 +233,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--lora-eviction-policy` | LoRA adapter eviction policy when the GPU memory pool is full. | `lru` | `lru`, `fifo` |
 | `--lora-backend` | Choose the kernel backend for multi-LoRA serving. | `triton` | `triton`, `csgmv` |
 | `--max-lora-chunk-size` | Maximum chunk size for the ChunkedSGMV LoRA backend. Only used when `--lora-backend` is `csgmv`. Larger values may improve performance. | `16` | `16`, `32`, `64`, `128` |
-| `--lora-cache-dir` | Root directory for LoRA adapters. When a request specifies an adapter that isn't loaded, the system will automatically check this directory and load it if found. Similar to vLLM's `lora_filesystem_resolver`. Can also be set via `SGLANG_LORA_CACHE_DIR` environment variable. | `None` | Type: str |
-| `--allow-runtime-lora-updating` | Allow automatic discovery and loading of LoRA adapters from `--lora-cache-dir` at runtime. Similar to `VLLM_ALLOW_RUNTIME_LORA_UPDATING` in vLLM. When enabled, adapters will be automatically reloaded if their weights are updated (useful for RL training scenarios). Can also be set via `SGLANG_ALLOW_RUNTIME_LORA_UPDATING` environment variable. | `False` | Bool flag (set to enable) |
+| `--runtime-lora-cache-dir` | Root directory for LoRA adapters. When set, enables automatic discovery and loading of adapters from this directory at runtime. When a request specifies an adapter that isn't loaded, the system will automatically check this directory and load it if found. Adapters will also be automatically reloaded if their weights are updated (useful for RL training scenarios). Can also be set via `SGLANG_RUNTIME_LORA_CACHE_DIR` environment variable. | `None` | Type: str |
 
 ## Kernel Backends (Attention, Sampling, Grammar, GEMM)
 | Argument | Description | Defaults | Options |

--- a/docs/advanced_features/server_arguments.md
+++ b/docs/advanced_features/server_arguments.md
@@ -233,6 +233,8 @@ Please consult the documentation below and [server_args.py](https://github.com/s
 | `--lora-eviction-policy` | LoRA adapter eviction policy when the GPU memory pool is full. | `lru` | `lru`, `fifo` |
 | `--lora-backend` | Choose the kernel backend for multi-LoRA serving. | `triton` | `triton`, `csgmv` |
 | `--max-lora-chunk-size` | Maximum chunk size for the ChunkedSGMV LoRA backend. Only used when `--lora-backend` is `csgmv`. Larger values may improve performance. | `16` | `16`, `32`, `64`, `128` |
+| `--lora-cache-dir` | Root directory for LoRA adapters. When a request specifies an adapter that isn't loaded, the system will automatically check this directory and load it if found. Similar to vLLM's `lora_filesystem_resolver`. Can also be set via `SGLANG_LORA_CACHE_DIR` environment variable. | `None` | Type: str |
+| `--allow-runtime-lora-updating` | Allow automatic discovery and loading of LoRA adapters from `--lora-cache-dir` at runtime. Similar to `VLLM_ALLOW_RUNTIME_LORA_UPDATING` in vLLM. When enabled, adapters will be automatically reloaded if their weights are updated (useful for RL training scenarios). Can also be set via `SGLANG_ALLOW_RUNTIME_LORA_UPDATING` environment variable. | `False` | Bool flag (set to enable) |
 
 ## Kernel Backends (Attention, Sampling, Grammar, GEMM)
 | Argument | Description | Defaults | Options |

--- a/python/sglang/srt/lora/lora_config.py
+++ b/python/sglang/srt/lora/lora_config.py
@@ -73,3 +73,26 @@ class LoRAConfig:
             logger = logging.getLogger(__name__)
             logger.warning(f"Failed to parse added_tokens.json: {e}")
             return None
+
+
+def is_valid_lora_adapter_path(adapter_path: str) -> bool:
+    """
+    Check if the specified path is a valid LoRA adapter directory.
+
+    Args:
+        adapter_path: Path to check
+
+    Returns:
+        True if the path is a valid LoRA adapter, False otherwise
+    """
+    config_file = os.path.join(adapter_path, "adapter_config.json")
+    if not os.path.exists(config_file):
+        return False
+
+    with open(config_file, "r") as f:
+        config = json.load(f)
+        return (
+            config.get("peft_type", "").lower() == "lora"
+            and "r" in config
+            and "target_modules" in config
+        )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2091,12 +2091,9 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
             if lora_path not in self.lora_ref_cache:
                 # Try auto-discovery from filesystem
-                if (
-                    self.server_args.allow_runtime_lora_updating
-                    and self.server_args.lora_cache_dir
-                ):
+                if self.server_args.runtime_lora_cache_dir:
                     adapter_path = os.path.normpath(
-                        os.path.join(self.server_args.lora_cache_dir, lora_path)
+                        os.path.join(self.server_args.runtime_lora_cache_dir, lora_path)
                     )
                     if is_valid_lora_adapter_path(adapter_path):
                         logger.info(
@@ -2122,10 +2119,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
             # Adapter is in cache, reload it
             cached_ref = self.lora_ref_cache[lora_path]
-            # If adapter is still in registry and allow_runtime_lora_updating is enabled,
+            # If adapter is still in registry and runtime_lora_cache_dir is set,
             # unload it first to pick up updated weights (for RL training scenario)
             if (
-                self.server_args.allow_runtime_lora_updating
+                self.server_args.runtime_lora_cache_dir
                 and lora_path in self.lora_registry._registry
             ):
                 logger.info(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3207,7 +3207,7 @@ class ServerArgs:
         parser.add_argument(
             "--allow-runtime-lora-updating",
             action="store_true",
-            default=get_bool_env_var("SGLANG_ALLOW_RUNTIME_LORA_UPDATING", False),
+            default=get_bool_env_var("SGLANG_ALLOW_RUNTIME_LORA_UPDATING", "false"),
             help="Allow automatic discovery and loading of LoRA adapters from --lora-cache-dir at runtime. "
             "Similar to VLLM_ALLOW_RUNTIME_LORA_UPDATING in vLLM. "
             "Can also be set via SGLANG_ALLOW_RUNTIME_LORA_UPDATING environment variable.",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

Add support for dynamic LoRA adapter discovery and loading from filesystem, similar to vLLM's `lora_filesystem_resolver`. This enables:
- Automatic discovery and loading of adapters from a configured directory
- Support for RL training scenarios where adapter weights are updated during training
- Multi-tenant environments without requiring server restarts

Addresses issue #15417.

## Modifications

- Added `--lora-cache-dir` and `--allow-runtime-lora-updating` server arguments
- Implemented `is_valid_lora_adapter_path()` function to validate LoRA adapter directories
- Modified `_resolve_lora_path()` in `tokenizer_manager.py` to:
  - Auto-discover adapters from filesystem when not in cache
  - Force reload adapters when `allow_runtime_lora_updating` is enabled (for RL training)
- Updated documentation in `lora.ipynb` and `server_arguments.md`


 
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
start  server:
```
 python -m sglang.launch_server \
    --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
    --enable-lora \
    --runtime-lora-cache-dir /tmp/sglang_lora_cache \
    --max-lora-rank 256 \
    --lora-target-modules all \
    --port 30000
```

Check whether the adapter is in the cache (it should NOT be) 
```
(.venv) root@04bb60a19a0b:~/sglang# curl http://localhost:30000/v1/models | jq '.data[] | select(.parent != null)'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   215  100   215    0     0  52903      0 --:--:-- --:--:-- --:--:-- 71666
```

Send the request (using an adapter that has not been preloaded)
```
(.venv) root@04bb60a19a0b:~/sglang# curl -X POST http://localhost:30000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "meta-llama/Meta-Llama-3.1-8B-Instruct:test_adapter",
        "messages": [{"role": "user", "content": "Test auto-discovery"}],
        "max_tokens": 10
    }'
{"id":"7f29fffa1cba4a18ae48f7e09e5370c6","object":"chat.completion","created":1766126048,"model":"meta-llama/Meta-Llama-3.1-8B-Instruct:test_adapter","choices":[{"index":0,"message":{"role":"assistant","content":"You are an text to SQL query translator. Users","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"length","matched_stop":null}],"usage":{"prompt_tokens":39,"total_tokens":49,"completion_tokens":10,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}(.venv) root@04bb60a19a0b:~/sglang#


[2025-12-19 06:32:49] The server is fired up and ready to roll!
[2025-12-19 06:33:36] INFO:     127.0.0.1:50696 - "GET /v1/models HTTP/1.1" 200 OK
[2025-12-19 06:34:05] Auto-discovering LoRA adapter 'test_adapter' from /tmp/sglang_lora_cache/test_adapter
[2025-12-19 06:34:05] Start load Lora adapter. Lora name=test_adapter, path=/tmp/sglang_lora_cache/test_adapter
[2025-12-19 06:34:05] LoRA adapter loading starts: LoRARef(lora_id=ea53009c851346c69a2814eac91bd528, lora_name=test_adapter, lora_path=/tmp/sglang_lora_cache/test_adapter, pinned=False). avail mem=4.77 GB
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 26.33it/s]

[2025-12-19 06:34:07] LoRA adapter loading completes: LoRARef(lora_id=ea53009c851346c69a2814eac91bd528, lora_name=test_adapter, lora_path=/tmp/sglang_lora_cache/test_adapter, pinned=False). avail mem=4.77 GB
[2025-12-19 06:34:07] Prefill batch, #new-seq: 1, #new-token: 39, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
[2025-12-19 06:34:08] INFO:     127.0.0.1:43446 - "POST /v1/chat/completions HTTP/1.1" 200 OK


(.venv) root@04bb60a19a0b:~/sglang#

```

Check the server logs, you should see:
<img width="1431" height="210" alt="image" src="https://github.com/user-attachments/assets/46861626-05cc-4b1b-8bc5-3df354024357" />


 Verify that the adapter is now loaded
 
<img width="1189" height="300" alt="image" src="https://github.com/user-attachments/assets/549863a9-a15a-4d34-ad37-f16aed957c50" />

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
