### PR TITLE
[sgl-kernel/build] Increase build parallel number in aarch64

### DIFF
--- a/sgl-kernel/build.sh
+++ b/sgl-kernel/build.sh
@@ -67,11 +67,12 @@ docker run --rm \
    # Setting these flags to reduce OOM chance only on ARM
    export CMAKE_BUILD_PARALLEL_LEVEL=$(( $(nproc)/3 < 48 ? $(nproc)/3 : 48 ))
    if [ \"${ARCH}\" = \"aarch64\" ]; then
-      export CUDA_NVCC_FLAGS=\"-Xcudafe --threads=2\"
-      export MAKEFLAGS='-j2'
-      export CMAKE_BUILD_PARALLEL_LEVEL=2
-      export NINJAFLAGS='-j2'
-      echo \"ARM detected: Using extra conservative settings (2 parallel jobs)\"
+      PARALLEL_AARCH64=$(( (j = ($(nproc) + 7) / 8) < 32 ? j : 32 ))
+      export CUDA_NVCC_FLAGS=\"-Xcudafe --threads=\${PARALLEL_AARCH64}\"
+      export MAKEFLAGS=\"-j\${PARALLEL_AARCH64}\"
+      export CMAKE_BUILD_PARALLEL_LEVEL=\"\${PARALLEL_AARCH64}\"
+      export NINJAFLAGS=\"-j\${PARALLEL_AARCH64}\"
+      echo \"ARM detected: Using extra conservative settings (\${PARALLEL_AARCH64} parallel jobs)\"
    fi
 
    CMAKE_TARBALL=\"cmake-\${CMAKE_VERSION_MAJOR}.\${CMAKE_VERSION_MINOR}-linux-${ARCH}.tar.gz\"


### PR DESCRIPTION
The parallel number is pretty small in arm. Increase it to 1/8 cpu cores.

## Motivation

Currently, the kernel builds in parallel in both x86 and arm64. But the parallel number was decreased to hardcoded 2 because some OOMs were observed on GB200. It causes building too slow on aarch64 servers.

## Modifications

Change the hardcoded 2 to 1/8 cpu cores number.

## Benchmarking and Profiling

Tested on Arm64 server with 256 cores. The peak cpu usage ~ 35% and memory usage is less than 500G

```
~/workspace/sglang/sgl-kernel# nproc
256
~/workspace/sglang/sgl-kernel# free -h
               total        used        free      shared  buff/cache   available
Mem:           988Gi       430Gi       515Gi        19Mi        43Gi       552Gi
Swap:             0B          0B          0B


```

## Checklist