### PR TITLE
Improve engine customization interface

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -91,94 +91,25 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 _is_cuda = is_cuda()
 
 
-def _launch_subprocesses(
-    server_args: ServerArgs, port_args: Optional[PortArgs] = None
-) -> Tuple[TokenizerManager, TemplateManager, Dict, PortArgs]:
-    """
-    Launch the TokenizerManager in the main process, the Scheduler in a subprocess, and the DetokenizerManager in another subprocess.
-    """
-    # Configure global environment
-    configure_logger(server_args)
-    _set_envs_and_config(server_args)
-    server_args.check_server_args()
+def init_tokenizer_manager(
+    server_args: ServerArgs,
+    port_args: PortArgs,
+    TokenizerManagerClass: Optional[TokenizerManager] = None,
+) -> Tuple[TokenizerManager, TemplateManager]:
+    # Launch tokenizer process
+    TokenizerManagerClass = TokenizerManagerClass or TokenizerManager
+    tokenizer_manager = TokenizerManagerClass(server_args, port_args)
 
-    # Allocate ports for inter-process communications
-    if port_args is None:
-        port_args = PortArgs.init_new(server_args)
-        logger.info(f"{server_args=}")
-
-    # Launch scheduler processes
-    scheduler_procs, scheduler_pipe_readers = _launch_scheduler_processes(
-        server_args=server_args,
-        port_args=port_args,
+    # Initialize templates
+    template_manager = TemplateManager()
+    template_manager.initialize_templates(
+        tokenizer_manager=tokenizer_manager,
+        model_path=server_args.model_path,
+        chat_template=server_args.chat_template,
+        completion_template=server_args.completion_template,
     )
 
-    if server_args.node_rank >= 1:
-        # In multi-node cases, non-zero rank nodes do not need to run tokenizer or detokenizer,
-        # so they can just wait here.
-
-        for reader in scheduler_pipe_readers:
-            data = reader.recv()
-            assert data["status"] == "ready"
-
-        if os.getenv("SGLANG_BLOCK_NONZERO_RANK_CHILDREN") == "0":
-            # When using `Engine` as a Python API, we don't want to block here.
-            return None, None, None, port_args
-
-        launch_dummy_health_check_server(
-            server_args.host, server_args.port, server_args.enable_metrics
-        )
-
-        for proc in scheduler_procs:
-            proc.join()
-            logger.error(
-                f"Scheduler or DataParallelController {proc.pid} terminated with {proc.exitcode}"
-            )
-        return None, None, None, port_args
-
-    # Launch detokenizer process
-    detoken_proc = mp.Process(
-        target=run_detokenizer_process,
-        args=(
-            server_args,
-            port_args,
-        ),
-    )
-    detoken_proc.start()
-
-    # Init tokenizer manager first, as the bootstrap server is initialized here
-    if server_args.tokenizer_worker_num == 1:
-        tokenizer_manager, template_manager = _init_tokenizer_manager(
-            server_args, port_args
-        )
-    else:
-        # Launch multi-tokenizer router
-        tokenizer_manager = MultiTokenizerRouter(server_args, port_args)
-        template_manager = None
-
-    # Wait for the model to finish loading
-    scheduler_infos = []
-    for i in range(len(scheduler_pipe_readers)):
-        try:
-            data = scheduler_pipe_readers[i].recv()
-        except EOFError:
-            logger.error(
-                f"Rank {i} scheduler is dead. Please check if there are relevant logs."
-            )
-            scheduler_procs[i].join()
-            logger.error(f"Exit code: {scheduler_procs[i].exitcode}")
-            raise
-
-        if data["status"] != "ready":
-            raise RuntimeError(
-                "Initialization failed. Please see the error messages above."
-            )
-        scheduler_infos.append(data)
-
-    # Get back some info from scheduler to tokenizer_manager
-    tokenizer_manager.max_req_input_len = scheduler_infos[0]["max_req_input_len"]
-
-    return tokenizer_manager, template_manager, scheduler_infos, port_args
+    return tokenizer_manager, template_manager
 
 
 class Engine(EngineBase):
@@ -197,8 +128,10 @@ class Engine(EngineBase):
 
     # Some fields to allow people to override the server args
     # and launch processes for their private forks.
-    launch_subprocesses_func: Callable = staticmethod(_launch_subprocesses)
     server_args_class: ServerArgs = ServerArgs
+    init_tokenizer_manager_func: Callable = staticmethod(init_tokenizer_manager)
+    run_scheduler_process_func: Callable = staticmethod(run_scheduler_process)
+    run_detokenizer_process_func: Callable = staticmethod(run_detokenizer_process)
 
     def __init__(self, **kwargs):
         """
@@ -224,7 +157,12 @@ class Engine(EngineBase):
 
         # Launch subprocesses
         tokenizer_manager, template_manager, scheduler_infos, port_args = (
-            self.launch_subprocesses_func(server_args=server_args)
+            _launch_subprocesses(
+                server_args=server_args,
+                init_tokenizer_manager_func=self.init_tokenizer_manager_func,
+                run_scheduler_process_func=self.run_scheduler_process_func,
+                run_detokenizer_process_func=self.run_detokenizer_process_func,
+            )
         )
         self.tokenizer_manager = tokenizer_manager
         self.template_manager = template_manager
@@ -873,32 +811,10 @@ def _set_envs_and_config(server_args: ServerArgs):
     mp.set_start_method("spawn", force=True)
 
 
-def _init_tokenizer_manager(
-    server_args: ServerArgs,
-    port_args: PortArgs,
-    TokenizerManagerClass: Optional[TokenizerManager] = None,
-) -> TokenizerManager:
-    # Launch tokenizer process
-    TokenizerManagerClass = TokenizerManagerClass or TokenizerManager
-    tokenizer_manager = TokenizerManagerClass(server_args, port_args)
-
-    # Initialize templates
-    template_manager = TemplateManager()
-    template_manager.initialize_templates(
-        tokenizer_manager=tokenizer_manager,
-        model_path=server_args.model_path,
-        chat_template=server_args.chat_template,
-        completion_template=server_args.completion_template,
-    )
-
-    return tokenizer_manager, template_manager
-
-
 def _launch_scheduler_processes(
     server_args: ServerArgs,
     port_args: PortArgs,
-    run_scheduler_process_func: Callable = run_scheduler_process,
-    run_data_parallel_controller_process_func: Callable = run_data_parallel_controller_process,
+    run_scheduler_process_func: Callable,
 ):
     scheduler_procs = []
 
@@ -959,10 +875,110 @@ def _launch_scheduler_processes(
         reader, writer = mp.Pipe(duplex=False)
         scheduler_pipe_readers = [reader]
         proc = mp.Process(
-            target=run_data_parallel_controller_process_func,
-            args=(server_args, port_args, writer),
+            target=run_data_parallel_controller_process,
+            kwargs=dict(
+                server_args=server_args,
+                port_args=port_args,
+                pipe_writer=writer,
+                run_scheduler_process_func=run_scheduler_process_func,
+            ),
         )
         proc.start()
         scheduler_procs.append(proc)
 
     return scheduler_procs, scheduler_pipe_readers
+
+
+def _launch_subprocesses(
+    server_args: ServerArgs,
+    init_tokenizer_manager_func: Callable,
+    run_scheduler_process_func: Callable,
+    run_detokenizer_process_func: Callable,
+    port_args: Optional[PortArgs] = None,
+) -> Tuple[TokenizerManager, TemplateManager, Tuple[Dict], PortArgs]:
+    """
+    Launch the TokenizerManager in the main process, the Scheduler in a subprocess, and the DetokenizerManager in another subprocess.
+    """
+    # Configure global environment
+    configure_logger(server_args)
+    _set_envs_and_config(server_args)
+    server_args.check_server_args()
+
+    # Allocate ports for inter-process communications
+    if port_args is None:
+        port_args = PortArgs.init_new(server_args)
+    logger.info(f"{server_args=}")
+
+    # Launch scheduler processes
+    scheduler_procs, scheduler_pipe_readers = _launch_scheduler_processes(
+        server_args=server_args,
+        port_args=port_args,
+        run_scheduler_process_func=run_scheduler_process_func,
+    )
+
+    if server_args.node_rank >= 1:
+        # In multi-node cases, non-zero rank nodes do not need to run tokenizer or detokenizer,
+        # so they can just wait here.
+
+        for reader in scheduler_pipe_readers:
+            data = reader.recv()
+            assert data["status"] == "ready"
+
+        if os.getenv("SGLANG_BLOCK_NONZERO_RANK_CHILDREN") == "0":
+            # When using `Engine` as a Python API, we don't want to block here.
+            return None, None, None, port_args
+
+        launch_dummy_health_check_server(
+            server_args.host, server_args.port, server_args.enable_metrics
+        )
+
+        for proc in scheduler_procs:
+            proc.join()
+            logger.error(
+                f"Scheduler or DataParallelController {proc.pid} terminated with {proc.exitcode}"
+            )
+        return None, None, None, port_args
+
+    # Launch detokenizer process
+    detoken_proc = mp.Process(
+        target=run_detokenizer_process_func,
+        args=(
+            server_args,
+            port_args,
+        ),
+    )
+    detoken_proc.start()
+
+    # Init tokenizer manager first, as the bootstrap server is initialized here
+    if server_args.tokenizer_worker_num == 1:
+        tokenizer_manager, template_manager = init_tokenizer_manager_func(
+            server_args, port_args
+        )
+    else:
+        # Launch multi-tokenizer router
+        tokenizer_manager = MultiTokenizerRouter(server_args, port_args)
+        template_manager = None
+
+    # Wait for the model to finish loading
+    scheduler_infos = []
+    for i in range(len(scheduler_pipe_readers)):
+        try:
+            data = scheduler_pipe_readers[i].recv()
+        except EOFError:
+            logger.error(
+                f"Rank {i} scheduler is dead. Please check if there are relevant logs."
+            )
+            scheduler_procs[i].join()
+            logger.error(f"Exit code: {scheduler_procs[i].exitcode}")
+            raise
+
+        if data["status"] != "ready":
+            raise RuntimeError(
+                "Initialization failed. Please see the error messages above."
+            )
+        scheduler_infos.append(data)
+
+    # Get back some info from scheduler to tokenizer_manager
+    tokenizer_manager.max_req_input_len = scheduler_infos[0]["max_req_input_len"]
+
+    return tokenizer_manager, template_manager, scheduler_infos, port_args

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -792,7 +792,7 @@ async def serve_grpc(
     # Start warmup in a separate thread
     warmup_thread = threading.Thread(
         target=_wait_and_warmup_grpc,
-        args=(server_args, None, health_servicer),
+        args=(server_args, health_servicer),
     )
     warmup_thread.start()
 
@@ -840,10 +840,7 @@ async def serve_grpc(
         logger.info("All scheduler processes terminated")
 
 
-def _execute_grpc_server_warmup(
-    server_args: ServerArgs,
-    pipe_finish_writer: Optional[mp.connection.Connection],
-):
+def _execute_grpc_server_warmup(server_args: ServerArgs):
     """Execute warmup for gRPC server by checking health and sending test request."""
     try:
         # Connect to the gRPC server
@@ -874,8 +871,6 @@ def _execute_grpc_server_warmup(
         if not success:
             error_msg = f"gRPC server warmup failed: Could not connect to server after 120 seconds. Last error: {last_error}"
             logger.error(error_msg)
-            if pipe_finish_writer is not None:
-                pipe_finish_writer.send(error_msg)
             channel.close()
             kill_process_tree(os.getpid())
             return False
@@ -938,8 +933,6 @@ def _execute_grpc_server_warmup(
             except Exception as e:
                 error_msg = f"gRPC warmup request failed: {e}"
                 logger.error(error_msg)
-                if pipe_finish_writer is not None:
-                    pipe_finish_writer.send(error_msg)
                 channel.close()
                 kill_process_tree(os.getpid())
                 return False
@@ -966,8 +959,6 @@ def _execute_grpc_server_warmup(
             except Exception as e:
                 error_msg = f"gRPC warmup request failed: {e}"
                 logger.error(error_msg)
-                if pipe_finish_writer is not None:
-                    pipe_finish_writer.send(error_msg)
                 channel.close()
                 kill_process_tree(os.getpid())
                 return False
@@ -980,8 +971,6 @@ def _execute_grpc_server_warmup(
             f"gRPC warmup failed with exception: {e}\n{get_exception_traceback()}"
         )
         logger.error(error_msg)
-        if pipe_finish_writer is not None:
-            pipe_finish_writer.send(error_msg)
         try:
             channel.close()
         except Exception:
@@ -992,12 +981,11 @@ def _execute_grpc_server_warmup(
 
 def _wait_and_warmup_grpc(
     server_args: ServerArgs,
-    pipe_finish_writer: Optional[mp.connection.Connection],
     health_servicer: Optional[SGLangHealthServicer] = None,
 ):
     """Wait for gRPC server to be ready and execute warmup."""
     if not server_args.skip_server_warmup:
-        if not _execute_grpc_server_warmup(server_args, pipe_finish_writer):
+        if not _execute_grpc_server_warmup(server_args):
             return
     else:
         logger.info("Skipping gRPC server warmup (skip_server_warmup=True)")
@@ -1007,6 +995,3 @@ def _wait_and_warmup_grpc(
         health_servicer.set_serving()
 
     logger.info("The server is fired up and ready to roll!")
-
-    if pipe_finish_writer is not None:
-        pipe_finish_writer.send("ready")

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -6,7 +6,6 @@ Uses GrpcRequestManager for orchestration without tokenization.
 import asyncio
 import dataclasses
 import logging
-import multiprocessing as mp
 import os
 import signal
 import threading

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -136,7 +136,7 @@ class SchedulerPPMixin:
 
             # When the server is idle, self-check and re-init some states
             if server_is_idle:
-                self.check_during_pp_idle()
+                self.self_check_during_idle()
 
     @DynamicGradMode()
     def event_loop_pp_disagg_prefill(self: Scheduler):
@@ -312,7 +312,7 @@ class SchedulerPPMixin:
 
             # When the server is idle, self-check and re-init some states
             if server_is_idle and len(self.disagg_prefill_inflight_queue) == 0:
-                self.check_during_pp_idle()
+                self.self_check_during_idle()
 
     @DynamicGradMode()
     def event_loop_pp_disagg_decode(self: Scheduler):
@@ -501,7 +501,7 @@ class SchedulerPPMixin:
                 queue_size += len(self.decode_offload_manager.ongoing_offload)
 
             if server_is_idle and queue_size == 0:
-                self.check_during_pp_idle()
+                self.self_check_during_idle()
 
     def init_pp_loop_state(self: Scheduler):
         self.pp_loop_size: int = self.pp_size + self.server_args.pp_async_batch_depth
@@ -699,12 +699,6 @@ class SchedulerPPMixin:
             )
 
         return predicted_size
-
-    def check_during_pp_idle(self: Scheduler):
-        self.check_memory()
-        self.check_tree_cache()
-        self.new_token_ratio = self.init_new_token_ratio
-        self.maybe_sleep_on_idle()
 
     def process_bootstrapped_queue(
         self: Scheduler, bootstrapped_rids: Optional[List[str]]

--- a/scripts/code_sync/guideline.md
+++ b/scripts/code_sync/guideline.md
@@ -47,5 +47,5 @@ It learns from [Copybara](https://github.com/google/copybara), a tool used at Go
                 default=ServerArgs.private_flag,
             )
     ```
-- Similarly, you can inherit `Engine` and override `launch_subprocesses_func`, `server_args_class`.
-- You can pass your own subprocesses launch functions to `launch_server.py::launch_server`
+- Similarly, you can inherit `Engine` and override its fields. You can override `server_args_class` to use your own ServerArgs,
+  override `init_tokenizer_manager_func` to use your own TokenizerManager, override `run_scheduler_process_func` to use your own scheduler.


### PR DESCRIPTION
We introduce a new interface to allow users to easily use their own ServerArgs, TokenizerManager, or Scheduler.
They can override the `Engine` class or pass these arguments to `launch_server`

```python
class Engine:
    # Some fields to allow people to override the server args
    # and launch processes for their private forks.
    server_args_class: ServerArgs = ServerArgs
    init_tokenizer_manager_func: Callable = staticmethod(init_tokenizer_manager)
    run_scheduler_process_func: Callable = staticmethod(run_scheduler_process)
    run_detokenizer_process_func: Callable = staticmethod(run_detokenizer_process)
```

```python
def launch_server(
    server_args: ServerArgs,
    init_tokenizer_manager_func: Callable = init_tokenizer_manager,
    run_scheduler_process_func: Callable = run_scheduler_process,
    run_detokenizer_process_func: Callable = run_detokenizer_process,
    execute_warmup_func: Callable = _execute_server_warmup,
    launch_callback: Optional[Callable[[], None]] = None,
):
```