### PR TITLE
[model-gateway]Enable IGW mode with gRPC router and auto enable IGW when service discovery is turned on

### DIFF
--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -8,9 +8,7 @@ use tracing::{debug, info};
 
 use crate::{
     config::RouterConfig,
-    core::{
-        ConnectionMode, JobQueue, LoadMonitor, WorkerRegistry, WorkerService, UNKNOWN_MODEL_ID,
-    },
+    core::{JobQueue, LoadMonitor, WorkerRegistry, WorkerService, UNKNOWN_MODEL_ID},
     data_connector::{
         create_storage, ConversationItemStorage, ConversationStorage, ResponseStorage,
     },
@@ -290,8 +288,8 @@ impl AppContextBuilder {
             .with_client(&router_config, request_timeout_secs)?
             .maybe_rate_limiter(&router_config)
             .with_tokenizer_registry(&router_config)?
-            .maybe_reasoning_parser_factory(&router_config)
-            .maybe_tool_parser_factory(&router_config)
+            .with_reasoning_parser_factory()
+            .with_tool_parser_factory()
             .with_worker_registry()
             .with_policy_registry(&router_config)
             .with_storage(&router_config)?
@@ -435,19 +433,17 @@ impl AppContextBuilder {
         Ok(Some(tokenizer))
     }
 
-    /// Create reasoning parser factory for gRPC mode
-    fn maybe_reasoning_parser_factory(mut self, config: &RouterConfig) -> Self {
-        if matches!(config.connection_mode, ConnectionMode::Grpc { .. }) {
-            self.reasoning_parser_factory = Some(ReasoningParserFactory::new());
-        }
+    /// Create reasoning parser factory for gRPC mode or IGW mode
+    fn with_reasoning_parser_factory(mut self) -> Self {
+        // Initialize reasoning parser factory
+        self.reasoning_parser_factory = Some(ReasoningParserFactory::new());
         self
     }
 
-    /// Create tool parser factory for gRPC mode
-    fn maybe_tool_parser_factory(mut self, config: &RouterConfig) -> Self {
-        if matches!(config.connection_mode, ConnectionMode::Grpc { .. }) {
-            self.tool_parser_factory = Some(ToolParserFactory::new());
-        }
+    /// Create tool parser factory for gRPC mode or IGW mode
+    fn with_tool_parser_factory(mut self) -> Self {
+        // Initialize tool parser factory
+        self.tool_parser_factory = Some(ToolParserFactory::new());
         self
     }
 

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -516,26 +516,20 @@ impl CliArgs {
         &self,
         prefill_urls: Vec<(String, Option<u16>)>,
     ) -> ConfigResult<RouterConfig> {
-        let mode = if self.enable_igw {
-            RoutingMode::Regular {
-                worker_urls: vec![],
-            }
-        } else if matches!(self.backend, Backend::Openai) {
+        // Determine routing mode based on backend type and PD disaggregation flag
+        // IGW mode doesn't change routing mode, only affects router initialization
+        let mode = if matches!(self.backend, Backend::Openai) {
             RoutingMode::OpenAI {
                 worker_urls: self.worker_urls.clone(),
             }
         } else if self.pd_disaggregation {
-            let decode_urls = self.decode.clone();
-
-            // Allow empty URLs to support dynamic worker addition
             RoutingMode::PrefillDecode {
                 prefill_urls,
-                decode_urls,
+                decode_urls: self.decode.clone(),
                 prefill_policy: self.prefill_policy.as_ref().map(|p| self.parse_policy(p)),
                 decode_policy: self.decode_policy.as_ref().map(|p| self.parse_policy(p)),
             }
         } else {
-            // Allow empty URLs to support dynamic worker addition
             RoutingMode::Regular {
                 worker_urls: self.worker_urls.clone(),
             }
@@ -762,10 +756,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse_from(filtered_args);
 
     // Handle subcommands or use direct args
-    let cli_args = match cli.command {
+    let mut cli_args = match cli.command {
         Some(Commands::Launch { args }) => args,
         None => cli.router_args,
     };
+
+    // Automatically enable IGW mode when service discovery is turned on
+    if cli_args.service_discovery && !cli_args.enable_igw {
+        println!("INFO: IGW mode automatically enabled because service discovery is turned on");
+        cli_args.enable_igw = true;
+    }
 
     println!("SGLang Router starting...");
     println!("Host: {}:{}", cli_args.host, cli_args.port);


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

  - Enable IGW mode to spin up gRPC routers (regular and PD) and select them preferentially when matching workers are present.
  - Auto-enable IGW when service discovery is requested, aligning router initialization with discovery-driven worker registration.
  - Improve readiness reporting by returning 200 when any registered worker is healthy.

## Motivation

  - IGW mode internally uses all types of routers; previously parser factories and router creation logic were tied to explicit single gRPC instance, leaving IGW without the necessary gRPC router coverage.
  - Service discovery implies IGW behavior; requiring a separate flag led to misconfiguration risk and silent misalignment between discovery and router mode.
  - Operators need the router manager to pick the best transport (gRPC vs HTTP, PD vs regular) based on available workers and to surface health when capacity exists.

## Modifications

  - `sgl-model-gateway/src/app_context.rs`: Initialize reasoning/tool parser factories when either gRPC or IGW is enabled, reflecting IGW’s gRPC router usage.
  - `sgl-model-gateway/src/main.rs`: Decouple routing-mode selection from IGW, streamline PD routing config, and automatically flip enable_igw on when service discovery is requested (with an info log).
  - `sgl-model-gateway/src/routers/router_manager.rs`: Always create a gRPC regular router in IGW mode; create HTTP and gRPC PD routers only when PD disaggregation is enabled; choose routers based on worker connection mode/role priority (grpc-pd > http-pd > grpc-regular > http-regular); update health endpoint to report ready if any worker is healthy.
 
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Screenshot

<img width="1920" height="1080" alt="Screenshot 2025-12-18 at 11 32 15 PM" src="https://github.com/user-attachments/assets/dfe69275-36f1-4362-90fe-b7c5e4c88442" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
