### PR TITLE
Make torchvision an optional dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -66,7 +66,6 @@ dependencies = [
   "torch==2.9.1",
   "torchaudio==2.9.1",
   "torchcodec==0.8.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. If not provided, transformer will use torchvision instead by default.
-  "torchvision",
   "torchao==0.9.0",
   "tqdm",
   "transformers==4.57.1",
@@ -82,6 +81,7 @@ dependencies = [
 
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
+vl = ["torchvision"]  # Required for vision-language models (InternVL, Qwen-VL video, DeepSeek-VL2)
 diffusion = [
   "PyYAML==6.0.1",
   "cloudpickle",


### PR DESCRIPTION
## Motivation

torchvision is a heavy dependency that can cause compatibility issues on some platforms (e.g., aarch64) and isn't needed by users who only use text-based LLMs. Making it optional reduces install friction and avoids version conflicts for the majority of sglang users.

Related discussion: Previously discussed with maintainers who indicated this change would be reasonable.

## Modifications

- Removed `torchvision` from main `dependencies` in `pyproject.toml`
- Added `vl = ["torchvision"]` as an optional dependency for vision-language model users

Users who need VL models (InternVL, Qwen-VL video, DeepSeek-VL2) can install with: pip install sglang[vl]


## Accuracy Tests

N/A - No changes to model outputs. This only affects dependency installation.

## Benchmarking and Profiling

N/A - No changes to inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)