### PR TITLE
feat(openai): use --preferred-sampling-params as defaults in OpenAI API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -87,7 +87,10 @@ class OpenAIServingResponses(OpenAIServingChat):
 
         # Use default sampling params from parent class (model config + preferred_sampling_params)
         # If not set by parent, initialize as empty dict
-        if not hasattr(self, "default_sampling_params") or self.default_sampling_params is None:
+        if (
+            not hasattr(self, "default_sampling_params")
+            or self.default_sampling_params is None
+        ):
             self.default_sampling_params = {}
 
         self.supports_browsing = (

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -85,8 +85,10 @@ class OpenAIServingResponses(OpenAIServingChat):
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
 
-        # Get default sampling params from model config if available
-        self.default_sampling_params = {}
+        # Use default sampling params from parent class (model config + preferred_sampling_params)
+        # If not set by parent, initialize as empty dict
+        if not hasattr(self, "default_sampling_params") or self.default_sampling_params is None:
+            self.default_sampling_params = {}
 
         self.supports_browsing = (
             tool_server.has_tool("browser") if tool_server else False


### PR DESCRIPTION
## Summary
- Makes `--preferred-sampling-params` CLI arg work as actual defaults for the OpenAI-compatible chat completion API
- Priority: user value > preferred_sampling_params > model generation_config > OpenAI defaults
- Fixes the responses endpoint to not override parent's default_sampling_params

This addresses the feature request to have `--preferred-sampling-params` actually set default sampling parameters for models that don't have a `generation_config.json`, such as the recent [MiMo-V2-Flash](https://huggingface.co/XiaomiMiMo/MiMo-V2-Flash) model.

## Changes
- `serving_chat.py`: Merge `preferred_sampling_params` with model generation config, with CLI params taking precedence
- `serving_responses.py`: Don't override parent class's `default_sampling_params` with empty dict

## Test plan
- [ ] Start server with `--preferred-sampling-params '{"temperature": 0.7, "top_p": 0.9}'`
- [ ] Verify chat completions use those defaults when not specified in request
- [ ] Verify request-level params still override the defaults

Fixes #15487

🤖 Generated with [Claude Code](https://claude.com/claude-code)