### PR TITLE
[model-gateway] update ManualPolicy with header-based routing

### DIFF
--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -337,6 +337,9 @@ pub enum PolicyConfig {
         bucket_adjust_interval_secs: usize,
     },
 
+    /// Manual routing policy supporting header-based routing:
+    /// - X-SMG-Target-Worker: Direct routing to a specific worker by URL
+    /// - X-SMG-Routing-Key: Consistent hash routing for session affinity
     #[serde(rename = "manual")]
     Manual,
 }

--- a/sgl-model-gateway/src/config/validation.rs
+++ b/sgl-model-gateway/src/config/validation.rs
@@ -147,7 +147,7 @@ impl ConfigValidator {
 
     fn validate_policy(policy: &PolicyConfig) -> ConfigResult<()> {
         match policy {
-            PolicyConfig::Random | PolicyConfig::RoundRobin => {}
+            PolicyConfig::Random | PolicyConfig::RoundRobin | PolicyConfig::Manual => {}
             PolicyConfig::CacheAware {
                 cache_threshold,
                 balance_abs_threshold: _,
@@ -226,7 +226,6 @@ impl ConfigValidator {
                     });
                 }
             }
-            PolicyConfig::Manual => {}
         }
         Ok(())
     }

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -136,7 +136,7 @@ struct CliArgs {
     #[arg(long, num_args = 0..)]
     worker_urls: Vec<String>,
 
-    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two"])]
+    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "manual"])]
     policy: String,
 
     #[arg(long, default_value_t = false)]
@@ -145,10 +145,10 @@ struct CliArgs {
     #[arg(long, action = ArgAction::Append)]
     decode: Vec<String>,
 
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two"])]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "manual"])]
     prefill_policy: Option<String>,
 
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two"])]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "manual"])]
     decode_policy: Option<String>,
 
     #[arg(long, default_value_t = 1800)]
@@ -415,6 +415,7 @@ impl CliArgs {
             "power_of_two" => PolicyConfig::PowerOfTwo {
                 load_check_interval_secs: 5,
             },
+            "manual" => PolicyConfig::Manual,
             _ => PolicyConfig::RoundRobin,
         }
     }

--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -190,10 +190,6 @@ pub fn init_metrics() {
         "smg_worker_errors_total",
         "Worker-level errors by worker_type, connection_mode, error_type"
     );
-    describe_counter!(
-        "smg_worker_manual_policy_branch_total",
-        "Manual policy execution branch by branch type"
-    );
 
     // Layer 3: Worker resilience metrics (circuit breaker)
     describe_gauge!(
@@ -805,6 +801,15 @@ impl Metrics {
         .increment(1);
     }
 
+    /// Record manual policy execution branch for routing decisions
+    pub fn record_worker_manual_policy_branch(branch: &'static str) {
+        counter!(
+            "smg_manual_policy_branch_total",
+            "branch" => branch
+        )
+        .increment(1);
+    }
+
     /// Set running requests per worker
     pub fn set_worker_requests_active(worker: &str, count: usize) {
         gauge!(
@@ -812,15 +817,6 @@ impl Metrics {
             "worker" => worker.to_string()
         )
         .set(count as f64);
-    }
-
-    /// Record manual policy execution branch
-    pub fn record_worker_manual_policy_branch(branch: &'static str) {
-        counter!(
-            "smg_worker_manual_policy_branch_total",
-            "branch" => branch
-        )
-        .increment(1);
     }
 
     /// Set worker health status

--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -517,16 +517,12 @@ mod tests {
         policy.init_workers(&workers);
 
         // Should select worker2 (lower load) despite cache affinity
+        let info = SelectWorkerInfo {
+            request_text: Some("test"),
+            ..Default::default()
+        };
         for _ in 0..5 {
-            let idx = policy
-                .select_worker(
-                    &workers,
-                    &SelectWorkerInfo {
-                        request_text: Some("test"),
-                        ..Default::default()
-                    },
-                )
-                .unwrap();
+            let idx = policy.select_worker(&workers, &info).unwrap();
             assert_eq!(idx, 1); // Should always pick worker2
         }
     }

--- a/sgl-model-gateway/src/policies/factory.rs
+++ b/sgl-model-gateway/src/policies/factory.rs
@@ -96,9 +96,6 @@ mod tests {
             bucket_adjust_interval_secs: 5,
         });
         assert_eq!(policy.name(), "bucket");
-
-        let policy = PolicyFactory::create_from_config(&PolicyConfig::Manual);
-        assert_eq!(policy.name(), "manual");
     }
 
     #[tokio::test]
@@ -113,8 +110,6 @@ mod tests {
         assert!(PolicyFactory::create_by_name("CacheAware").is_some());
         assert!(PolicyFactory::create_by_name("bucket").is_some());
         assert!(PolicyFactory::create_by_name("Bucket").is_some());
-        assert!(PolicyFactory::create_by_name("manual").is_some());
-        assert!(PolicyFactory::create_by_name("Manual").is_some());
         assert!(PolicyFactory::create_by_name("unknown").is_none());
     }
 }

--- a/sgl-model-gateway/src/policies/mod.rs
+++ b/sgl-model-gateway/src/policies/mod.rs
@@ -57,11 +57,6 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
         false // Default: most policies don't need request text
     }
 
-    /// Check if this policy needs routing_id for routing decisions
-    fn needs_routing_id(&self) -> bool {
-        false // Default: most policies don't need routing_id
-    }
-
     /// Update worker load information
     ///
     /// This is called periodically with current load information for load-aware policies.
@@ -147,8 +142,11 @@ pub(crate) fn normalize_model_key(model_id: &str) -> &str {
 pub struct SelectWorkerInfo<'a> {
     /// Request text for cache-aware routing
     pub request_text: Option<&'a str>,
-    /// Routing ID for manual routing policy (consistent hashing)
-    pub routing_id: Option<&'a str>,
+    /// HTTP headers for header-based routing policies
+    /// Policies can extract routing information from headers like:
+    /// - X-Target-Worker: Direct routing to a specific worker by URL
+    /// - X-Routing-Key: Consistent hash routing for session affinity
+    pub headers: Option<&'a http::HeaderMap>,
 }
 
 #[cfg(test)]

--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -94,9 +94,6 @@ pub struct PreparationOutput {
     /// Original text (for chat) or resolved text (for generate)
     pub original_text: Option<String>,
 
-    /// Routing ID for manual routing policy
-    pub routing_id: Option<String>,
-
     /// Tokenized input
     pub token_ids: Vec<u32>,
 

--- a/sgl-model-gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -19,7 +19,6 @@ use crate::{
             context::{PreparationOutput, RequestContext, RequestType},
             utils,
         },
-        header_utils,
     },
 };
 
@@ -124,7 +123,6 @@ impl HarmonyPreparationStage {
         // Step 4: Store results
         ctx.state.preparation = Some(PreparationOutput {
             original_text: None,
-            routing_id: header_utils::extract_routing_id(ctx.input.headers.as_ref()),
             token_ids: build_output.input_ids,
             processed_messages: None,
             tool_constraints,
@@ -205,7 +203,6 @@ impl HarmonyPreparationStage {
         // Step 4: Store results with constraint
         ctx.state.preparation = Some(PreparationOutput {
             original_text: None,
-            routing_id: header_utils::extract_routing_id(ctx.input.headers.as_ref()),
             token_ids: build_output.input_ids,
             processed_messages: None,
             tool_constraints: constraint,

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -15,7 +15,6 @@ use crate::{
             context::{PreparationOutput, RequestContext},
             utils,
         },
-        header_utils,
     },
 };
 
@@ -97,7 +96,6 @@ impl ChatPreparationStage {
         // Store results in context
         ctx.state.preparation = Some(PreparationOutput {
             original_text: Some(processed_messages.text.clone()),
-            routing_id: header_utils::extract_routing_id(ctx.input.headers.as_ref()),
             token_ids,
             processed_messages: Some(processed_messages),
             tool_constraints: tool_call_constraint,

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -13,7 +13,6 @@ use crate::{
             context::{PreparationOutput, RequestContext, RequestType},
             utils,
         },
-        header_utils,
     },
 };
 
@@ -48,9 +47,8 @@ impl PipelineStage for EmbeddingPreparationStage {
             ));
         };
 
-        // Extract text from request before borrowing ctx mutably
+        // Extract text from request
         let text = request.extract_text_for_routing();
-        let routing_id = header_utils::extract_routing_id(ctx.input.headers.as_ref());
         if text.is_empty() {
             return Err(error::bad_request(
                 "empty_input",
@@ -79,7 +77,6 @@ impl PipelineStage for EmbeddingPreparationStage {
         // Store preparation output
         ctx.state.preparation = Some(PreparationOutput {
             original_text: Some(text),
-            routing_id,
             token_ids,
             processed_messages: None,
             tool_constraints: None,

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -15,7 +15,6 @@ use crate::{
             context::{PreparationOutput, RequestContext},
             utils,
         },
-        header_utils,
     },
     tokenizer::traits::Tokenizer,
 };
@@ -69,7 +68,6 @@ impl GeneratePreparationStage {
 
         ctx.state.preparation = Some(PreparationOutput {
             original_text,
-            routing_id: header_utils::extract_routing_id(ctx.input.headers.as_ref()),
             token_ids,
             processed_messages: None,
             tool_constraints: None,

--- a/sgl-model-gateway/src/routers/header_utils.rs
+++ b/sgl-model-gateway/src/routers/header_utils.rs
@@ -157,17 +157,6 @@ pub fn apply_provider_headers(
     req
 }
 
-/// Header name for routing key used by manual routing policy
-pub const ROUTING_KEY_HEADER: &str = "X-SMG-Routing-Key";
-
-/// Extract routing ID from HTTP headers for manual routing policy
-pub fn extract_routing_id(headers: Option<&HeaderMap>) -> Option<String> {
-    headers
-        .and_then(|h| h.get(ROUTING_KEY_HEADER))
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())
-}
-
 /// Extract auth header with passthrough semantics.
 ///
 /// Passthrough mode: User's Authorization header takes priority.
@@ -193,32 +182,4 @@ pub fn extract_auth_header(
             .as_ref()
             .and_then(|k| HeaderValue::from_str(&format!("Bearer {}", k)).ok())
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extract_routing_id_with_header() {
-        let mut headers = HeaderMap::new();
-        headers.insert(ROUTING_KEY_HEADER, HeaderValue::from_static("user-123"));
-        let result = extract_routing_id(Some(&headers));
-        assert_eq!(result, Some("user-123".to_string()));
-    }
-
-    #[test]
-    fn test_extract_routing_id_without_header() {
-        let headers = HeaderMap::new();
-        let result = extract_routing_id(Some(&headers));
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_extract_routing_id_empty_value() {
-        let mut headers = HeaderMap::new();
-        headers.insert(ROUTING_KEY_HEADER, HeaderValue::from_static(""));
-        let result = extract_routing_id(Some(&headers));
-        assert_eq!(result, Some("".to_string()));
-    }
 }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -27,7 +27,7 @@ use crate::{
         metrics::{bool_to_static_str, metrics_labels, Metrics},
         otel_trace::inject_trace_context_http,
     },
-    policies::PolicyRegistry,
+    policies::{PolicyRegistry, SelectWorkerInfo},
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
@@ -39,7 +39,7 @@ use crate::{
         responses::{ResponsesGetParams, ResponsesRequest},
     },
     routers::{
-        error,
+        error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
         header_utils, RouterTrait,
     },
@@ -140,7 +140,8 @@ impl Router {
     fn select_worker_for_model(
         &self,
         model_id: Option<&str>,
-        info: &crate::policies::SelectWorkerInfo,
+        text: Option<&str>,
+        headers: Option<&HeaderMap>,
     ) -> Option<Arc<dyn Worker>> {
         let effective_model_id = if !self.enable_igw { None } else { model_id };
 
@@ -168,7 +169,13 @@ impl Router {
             None => self.policy_registry.get_default_policy(),
         };
 
-        let idx = policy.select_worker(&available, info)?;
+        let idx = policy.select_worker(
+            &available,
+            &SelectWorkerInfo {
+                request_text: text,
+                headers,
+            },
+        )?;
 
         // Record worker selection metric (Layer 3)
         Metrics::record_worker_selection(
@@ -191,11 +198,6 @@ impl Router {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
         let text = typed_req.extract_text_for_routing();
-        let routing_id = header_utils::extract_routing_id(headers);
-        let info = crate::policies::SelectWorkerInfo {
-            request_text: Some(&text),
-            routing_id: routing_id.as_deref(),
-        };
         let model = model_id.unwrap_or("default");
         let endpoint = route_to_endpoint(route);
 
@@ -214,7 +216,7 @@ impl Router {
             // operation per attempt
             |_: u32| async {
                 let res = self
-                    .route_typed_request_once(headers, typed_req, route, model_id, is_stream, &info)
+                    .route_typed_request_once(headers, typed_req, route, model_id, is_stream, &text)
                     .await;
 
                 // Need to be outside `route_typed_request_once` because that function has multiple return paths
@@ -272,9 +274,9 @@ impl Router {
         route: &'static str,
         model_id: Option<&str>,
         is_stream: bool,
-        info: &crate::policies::SelectWorkerInfo<'_>,
+        text: &str,
     ) -> Response {
-        let worker = match self.select_worker_for_model(model_id, info) {
+        let worker = match self.select_worker_for_model(model_id, Some(text), headers) {
             Some(w) => w,
             None => {
                 return error::service_unavailable(
@@ -695,8 +697,6 @@ fn convert_reqwest_error(e: reqwest::Error) -> Response {
 }
 
 use async_trait::async_trait;
-
-use crate::routers::error::extract_error_code_from_response;
 
 #[async_trait]
 impl RouterTrait for Router {

--- a/sgl-model-gateway/tests/cache_aware_backward_compat_test.rs
+++ b/sgl-model-gateway/tests/cache_aware_backward_compat_test.rs
@@ -103,24 +103,16 @@ fn test_mixed_model_ids() {
 
     let default_workers: Vec<Arc<dyn Worker>> =
         vec![Arc::new(worker1.clone()), Arc::new(worker3.clone())];
-    let selected = policy.select_worker(
-        &default_workers,
-        &SelectWorkerInfo {
-            request_text: Some("test request"),
-            ..Default::default()
-        },
-    );
+    let info = SelectWorkerInfo {
+        request_text: Some("test request"),
+        ..Default::default()
+    };
+    let selected = policy.select_worker(&default_workers, &info);
     assert!(selected.is_some(), "Should select from default workers");
 
     let llama_workers: Vec<Arc<dyn Worker>> =
         vec![Arc::new(worker2.clone()), Arc::new(worker4.clone())];
-    let selected = policy.select_worker(
-        &llama_workers,
-        &SelectWorkerInfo {
-            request_text: Some("test request"),
-            ..Default::default()
-        },
-    );
+    let selected = policy.select_worker(&llama_workers, &info);
     assert!(selected.is_some(), "Should select from llama-3 workers");
 
     let all_workers: Vec<Arc<dyn Worker>> = vec![
@@ -129,13 +121,7 @@ fn test_mixed_model_ids() {
         Arc::new(worker3.clone()),
         Arc::new(worker4.clone()),
     ];
-    let selected = policy.select_worker(
-        &all_workers,
-        &SelectWorkerInfo {
-            request_text: Some("test request"),
-            ..Default::default()
-        },
-    );
+    let selected = policy.select_worker(&all_workers, &info);
     assert!(selected.is_some(), "Should select from all workers");
 }
 


### PR DESCRIPTION
- `X-SMG-Target-Worker`: Route by worker index (0-based), O(1) lookup
- `X-SMG-Routing-Key`: Consistent hash routing for session affinity

Key changes:
- Removed DashMap storage and RoutingInfo tracking
- Use `std::hash::DefaultHasher` for consistent hashing
- Pass headers through `SelectWorkerInfo`
- Removed `routing_id` field from all protocol types
- Added --policy manual to CLI options


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
