### PR TITLE
ci: migrate MLA tests to test/registered/mla/

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -433,7 +433,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [0, 1, 2]
+        partition: [0, 1, 2, 3]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -454,7 +454,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd test/
-          python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 3
+          python3 run_suite.py --hw cuda --suite stage-b-test-small-1-gpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size 4
 
   stage-b-test-large-1-gpu:
     needs: [check-changes, call-gate, stage-a-test-1, sgl-kernel-build-wheels]

--- a/test/registered/mla/test_mla.py
+++ b/test/registered/mla/test_mla.py
@@ -2,20 +2,29 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
-    DEFAULT_MLA_FP8_MODEL_NAME_FOR_TEST,
+    DEFAULT_MLA_MODEL_NAME_FOR_TEST,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
 )
 
+# MLA attention test with MGSM evaluation
+register_cuda_ci(est_time=194, suite="stage-b-test-small-1-gpu")
+register_amd_ci(
+    est_time=242,
+    suite="stage-a-test-1",
+    disabled="see https://github.com/sgl-project/sglang/issues/13107",
+)
+
 
 class TestMLA(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = DEFAULT_MLA_FP8_MODEL_NAME_FOR_TEST
+        cls.model = DEFAULT_MLA_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
         cls.process = popen_launch_server(
             cls.model,
@@ -23,8 +32,11 @@ class TestMLA(CustomTestCase):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=[
                 "--trust-remote-code",
-                "--kv-cache-dtype",
-                "fp8_e5m2",
+                "--enable-torch-compile",
+                "--torch-compile-max-bs",
+                "4",
+                "--chunked-prefill-size",
+                "256",
             ],
         )
 
@@ -42,7 +54,7 @@ class TestMLA(CustomTestCase):
         )
 
         metrics = run_eval(args)
-        assert metrics["score"] >= 0.8
+        self.assertGreater(metrics["score"], 0.8)
 
 
 if __name__ == "__main__":

--- a/test/registered/mla/test_mla_deepseek_v3.py
+++ b/test/registered/mla/test_mla_deepseek_v3.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import requests
 
 from sglang.srt.utils import is_cuda, is_hip, kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -12,6 +13,14 @@ from sglang.test.test_utils import (
     CustomTestCase,
     is_in_ci,
     popen_launch_server,
+)
+
+# DeepSeek-V3 MLA tests with torch compile, FA3, and MTP speculative decoding
+register_cuda_ci(est_time=442, suite="stage-b-test-small-1-gpu")
+register_amd_ci(
+    est_time=221,
+    suite="stage-a-test-1",
+    disabled="see https://github.com/sgl-project/sglang/issues/12574",
 )
 
 

--- a/test/registered/mla/test_mla_flashinfer.py
+++ b/test/registered/mla/test_mla_flashinfer.py
@@ -1,8 +1,3 @@
-"""
-Usage:
-python3 test/srt/test_flashmla.py
-"""
-
 import unittest
 from types import SimpleNamespace
 
@@ -10,36 +5,39 @@ import requests
 import torch
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.test_utils import (
-    DEFAULT_MODEL_NAME_FOR_TEST_MLA,
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
 )
 
+# FlashInfer MLA backend tests with MTP speculative decoding
+register_cuda_ci(est_time=302, suite="stage-b-test-small-1-gpu")
 
-class TestFlashMLAAttnBackend(unittest.TestCase):
+
+class TestFlashinferMLA(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+        cls.model = "lmsys/sglang-ci-dsv3-test"
         cls.base_url = DEFAULT_URL_FOR_TEST
         other_args = ["--trust-remote-code"]
         if torch.cuda.is_available() and torch.version.cuda:
             other_args.extend(
                 [
+                    "--enable-torch-compile",
                     "--cuda-graph-max-bs",
-                    "2",
+                    "4",
                     "--attention-backend",
-                    "flashmla",
+                    "flashinfer",
                 ]
             )
-        # Use longer timeout for DeepGEMM JIT compilation which can take 10-20 minutes
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 2,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=other_args,
         )
 
@@ -60,10 +58,10 @@ class TestFlashMLAAttnBackend(unittest.TestCase):
         metrics = run_eval_few_shot_gsm8k(args)
         print(metrics)
 
-        self.assertGreater(metrics["accuracy"], 0.60)
+        self.assertGreater(metrics["accuracy"], 0.615)
 
 
-class TestFlashMLAMTP(CustomTestCase):
+class TestFlashinferMLAMTP(CustomTestCase):
     @classmethod
     def setUpClass(cls):
         cls.model = "lmsys/sglang-ci-dsv3-test"
@@ -74,29 +72,25 @@ class TestFlashMLAMTP(CustomTestCase):
                 [
                     "--cuda-graph-max-bs",
                     "4",
-                    "--disable-radix",
                     "--enable-torch-compile",
                     "--torch-compile-max-bs",
                     "1",
                     "--speculative-algorithm",
                     "EAGLE",
-                    "--speculative-draft-model-path",
-                    "lmsys/sglang-ci-dsv3-test-NextN",
                     "--speculative-num-steps",
-                    "2",
+                    "3",
                     "--speculative-eagle-topk",
                     "1",
                     "--speculative-num-draft-tokens",
-                    "3",
+                    "4",
                     "--attention-backend",
-                    "flashmla",
+                    "flashinfer",
                 ]
             )
-        # Use longer timeout for DeepGEMM JIT compilation which can take 10-20 minutes
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 2,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             other_args=other_args,
         )
 
@@ -127,7 +121,7 @@ class TestFlashMLAMTP(CustomTestCase):
             "avg_spec_accept_length"
         ]
         print(f"{avg_spec_accept_length=}")
-        self.assertGreater(avg_spec_accept_length, 2.4)
+        self.assertGreater(avg_spec_accept_length, 2.5)
 
 
 if __name__ == "__main__":

--- a/test/registered/mla/test_mla_int8_deepseek_v3.py
+++ b/test/registered/mla/test_mla_int8_deepseek_v3.py
@@ -5,6 +5,7 @@ import requests
 import torch
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -13,6 +14,9 @@ from sglang.test.test_utils import (
     is_in_ci,
     popen_launch_server,
 )
+
+# DeepSeek-V3 INT8 quantization tests (channel and block INT8)
+register_cuda_ci(est_time=300, suite="stage-b-test-small-1-gpu")
 
 
 class TestMLADeepseekV3ChannelInt8(CustomTestCase):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -58,7 +58,6 @@ suites = {
         TestFile("test_constrained_decoding.py", 111),
         TestFile("test_eval_fp8_accuracy.py", 250),
         TestFile("test_external_models.py", 30),
-        TestFile("test_flashmla.py", 230),
         TestFile("test_fp8_utils.py", 9),
         TestFile("rotary_embedding/test_mrope.py", 10),
         TestFile("test_fused_moe.py", 80),
@@ -71,11 +70,6 @@ suites = {
         TestFile("test_mamba_unittest.py", 9),
         TestFile("test_metrics.py", 32),
         TestFile("test_metrics_utils.py", 1),
-        TestFile("test_mla.py", 194),
-        TestFile("test_mla_deepseek_v3.py", 442),
-        TestFile("test_mla_flashinfer.py", 302),
-        TestFile("test_mla_fp8.py", 77),
-        TestFile("test_mla_int8_deepseek_v3.py", 300),
         TestFile("test_model_hooks.py", 6),
         TestFile("test_modelopt_loader.py", 11),
         TestFile("test_multi_tokenizer.py", 230),
@@ -247,8 +241,6 @@ suite_amd = {
         TestFile("test_jinja_template_utils.py", 1),
         TestFile("test_metrics.py", 32),
         TestFile("test_metrics_utils.py", 1),
-        # TestFile("test_mla.py", 242), # Disabled temporarily, see https://github.com/sgl-project/sglang/issues/13107
-        # TestFile("test_mla_deepseek_v3.py", 221), # Temporarily disabled, see https://github.com/sgl-project/sglang/issues/12574
         TestFile("test_no_chunked_prefill.py", 108),
         TestFile("test_page_size.py", 60),
         TestFile("test_penalty.py", 180),
@@ -275,7 +267,6 @@ suite_amd = {
     ],
     "per-commit-amd-mi35x": [
         TestFile("test_gpt_oss_1gpu.py", 750),
-        TestFile("test_mla.py", 242),
     ],
     "per-commit-2-gpu-amd": [
         # TestFile("lora/test_lora_tp.py", 116), # Disabled temporarily, see https://github.com/sgl-project/sglang/issues/13107. Moved to test/registered/lora/


### PR DESCRIPTION
## Summary
- Move 6 MLA test files from `test/srt/` to `test/registered/mla/` with CI registry decorators
- Remove MLA test entries from legacy `test/srt/run_suite.py`

## Test Files Migrated

| Test File | CUDA Suite | AMD Suite |
|-----------|------------|-----------|
| test_mla.py | stage-b-test-small-1-gpu (194s) | stage-a-test-1 (disabled #13107) |
| test_mla_deepseek_v3.py | stage-b-test-small-1-gpu (442s) | stage-a-test-1 (disabled #12574) |
| test_mla_flashinfer.py | stage-b-test-small-1-gpu (302s) | - |
| test_mla_fp8.py | stage-b-test-small-1-gpu (77s) | - |
| test_mla_int8_deepseek_v3.py | stage-b-test-small-1-gpu (300s) | - |
| test_flashmla.py | stage-b-test-small-1-gpu (230s) | - |

**Total CUDA estimated time:** ~1545s (~25.8 min) - within 30 min threshold

## Test plan
- [ ] CI passes for stage-b-test-small-1-gpu suite
- [ ] Verify MLA tests are detected by `test/run_suite.py`

Part of #13808