### PR TITLE
[Diffusion] Simplify `--perf-dump-path` JSON output (remove duplicate denoise steps)

### DIFF
--- a/python/sglang/multimodal_gen/docs/profiling.md
+++ b/python/sglang/multimodal_gen/docs/profiling.md
@@ -67,7 +67,7 @@ Besides profiler traces, you can also dump a lightweight JSON report that contai
 
 This is useful to quickly identify which stage dominates end-to-end latency, and whether denoising steps have uniform runtimes (and if not, which step has an abnormal spike).
 
-The dumped JSON contains a `denoise_steps_ms` field formatted as an array of objects, each with a `step` index and `duration_ms`.
+The dumped JSON contains a `denoise_steps_ms` field formatted as an array of objects, each with a `step` key (the step index) and a `duration_ms` key.
 
 Example:
 

--- a/python/sglang/multimodal_gen/docs/profiling.md
+++ b/python/sglang/multimodal_gen/docs/profiling.md
@@ -67,6 +67,8 @@ Besides profiler traces, you can also dump a lightweight JSON report that contai
 
 This is useful to quickly identify which stage dominates end-to-end latency, and whether denoising steps have uniform runtimes (and if not, which step has an abnormal spike).
 
+The dumped JSON contains a `denoise_steps_ms` field formatted as an array of objects, each with a `step` index and `duration_ms`.
+
 Example:
 
 ```bash

--- a/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
+++ b/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
@@ -207,10 +207,9 @@ class PerformanceLogger:
             for name, duration_ms in timings.stages.items()
         ]
 
-        denoise_steps_ms = list(timings.steps)
-        denoise_steps = [
-            {"index": idx, "duration_ms": duration_ms}
-            for idx, duration_ms in enumerate(denoise_steps_ms)
+        denoise_steps_ms = [
+            {"step": idx, "duration_ms": duration_ms}
+            for idx, duration_ms in enumerate(timings.steps)
         ]
 
         report = {
@@ -221,7 +220,6 @@ class PerformanceLogger:
             "total_duration_ms": timings.total_duration_ms,
             "steps": formatted_steps,
             "denoise_steps_ms": denoise_steps_ms,
-            "denoise_steps": denoise_steps,
             "meta": meta or {},
         }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

```shell
CUDA_VISIBLE_DEVICES=7 sglang generate  --pin-cpu-memory --prompt='A curious raccoon' --save-output --log-level=debug --width=720 --height=720 --output-path=outputs --model-path=/home/lmsys/bbuf/FLUX.1-dev --perf-dump-path /home/lmsys/bbuf/dump/flux.1.dev_pr.json
```

## main:

```shell
{
  "timestamp": "2025-12-20T16:44:02.790668+00:00",
  "request_id": "mocked_fake_id_for_offline_generate",
  "commit_hash": "N/A",
  "tag": "cli_generate",
  "total_duration_ms": 17793.82056836039,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 0.05917716771364212
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 380.8412682265043
    },
    {
      "name": "ConditioningStage",
      "duration_ms": 0.015486963093280792
    },
    {
      "name": "TimestepPreparationStage",
      "duration_ms": 49.75398723036051
    },
    {
      "name": "LatentPreparationStage",
      "duration_ms": 0.18907710909843445
    },
    {
      "name": "DenoisingStage",
      "duration_ms": 16625.6210450083
    },
    {
      "name": "DecodingStage",
      "duration_ms": 578.7995513528585
    }
  ],
  "denoise_steps_ms": [
    1189.9274000898004,
    30.193448066711426,
    87.71312329918146,
    87.95888256281614,
    88.12621980905533,
    88.1623923778534,
    88.15256599336863,
    88.20818737149239,
    88.33575807511806,
    88.21670059114695,
    89.98022694140673,
    89.16708547621965,
    89.35186360031366,
    88.64722400903702,
    88.83230481296778,
    88.33552990108728,
    89.0057822689414,
    88.94340693950653,
    88.52302748709917,
    88.50818872451782,
    88.56301382184029,
    88.20297848433256,
    89.17160052806139,
    88.37488479912281,
    88.97067047655582,
    88.84002361446619,
    88.26464135199785,
    88.69576081633568,
    88.74852303415537,
    88.819719851017,
    88.85306864976883,
    88.46315555274487,
    88.64742796868086,
    88.69602996855974,
    89.21477664262056,
    88.18568289279938,
    88.96369952708483,
    88.58739957213402,
    89.33801669627428,
    88.9377212151885,
    88.86127080768347,
    89.11025896668434,
    88.61325681209564,
    88.11667282134295,
    88.64198718219995,
    88.81322294473648,
    89.67370167374611,
    88.4940167888999,
    88.90728000551462,
    88.8472767546773
  ],
  "denoise_steps": [
    {
      "index": 0,
      "duration_ms": 1189.9274000898004
    },
    {
      "index": 1,
      "duration_ms": 30.193448066711426
    },
    {
      "index": 2,
      "duration_ms": 87.71312329918146
    },
    {
      "index": 3,
      "duration_ms": 87.95888256281614
    },
    {
      "index": 4,
      "duration_ms": 88.12621980905533
    },
    {
      "index": 5,
      "duration_ms": 88.1623923778534
    },
    {
      "index": 6,
      "duration_ms": 88.15256599336863
    },
    {
      "index": 7,
      "duration_ms": 88.20818737149239
    },
    {
      "index": 8,
      "duration_ms": 88.33575807511806
    },
    {
      "index": 9,
      "duration_ms": 88.21670059114695
    },
    {
      "index": 10,
      "duration_ms": 89.98022694140673
    },
    {
      "index": 11,
      "duration_ms": 89.16708547621965
    },
    {
      "index": 12,
      "duration_ms": 89.35186360031366
    },
    {
      "index": 13,
      "duration_ms": 88.64722400903702
    },
    {
      "index": 14,
      "duration_ms": 88.83230481296778
    },
    {
      "index": 15,
      "duration_ms": 88.33552990108728
    },
    {
      "index": 16,
      "duration_ms": 89.0057822689414
    },
    {
      "index": 17,
      "duration_ms": 88.94340693950653
    },
    {
      "index": 18,
      "duration_ms": 88.52302748709917
    },
    {
      "index": 19,
      "duration_ms": 88.50818872451782
    },
    {
      "index": 20,
      "duration_ms": 88.56301382184029
    },
    {
      "index": 21,
      "duration_ms": 88.20297848433256
    },
    {
      "index": 22,
      "duration_ms": 89.17160052806139
    },
    {
      "index": 23,
      "duration_ms": 88.37488479912281
    },
    {
      "index": 24,
      "duration_ms": 88.97067047655582
    },
    {
      "index": 25,
      "duration_ms": 88.84002361446619
    },
    {
      "index": 26,
      "duration_ms": 88.26464135199785
    },
    {
      "index": 27,
      "duration_ms": 88.69576081633568
    },
    {
      "index": 28,
      "duration_ms": 88.74852303415537
    },
    {
      "index": 29,
      "duration_ms": 88.819719851017
    },
    {
      "index": 30,
      "duration_ms": 88.85306864976883
    },
    {
      "index": 31,
      "duration_ms": 88.46315555274487
    },
    {
      "index": 32,
      "duration_ms": 88.64742796868086
    },
    {
      "index": 33,
      "duration_ms": 88.69602996855974
    },
    {
      "index": 34,
      "duration_ms": 89.21477664262056
    },
    {
      "index": 35,
      "duration_ms": 88.18568289279938
    },
    {
      "index": 36,
      "duration_ms": 88.96369952708483
    },
    {
      "index": 37,
      "duration_ms": 88.58739957213402
    },
    {
      "index": 38,
      "duration_ms": 89.33801669627428
    },
    {
      "index": 39,
      "duration_ms": 88.9377212151885
    },
    {
      "index": 40,
      "duration_ms": 88.86127080768347
    },
    {
      "index": 41,
      "duration_ms": 89.11025896668434
    },
    {
      "index": 42,
      "duration_ms": 88.61325681209564
    },
    {
      "index": 43,
      "duration_ms": 88.11667282134295
    },
    {
      "index": 44,
      "duration_ms": 88.64198718219995
    },
    {
      "index": 45,
      "duration_ms": 88.81322294473648
    },
    {
      "index": 46,
      "duration_ms": 89.67370167374611
    },
    {
      "index": 47,
      "duration_ms": 88.4940167888999
    },
    {
      "index": 48,
      "duration_ms": 88.90728000551462
    },
    {
      "index": 49,
      "duration_ms": 88.8472767546773
    }
  ],
  "meta": {
    "prompt": "A curious raccoon",
    "model": "/home/lmsys/bbuf/FLUX.1-dev"
  }
}
```

### pr

```shell
{
  "timestamp": "2025-12-20T16:45:15.602292+00:00",
  "request_id": "mocked_fake_id_for_offline_generate",
  "commit_hash": "N/A",
  "tag": "cli_generate",
  "total_duration_ms": 16623.542566783726,
  "steps": [
    {
      "name": "InputValidationStage",
      "duration_ms": 0.050195492804050446
    },
    {
      "name": "TextEncodingStage",
      "duration_ms": 214.03027791529894
    },
    {
      "name": "ConditioningStage",
      "duration_ms": 0.0275513157248497
    },
    {
      "name": "TimestepPreparationStage",
      "duration_ms": 20.57270798832178
    },
    {
      "name": "LatentPreparationStage",
      "duration_ms": 0.19795261323451996
    },
    {
      "name": "DenoisingStage",
      "duration_ms": 15730.156607925892
    },
    {
      "name": "DecodingStage",
      "duration_ms": 499.5251717045903
    }
  ],
  "denoise_steps_ms": [
    {
      "step": 0,
      "duration_ms": 904.1478438302875
    },
    {
      "step": 1,
      "duration_ms": 31.581155955791473
    },
    {
      "step": 2,
      "duration_ms": 86.26624755561352
    },
    {
      "step": 3,
      "duration_ms": 87.91540563106537
    },
    {
      "step": 4,
      "duration_ms": 88.38593773543835
    },
    {
      "step": 5,
      "duration_ms": 88.79596274346113
    },
    {
      "step": 6,
      "duration_ms": 88.53302616626024
    },
    {
      "step": 7,
      "duration_ms": 88.29048089683056
    },
    {
      "step": 8,
      "duration_ms": 88.99596147239208
    },
    {
      "step": 9,
      "duration_ms": 88.23350351303816
    },
    {
      "step": 10,
      "duration_ms": 89.66262731701136
    },
    {
      "step": 11,
      "duration_ms": 89.65202886611223
    },
    {
      "step": 12,
      "duration_ms": 89.15230259299278
    },
    {
      "step": 13,
      "duration_ms": 89.01643101125956
    },
    {
      "step": 14,
      "duration_ms": 88.37343193590641
    },
    {
      "step": 15,
      "duration_ms": 88.1242910400033
    },
    {
      "step": 16,
      "duration_ms": 88.53876311331987
    },
    {
      "step": 17,
      "duration_ms": 88.12840189784765
    },
    {
      "step": 18,
      "duration_ms": 88.29326368868351
    },
    {
      "step": 19,
      "duration_ms": 88.93929328769445
    },
    {
      "step": 20,
      "duration_ms": 88.2862750440836
    },
    {
      "step": 21,
      "duration_ms": 89.30220920592546
    },
    {
      "step": 22,
      "duration_ms": 89.5460657775402
    },
    {
      "step": 23,
      "duration_ms": 88.75859621912241
    },
    {
      "step": 24,
      "duration_ms": 89.21344019472599
    },
    {
      "step": 25,
      "duration_ms": 88.16350717097521
    },
    {
      "step": 26,
      "duration_ms": 88.71318027377129
    },
    {
      "step": 27,
      "duration_ms": 88.3127823472023
    },
    {
      "step": 28,
      "duration_ms": 88.97008746862411
    },
    {
      "step": 29,
      "duration_ms": 88.52356486022472
    },
    {
      "step": 30,
      "duration_ms": 89.39732983708382
    },
    {
      "step": 31,
      "duration_ms": 89.41111341118813
    },
    {
      "step": 32,
      "duration_ms": 89.20713141560555
    },
    {
      "step": 33,
      "duration_ms": 88.8034999370575
    },
    {
      "step": 34,
      "duration_ms": 88.79036642611027
    },
    {
      "step": 35,
      "duration_ms": 89.57242593169212
    },
    {
      "step": 36,
      "duration_ms": 88.89671694487333
    },
    {
      "step": 37,
      "duration_ms": 88.30914087593555
    },
    {
      "step": 38,
      "duration_ms": 88.43822591006756
    },
    {
      "step": 39,
      "duration_ms": 88.63136172294617
    },
    {
      "step": 40,
      "duration_ms": 88.6586606502533
    },
    {
      "step": 41,
      "duration_ms": 88.55385147035122
    },
    {
      "step": 42,
      "duration_ms": 88.57719227671623
    },
    {
      "step": 43,
      "duration_ms": 88.44835963100195
    },
    {
      "step": 44,
      "duration_ms": 88.80006894469261
    },
    {
      "step": 45,
      "duration_ms": 88.736473582685
    },
    {
      "step": 46,
      "duration_ms": 89.2184404656291
    },
    {
      "step": 47,
      "duration_ms": 88.41401617974043
    },
    {
      "step": 48,
      "duration_ms": 89.56742845475674
    },
    {
      "step": 49,
      "duration_ms": 88.38559128344059
    }
  ],
  "meta": {
    "prompt": "A curious raccoon",
    "model": "/home/lmsys/bbuf/FLUX.1-dev"
  }
}
```



## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
