### PR TITLE
[model-gateway] add retry and circuit breaker support to gRPC routers

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -8,7 +8,7 @@ use super::PipelineStage;
 use crate::routers::{
     error,
     grpc::{
-        context::{ClientSelection, ExecutionResult, LoadGuards, RequestContext},
+        context::{ClientSelection, ExecutionResult, LoadGuards, RequestContext, WorkerSelection},
         proto_wrapper::{ProtoGenerateRequest, ProtoStream},
     },
 };
@@ -96,9 +96,10 @@ impl PipelineStage for RequestExecutionStage {
 
         let result = async {
             match self.mode {
-                ExecutionMode::Single => self.execute_single(proto_request, clients).await,
+                ExecutionMode::Single => self.execute_single(proto_request, clients, workers).await,
                 ExecutionMode::DualDispatch => {
-                    self.execute_dual_dispatch(proto_request, clients).await
+                    self.execute_dual_dispatch(proto_request, clients, workers)
+                        .await
                 }
             }
         }
@@ -120,6 +121,7 @@ impl RequestExecutionStage {
         &self,
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
+        workers: &WorkerSelection,
     ) -> Result<ExecutionResult, Response> {
         let client = clients.single_mut().ok_or_else(|| {
             error!(
@@ -132,7 +134,12 @@ impl RequestExecutionStage {
             )
         })?;
 
-        let stream = client.generate(proto_request).await.map_err(|e| {
+        let result = client.generate(proto_request).await;
+
+        // Record circuit breaker outcome
+        workers.record_outcome(result.is_ok());
+
+        let stream = result.map_err(|e| {
             error!(
                 function = "execute_single",
                 error = %e,
@@ -151,6 +158,7 @@ impl RequestExecutionStage {
         &self,
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
+        workers: &WorkerSelection,
     ) -> Result<ExecutionResult, Response> {
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
@@ -170,6 +178,9 @@ impl RequestExecutionStage {
             prefill_client.generate(prefill_request),
             decode_client.generate(decode_request)
         );
+
+        // Record circuit breaker outcomes for each worker individually
+        workers.record_dual_outcomes(prefill_result.is_ok(), decode_result.is_ok());
 
         // Handle prefill result
         let prefill_stream = match prefill_result {

--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -368,6 +368,25 @@ impl WorkerSelection {
         }
     }
 
+    /// Record circuit breaker outcome for all workers
+    pub fn record_outcome(&self, success: bool) {
+        match self {
+            Self::Single { worker } => worker.record_outcome(success),
+            Self::Dual { prefill, decode } => {
+                prefill.record_outcome(success);
+                decode.record_outcome(success);
+            }
+        }
+    }
+
+    /// Record circuit breaker outcomes for dual dispatch (individual tracking)
+    pub fn record_dual_outcomes(&self, prefill_success: bool, decode_success: bool) {
+        if let Self::Dual { prefill, decode } = self {
+            prefill.record_outcome(prefill_success);
+            decode.record_outcome(decode_success);
+        }
+    }
+
     #[allow(clippy::type_complexity)]
     pub fn dual(&self) -> Option<(&Arc<dyn Worker>, &Arc<dyn Worker>)> {
         match self {


### PR DESCRIPTION
- Add circuit breaker outcome recording to WorkerSelection in context.rs
- Record outcomes in request_execution.rs after gRPC calls complete
- Add RetryExecutor with exponential backoff to GrpcRouter and GrpcPDRouter
- Use is_retryable_status for 408, 429, 500, 502, 503, 504 status codes
- Record retry metrics with proper worker labels (WORKER_REGULAR, WORKER_PREFILL, WORKER_DECODE)
- Consistent with HTTP router retry patterns

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
