### PR TITLE
ci: migrate remaining spec/eagle tests to test/registered/spec/

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -634,6 +634,43 @@ jobs:
           fi
           python3 run_suite.py --hw cuda --suite stage-c-test-large-4-gpu $CONTINUE_ON_ERROR_FLAG
 
+  stage-c-test-large-4-gpu-b200:
+    needs: [check-changes, call-gate, stage-b-test-small-1-gpu, stage-b-test-large-1-gpu, stage-b-test-large-2-gpu, stage-b-test-4-gpu-b200, sgl-kernel-build-wheels]
+    if: |
+      always() &&
+      (
+        (inputs.target_stage == 'stage-c-test-large-4-gpu-b200') ||
+        (
+          !inputs.target_stage &&
+          (github.event_name == 'schedule' || (!failure() && !cancelled())) &&
+          ((needs.check-changes.outputs.main_package == 'true') || (needs.check-changes.outputs.sgl_kernel == 'true'))
+        )
+      )
+    runs-on: ${{ needs.check-changes.outputs.b200_runner }}
+    env:
+      RUNNER_LABELS: ${{ needs.check-changes.outputs.b200_runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        if: needs.check-changes.outputs.sgl_kernel == 'true'
+        uses: actions/download-artifact@v6
+        with:
+          path: sgl-kernel/dist/
+          merge-multiple: true
+          pattern: wheel-python3.10-cuda12.9
+
+      - name: Install dependencies
+        run: |
+          CUSTOM_BUILD_SGL_KERNEL=${{needs.check-changes.outputs.sgl_kernel}} IS_BLACKWELL=1 bash scripts/ci/ci_install_dependency.sh
+
+      - name: Run test
+        timeout-minutes: 30
+        run: |
+          cd test/
+          IS_BLACKWELL=1 python3 run_suite.py --hw cuda --suite stage-c-test-large-4-gpu-b200
+
   multimodal-gen-test-1-gpu:
     needs: [check-changes, call-gate, sgl-kernel-build-wheels]
     if: |

--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -148,6 +148,7 @@ def handle_rerun_stage(
         "stage-b-test-large-1-gpu",
         "stage-b-test-large-2-gpu",
         "stage-c-test-large-4-gpu",
+        "stage-c-test-large-4-gpu-b200",
         "multimodal-gen-test-1-gpu",
         "multimodal-gen-test-2-gpu",
         "quantization-test",

--- a/test/registered/spec/eagle/test_eagle_dp_attention.py
+++ b/test/registered/spec/eagle/test_eagle_dp_attention.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import requests
 
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.send_one import BenchArgs, send_one_prompt
 from sglang.test.test_utils import (
@@ -17,6 +18,9 @@ from sglang.test.test_utils import (
     popen_launch_server,
     write_github_step_summary,
 )
+
+# EAGLE3 with DP attention (tp=2, dp=2, requires 4 GPUs)
+register_cuda_ci(est_time=200, suite="stage-c-test-large-4-gpu")
 
 
 class TestEAGLE3EngineDPAttention(CustomTestCase):

--- a/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention.py
@@ -5,6 +5,7 @@ import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.test_utils import (
     DEFAULT_MODEL_NAME_FOR_TEST_MLA,
@@ -14,6 +15,9 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
+
+# EAGLE with DP attention on B200 (tp=2, dp=2, requires 4 B200 GPUs)
+register_cuda_ci(est_time=300, suite="stage-c-test-large-4-gpu-b200")
 
 
 def test_gsm8k(base_url: str):

--- a/test/registered/spec/test_constrained_decoding_spec_reasoning.py
+++ b/test/registered/spec/test_constrained_decoding_spec_reasoning.py
@@ -4,12 +4,16 @@ import unittest
 import openai
 
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
 )
+
+# Constrained decoding with EAGLE3 speculative reasoning (tp=2)
+register_cuda_ci(est_time=60, suite="stage-b-test-large-2-gpu")
 
 
 class ServerWithGrammar(CustomTestCase):

--- a/test/registered/spec/test_speculative_registry.py
+++ b/test/registered/spec/test_speculative_registry.py
@@ -5,6 +5,10 @@ from sglang.srt.speculative.spec_info import (
     SpeculativeAlgorithm,
     register_speculative_algorithm,
 )
+from sglang.test.ci.ci_register import register_cuda_ci
+
+# Speculative decoding registry unit tests (no GPU required)
+register_cuda_ci(est_time=8, suite="stage-b-test-small-1-gpu")
 
 
 class DummyWorker:

--- a/test/registered/spec/test_standalone_speculative_decoding.py
+++ b/test/registered/spec/test_standalone_speculative_decoding.py
@@ -5,6 +5,7 @@ import requests
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_STANDALONE,
@@ -14,6 +15,9 @@ from sglang.test.test_utils import (
     CustomTestCase,
     popen_launch_server,
 )
+
+# Standalone speculative decoding tests (FA3, Triton, FlashInfer backends)
+register_cuda_ci(est_time=150, suite="stage-b-test-small-1-gpu")
 
 GSM_DATASET_PATH = None
 

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -26,6 +26,7 @@ PER_COMMIT_SUITES = {
         "stage-b-test-large-2-gpu",
         "stage-c-test-large-4-gpu",
         "stage-b-test-4-gpu-b200",
+        "stage-c-test-large-4-gpu-b200",
     ],
     HWBackend.NPU: [],
 }

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -86,11 +86,9 @@ suites = {
         TestFile("test_retract_decode.py", 259),
         TestFile("test_score_api.py", 260),
         TestFile("test_server_args.py", 9),
-        TestFile("test_speculative_registry.py", 8),
         TestFile("test_skip_tokenizer_init.py", 77),
         TestFile("test_srt_endpoint.py", 127),
         TestFile("test_srt_engine.py", 252),
-        TestFile("test_standalone_speculative_decoding.py", 150),
         TestFile("test_start_profile.py", 41),
         TestFile("test_profile_merger.py", 8),
         TestFile("test_profile_merger_http_api.py", 9),
@@ -116,13 +114,11 @@ suites = {
         TestFile("models/test_glm4_moe_models.py", 100),
         TestFile("models/test_kimi_linear_models.py", 90),
         TestFile("rl/test_update_weights_from_distributed.py", 103),
-        TestFile("test_constrained_decoding_spec_reasoning.py", 60),
         TestFile("test_data_parallelism.py", 73),
         TestFile("test_disaggregation_basic.py", 400),
         TestFile("test_dp_attention.py", 350),
         TestFile("test_load_weights_from_remote_instance.py", 72),
         TestFile("test_patch_torch.py", 19),
-        TestFile("test_eagle_dp_attention.py", 200),
     ],
     "per-commit-4-gpu": [
         TestFile("models/test_qwen3_next_models.py", 650),
@@ -152,7 +148,6 @@ suites = {
         TestFile("test_fp8_blockwise_gemm.py", 280),
         TestFile("test_gpt_oss_4gpu.py", 700),
         TestFile("test_llama31_fp4.py", 90),
-        TestFile("test_eagle_infer_beta_dp_attention.py", 300),
     ],
     # "per-commit-8-gpu-b200": [
     #     TestFile("test_mistral_large3_basic.py", 275),  # Moved to nightly - large model


### PR DESCRIPTION
## Summary
- Move 5 remaining speculative decoding test files from `test/srt/` to `test/registered/spec/` with CI registry decorators
- Remove test entries from legacy `test/srt/run_suite.py`

## Test Files Migrated

| Test File | Target Suite | Est. Time |
|-----------|--------------|-----------|
| test_speculative_registry.py | stage-b-test-small-1-gpu | 8s |
| test_standalone_speculative_decoding.py | stage-b-test-small-1-gpu | 150s |
| test_constrained_decoding_spec_reasoning.py | stage-b-test-large-2-gpu | 60s |
| test_eagle_dp_attention.py | stage-c-test-large-4-gpu | 200s |
| test_eagle_infer_beta_dp_attention.py | stage-c-test-large-4-gpu-b200 | 300s |

## Test plan
- [ ] CI passes for affected suites
- [ ] Verify tests are detected by `test/run_suite.py`

Part of #13808