### PR TITLE
fix(pooler): use lazy import to avoid vllm dependency on CPU

### DIFF
--- a/python/sglang/srt/layers/pooler.py
+++ b/python/sglang/srt/layers/pooler.py
@@ -9,7 +9,6 @@ import torch
 import torch.nn as nn
 from transformers import PretrainedConfig
 
-from sglang.srt.layers.activation import get_cross_encoder_activation_function
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
@@ -96,6 +95,11 @@ class CrossEncodingPooler(nn.Module):
         super().__init__()
         self.classifier = classifier
         self.pooler = pooler
+
+        # Lazy import to avoid strict hardware dependency at module load time
+        # This allows importing pooler.py on CPU-only environments without vllm
+        from sglang.srt.layers.activation import get_cross_encoder_activation_function
+
         self.default_activation_function = get_cross_encoder_activation_function(config)
 
     def forward(


### PR DESCRIPTION
## Summary
Move the import of `get_cross_encoder_activation_function` from module level to inside `CrossEncodingPooler.__init__`. This allows importing `pooler.py` (and transitively `weight_sync.utils`) on CPU-only environments without requiring vllm to be installed.

## Problem
In v0.5.6, the import chain:
```
sglang.srt.weight_sync.utils 
  → model_runner 
  → pooler 
  → activation
```
would crash on CPU nodes (without vllm) with `ModuleNotFoundError: No module named 'vllm'`.

This breaks distributed workflows (e.g., Ray-based verl drivers/orchestrators) that run on CPU nodes but need to import sglang utilities for coordination.

## Solution
Use lazy import inside `CrossEncodingPooler.__init__` instead of module-level import. The import only happens when `CrossEncodingPooler` is actually instantiated, not when the module is loaded.

## Test plan
- [ ] Import `sglang.srt.weight_sync.utils` on CPU-only environment without vllm - should not crash
- [ ] Existing tests for `CrossEncodingPooler` should still pass

Fixes #15643

🤖 Generated with [Claude Code](https://claude.com/claude-code)