### PR TITLE
fix(responses): use copy.copy() instead of copy() for proper module usage

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -689,7 +689,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             messages.append(get_user_message(request.input))
         else:
             if prev_response is not None:
-                prev_outputs = copy(prev_response.output)
+                prev_outputs = copy.copy(prev_response.output)
             else:
                 prev_outputs = []
             for response_msg in request.input:


### PR DESCRIPTION
## Summary
- Fix incorrect usage of `copy()` that causes `TypeError` when using `previous_response_id` with the Responses API
- The `copy` module is imported as `import copy`, so `copy.copy()` should be used instead of `copy()`

## Issue
Fixes #15735

## Root Cause
At line 692, the code uses `copy(prev_response.output)` but since the import is `import copy`, this tries to call the module itself as a function, which fails.

## Fix
Change `copy(prev_response.output)` to `copy.copy(prev_response.output)`

## Test Plan
- The fix is a one-line change to correct the function call
- The error reported in #15735 should be resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)