### PR TITLE
Tiny add flush for CI crash locating

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -147,9 +147,12 @@ class Envs:
     SGLANG_LOG_MS = EnvBool(False)
     SGLANG_DISABLE_REQUEST_LOGGING = EnvBool(False)
 
-    # Test & Debug
+    # SGLang CI
     SGLANG_IS_IN_CI = EnvBool(False)
     SGLANG_IS_IN_CI_AMD = EnvBool(False)
+    SGLANG_TEST_MAX_RETRY = EnvInt(None)
+
+    # Test & Debug
     SGLANG_TEST_STUCK_DETOKENIZER = EnvFloat(0)
     SGLANG_TEST_STUCK_DP_CONTROLLER = EnvFloat(0)
     SGLANG_TEST_STUCK_TOKENIZER = EnvFloat(0)

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -1714,7 +1714,10 @@ class CustomTestCase(unittest.TestCase):
         )
 
     def setUp(self):
-        print(f"[CI Test Method] {self.__class__.__name__}.{self._testMethodName}")
+        print(
+            f"[CI Test Method] {self.__class__.__name__}.{self._testMethodName}",
+            flush=True,
+        )
 
 
 def dump_bench_raw_result(

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -1705,9 +1705,9 @@ async def send_concurrent_generate_requests_with_custom_params(
 
 class CustomTestCase(unittest.TestCase):
     def _callTestMethod(self, method):
-        max_retry = int(
-            os.environ.get("SGLANG_TEST_MAX_RETRY", "1" if is_in_ci() else "0")
-        )
+        max_retry = envs.SGLANG_TEST_MAX_RETRY.get()
+        if max_retry is None:
+            max_retry = 1 if is_in_ci() else 0
         retry(
             lambda: super(CustomTestCase, self)._callTestMethod(method),
             max_retry=max_retry,


### PR DESCRIPTION
**We may see a crash here**

<img width="995" height="432" alt="image" src="https://github.com/user-attachments/assets/974c4921-33d5-428f-b09a-a00e881aff0a" />

**But the correct subtest title shows behind the crash log**

<img width="809" height="247" alt="image" src="https://github.com/user-attachments/assets/0ba47125-4f59-474f-855b-4f7f3d5729c1" />

