### PR TITLE
perf(diffusion): Keep image encoder/processor on GPU by default to cut latency

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -231,7 +231,7 @@ class ServerArgs:
     use_fsdp_inference: bool = False
     dit_layerwise_offload: bool = False
     text_encoder_cpu_offload: bool = True
-    image_encoder_cpu_offload: bool = True
+    image_encoder_cpu_offload: bool = False
     vae_cpu_offload: bool = True
     pin_cpu_memory: bool = True
 
@@ -880,12 +880,12 @@ class ServerArgs:
             self.disable_autocast = False
 
         # Validate mode consistency
-        assert isinstance(
-            self.mode, ExecutionMode
-        ), f"Mode must be an ExecutionMode enum, got {type(self.mode)}"
-        assert (
-            self.mode in ExecutionMode.choices()
-        ), f"Invalid execution mode: {self.mode}"
+        assert isinstance(self.mode, ExecutionMode), (
+            f"Mode must be an ExecutionMode enum, got {type(self.mode)}"
+        )
+        assert self.mode in ExecutionMode.choices(), (
+            f"Invalid execution mode: {self.mode}"
+        )
 
         if self.tp_size == -1:
             self.tp_size = 1


### PR DESCRIPTION
### Motivation
Per-request CPU↔GPU hops for the image processor/encoder add latency and kernel re-inits, I believe keeping them resident would remove two device transfers per request improving latency (when VRAM allows)

### Summary
Around 6% lower mean latency
- Cached the image processor/encoder device in `ImageEncodingStage` to avoid redundant `.to()` calls each request.
- Stopped unconditional offload back to CPU; offload now only happens when `image_encoder_cpu_offload` is enabled.
- Changed `image_encoder_cpu_offload` to `False` so the image encoder/processor remains resident on GPU out of the box.

Ran FLUX.1-dev on 1x A100 with deterministic settings.
```bash
sglang generate \
  --model-path black-forest-labs/FLUX.1-dev \
  --prompt "A cat in a hat" \
  --image-path "$IMG" \
  --height 1024 --width 1024 --num-inference-steps 20 \
  --seed 1024 
```

**Results:**
**Single-stream (per-request latency, 10 runs)**
- Baseline `avg_total_ms`: **24,795.12 ms**
- After `avg_total_ms`: **23,288.12 ms**
- Improvement: ~ **6.1% faster per request**

**Multi-stream (20 requests, concurrency=4):**
- Throughput (`req/s`): **0.0475 → 0.0544** (~**14.6%** improvement)
- Avg latency (`s`): **78.74 → 67.98** (~**13.7%** improvement)
- P95 latency (`s`): **128.84 → 91.26** (~**29.2%** improvement)