### PR TITLE
[MTP][spec_v2] Fix TRTLLM MLA backend crash in EAGLE draft_extend mode 

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1071,13 +1071,18 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     )
 
                     if self.padded_q_buffer is not None:
-                        padded_q = self.padded_q_buffer[:bs, :actual_max_seq_len_q, :, :].to(
-                            dtype=q.dtype
-                        )
+                        padded_q = self.padded_q_buffer[
+                            :bs, :actual_max_seq_len_q, :, :
+                        ].to(dtype=q.dtype)
                         padded_q.zero_()
                     else:
                         padded_q = torch.zeros(
-                            (bs, actual_max_seq_len_q, layer.tp_q_head_num, layer.head_dim),
+                            (
+                                bs,
+                                actual_max_seq_len_q,
+                                layer.tp_q_head_num,
+                                layer.head_dim,
+                            ),
                             dtype=q.dtype,
                             device=q.device,
                         )

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -549,10 +549,13 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             else:
                 metadata.max_seq_len_q = 1
                 metadata.sum_seq_lens_q = bs
+            # Note: The actual tokens per sequence is accept_length + 1 (accepted tokens + current token)
+            # We need to add 1 to match the actual q tensor shape
+            extend_seq_lens = accept_length + 1
             metadata.cu_seqlens_q[1:].copy_(
-                torch.cumsum(accept_length, dim=0, dtype=torch.int32)
+                torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32)
             )
-            metadata.seq_lens_q.copy_(accept_length)
+            metadata.seq_lens_q.copy_(extend_seq_lens)
             # see NOTE(draft_extend seq_len handling)
             seq_lens = seq_lens[:bs] - metadata.seq_lens_q + metadata.max_seq_len_q
             metadata.seq_lens_k.copy_(seq_lens.to(torch.int32))
@@ -1043,9 +1046,67 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 max_seq_len = (
                     metadata.max_seq_len_k + forward_batch.spec_info.draft_token_num
                 )
+                # For target_verify, all sequences have the same number of draft tokens
+                q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
+                needs_unpad = False
             else:
-                max_seq_len = metadata.max_seq_len_k + metadata.max_seq_len_q
-            q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
+                # For draft_extend, sequences may have varying accept_lengths
+                max_seq_len_q = metadata.max_seq_len_q
+                total_tokens = q.shape[0]
+                tokens_per_seq = total_tokens // bs if bs > 0 else 0
+
+                # Check if q can be directly reshaped to (bs, tokens_per_seq, ...)
+                # This is true when total_tokens is evenly divisible by bs
+                # (e.g., during CUDA graph capture/replay where all sequences have same length)
+                can_direct_view = (total_tokens % bs == 0) if bs > 0 else False
+
+                if can_direct_view:
+                    # Use actual tokens_per_seq from q tensor shape
+                    max_seq_len = metadata.max_seq_len_k + tokens_per_seq
+                    q = q.view(bs, tokens_per_seq, layer.tp_q_head_num, layer.head_dim)
+                    needs_unpad = False
+                    unpad_seq_lens_q = None
+                    unpad_cu_seqlens_q = None
+                    unpad_sum_seq_lens_q = None
+                else:
+                    # Sequences have varying lengths, need to pad the query
+                    # Use values from forward_batch instead of metadata to ensure consistency
+                    actual_seq_lens_q = forward_batch.extend_seq_lens
+                    actual_max_seq_len_q = max(forward_batch.extend_seq_lens_cpu)
+                    actual_sum_seq_lens_q = total_tokens  # Use actual input token count
+
+                    max_seq_len = metadata.max_seq_len_k + actual_max_seq_len_q
+
+                    # Compute cu_seqlens_q from actual seq_lens
+                    actual_cu_seqlens_q = torch.nn.functional.pad(
+                        torch.cumsum(actual_seq_lens_q, dim=0, dtype=torch.int32),
+                        (1, 0),
+                    )
+
+                    # Use pre-allocated buffer for CUDA graph compatibility
+                    if self.padded_q_buffer is not None:
+                        padded_q = self.padded_q_buffer[:bs, :actual_max_seq_len_q, :, :].to(
+                            dtype=q.dtype
+                        )
+                        padded_q.zero_()
+                    else:
+                        padded_q = torch.zeros(
+                            (bs, actual_max_seq_len_q, layer.tp_q_head_num, layer.head_dim),
+                            dtype=q.dtype,
+                            device=q.device,
+                        )
+
+                    q = self.pad_draft_extend_query(
+                        q,
+                        padded_q,
+                        actual_seq_lens_q,
+                        actual_cu_seqlens_q,
+                    )
+                    needs_unpad = True
+                    unpad_seq_lens_q = actual_seq_lens_q
+                    unpad_cu_seqlens_q = actual_cu_seqlens_q
+                    unpad_sum_seq_lens_q = actual_sum_seq_lens_q
+
             assert kv_cache.dtype == self.data_type
 
             raw_out = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
@@ -1061,7 +1122,18 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 bmm1_scale=bmm1_scale,
             )
 
-            output = raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+            if needs_unpad:
+                # Unpad the output for draft_extend mode with varying lengths
+                # Use the actual values computed during padding, not from metadata
+                output = self.unpad_draft_extend_output(
+                    raw_out,
+                    unpad_cu_seqlens_q,
+                    unpad_seq_lens_q,
+                    unpad_sum_seq_lens_q,
+                )
+                output = output.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+            else:
+                output = raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
             return output
 
         if k_rope is not None:


### PR DESCRIPTION
## Motivation

Fix a crash in TRTLLM MLA backend during EAGLE speculative decoding in `draft_extend` mode when sequences have varying `accept_length` values.

This can be reproduced by the following agg command (and also intermittency issues in the disagg setup in benchmark section):
```
SGLANG_ENABLE_SPEC_V2=1 SGLANG_FLASHINFER_FP4_GEMM_BACKEND=cutlass SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK=1 python3 -m sglang.launch_server     --model-path ${MODEL}     --served-model-name dsr1     --tp 4     --attention-backend trtllm_mla     --moe-runner-backend flashinfer_trtllm     --moe-dense-tp-size 1     --quantization modelopt_fp4     --kv-cache-dtype fp8_e4m3     --disable-radix-cache     --chunked-prefill-size -1     --speculative-algorithm EAGLE     --speculative-num-steps 2     --speculative-eagle-topk 1     --speculative-num-draft-tokens 3     --mem-fraction-static 0.80
```
Error:
```
File "/sgl-workspace/sglang/python/sglang/srt/layers/attention/trtllm_mla_backend.py", line 1046, in forward_extend
    q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: shape '[9, -1, 32, 576]' is invalid for input of size 516096

```

## Modifications

1. **`forward_extend`**: Added `can_direct_view` check to handle varying sequence lengths with padding/unpadding when `total_tokens % bs != 0`

2. **`init_forward_metadata_replay_cuda_graph`**: Fixed `seq_lens_q` computation to use `accept_length + 1`

## Accuracy Tests

```bash
python -m sglang.test.run_eval \
    --eval-name longbench_v2 \
    --host 127.0.0.1 --port 30000 \
    --model nvidia/DeepSeek-R1-0528-NVFP4-v2 \
    --max-context-length 128000 \
    --max-tokens 16384 \
    --num-threads 16
```
**Score: 0.601**

## Benchmarking

```

  decode_environment:
    DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
    FLASHINFER_DISABLE_VERSION_CHECK: '1'
    FLASHINFER_WORKSPACE_BASE: /configs/flashinfer-cache
    MC_FORCE_MNNVL: '1'
    NCCL_CUMEM_ENABLE: '1'
    NCCL_MNNVL_ENABLE: '1'
    PYTHONUNBUFFERED: '1'
    SGLANG_DECODE_BOOTSTRAP_TIMEOUT: '1000'
    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: '1'
    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: '100000'
    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: '100000'
    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: '100000'
    SGLANG_ENABLE_JIT_DEEPGEMM: 'false'
    SGLANG_FLASHINFER_FP4_GEMM_BACKEND: cutlass
    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: '0'
    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
    SGLANG_ENABLE_SPEC_V2: '1'
    # DEBUG: Scale FutureMap buffer to test overwrite hypothesis (default=1, set 8/16 to test)
    SGLANG_FUTURE_MAP_SCALE: '8'

  prefill_environment:
    DYN_SKIP_SGLANG_LOG_FORMATTING: '1'
    FLASHINFER_DISABLE_VERSION_CHECK: '1'
    FLASHINFER_WORKSPACE_BASE: /configs/flashinfer-cache
    MC_FORCE_MNNVL: '1'
    NCCL_CUMEM_ENABLE: '1'
    NCCL_MNNVL_ENABLE: '1'
    PYTHONUNBUFFERED: '1'
    SGLANG_DECODE_BOOTSTRAP_TIMEOUT: '1000'
    SGLANG_DISABLE_TP_MEMORY_INBALANCE_CHECK: '1'
    SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT: '100000'
    SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE: '100000'
    SGLANG_DISAGGREGATION_WAITING_TIMEOUT: '100000'
    SGLANG_ENABLE_JIT_DEEPGEMM: 'false'
    SGLANG_FLASHINFER_FP4_GEMM_BACKEND: cutlass
    SGLANG_MOONCAKE_CUSTOM_MEM_POOL: 'True'
    SGLANG_USE_MESSAGE_QUEUE_BROADCASTER: '0'
    TORCH_DISTRIBUTED_DEFAULT_TIMEOUT: '1800'
    SGLANG_ENABLE_SPEC_V2: '1'

  sglang_config:
    decode:
      attention-backend: trtllm_mla
      chunked-prefill-size: -1
      context-length: 136000
      cuda-graph-max-bs: 256
      # EXPERIMENT: Set DP=1 to make decode_tp=4 (same as prefill attn_tp=4)
      # Original: data-parallel-size: 4, enable-dp-attention: true, expert-parallel-size: 4
      data-parallel-size: 1
      disable-radix-cache: true
      disaggregation-bootstrap-port: 30001
      disaggregation-mode: decode
      disaggregation-transfer-backend: nixl
      # enable-dp-attention: true  # Disabled because DP=1
      enable-symm-mem: true
      expert-parallel-size: 1
      kv-cache-dtype: fp8_e4m3
      mem-fraction-static: 0.85
      model-path: /model/
      moe-dense-tp-size: 1
      moe-runner-backend: flashinfer_trtllm
      prefill-round-robin-balance: true
      quantization: modelopt_fp4
      scheduler-recv-interval: 1
      served-model-name: nvidia/DeepSeek-R1-0528-NVFP4-v2
      speculative-algorithm: "EAGLE"
      speculative-num-steps: 2
      speculative-eagle-topk: 1
      speculative-num-draft-tokens: 3
      stream-interval: 10
      tensor-parallel-size: 4
      trust-remote-code: true
      watchdog-timeout: 1000000

    prefill:
      attention-backend: trtllm_mla
      chunked-prefill-size: -1
      context-length: 136000
      data-parallel-size: 1
      disable-radix-cache: true
      disaggregation-bootstrap-port: 30001
      disaggregation-mode: prefill
      disaggregation-transfer-backend: nixl
      enable-symm-mem: true
      expert-parallel-size: 1
      kv-cache-dtype: fp8_e4m3
      load-balance-method: round_robin
      max-running-requests: 16
      mem-fraction-static: 0.72
      model-path: /model/
      moe-dense-tp-size: 1
      moe-runner-backend: flashinfer_trtllm
      pipeline-parallel-size: 1
      quantization: modelopt_fp4
      scheduler-recv-interval: 1
      served-model-name: nvidia/DeepSeek-R1-0528-NVFP4-v2
      stream-interval: 10
      tensor-parallel-size: 4
      trust-remote-code: true
      watchdog-timeout: 1000000
      speculative-algorithm: "EAGLE"
      speculative-num-steps: 2
      speculative-eagle-topk: 1
      speculative-num-draft-tokens: 3
```

| Metric | Before | After |
|--------|--------|-------|
| Accept Length | 1.3 | **2.41** |
| Accept Rate | ~43% | **~80%** |
<img width="2100" height="1200" alt="image" src="https://github.com/user-attachments/assets/a3777e9c-f5c5-4c50-9960-7bf59868f92d" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).