### PR TITLE
Clean up the `__init__` of TokenizerManager and DetokenizerManager

### DIFF
--- a/python/sglang/srt/custom_op.py
+++ b/python/sglang/srt/custom_op.py
@@ -1,3 +1,9 @@
+"""
+The definition of CustomOps for multi hardware dispatching.
+
+TODO: Move this to python/sglang/srt/layers/custom_op.py
+"""
+
 from torch import nn
 
 from sglang.srt.utils import (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -298,7 +298,7 @@ class Scheduler(
         self.init_metrics(tp_rank, pp_rank, dp_rank)
 
         # Init inter-process communication
-        self.init_sockets(server_args, port_args)
+        self.init_ipc_channels(port_args)
 
         # Init PD-multiplexing context
         if self.enable_pdmux:
@@ -354,7 +354,7 @@ class Scheduler(
             else None
         )
 
-    def init_sockets(self, server_args: ServerArgs, port_args: PortArgs):
+    def init_ipc_channels(self, port_args: PortArgs):
         context = zmq.Context(2)
         self.idle_sleeper = None
 
@@ -369,7 +369,7 @@ class Scheduler(
             send_to_tokenizer = get_zmq_socket(
                 context, zmq.PUSH, port_args.tokenizer_ipc_name, False
             )
-            if server_args.skip_tokenizer_init:
+            if self.server_args.skip_tokenizer_init:
                 # Directly send to the TokenizerManager
                 send_to_detokenizer = get_zmq_socket(
                     context, zmq.PUSH, port_args.tokenizer_ipc_name, False

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1515,6 +1515,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                     "Signal SIGTERM received while health check failed. Force exiting."
                 )
                 self.dump_requests_before_crash()
+                self.force_exit_handler()
                 break
 
             elif get_bool_env_var("SGL_FORCE_SHUTDOWN"):
@@ -1522,6 +1523,7 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
                 logger.error(
                     "Signal SIGTERM received while force shutdown flag set. Force exiting."
                 )
+                self.force_exit_handler()
                 break
 
             logger.info(
@@ -1535,6 +1537,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
 
         kill_process_tree(os.getpid(), include_parent=True)
         sys.exit(0)
+
+    def force_exit_handler(self):
+        """Put some custom force exit logic here."""
+        pass
 
     async def handle_loop(self):
         """The event loop that handles requests"""


### PR DESCRIPTION
make them into multiple smaller functions to allow easier override