### PR TITLE
fix(diffusion): fall back to SDPA on SM120 GPUs

### DIFF
--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -20,7 +20,7 @@ from sglang.multimodal_gen.runtime.platforms.interface import (
     Platform,
     PlatformEnum,
 )
-from sglang.multimodal_gen.runtime.utils.common import is_blackwell
+from sglang.multimodal_gen.runtime.utils.common import is_blackwell, is_sm120
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.utils import import_pynvml
 
@@ -162,7 +162,6 @@ class CudaPlatformBase(Platform):
                 )
 
                 logger.info("Using Sage Attention 3 backend")
-
                 return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3.SageAttention3Backend"
             except ImportError as e:
                 logger.info(e)
@@ -224,6 +223,7 @@ class CudaPlatformBase(Platform):
         elif selected_backend:
             raise ValueError(f"Invalid attention backend for {cls.device_name}")
         else:
+
             if is_blackwell():
                 from sglang.multimodal_gen.runtime.layers.attention.backends.flash_attn import (
                     set_fa_ver,
@@ -231,10 +231,32 @@ class CudaPlatformBase(Platform):
 
                 set_fa_ver(4)
             target_backend = AttentionBackendEnum.FA
+            if is_sm120():
+                try:
+                    from sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3 import (  # noqa: F401
+                        SageAttention3Backend,
+                    )
+
+                    logger.info("Using Sage Attention 3 backend")
+                    return "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3.SageAttention3Backend"
+                except ImportError as e:
+                    logger.info(e)
+                    logger.info(
+                        "Sage Attention 3 backend is not installed, Falling back to Torch SDPA (To install it, see https://github.com/thu-ml/SageAttention/tree/main/sageattention3_blackwell#installation)"
+                    )
+                    target_backend = AttentionBackendEnum.TORCH_SDPA
 
         if not cls.has_device_capability(80):
             logger.info(
                 "Cannot use FlashAttention backend for Volta and Turing " "GPUs."
+            )
+            target_backend = AttentionBackendEnum.TORCH_SDPA
+        elif is_sm120():
+            # SM120 (Blackwell workstation/consumer GPUs like RTX PRO 6000) is not
+            # supported by sgl-kernel's flash_attn, which only supports SM90/SM100.
+            logger.info(
+                "Cannot use FlashAttention backend for SM120 GPUs. "
+                "sgl-kernel flash_attn only supports SM90 (Hopper) and SM100 (Blackwell Ultra)."
             )
             target_backend = AttentionBackendEnum.TORCH_SDPA
         elif dtype not in (torch.float16, torch.bfloat16):
@@ -243,7 +265,6 @@ class CudaPlatformBase(Platform):
                 "torch.float16 or torch.bfloat16."
             )
             target_backend = AttentionBackendEnum.TORCH_SDPA
-
         # FlashAttn is valid for the model, checking if the package is
         # installed.
         if target_backend == AttentionBackendEnum.FA:


### PR DESCRIPTION
## Summary
- Fall back to Torch SDPA backend on SM120 (Blackwell workstation/consumer) GPUs for diffusion models
- SM120 GPUs like RTX PRO 6000 are not supported by sgl-kernel's flash_attn

## Issue
Fixes #15342

## Root Cause
The code at line 249 checks `has_device_capability(80)` which returns True for SM120 (12.0 >= 8.0). However, sgl-kernel's flash_attn only supports SM90 (Hopper) and SM100 (Blackwell Ultra), not SM120.

This causes the error:
```
NotImplementedError: flash_attn at sgl-kernel is only supported on sm90 and above
```

The error message is misleading - it says "sm90 and above" but actually only SM90 and SM100 are supported.

## Fix
Add an explicit check for `is_sm120()` to fall back to Torch SDPA backend, similar to how PR #15766 fixed the same issue for TRT AllReduce Fusion in server_args.py.

## Test Plan
- On SM120 GPUs (RTX PRO 6000 Blackwell), diffusion models should now use SDPA backend instead of failing
- On SM90/SM100 GPUs, FlashAttention will still be used

🤖 Generated with [Claude Code](https://claude.com/claude-code)