### PR TITLE
Fix reasoning parser in non-stream

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -38,7 +38,8 @@ class BaseReasoningFormatDetector:
         One-time parsing: Detects and parses reasoning sections in the provided text.
         Returns both reasoning content and normal text separately.
         """
-        in_reasoning = self._in_reasoning or self.think_start_token in text
+        # self._in_reasoning is only for streaming parsing
+        in_reasoning = self.think_start_token in text or self.think_end_token in text
 
         if not in_reasoning:
             return StreamingParseResult(normal_text=text)
@@ -315,6 +316,7 @@ class ReasoningParser:
         "step3": DeepSeekR1Detector,
         "nano_v3": NanoV3Detector,
         "interns1": Qwen3Detector,
+        "mimo": Qwen3Detector,
     }
 
     def __init__(

--- a/test/srt/test_reasoning_parser.py
+++ b/test/srt/test_reasoning_parser.py
@@ -66,13 +66,14 @@ class TestBaseReasoningFormatDetector(CustomTestCase):
 
     def test_detect_and_parse_force_reasoning(self):
         """Test forced reasoning mode."""
+        # For non-stream request, if no tags, the text should be normal
         detector = BaseReasoningFormatDetector(
             "<think>", "</think>", force_reasoning=True
         )
-        text = "This should be reasoning"
+        text = "This should be normal"
         result = detector.detect_and_parse(text)
-        self.assertEqual(result.reasoning_text, "This should be reasoning")
-        self.assertEqual(result.normal_text, "")
+        self.assertEqual(result.reasoning_text, "")
+        self.assertEqual(result.normal_text, "This should be normal")
 
     def test_parse_streaming_increment_normal(self):
         """Test streaming parse of normal text."""
@@ -167,11 +168,11 @@ class TestDeepSeekR1Detector(CustomTestCase):
         """Test parsing DeepSeek-R1 format."""
         text = "I need to think about this. The answer is 42."
         result = self.detector.detect_and_parse(text)
-        # Should be treated as reasoning because force_reasoning=True
+        # For non-stream request, if no tags, the text should be normal
+        self.assertEqual(result.reasoning_text, "")
         self.assertEqual(
-            result.reasoning_text, "I need to think about this. The answer is 42."
+            result.normal_text, "I need to think about this. The answer is 42."
         )
-        self.assertEqual(result.normal_text, "")
 
     def test_detect_and_parse_with_end_token(self):
         """Test parsing with end token."""


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Standardizes the behavior for non-streaming requests when `force_reasoning` is enabled. Currently, if a response lacks `<think>` or `</think>` tags, the system may handle it inconsistently. This change ensures that if no reasoning tags are detected, the response is treated as a standard completion ("normal_text"), ensuring the user receives the final result regardless of the internal reasoning format.

## Modifications

<!-- Detail the changes made in this pull request. -->
Updated the logic for non-streaming requests using `force_reasoning`.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)

close #15446 