### PR TITLE
Add `unbalanced_model_loading_timeout_s` Configuration

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -93,6 +93,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_IS_FIRST_RANK_ON_NODE` | Indicates if the current process is the first rank on its node | `"true"` |
 | `SGLANG_PP_LAYER_PARTITION` | Pipeline parallel layer partition specification | Not set |
 | `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS` | Set one visible device per process for distributed computing | `false` |
+| `SGLANG_UNBALANCED_MODEL_LOADING_TIMEOUT_S` | Timeout (seconds) for `dist.monitored_barrier` during model loading (used to detect straggler ranks) | `480` |
 
 ## Testing & Debugging (Internal/CI)
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -248,7 +248,9 @@ def add_chunked_prefix_cache_attention_backend(backend_name):
 
 
 # Detect stragger ranks in model loading
-UNBALANCED_MODEL_LOADING_TIMEOUT_S = 480  # leave more time for post data processing
+UNBALANCED_MODEL_LOADING_TIMEOUT_S = int(
+    os.getenv("SGLANG_UNBALANCED_MODEL_LOADING_TIMEOUT_S", "480")
+)
 
 # the ratio of mamba cache pool size to max_running_requests
 MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO = 3
@@ -1022,7 +1024,10 @@ class ModelRunner:
                 dist.monitored_barrier(
                     group=get_tp_group().cpu_group,
                     timeout=datetime.timedelta(
-                        seconds=UNBALANCED_MODEL_LOADING_TIMEOUT_S
+                        seconds=(
+                            self.server_args.unbalanced_model_loading_timeout_s
+                            or UNBALANCED_MODEL_LOADING_TIMEOUT_S
+                        )
                     ),
                     wait_all_ranks=True,
                 )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -326,6 +326,9 @@ class ServerArgs:
     watchdog_timeout: float = 300
     soft_watchdog_timeout: Optional[float] = None
     dist_timeout: Optional[int] = None  # timeout for torch.distributed
+    unbalanced_model_loading_timeout_s: Optional[int] = (
+        None  # monitored_barrier timeout during model loading
+    )
     download_dir: Optional[str] = None
     base_gpu_id: int = 0
     gpu_id_step: int = 1
@@ -2867,6 +2870,13 @@ class ServerArgs:
             type=int,
             default=ServerArgs.dist_timeout,
             help="Set timeout for torch.distributed initialization.",
+        )
+        parser.add_argument(
+            "--unbalanced-model-loading-timeout-s",
+            type=int,
+            default=ServerArgs.unbalanced_model_loading_timeout_s,
+            help="Timeout (seconds) for dist.monitored_barrier during model loading (straggler rank detection). "
+            "Overrides SGLANG_UNBALANCED_MODEL_LOADING_TIMEOUT_S if set.",
         )
         parser.add_argument(
             "--download-dir",


### PR DESCRIPTION
- `SGLANG_UNBALANCED_MODEL_LOADING_TIMEOUT_S` env
- `ServerArgs` includes `unbalanced_model_loading_timeout_s`

At scale, the default is too short, make configurable