### PR TITLE
[Fix] CPU-only chained import crashes due to no vllm import in activation

### DIFF
--- a/python/sglang/srt/layers/pooler.py
+++ b/python/sglang/srt/layers/pooler.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
 
-from sglang.srt.layers.activation import get_cross_encoder_activation_function
+
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
@@ -96,6 +96,7 @@ class CrossEncodingPooler(nn.Module):
         super().__init__()
         self.classifier = classifier
         self.pooler = pooler
+        from sglang.srt.layers.activation import get_cross_encoder_activation_function
         self.default_activation_function = get_cross_encoder_activation_function(config)
 
     def forward(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In sglang v0.5.6, importing sglang components on CPU-only environment leads to a crash due to no vllm installed. This may cause a range of crashes due to the dependency between components (according to #15643). Specifically, in python/sglang/srt/layers/activation.py, at the end of the code, there is a manual import of vllm for CPU-only environment. However, there is no vllm installed by running this single test:

```
sglang git:(main) CUDA_VISIBLE_DEVICES="" python -c "from sglang.srt.weight_sync import utils"
...
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/sgl-workspace/sglang/python/sglang/srt/weight_sync/utils.py", line 10, in <module>
    from sglang.srt.model_executor.model_runner import LocalSerializedTensor
  File "/sgl-workspace/sglang/python/sglang/srt/model_executor/model_runner.py", line 106, in <module>
    from sglang.srt.layers.pooler import EmbeddingPoolerOutput
  File "/sgl-workspace/sglang/python/sglang/srt/layers/pooler.py", line 12, in <module>
    from sglang.srt.layers.activation import get_cross_encoder_activation_function
  File "/sgl-workspace/sglang/python/sglang/srt/layers/activation.py", line 389, in <module>
    from vllm.model_executor.layers.activation import (  # noqa: F401
ModuleNotFoundError: No module named 'vllm'
```

This causes crashes in pooler.py when importing activation, in model_runner.py when importing pooler, and in any files import model_runner.

## Modifications

<!-- Detail the changes made in this pull request. -->

To avoid chained crashes in CPU-only environment, I simply moved the activation import line of code from the top to CrossEntropyPooler class.
`from sglang.srt.layers.activation import get_cross_encoder_activation_function`

It can also be fixed by adding error handling in the cpu-only condition. Please let me know if this is a more anticipated way to fix it.

## Checklist

- [ x] Format code 
