### PR TITLE
[Diffusion] Wan video model support zero-cost weight offload and overlap with compute

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -423,6 +423,9 @@ def initialize_model_parallel(
         ring_group=PROCESS_GROUP.RING_PG,
     )
 
+    if ulysses_degree > 1:
+        _warmup_ulysses_communication()
+
     global _TP
     assert _TP is None, "Tensor parallel group is already initialized"
     _TP = init_parallel_group_coordinator(
@@ -933,6 +936,51 @@ def get_ring_parallel_world_size():
 
 def get_ring_parallel_rank():
     return get_sp_group().ring_rank
+
+
+def _warmup_ulysses_communication():
+    """
+    Warmup NCCL communication for Ulysses all-to-all to avoid first-step latency.
+    
+    This function performs a dummy all-to-all operation to initialize NCCL communication
+    channels, which can take several seconds on the first call.
+    """
+    import logging
+    import time
+    
+    logger = logging.getLogger(__name__)
+    logger.info("Warming up Ulysses all-to-all communication...")
+    
+    try:
+        import torch.distributed._functional_collectives as ft_c
+        
+        ulysses_pg = get_sp_group().ulysses_group
+        if ulysses_pg is None:
+            logger.warning("Ulysses group not initialized, skipping warmup")
+            return
+        
+        warmup_start = time.time()
+        
+        device = torch.device(f"cuda:{get_world_group().local_rank}")
+        dummy_tensor = torch.randn(1024, device=device, dtype=torch.float32)
+        
+        output = ft_c.all_to_all_single(
+            dummy_tensor,
+            output_split_sizes=None,
+            input_split_sizes=None,
+            group=ulysses_pg
+        )
+        
+        if isinstance(output, ft_c.AsyncCollectiveTensor):
+            output = output.wait()
+        
+        torch.cuda.synchronize()
+        
+        warmup_time = (time.time() - warmup_start) * 1000
+        logger.info(f"Ulysses communication warmup completed in {warmup_time:.2f}ms")
+        
+    except Exception as e:
+        logger.warning(f"Ulysses communication warmup failed: {e}. Continuing without warmup.")
 
 
 # PP

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -957,7 +957,7 @@ def _warmup_ulysses_communication():
         warmup_start = time.time()
 
         device = torch.device(f"cuda:{get_world_group().local_rank}")
-        dummy_tensor = torch.randn(1024, device=device, dtype=torch.float32)
+        dummy_tensor = torch.zeros(1024, device=device, dtype=torch.float32)
 
         output = ft_c.all_to_all_single(
             dummy_tensor,

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -32,6 +32,7 @@ If you only need to use the distributed environment without model parallelism,
 """
 import contextlib
 import os
+import time
 import weakref
 from collections import namedtuple
 from collections.abc import Callable
@@ -66,8 +67,6 @@ _CFG: Optional[GroupCoordinator] = None
 _DP: Optional[GroupCoordinator] = None
 _DIT: Optional[GroupCoordinator] = None
 _VAE: Optional[GroupCoordinator] = None
-
-logger = init_logger(__name__)
 
 TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
 
@@ -941,46 +940,44 @@ def get_ring_parallel_rank():
 def _warmup_ulysses_communication():
     """
     Warmup NCCL communication for Ulysses all-to-all to avoid first-step latency.
-    
+
     This function performs a dummy all-to-all operation to initialize NCCL communication
     channels, which can take several seconds on the first call.
     """
-    import logging
-    import time
-    
-    logger = logging.getLogger(__name__)
     logger.info("Warming up Ulysses all-to-all communication...")
-    
+
     try:
         import torch.distributed._functional_collectives as ft_c
-        
+
         ulysses_pg = get_sp_group().ulysses_group
         if ulysses_pg is None:
             logger.warning("Ulysses group not initialized, skipping warmup")
             return
-        
+
         warmup_start = time.time()
-        
+
         device = torch.device(f"cuda:{get_world_group().local_rank}")
         dummy_tensor = torch.randn(1024, device=device, dtype=torch.float32)
-        
+
         output = ft_c.all_to_all_single(
             dummy_tensor,
             output_split_sizes=None,
             input_split_sizes=None,
-            group=ulysses_pg
+            group=ulysses_pg,
         )
-        
+
         if isinstance(output, ft_c.AsyncCollectiveTensor):
             output = output.wait()
-        
+
         torch.cuda.synchronize()
-        
+
         warmup_time = (time.time() - warmup_start) * 1000
         logger.info(f"Ulysses communication warmup completed in {warmup_time:.2f}ms")
-        
+
     except Exception as e:
-        logger.warning(f"Ulysses communication warmup failed: {e}. Continuing without warmup.")
+        logger.warning(
+            f"Ulysses communication warmup failed: {e}. Continuing without warmup."
+        )
 
 
 # PP

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -956,15 +956,8 @@ def _warmup_ulysses_communication():
 
         warmup_start = time.time()
 
-        device = get_local_torch_device()
-        if device.type != "cuda":
-            logger.info(
-                "Ulysses communication warmup is only supported on CUDA, got %s; skipping.",
-                device.type,
-            )
-            return
-
-        dummy_tensor = torch.zeros(1024, device=device, dtype=torch.float32)
+        device = torch.device(f"cuda:{get_world_group().local_rank}")
+        dummy_tensor = torch.randn(1024, device=device, dtype=torch.float32)
 
         output = ft_c.all_to_all_single(
             dummy_tensor,

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -956,8 +956,15 @@ def _warmup_ulysses_communication():
 
         warmup_start = time.time()
 
-        device = torch.device(f"cuda:{get_world_group().local_rank}")
-        dummy_tensor = torch.randn(1024, device=device, dtype=torch.float32)
+        device = get_local_torch_device()
+        if device.type != "cuda":
+            logger.info(
+                "Ulysses communication warmup is only supported on CUDA, got %s; skipping.",
+                device.type,
+            )
+            return
+
+        dummy_tensor = torch.zeros(1024, device=device, dtype=torch.float32)
 
         output = ft_c.all_to_all_single(
             dummy_tensor,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loader.py
@@ -713,8 +713,8 @@ class TransformerLoader(ComponentLoader):
                     num_layers=num_layers,
                     enabled=True,
                     pin_cpu_memory=server_args.pin_cpu_memory,
+                    auto_initialize=True,
                 )
-                mgr.initialize()
                 setattr(model, "_layerwise_offload_manager", mgr)
 
         return model

--- a/python/sglang/multimodal_gen/runtime/loader/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loader.py
@@ -43,6 +43,9 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     get_diffusers_component_config,
     get_hf_config,
 )
+from sglang.multimodal_gen.runtime.utils.layerwise_offload import (
+    LayerwiseOffloadManager,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
@@ -696,6 +699,23 @@ class TransformerLoader(ComponentLoader):
         ), "Model dtype does not match default dtype"
 
         model = model.eval()
+
+        if server_args.dit_layerwise_offload and hasattr(model, "blocks"):
+            try:
+                num_layers = len(getattr(model, "blocks"))
+            except Exception:
+                num_layers = None
+
+            if isinstance(num_layers, int) and num_layers > 0:
+                mgr = LayerwiseOffloadManager(
+                    model,
+                    module_list_attr="blocks",
+                    num_layers=num_layers,
+                    enabled=True,
+                    pin_cpu_memory=server_args.pin_cpu_memory,
+                )
+                mgr.initialize()
+                setattr(model, "_layerwise_offload_manager", mgr)
 
         return model
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -800,9 +800,7 @@ class WanTransformer3DModel(CachableDiT):
                         hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
                     )
                     torch.cuda.current_stream().wait_stream(offload_mgr.copy_stream)
-                    # NOTE: Do not release layer weights here to allow cache-dit to reuse skipped blocks.
-                    # Weights remain on GPU until denoising completes, then released via release_all() in _post_denoising_loop.
-                    # offload_mgr.release_layer(i)
+                    offload_mgr.release_layer(i)
             else:
                 for block in self.blocks:
                     hidden_states = block(

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -800,7 +800,9 @@ class WanTransformer3DModel(CachableDiT):
                         hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
                     )
                     torch.cuda.current_stream().wait_stream(offload_mgr.copy_stream)
-                    offload_mgr.release_layer(i)
+                    # NOTE: Do not release layer weights here to allow cache-dit to reuse skipped blocks.
+                    # Weights remain on GPU until denoising completes, then released via release_all() in _post_denoising_loop.
+                    # offload_mgr.release_layer(i)
             else:
                 for block in self.blocks:
                     hidden_states = block(

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -792,10 +792,20 @@ class WanTransformer3DModel(CachableDiT):
             if enable_teacache:
                 original_hidden_states = hidden_states.clone()
 
-            for block in self.blocks:
-                hidden_states = block(
-                    hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
-                )
+            offload_mgr = getattr(self, "_layerwise_offload_manager", None)
+            if offload_mgr is not None and getattr(offload_mgr, "enabled", False):
+                for i, block in enumerate(self.blocks):
+                    offload_mgr.prefetch_layer(i + 1, non_blocking=True)
+                    hidden_states = block(
+                        hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
+                    )
+                    torch.cuda.current_stream().wait_stream(offload_mgr.copy_stream)
+                    offload_mgr.release_layer(i)
+            else:
+                for block in self.blocks:
+                    hidden_states = block(
+                        hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
+                    )
             # if teacache is enabled, we need to cache the original hidden states
             if enable_teacache:
                 self.maybe_cache_states(hidden_states, original_hidden_states)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -710,6 +710,15 @@ class DenoisingStage(PipelineStage):
             latents, batch
         )
 
+        offload_mgr = getattr(self.transformer, "_layerwise_offload_manager", None)
+        if offload_mgr is not None and getattr(offload_mgr, "enabled", False):
+            offload_mgr.release_all()
+
+        if self.transformer_2 is not None:
+            offload_mgr_2 = getattr(self.transformer_2, "_layerwise_offload_manager", None)
+            if offload_mgr_2 is not None and getattr(offload_mgr_2, "enabled", False):
+                offload_mgr_2.release_all()
+
         # Save STA mask search results if needed
         if (
             st_attn_available

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -715,7 +715,9 @@ class DenoisingStage(PipelineStage):
             offload_mgr.release_all()
 
         if self.transformer_2 is not None:
-            offload_mgr_2 = getattr(self.transformer_2, "_layerwise_offload_manager", None)
+            offload_mgr_2 = getattr(
+                self.transformer_2, "_layerwise_offload_manager", None
+            )
             if offload_mgr_2 is not None and getattr(offload_mgr_2, "enabled", False):
                 offload_mgr_2.release_all()
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -197,20 +197,30 @@ class DenoisingStage(PipelineStage):
             dummy_encoder_hidden_states = batch.encoder_hidden_states[:1].clone()
 
         with torch.no_grad():
-            _ = self.transformer(
-                hidden_states=dummy_latents,
-                encoder_hidden_states=dummy_encoder_hidden_states,
-                timestep=dummy_timestep,
-                guidance=None,
-            )
+            with set_forward_context(
+                current_timestep=0,
+                attn_metadata=None,
+                forward_batch=batch,
+            ):
+                _ = self.transformer(
+                    hidden_states=dummy_latents,
+                    encoder_hidden_states=dummy_encoder_hidden_states,
+                    timestep=dummy_timestep,
+                    guidance=None,
+                )
 
-        if self.transformer_2 is not None:
-            _ = self.transformer_2(
-                hidden_states=dummy_latents,
-                encoder_hidden_states=dummy_encoder_hidden_states,
-                timestep=dummy_timestep,
-                guidance=None,
-            )
+            if self.transformer_2 is not None:
+                with set_forward_context(
+                    current_timestep=0,
+                    attn_metadata=None,
+                    forward_batch=batch,
+                ):
+                    _ = self.transformer_2(
+                        hidden_states=dummy_latents,
+                        encoder_hidden_states=dummy_encoder_hidden_states,
+                        timestep=dummy_timestep,
+                        guidance=None,
+                    )
 
         if torch.cuda.is_available():
             torch.cuda.synchronize()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -147,6 +147,8 @@ class DenoisingStage(PipelineStage):
         # cache-dit state (for delayed mounting and idempotent control)
         self._cache_dit_enabled = False
         self._cached_num_steps = None
+        # warmup state
+        self._warmup_done = False
 
     def torch_compile_module(self, module):
         """
@@ -168,6 +170,54 @@ class DenoisingStage(PipelineStage):
         compiled_forward = torch.compile(getattr(module, "forward"), mode=mode)
         setattr(module, "forward", compiled_forward)
         return module
+
+    def _run_warmup(self, batch: Req, server_args: ServerArgs) -> None:
+        """
+        Run a warmup forward pass to initialize NCCL communication, torch.compile,
+        and CUDA kernels. This reduces the latency of the first real denoising step.
+
+        In serving mode, the warmup state is cached across requests.
+        """
+        if self._warmup_done:
+            return
+
+        logger.info("Running warmup step to initialize kernels and communication...")
+        warmup_start = time.time()
+
+        dummy_timestep = torch.tensor(
+            [999], device=batch.latents.device, dtype=torch.long
+        )
+
+        dummy_latents = batch.latents[:1].clone()
+        dummy_encoder_hidden_states = None
+        if (
+            hasattr(batch, "encoder_hidden_states")
+            and batch.encoder_hidden_states is not None
+        ):
+            dummy_encoder_hidden_states = batch.encoder_hidden_states[:1].clone()
+
+        with torch.no_grad():
+            _ = self.transformer(
+                hidden_states=dummy_latents,
+                encoder_hidden_states=dummy_encoder_hidden_states,
+                timestep=dummy_timestep,
+                guidance=None,
+            )
+
+        if self.transformer_2 is not None:
+            _ = self.transformer_2(
+                hidden_states=dummy_latents,
+                encoder_hidden_states=dummy_encoder_hidden_states,
+                timestep=dummy_timestep,
+                guidance=None,
+            )
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        self._warmup_done = True
+        warmup_time = (time.time() - warmup_start) * 1000
+        logger.info(f"Warmup completed in {warmup_time:.2f}ms")
 
     def _maybe_enable_cache_dit(self, num_inference_steps: int) -> None:
         """Enable cache-dit on the transformers if configured (idempotent).
@@ -965,6 +1015,9 @@ class DenoisingStage(PipelineStage):
         # Initialize lists for ODE trajectory
         trajectory_timesteps: list[torch.Tensor] = []
         trajectory_latents: list[torch.Tensor] = []
+
+        # Run warmup on first forward call to reduce first step latency
+        self._run_warmup(batch, server_args)
 
         # Run denoising loop
         denoising_start_time = time.time()

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -559,8 +559,7 @@ class ServerArgs:
             action=StoreBoolean,
             default=ServerArgs.dit_layerwise_offload,
             help="Enable layerwise CPU offload with async H2D prefetch overlap for supported DiT models (e.g., Wan). "
-            "Cannot be used together with dit_cpu_offload or use_fsdp_inference. "
-            "Compatible with cache-dit (requires cache-dit with offload awareness support).",
+            "Cannot be used together with cache-dit (SGLANG_CACHE_DIT_ENABLED), dit_cpu_offload, or use_fsdp_inference.",
         )
         parser.add_argument(
             "--use-fsdp-inference",
@@ -908,14 +907,21 @@ class ServerArgs:
         if self.dit_layerwise_offload:
             if self.use_fsdp_inference:
                 logger.warning(
-                    "dit_layerwise_offload is enabled, automatically disabling use_fsdp_inference (incompatible)."
+                    "dit_layerwise_offload is enabled, automatically disabling use_fsdp_inference."
                 )
                 self.use_fsdp_inference = False
             if self.dit_cpu_offload:
                 logger.warning(
-                    "dit_layerwise_offload is enabled, automatically disabling dit_cpu_offload (incompatible)."
+                    "dit_layerwise_offload is enabled, automatically disabling dit_cpu_offload."
                 )
                 self.dit_cpu_offload = False
+            if os.getenv("SGLANG_CACHE_DIT_ENABLED", "").lower() == "true":
+                raise ValueError(
+                    "dit_layerwise_offload cannot be enabled together with cache-dit. "
+                    "cache-dit may reuse skipped blocks whose weights have been released by layerwise offload, "
+                    "causing shape mismatch errors. "
+                    "Please disable either --dit-layerwise-offload or SGLANG_CACHE_DIT_ENABLED."
+                )
 
         # autocast
         is_flux = (

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -559,7 +559,8 @@ class ServerArgs:
             action=StoreBoolean,
             default=ServerArgs.dit_layerwise_offload,
             help="Enable layerwise CPU offload with async H2D prefetch overlap for supported DiT models (e.g., Wan). "
-            "Cannot be used together with cache-dit (SGLANG_CACHE_DIT_ENABLED), dit_cpu_offload, or use_fsdp_inference.",
+            "Cannot be used together with dit_cpu_offload or use_fsdp_inference. "
+            "Compatible with cache-dit (requires cache-dit with offload awareness support).",
         )
         parser.add_argument(
             "--use-fsdp-inference",
@@ -915,13 +916,6 @@ class ServerArgs:
                     "dit_layerwise_offload is enabled, automatically disabling dit_cpu_offload (incompatible)."
                 )
                 self.dit_cpu_offload = False
-            if os.getenv("SGLANG_CACHE_DIT_ENABLED", "").lower() == "true":
-                raise ValueError(
-                    "dit_layerwise_offload cannot be enabled together with cache-dit. "
-                    "cache-dit may reuse skipped blocks whose weights have been released by layerwise offload, "
-                    "causing shape mismatch errors. "
-                    "Please disable either --dit-layerwise-offload or SGLANG_CACHE_DIT_ENABLED."
-                )
 
         # autocast
         is_flux = (

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -558,7 +558,9 @@ class ServerArgs:
             "--dit-layerwise-offload",
             action=StoreBoolean,
             default=ServerArgs.dit_layerwise_offload,
-            help="Enable layerwise CPU offload with async H2D prefetch overlap for supported DiT models (e.g., Wan).",
+            help="Enable layerwise CPU offload with async H2D prefetch overlap for supported DiT models (e.g., Wan). "
+            "Cannot be used together with dit_cpu_offload or use_fsdp_inference. "
+            "When used with cache-dit, weights remain on GPU until denoising completes.",
         )
         parser.add_argument(
             "--use-fsdp-inference",

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -20,10 +20,14 @@ class LayerwiseOffloadManager:
         self.pin_cpu_memory = pin_cpu_memory
 
         self.enabled = bool(enabled and torch.cuda.is_available())
-        self.device = torch.device("cuda", torch.cuda.current_device()) if self.enabled else None
+        self.device = (
+            torch.device("cuda", torch.cuda.current_device()) if self.enabled else None
+        )
         self.copy_stream = torch.cuda.Stream() if self.enabled else None
 
-        self._layer_name_re = re.compile(rf"(^|\.){re.escape(module_list_attr)}\.(\d+)(\.|$)")
+        self._layer_name_re = re.compile(
+            rf"(^|\.){re.escape(module_list_attr)}\.(\d+)(\.|$)"
+        )
 
         self._cpu_weights: Dict[int, Dict[str, torch.Tensor]] = {}
         self._cpu_dtypes: Dict[int, Dict[str, torch.dtype]] = {}

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -55,6 +55,7 @@ class LayerwiseOffloadManager:
         if self.device is not None:
             tensor.data = torch.empty((1,), device=self.device, dtype=tensor.dtype)
 
+    @torch.compiler.disable
     def initialize(self) -> None:
         if not self.enabled:
             return
@@ -78,6 +79,7 @@ class LayerwiseOffloadManager:
         if self.copy_stream is not None:
             torch.cuda.current_stream().wait_stream(self.copy_stream)
 
+    @torch.compiler.disable
     def prefetch_layer(self, layer_idx: int, non_blocking: bool = True) -> None:
         if not self.enabled or self.device is None or self.copy_stream is None:
             return
@@ -110,6 +112,7 @@ class LayerwiseOffloadManager:
 
         self._gpu_layers[layer_idx] = param_names
 
+    @torch.compiler.disable
     def release_layer(self, layer_idx: int) -> None:
         if not self.enabled or self.device is None:
             return

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -4,6 +4,7 @@ from typing import Dict, Set
 import torch
 
 
+# Adapted from skywork AI Infra diffusion optimize
 class LayerwiseOffloadManager:
     def __init__(
         self,

--- a/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/utils/layerwise_offload.py
@@ -1,0 +1,128 @@
+import re
+from typing import Dict, Set
+
+import torch
+
+
+class LayerwiseOffloadManager:
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        *,
+        module_list_attr: str,
+        num_layers: int,
+        enabled: bool,
+        pin_cpu_memory: bool = True,
+    ) -> None:
+        self.model = model
+        self.module_list_attr = module_list_attr
+        self.num_layers = num_layers
+        self.pin_cpu_memory = pin_cpu_memory
+
+        self.enabled = bool(enabled and torch.cuda.is_available())
+        self.device = torch.device("cuda", torch.cuda.current_device()) if self.enabled else None
+        self.copy_stream = torch.cuda.Stream() if self.enabled else None
+
+        self._layer_name_re = re.compile(rf"(^|\.){re.escape(module_list_attr)}\.(\d+)(\.|$)")
+
+        self._cpu_weights: Dict[int, Dict[str, torch.Tensor]] = {}
+        self._cpu_dtypes: Dict[int, Dict[str, torch.dtype]] = {}
+        self._gpu_layers: Dict[int, Set[str]] = {}
+
+        self._named_parameters: Dict[str, torch.nn.Parameter] = {}
+        self._named_buffers: Dict[str, torch.Tensor] = {}
+
+    def _match_layer_idx(self, name: str) -> int | None:
+        m = self._layer_name_re.search(name)
+        if not m:
+            return None
+        try:
+            return int(m.group(2))
+        except Exception:
+            return None
+
+    def _offload_tensor(self, name: str, tensor: torch.Tensor, layer_idx: int) -> None:
+        if layer_idx not in self._cpu_weights:
+            self._cpu_weights[layer_idx] = {}
+            self._cpu_dtypes[layer_idx] = {}
+
+        cpu_weight = tensor.detach().to("cpu")
+        if self.pin_cpu_memory:
+            cpu_weight = cpu_weight.pin_memory()
+        self._cpu_weights[layer_idx][name] = cpu_weight
+        self._cpu_dtypes[layer_idx][name] = tensor.dtype
+
+        if self.device is not None:
+            tensor.data = torch.empty((1,), device=self.device, dtype=tensor.dtype)
+
+    def initialize(self) -> None:
+        if not self.enabled:
+            return
+
+        self._named_parameters = dict(self.model.named_parameters())
+        self._named_buffers = dict(self.model.named_buffers())
+
+        for name, param in self._named_parameters.items():
+            layer_idx = self._match_layer_idx(name)
+            if layer_idx is None or layer_idx >= self.num_layers:
+                continue
+            self._offload_tensor(name, param, layer_idx)
+
+        for name, buf in self._named_buffers.items():
+            layer_idx = self._match_layer_idx(name)
+            if layer_idx is None or layer_idx >= self.num_layers:
+                continue
+            self._offload_tensor(name, buf, layer_idx)
+
+        self.prefetch_layer(0, non_blocking=False)
+        if self.copy_stream is not None:
+            torch.cuda.current_stream().wait_stream(self.copy_stream)
+
+    def prefetch_layer(self, layer_idx: int, non_blocking: bool = True) -> None:
+        if not self.enabled or self.device is None or self.copy_stream is None:
+            return
+        if layer_idx < 0 or layer_idx >= self.num_layers:
+            return
+        if layer_idx in self._gpu_layers:
+            return
+        if layer_idx not in self._cpu_weights:
+            return
+
+        self.copy_stream.wait_stream(torch.cuda.current_stream())
+
+        param_names: Set[str] = set()
+
+        for name, cpu_weight in self._cpu_weights[layer_idx].items():
+            if name in self._named_parameters:
+                target = self._named_parameters[name]
+            else:
+                target = self._named_buffers[name]
+
+            gpu_weight = torch.empty(
+                cpu_weight.shape,
+                dtype=self._cpu_dtypes[layer_idx][name],
+                device=self.device,
+            )
+            with torch.cuda.stream(self.copy_stream):
+                gpu_weight.copy_(cpu_weight, non_blocking=non_blocking)
+            target.data = gpu_weight
+            param_names.add(name)
+
+        self._gpu_layers[layer_idx] = param_names
+
+    def release_layer(self, layer_idx: int) -> None:
+        if not self.enabled or self.device is None:
+            return
+        if layer_idx <= 0:
+            return
+
+        param_names = self._gpu_layers.pop(layer_idx, None)
+        if not param_names:
+            return
+
+        for name in param_names:
+            if name in self._named_parameters:
+                target = self._named_parameters[name]
+            else:
+                target = self._named_buffers[name]
+            target.data = torch.empty((1,), device=self.device, dtype=target.dtype)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

I have identified the reason for the slow speed of wan2.2. A full profiler would reveal that the first step and the 19th step are significantly slower and have similar speeds, while all other intermediate steps are fast and fully meet the expected 2x speed improvement from cp4 to cp8. The first and 19th steps are about 7 times slower than a normal step, equivalent to 7 normal steps. 

The reason is that wan2.2 uses dual transformers, and we have `dit_cpu_offload` enabled. Therefore, the weights are on cpu after loaded, and during the first step, the weights of both `transformer` and `transformer_2` are copied from the CPU to the CUDA device, making the first step very slow. Then, at the 19th step, a dual-stream switch occurs, requiring both `transformer` and `transformer_2` to be offloaded back to the CPU, their weights swapped, and then copied back to the CUDA device. 

## main branch:

```bash
sglang generate   --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 8   --ulysses-degree 8 --attention-backend sage_attn  --enable-torch-compile --prompt "A cat walks on the grass, realistic" --num-frames 81 --height 720 --width 1280 --num-inference-steps 27 --guidance-scale 3.5 --guidance-scale-2 4.0 --perf-dump-path /home/lmsys/bbuf/dump/wan_step_profile_cp8_main.json

100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 27/27 [02:28<00:00,  5.52s/it]
[12-19 08:37:22] [DenoisingStage] average time per step: 5.5156 seconds
[12-19 08:37:23] [DenoisingStage] finished in 149.6943 seconds



"denoise_steps_ms": [
    35999.06893167645,
    3261.483933776617,
    3270.5406425520778,
    3267.8588768467307,
    3260.3964526206255,
    3263.016454875469,
    3268.026988953352,
    3264.5184732973576,
    3264.636719599366,
    3267.1875776723027,
    3268.562350422144,
    3268.1023878976703,
    3266.7769035324454,
    3268.044295720756,
    3264.268895611167,
    3271.0087513551116,
    3267.674465663731,
    3266.1060262471437,
    31282.590138725936,
    3263.5639663785696,
    3262.301029637456,
    3262.3210102319717,
    3261.833382770419,
    3264.719443395734,
    3265.314467251301,
    3267.530156299472,
    3261.9533529505134
  ],
```

### pr

```bash
sglang generate   --model-path Wan-AI/Wan2.2-T2V-A14B-Diffusers   --text-encoder-cpu-offload   --pin-cpu-memory   --num-gpus 8   --ulysses-degree 8 --attention-backend sage_attn  --enable-torch-compile --prompt "A cat walks on the grass, realistic" --num-frames 81 --height 720 --width 1280 --num-inference-steps 27 --guidance-scale 3.5 --guidance-scale-2 4.0 --dit-layerwise-offload true --perf-dump-path /home/lmsys/bbuf/dump/wan_step_profile_cp8_async_offload.json


100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 27/27 [01:33<00:00,  3.46s/it]
[12-20 02:59:10] [DenoisingStage] average time per step: 3.4553 seconds
[12-20 02:59:10] [DenoisingStage] finished in 94.2283 seconds

"denoise_steps_ms": [
    7717.6975486800075,
    3275.042257271707,
    3280.2467988803983,
    3282.276245765388,
    3292.9044039919972,
    3286.5121429786086,
    3273.5616639256477,
    3271.6003246605396,
    3275.5934856832027,
    3291.9061705470085,
    3293.934356421232,
    3289.3909830600023,
    3298.0582248419523,
    3300.408118404448,
    3305.0247132778168,
    3299.3013756349683,
    3302.0150866359472,
    3299.040620215237,
    3291.0401169210672,
    3296.6199973598123,
    3290.26335850358,
    3302.190547809005,
    3295.942653901875,
    3297.3329443484545,
    3297.713255509734,
    3295.0284238904715,
    3290.1963284239173
  ],
```


**149.69->94.22s, speed up 58%** 。


<img width="2136" height="1270" alt="图片" src="https://github.com/user-attachments/assets/1cdf8ab6-9f0e-4e8e-b680-fbef419a970f" />

memcpy and compute are completely overlapped, with no additional overhead. 


## Warmup

Whether torch compile is enabled or not, I found that the performance of the first step is about 7 times slower than the subsequent steps, which is unacceptable. I profiled the full stage for both scenarios and discovered that the reason for the long initialization time is the initialization overhead of the NCCL All2All. This overhead should not be in the denoise stage but should be handled in advance. Therefore, I implemented a pre-warmup logic specifically for the All2All operation to eliminate this overhead. Now, without torch compile, the time for the first step is almost the same as that of the subsequent steps. Even with compile enabled, the time for the first step is only about twice that of the subsequent steps. 

<img width="1198" height="786" alt="5f69d545-37be-4156-b92a-c8397fb7359a" src="https://github.com/user-attachments/assets/c5c0fa46-eb59-4aef-9777-a94c6d68153c" />


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
