### PR TITLE
perf(scheduler): track num_reasoning_tokens incrementally when appending tokens

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -107,8 +107,8 @@ class SchedulerOutputProcessorMixin:
                     continue
 
                 if req.is_chunked <= 0:
-                    # req output_ids are set here
-                    req.output_ids.append(next_token_id)
+                    # req output_ids are set here (with reasoning token tracking)
+                    req.append_output_token(next_token_id)
                     req.check_finished()
 
                     if req.finished():
@@ -298,7 +298,7 @@ class SchedulerOutputProcessorMixin:
         req = batch.reqs[0]
 
         for next_token_id in next_token_ids:
-            req.output_ids.append(next_token_id)
+            req.append_output_token(next_token_id)
             req.check_finished()
 
             if req.finished():
@@ -353,10 +353,10 @@ class SchedulerOutputProcessorMixin:
 
             new_accepted_len = 1
             if batch.spec_algorithm.is_none():
-                req.output_ids.append(next_token_id)
+                req.append_output_token(next_token_id)
             elif batch.is_v2_eagle:
                 # Only v2 eagle's output_ids are updated here.
-                req.output_ids.extend(next_token_id)
+                req.extend_output_tokens(next_token_id)
                 new_accepted_len = len(next_token_id)
 
             req.check_finished(new_accepted_len)


### PR DESCRIPTION
## Summary

This optimization (issue #13250) avoids having to scan `output_ids` to count reasoning tokens after the fact. Instead, reasoning tokens are tracked incrementally as tokens are appended.

### Changes:
- Add `num_reasoning_tokens` and `think_end_seen` fields to `Req` class
- Add `append_output_token()` method that tracks reasoning tokens
- Add `extend_output_tokens()` for speculative decoding multi-token case
- Update all `output_ids.append()` calls to use the new method

### Tracking Logic:
- Before `think_end_id`: all tokens are reasoning tokens (increment count)
- After `think_end_id`: tokens are NOT reasoning tokens (don't increment)

Fixes #13250

## Test plan

- [ ] Verify reasoning token count matches expected values for models with `--reasoning-parser`
- [ ] Verify no regression in non-reasoning model inference
- [ ] Verify speculative decoding with reasoning models works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)