### PR TITLE
Cleanup `ModelRunner`

### DIFF
--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -112,7 +112,6 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_TEST_RETRACT_NO_PREFILL_BS` | When SGLANG_TEST_RETRACT is enabled, no prefill is performed if the batch size exceeds SGLANG_TEST_RETRACT_NO_PREFILL_BS. | `2 ** 31`     |
 | `SGLANG_RECORD_STEP_TIME` | Record step time for profiling | `false` |
 | `SGLANG_TEST_REQUEST_TIME_STATS` | Test request time statistics | `false` |
-| `SGLANG_CI_SMALL_KV_SIZE` | Use small KV cache size in CI | `-1` |
 
 ## Profiling & Benchmarking
 

--- a/docs/references/environment_variables.md
+++ b/docs/references/environment_variables.md
@@ -67,7 +67,7 @@ SGLang supports various environment variables that can be used to configure its 
 | `SGLANG_DEBUG_MEMORY_POOL` | Enable memory pool debugging | `false` |
 | `SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION` | Clip max new tokens estimation for memory planning | `4096` |
 | `SGLANG_DETOKENIZER_MAX_STATES` | Maximum states for detokenizer | Default value based on system |
-| `SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK` | Disable checks for memory imbalance across Tensor Parallel ranks | Not set (defaults to enabled check) |
+| `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK` | Enable checks for memory imbalance across Tensor Parallel ranks | `true` |
 
 ## Model-Specific Options
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -146,6 +146,7 @@ class Envs:
     SGLANG_TEST_MAX_RETRY = EnvInt(None)
 
     # Test & Debug
+    SGLANG_DETECT_SLOW_RANK = EnvBool(False)
     SGLANG_TEST_STUCK_DETOKENIZER = EnvFloat(0)
     SGLANG_TEST_STUCK_DP_CONTROLLER = EnvFloat(0)
     SGLANG_TEST_STUCK_TOKENIZER = EnvFloat(0)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -173,7 +173,6 @@ class Envs:
     SGLANG_TEST_RETRACT_NO_PREFILL_BS = EnvInt(2 ** 31)
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY = EnvInt(0)
     SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE = EnvBool(True)
-    SGLANG_CI_SMALL_KV_SIZE = EnvInt(-1)
 
     # Scheduler: new token ratio hyperparameters
     SGLANG_INIT_NEW_TOKEN_RATIO = EnvFloat(0.7)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -167,6 +167,7 @@ class Envs:
     SGLANG_OTLP_EXPORTER_SCHEDULE_DELAY_MILLIS = EnvInt(500)
     SGLANG_OTLP_EXPORTER_MAX_EXPORT_BATCH_SIZE = EnvInt(64)
     SGLANG_NATIVE_MOVE_KV_CACHE = EnvBool(False)
+    SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK = EnvBool(True)
 
     # Scheduler: memory leak test
     SGLANG_TEST_RETRACT = EnvBool(False)
@@ -416,6 +417,10 @@ def _convert_SGL_to_SGLANG():
     )
     _print_deprecated_env(
         "SGLANG_MOE_NVFP4_DISPATCH", "SGLANG_CUTEDSL_MOE_NVFP4_DISPATCH"
+    )
+    _print_deprecated_env(
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK",
+        "SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK",
     )
 
     for key, value in os.environ.items():

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1493,7 +1493,7 @@ class ModelRunner:
 
         return result
 
-    def get_kv_cache_cell_size(self, num_layers: int) -> int:
+    def get_cell_size_per_token(self, num_layers: int) -> int:
         kv_size = torch._utils._element_size(self.kv_cache_dtype)
         if self.use_mla_backend:
             cell_size = (
@@ -1579,7 +1579,7 @@ class ModelRunner:
         else:
             num_layers = self.num_effective_layers
 
-        cell_size = self.get_kv_cache_cell_size(num_layers)
+        cell_size = self.get_cell_size_per_token(num_layers)
 
         rest_memory = available_gpu_memory - total_gpu_memory * (
             1 - self.mem_fraction_static

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1826,7 +1826,6 @@ class ModelRunner:
         max_num_reqs = server_args.max_running_requests
         max_total_tokens = server_args.max_total_tokens
         self.max_total_num_tokens = self.profile_max_num_token(total_gpu_memory)
-        print(f"\x1b[31m{self.max_total_num_tokens=}\x1b[0m")
 
         if max_num_reqs is None:
             max_num_reqs = min(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -372,8 +372,9 @@ class ModelRunner:
 
         self._weight_checker = WeightChecker(model_runner=self)
 
-        if get_bool_env_var("SGLANG_DETECT_SLOW_RANK"):
+        if envs.SGLANG_DETECT_SLOW_RANK.get():
             slow_rank_detector.execute()
+
         # Init mindspore running environment when model impl is "mindspore"
         self.init_mindspore_runner()
 
@@ -1832,6 +1833,7 @@ class ModelRunner:
         max_num_reqs = server_args.max_running_requests
         max_total_tokens = server_args.max_total_tokens
         self.max_total_num_tokens = self.profile_max_num_token(total_gpu_memory)
+        print(f"\x1b[31m{self.max_total_num_tokens=}\x1b[0m")
 
         if max_num_reqs is None:
             max_num_reqs = min(

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1837,12 +1837,6 @@ class ModelRunner:
 
         self.max_total_num_tokens = self.profile_max_num_token(total_gpu_memory)
 
-        if (small_kv_size := envs.SGLANG_CI_SMALL_KV_SIZE.get()) > 0:
-            logger.info(
-                f"Use a small KV cache pool size ({small_kv_size}) for local tests"
-            )
-            self.max_total_num_tokens = small_kv_size
-
         if max_num_reqs is None:
             max_num_reqs = min(
                 max(
@@ -1875,9 +1869,11 @@ class ModelRunner:
             if self.is_draft_worker:
                 self.max_total_num_tokens = self.server_args.draft_runner_cache_size
                 max_num_reqs = self.server_args.max_num_reqs
+                print(f"Draft worker: {self.max_total_num_tokens=}, {max_num_reqs=}")
             else:
                 self.server_args.draft_runner_cache_size = self.max_total_num_tokens
                 self.server_args.max_num_reqs = max_num_reqs
+                print(f"Target worker: {self.max_total_num_tokens=}, {max_num_reqs=}")
 
         if max_total_tokens is not None:
             if max_total_tokens > self.max_total_num_tokens:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -167,7 +167,6 @@ from sglang.srt.utils import (
     get_cpu_ids_by_node,
     get_local_ip_auto,
     init_custom_process_group,
-    is_cuda,
     is_float4_e2m1fn_x2,
     is_hip,
     is_npu,
@@ -179,7 +178,6 @@ from sglang.srt.utils import (
     reserve_rope_cache_for_long_sequences,
     set_cuda_arch,
     slow_rank_detector,
-    xpu_has_xmx_support,
 )
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.offloader import (
@@ -198,11 +196,9 @@ from sglang.srt.weight_sync.tensor_bucket import (
     FlattenedTensorMetadata,
 )
 
-_is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu_amx_available = cpu_has_amx_support()
-_is_xpu_xmx_available = xpu_has_xmx_support()
 
 if _is_npu:
     from sglang.srt.hardware_backend.npu.utils import init_npu_backend

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1861,15 +1861,9 @@ class ModelRunner:
             if self.is_draft_worker:
                 self.max_total_num_tokens = self.server_args.draft_runner_cache_size
                 max_num_reqs = self.server_args.max_num_reqs
-                print(
-                    f"\x1b[31mDraft worker: {self.max_total_num_tokens=}, {max_num_reqs=}\x1b[0m"
-                )
             else:
                 self.server_args.draft_runner_cache_size = self.max_total_num_tokens
                 self.server_args.max_num_reqs = max_num_reqs
-                print(
-                    f"\x1b[31mTarget worker: {self.max_total_num_tokens=}, {max_num_reqs=}\x1b[0m"
-                )
 
         if max_total_tokens is not None:
             if max_total_tokens > self.max_total_num_tokens:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1500,18 +1500,21 @@ class ModelRunner:
             distributed=get_world_group().world_size > 1,
             cpu_group=get_world_group().cpu_group,
         )
+
+        # Get the number of layers used for KV cache calculation
         if self.is_draft_worker:
             num_layers = getattr(
                 self.model_config.hf_config,
                 "num_nextn_predict_layers",
                 self.num_effective_layers,
             )
-        elif config := self.mambaish_config:
-            num_layers = len(config.full_attention_layer_ids)
+        elif mambaish := self.mambaish_config:
+            num_layers = len(mambaish.full_attention_layer_ids)
         elif self.model_config.full_attention_layer_ids:
             num_layers = len(self.model_config.full_attention_layer_ids)
         else:
             num_layers = self.num_effective_layers
+
         if self.use_mla_backend:
             cell_size = (
                 (self.model_config.kv_lora_rank + self.model_config.qk_rope_head_dim)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1861,11 +1861,15 @@ class ModelRunner:
             if self.is_draft_worker:
                 self.max_total_num_tokens = self.server_args.draft_runner_cache_size
                 max_num_reqs = self.server_args.max_num_reqs
-                print(f"Draft worker: {self.max_total_num_tokens=}, {max_num_reqs=}")
+                print(
+                    f"\x1b[31mDraft worker: {self.max_total_num_tokens=}, {max_num_reqs=}\x1b[0m"
+                )
             else:
                 self.server_args.draft_runner_cache_size = self.max_total_num_tokens
                 self.server_args.max_num_reqs = max_num_reqs
-                print(f"Target worker: {self.max_total_num_tokens=}, {max_num_reqs=}")
+                print(
+                    f"\x1b[31mTarget worker: {self.max_total_num_tokens=}, {max_num_reqs=}\x1b[0m"
+                )
 
         if max_total_tokens is not None:
             if max_total_tokens > self.max_total_num_tokens:

--- a/test/registered/spec/eagle/test_eagle_infer_b.py
+++ b/test/registered/spec/eagle/test_eagle_infer_b.py
@@ -290,14 +290,16 @@ class TestEAGLEServerBasic(EagleServerBase):
 
 
 class TestEAGLERetract(TestEAGLEServerBasic):
-    extra_args = ["--chunked-prefill-size", 128, "--max-running-requests", 64]
+    extra_args = [
+        "--chunked-prefill-size=128",
+        "--max-running-requests=64",
+        "--max-total-tokens=4500",  # Set a smaller KV cache to trigger retract more easily
+    ]
 
     @classmethod
     def setUpClass(cls):
         # These config helps find a leak.
-        with envs.SGLANG_TEST_RETRACT.override(
-            True
-        ), envs.SGLANG_CI_SMALL_KV_SIZE.override(4500):
+        with envs.SGLANG_TEST_RETRACT.override(True):
             super().setUpClass()
 
 


### PR DESCRIPTION
- `SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK` -> `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK`
- Move some logic into a separate function in `ModelRunner`: `configure_kv_cache_dtype`, `get_cell_size_per_token`.
- Remove `SGLANG_CI_SMALL_KV_SIZE`, which is a duplicate of `--max-total-tokens`.