### PR TITLE
[CI] Add tests to validate the size, extension, and format of output images/videos.

### DIFF
--- a/python/sglang/multimodal_gen/test/server/test_server_utils.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_utils.py
@@ -882,9 +882,26 @@ def get_generate_fn(
         img_data = base64.b64decode(result.data[0].b64_json)
         # Infer expected format from request parameters
         expected_ext = get_expected_image_format(req_output_format, req_background)
-        tmp_path = f"{rid}.{expected_ext}"
+        expected_filename = f"{rid}.{expected_ext}"
+        tmp_path = expected_filename
         with open(tmp_path, "wb") as f:
             f.write(img_data)
+
+        # Validate output file
+        expected_width, expected_height = None, None
+        if output_size:
+            parts = output_size.split("x")
+            if len(parts) == 2:
+                expected_width, expected_height = int(parts[0]), int(parts[1])
+        validate_image_file(
+            tmp_path,
+            expected_filename,
+            expected_width,
+            expected_height,
+            output_format=req_output_format,
+            background=req_background,
+        )
+
         upload_file_to_slack(
             case_id=case_id,
             model=model_path,
@@ -935,9 +952,26 @@ def get_generate_fn(
         img_data = base64.b64decode(result.data[0].b64_json)
         # Infer expected format from request parameters
         expected_ext = get_expected_image_format(req_output_format, req_background)
-        tmp_path = f"{rid}.{expected_ext}"
+        expected_filename = f"{rid}.{expected_ext}"
+        tmp_path = expected_filename
         with open(tmp_path, "wb") as f:
             f.write(img_data)
+
+        # Validate output file
+        expected_width, expected_height = None, None
+        if sampling_params.output_size:
+            parts = sampling_params.output_size.split("x")
+            if len(parts) == 2:
+                expected_width, expected_height = int(parts[0]), int(parts[1])
+        validate_image_file(
+            tmp_path,
+            expected_filename,
+            expected_width,
+            expected_height,
+            output_format=req_output_format,
+            background=req_background,
+        )
+
         upload_file_to_slack(
             case_id=case_id,
             model=model_path,

--- a/python/sglang/multimodal_gen/test/server/test_server_utils.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_utils.py
@@ -89,11 +89,6 @@ def parse_dimensions(size_string: str | None) -> tuple[int | None, int | None]:
 
     Returns:
         Tuple of (width, height) as integers if parsing succeeds, (None, None) otherwise.
-        Returns (None, None) if:
-        - size_string is None or empty
-        - size_string doesn't contain exactly one "x" separator
-        - width or height cannot be converted to int
-        - width or height is <= 0
     """
     if not size_string:
         return (None, None)

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -99,11 +99,7 @@ def is_mp4(data: bytes) -> bool:
     """
     if len(data) < 8:
         return False
-    return (
-        data[:4] == b"\x00\x00\x00\x18"
-        or data[:4] == b"\x00\x00\x00\x1c"
-        or data[4:8] == b"ftyp"
-    )
+    return data[4:8] == b"ftyp"
 
 
 def is_jpeg(data: bytes) -> bool:

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -92,12 +92,7 @@ def get_dynamic_server_port() -> int:
 
 
 def is_mp4(data: bytes) -> bool:
-    """Check if data represents a valid MP4 file by magic bytes.
-
-    MP4 files start with an 'ftyp' atom. Common patterns:
-    - First 4 bytes indicate box size (e.g., 0x18=24, 0x1c=28)
-    - Bytes 4-8 contain the box type 'ftyp'
-    """
+    """Check if data represents a valid MP4 file by magic bytes."""
     if len(data) < 8:
         return False
     return data[4:8] == b"ftyp"
@@ -123,14 +118,9 @@ def get_expected_image_format(
     background: str | None = None,
 ) -> str:
     """Infer expected image format based on request parameters.
-
-    This replicates the server-side logic in image_api._choose_ext()
-    to determine what format the server will produce.
-
     Args:
         output_format: The output_format parameter from the request (png/jpeg/webp/jpg)
         background: The background parameter from the request (transparent/opaque/auto)
-
     Returns:
         Expected file extension: "jpg", "png", or "webp"
     """
@@ -261,16 +251,7 @@ def validate_image_file(
     output_format: str | None = None,
     background: str | None = None,
 ) -> None:
-    """Validate image output file: existence, extension, size, filename, format, dimensions.
-
-    Args:
-        file_path: Path to the image file
-        expected_filename: Expected filename (e.g., "1234567890.jpg")
-        expected_width: Expected image width (optional)
-        expected_height: Expected image height (optional)
-        output_format: The output_format from request (to infer expected format)
-        background: The background from request (to infer expected format)
-    """
+    """Validate image output file: existence, extension, size, filename, format, dimensions."""
     # Infer expected format from request parameters
     expected_ext = get_expected_image_format(output_format, background)
 
@@ -388,14 +369,7 @@ def validate_video_file(
     expected_width: int | None = None,
     expected_height: int | None = None,
 ) -> None:
-    """Validate video output file: existence, extension, size, filename, format, dimensions.
-
-    Args:
-        file_path: Path to the video file
-        expected_filename: Expected filename (e.g., "abc123-def456.mp4")
-        expected_width: Expected video width (optional)
-        expected_height: Expected video height (optional)
-    """
+    """Validate video output file: existence, extension, size, filename, format, dimensions."""
     # 1. File existence
     assert os.path.exists(file_path), f"Video file does not exist: {file_path}"
 


### PR DESCRIPTION
## Motivation

Add tests to validate the size, extension, and format of output images/videos.

## Modifications

**`python/sglang/multimodal_gen/test/test_utils.py`**:
- Add `is_webp()` function for WebP format detection
- Add `get_expected_image_format(output_format, background)` function that replicates server-side logic (`image_api._choose_ext`) to infer expected image format based on request parameters
- Modify `validate_image_file()` to accept `output_format` and `background` parameters, dynamically validating file extension and magic bytes based on inferred format

**`python/sglang/multimodal_gen/test/server/test_server_utils.py`**:
- Modify `generate_image()`, `generate_image_edit()`, and `generate_image_edit_url()` to use `get_expected_image_format()` for inferring file extension instead of hardcoding `.png`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)