### PR TITLE
[ci] remove rust benchmark in unit test ci

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -131,20 +131,6 @@ jobs:
           cd sgl-model-gateway/
           cargo test
 
-      - name: Check benchmark compilation
-        run: |
-          source "$HOME/.cargo/env"
-          cd sgl-model-gateway/
-          cargo check --benches
-
-      - name: Quick benchmark sanity check
-        timeout-minutes: 15
-        run: |
-          source "$HOME/.cargo/env"
-          cd sgl-model-gateway/
-          # Run quick benchmarks to ensure they work using Python script
-          python3 scripts/run_benchmarks.py --quick
-
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats


### PR DESCRIPTION
shit fails all the time due to how long it takes to compile
deleting it as this is already in benchmark workflow