### PR TITLE
fix input validation in multi-gpu inference

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/input_validation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/input_validation.py
@@ -303,7 +303,7 @@ class InputValidationStage(PipelineStage):
                 )
 
         temporal_compression_ratio = (
-            self.server_args.pipeline_config.vae_config.temporal_compression_ratio
+            server_args.pipeline_config.vae_config.temporal_compression_ratio
         )
         spatial_seq_len = (batch.height * batch.width) // (
             temporal_compression_ratio * temporal_compression_ratio


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When running Wan2.1 inference with multi-GPU enabled, an error is raised even though the input resolution itself is valid:

``` text
    raise Exception(f"{output_batch.error}")
Exception: Error executing request None: Width must be divisible by (8 x num_gpus) but 720 % (8 * 8) != 0.
[12-19 19:05:19] Completed batch processing. Generated 0 outputs in 0.00 seconds.
```

*Minimal Reproduction*

```python
from sglang.multimodal_gen import DiffGenerator

def main():

    prompt = "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window."
    negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"


    generator = DiffGenerator.from_pretrained(
        model_path="Wan2.1-T2V-14B-Diffusers",
        num_gpus=8,
        ulysses_degree=8,
        dit_cpu_offload=False,
        use_fsdp_inference=True,
        text_encoder_cpu_offload=False,
        image_encoder_cpu_offload=False,
        vae_cpu_offload=False,
    )

    video = generator.generate(
        sampling_params_kwargs=dict(
            prompt=prompt,
            negative_prompt=negative_prompt,
            num_frames=81,
            height=1280,
            width=720,
            fps=15,
            num_inference_steps=50,
            guidance_scale=5.0,
            output_path="result/",
            save_output=True
        )
    )

if __name__ == '__main__':
    main()
```

Root Cause Analysis

The error message checks divisibility on the original image width, but this is misleading.

In practice, multi-GPU sharding happens on the latent sequence produced by vae.encode, not on the original spatial resolution (height / width).
Therefore, the actual requirement is:

The latent sequence length after VAE encoding must be divisible by num_gpus.

However, the current validation logic directly enforces:

width % (8 * num_gpus) == 0


which incorrectly couples the constraint to the input resolution rather than the latent representation.

Expected Behavior

The divisibility check should be applied to the latent sequence length, or the error message should clearly indicate that the constraint originates from VAE latent sharding, not from the raw image width.


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
