### PR TITLE
[Feat] lora strength param

### DIFF
--- a/python/sglang/multimodal_gen/docs/openai_api.md
+++ b/python/sglang/multimodal_gen/docs/openai_api.md
@@ -246,6 +246,8 @@ Loads a LoRA adapter and merges its weights into the model.
 **Parameters:**
 - `lora_nickname` (string, required): A unique identifier for this LoRA
 - `lora_path` (string, optional): Path to the `.safetensors` file or Hugging Face repo ID. Required for the first load; optional if re-activating a cached nickname
+- `target` (string, optional): Which transformer(s) to apply the LoRA to. One of "all" (default), "transformer", "transformer_2", "critic"
+- `strength` (float, optional): LoRA strength for merge, default 1.0. Values < 1.0 reduce the effect, values > 1.0 amplify the effect
 
 **Curl Example:**
 
@@ -254,7 +256,8 @@ curl -X POST http://localhost:30010/v1/set_lora \
   -H "Content-Type: application/json" \
   -d '{
         "lora_nickname": "lora_name",
-        "lora_path": "/path/to/lora.safetensors"
+        "lora_path": "/path/to/lora.safetensors",
+        "strength": 0.8
       }'
 ```
 
@@ -268,11 +271,16 @@ Manually merges the currently set LoRA weights into the base model.
 
 **Endpoint:** `POST /v1/merge_lora_weights`
 
+**Parameters:**
+- `target` (string, optional): Which transformer(s) to merge. One of "all" (default), "transformer", "transformer_2", "critic"
+- `strength` (float, optional): LoRA strength for merge, default 1.0. Values < 1.0 reduce the effect, values > 1.0 amplify the effect
+
 **Curl Example:**
 
 ```bash
 curl -X POST http://localhost:30010/v1/merge_lora_weights \
-  -H "Content-Type: application/json"
+  -H "Content-Type: application/json" \
+  -d '{"strength": 0.8}'
 ```
 
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -303,7 +303,11 @@ class DiffGenerator:
             raise RuntimeError(f"{failure_msg}: {error_msg}")
 
     def set_lora(
-        self, lora_nickname: str, lora_path: str | None = None, target: str = "all"
+        self,
+        lora_nickname: str,
+        lora_path: str | None = None,
+        target: str = "all",
+        strength: float = 1.0,
     ) -> None:
         """
         Set a LoRA adapter for the specified transformer(s).
@@ -316,13 +320,17 @@ class DiffGenerator:
                 - "transformer": Apply only to the primary transformer (high noise for Wan2.2)
                 - "transformer_2": Apply only to transformer_2 (low noise for Wan2.2)
                 - "critic": Apply only to the critic model
+            strength: LoRA strength for merge, default 1.0.
         """
         req = SetLoraReq(
-            lora_nickname=lora_nickname, lora_path=lora_path, target=target
+            lora_nickname=lora_nickname,
+            lora_path=lora_path,
+            target=target,
+            strength=strength,
         )
         self._send_lora_request(
             req,
-            f"Successfully set LoRA adapter: {lora_nickname} (target: {target})",
+            f"Successfully set LoRA adapter: {lora_nickname} (target: {target}, strength: {strength})",
             "Failed to set LoRA adapter",
         )
 
@@ -340,17 +348,18 @@ class DiffGenerator:
             "Failed to unmerge LoRA weights",
         )
 
-    def merge_lora_weights(self, target: str = "all") -> None:
+    def merge_lora_weights(self, target: str = "all", strength: float = 1.0) -> None:
         """
         Merge LoRA weights into the base model.
 
         Args:
             target: Which transformer(s) to merge.
+            strength: LoRA strength for merge, default 1.0.
         """
-        req = MergeLoraWeightsReq(target=target)
+        req = MergeLoraWeightsReq(target=target, strength=strength)
         self._send_lora_request(
             req,
-            f"Successfully merged LoRA weights (target: {target})",
+            f"Successfully merged LoRA weights (target: {target}, strength: {strength})",
             "Failed to merge LoRA weights",
         )
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/common_api.py
@@ -39,6 +39,7 @@ async def set_lora(
     lora_nickname: str = Body(..., embed=True),
     lora_path: Optional[str] = Body(None, embed=True),
     target: str = Body("all", embed=True),
+    strength: float = Body(1.0, embed=True),
 ):
     """
     Set a LoRA adapter for the specified transformer(s).
@@ -51,11 +52,18 @@ async def set_lora(
             - "transformer": Apply only to the primary transformer (high noise for Wan2.2)
             - "transformer_2": Apply only to transformer_2 (low noise for Wan2.2)
             - "critic": Apply only to the critic model
+        strength: LoRA strength for merge, default 1.0. Values < 1.0 reduce the effect,
+            values > 1.0 amplify the effect.
     """
-    req = SetLoraReq(lora_nickname=lora_nickname, lora_path=lora_path, target=target)
+    req = SetLoraReq(
+        lora_nickname=lora_nickname,
+        lora_path=lora_path,
+        target=target,
+        strength=strength,
+    )
     return await _handle_lora_request(
         req,
-        f"Successfully set LoRA adapter: {lora_nickname} (target: {target})",
+        f"Successfully set LoRA adapter: {lora_nickname} (target: {target}, strength: {strength})",
         "Failed to set LoRA adapter",
     )
 
@@ -63,6 +71,7 @@ async def set_lora(
 @router.post("/merge_lora_weights")
 async def merge_lora_weights(
     target: str = Body("all", embed=True),
+    strength: float = Body(1.0, embed=True),
 ):
     """
     Merge LoRA weights into the base model.
@@ -70,11 +79,13 @@ async def merge_lora_weights(
     Args:
         target: Which transformer(s) to merge. One of "all", "transformer",
                 "transformer_2", "critic".
+        strength: LoRA strength for merge, default 1.0. Values < 1.0 reduce the effect,
+            values > 1.0 amplify the effect.
     """
-    req = MergeLoraWeightsReq(target=target)
+    req = MergeLoraWeightsReq(target=target, strength=strength)
     return await _handle_lora_request(
         req,
-        f"Successfully merged LoRA weights (target: {target})",
+        f"Successfully merged LoRA weights (target: {target}, strength: {strength})",
         "Failed to merge LoRA weights",
     )
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -25,11 +25,13 @@ class SetLoraReq:
     lora_nickname: str
     lora_path: Optional[str] = None
     target: str = "all"  # "all", "transformer", "transformer_2", "critic"
+    strength: float = 1.0  # LoRA strength for merge, default 1.0
 
 
 @dataclasses.dataclass
 class MergeLoraWeightsReq:
     target: str = "all"  # "all", "transformer", "transformer_2", "critic"
+    strength: float = 1.0  # LoRA strength for merge, default 1.0
 
 
 @dataclasses.dataclass

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -56,6 +56,7 @@ class BaseLayerWithLoRA(nn.Module):
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha
         self.lora_path: str | None = None
+        self.strength: float = 1.0
 
         self.lora_A = None
         self.lora_B = None
@@ -101,17 +102,22 @@ class BaseLayerWithLoRA(nn.Module):
         A: torch.Tensor,
         B: torch.Tensor,
         lora_path: str | None = None,
+        strength: float = 1.0,
     ) -> None:
         self.lora_A = torch.nn.Parameter(
             A
         )  # share storage with weights in the pipeline
         self.lora_B = torch.nn.Parameter(B)
         self.disable_lora = False
+        self.strength = strength
         self.merge_lora_weights()
         self.lora_path = lora_path
 
     @torch.no_grad()
-    def merge_lora_weights(self) -> None:
+    def merge_lora_weights(self, strength: float | None = None) -> None:
+        if strength is not None:
+            self.strength = strength
+
         if self.disable_lora:
             return
 
@@ -136,9 +142,10 @@ class BaseLayerWithLoRA(nn.Module):
             data = self.base_layer.weight.data.to(
                 get_local_torch_device()
             ).full_tensor()
-            data += self.slice_lora_b_weights(self.lora_B).to(
+            lora_delta = self.slice_lora_b_weights(self.lora_B).to(
                 data
             ) @ self.slice_lora_a_weights(self.lora_A).to(data)
+            data += self.strength * lora_delta
             unsharded_base_layer.weight = nn.Parameter(data.to(current_device))
             if isinstance(getattr(self.base_layer, "bias", None), DTensor):
                 unsharded_base_layer.bias = nn.Parameter(
@@ -161,9 +168,10 @@ class BaseLayerWithLoRA(nn.Module):
         else:
             current_device = self.base_layer.weight.data.device
             data = self.base_layer.weight.data.to(get_local_torch_device())
-            data += self.slice_lora_b_weights(
+            lora_delta = self.slice_lora_b_weights(
                 self.lora_B.to(data)
             ) @ self.slice_lora_a_weights(self.lora_A.to(data))
+            data += self.strength * lora_delta
             self.base_layer.weight.data = data.to(current_device, non_blocking=True)
 
         self.merged = True

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -145,6 +145,10 @@ class BaseLayerWithLoRA(nn.Module):
             lora_delta = self.slice_lora_b_weights(self.lora_B).to(
                 data
             ) @ self.slice_lora_a_weights(self.lora_A).to(data)
+            # Apply lora_alpha / lora_rank scaling for consistency with forward()
+            if self.lora_alpha is not None and self.lora_rank is not None:
+                if self.lora_alpha != self.lora_rank:
+                    lora_delta = lora_delta * (self.lora_alpha / self.lora_rank)
             data += self.strength * lora_delta
             unsharded_base_layer.weight = nn.Parameter(data.to(current_device))
             if isinstance(getattr(self.base_layer, "bias", None), DTensor):
@@ -171,6 +175,10 @@ class BaseLayerWithLoRA(nn.Module):
             lora_delta = self.slice_lora_b_weights(
                 self.lora_B.to(data)
             ) @ self.slice_lora_a_weights(self.lora_A.to(data))
+            # Apply lora_alpha / lora_rank scaling for consistency with forward()
+            if self.lora_alpha is not None and self.lora_rank is not None:
+                if self.lora_alpha != self.lora_rank:
+                    lora_delta = lora_delta * (self.lora_alpha / self.lora_rank)
             data += self.strength * lora_delta
             self.base_layer.weight.data = data.to(current_device, non_blocking=True)
 

--- a/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/lora/linear.py
@@ -85,6 +85,7 @@ class BaseLayerWithLoRA(nn.Module):
                 delta = delta * (
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
+            delta = delta * self.strength
             out, output_bias = self.base_layer(x)
             return out + delta, output_bias
         else:
@@ -407,6 +408,7 @@ class LinearWithLoRA(BaseLayerWithLoRA):
                 delta = delta * (
                     self.lora_alpha / self.lora_rank  # type: ignore
                 )  # type: ignore
+            delta = delta * self.strength
             # nn.Linear.forward() returns a single tensor, not a tuple
             out = self.base_layer(x)
             return out + delta

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -129,7 +129,11 @@ class GPUWorker:
             return output_batch
 
     def set_lora(
-        self, lora_nickname: str, lora_path: str | None = None, target: str = "all"
+        self,
+        lora_nickname: str,
+        lora_path: str | None = None,
+        target: str = "all",
+        strength: float = 1.0,
     ) -> None:
         """
         Set the LoRA adapter for the pipeline.
@@ -138,19 +142,21 @@ class GPUWorker:
             lora_nickname: The nickname of the adapter.
             lora_path: Path to the LoRA adapter.
             target: Which transformer(s) to apply the LoRA to.
+            strength: LoRA strength for merge, default 1.0.
         """
         assert self.pipeline is not None
-        self.pipeline.set_lora(lora_nickname, lora_path, target)
+        self.pipeline.set_lora(lora_nickname, lora_path, target, strength)
 
-    def merge_lora_weights(self, target: str = "all") -> None:
+    def merge_lora_weights(self, target: str = "all", strength: float = 1.0) -> None:
         """
         Merge LoRA weights.
 
         Args:
             target: Which transformer(s) to merge.
+            strength: LoRA strength for merge, default 1.0.
         """
         assert self.pipeline is not None
-        self.pipeline.merge_lora_weights(target)
+        self.pipeline.merge_lora_weights(target, strength)
 
     def unmerge_lora_weights(self, target: str = "all") -> None:
         """

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -85,12 +85,12 @@ class Scheduler:
     def _handle_set_lora(self, reqs: List[Any]):
         # TODO: return set status
         req = reqs[0]
-        self.worker.set_lora(req.lora_nickname, req.lora_path, req.target)
+        self.worker.set_lora(req.lora_nickname, req.lora_path, req.target, req.strength)
         return {"status": "ok"}
 
     def _handle_merge_lora(self, reqs: List[Any]):
         req = reqs[0]
-        self.worker.merge_lora_weights(req.target)
+        self.worker.merge_lora_weights(req.target, req.strength)
         return {"status": "ok"}
 
     def _handle_unmerge_lora(self, reqs: List[Any]):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
Enhance LoRA functionality by adding optional parameters for strength and target transformer in set and merge methods. Update documentation and examples to reflect these changes.
## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
Added `strength: float = 1.0` parameter to the following APIs:

**`set_lora`** - Set LoRA adapter with custom merge strength
- `utils.py`: `SetLoraReq` dataclass
- `common_api.py`: `/v1/set_lora` endpoint
- `diffusion_generator.py`: `set_lora()` method
- `scheduler.py`: `_handle_set_lora()`
- `gpu_worker.py`: `set_lora()`
- `lora_pipeline.py`: `set_lora()`, `_apply_lora_to_layers()`

**`merge_lora_weights`** - Re-merge with different strength
- `utils.py`: `MergeLoraWeightsReq` dataclass
- `common_api.py`: `/v1/merge_lora_weights` endpoint
- `diffusion_generator.py`: `merge_lora_weights()` method
- `scheduler.py`: `_handle_merge_lora()`
- `gpu_worker.py`: `merge_lora_weights()`
- `lora_pipeline.py`: `merge_lora_weights()`

**Core implementation**
- `linear.py`: `BaseLayerWithLoRA` - added `self.strength` attribute, modified `set_lora_weights()` and `merge_lora_weights()` to apply strength scaling: `data += strength * (lora_B @ lora_A)`
- Add scaling for lora_alpha and lora_rank in LoRA layer updates for consistency in forward pass.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
no_lora_baseline

https://github.com/user-attachments/assets/20f17875-441f-4079-b87b-af648d7cbd55

basic_strength_0.5

https://github.com/user-attachments/assets/a955840d-9182-4658-bb7f-29703e10d13b

basic_strength_1.0

https://github.com/user-attachments/assets/c5812dd4-c61e-4891-8c8c-a826d57a507d

basic_strength_1.5

https://github.com/user-attachments/assets/1a16e2ae-77de-47a9-8529-50d7984133b7

merge_initial

https://github.com/user-attachments/assets/e2a7d191-b058-4d84-8f13-b41515eab589

merge_remerge_weaker

https://github.com/user-attachments/assets/8918aa3d-8717-4445-9144-490437e2ef6e


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
