### PR TITLE
Optimize MiMo-V2-Flash by flashinfer fused allreduce

### DIFF
--- a/python/sglang/srt/models/mimo_v2_flash.py
+++ b/python/sglang/srt/models/mimo_v2_flash.py
@@ -13,7 +13,7 @@
 # ==============================================================================
 
 import logging
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -45,7 +45,11 @@ from sglang.srt.layers.linear import (
     RowParallelLinear,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.moe import get_moe_a2a_backend, get_moe_runner_backend
+from sglang.srt.layers.moe import (
+    get_moe_a2a_backend,
+    get_moe_runner_backend,
+    should_use_flashinfer_cutlass_moe_fp4_allgather,
+)
 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
 from sglang.srt.layers.moe.topk import TopK, TopKOutputFormat
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -110,13 +114,21 @@ class MiMoV2MLP(nn.Module):
             )
         self.act_fn = SiluAndMul()
 
-    def forward(self, x, forward_batch: ForwardBatch = None):
+    def forward(
+        self,
+        x,
+        forward_batch: ForwardBatch = None,
+        should_allreduce_fusion: bool = False,
+        use_reduce_scatter: bool = False,
+    ):
         if (self.tp_size == 1) and x.shape[0] == 0:
             return x
 
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
+        x, _ = self.down_proj(
+            x, skip_all_reduce=should_allreduce_fusion or use_reduce_scatter
+        )
         return x
 
 
@@ -250,11 +262,13 @@ class MiMoV2MoE(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: Optional[ForwardBatch] = None,
         should_allreduce_fusion: bool = False,
+        use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
         if not self._enable_a2a_moe:
             return self.forward_normal(
                 hidden_states,
                 should_allreduce_fusion,
+                use_reduce_scatter,
             )
         else:
             return self.forward_deepep(hidden_states, forward_batch)
@@ -263,6 +277,7 @@ class MiMoV2MoE(nn.Module):
         self,
         hidden_states: torch.Tensor,
         should_allreduce_fusion: bool = False,
+        use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
 
         if hidden_states.shape[0] > 0:
@@ -274,7 +289,12 @@ class MiMoV2MoE(nn.Module):
 
         final_hidden_states = self.experts(hidden_states, topk_output)
 
-        if self.tp_size > 1 and not should_allreduce_fusion:
+        if (
+            self.tp_size > 1
+            and not should_allreduce_fusion
+            and not use_reduce_scatter
+            and not should_use_flashinfer_cutlass_moe_fp4_allgather()
+        ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         return final_hidden_states
@@ -527,6 +547,8 @@ class MiMoV2DecoderLayer(nn.Module):
             layer_scatter_modes=self.layer_scatter_modes,
             input_layernorm=self.input_layernorm,
             post_attention_layernorm=self.post_attention_layernorm,
+            allow_reduce_scatter=True,
+            is_last_layer=(self.layer_id == self.config.num_hidden_layers - 1),
         )
 
     def forward(
@@ -535,10 +557,16 @@ class MiMoV2DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Self Attention
-        hidden_states, residual = self.layer_communicator.prepare_attn(
-            hidden_states, residual, forward_batch
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+            )
         )
 
         if hidden_states.shape[0] != 0:
@@ -552,11 +580,27 @@ class MiMoV2DecoderLayer(nn.Module):
             hidden_states, residual, forward_batch
         )
 
-        hidden_states = self.mlp(hidden_states, forward_batch)
-
-        hidden_states, residual = self.layer_communicator.postprocess_layer(
-            hidden_states, residual, forward_batch
+        should_allreduce_fusion = (
+            self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
+                forward_batch
+            )
         )
+
+        # For DP with padding, reduce scatter can be used instead of all-reduce.
+        use_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(
+            forward_batch
+        )
+
+        hidden_states = self.mlp(
+            hidden_states, forward_batch, should_allreduce_fusion, use_reduce_scatter
+        )
+
+        if should_allreduce_fusion:
+            hidden_states._sglang_needs_allreduce_fusion = True
+        else:
+            hidden_states, residual = self.layer_communicator.postprocess_layer(
+                hidden_states, residual, forward_batch
+            )
 
         return hidden_states, residual
 
@@ -625,6 +669,11 @@ class MiMoV2Model(nn.Module):
     def get_input_embeddings(self) -> nn.Embedding:
         return self.embed_tokens
 
+    def set_eagle3_layers_to_capture(self, layers_to_capture: List[int]):
+        self.layers_to_capture = layers_to_capture
+        for layer_id in self.layers_to_capture:
+            setattr(self.layers[layer_id], "_is_layer_to_capture", True)
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -643,6 +692,8 @@ class MiMoV2Model(nn.Module):
             assert pp_proxy_tensors is not None
             hidden_states = pp_proxy_tensors["hidden_states"]
             residual = pp_proxy_tensors["residual"]
+
+        aux_hidden_states = []
         for i in range(self.start_layer, self.end_layer):
             layer = self.layers[i]
             hidden_states, residual = layer(
@@ -650,6 +701,11 @@ class MiMoV2Model(nn.Module):
                 hidden_states,
                 forward_batch,
                 residual,
+                captured_last_layer_outputs=(
+                    aux_hidden_states
+                    if getattr(layer, "_is_layer_to_capture", False)
+                    else None
+                ),
             )
 
         hidden_states_before_norm = None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to make MiMo-V2-Flash model leverage FlashInfer fused_allreduce to fuse allreduce+rmsnorm+residual_add.
The E2E TTFT reduce 5.1%.

```
➜  sglang git:(main) python3 -m sglang.launch_server --model XiaomiMiMo/MiMo-V2-Flash --tp-size 4 --port 30000 --attention-backend triton --disable-radix-cache --trust-remote-code --enable-flashinfer-allreduce-fusion
......
[2025-12-19 07:41:50] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:41:51] Using default HuggingFace chat template with detected content format: string
You are using a model of type mimo_v2_flash to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
[2025-12-19 07:41:59 TP1] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
You are using a model of type mimo_v2_flash to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
You are using a model of type mimo_v2_flash to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
[2025-12-19 07:42:00 TP1] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:00 TP1] Init torch distributed begin.
You are using a model of type mimo_v2_flash to instantiate a model of type . This is not supported for all configurations of models and can yield errors.
[2025-12-19 07:42:00 TP3] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:00 TP0] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:00 TP2] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:01 TP3] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:01 TP3] Init torch distributed begin.
[2025-12-19 07:42:01 TP0] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:01 TP0] Init torch distributed begin.
[2025-12-19 07:42:01 TP2] DeepGemm is enabled but the scale_fmt of checkpoint is not ue8m0. This might cause accuracy degradation on Blackwell.
[2025-12-19 07:42:01 TP2] Init torch distributed begin.
[rank3]:[W1219 07:42:02.718905056 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[rank1]:[W1219 07:42:02.752562321 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[rank2]:[W1219 07:42:03.926457611 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[rank0]:[W1219 07:42:03.934431221 ProcessGroupGloo.cpp:516] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[2025-12-19 07:42:03 TP0] sglang is using nccl==2.27.5
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[2025-12-19 07:42:05 TP0] Init torch distributed ends. mem usage=1.46 GB
[2025-12-19 07:42:05 TP3] Init torch distributed ends. mem usage=1.33 GB
[2025-12-19 07:42:05 TP2] Init torch distributed ends. mem usage=1.49 GB
[2025-12-19 07:42:05 TP1] Init torch distributed ends. mem usage=1.49 GB
[2025-12-19 07:42:06 TP0] Load weight begin. avail mem=176.25 GB
[2025-12-19 07:42:06 TP0] Detected fp8 checkpoint.
[2025-12-19 07:42:06 TP0] Skipping block quantization checks for weight partition.
[2025-12-19 07:42:06 TP1] Load weight begin. avail mem=176.22 GB
[2025-12-19 07:42:06 TP1] Skipping block quantization checks for weight partition.
[2025-12-19 07:42:06 TP2] Load weight begin. avail mem=176.22 GB
[2025-12-19 07:42:06 TP3] Load weight begin. avail mem=176.38 GB
[2025-12-19 07:42:06 TP2] Skipping block quantization checks for weight partition.
[2025-12-19 07:42:06 TP3] Skipping block quantization checks for weight partition.
[2025-12-19 07:42:06 TP0] Found local HF snapshot for XiaomiMiMo/MiMo-V2-Flash at /root/.cache/huggingface/hub/models--XiaomiMiMo--MiMo-V2-Flash/snapshots/5a6637311bf106051fc92b9cff04f836d8a017c5; skipping download.
Loading safetensors checkpoint shards:   0% Completed | 0/145 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   1% Completed | 1/145 [00:00<01:40,  1.43it/s]
Loading safetensors checkpoint shards:   1% Completed | 2/145 [00:01<01:11,  1.99it/s]
Loading safetensors checkpoint shards:   2% Completed | 3/145 [00:01<01:24,  1.67it/s]
Loading safetensors checkpoint shards:   3% Completed | 4/145 [00:02<01:09,  2.04it/s]
Loading safetensors checkpoint shards:   3% Completed | 5/145 [00:02<01:01,  2.29it/s]
Loading safetensors checkpoint shards:   4% Completed | 6/145 [00:02<01:03,  2.18it/s]
Loading safetensors checkpoint shards:   5% Completed | 7/145 [00:03<01:16,  1.82it/s]
Loading safetensors checkpoint shards:   6% Completed | 8/145 [00:04<01:11,  1.92it/s]
Loading safetensors checkpoint shards:   6% Completed | 9/145 [00:04<01:12,  1.88it/s]
Loading safetensors checkpoint shards:   8% Completed | 11/145 [00:05<01:00,  2.21it/s]
Loading safetensors checkpoint shards:   8% Completed | 12/145 [00:05<01:00,  2.20it/s]
Loading safetensors checkpoint shards:   9% Completed | 13/145 [00:06<00:59,  2.22it/s]
Loading safetensors checkpoint shards:  11% Completed | 16/145 [00:06<00:40,  3.22it/s]
Loading safetensors checkpoint shards:  12% Completed | 17/145 [00:07<00:43,  2.94it/s]
Loading safetensors checkpoint shards:  13% Completed | 19/145 [00:07<00:37,  3.33it/s]
Loading safetensors checkpoint shards:  15% Completed | 22/145 [00:08<00:34,  3.55it/s]
Loading safetensors checkpoint shards:  18% Completed | 26/145 [00:08<00:19,  5.97it/s]
Loading safetensors checkpoint shards:  19% Completed | 28/145 [00:09<00:19,  5.91it/s]
Loading safetensors checkpoint shards:  21% Completed | 30/145 [00:09<00:23,  4.96it/s]
Loading safetensors checkpoint shards:  21% Completed | 31/145 [00:10<00:30,  3.76it/s]
Loading safetensors checkpoint shards:  23% Completed | 34/145 [00:10<00:26,  4.20it/s]
Loading safetensors checkpoint shards:  24% Completed | 35/145 [00:11<00:31,  3.55it/s]
Loading safetensors checkpoint shards:  25% Completed | 36/145 [00:11<00:36,  3.02it/s]
Loading safetensors checkpoint shards:  26% Completed | 37/145 [00:12<00:38,  2.80it/s]
Loading safetensors checkpoint shards:  27% Completed | 39/145 [00:12<00:33,  3.14it/s]
Loading safetensors checkpoint shards:  28% Completed | 41/145 [00:13<00:30,  3.43it/s]
Loading safetensors checkpoint shards:  29% Completed | 42/145 [00:14<00:38,  2.66it/s]
Loading safetensors checkpoint shards:  30% Completed | 43/145 [00:14<00:32,  3.16it/s]
Loading safetensors checkpoint shards:  30% Completed | 44/145 [00:14<00:32,  3.15it/s]
Loading safetensors checkpoint shards:  31% Completed | 45/145 [00:14<00:34,  2.87it/s]
Loading safetensors checkpoint shards:  32% Completed | 47/145 [00:15<00:34,  2.87it/s]
Loading safetensors checkpoint shards:  33% Completed | 48/145 [00:16<00:34,  2.80it/s]
Loading safetensors checkpoint shards:  34% Completed | 49/145 [00:16<00:36,  2.64it/s]
Loading safetensors checkpoint shards:  34% Completed | 50/145 [00:17<00:43,  2.16it/s]
Loading safetensors checkpoint shards:  35% Completed | 51/145 [00:17<00:45,  2.04it/s]
Loading safetensors checkpoint shards:  36% Completed | 52/145 [00:18<00:44,  2.08it/s]
Loading safetensors checkpoint shards:  37% Completed | 54/145 [00:18<00:34,  2.62it/s]
Loading safetensors checkpoint shards:  38% Completed | 55/145 [00:19<00:36,  2.45it/s]
Loading safetensors checkpoint shards:  39% Completed | 56/145 [00:19<00:36,  2.42it/s]
Loading safetensors checkpoint shards:  39% Completed | 57/145 [00:20<00:38,  2.31it/s]
Loading safetensors checkpoint shards:  40% Completed | 58/145 [00:20<00:44,  1.94it/s]
Loading safetensors checkpoint shards:  41% Completed | 59/145 [00:21<00:43,  1.96it/s]
Loading safetensors checkpoint shards:  41% Completed | 60/145 [00:22<00:48,  1.75it/s]
Loading safetensors checkpoint shards:  42% Completed | 61/145 [00:22<00:43,  1.95it/s]
Loading safetensors checkpoint shards:  43% Completed | 62/145 [00:23<00:47,  1.76it/s]
Loading safetensors checkpoint shards:  45% Completed | 65/145 [00:23<00:31,  2.54it/s]
Loading safetensors checkpoint shards:  48% Completed | 69/145 [00:23<00:15,  4.90it/s]
Loading safetensors checkpoint shards:  49% Completed | 71/145 [00:24<00:14,  5.03it/s]
Loading safetensors checkpoint shards:  50% Completed | 73/145 [00:24<00:14,  4.88it/s]
Loading safetensors checkpoint shards:  51% Completed | 74/145 [00:25<00:20,  3.47it/s]
Loading safetensors checkpoint shards:  52% Completed | 75/145 [00:25<00:22,  3.11it/s]
Loading safetensors checkpoint shards:  52% Completed | 76/145 [00:26<00:23,  2.88it/s]
Loading safetensors checkpoint shards:  53% Completed | 77/145 [00:26<00:23,  2.85it/s]
Loading safetensors checkpoint shards:  54% Completed | 78/145 [00:27<00:29,  2.26it/s]
Loading safetensors checkpoint shards:  55% Completed | 80/145 [00:28<00:24,  2.66it/s]
Loading safetensors checkpoint shards:  56% Completed | 81/145 [00:28<00:23,  2.70it/s]
Loading safetensors checkpoint shards:  58% Completed | 84/145 [00:29<00:18,  3.21it/s]
Loading safetensors checkpoint shards:  59% Completed | 85/145 [00:29<00:20,  2.95it/s]
Loading safetensors checkpoint shards:  59% Completed | 86/145 [00:29<00:20,  2.94it/s]
Loading safetensors checkpoint shards:  60% Completed | 87/145 [00:30<00:24,  2.35it/s]
Loading safetensors checkpoint shards:  61% Completed | 88/145 [00:31<00:28,  1.99it/s]
Loading safetensors checkpoint shards:  61% Completed | 89/145 [00:32<00:31,  1.78it/s]
Loading safetensors checkpoint shards:  63% Completed | 91/145 [00:32<00:22,  2.38it/s]
Loading safetensors checkpoint shards:  63% Completed | 92/145 [00:32<00:21,  2.49it/s]
Loading safetensors checkpoint shards:  64% Completed | 93/145 [00:33<00:25,  2.07it/s]
Loading safetensors checkpoint shards:  67% Completed | 97/145 [00:34<00:12,  3.92it/s]
Loading safetensors checkpoint shards:  68% Completed | 98/145 [00:34<00:15,  3.00it/s]
Loading safetensors checkpoint shards:  68% Completed | 99/145 [00:35<00:16,  2.80it/s]
Loading safetensors checkpoint shards:  70% Completed | 101/145 [00:35<00:13,  3.23it/s]
Loading safetensors checkpoint shards:  71% Completed | 103/145 [00:36<00:13,  3.18it/s]
Loading safetensors checkpoint shards:  72% Completed | 104/145 [00:36<00:14,  2.75it/s]
Loading safetensors checkpoint shards:  72% Completed | 105/145 [00:37<00:14,  2.81it/s]
Loading safetensors checkpoint shards:  74% Completed | 107/145 [00:37<00:11,  3.27it/s]
Loading safetensors checkpoint shards:  74% Completed | 108/145 [00:38<00:12,  2.99it/s]
Loading safetensors checkpoint shards:  75% Completed | 109/145 [00:38<00:15,  2.34it/s]
Loading safetensors checkpoint shards:  77% Completed | 111/145 [00:39<00:11,  3.06it/s]
Loading safetensors checkpoint shards:  78% Completed | 113/145 [00:39<00:10,  2.94it/s]
Loading safetensors checkpoint shards:  79% Completed | 114/145 [00:40<00:13,  2.37it/s]
Loading safetensors checkpoint shards:  79% Completed | 115/145 [00:40<00:12,  2.49it/s]
Loading safetensors checkpoint shards:  81% Completed | 117/145 [00:41<00:08,  3.17it/s]
Loading safetensors checkpoint shards:  81% Completed | 118/145 [00:41<00:09,  2.91it/s]
Loading safetensors checkpoint shards:  83% Completed | 120/145 [00:42<00:08,  3.09it/s]
Loading safetensors checkpoint shards:  84% Completed | 122/145 [00:42<00:06,  3.34it/s]
Loading safetensors checkpoint shards:  86% Completed | 124/145 [00:43<00:05,  3.80it/s]
Loading safetensors checkpoint shards:  87% Completed | 126/145 [00:43<00:04,  3.97it/s]
Loading safetensors checkpoint shards:  88% Completed | 127/145 [00:44<00:04,  3.67it/s]
Loading safetensors checkpoint shards:  88% Completed | 128/145 [00:44<00:05,  3.26it/s]
[2025-12-19 07:42:52 TP1] Setting sliding_window_size to be attention_chunk_size: 128
[2025-12-19 07:42:52 TP1] Load weight end. type=MiMoV2FlashForCausalLM, dtype=torch.bfloat16, avail mem=103.19 GB, mem usage=73.04 GB.
Loading safetensors checkpoint shards:  89% Completed | 129/145 [00:45<00:06,  2.51it/s]
Loading safetensors checkpoint shards:  90% Completed | 130/145 [00:45<00:06,  2.36it/s]
Loading safetensors checkpoint shards:  90% Completed | 131/145 [00:46<00:06,  2.33it/s]
Loading safetensors checkpoint shards:  92% Completed | 133/145 [00:46<00:03,  3.70it/s]
Loading safetensors checkpoint shards:  94% Completed | 136/145 [00:46<00:01,  5.10it/s]
Loading safetensors checkpoint shards:  95% Completed | 138/145 [00:47<00:01,  4.74it/s]
[2025-12-19 07:42:54 TP3] Setting sliding_window_size to be attention_chunk_size: 128
[2025-12-19 07:42:54 TP3] Load weight end. type=MiMoV2FlashForCausalLM, dtype=torch.bfloat16, avail mem=103.34 GB, mem usage=73.04 GB.
Loading safetensors checkpoint shards:  96% Completed | 139/145 [00:47<00:01,  3.19it/s]
[2025-12-19 07:42:55 TP2] Setting sliding_window_size to be attention_chunk_size: 128
[2025-12-19 07:42:55 TP2] Load weight end. type=MiMoV2FlashForCausalLM, dtype=torch.bfloat16, avail mem=103.19 GB, mem usage=73.04 GB.
Loading safetensors checkpoint shards:  98% Completed | 142/145 [00:48<00:00,  3.75it/s]
Loading safetensors checkpoint shards:  99% Completed | 143/145 [00:48<00:00,  3.50it/s]
Loading safetensors checkpoint shards:  99% Completed | 144/145 [00:49<00:00,  3.32it/s]
Loading safetensors checkpoint shards: 100% Completed | 145/145 [00:49<00:00,  2.87it/s]
Loading safetensors checkpoint shards: 100% Completed | 145/145 [00:49<00:00,  2.91it/s]

[2025-12-19 07:42:57 TP0] Setting sliding_window_size to be attention_chunk_size: 128
[2025-12-19 07:42:57 TP0] Load weight end. type=MiMoV2FlashForCausalLM, dtype=torch.bfloat16, avail mem=103.22 GB, mem usage=73.04 GB.
[2025-12-19 07:42:57 TP0] Using KV cache dtype: torch.bfloat16
[2025-12-19 07:42:57 TP0] The available memory for KV cache is 77.63 GB.
[2025-12-19 07:42:57 TP0] Use sliding window memory pool. full_layer_tokens=1496958, swa_layer_tokens=1496958
[2025-12-19 07:42:57 TP3] The available memory for KV cache is 77.63 GB.
[2025-12-19 07:42:57 TP3] Use sliding window memory pool. full_layer_tokens=1496958, swa_layer_tokens=1496958
[2025-12-19 07:42:57 TP2] The available memory for KV cache is 77.63 GB.
[2025-12-19 07:42:57 TP2] Use sliding window memory pool. full_layer_tokens=1496958, swa_layer_tokens=1496958
[2025-12-19 07:42:57 TP1] The available memory for KV cache is 77.63 GB.
[2025-12-19 07:42:57 TP1] Use sliding window memory pool. full_layer_tokens=1496958, swa_layer_tokens=1496958
[2025-12-19 07:42:57 TP3] KV Cache is allocated. #tokens: 1496958, K size: 41.76 GB, V size: 27.84 GB
[2025-12-19 07:42:57 TP0] KV Cache is allocated. #tokens: 1496958, K size: 41.76 GB, V size: 27.84 GB
[2025-12-19 07:42:57 TP2] KV Cache is allocated. #tokens: 1496958, K size: 41.76 GB, V size: 27.84 GB
[2025-12-19 07:42:57 TP1] KV Cache is allocated. #tokens: 1496958, K size: 41.76 GB, V size: 27.84 GB
[2025-12-19 07:42:57 TP2] KV Cache is allocated. #tokens: 1496958, K size: 4.82 GB, V size: 3.21 GB
[2025-12-19 07:42:57 TP2] SWAKVPool mem usage: 77.63 GB, swa size: 1496958, full size: 1496958
[2025-12-19 07:42:57 TP0] KV Cache is allocated. #tokens: 1496958, K size: 4.82 GB, V size: 3.21 GB
[2025-12-19 07:42:57 TP0] SWAKVPool mem usage: 77.63 GB, swa size: 1496958, full size: 1496958
[2025-12-19 07:42:57 TP2] Memory pool end. avail mem=22.56 GB
[2025-12-19 07:42:57 TP1] KV Cache is allocated. #tokens: 1496958, K size: 4.82 GB, V size: 3.21 GB
[2025-12-19 07:42:57 TP0] Memory pool end. avail mem=22.59 GB
[2025-12-19 07:42:57 TP1] SWAKVPool mem usage: 77.63 GB, swa size: 1496958, full size: 1496958
[2025-12-19 07:42:57 TP1] Memory pool end. avail mem=22.56 GB
[2025-12-19 07:42:57 TP3] KV Cache is allocated. #tokens: 1496958, K size: 4.82 GB, V size: 3.21 GB
[2025-12-19 07:42:57 TP3] SWAKVPool mem usage: 77.63 GB, swa size: 1496958, full size: 1496958
[2025-12-19 07:42:57 TP3] Memory pool end. avail mem=22.71 GB
[2025-12-19 07:42:57 TP0] Capture cuda graph begin. This can take up to several minutes. avail mem=22.52 GB
[2025-12-19 07:42:57 TP0] Capture cuda graph bs [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]
[2025-12-19 07:42:57 TP1] Capture cuda graph begin. This can take up to several minutes. avail mem=22.49 GB
[2025-12-19 07:42:57 TP2] Capture cuda graph begin. This can take up to several minutes. avail mem=22.49 GB
[2025-12-19 07:42:57 TP3] Capture cuda graph begin. This can take up to several minutes. avail mem=22.65 GB
Capturing batches (bs=512 avail_mem=21.08 GB):   0%|                                                                                                                                                                       | 0/52 [00:00<?, ?it/s][2025-12-19 07:42:59 TP0] Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`
[2025-12-19 07:42:59 TP0] Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=3392, K=4096, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep_gemm`.
[2025-12-19 07:42:59 TP0] Required memory for warmup: 0.344970703125GB, Available memory: 21.05548095703125GB
DeepGEMM warmup: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32768/32768 [00:02<00:00, 11118.98it/s]
/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py:4876: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.<00:00, 11563.31it/s]
  warnings.warn(  # warn only once
rank 0 allocated ipc_handles: [['0x79c600000000', '0x79c5f6000000', '0x79c5c4000000', '0x79c5c0000000'], ['0x79ccb1c00000', '0x79ccb1e00000', '0x79ccdfc00000', '0x79ccdfe00000'], ['0x79c5b4000000', '0x79c5a8000000', '0x79c59c000000', '0x79c590000000']]
rank 3 allocated ipc_handles: [['0x7ea344000000', '0x7ea30a000000', '0x7ea306000000', '0x7ea348000000'], ['0x7ea9fde00000', '0x7eaa2bc00000', '0x7eaa2be00000', '0x7ea9fdc00000'], ['0x7ea2ee000000', '0x7ea2e2000000', '0x7ea2d6000000', '0x7ea2fa000000']]
rank 1 allocated ipc_handles: [['0x7e20e8000000', '0x7e20ec000000', '0x7e20ae000000', '0x7e20aa000000'], ['0x7e290de00000', '0x7e290dc00000', '0x7e293bc00000', '0x7e293be00000'], ['0x7e2092000000', '0x7e209e000000', '0x7e2086000000', '0x7e207a000000']]
rank 2 allocated ipc_handles: [['0x7ed986000000', '0x7ed982000000', '0x7ed9bc000000', '0x7ed97e000000'], ['0x7ee1e1e00000', '0x7ee20fc00000', '0x7ee1e1c00000', '0x7ee20fe00000'], ['0x7ed966000000', '0x7ed95a000000', '0x7ed972000000', '0x7ed94e000000']]
[2025-12-19 07:43:04.375] [info] lamportInitialize start: buffer: 0x79c5b4000000, size: 100663296
[2025-12-19 07:43:04.426] [info] lamportInitialize start: buffer: 0x7e209e000000, size: 100663296
set flag_ptr[3] = lamport_comm_size:  67108864
Rank 0 workspace[0] 0x79c600000000
Rank 0 workspace[1] 0x79c5f6000000
Rank 0 workspace[2] 0x79c5c4000000
Rank 0 workspace[3] 0x79c5c0000000
Rank 0 workspace[4] 0x79ccb1c00000
Rank 0 workspace[5] 0x79ccb1e00000
Rank 0 workspace[6] 0x79ccdfc00000
Rank 0 workspace[7] 0x79ccdfe00000
Rank 0 workspace[8] 0x79c5b4000000
Rank 0 workspace[9] 0x79c5a8000000
Rank 0 workspace[10] 0x79c59c000000
Rank 0 workspace[11] 0x79c590000000
Rank 0 workspace[12] 0x79eedb264400
/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py:4876: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
  warnings.warn(  # warn only once
[2025-12-19 07:43:04.474] [info] lamportInitialize start: buffer: 0x7ed972000000, size: 100663296
set flag_ptr[3] = lamport_comm_size:  67108864
Rank 1 workspace[0] 0x7e20e8000000
Rank 1 workspace[1] 0x7e20ec000000
Rank 1 workspace[2] 0x7e20ae000000
Rank 1 workspace[3] 0x7e20aa000000
Rank 1 workspace[4] 0x7e290de00000
Rank 1 workspace[5] 0x7e290dc00000
Rank 1 workspace[6] 0x7e293bc00000
Rank 1 workspace[7] 0x7e293be00000
Rank 1 workspace[8] 0x7e2092000000
Rank 1 workspace[9] 0x7e209e000000
Rank 1 workspace[10] 0x7e2086000000
Rank 1 workspace[11] 0x7e207a000000
Rank 1 workspace[12] 0x7e49d9264400
[2025-12-19 07:43:04.526] [info] lamportInitialize start: buffer: 0x7ea2fa000000, size: 100663296
set flag_ptr[3] = lamport_comm_size:  67108864
Rank 2 workspace[0] 0x7ed986000000
Rank 2 workspace[1] 0x7ed982000000
Rank 2 workspace[2] 0x7ed9bc000000
Rank 2 workspace[3] 0x7ed97e000000
Rank 2 workspace[4] 0x7ee1e1e00000
Rank 2 workspace[5] 0x7ee20fc00000
Rank 2 workspace[6] 0x7ee1e1c00000
Rank 2 workspace[7] 0x7ee20fe00000
Rank 2 workspace[8] 0x7ed966000000
Rank 2 workspace[9] 0x7ed95a000000
Rank 2 workspace[10] 0x7ed972000000
Rank 2 workspace[11] 0x7ed94e000000
Rank 2 workspace[12] 0x7f02b1264400
set flag_ptr[3] = lamport_comm_size:  67108864
Rank 3 workspace[0] 0x7ea344000000
Rank 3 workspace[1] 0x7ea30a000000
Rank 3 workspace[2] 0x7ea306000000
Rank 3 workspace[3] 0x7ea348000000
Rank 3 workspace[4] 0x7ea9fde00000
Rank 3 workspace[5] 0x7eaa2bc00000
Rank 3 workspace[6] 0x7eaa2be00000
Rank 3 workspace[7] 0x7ea9fdc00000
Rank 3 workspace[8] 0x7ea2ee000000
Rank 3 workspace[9] 0x7ea2e2000000
Rank 3 workspace[10] 0x7ea2d6000000
Rank 3 workspace[11] 0x7ea2fa000000
Rank 3 workspace[12] 0x7ecc2b264400
[2025-12-19 07:43:04 TP0] FlashInfer workspace initialized for rank 0, world_size 4
[2025-12-19 07:43:04 TP1] FlashInfer workspace initialized for rank 1, world_size 4
[2025-12-19 07:43:04 TP2] FlashInfer workspace initialized for rank 2, world_size 4
[2025-12-19 07:43:04 TP3] FlashInfer workspace initialized for rank 3, world_size 4
[2025-12-19 07:43:04 TP0] Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`
[2025-12-19 07:43:04 TP0] Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=8192, K=4096, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep_gemm`.
[2025-12-19 07:43:04 TP0] Required memory for warmup: 0.65625GB, Available memory: 19.893310546875GB
DeepGEMM warmup: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32768/32768 [00:02<00:00, 11823.96it/s]
[2025-12-19 07:43:07 TP0] Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`
[2025-12-19 07:43:07 TP0] Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=4096, K=4096, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep_gemm`.
[2025-12-19 07:43:07 TP0] Required memory for warmup: 0.390625GB, Available memory: 19.893310546875GB
DeepGEMM warmup: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32768/32768 [00:02<00:00, 11785.43it/s]
[2025-12-19 07:43:10 TP0] Entering DeepGEMM JIT Pre-Compile session. It may take a long time (typically 10-20 mins) if you have not run `sglang.compile_deep_gemm`. It is recommended to run `sglang.compile_deep_gemm` with same args as `sglang.launch_server` for pre-compilation to reduce the overhead if you have not run it before. For example: `python3 -m sglang.compile_deep_gemm --model deepseek-ai/DeepSeek-V3 --tp 8 --trust-remote-code`
[2025-12-19 07:43:10 TP0] Try DeepGEMM JIT Compiling for <GEMM_NT_F8F8BF16> N=3712, K=4096, num_groups=1 with all Ms. It only takes a little time (typically 1 sec) if you have run `python3 -m sglang.compile_deep_gemm`.
[2025-12-19 07:43:10 TP0] Required memory for warmup: 0.36572265625GB, Available memory: 19.893310546875GB
DeepGEMM warmup: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32768/32768 [00:02<00:00, 11815.63it/s]
[2025-12-19 07:43:13 TP1] Using default MoE kernel config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP1] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP2] Using default MoE kernel config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP2] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP3] Using default MoE kernel config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP3] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP0] Using default MoE kernel config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
[2025-12-19 07:43:13 TP0] Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=256,N=512,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
Capturing batches (bs=1 avail_mem=19.16 GB): 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 52/52 [00:35<00:00,  1.45it/s]
[2025-12-19 07:43:33 TP0] Registering 52 cuda graph addresses
[2025-12-19 07:43:34 TP2] Capture cuda graph end. Time elapsed: 36.40 s. mem usage=3.41 GB. avail mem=19.09 GB.
[2025-12-19 07:43:34 TP1] Capture cuda graph end. Time elapsed: 36.41 s. mem usage=3.41 GB. avail mem=19.09 GB.
[2025-12-19 07:43:34 TP0] Capture cuda graph end. Time elapsed: 36.45 s. mem usage=3.38 GB. avail mem=19.15 GB.
[2025-12-19 07:43:34 TP3] Capture cuda graph end. Time elapsed: 36.41 s. mem usage=3.25 GB. avail mem=19.40 GB.
[2025-12-19 07:43:35 TP0] max_total_num_tokens=1496958, chunked_prefill_size=16384, max_prefill_tokens=16384, max_running_requests=2923, context_len=262144, available_gpu_mem=19.15 GB
[2025-12-19 07:43:35] INFO:     Started server process [37082]
[2025-12-19 07:43:35] INFO:     Waiting for application startup.
[2025-12-19 07:43:35] INFO:     Application startup complete.
[2025-12-19 07:43:35] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2025-12-19 07:43:36] INFO:     127.0.0.1:33800 - "GET /model_info HTTP/1.1" 200 OK
[2025-12-19 07:43:36 TP0] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, full token usage: 0.00, swa token usage: 0.00, #running-req: 0, #queue-req: 0,
[2025-12-19 07:43:38] INFO:     127.0.0.1:33814 - "POST /generate HTTP/1.1" 200 OK
[2025-12-19 07:43:38] The server is fired up and ready to roll!
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Main:
```
➜  sglang_dev2 git:(main) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:20<00:00,  9.58it/s]
Accuracy: 0.810
Invalid: 0.000
Latency: 21.098 s
Output throughput: 1272.783 token/s
```

PR:
```
➜  sglang git:(main) python3 benchmark/gsm8k/bench_sglang.py --num-questions 200 --parallel 128 --num-shots 8 --port 30000
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:19<00:00, 10.37it/s]
Accuracy: 0.805
Invalid: 0.000
Latency: 19.428 s
Output throughput: 1411.231 token/s
```

## Benchmarking and Profiling
8xB200 
TTFT:
683.26ms --> 648.45ms

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
Server:
```
➜  sglang git:(main) python3 -m sglang.launch_server --model XiaomiMiMo/MiMo-V2-Flash --tp-size 4 --port 30000 --attention-backend triton --disable-radix-cache --trust-remote-code --enable-flashinfer-allreduce-fusion
```

Client:
```
➜  sglang_dev2 git:(main) python3 -m sglang.bench_serving --backend sglang --num-prompts 500 --dataset-name random --random-input 1024 --random-output 20 --port 30000 --random-range-ratio 1.0 --max-concurrency 32 --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json

Baseline:
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 32
Successful requests:                     500
Benchmark duration (s):                  18.67
Total input tokens:                      512000
Total input text tokens:                 512000
Total input vision tokens:               0
Total generated tokens:                  10000
Total generated tokens (retokenized):    9993
Request throughput (req/s):              26.78
Input token throughput (tok/s):          27427.42
Output token throughput (tok/s):         535.69
Peak output token throughput (tok/s):    640.00
Peak concurrent requests:                64
Total token throughput (tok/s):          27963.11
Concurrency:                             31.14
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1162.42
Median E2E Latency (ms):                 1113.95
---------------Time to First Token----------------
Mean TTFT (ms):                          683.26
Median TTFT (ms):                        609.88
P99 TTFT (ms):                           1484.36
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.22
Median TPOT (ms):                        27.44
P99 TPOT (ms):                           64.25
---------------Inter-Token Latency----------------
Mean ITL (ms):                           25.22
Median ITL (ms):                         18.40
P95 ITL (ms):                            21.57
P99 ITL (ms):                            198.62
Max ITL (ms):                            1209.78
==================================================

PR:
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    inf
Max request concurrency:                 32
Successful requests:                     500
Benchmark duration (s):                  17.58
Total input tokens:                      512000
Total input text tokens:                 512000
Total input vision tokens:               0
Total generated tokens:                  10000
Total generated tokens (retokenized):    9977
Request throughput (req/s):              28.44
Input token throughput (tok/s):          29120.35
Output token throughput (tok/s):         568.76
Peak output token throughput (tok/s):    640.00
Peak concurrent requests:                64
Total token throughput (tok/s):          29689.11
Concurrency:                             31.21
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1097.54
Median E2E Latency (ms):                 1095.20
---------------Time to First Token----------------
Mean TTFT (ms):                          648.45
Median TTFT (ms):                        578.90
P99 TTFT (ms):                           840.72
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          23.64
Median TPOT (ms):                        27.14
P99 TPOT (ms):                           44.43
---------------Inter-Token Latency----------------
Mean ITL (ms):                           23.64
Median ITL (ms):                         18.03
P95 ITL (ms):                            21.00
P99 ITL (ms):                            199.42
Max ITL (ms):                            580.63
==================================================
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
