### PR TITLE
Fix: Accept transformers 5.0.0rc0+ for GLM-4.6V models

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -851,14 +851,14 @@ class ModelConfig:
         needs_tf_v5 = is_glm_46vmoe
 
         tf_version = version.parse(tf_version_str)
-        required_version = version.parse("5.0.0")
+        required_version = version.parse("5.0.0rc0")
 
         if tf_version < required_version:
             if needs_tf_v5:
                 raise ValueError(
                     f"Transformers version {tf_version_str} is not supported for model {self.model_path} "
                     f"or model type {self.hf_config.model_type}. "
-                    "Please upgrade transformers to >= 5.0.0."
+                    "Please upgrade transformers to >= 5.0.0rc0."
                 )
         elif not needs_tf_v5:
             logger.warning(


### PR DESCRIPTION
## Motivation

#14998 introduced a version check for GLM-4.6V models that requires `transformers >= 5.0.0`. However, the stable version `5.0.0` doesn't exist yet - only release candidates `5.0.0rc0` and `5.0.0rc1` are currently available. This caused GLM-4.6V models to fail loading in SGLang 0.5.6.post2 and nightly builds, as the version check would reject the available `5.0.0rc0` and `5.0.0rc1` versions.

## Modifications

Changed the `required_version` from `"5.0.0"` to `"5.0.0rc0"` to correctly accept the currently available transformers release candidates. This allows GLM-4.6V models to load properly with `transformers >= 5.0.0rc0`.

## Accuracy Tests

N/A - This is a version check fix that doesn't affect model outputs.

## Benchmarking and Profiling

N/A - This change only affects the version validation logic, not inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)