### PR TITLE
[diffusion] ZImage support Tensor Parallel

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -8,7 +8,13 @@ from sglang.multimodal_gen.configs.models.dits.zimage import ZImageDitConfig
 from sglang.multimodal_gen.runtime.layers.activation import SiluAndMul
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
 from sglang.multimodal_gen.runtime.layers.layernorm import RMSNorm
-from sglang.multimodal_gen.runtime.layers.linear import ReplicatedLinear
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import _apply_rotary_emb
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
@@ -36,9 +42,13 @@ class TimestepEmbedder(nn.Module):
 
         self.mlp = nn.ModuleList(
             [
-                ReplicatedLinear(frequency_embedding_size, mid_size, bias=True),
+                ColumnParallelLinear(
+                    frequency_embedding_size, mid_size, bias=True, gather_output=False
+                ),
                 nn.SiLU(),
-                ReplicatedLinear(mid_size, out_size, bias=True),
+                RowParallelLinear(
+                    mid_size, out_size, bias=True, input_is_parallel=True
+                ),
             ]
         )
 
@@ -74,9 +84,11 @@ class TimestepEmbedder(nn.Module):
 class FeedForward(nn.Module):
     def __init__(self, dim: int, hidden_dim: int):
         super().__init__()
-        # Use ReplicatedLinear for gate and up projection (fused)
-        self.w13 = ReplicatedLinear(dim, hidden_dim * 2, bias=False)
-        self.w2 = ReplicatedLinear(hidden_dim, dim, bias=False)
+        # Use MergedColumnParallelLinear for gate and up projection (fused)
+        self.w13 = MergedColumnParallelLinear(
+            dim, [hidden_dim, hidden_dim], bias=False, gather_output=False
+        )
+        self.w2 = RowParallelLinear(hidden_dim, dim, bias=False, input_is_parallel=True)
         self.act = SiluAndMul()
 
     def forward(self, x):
@@ -97,14 +109,17 @@ class ZImageAttention(nn.Module):
     ) -> None:
         super().__init__()
         self.dim = dim
-        self.num_heads = num_heads
-        self.num_kv_heads = num_kv_heads
         self.head_dim = dim // num_heads
         self.qk_norm = qk_norm
 
-        # Use ReplicatedLinear for QKV projection (fused)
-        qkv_dim = dim + 2 * (num_kv_heads * self.head_dim)
-        self.to_qkv = ReplicatedLinear(dim, qkv_dim, bias=False)
+        # Use QKVParallelLinear for QKV projection (fused)
+        self.to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=self.head_dim,
+            total_num_heads=num_heads,
+            total_num_kv_heads=num_kv_heads,
+            bias=False,
+        )
 
         if self.qk_norm:
             self.norm_q = RMSNorm(self.head_dim, eps=eps)
@@ -113,7 +128,9 @@ class ZImageAttention(nn.Module):
             self.norm_q = None
             self.norm_k = None
 
-        self.to_out = nn.ModuleList([ReplicatedLinear(dim, dim, bias=False)])
+        self.to_out = nn.ModuleList(
+            [RowParallelLinear(dim, dim, bias=False, input_is_parallel=True)]
+        )
 
         self.attn = USPAttention(
             num_heads=num_heads,
@@ -130,12 +147,13 @@ class ZImageAttention(nn.Module):
         freqs_cis: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ):
         qkv, _ = self.to_qkv(hidden_states)
-        kv_dim = self.head_dim * self.num_kv_heads
-        q, k, v = torch.split(qkv, [self.dim, kv_dim, kv_dim], dim=-1)
+        q_dim = self.to_qkv.num_heads * self.head_dim
+        kv_dim = self.to_qkv.num_kv_heads * self.head_dim
+        q, k, v = torch.split(qkv, [q_dim, kv_dim, kv_dim], dim=-1)
 
-        q = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
-        k = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
-        v = v.view(*v.shape[:-1], self.num_kv_heads, self.head_dim)
+        q = q.view(*q.shape[:-1], self.to_qkv.num_heads, self.head_dim)
+        k = k.view(*k.shape[:-1], self.to_qkv.num_kv_heads, self.head_dim)
+        v = v.view(*v.shape[:-1], self.to_qkv.num_kv_heads, self.head_dim)
 
         if self.norm_q is not None:
             q = self.norm_q(q)
@@ -251,7 +269,9 @@ class FinalLayer(nn.Module):
     def __init__(self, hidden_size, out_channels):
         super().__init__()
         self.norm_final = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
-        self.linear = ReplicatedLinear(hidden_size, out_channels, bias=True)
+        self.linear = ColumnParallelLinear(
+            hidden_size, out_channels, bias=True, gather_output=True
+        )
 
         self.act = nn.SiLU()
         self.adaLN_modulation = nn.Sequential(
@@ -373,10 +393,11 @@ class ZImageTransformer2DModel(CachableDiT):
         for patch_idx, (patch_size, f_patch_size) in enumerate(
             zip(self.all_patch_size, self.all_f_patch_size)
         ):
-            x_embedder = ReplicatedLinear(
+            x_embedder = ColumnParallelLinear(
                 f_patch_size * patch_size * patch_size * self.in_channels,
                 self.dim,
                 bias=True,
+                gather_output=True,
             )
             all_x_embedder[f"{patch_size}-{f_patch_size}"] = x_embedder
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

support tp for zimage; however, it's important to note that zimage currently does not support SP due to issues with the input latent dimensions  is 5(b t c h w), and some modifications may be needed in the future.

## Motivation

support tensor parallel
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

zimage.py
<!-- Detail the changes made in this pull request. -->

**TP 2**
```
root@b727fef50438:/sgl-workspace/sglang# UDA_VISIBLE_DEVICES=0,1 sglang generate  --pin-cpu-memory --prompt='A curious raccoon' --save-output --log
-level=debug --width=720 --height=720 --output-path=outputs --model-path=Tongyi-MAI/Z-Image-Turbo --tp-size 2

[12-25 23:23:25] [TimestepPreparationStage] timesteps: tensor([1000.0000,  954.6938,  900.3591,  833.9980,  751.1211,  644.6863,
         502.9850,  305.0089,    8.9286], device='cuda:0')
[12-25 23:23:25] [TimestepPreparationStage] finished in 0.0317 seconds
[12-25 23:23:25] [LatentPreparationStage] started...
[12-25 23:23:25] [LatentPreparationStage] finished in 0.0024 seconds
[12-25 23:23:25] [DenoisingStage] started...
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:02<00:00,  3.89it/s]
[12-25 23:23:27] [DenoisingStage] average time per step: 0.2571 seconds
[12-25 23:23:27] [DenoisingStage] finished in 2.3205 seconds
[12-25 23:23:27] [DecodingStage] started...
[12-25 23:23:29] [DecodingStage] finished in 1.1537 seconds
``` 
**TP 4**
no support because total_headnums is 30 cannot divided by 4

