### PR TITLE
Add MTP speculative decoding support for Triton attention backend for Mimo-v2-Flash

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -636,7 +636,6 @@ class Scheduler(
 
                 self.tree_cache = SWAChunkCache(params)
         else:
-
             if envs.SGLANG_EXPERIMENTAL_CPP_RADIX_TREE.get():
                 # lazy import to avoid JIT overhead
                 from sglang.srt.mem_cache.radix_cache_cpp import RadixCacheCpp
@@ -1916,7 +1915,6 @@ class Scheduler(
 
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
-
             if self.enable_lora:
                 new_lora_set = (
                     lora_set

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -153,9 +153,10 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
         self.draft_tp_context = (
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
-        with self.draft_tp_context(
-            self.draft_runner_list[0].tp_group
-        ), speculative_moe_backend_context():
+        with (
+            self.draft_tp_context(self.draft_runner_list[0].tp_group),
+            speculative_moe_backend_context(),
+        ):
             self.init_attention_backend()
             self.init_cuda_graphs()
 
@@ -173,19 +174,20 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
             self.draft_runner_list[i].model.set_embed_and_head(embed, head)
 
     def init_attention_backend(self):
-        # Create attn backends
+        # Create attn backends using DraftBackendFactory for backend flexibility
+        # This allows MTP to work with non-FA3 backends (e.g., Triton, FlashInfer)
+        from sglang.srt.speculative.draft_utils import DraftBackendFactory
+
         self.draft_extend_attn_backend_list = []
         for step in range(self.speculative_num_steps):
-            from sglang.srt.layers.attention.flashattention_backend import (
-                FlashAttentionBackend,
+            draft_backend_factory = DraftBackendFactory(
+                self.server_args,
+                self.draft_runner_list[step],
+                self.topk,
+                self.speculative_num_steps,
             )
-
             self.draft_extend_attn_backend_list.append(
-                FlashAttentionBackend(
-                    model_runner=self.draft_runner_list[step],
-                    skip_prefill=False,
-                    speculative_step_id=step,
-                )
+                draft_backend_factory.create_draft_extend_backend()
             )
             self.draft_runner_list[step].attn_backend = (
                 self.draft_extend_attn_backend_list[-1]


### PR DESCRIPTION
The PR adds Triton backend support for MTP speculative decoding, which is important because:                                   
     - Triton works on all GPUs (including Ampere, Hopper, and Blackwell)                                                           
     - Previously MTP was hardcoded to use FlashAttentionBackend (FA3)                                                              
     - Now users on non-Hopper hardware or those preferring Triton can use MTP speculative decoding  
      - Adds `DRAFT_EXTEND_V2` mode support to the Triton attention backend for MTP speculative decoding
      - Uses `DraftBackendFactory` in `mtp_worker_v2.py` to allow backend flexibility 
      -  instead of hardcoding FlashAttention
      - Test system 4x 6000 Pro Blackwell workstation cards


