### PR TITLE
Tiny fix test eagle infer b.

### DIFF
--- a/test/registered/spec/eagle/test_eagle_infer_b.py
+++ b/test/registered/spec/eagle/test_eagle_infer_b.py
@@ -295,9 +295,9 @@ class TestEAGLERetract(TestEAGLEServerBasic):
     @classmethod
     def setUpClass(cls):
         # These config helps find a leak.
-        # FIXME(lsyin): use override context manager
-        envs.SGLANG_CI_SMALL_KV_SIZE.set(4500)
-        with envs.SGLANG_TEST_RETRACT.override(True):
+        with envs.SGLANG_TEST_RETRACT.override(
+            True
+        ), envs.SGLANG_CI_SMALL_KV_SIZE.override(4500):
             super().setUpClass()
 
 


### PR DESCRIPTION
Due to the wrong usage of the small KV cache size environment, the other tests in `test_eagle_infer_b.py` are also infected by this small KV cache size, which leads to an out-of-memory problem.