### PR TITLE
[VLM] Support apply qk norm in multi cuda streams

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -22,6 +22,10 @@ from sglang.srt.utils import (
     is_npu,
     print_info_once,
 )
+from sglang.srt.utils.multi_stream_utils import (
+    maybe_execute_in_parallel,
+    with_multi_stream,
+)
 
 _is_cuda = is_cuda()
 _is_npu = is_npu()
@@ -532,6 +536,7 @@ class VisionAttention(nn.Module):
             [torch.Tensor, torch.Tensor, Any, Any], Tuple[torch.Tensor, torch.Tensor]
         ] = None,
         use_data_parallel: bool = False,
+        aux_stream: Optional[torch.cuda.Stream] = None,
         **kwargs,
     ):
         super().__init__()
@@ -620,6 +625,8 @@ class VisionAttention(nn.Module):
             tp_size=self.tp_size,
             prefix=add_prefix("proj", prefix),
         )
+        self.aux_stream = aux_stream
+        self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
 
     def _determine_attention_backend(self, passed_backend: Optional[str]) -> str:
         """Decide the multimodal attention backend string.
@@ -655,20 +662,41 @@ class VisionAttention(nn.Module):
 
     def _apply_qk_norm(self, q: torch.Tensor, k: torch.Tensor):
         """apply qk norm for internvl vit attn"""
-        q = q.flatten(1, 2)
-        k = k.flatten(1, 2)
 
-        if self.tp_size > 1:
-            q = tensor_model_parallel_all_gather(q.contiguous())
-            k = tensor_model_parallel_all_gather(k.contiguous())
-        q = self.q_norm(q)
-        k = self.k_norm(k)
-        if self.tp_size > 1:
-            splitter = partial(split_tensor_along_last_dim, num_partitions=self.tp_size)
-            q = splitter(q)[self.tp_rank]
-            k = splitter(k)[self.tp_rank]
-        q = q.unflatten(-1, (-1, self.head_size))
-        k = k.unflatten(-1, (-1, self.head_size))
+        def q_l2norm():
+            q_ = q.flatten(1, 2)
+            if self.tp_size > 1:
+                q_ = tensor_model_parallel_all_gather(q_.contiguous())
+            q_ = self.q_norm(q_)
+            if self.tp_size > 1:
+                splitter = partial(
+                    split_tensor_along_last_dim, num_partitions=self.tp_size
+                )
+                q_ = splitter(q_)[self.tp_rank]
+            q_ = q_.unflatten(-1, (-1, self.head_size))
+            return q_
+
+        def k_l2norm():
+            k_ = k.flatten(1, 2)
+            if self.tp_size > 1:
+                k_ = tensor_model_parallel_all_gather(k_.contiguous())
+            k_ = self.k_norm(k_)
+            if self.tp_size > 1:
+                splitter = partial(
+                    split_tensor_along_last_dim, num_partitions=self.tp_size
+                )
+                k_ = splitter(k_)[self.tp_rank]
+            k_ = k_.unflatten(-1, (-1, self.head_size))
+            return k_
+
+        with with_multi_stream(True):
+            q, k = maybe_execute_in_parallel(
+                q_l2norm,
+                k_l2norm,
+                self.ln_events[0],
+                self.ln_events[1],
+                self.aux_stream,
+            )
         return q, k
 
     def forward(

--- a/python/sglang/srt/utils/multi_stream_utils.py
+++ b/python/sglang/srt/utils/multi_stream_utils.py
@@ -1,0 +1,77 @@
+# Adapted from trtllm.
+
+import threading
+from contextlib import contextmanager
+from typing import Any, Callable, Optional
+
+import torch
+
+
+class do_multi_stream_local(threading.local):
+
+    def __init__(self):
+        self.do_multi_stream = False
+
+
+_local = do_multi_stream_local()
+
+
+def set_do_multi_stream(enable: bool):
+    _local.do_multi_stream = enable
+
+
+def do_multi_stream() -> bool:
+    return _local.do_multi_stream
+
+
+@contextmanager
+def with_multi_stream(enable: bool):
+    prev_do_multi_stream = _local.do_multi_stream
+    set_do_multi_stream(enable)
+    try:
+        yield
+    finally:
+        set_do_multi_stream(prev_do_multi_stream)
+
+
+def maybe_execute_in_parallel(
+    fn0: Callable,
+    fn1: Callable,
+    event0: torch.cuda.Event,
+    event1: torch.cuda.Event,
+    aux_stream: Optional[torch.cuda.Stream] = None,
+) -> tuple[Any, Any]:
+    """Utility function to run two functions in two cuda streams in parallel. Multi-stream is
+    only enabled when cuda graph is turned on because switch stream has extra host overhead.
+
+    This design is mainly for low latency use case. It needs to be improved for max throughput
+    use case.
+    For simplicity, fn0 and fn1 do not support inputs.
+
+    Args:
+        fn0 (Callable): callable for the default stream
+        fn1 (Callable): callable for the second stream, aux_stream
+        event0 (torch.cuda.Event): cuda event for fn0
+        event1 (torch.cuda.Event): cuda event for fn1
+        aux_stream (Optional[torch.cuda.Stream]): the second cuda stream for fn1.
+            Multi-stream is disabled when aux_stream is None.
+
+    Returns:
+        tuple[Any, Any]: the return values of fn0() and fn1()
+    """
+
+    multi_stream = do_multi_stream() and aux_stream is not None
+
+    if multi_stream:
+        event0.record()
+        result0 = fn0()
+
+        with torch.cuda.stream(aux_stream):
+            event0.wait()
+            result1 = fn1()
+            event1.record()
+        event1.wait()
+    else:
+        result0 = fn0()
+        result1 = fn1()
+    return (result0, result1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Support apply qk normalization in multi cuda streams.
Improved performance in case VLM models qk_normalization setting true.
<img width="2031" height="1206" alt="image" src="https://github.com/user-attachments/assets/5a0981b2-815d-41a1-b73c-acfb95d1a8ac" />
<img width="2492" height="1560" alt="image" src="https://github.com/user-attachments/assets/f69a4b70-abf3-4a2f-aceb-55bdabceeb90" />
<img width="2968" height="1532" alt="image" src="https://github.com/user-attachments/assets/e1c708ac-2f9b-44c0-bb23-58fee66b46b4" />

For tp=1 the overlap can be more efficient.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Server:
Setting: config.json
    "qk_normalization": true,
```
$python3 -m sglang.launch_server --host 127.0.0.1 --mem-fraction-static 0.7 --port 30000 --dtype auto --max-running-requests 16 --chunked-prefill-size 8192 --attention-backend flashinfer --tp 1 --enable-multimodal --chat-template internvl-2-5 --model OpenGVLab/InternVL2_5-8B --disable-radix-cache
```

Main:
```
$python3 -m lmms_eval --model openai_compatible --model_args model_version=OpenGVLab/InternVL2_5-8B   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-12-24 14:44:45 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-12-24 14:44:48 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-12-24 14:44:48 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-12-24 14:44:48 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-12-24 14:44:51 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-12-24 14:44:51 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 14236.64it/s]
2025-12-24 14:44:51 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:23<00:00,  2.57s/it]2025-12-24 14:48:15 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1627.929s, Total tokens: 1909, Avg speed: 1.2 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:23<00:00,  3.57s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11543.50it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.7}, 'Art': {'num': 30, 'acc': 0.66667}, 'Art_Theory': {'num': 30, 'acc': 0.86667}, 'Design': {'num': 30, 'acc': 0.76667}, 'Music': {'num': 30, 'acc': 0.5}, 'Overall-Business': {'num': 150, 'acc': 0.44667}, 'Accounting': {'num': 30, 'acc': 0.46667}, 'Economics': {'num': 30, 'acc': 0.43333}, 'Finance': {'num': 30, 'acc': 0.33333}, 'Manage': {'num': 30, 'acc': 0.46667}, 'Marketing': {'num': 30, 'acc': 0.53333}, 'Overall-Science': {'num': 150, 'acc': 0.40667}, 'Biology': {'num': 30, 'acc': 0.46667}, 'Chemistry': {'num': 30, 'acc': 0.3}, 'Geography': {'num': 30, 'acc': 0.5}, 'Math': {'num': 30, 'acc': 0.4}, 'Physics': {'num': 30, 'acc': 0.36667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.55333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.46667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.5}, 'Pharmacy': {'num': 30, 'acc': 0.63333}, 'Public_Health': {'num': 30, 'acc': 0.53333}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.69167}, 'History': {'num': 30, 'acc': 0.66667}, 'Literature': {'num': 30, 'acc': 0.86667}, 'Sociology': {'num': 30, 'acc': 0.63333}, 'Psychology': {'num': 30, 'acc': 0.6}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.4}, 'Agriculture': {'num': 30, 'acc': 0.43333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.3}, 'Computer_Science': {'num': 30, 'acc': 0.53333}, 'Electronics': {'num': 30, 'acc': 0.43333}, 'Energy_and_Power': {'num': 30, 'acc': 0.43333}, 'Materials': {'num': 30, 'acc': 0.33333}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.33333}, 'Overall': {'num': 900, 'acc': 0.51333}}
fatal: not a git repository (or any of the parent directories): .git
2025-12-24 14:48:15 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=OpenGVLab/InternVL2_5-8B), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5133|±  |   N/A|
```

PR:
```
[root  /root] 三 12月 24 14:37:58 
$python3 -m lmms_eval --model openai_compatible --model_args model_version=OpenGVLab/InternVL2_5-8B   --tasks mmmu_val   --batch_size 16
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
2025-12-24 14:38:08 | INFO     | __main__:cli_evaluate:311 - Verbosity set to INFO
2025-12-24 14:38:10 | INFO     | __main__:cli_evaluate_single:400 - Evaluation tracker args: {'token': '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'}
2025-12-24 14:38:10 | INFO     | __main__:cli_evaluate_single:480 - Selected Tasks: ['mmmu_val']
2025-12-24 14:38:10 | INFO     | lmms_eval.evaluator:simple_evaluate:161 - Setting random seed to 0 | Setting numpy seed to 1234 | Setting torch manual seed to 1234
2025-12-24 14:38:14 | INFO     | lmms_eval.evaluator:evaluate:402 - Running on rank 0 (local rank 0)
2025-12-24 14:38:14 | INFO     | lmms_eval.api.task:build_all_requests:427 - Building contexts for mmmu_val on rank 0...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 14156.13it/s]
2025-12-24 14:38:14 | INFO     | lmms_eval.evaluator:evaluate:495 - Running generate_until requests
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:22<00:00,  2.57s/it]2025-12-24 14:41:36 | INFO     | lmms_eval.models.model_utils.gen_metrics:log_metrics:48 - Metric summary - Total time: 1611.530s, Total tokens: 1909, Avg speed: 1.2 tokens/s
Model Responding: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 57/57 [03:22<00:00,  3.55s/it]
Postprocessing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 900/900 [00:00<00:00, 11384.40it/s]
{'Overall-Art and Design': {'num': 120, 'acc': 0.69167}, 'Art': {'num': 30, 'acc': 0.66667}, 'Art_Theory': {'num': 30, 'acc': 0.86667}, 'Design': {'num': 30, 'acc': 0.76667}, 'Music': {'num': 30, 'acc': 0.46667}, 'Overall-Business': {'num': 150, 'acc': 0.44667}, 'Accounting': {'num': 30, 'acc': 0.46667}, 'Economics': {'num': 30, 'acc': 0.43333}, 'Finance': {'num': 30, 'acc': 0.33333}, 'Manage': {'num': 30, 'acc': 0.46667}, 'Marketing': {'num': 30, 'acc': 0.53333}, 'Overall-Science': {'num': 150, 'acc': 0.42}, 'Biology': {'num': 30, 'acc': 0.5}, 'Chemistry': {'num': 30, 'acc': 0.33333}, 'Geography': {'num': 30, 'acc': 0.5}, 'Math': {'num': 30, 'acc': 0.4}, 'Physics': {'num': 30, 'acc': 0.36667}, 'Overall-Health and Medicine': {'num': 150, 'acc': 0.55333}, 'Basic_Medical_Science': {'num': 30, 'acc': 0.46667}, 'Clinical_Medicine': {'num': 30, 'acc': 0.63333}, 'Diagnostics_and_Laboratory_Medicine': {'num': 30, 'acc': 0.5}, 'Pharmacy': {'num': 30, 'acc': 0.63333}, 'Public_Health': {'num': 30, 'acc': 0.53333}, 'Overall-Humanities and Social Science': {'num': 120, 'acc': 0.69167}, 'History': {'num': 30, 'acc': 0.66667}, 'Literature': {'num': 30, 'acc': 0.86667}, 'Sociology': {'num': 30, 'acc': 0.63333}, 'Psychology': {'num': 30, 'acc': 0.6}, 'Overall-Tech and Engineering': {'num': 210, 'acc': 0.39524}, 'Agriculture': {'num': 30, 'acc': 0.43333}, 'Architecture_and_Engineering': {'num': 30, 'acc': 0.3}, 'Computer_Science': {'num': 30, 'acc': 0.53333}, 'Electronics': {'num': 30, 'acc': 0.43333}, 'Energy_and_Power': {'num': 30, 'acc': 0.43333}, 'Materials': {'num': 30, 'acc': 0.3}, 'Mechanical_Engineering': {'num': 30, 'acc': 0.33333}, 'Overall': {'num': 900, 'acc': 0.51333}}
fatal: not a git repository (or any of the parent directories): .git
2025-12-24 14:41:36 | INFO     | lmms_eval.loggers.evaluation_tracker:save_results_aggregated:239 - Output path not provided, skipping saving results aggregated
openai_compatible (model_version=OpenGVLab/InternVL2_5-8B), gen_kwargs: (), limit: None, num_fewshot: None, batch_size: 16
| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
|--------|------:|------|-----:|--------|---|-----:|---|------|
|mmmu_val|      0|none  |     0|mmmu_acc|↑  |0.5133|±  |   N/A|
```


## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
