### PR TITLE
Fix AttributeError in the trace_req_start function

### DIFF
--- a/python/sglang/srt/tracing/trace.py
+++ b/python/sglang/srt/tracing/trace.py
@@ -463,7 +463,7 @@ def trace_req_start(
     if str(bootstrap_room) not in remote_trace_contexts:
         attrs = {"bootstrap_room": str(hex(bootstrap_room))}
         external_trace_context = _trace_context_propagator.extract(
-            external_trace_header
+            external_trace_header if external_trace_header is not None else {}
         )
         bootstrap_room_span = tracer.start_span(
             name=f"Bootstrap Room {hex(bootstrap_room)}",


### PR DESCRIPTION
## Motivation
When --otlp-traces-endpoint is enabled, the tracing system attempts to extract context from external_trace_header. However, if external_trace_header is None, the code crashes with:
`
AttributeError: 'NoneType' object has no attribute 'get'
`

## Modifications

## Accuracy Tests

## Benchmarking and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
