### PR TITLE
feat: enhance accuracy for baichuan2-13B chat/base from 0 to 50%

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -420,7 +420,8 @@ class ModelConfig:
                         or self.hf_text_config.head_dim is None
                     ):
                         setattr(self.hf_text_config, "head_dim", self.head_dim)
-
+            elif "BaichuanForCausalLM" in self.hf_config.architectures:
+                self.use_alibi = True if self.hf_config.hidden_size !=4096 else False
             self.attention_arch = AttentionArch.MHA
 
         self.num_attention_heads = self.hf_text_config.num_attention_heads

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -242,6 +242,8 @@ class AscendAttnBackend(AttentionBackend):
             self.q_head_dim = (
                 self.qk_rope_head_dim + model_runner.model_config.qk_nope_head_dim
             )
+        else:
+            self.use_alibi = hasattr(model_runner.model_config, "use_alibi") and model_runner.model_config.use_alibi
         self.native_attn = TorchNativeAttnBackend(model_runner)
         self.graph_metadata = {}
         self.max_context_len = model_runner.model_config.context_len
@@ -421,7 +423,99 @@ class AscendAttnBackend(AttentionBackend):
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 0
+    
+    def _generate_alibi_bias(
+        self,
+        seq_len: int,
+        slopes: torch.Tensor,
+        num_heads: int,
+        device: torch.device
+    ) -> torch.Tensor:
+        position_point = torch.arange(seq_len) - seq_len + 1
+        position_point = position_point.unsqueeze(0).unsqueeze(0).expand(num_heads, -1, -1)
+        diag = torch.diag(position_point[0])
+        position_point = position_point - diag.unsqueeze(0).unsqueeze(0).transpose(-1, -2)
+        position_point = position_point.to(device)
+        alibi = slopes.unsqueeze(1).unsqueeze(1) * position_point
+        alibi_bias = alibi.view(num_heads, 1, seq_len)
+        alibi_bias = alibi_bias.to(device).to(torch.bfloat16)
+        return alibi_bias
+    
+    def generate_alibi_bias(
+        self,
+        q_seq_len: int,
+        kv_seq_len: int,
+        slopes: torch.Tensor,
+        num_heads: int,
+        device: torch.device
+    ) -> torch.Tensor:
+        if not hasattr(self, "alibi_bias") or self.alibi_bias is None:
+            MAX_LEN_ALB=5000
+            seq_len=max(kv_seq_len,q_seq_len)
+            seq_len=max(seq_len,MAX_LEN_ALB)
+            self.alibi_bias = self._generate_alibi_bias(seq_len,slopes,num_heads,device)
+        return self.alibi_bias
+    
+    def attn_alibi(self,q,k_cache,v_cache,mask,block_tables,seq_lens,query_lens,scale_value,num_heads,slopes,is_extend):
+        curr=0
+        num_prompts=query_lens.shape[0]
+        head_size = k_cache.shape[3]
+        head_size_v = v_cache.shape[3]
+        block_size = k_cache.shape[1]
+        attn_output = []
+        for i in range(num_prompts):
+            seq_len = seq_lens[i].item()
+            block_table = block_tables[i]
 
+            j= torch.arange(seq_len,device=block_table.device)
+
+            block_number = block_table[j // block_size]
+            block_offset = j % block_size
+
+            k = k_cache[block_number,block_offset]
+            v = v_cache[block_number,block_offset]
+            k = k.view(seq_len, num_heads, head_size)
+            v = v.view(seq_len, num_heads, head_size_v)
+            
+            if is_extend:
+                q_len = query_lens[i].item()
+                querys = q[curr :curr + q_len]
+                assert q_len==seq_len, "Warning: Q sequence length is not consistant with KV sequence length during Prefill phase."
+            else:
+                q_len = 1
+                querys = q[curr :curr + 1]
+            
+            querys = querys.to(torch.float32)
+            querys = querys * scale_value
+            querys = querys.permute(1, 0, 2)
+            k = k.permute(1, 2, 0)
+
+            score = torch.matmul(querys, k)
+            if is_extend:
+                score = score + mask[:, :seq_len, :seq_len]
+            score = score.to(torch.float32)
+            if slopes is not None:
+                alibi_bias = self.generate_alibi_bias(
+                    q_seq_len=q_len,
+                    kv_seq_len=seq_len,
+                    slopes=slopes,
+                    num_heads=num_heads,
+                    device=q.device)
+                score = score + alibi_bias[:,:q_len,:seq_len]
+            score = torch.max(
+                score, torch.tensor(torch.finfo(score.dtype).min)
+                )
+            p = torch.nn.functional.softmax(score, dim=-1)
+            v = v.permute(1,0,2)
+            out = torch.matmul(p, v)
+            out = out.permute(1, 0, 2)
+            out = out.reshape(-1, num_heads * head_size_v)
+            attn_output.append(out)
+            curr += q_len
+        attn_output = torch.cat(attn_output, dim=0).to(q.dtype).to(q.device)
+        attn_output = attn_output.view(-1, num_heads * head_size)
+        return attn_output
+    
     def do_cp_balance_attn(
         self,
         q_nope,
@@ -610,6 +704,7 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
         topk_indices: Optional[torch.Tensor] = None,
+        slopes:  Optional[torch.Tensor] = None,
     ):
         if topk_indices is not None:
             return self.forward_sparse(
@@ -682,26 +777,45 @@ class AscendAttnBackend(AttentionBackend):
 
             else:
                 if layer.qk_head_dim <= 128:
-                    query = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
-                    attn_output = torch.empty(
-                        (query.shape[0], layer.tp_q_head_num * layer.v_head_dim),
-                        dtype=query.dtype,
-                        device=query.device,
-                    )
+                    if not self.use_alibi:
+                        query = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
+                        attn_output = torch.empty(
+                            (query.shape[0], layer.tp_q_head_num * layer.v_head_dim),
+                            dtype=query.dtype,
+                            device=query.device,
+                        )
 
-                    torch_npu._npu_flash_attention_qlens(
-                        query=query,
-                        key_cache=k_cache,
-                        value_cache=v_cache,
-                        mask=self.mask,
-                        block_table=self.forward_metadata.block_tables,
-                        seq_len=self.forward_metadata.extend_seq_lens_cpu_int,
-                        context_lens=self.forward_metadata.seq_lens_cpu_int,
-                        scale_value=layer.scaling,
-                        num_heads=layer.tp_q_head_num,
-                        num_kv_heads=layer.tp_k_head_num,
-                        out=attn_output,
-                    )
+                        torch_npu._npu_flash_attention_qlens(
+                            query=query,
+                            key_cache=k_cache,
+                            value_cache=v_cache,
+                            mask=self.mask,
+                            block_table=self.forward_metadata.block_tables,
+                            seq_len=self.forward_metadata.extend_seq_lens_cpu_int,
+                            context_lens=self.forward_metadata.seq_lens_cpu_int,
+                            scale_value=layer.scaling,
+                            num_heads=layer.tp_q_head_num,
+                            num_kv_heads=layer.tp_k_head_num,
+                            out=attn_output,
+                        )
+                    else:
+                        max_seq_len = max(self.forward_metadata.seq_lens_cpu_int)
+                        mask = torch.ones(size=(1, max_seq_len, max_seq_len), dtype=q.dtype)
+                        mask = mask.float().fill_(float("-inf")).type_as(mask)
+                        mask = torch.triu(mask, 1).to(q.device)
+                        attn_output = self.attn_alibi(
+                            q=q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                            k_cache=k_cache,
+                            v_cache=v_cache,
+                            mask=mask,
+                            block_tables=self.forward_metadata.block_tables,
+                            seq_lens=self.forward_metadata.seq_lens_cpu_int,
+                            query_lens=self.forward_metadata.extend_seq_lens_cpu_int,
+                            scale_value=layer.scaling,
+                            num_heads=layer.tp_q_head_num,
+                            slopes=slopes,
+                            is_extend=True
+                        )
                 else:
                     if layer.qk_head_dim != layer.v_head_dim:
                         attn_output = q.new_empty(
@@ -1239,6 +1353,7 @@ class AscendAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
         topk_indices: Optional[torch.Tensor] = None,
+        slopes:  Optional[torch.Tensor] = None,
     ):
         if is_mla_preprocess_enabled():
             # MLAPO does saving kv_cache
@@ -1308,23 +1423,38 @@ class AscendAttnBackend(AttentionBackend):
             else:
                 query = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
                 num_tokens = query.shape[0]
-                attn_output = torch.empty(
-                    (num_tokens, layer.tp_q_head_num, layer.v_head_dim),
-                    dtype=query.dtype,
-                    device=query.device,
-                )
+                if not self.use_alibi:
+                    attn_output = torch.empty(
+                        (num_tokens, layer.tp_q_head_num, layer.v_head_dim),
+                        dtype=query.dtype,
+                        device=query.device,
+                    )
 
-                torch_npu._npu_paged_attention(
-                    query=query,
-                    key_cache=k_cache,
-                    value_cache=v_cache,
-                    num_heads=layer.tp_q_head_num,
-                    num_kv_heads=layer.tp_k_head_num,
-                    scale_value=layer.scaling,
-                    block_table=self.forward_metadata.block_tables,
-                    context_lens=self.forward_metadata.seq_lens_cpu_int,
-                    out=attn_output,
-                )
+                    torch_npu._npu_paged_attention(
+                        query=query,
+                        key_cache=k_cache,
+                        value_cache=v_cache,
+                        num_heads=layer.tp_q_head_num,
+                        num_kv_heads=layer.tp_k_head_num,
+                        scale_value=layer.scaling,
+                        block_table=self.forward_metadata.block_tables,
+                        context_lens=self.forward_metadata.seq_lens_cpu_int,
+                        out=attn_output,
+                    )
+                else:
+                    attn_output = self.attn_alibi(
+                        q=query,
+                        k_cache=k_cache,
+                        v_cache=v_cache,
+                        mask=None,
+                        block_tables=self.forward_metadata.block_tables,
+                        seq_lens=self.forward_metadata.seq_lens_cpu_int,
+                        query_lens=torch.ones(num_tokens,dtype=torch.int32),
+                        scale_value=layer.scaling,
+                        num_heads=layer.tp_q_head_num,
+                        slopes=slopes,
+                        is_extend=False
+                    )
             return attn_output.view(num_tokens, layer.tp_q_head_num * layer.v_head_dim)
         else:
             if save_kv_cache:

--- a/python/sglang/srt/models/baichuan.py
+++ b/python/sglang/srt/models/baichuan.py
@@ -32,7 +32,7 @@ from sglang.srt.distributed import (
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
-    MergedColumnParallelLinear,
+    ColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
 )
@@ -46,7 +46,8 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, is_npu
+_is_npu = is_npu()
 
 
 def _get_alibi_slopes(total_num_heads: int) -> torch.Tensor:
@@ -84,12 +85,19 @@ class BaiChuanMLP(nn.Module):
         prefix: str = "",
     ):
         super().__init__()
-        self.gate_up_proj = MergedColumnParallelLinear(
+        self.gate_proj = ColumnParallelLinear(
             hidden_size,
-            [intermediate_size] * 2,
+            intermediate_size,
             bias=False,
             quant_config=quant_config,
-            prefix=add_prefix("gate_up_proj", prefix),
+            prefix=add_prefix("gate_proj", prefix),
+        )
+        self.up_proj = ColumnParallelLinear(
+            hidden_size,
+            intermediate_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("up_proj", prefix),
         )
         self.down_proj = RowParallelLinear(
             intermediate_size,
@@ -103,13 +111,15 @@ class BaiChuanMLP(nn.Module):
                 f"Unsupported activation: {hidden_act}. "
                 "Only silu is supported for now."
             )
-        self.act_fn = SiluAndMul()
+        self.act_fn = torch.nn.functional.silu
 
     def forward(self, x):
-        gate_up, _ = self.gate_up_proj(x)
-        x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
-        return x
+        d = x.dtype
+        x0, _ = self.gate_proj(x)
+        x1, _ = self.up_proj(x)
+        y = self.act_fn(x0.to(torch.float32)) * x1.permute(0, 1)
+        z, _ = self.down_proj(y)
+        return z.to(d)
 
 
 class BaiChuanAttention(nn.Module):
@@ -124,29 +134,21 @@ class BaiChuanAttention(nn.Module):
         max_position_embeddings: int = 8192,
         quant_config: Optional[QuantizationConfig] = None,
         layer_id: int = 0,
+        dtype: Optional[torch.dtype] = torch.bfloat16,
         prefix: str = "",
     ):
         super().__init__()
         self.hidden_size = hidden_size
-        tensor_model_parallel_world_size = get_tensor_model_parallel_world_size()
         tp_size = get_tensor_model_parallel_world_size()
         self.total_num_heads = num_heads
-        assert self.total_num_heads % tensor_model_parallel_world_size == 0
-        self.num_heads = self.total_num_heads // tensor_model_parallel_world_size
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
         self.head_dim = hidden_size // self.total_num_heads
-        self.postion_embedding = position_embedding
+        self.position_embedding = position_embedding
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
-        self.total_num_kv_heads = self.num_heads
-        if self.total_num_kv_heads >= tp_size:
-            # Number of KV heads is greater than TP size, so we partition
-            # the KV heads across multiple tensor parallel GPUs.
-            assert self.total_num_kv_heads % tp_size == 0
-        else:
-            # Number of KV heads is less than TP size, so we replicate
-            # the KV heads across multiple tensor parallel GPUs.
-            assert tp_size % self.total_num_kv_heads == 0
-        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.total_num_kv_heads = self.total_num_heads
+        self.num_kv_heads = self.num_heads
 
         # pylint: disable=invalid-name
         self.W_pack = QKVParallelLinear(
@@ -156,26 +158,29 @@ class BaiChuanAttention(nn.Module):
             self.total_num_heads,
             bias=False,
             quant_config=quant_config,
+            prefix=add_prefix("W_pack", prefix),
         )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
             bias=False,
             quant_config=quant_config,
+            prefix=add_prefix("o_proj", prefix),
         )
+        self.scaling = self.head_dim**-0.5
         # Create the alibi slopes and slice them.
-        if self.postion_embedding == "ALIBI":
+        if self.position_embedding == "ALIBI":
             tp_rank = get_tensor_model_parallel_rank()
             head_start = tp_rank * self.num_heads
             head_end = (tp_rank + 1) * self.num_heads
             alibi_slopes = _get_alibi_slopes(self.total_num_heads)
-            alibi_slopes = alibi_slopes[head_start:head_end].tolist()
+            alibi_slopes = alibi_slopes[head_start: head_end]
+            self.alibi_slopes = torch.tensor(alibi_slopes, dtype=dtype, device="npu" if _is_npu else "cuda")
 
-            scaling = self.head_dim**-0.5
             self.attn = RadixAttention(
                 self.num_heads,
                 self.head_dim,
-                scaling,
+                self.scaling,
                 num_kv_heads=self.num_kv_heads,
                 layer_id=layer_id,
                 quant_config=quant_config,
@@ -188,7 +193,7 @@ class BaiChuanAttention(nn.Module):
                 max_position=self.max_position_embeddings,
                 base=self.rope_theta,
             )
-            self.scaling = self.head_dim**-0.5
+
             self.attn = RadixAttention(
                 self.num_heads,
                 self.head_dim,
@@ -207,9 +212,12 @@ class BaiChuanAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.W_pack(hidden_states)
         q, k, v = qkv.chunk(chunks=3, dim=-1)
-        if self.postion_embedding != "ALIBI":
+        if self.position_embedding != "ALIBI":
             q, k = self.rotary_emb(positions, q, k)
-        attn_output = self.attn(q, k, v, forward_batch)
+            attn_output = self.attn(q, k, v, forward_batch)
+        else:
+            attn_output = self.attn(q, k, v, forward_batch, slopes=self.alibi_slopes)
+            
         output, _ = self.o_proj(attn_output)
         return output
 
@@ -292,6 +300,8 @@ class BaiChuanModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            prefix=add_prefix("embed_tokens",prefix),
         )
         self.layers = nn.ModuleList(
             [
@@ -330,19 +340,25 @@ class BaiChuanModel(nn.Module):
 class BaiChuanBaseForCausalLM(nn.Module):
     packed_modules_mapping = {
         "W_pack": ["W_pack"],
-        "gate_up_proj": [
-            "gate_proj",
-            "up_proj",
+        "gate_proj": [
+            "gate_proj"
+        ],
+        "up_proj": [
+            "up_proj"
+        ],
+        "down_proj": [
+            "down_proj"
         ],
     }
     # LoRA specific attributes
     supported_lora_modules = [
         "W_pack",
         "o_proj",
-        "gate_up_proj",
+        "gate_proj",
+        "up_proj",
         "down_proj",
     ]
-    embedding_modules = {}
+    embedding_modules = {"embed_tokens":["embed_tokens"],}
     embedding_padding_modules = []
 
     def __init__(
@@ -383,11 +399,6 @@ class BaiChuanBaseForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
@@ -403,24 +414,11 @@ class BaiChuanBaseForCausalLM(nn.Module):
                 if is_baichuan2:
                     loaded_weight = torch.nn.functional.normalize(loaded_weight)
 
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
 
 
 class BaichuanForCausalLM(BaiChuanBaseForCausalLM):


### PR DESCRIPTION
## Motivation

Previously, the Baichuan-2-13B model exhibited zero effective accuracy—it failed to generate meaningful outputs for any queries and repeatedly repeated certain phrases. This issue persisted across both NPU and GPU environments, with near-zero performance on the GSM8K benchmark.


## Modifications
As follows.

## Accuracy Tests
The model now generates coherent and correct responses to individual queries.
GSM8K benchmark performance improved significantly: 1-shot accuracy reaches 56%. (the original model achieved 52% accuracy with 4-shot prompting)

<img width="1409" height="175" alt="image" src="https://github.com/user-attachments/assets/5c3ee2e9-9425-4003-ae5c-a2bd603332ab" />
