### PR TITLE
Fix inconsistent input_ids and seq_lens

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -874,6 +874,7 @@ class ForwardBatch:
 
     def _pad_inputs_to_size(self, model_runner: ModelRunner, num_tokens, bs):
         # padding
+        num_pad = num_tokens - self.input_ids.shape[0]
         self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
         self.req_pool_indices = self._pad_tensor_to_size(self.req_pool_indices, bs)
         self.lora_ids.extend((bs - len(self.lora_ids)) * [None])
@@ -887,10 +888,14 @@ class ForwardBatch:
         self.seq_lens = self._pad_tensor_to_size(
             self.seq_lens, bs, value=seq_len_fill_value
         )
+        if self.forward_mode.is_extend() and len(self.seq_lens) > 0:
+            self.seq_lens[-1] += num_pad
         if self.seq_lens_cpu is not None:
             self.seq_lens_cpu = self._pad_tensor_to_size(
                 self.seq_lens_cpu, bs, value=seq_len_fill_value
             )
+            if self.forward_mode.is_extend() and len(self.seq_lens_cpu) > 0:
+                self.seq_lens_cpu[-1] += num_pad
 
         self.out_cache_loc = self._pad_tensor_to_size(self.out_cache_loc, num_tokens)
         if self.encoder_lens is not None:


### PR DESCRIPTION
In `prepare_attn_tp_scatter_input`, `input_ids` needs to be padded to a multiple of `attention_tp_size`, but `seq_lens` is not modified accordingly. For example, for a single sequence of length 21, len(input_ids) = 21 and seq_lens = [21]. After padding, len(input_ids) = 24 while seq_lens remains [21].

```python
import torch
from flashinfer.prefill import BatchPrefillWithRaggedKVCacheWrapper

ws = torch.empty(128 * 1024**2, dtype=torch.uint8, device="cuda")
wrapper_raged = BatchPrefillWithRaggedKVCacheWrapper(ws, "NHD", backend="fa3")
seq_len = 21
seq_len_with_pad = 24
q = torch.randn(seq_len_with_pad, 16, 128, device="cuda", dtype=torch.bfloat16)
k = torch.randn(seq_len_with_pad, 1, 128, device="cuda", dtype=torch.bfloat16)
v = torch.randn(seq_len_with_pad, 1, 128, device="cuda", dtype=torch.bfloat16)

q[seq_len:] = torch.nan
k[seq_len:] = torch.nan
v[seq_len:] = torch.nan

wrapper_raged.plan(
    qo_indptr=torch.tensor([0, seq_len], dtype=torch.int64, device="cuda"),
    kv_indptr=torch.tensor([0, seq_len], dtype=torch.int64, device="cuda"),
    num_qo_heads=16,
    num_kv_heads=1,
    head_dim_qk=128,
    q_data_type=torch.bfloat16,
)

o = wrapper_raged.run(q, k, v)
print(o.view(o.shape[0], -1).sum(dim=-1))
```

NaNs in the regions outside indptr will cause a large number of NaNs in the output:

```
tensor([nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, 0., 0., 0.],
       device='cuda:0', dtype=torch.bfloat16)
```

So how are the NaNs in the padded part introduced?

Because the padded part is outside `indptr`, the values in the padded region of flashinfer’s output are undefined. We found that for some inputs, `BatchPrefillWithPagedKVCacheWrapper.run` may return NaNs in the padded region.

In this patch, we modify `seq_lens` to make it consistent with `len(input_ids)`, ensuring that the lengths of `qo_indptr` and `q` match, thereby avoiding NaNs during the attention computation.

@ch-wan 

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
