### PR TITLE
[1/N] Integrate Sonic-Moe

### DIFF
--- a/python/sglang/srt/layers/moe/sonic_moe.py
+++ b/python/sglang/srt/layers/moe/sonic_moe.py
@@ -1,0 +1,322 @@
+"""
+Sonic MoE integration for SGLang.
+Sonic MoE is a high-performance Mixture-of-Experts implementation optimized
+for NVIDIA Hopper GPUs (H100/H200). This module provides integration with
+SGLang's MoE infrastructure.
+Reference: https://github.com/Dao-AILab/sonic-moe
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, List, Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_cuda, is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+_is_hip = is_hip()
+_is_cuda = is_cuda()
+_is_cpu_amx_available = cpu_has_amx_support()
+_is_cpu = is_cpu()
+
+if _is_cuda:
+    pass
+elif _is_cpu and _is_cpu_amx_available:
+    pass
+
+
+padding_size = 128 if bool(int(os.getenv("SGLANG_MOE_PADDING", "0"))) else 0
+
+logger = logging.getLogger(__name__)
+
+# Lazy import for optional Sonic MoE dependency
+_SONICMOE_AVAILABLE: bool | None = None
+
+
+def _check_sonicmoe_available() -> bool:
+    """Check if Sonic MoE is available."""
+    global _SONICMOE_AVAILABLE
+    if _SONICMOE_AVAILABLE is None:
+        try:
+            import sonicmoe  # noqa: F401
+
+            _SONICMOE_AVAILABLE = True
+        except ImportError:
+            _SONICMOE_AVAILABLE = False
+            logger.warning_once(
+                "Sonic MoE is not installed. Install it from "
+                "https://github.com/Dao-AILab/sonic-moe for Hopper GPU "
+                "optimized MoE kernels."
+            )
+    return _SONICMOE_AVAILABLE
+
+
+def _is_hopper_gpu() -> bool:
+    """Check if the current GPU is a Hopper architecture GPU."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        major, _ = torch.cuda.get_device_capability()
+        return major >= 9  # Hopper is compute capability 9.0
+    except Exception:
+        return False
+
+
+def is_sonic_moe_supported(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    moe_runner_config: MoeRunnerConfig,
+    *,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    per_channel_quant: bool = False,
+    block_shape: Optional[List[int]] = None,
+    b1: Optional[torch.Tensor] = None,
+    b2: Optional[torch.Tensor] = None,
+) -> bool:
+    """
+    Check if Sonic MoE can be used for the given configuration.
+    Requirements:
+    - Sonic MoE package must be installed
+    - Must be running on Hopper GPU (H100/H200)
+    - Hidden states must be bfloat16 or float16
+    - Weights must be in compatible format
+    """
+    if not _check_sonicmoe_available():
+        logger.debug("SonicMoE disabled: sonicmoe package not available.")
+        return False
+    if not is_cuda() or not _is_hopper_gpu():
+        logger.debug("SonicMoE disabled: requires Hopper (H100/H200) GPU.")
+        return False
+
+    # dtype / layout
+    if hidden_states.dtype not in (torch.float16, torch.bfloat16):
+        logger.debug(
+            f"SonicMoE disabled: hidden_states must be bfloat16 or float16, "
+            f"got {hidden_states.dtype}."
+        )
+        return False
+    if w1.dtype != hidden_states.dtype or w2.dtype != hidden_states.dtype:
+        return False
+    if w1.dim() != 3 or w2.dim() != 3:
+        logger.debug(
+            f"SonicMoE disabled: weights must be 3D, got w1.dim={w1.dim()}, "
+            f"w2.dim={w2.dim()}."
+        )
+        return False
+
+    if b1 is not None or b2 is not None:
+        return False
+    if use_fp8_w8a8 or use_int8_w8a8 or use_int8_w8a16 or use_int4_w4a16:
+        return False
+    if per_channel_quant or block_shape is not None:
+        return False
+
+    # EP / filter_expert: SonicMoE doesn't support expert_map
+    if (
+        moe_runner_config.num_experts is not None
+        and moe_runner_config.num_local_experts is not None
+        and moe_runner_config.num_experts != moe_runner_config.num_local_experts
+    ):
+        return False
+
+    if not moe_runner_config.is_gated:
+        return False
+    if moe_runner_config.activation not in ("silu", "gelu", "relu"):
+        return False
+
+    if moe_runner_config.apply_router_weight_on_input:
+        return False
+
+    return True
+
+
+# TODO(yuan-luo): This function needs to be revised.
+def _convert_weights_to_sonic_format(
+    w1: torch.Tensor, w2: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Convert SGLang weight format to Sonic MoE format.
+    SGLang format: [E, N, K] (num_experts, intermediate_size, hidden_size)
+    Sonic format: [I, H, E] where the weight is accessed via permute(1, 2, 0)
+    For Sonic MoE's functional API, weights are passed as [I, H, E] format
+    which is then internally permuted to [E, H, I] for computation.
+    """
+    # Make sure original weights are contiguous in their original layout.
+    w1 = w1.contiguous()  # [E, 2N, K]
+    w2 = w2.contiguous()  # [E, K, N]
+
+    # Keep as a strided view (no .contiguous() here)
+    w1_sonic = w1.permute(1, 2, 0)  # [2N, K, E], stride typically (K, 1, 2N*K)
+    w2_sonic = w2.permute(1, 2, 0)  # [K, N, E],  stride typically (N, 1, K*N)
+    return w1_sonic, w2_sonic
+
+
+def sonic_experts_impl(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    activation: str,
+    routed_scaling_factor: Optional[float],
+) -> torch.Tensor:
+    """
+    Refer to sonicmoe.functional TC routing + Up/DownProjection
+    """
+    from sonicmoe.count_cumsum import count_cumsum
+    from sonicmoe.enums import ActivationType
+    from sonicmoe.functional import (
+        TC_topk_router_metadata,
+        _DownProjection,
+        _UpProjection,
+    )
+
+    # shape
+    M, K = hidden_states.shape
+    num_experts = w1.size(0)
+    topk = topk_ids.size(1)
+
+    # SonicMoE supports int32 expert ids
+    if topk_ids.dtype != torch.int32:
+        topk_ids_i32 = topk_ids.to(torch.int32)
+    else:
+        topk_ids_i32 = topk_ids
+
+    # convert weight format (with cache)
+    w1_sonic, w2_sonic = _convert_weights_to_sonic_format(w1, w2)
+
+    # activation
+    act_map = {"silu": "SWIGLU", "gelu": "GEGLU", "relu": "RELU"}
+    act_enum = getattr(ActivationType, act_map.get(activation, "SWIGLU"))
+
+    # routing metadata
+    topk_indices_flat = topk_ids_i32.reshape(-1)
+    _expert_freq, expert_freq_offset = count_cumsum(
+        topk_indices_flat, num_experts, do_cumsum=True
+    )
+    (
+        expert_freq_offset,
+        x_gather_idx,
+        s_scatter_idx,
+        s_reverse_scatter_idx,
+        num_activated_expert_per_token_offset,
+    ) = TC_topk_router_metadata(topk_ids_i32, expert_freq_offset, topk)
+
+    total_expert_freq = M * topk
+    stream_id = torch.cuda.current_stream().cuda_stream
+
+    # Up projection (GLU fused)
+    y1, z = _UpProjection.apply(
+        hidden_states,
+        w1_sonic,
+        None,  # b1
+        expert_freq_offset,
+        total_expert_freq,
+        topk,
+        stream_id,
+        x_gather_idx,
+        s_scatter_idx,
+        s_reverse_scatter_idx,
+        num_activated_expert_per_token_offset,
+        False,  # is_varlen_K
+        act_enum,
+        True,  # is_inference_mode_enabled
+    )
+
+    # Down projection: Sonic internally weight+reduce
+    o = _DownProjection.apply(
+        y1,
+        z,
+        w2_sonic,
+        None,  # b2
+        topk_weights,
+        expert_freq_offset,
+        M,
+        topk,
+        stream_id,
+        x_gather_idx,
+        s_scatter_idx,
+        s_reverse_scatter_idx,
+        num_activated_expert_per_token_offset,
+        False,  # is_varlen_K
+        act_enum,
+    )
+
+    if routed_scaling_factor is not None and routed_scaling_factor != 1.0:
+        o = o.mul(routed_scaling_factor)
+
+    return o
+
+
+def sonic_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_output: StandardTopKOutput,
+    moe_runner_config: MoeRunnerConfig = MoeRunnerConfig(),
+    b1: Optional[torch.Tensor] = None,
+    b2: Optional[torch.Tensor] = None,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    per_channel_quant: bool = False,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+    w1_zp: Optional[torch.Tensor] = None,
+    w2_zp: Optional[torch.Tensor] = None,
+    a1_scale: Optional[torch.Tensor] = None,
+    a2_scale: Optional[torch.Tensor] = None,
+    block_shape: Optional[List[int]] = None,
+) -> torch.Tensor:
+    """
+    Compliant with sglang.fused_moe.fused_moe signature
+    """
+    topk_weights, topk_ids, _ = topk_output
+
+    assert is_sonic_moe_supported(
+        hidden_states,
+        w1,
+        w2,
+        moe_runner_config,
+        use_fp8_w8a8=use_fp8_w8a8,
+        use_int8_w8a8=use_int8_w8a8,
+        use_int8_w8a16=use_int8_w8a16,
+        use_int4_w4a16=use_int4_w4a16,
+        per_channel_quant=per_channel_quant,
+        block_shape=block_shape,
+        b1=b1,
+        b2=b2,
+    ), "SonicMoE unsupported for this configuration (fallback recommended)."
+
+    assert w1_scale is None and w2_scale is None
+    assert w1_zp is None and w2_zp is None
+    assert a1_scale is None and a2_scale is None
+    assert moe_runner_config.gemm1_alpha is None
+    assert moe_runner_config.gemm1_clamp_limit is None
+
+    out = sonic_experts_impl(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        activation=moe_runner_config.activation,
+        routed_scaling_factor=moe_runner_config.routed_scaling_factor,
+    )
+
+    if moe_runner_config.inplace:
+        hidden_states.copy_(out)
+        return hidden_states
+    return out

--- a/test/srt/test_sonic_moe.py
+++ b/test/srt/test_sonic_moe.py
@@ -1,0 +1,173 @@
+import unittest
+
+import torch
+from tqdm import tqdm
+
+from sglang.srt.layers.activation import SiluAndMul
+from sglang.srt.layers.moe.moe_runner import MoeRunnerConfig
+
+# Replaced fused_moe with sonic_moe for this test.
+from sglang.srt.layers.moe.sonic_moe import sonic_moe
+from sglang.srt.layers.moe.topk import TopKConfig, select_experts
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.utils import is_hip
+from sglang.test.test_utils import CustomTestCase
+
+_is_hip = is_hip()
+
+
+class TestSonicMOE(CustomTestCase):
+    NUM_EXPERTS = [64]
+    TOP_KS = [2, 8]
+
+    @staticmethod
+    def create_random_cuda_tensor(shape, dtype, mean=0, std=0.01):
+        """Create a random CUDA tensor.
+
+        Args:
+            shape: Tensor shape.
+            dtype: Data type.
+            mean: Mean value.
+            std: Standard deviation.
+
+        Returns:
+            torch.Tensor: Randomly initialized CUDA tensor.
+        """
+        return torch.empty(shape, dtype=dtype, device="cuda").normal_(mean, std)
+
+    def get_tolerance(self, dtype):
+        """Get tolerance values for different data types.
+
+        Args:
+            dtype: Data type.
+
+        Returns:
+            tuple: (relative tolerance, absolute tolerance)
+        """
+        if dtype == torch.float32:
+            return 1e-3, 1e-5
+        elif dtype in [torch.float16, torch.bfloat16]:
+            return 1e-1, 1e-2
+        else:
+            return 1e-2, 1e-2  # Default values for other types
+
+    def torch_naive_moe(self, a, w1, w2, score, topk):
+        """Naive MoE implementation in PyTorch (reference).
+
+        Args:
+            a: Hidden states, shape (M, K).
+            w1: Up projection weights, shape (E, 2*N, K).
+            w2: Down projection weights, shape (E, K, N).
+            score: Router logits, shape (M, E).
+            topk: Top-k experts per token.
+
+        Returns:
+            torch.Tensor: Output tensor, shape (M, N).
+        """
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+        B, D = a.shape
+        a = a.view(B, -1, D).repeat(1, topk, 1).reshape(-1, D)
+        out = torch.zeros(B * topk, w2.shape[1], dtype=a.dtype, device=a.device)
+
+        score = torch.softmax(score, dim=-1, dtype=torch.float32)
+        topk_weight, topk_ids = torch.topk(score, topk)
+        topk_weight = topk_weight.view(-1)
+        topk_ids = topk_ids.view(-1)
+
+        w1_compute = w1
+        w2_compute = w2
+
+        for i in range(w1_compute.shape[0]):
+            mask = topk_ids == i
+            if mask.sum():
+                out[mask] = SiluAndMul()(
+                    a[mask] @ w1_compute[i].transpose(0, 1)
+                ) @ w2_compute[i].transpose(0, 1)
+
+        return (
+            out.view(B, -1, w2.shape[1]) * topk_weight.view(B, -1, 1).to(out.dtype)
+        ).sum(dim=1)
+
+    def _test_case(self, m, n, k, e, topk, dtype):
+        """Single test case comparing Sonic MoE vs torch naive reference."""
+        rtol, atol = self.get_tolerance(dtype)
+
+        # Sonic MoE requires CUDA.
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required for Sonic MoE test.")
+
+        # Sonic MoE is CUDA-only; skip on HIP/ROCm.
+        if _is_hip:
+            self.skipTest("Skip on HIP/ROCm: Sonic MoE is CUDA-only.")
+
+        # Sonic MoE is expected to run on Hopper (compute capability 9.x).
+        capability = torch.cuda.get_device_capability()
+        if capability[0] < 9:
+            self.skipTest(f"Skip non-Hopper GPU: require CC>=9.x, got {capability}.")
+
+        a = self.create_random_cuda_tensor((m, k), dtype)
+        w1 = self.create_random_cuda_tensor((e, 2 * n, k), dtype)
+        w2 = self.create_random_cuda_tensor((e, k, n), dtype)
+        score = self.create_random_cuda_tensor((m, e), dtype)
+
+        topk_output = select_experts(
+            hidden_states=a,
+            router_logits=score,
+            topk_config=TopKConfig(top_k=topk, renormalize=False),
+        )
+
+        # Skip if Sonic MoE is not available/supported for this configuration.
+        non_fused_no_combine_config = MoeRunnerConfig(
+            inplace=False, no_combine=True, top_k=topk
+        )
+
+        # if not is_sonic_moe_supported(a, w1, w2, non_fused_no_combine_config):
+        #     self.skipTest("Sonic MoE is not installed or not supported on this setup.")
+
+        sonic_output = sonic_moe(a, w1, w2, topk_output)
+        torch_output = self.torch_naive_moe(a, w1, w2, score, topk)
+
+        torch.testing.assert_close(sonic_output, torch_output, rtol=rtol, atol=atol)
+
+    def test_various_configurations(self):
+        m_values = [1, 33, 64, 222]
+        n_values = [128, 1024]
+        k_values = [128, 511, 1024]
+        dtypes = [torch.float16, torch.bfloat16]
+
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+        # Calculate total number of tests.
+        total_tests = (
+            len(m_values)
+            * len(n_values)
+            * len(k_values)
+            * len(self.NUM_EXPERTS)
+            * len(self.TOP_KS)
+            * len(dtypes)
+        )
+
+        # Create progress bar.
+        with tqdm(total=total_tests, desc="Running MoE tests") as pbar:
+            for m in m_values:
+                for n in n_values:
+                    for k in k_values:
+                        for e in self.NUM_EXPERTS:
+                            for topk in self.TOP_KS:
+                                for dtype in dtypes:
+                                    with self.subTest(
+                                        m=m,
+                                        n=n,
+                                        k=k,
+                                        e=e,
+                                        topk=topk,
+                                        dtype=dtype,
+                                    ):
+                                        self._test_case(m, n, k, e, topk, dtype)
+                                        torch.cuda.empty_cache()
+                                    pbar.update(1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
SonicMoE is a simple but blazing-fast Mixture-of-Experts (MoE) implementation optimized for NVIDIA Hopper architecture GPUs. It mainly leverages [CuTeDSL](https://docs.nvidia.com/cutlass/media/docs/pythonDSL/cute_dsl_general/dsl_introduction.html) and [Triton](https://triton-lang.org/main/getting-started/tutorials/index.html) to deliver state-of-the-art performance through IO-aware optimizations.

https://github.com/Dao-AILab/sonic-moe

This PR is to integrate SonicMoe into SGLang, being compliant with fused_moe interface.

This PR covers introduce Sonic-MoE into SGLang, and introduce unit test to make sure the accuracy. 
The following PR will integrate it into MoE framework and make e-2-e working.

Env:
H800
CUDA Version: 12.9
Python 3.12.3
Torch 2.9.1+cu129

```
root@6996fb46042d:/sgl-workspace/sglang# python test_sonic_moe.py -vvvv
test_various_configurations (__main__.TestSonicMOE.test_various_configurations) ... [CI Test Method] TestSonicMOE.test_various_configurations
Running MoE tests:   0%|                                                                                                                                                                 | 0/8 [00:00<?, ?it/s]/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/utils/__init__.py:22: DeprecationWarning: SMEM_CAPACITY is deprecated: Use get_smem_capacity_in_bytes from cutlass.utils.smem_capacity instead
  from .blackwell_helpers import (
/usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/utils/__init__.py:34: DeprecationWarning: SMEM_CAPACITY is deprecated: Use get_smem_capacity_in_bytes from cutlass.utils.smem_capacity instead
  from .hopper_helpers import (
ninja: no work to do.
Running MoE tests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:23<00:00,  2.93s/it]
ok

----------------------------------------------------------------------
Ran 1 test in 23.423s

OK
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
