### PR TITLE
[sgl-kernel] Streamline kernel size report (Top 20 only) and clean up

### DIFF
--- a/sgl-kernel/README.md
+++ b/sgl-kernel/README.md
@@ -104,7 +104,9 @@ m.impl("fwd", torch::kCUDA, make_pytorch_shim(&mha_fwd));
 
 ## Kernel Size Analysis
 
-Analyze CUDA kernel sizes in compiled wheel files to identify optimization opportunities:
+Analyze CUDA kernel sizes in compiled wheel files to identify oversized kernels and template-instantiation bloat:
+
+This tool requires `cubloaty` (install with `pip install cubloaty`) to work.
 
 ```bash
 # Install cubloaty
@@ -118,9 +120,9 @@ python analyze_whl_kernel_sizes.py path/to/sgl_kernel-*.whl --output my_analysis
 ```
 
 The tool generates:
-- Text report with kernel groups (by name prefix) and individual kernel sizes
-- JSON file with detailed structured data
-- Timing information for each analysis step
+- A text report with:
+  - Kernel groups (by name prefix)
+  - Individual kernel sizes (sorted by size)
 
 Use this to identify large kernels and potential template instantiation bloat.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Follow https://github.com/sgl-project/sglang/pull/14544

Cleans up `sgl-kernel/analyze_whl_kernel_sizes.py` by removing noisy non-essential prints/comments and keeping the output focused on the text report, which summarizes only the Top 20 kernel name-prefix groups and Top 20 individual kernels (with an aggregated “Other” row for the rest).

In h200:

```shell
============================================================================================================================================
CUDA Kernel Size Analysis
============================================================================================================================================

Total kernels: 10272
Total size: 1631.91 MB (1,711,178,912 bytes)
Average kernel size: 162.68 KB

============================================================================================================================================
Kernel Groups (by name prefix) - Top 20
============================================================================================================================================
Rank   Kernel Prefix                                                                    Count    Total (MB)   %       
--------------------------------------------------------------------------------------------------------------------------------------------
1      void cutlass::device_kernel                                                      3648     651.90       39.95   
2      void marlin_moe_wna16::Marlin                                                    720      370.32       22.69   
3      void marlin::Marlin                                                              1080     292.63       17.93   
4      void fast_hadamard_transform_kernel                                              294      89.20        5.47    
5      void flash::flash_fwd_sparse_kernel                                              32       11.43        0.70    
6      void cutlass::Kernel2                                                            96       11.24        0.69    
7      void per_token_group_quant_8bit_kernel                                           196      8.82         0.54    
8      void flashinfer::sampling::TopKTopPSamplingFromProbKernel                        40       7.54         0.46    
9      void flashinfer::sampling::TopKSamplingFromProbKernel                            40       7.50         0.46    
10     void router_gemm_kernel_bf16_output                                              64       6.89         0.42    
11     void router_gemm_kernel_float_output                                             64       6.83         0.42    
12     void mscclpp::executionKernel                                                    30       5.48         0.34    
13     void moe_fused_gate_kernel                                                       24       3.51         0.22    
14     void flashinfer::sampling::OnlineSoftmaxFusedKernel                              40       3.44         0.21    
15     void topkGatingSigmoid                                                           54       3.43         0.21    
16     void flashinfer::sampling::ChainSpeculativeSampling                              20       3.33         0.20    
17     void flashinfer::sampling::TopPSamplingFromProbKernel                            20       3.28         0.20    
18     void flashinfer::norm::FusedAddRMSNormKernel                                     30       3.15         0.19    
19     void topkGatingSoftmax                                                           54       3.03         0.19    
20     void flashinfer::BatchQKApplyRotaryPosIdsCosSinCacheEnhancedKernel               96       2.92         0.18    
Other  (remaining 1312 kernel groups)                                                   3630     136.04       8.34    

============================================================================================================================================
Individual Kernels (sorted by size) - Top 20
============================================================================================================================================
Rank   File                                     Kernel Name                                                            Size (KB)    Size (MB)    %       
--------------------------------------------------------------------------------------------------------------------------------------------
1      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1475.00      1.4404       0.09    
2      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1434.25      1.4006       0.09    
3      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1400.88      1.3680       0.08    
4      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1362.38      1.3304       0.08    
5      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1267.00      1.2373       0.08    
6      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1257.00      1.2275       0.08    
7      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1191.88      1.1639       0.07    
8      common_ops.abi3.so                       void cutlass::device_kernel<cutlass::fmha::kernel::Sm100FmhaMlaK...    1183.00      1.1553       0.07    
9      common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__nv_bfloat16, 1125899923621888l, ...    1029.50      1.0054       0.06    
10     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__nv_bfloat16, 1125899923621888l, ...    1029.50      1.0054       0.06    
11     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__nv_bfloat16, 1125899923621888l, ...    998.62       0.9752       0.06    
12     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__nv_bfloat16, 1125899923621888l, ...    998.62       0.9752       0.06    
13     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__half, 1125899923621888l, 1125899...    977.88       0.9550       0.06    
14     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__half, 1125899923621888l, 1125899...    977.88       0.9550       0.06    
15     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__nv_bfloat16, 1125899907892224l, ...    968.12       0.9454       0.06    
16     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__nv_bfloat16, 1125899907892224l, ...    968.12       0.9454       0.06    
17     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__half, 1125899907892224l, 1125899...    947.88       0.9257       0.06    
18     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__half, 1125899907892224l, 1125899...    947.88       0.9257       0.06    
19     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__half, 1125899923621888l, 1125899...    947.12       0.9249       0.06    
20     common_ops.abi3.so                       void marlin_moe_wna16::Marlin<__half, 1125899923621888l, 1125899...    947.12       0.9249       0.06    
Other  (remaining 10252 kernels)                                                                                       1648763.53   1610.1206    98.66   
```


## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
