### PR TITLE
[Feature] JIT Fused QK norm + qk norm clean up

### DIFF
--- a/python/sglang/jit_kernel/benchmark/bench_qknorm.py
+++ b/python/sglang/jit_kernel/benchmark/bench_qknorm.py
@@ -1,0 +1,116 @@
+import itertools
+import os
+from typing import Tuple
+
+import torch
+import triton
+import triton.testing
+
+IS_CI = (
+    os.getenv("CI", "false").lower() == "true"
+    or os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+)
+
+alt_stream = torch.cuda.Stream()
+
+
+def sglang_aot_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    use_alt_stream: bool = True,
+) -> None:
+    from sgl_kernel import rmsnorm
+
+    q = q.view(-1, HEAD_DIM)
+    k = k.view(-1, HEAD_DIM)
+    if not use_alt_stream:
+        rmsnorm(q, q_weight, out=q)
+        rmsnorm(k, k_weight, out=k)
+        return
+    current_stream = torch.cuda.current_stream()
+    alt_stream.wait_stream(current_stream)
+    rmsnorm(q, q_weight, out=q)
+    with torch.cuda.stream(alt_stream):
+        rmsnorm(k, k_weight, out=k)
+    current_stream.wait_stream(alt_stream)
+
+
+def sglang_jit_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+) -> None:
+    from sglang.jit_kernel.norm import fused_inplace_qknorm
+
+    fused_inplace_qknorm(q, k, q_weight, k_weight)
+
+
+def flashinfer_jit_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+) -> None:
+    from flashinfer.norm import rmsnorm
+
+    rmsnorm(q, q_weight, out=q)
+    rmsnorm(k, k_weight, out=k)
+
+
+HEAD_DIM = 128
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+
+if IS_CI:
+    BS_RANGE = [16]
+    GQA_RANGE = [4]
+    KV_HEAD_RANGE = [1]
+else:
+    BS_RANGE = [2**n for n in range(0, 14)]
+    GQA_RANGE = [4, 8]
+    KV_HEAD_RANGE = [1, 2, 4, 8]
+
+LINE_VALS = ["aot", "jit", "flashinfer"]
+LINE_NAMES = ["SGL Kernel", "SGL JIT Kernel", "FlashInfer"]
+STYLES = [("orange", "-"), ("blue", "--"), ("green", "-.")]
+
+configs = list(itertools.product(GQA_RANGE, KV_HEAD_RANGE, BS_RANGE))
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["GQA", "num_kv_heads", "batch_size"],
+        x_vals=configs,
+        line_arg="provider",
+        line_vals=LINE_VALS,
+        line_names=LINE_NAMES,
+        styles=STYLES,
+        ylabel="us",
+        plot_name="qknorm-performance",
+        args={},
+    )
+)
+def benchmark(
+    batch_size: int, GQA: int, num_kv_heads: int, provider: str
+) -> Tuple[float, float, float]:
+    num_qo_heads = GQA * num_kv_heads
+    q = torch.randn((batch_size, num_qo_heads, HEAD_DIM), dtype=DTYPE, device=DEVICE)
+    k = torch.randn((batch_size, num_kv_heads, HEAD_DIM), dtype=DTYPE, device=DEVICE)
+    q_weight = torch.randn(HEAD_DIM, dtype=DTYPE, device=DEVICE)
+    k_weight = torch.randn(HEAD_DIM, dtype=DTYPE, device=DEVICE)
+    FN_MAP = {
+        "aot": sglang_aot_qknorm,
+        "jit": sglang_jit_qknorm,
+        "flashinfer": flashinfer_jit_qknorm,
+    }
+    fn = lambda: FN_MAP[provider](q, k, q_weight, k_weight)
+    quantiles = [0.5, 0.2, 0.8]
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(fn, quantiles=quantiles)  # type: ignore
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms
+
+
+if __name__ == "__main__":
+    benchmark.run(print_data=True)

--- a/python/sglang/jit_kernel/csrc/norm.cuh
+++ b/python/sglang/jit_kernel/csrc/norm.cuh
@@ -65,7 +65,6 @@ __always_inline __device__ void apply_norm(void* __restrict__ input, const void*
   for (auto i = 0u; i < kLoopCount; ++i) {
     const auto fp16_input = input_vec.data[i];
     const auto fp32_input = to_float2(fp16_input);
-    input_vec.data[i] = fp16_input;
     sum_of_squares += fp32_input.x * fp32_input.x;
     sum_of_squares += fp32_input.y * fp32_input.y;
   }

--- a/python/sglang/jit_kernel/csrc/norm.cuh
+++ b/python/sglang/jit_kernel/csrc/norm.cuh
@@ -1,0 +1,192 @@
+#include <sgl_kernel/runtime.cuh>
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/utils.h>
+#include <sgl_kernel/warp.cuh>
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace {
+
+[[maybe_unused]]
+__device__ auto to_float2(nv_bfloat162 x) -> float2 {
+  return __bfloat1622float2(x);
+}
+
+[[maybe_unused]]
+__device__ auto to_float2(half2 x) -> float2 {
+  return __half22float2(x);
+}
+
+template <typename T>
+__device__ auto from_float2(float2 x) -> T {
+  if constexpr (std::is_same_v<T, nv_bfloat162>) {
+    return __float22bfloat162_rn(x);
+  } else if constexpr (std::is_same_v<T, half2>) {
+    return __float22half2_rn(x);
+  } else {
+    static_assert(sizeof(T) == 0, "Unsupported type");
+  }
+}
+
+struct QKNormParams {
+  void* __restrict__ q;
+  void* __restrict__ k;  // k is offset by -num_qo_heads * head_dim elements
+  int64_t q_stride;
+  int64_t k_stride;
+  uint32_t num_qo_heads;
+  uint32_t num_kv_heads;
+  float eps;
+  const void* __restrict__ q_weight;
+  const void* __restrict__ k_weight;
+  uint32_t num_tokens;
+};
+
+template <int64_t kHeadDim, typename PackedFloat>
+__always_inline __device__ void apply_norm(void* __restrict__ input, const void* __restrict__ weight, float eps) {
+  using namespace device;
+
+  constexpr auto kLoopCount = kHeadDim / (kWarpThreads * 2);
+  static_assert(kHeadDim % (kWarpThreads * 2) == 0);
+
+  const auto lane_id = threadIdx.x % kWarpThreads;
+  float sum_of_squares = 0.0f;
+
+  using vec_t = device_vec<PackedFloat, kLoopCount>;
+  auto input_vec = static_cast<const vec_t*>(input)[lane_id];
+
+#pragma unroll
+  for (auto i = 0u; i < kLoopCount; ++i) {
+    const auto fp16_input = input_vec.data[i];
+    const auto fp32_input = to_float2(fp16_input);
+    input_vec.data[i] = fp16_input;
+    sum_of_squares += fp32_input.x * fp32_input.x;
+    sum_of_squares += fp32_input.y * fp32_input.y;
+  }
+
+  sum_of_squares = warp::reduce_sum(sum_of_squares);
+  const auto norm_factor = rsqrtf(sum_of_squares / kHeadDim + eps);
+  const auto weight_vec = static_cast<const vec_t*>(weight)[lane_id];
+
+  vec_t output_vec;
+#pragma unroll
+  for (auto i = 0u; i < kLoopCount; ++i) {
+    const auto fp32_weight = to_float2(weight_vec.data[i]);
+    const auto fp32_input = to_float2(input_vec.data[i]);
+    output_vec.data[i] = from_float2<PackedFloat>({
+        fp32_input.x * norm_factor * fp32_weight.x,
+        fp32_input.y * norm_factor * fp32_weight.y,
+    });
+  }
+
+  static_cast<vec_t*>(input)[lane_id] = output_vec;
+}
+
+constexpr uint32_t kWarpsPerBlock = 4;
+constexpr uint32_t kThreadsPerBlock = kWarpsPerBlock * device::kWarpThreads;
+
+template <int64_t kHeadDim, typename PackedFloat, typename Float>
+__global__ void fused_qknorm(const QKNormParams __grid_constant__ params) {
+  using namespace device;
+
+  static_assert(sizeof(Float) == 2 && sizeof(PackedFloat) == 4, "Only support FP16/BF16");
+  const auto& [q, k, q_stride, k_stride, num_qo_heads, num_kv_heads, eps, q_weight, k_weight, num_tokens] = params;
+
+  const auto num_blks = gridDim.x;
+  const auto num_workers = num_blks * kWarpsPerBlock;
+  const auto num_q_and_k_heads = num_qo_heads + num_kv_heads;
+  const auto num_works = num_q_and_k_heads * num_tokens;
+  const auto start_worker_id = blockIdx.x * kWarpsPerBlock + threadIdx.x / kWarpThreads;
+
+  cudaGridDependencySynchronize();
+  for (auto idx = start_worker_id; idx < num_works; idx += num_workers) {
+    const int64_t token_id = idx / num_q_and_k_heads;
+    const int64_t head_id = idx % num_q_and_k_heads;
+    const auto load_q = head_id < num_qo_heads;
+    const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * kHeadDim))
+                              : pointer::offset(k, 2 * (token_id * k_stride + head_id * kHeadDim));
+    const auto weight = load_q ? q_weight : k_weight;
+    apply_norm<kHeadDim, PackedFloat>(input, weight, eps);
+  }
+  cudaTriggerProgrammaticLaunchCompletion();
+}
+
+template <int64_t kHeadDim>
+struct QKNormKernel {
+  template <typename PackedFloat, typename Float>
+  static constexpr auto qknorm_kernel = fused_qknorm<kHeadDim, PackedFloat, Float>;
+
+  static void
+  run(const tvm::ffi::TensorView q,
+      const tvm::ffi::TensorView k,
+      const tvm::ffi::TensorView q_weight,
+      const tvm::ffi::TensorView k_weight,
+      float eps) {
+    using namespace host;
+    auto N = SymbolicSize{"num_tokens"};
+    auto Q = SymbolicSize{"num_qo_heads"};
+    auto K = SymbolicSize{"num_kv_heads"};
+    auto D = SymbolicSize{"head_dim"};
+    auto Sq = SymbolicSize{"q_stride"};
+    auto Sk = SymbolicSize{"k_stride"};
+    auto dtype = SymbolicDType{};
+    auto device = SymbolicDevice{};
+
+    TensorMatcher({N, Q, D})  //
+        .with_strides({Sq, D, 1})
+        .with_dtype<nv_bfloat16, half>(dtype)
+        .with_device<kDLCUDA>(device)
+        .verify(q);
+
+    TensorMatcher({N, K, D})  //
+        .with_strides({Sk, D, 1})
+        .with_dtype<nv_bfloat16, half>(dtype)
+        .with_device<kDLCUDA>(device)
+        .verify(k);
+
+    TensorMatcher({D})  //
+        .with_dtype<nv_bfloat16, half>(dtype)
+        .with_device<kDLCUDA>(device)
+        .verify(q_weight)
+        .verify(k_weight);
+
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto num_qo_heads = static_cast<uint32_t>(Q.unwrap());
+    const auto num_kv_heads = static_cast<uint32_t>(K.unwrap());
+    const auto head_dim = D.unwrap();
+    RuntimeCheck(head_dim == kHeadDim, "Wrong head_dim: ", head_dim, ". Expected:", kHeadDim);
+    const auto params = QKNormParams{
+        .q = q.data_ptr(),
+        .k = pointer::offset(k.data_ptr(), -2 * static_cast<int64_t>(num_qo_heads) * kHeadDim),
+        .q_stride = static_cast<int64_t>(Sq.unwrap()),
+        .k_stride = static_cast<int64_t>(Sk.unwrap()),
+        .num_qo_heads = num_qo_heads,
+        .num_kv_heads = num_kv_heads,
+        .eps = eps,
+        .q_weight = q_weight.data_ptr(),
+        .k_weight = k_weight.data_ptr(),
+        .num_tokens = num_tokens,
+    };
+    const bool use_bf16 = dtype.holds_value<nv_bfloat16>();
+    // only initialize once to avoid overhead
+    static const uint32_t kMaxOccupancyTable[2] = {
+        runtime::get_blocks_per_sm(qknorm_kernel<half2, half>, kThreadsPerBlock),
+        runtime::get_blocks_per_sm(qknorm_kernel<nv_bfloat162, nv_bfloat16>, kThreadsPerBlock),
+    };
+    static const uint32_t kNumSM = runtime::get_sm_count(device.unwrap().device_id);
+    const auto kernel = use_bf16 ? qknorm_kernel<nv_bfloat162, nv_bfloat16> : qknorm_kernel<half2, half>;
+    const auto max_occupancy = use_bf16 ? kMaxOccupancyTable[1] : kMaxOccupancyTable[0];
+    const auto num_works = (num_qo_heads + num_kv_heads) * num_tokens;
+    const auto num_blocks = std::min(kNumSM * max_occupancy, div_ceil(num_works, kWarpsPerBlock));
+    LaunchKernel(num_blocks, kThreadsPerBlock, device.unwrap())  //
+        .enable_pdl(true)(kernel, params);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/include/sgl_kernel/runtime.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/runtime.cuh
@@ -7,6 +7,7 @@
 
 namespace host::runtime {
 
+// Return the maximum number of active blocks per SM for the given kernel
 template <typename T>
 inline auto get_blocks_per_sm(T&& kernel, int32_t block_dim, std::size_t dynamic_smem = 0) -> uint32_t {
   int num_blocks_per_sm = 0;
@@ -15,6 +16,7 @@ inline auto get_blocks_per_sm(T&& kernel, int32_t block_dim, std::size_t dynamic
   return static_cast<uint32_t>(num_blocks_per_sm);
 }
 
+// Return the number of SMs for the given device
 inline auto get_sm_count(int device_id) -> uint32_t {
   cudaDeviceProp device_prop;
   RuntimeDeviceCheck(cudaGetDeviceProperties(&device_prop, device_id));

--- a/python/sglang/jit_kernel/include/sgl_kernel/runtime.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/runtime.cuh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <sgl_kernel/utils.cuh>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace host::runtime {
+
+template <typename T>
+inline auto get_blocks_per_sm(T&& kernel, int32_t block_dim, std::size_t dynamic_smem = 0) -> uint32_t {
+  int num_blocks_per_sm = 0;
+  RuntimeDeviceCheck(
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks_per_sm, kernel, block_dim, dynamic_smem));
+  return static_cast<uint32_t>(num_blocks_per_sm);
+}
+
+inline auto get_sm_count(int device_id) -> uint32_t {
+  cudaDeviceProp device_prop;
+  RuntimeDeviceCheck(cudaGetDeviceProperties(&device_prop, device_id));
+  return static_cast<uint32_t>(device_prop.multiProcessorCount);
+}
+
+}  // namespace host::runtime

--- a/python/sglang/jit_kernel/include/sgl_kernel/tensor.h
+++ b/python/sglang/jit_kernel/include/sgl_kernel/tensor.h
@@ -154,7 +154,7 @@ inline auto& operator<<(std::ostream& os, PrintAbleSpan<T> span) {
 }  // namespace details
 
 template <typename T>
-inline bool holds_dtype(DLDataType dtype) {
+inline bool is_type(DLDataType dtype) {
   return dtype == details::dtype_trait<T>::value;
 }
 
@@ -265,8 +265,8 @@ struct SymbolicDType {
   }
 
   template <typename T>
-  auto holds_value() const -> bool {
-    return holds_dtype<T>(m_value);
+  auto is_type() const -> bool {
+    return ::host::is_type<T>(m_value);
   }
 
  private:

--- a/python/sglang/jit_kernel/include/sgl_kernel/tensor.h
+++ b/python/sglang/jit_kernel/include/sgl_kernel/tensor.h
@@ -153,6 +153,11 @@ inline auto& operator<<(std::ostream& os, PrintAbleSpan<T> span) {
 
 }  // namespace details
 
+template <typename T>
+inline bool holds_dtype(DLDataType dtype) {
+  return dtype == details::dtype_trait<T>::value;
+}
+
 struct SymbolicSize {
  public:
   SymbolicSize(std::string_view annotation = {}) : m_value(details::kNullSize), m_annotation(annotation) {}
@@ -257,6 +262,11 @@ struct SymbolicDType {
     } else {
       this->set_value(dtype);
     }
+  }
+
+  template <typename T>
+  auto holds_value() const -> bool {
+    return holds_dtype<T>(m_value);
   }
 
  private:

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -79,6 +79,24 @@ struct device_vec {
   T data[N];
 };
 
+template <bool kUsePDL>
+__forceinline__ __device__ void PDLWaitPrimary() {
+#ifndef USE_ROCM
+  if constexpr (kUsePDL) {
+    asm volatile("griddepcontrol.wait;");
+  }
+#endif
+}
+
+template <bool kUsePDL>
+__forceinline__ __device__ void PDLTriggerSecondary() {
+#ifndef USE_ROCM
+  if constexpr (kUsePDL) {
+    asm volatile("griddepcontrol.launch_dependents;");
+  }
+#endif
+}
+
 }  // namespace device
 
 namespace host {

--- a/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/utils.cuh
@@ -120,6 +120,18 @@ struct LaunchKernel {
     return static_cast<cudaStream_t>(::TVMFFIEnvGetStream(device.device_type, device.device_id));
   }
 
+  auto enable_pdl(bool enabled = true) -> LaunchKernel& {
+    if (enabled) {
+      m_attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+      m_attrs[0].val.programmaticStreamSerializationAllowed = true;
+      m_config.numAttrs = 1;
+      m_config.attrs = m_attrs;
+    } else {
+      m_config.numAttrs = 0;
+    }
+    return *this;
+  }
+
   template <typename T, typename... Args>
   auto operator()(T&& kernel, Args&&... args) const -> void {
     RuntimeDeviceCheck(::cudaLaunchKernelEx(&m_config, kernel, std::forward<Args>(args)...), m_location);
@@ -142,7 +154,7 @@ struct LaunchKernel {
 
   cudaLaunchConfig_t m_config;
   const DebugInfo m_location;
-  /// TODO: We can add a queue to store the attributes (e.g. for PDL) if needed in the future.
+  cudaLaunchAttribute m_attrs[1];
 };
 
 }  // namespace host

--- a/python/sglang/jit_kernel/include/sgl_kernel/warp.cuh
+++ b/python/sglang/jit_kernel/include/sgl_kernel/warp.cuh
@@ -1,0 +1,14 @@
+#pragma once
+
+// Some warp primitives
+namespace device::warp {
+
+template <typename T>
+__always_inline __device__ T reduce_sum(T val, uint32_t active_mask = 0xffffffff) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1)
+    val += __shfl_xor_sync(active_mask, val, mask, 32);
+  return val;
+}
+
+}  // namespace device::warp

--- a/python/sglang/jit_kernel/norm.py
+++ b/python/sglang/jit_kernel/norm.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
-import functools
 import logging
 from typing import TYPE_CHECKING
 
 import torch
 
-from sglang.jit_kernel.utils import is_arch_support_pdl, load_jit, make_cpp_args
+from sglang.jit_kernel.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
 
-@functools.cache
+@cache_once
 def _jit_norm_module(head_dims: int) -> Module:
     args = make_cpp_args(head_dims, is_arch_support_pdl())
     return load_jit(
@@ -23,7 +27,7 @@ def _jit_norm_module(head_dims: int) -> Module:
     )
 
 
-@functools.cache
+@cache_once
 def can_use_fused_inplace_qknorm(head_dim: int) -> bool:
     logger = logging.getLogger(__name__)
     if head_dim not in [64, 128, 256]:

--- a/python/sglang/jit_kernel/norm.py
+++ b/python/sglang/jit_kernel/norm.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.jit_kernel.utils import load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@functools.cache
+def _jit_norm_module(head_dims: int) -> Module:
+    args = make_cpp_args(head_dims)  # pass all the template argument
+    return load_jit(
+        "norm",
+        *args,
+        cuda_files=["norm.cuh"],
+        cuda_wrappers=[("qknorm", f"QKNormKernel<{args}>::run")],
+    )
+
+
+def fused_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float = 1e-6,
+    *,
+    head_dim: int = 0,
+) -> None:
+    head_dim = head_dim or q.size(-1)
+    module = _jit_norm_module(head_dim)
+    module.qknorm(q, k, q_weight, k_weight, eps)

--- a/python/sglang/jit_kernel/tests/test_qknorm.py
+++ b/python/sglang/jit_kernel/tests/test_qknorm.py
@@ -1,0 +1,85 @@
+import torch
+import triton
+
+
+def sglang_aot_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+) -> None:
+    from sgl_kernel import rmsnorm
+
+    head_dim = q.shape[-1]
+    q = q.view(-1, head_dim)
+    k = k.view(-1, head_dim)
+    rmsnorm(q, q_weight, out=q)
+    rmsnorm(k, k_weight, out=k)
+
+
+def sglang_jit_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+) -> None:
+    from sglang.jit_kernel.norm import fused_inplace_qknorm
+
+    fused_inplace_qknorm(q, k, q_weight, k_weight)
+
+
+def flashinfer_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+) -> None:
+    from flashinfer.norm import rmsnorm
+
+    rmsnorm(q, q_weight, out=q)
+    rmsnorm(k, k_weight, out=k)
+
+
+@torch.compile()
+def torch_impl_qknorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float = 1e-6,
+) -> None:
+    q_mean = q.float().pow(2).mean(dim=-1, keepdim=True)
+    k_mean = k.float().pow(2).mean(dim=-1, keepdim=True)
+    q_norm = (q_mean + eps).rsqrt()
+    k_norm = (k_mean + eps).rsqrt()
+    q.copy_(q.float() * q_norm * q_weight.float())
+    k.copy_(k.float() * k_norm * k_weight.float())
+
+
+# NOTE(dark): sgl_kernel use flashinfer template, which is bitwise identical to flashinfer impl.
+# However, sgl-jit-kernel, flashinfer, torch_impl, may have small numerical differences.
+# so we allow a small rel/abs tolerance in correctness test.
+def main():
+    N_K = 2
+    N_Q = 16
+    DEVICE = "cuda"
+    DTYPE = torch.bfloat16
+    BS_LIST = [2**n for n in range(0, 15)]
+    BS_LIST += [x + 1 + i for i, x in enumerate(BS_LIST)]
+    for HEAD_DIM in [64, 128, 256]:
+        for BS in BS_LIST:
+            q = torch.randn(BS, N_Q, HEAD_DIM, device=DEVICE, dtype=DTYPE)
+            k = torch.randn(BS, N_K, HEAD_DIM, device=DEVICE, dtype=DTYPE)
+            q_weight = torch.randn(HEAD_DIM, device=DEVICE, dtype=DTYPE)
+            k_weight = torch.randn(HEAD_DIM, device=DEVICE, dtype=DTYPE)
+            q_k_aot = (q.clone(), k.clone())
+            q_k_jit = (q.clone(), k.clone())
+            sglang_aot_qknorm(q_k_aot[0], q_k_aot[1], q_weight, k_weight)
+            sglang_jit_qknorm(q_k_jit[0], q_k_jit[1], q_weight, k_weight)
+            triton.testing.assert_close(q_k_aot[0], q_k_jit[0], atol=1e-2, rtol=1e-2)
+            triton.testing.assert_close(q_k_aot[1], q_k_jit[1], atol=1e-2, rtol=1e-2)
+        print(f"HEAD_DIM={HEAD_DIM} correctness test passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -1,9 +1,25 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import pathlib
 from functools import lru_cache
-from typing import TYPE_CHECKING, List, Tuple, TypeAlias, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    TypeAlias,
+    TypeVar,
+    Union,
+    overload,
+)
+
+import torch
+
+from sglang.srt.utils.common import direct_register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi import Module
@@ -134,9 +150,132 @@ def load_jit(
     )
 
 
-@functools.cache
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def cache_once(fn: F) -> F:
+    """
+    NOTE: `functools.lru_cache` is not compatible with `torch.compile`
+    So we manually implement a simple cache_once decorator to replace it.
+    """
+    result_map = {}
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        key = (args, tuple(sorted(kwargs.items(), key=lambda x: x[0])))
+        if key not in result_map:
+            result_map[key] = fn(*args, **kwargs)
+        return result_map[key]
+
+    return wrapper  # type: ignore
+
+
+@cache_once
 def is_arch_support_pdl() -> bool:
     import torch
 
     device = torch.cuda.current_device()
     return torch.cuda.get_device_capability(device)[0] >= 9
+
+
+def fake_inplace_impl(*args, **kwargs) -> None:
+    pass
+
+
+@overload
+def register_jit_op(
+    fn: F,
+    *,
+    op_name: Optional[str] = None,
+    out_list: Optional[List[int]] = None,
+    out_args: Optional[List[str]] = None,
+    fake_impl: Optional[Callable] = fake_inplace_impl,
+) -> F: ...
+
+
+@overload
+def register_jit_op(
+    *,
+    op_name: Optional[str] = None,
+    out_list: Optional[List[int]] = None,
+    out_args: Optional[List[str]] = None,
+    fake_impl: Optional[Callable] = fake_inplace_impl,
+) -> Callable[[F], F]: ...
+
+
+# Real implementation
+def register_jit_op(
+    fn=None,
+    *,
+    op_name: Optional[str] = None,
+    out_list: Optional[List[int]] = None,
+    out_args: Optional[List[str]] = None,
+    fake_impl: Optional[Callable] = fake_inplace_impl,
+) -> Any:
+    """
+    A decorator to register a JIT custom operator.
+
+    Example usage:
+    ```python
+    @register_jit_op(op_name="my_op", out_list=[0])
+    def my_inplace_op(x: torch.Tensor) -> None:
+        x.add_(1)
+
+    def fake_impl(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x + y
+
+    @register_jit_op(op_name="my_op2", out_args=["x"], fake_impl=fake_impl)
+    def my_op(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x.add_(y)
+    ```
+
+    :param fn: The function to be registered as a JIT custom operator.
+               If None, return a decorator.
+    :type fn: Callable
+    :param op_name: The name of the operator. If None, use the function name
+    :type op_name: Optional[str]
+    :param out_list: A list of argument indices that are mutated in-place.
+    :type out_list: Optional[List[int]]
+    :param out_args: A list of argument names that are mutated in-place.
+    :type out_args: Optional[List[str]]
+    :param fake_impl: A fake implementation for the operator, used for
+                      torch.compile compatibility.
+                      By default, a no-op function is used, which suits
+                      for most in-place operations.
+    :type fake_impl: Optional[Callable]
+    :return: The registered JIT custom operator, or a decorator.
+             NOTE: the real register will occur at the first call of the function.
+    :rtype: Callable
+    """
+
+    def decorator(fn):
+        real_impl = None
+        resolved_name = op_name or fn.__name__
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            nonlocal real_impl
+            if real_impl is None:
+                if not hasattr(torch.ops.sglang, resolved_name):
+                    signature = inspect.signature(fn)
+                    mutates_args = []
+                    param_names = list(signature.parameters.keys())
+                    for id in out_list or []:
+                        mutates_args.append(param_names[id])
+                    for name in out_args or []:
+                        mutates_args.append(name)
+                    mutates_args = list(set(mutates_args))
+                    direct_register_custom_op(
+                        op_name=resolved_name,
+                        op_func=fn,
+                        mutates_args=mutates_args,
+                        fake_impl=fake_impl,
+                    )
+                real_impl = getattr(torch.ops.sglang, resolved_name)
+            return real_impl(*args, **kwargs)
+
+        return wrapper
+
+    if fn is not None:
+        return decorator(fn)
+    return decorator

--- a/python/sglang/jit_kernel/utils.py
+++ b/python/sglang/jit_kernel/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import pathlib
 from functools import lru_cache
 from typing import TYPE_CHECKING, List, Tuple, TypeAlias, Union
@@ -131,3 +132,11 @@ def load_jit(
         extra_include_paths=DEFAULT_INCLUDE + extra_include_paths,
         build_directory=build_directory,
     )
+
+
+@functools.cache
+def is_arch_support_pdl() -> bool:
+    import torch
+
+    device = torch.cuda.current_device()
+    return torch.cuda.get_device_capability(device)[0] >= 9

--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -75,6 +75,7 @@ from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.utils import (
+    apply_qk_norm,
     create_fused_set_kv_buffer_arg,
     enable_fused_set_kv_buffer,
 )
@@ -507,28 +508,6 @@ class BailingMoEAttention(nn.Module):
 
         self.alt_stream = alt_stream
 
-    def _apply_qk_norm(
-        self, q: torch.Tensor, k: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # overlap qk norm
-        if self.alt_stream is not None and get_is_capture_mode():
-            current_stream = torch.cuda.current_stream()
-            self.alt_stream.wait_stream(current_stream)
-            q_by_head = q.reshape(-1, self.head_dim)
-            q_by_head = self.query_layernorm(q_by_head)
-            with torch.cuda.stream(self.alt_stream):
-                k_by_head = k.reshape(-1, self.head_dim)
-                k_by_head = self.key_layernorm(k_by_head)
-            current_stream.wait_stream(self.alt_stream)
-        else:
-            q_by_head = q.reshape(-1, self.head_dim)
-            q_by_head = self.query_layernorm(q_by_head)
-            k_by_head = k.reshape(-1, self.head_dim)
-            k_by_head = self.key_layernorm(k_by_head)
-        q = q_by_head.view(q.shape)
-        k = k_by_head.view(k.shape)
-        return q, k
-
     def forward(
         self,
         positions: torch.Tensor,
@@ -540,7 +519,14 @@ class BailingMoEAttention(nn.Module):
         qkv, _ = self.query_key_value(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         if self.use_qk_norm:
-            q, k = self._apply_qk_norm(q, k)
+            q, k = apply_qk_norm(
+                q=q,
+                k=k,
+                q_norm=self.query_layernorm,
+                k_norm=self.key_layernorm,
+                head_dim=self.head_dim,
+                alt_stream=self.alt_stream,
+            )
         q, k = self.rotary_emb(
             positions,
             q,

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -21,7 +21,6 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
-from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
@@ -29,6 +28,7 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.models.qwen2 import Qwen2MLP as Qwen3MLP
 from sglang.srt.models.qwen2 import Qwen2Model
+from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, is_cuda, is_npu
 
@@ -138,32 +138,17 @@ class Qwen3Attention(nn.Module):
         )
         self.alt_stream = alt_stream
 
-    def _apply_qk_norm(
-        self, q: torch.Tensor, k: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # overlap qk norm
-        if self.alt_stream is not None and get_is_capture_mode():
-            current_stream = torch.cuda.current_stream()
-            self.alt_stream.wait_stream(current_stream)
-            q_by_head = q.reshape(-1, self.head_dim)
-            q_by_head = self.q_norm(q_by_head)
-            with torch.cuda.stream(self.alt_stream):
-                k_by_head = k.reshape(-1, self.head_dim)
-                k_by_head = self.k_norm(k_by_head)
-            current_stream.wait_stream(self.alt_stream)
-        else:
-            q_by_head = q.reshape(-1, self.head_dim)
-            q_by_head = self.q_norm(q_by_head)
-            k_by_head = k.reshape(-1, self.head_dim)
-            k_by_head = self.k_norm(k_by_head)
-        q = q_by_head.view(q.shape)
-        k = k_by_head.view(k.shape)
-        return q, k
-
     def forward_prepare_native(self, positions, hidden_states):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self._apply_qk_norm(q, k)
+        q, k = apply_qk_norm(
+            q=q,
+            k=k,
+            q_norm=self.q_norm,
+            k_norm=self.k_norm,
+            head_dim=self.head_dim,
+            alt_stream=self.alt_stream,
+        )
         q, k = self.rotary_emb(positions, q, k)
         return q, k, v
 

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -57,12 +57,12 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding, get_rope
 from sglang.srt.layers.utils import get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
-from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2_moe import Qwen2MoeMLP as Qwen3MoeMLP
 from sglang.srt.models.qwen2_moe import Qwen2MoeModel
 from sglang.srt.models.utils import (
+    apply_qk_norm,
     create_fused_set_kv_buffer_arg,
     enable_fused_set_kv_buffer,
 )
@@ -498,31 +498,6 @@ class Qwen3MoeAttention(nn.Module):
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.alt_stream = alt_stream
 
-    def _apply_qk_norm(
-        self, q: torch.Tensor, k: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # overlap qk norm
-        if self.alt_stream is not None and get_is_capture_mode():
-            current_stream = torch.cuda.current_stream()
-            self.alt_stream.wait_stream(current_stream)
-            q_by_head = q.reshape(-1, self.head_dim)
-            q_by_head = self.q_norm(q_by_head)
-            with torch.cuda.stream(self.alt_stream):
-                k_by_head = k.reshape(-1, self.head_dim)
-                k_by_head = self.k_norm(k_by_head)
-            current_stream.wait_stream(self.alt_stream)
-            q = q_by_head.view(q.shape)
-            k = k_by_head.view(k.shape)
-            return q, k
-        else:
-            q_by_head = q.reshape(-1, self.head_dim)
-            q_by_head = self.q_norm(q_by_head)
-            k_by_head = k.reshape(-1, self.head_dim)
-            k_by_head = self.k_norm(k_by_head)
-        q = q_by_head.view(q.shape)
-        k = k_by_head.view(k.shape)
-        return q, k
-
     def op_prepare(self, state):
         state.attn_intermediate_state = self.forward_prepare(
             positions=state.positions,
@@ -604,7 +579,14 @@ class Qwen3MoeAttention(nn.Module):
         else:
             # Fallback to non-fused QK Norm & RoPE implementation
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-            q, k = self._apply_qk_norm(q, k)
+            q, k = apply_qk_norm(
+                q=q,
+                k=k,
+                q_norm=self.q_norm,
+                k_norm=self.k_norm,
+                head_dim=self.head_dim,
+                alt_stream=self.alt_stream,
+            )
             q, k = self.rotary_emb(
                 positions,
                 q,

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -22,6 +22,7 @@ import numpy as np
 import torch
 
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
+from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_cuda
@@ -230,6 +231,7 @@ def apply_qk_norm(
         _is_cuda  # TODO(dark): have not tested on ROCm or other backends
         and allow_inplace  # TODO(dark): this can be relaxed if needed
         and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
+        and not envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
         and can_use_fused_inplace_qknorm(head_dim)
     ):
         fused_inplace_qknorm(

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -22,6 +22,7 @@ import numpy as np
 import torch
 
 from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
+from sglang.jit_kernel.utils import register_jit_op
 from sglang.srt.environ import envs
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -261,3 +262,7 @@ def apply_qk_norm(
     q = q_by_head.view(q.shape)
     k = k_by_head.view(k.shape)
     return q, k
+
+
+# Register the inplace op
+fused_inplace_qknorm = register_jit_op(fused_inplace_qknorm, out_args=["q", "k"])

--- a/python/sglang/srt/models/utils.py
+++ b/python/sglang/srt/models/utils.py
@@ -11,24 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 import numpy as np
 import torch
 
+from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_cuda
 
+if TYPE_CHECKING:
+    from sglang.srt.layers.layernorm import RMSNorm
+
 _is_cuda = is_cuda()
-
-
-if _is_cuda:
-    from sgl_kernel import FusedSetKVBufferArg
 
 WeightsMapping = Mapping[str, Optional[str]]
 """If a key maps to a value of `None`, the corresponding weight is ignored."""
@@ -113,6 +114,8 @@ def create_fused_set_kv_buffer_arg(
     layer: RadixAttention,
     forward_batch: ForwardBatch,
 ):
+    from sgl_kernel import FusedSetKVBufferArg
+
     layer_id = layer.layer_id
     token_to_kv_pool = forward_batch.token_to_kv_pool
 
@@ -191,3 +194,68 @@ class RotaryPosMixin:
         wpos_ids = wpos_ids.flatten()
 
         return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+
+
+def apply_qk_norm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_norm: RMSNorm,
+    k_norm: RMSNorm,
+    head_dim: int,
+    alt_stream: Optional[torch.cuda.Stream] = None,
+    allow_inplace: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Apply QK normalization for query and key tensors.
+    If eligible, we will use JIT fused inplace QK normalization for better performance.
+
+    Args:
+        q: Query tensor of shape [batch_size, ...]
+        k: Key tensor of shape [batch_size, ...]
+        q_norm: RMSNorm layer for query normalization
+        k_norm: RMSNorm layer for key normalization
+        head_dim: Dimension of each attention head
+        alt_stream: Optional alternative CUDA stream for overlapping computation
+        allow_inplace: Whether to allow inplace normalization. (True for better performance)
+
+    Returns:
+        Tuple of normalized query and key tensors
+    """
+    from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+
+    batch_size = q.size(0)
+    q_eps = q_norm.variance_epsilon
+    k_eps = k_norm.variance_epsilon
+    if (
+        _is_cuda  # TODO(dark): have not tested on ROCm or other backends
+        and allow_inplace  # TODO(dark): this can be relaxed if needed
+        and (q_eps == k_eps)  # TODO(dark): this can also be relaxed
+        and can_use_fused_inplace_qknorm(head_dim)
+    ):
+        fused_inplace_qknorm(
+            q=q.view(batch_size, -1, head_dim),
+            k=k.view(batch_size, -1, head_dim),
+            q_weight=q_norm.weight,
+            k_weight=k_norm.weight,
+            head_dim=head_dim,
+            eps=q_eps,
+        )
+        return q, k
+
+    if alt_stream is not None and get_is_capture_mode():
+        current_stream = torch.cuda.current_stream()
+        alt_stream.wait_stream(current_stream)
+        q_by_head = q.reshape(-1, head_dim)
+        q_by_head = q_norm(q_by_head)
+        with torch.cuda.stream(alt_stream):
+            k_by_head = k.reshape(-1, head_dim)
+            k_by_head = k_norm(k_by_head)
+        current_stream.wait_stream(alt_stream)
+    else:
+        q_by_head = q.reshape(-1, head_dim)
+        q_by_head = q_norm(q_by_head)
+        k_by_head = k.reshape(-1, head_dim)
+        k_by_head = k_norm(k_by_head)
+    q = q_by_head.view(q.shape)
+    k = k_by_head.view(k.shape)
+    return q, k


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
1. QK Norm kernel is not efficient enough. Around 2 months ago, flashinfer has released a newer version of [QK-norm](https://github.com/flashinfer-ai/flashinfer/pull/1843), which has not been integrated into sgl-kernel. This may lead to poor performance in prefill stage.
2. QK Norm can not fully utilize GPU bandwidth when the batch size is relatively small.
3. Too many redundant code `_apply_qk_norm`.

## Modifications

1. Implement JIT fused qk norm kernel. Similar to flashinfer, we use persistent kernel.
2. Use JIT fused qk norm whenever possible.
3. Clean up redundant logic `_apply_qk_norm`. Move them to `sglang/srt/models/utils.py`.

Note: since our JIT kernel only support head_dim `[64,128,256]`, this can also be moved into sgl-kernel in the future without siginificantly increase binary size.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
WIP.

## Benchmarking and Profiling

E2E around 1~2% on Qwen3 models.

<details>
<summary>Kernel Benchmark Latency (us) on H200 (head_dim=128)</summary>

| GQA | num_kv_heads | batch_size | SGL AOT Kernel | SGL JIT Kernel | FlashInfer  |   PyTorch |
| --- | ------------ | ---------- | -------------- | -------------- | ----------- | --------- |
| 4   |          1   |        1.0 |       1.602216 |       0.967299 |   4.147745  |  2.210164 |
| 4   |          1   |        2.0 |       1.971132 |       1.129724 |   4.082101  |  2.216914 |
| 4   |          1   |        4.0 |       2.046463 |       1.161237 |   4.260650  |  2.446676 |
| 4   |          1   |        8.0 |       2.056453 |       1.177705 |   4.127348  |  2.469167 |
| 4   |          1   |       16.0 |       2.070655 |       1.210284 |   4.242177  |  2.491159 |
| 4   |          1   |       32.0 |       2.146091 |       1.235676 |   4.423212  |  2.606742 |
| 4   |          1   |       64.0 |       2.218982 |       1.257530 |   4.510034  |  2.710421 |
| 4   |          1   |      128.0 |       2.497092 |       1.374964 |   4.580845  |  2.817401 |
| 4   |          1   |      256.0 |       3.116057 |       1.546483 |   4.579036  |  3.071840 |
| 4   |          1   |      512.0 |       4.905310 |       2.016863 |   4.698664  |  3.780974 |
| 4   |          1   |     1024.0 |       8.032317 |       2.829033 |   5.164029  |  5.242347 |
| 4   |          1   |     2048.0 |      14.227522 |       3.949354 |   5.849227  |  8.328087 |
| 4   |          1   |     4096.0 |      26.553799 |       4.718069 |   7.889430  | 14.549551 |
| 4   |          1   |     8192.0 |      51.193776 |       5.929556 |  12.844778  | 26.873150 |
| 4   |          2   |        1.0 |       1.973113 |       1.135202 |   4.056827  |  2.218648 |
| 4   |          2   |        2.0 |       2.049635 |       1.174577 |   4.268414  |  2.448797 |
| 4   |          2   |        4.0 |       1.838493 |       1.186040 |   4.131957  |  2.472057 |
| 4   |          2   |        8.0 |       2.075420 |       1.223204 |   4.358434  |  2.501710 |
| 4   |          2   |       16.0 |       2.146743 |       1.237090 |   4.430364  |  2.612028 |
| 4   |          2   |       32.0 |       2.224000 |       1.275996 |   4.664317  |  2.707676 |
| 4   |          2   |       64.0 |       2.498599 |       1.381083 |   4.668938  |  2.810551 |
| 4   |          2   |      128.0 |       3.304765 |       1.554070 |   4.638308  |  3.072464 |
| 4   |          2   |      256.0 |       4.910514 |       2.033047 |   4.675055  |  3.783757 |
| 4   |          2   |      512.0 |       8.034118 |       2.827229 |   5.185844  |  5.237069 |
| 4   |          2   |     1024.0 |      14.051559 |       3.956178 |   5.871687  |  8.326787 |
| 4   |          2   |     2048.0 |      26.555363 |       4.723587 |   7.890730  | 14.554491 |
| 4   |          2   |     4096.0 |      51.204209 |       5.967548 |  12.810800  | 26.865454 |
| 4   |          2   |     8192.0 |     100.506665 |      10.681090 |  22.567152  | 51.510706 |
| 4   |          4   |        1.0 |       2.049338 |       1.179208 |   4.258082  |  2.444852 |
| 4   |          4   |        2.0 |       2.060563 |       1.178384 |   4.132504  |  2.470129 |
| 4   |          4   |        4.0 |       2.074426 |       1.224661 |   4.419047  |  2.486625 |
| 4   |          4   |        8.0 |       2.146800 |       1.243366 |   4.431141  |  2.613374 |
| 4   |          4   |       16.0 |       1.977443 |       1.275281 |   4.548108  |  2.720860 |
| 4   |          4   |       32.0 |       2.498298 |       1.382079 |   4.589099  |  2.809886 |
| 4   |          4   |       64.0 |       3.304652 |       1.558480 |   4.638347  |  3.072272 |
| 4   |          4   |      128.0 |       4.912402 |       2.039143 |   4.670729  |  3.785166 |
| 4   |          4   |      256.0 |       8.031794 |       2.863567 |   5.185206  |  5.237654 |
| 4   |          4   |      512.0 |      14.227032 |       3.968998 |   5.845436  |  8.324923 |
| 4   |          4   |     1024.0 |      26.555411 |       4.708028 |   7.893088  | 14.546558 |
| 4   |          4   |     2048.0 |      51.191171 |       5.952161 |  12.851992  | 26.866253 |
| 4   |          4   |     4096.0 |     100.500408 |      10.683963 |  22.568350  | 51.440001 |
| 4   |          4   |     8192.0 |     198.997016 |      22.859876 |  46.764163  |101.185289 |
| 4   |          8   |        1.0 |       2.057232 |       1.187613 |   4.095947  |  2.456053 |
| 4   |          8   |        2.0 |       2.075319 |       1.224966 |   4.326579  |  2.495948 |
| 4   |          8   |        4.0 |       2.147293 |       1.235857 |   4.503845  |  2.598718 |
| 4   |          8   |        8.0 |       2.223401 |       1.274508 |   4.551287  |  2.720107 |
| 4   |          8   |       16.0 |       2.499761 |       1.382484 |   4.589297  |  2.807916 |
| 4   |          8   |       32.0 |       3.304863 |       1.581218 |   4.638084  |  3.073978 |
| 4   |          8   |       64.0 |       4.722954 |       2.025154 |   4.672783  |  3.789915 |
| 4   |          8   |      128.0 |       8.030740 |       2.837629 |   5.152085  |  5.237443 |
| 4   |          8   |      256.0 |      14.224144 |       3.968735 |   5.843177  |  8.326346 |
| 4   |          8   |      512.0 |      26.548503 |       4.736224 |   7.877057  | 14.548110 |
| 4   |          8   |     1024.0 |      51.189130 |       5.930764 |  12.812288  | 26.821492 |
| 4   |          8   |     2048.0 |     100.369806 |      10.720507 |  22.623180  | 51.433407 |
| 4   |          8   |     4096.0 |     198.991034 |      22.912703 |  46.883177  |101.183354 |
| 4   |          8   |     8192.0 |     396.153278 |      48.456803 |  90.865334  |200.319835 |
| 8   |          1   |        1.0 |       1.660214 |       1.134311 |   4.053002  |  2.204968 |
| 8   |          1   |        2.0 |       2.063375 |       1.152339 |   4.104204  |  2.438979 |
| 8   |          1   |        4.0 |       2.048348 |       1.184119 |   4.094758  |  2.457241 |
| 8   |          1   |        8.0 |       2.091486 |       1.199920 |   4.262926  |  2.395754 |
| 8   |          1   |       16.0 |       2.101410 |       1.259972 |   4.303576  |  2.648056 |
| 8   |          1   |       32.0 |       2.211657 |       1.256035 |   4.426617  |  2.618278 |
| 8   |          1   |       64.0 |       2.425739 |       1.355766 |   4.569506  |  2.726263 |
| 8   |          1   |      128.0 |       3.152905 |       1.532012 |   4.588152  |  3.035327 |
| 8   |          1   |      256.0 |       4.425606 |       1.902914 |   4.630433  |  3.648836 |
| 8   |          1   |      512.0 |       7.447579 |       2.679543 |   5.177979  |  5.030939 |
| 8   |          1   |     1024.0 |      12.978922 |       3.924003 |   5.903701  |  7.690500 |
| 8   |          1   |     2048.0 |      24.080260 |       4.509180 |   7.425713  | 13.256224 |
| 8   |          1   |     4096.0 |      46.263833 |       5.730878 |  12.149372  | 24.367141 |
| 8   |          1   |     8192.0 |      90.507927 |       9.801896 |  21.008092  | 46.509898 |
| 8   |          2   |        1.0 |       2.064506 |       1.150009 |   4.104689  |  2.439759 |
| 8   |          2   |        2.0 |       2.048290 |       1.183201 |   4.095368  |  2.456052 |
| 8   |          2   |        4.0 |       1.872091 |       1.213490 |   4.290765  |  2.397189 |
| 8   |          2   |        8.0 |       2.103361 |       1.260300 |   4.303000  |  2.647652 |
| 8   |          2   |       16.0 |       2.211406 |       1.266252 |   4.485983  |  2.654824 |
| 8   |          2   |       32.0 |       2.426277 |       1.353754 |   4.508568  |  2.729922 |
| 8   |          2   |       64.0 |       3.151445 |       1.525999 |   4.588223  |  3.037183 |
| 8   |          2   |      128.0 |       4.600527 |       1.904346 |   4.592388  |  3.643603 |
| 8   |          2   |      256.0 |       7.438590 |       2.676125 |   5.177108  |  5.031077 |
| 8   |          2   |      512.0 |      12.984543 |       3.914288 |   5.871477  |  7.690347 |
| 8   |          2   |     1024.0 |      23.866795 |       4.510011 |   7.394907  | 13.228737 |
| 8   |          2   |     2048.0 |      46.198835 |       5.736124 |  12.134384  | 24.368680 |
| 8   |          2   |     4096.0 |      90.510744 |       9.821377 |  20.995621  | 46.512056 |
| 8   |          2   |     8192.0 |     179.314180 |      20.053768 |  41.638584  | 91.337495 |
| 8   |          4   |        1.0 |       2.046420 |       1.175872 |   4.097494  |  2.455421 |
| 8   |          4   |        2.0 |       2.090495 |       1.210281 |   4.204116  |  2.390348 |
| 8   |          4   |        4.0 |       2.103140 |       1.260213 |   4.303335  |  2.646751 |
| 8   |          4   |        8.0 |       2.211287 |       1.273012 |   4.482001  |  2.611962 |
| 8   |          4   |       16.0 |       2.220915 |       1.362798 |   4.509473  |  2.731405 |
| 8   |          4   |       32.0 |       3.151757 |       1.533456 |   4.657780  |  3.030493 |
| 8   |          4   |       64.0 |       4.602847 |       1.910799 |   4.596051  |  3.650759 |
| 8   |          4   |      128.0 |       7.438587 |       2.716375 |   5.158408  |  5.047253 |
| 8   |          4   |      256.0 |      12.956142 |       3.926019 |   5.870062  |  7.686410 |
| 8   |          4   |      512.0 |      24.049866 |       4.509933 |   7.407691  | 13.227090 |
| 8   |          4   |     1024.0 |      46.203743 |       5.739054 |  12.169481  | 24.367745 |
| 8   |          4   |     2048.0 |      90.506814 |       9.839303 |  21.047479  | 46.510143 |
| 8   |          4   |     4096.0 |     179.320431 |      20.028844 |  41.554052  | 91.335621 |
| 8   |          4   |     8192.0 |     356.758100 |      44.002492 |  82.021558  |180.347889 |
| 8   |          8   |        1.0 |       2.091602 |       1.217257 |   4.242791  |  2.395733 |
| 8   |          8   |        2.0 |       2.101548 |       1.260544 |   4.303451  |  2.647919 |
| 8   |          8   |        4.0 |       2.213135 |       1.268818 |   4.503230  |  2.649711 |
| 8   |          8   |        8.0 |       2.426232 |       1.357569 |   4.570823  |  2.724038 |
| 8   |          8   |       16.0 |       3.151602 |       1.516329 |   4.576696  |  3.031661 |
| 8   |          8   |       32.0 |       4.602788 |       1.915288 |   4.657099  |  3.651862 |
| 8   |          8   |       64.0 |       7.258208 |       2.713892 |   5.160116  |  5.028964 |
| 8   |          8   |      128.0 |      12.985743 |       3.924281 |   5.868523  |  7.670379 |
| 8   |          8   |      256.0 |      24.046876 |       4.501554 |   7.398339  | 13.227310 |
| 8   |          8   |      512.0 |      46.202775 |       5.739965 |  12.145323  | 24.373176 |
| 8   |          8   |     1024.0 |      90.510368 |       9.904544 |  21.005994  | 46.513264 |
| 8   |          8   |     2048.0 |     179.318836 |      20.015311 |  41.564332  | 91.198415 |
| 8   |          8   |     4096.0 |     356.774989 |      43.970684 |  82.019536  |180.342816 |
| 8   |          8   |     8192.0 |     711.237124 |      84.883776 | 160.825233  |357.91069  |

</details>

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
