### PR TITLE
[NPU] Add pyhccl

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pyhccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pyhccl.py
@@ -1,0 +1,210 @@
+
+# Adapted from https://github.com/vllm-project/vllm-ascend/blob/v0.11.0-dev/vllm_ascend/distributed/device_communicators/pyhccl.py
+
+from typing import Optional, Union
+import logging
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup, ReduceOp
+
+from sglang.srt.distributed.utils import StatelessProcessGroup
+
+from sglang.srt.distributed.device_communicators.pyhccl_wrapper import (
+    HCCLLibrary, aclrtStream_t, buffer_type, hcclComm_t, hcclDataTypeEnum,
+    hcclRedOpTypeEnum, hcclUniqueId, current_stream)
+
+logger = logging.getLogger(__name__)
+
+class PyHcclCommunicator:
+
+    def __init__(
+        self,
+        group: Union[ProcessGroup, StatelessProcessGroup],
+        device: Union[int, str, torch.device],
+        library_path: Optional[str] = None,
+    ):
+        """
+        Args:
+            group: the process group to work on. If None, it will use the
+                default process group.
+            device: the device to bind the PyHcclCommunicator to. If None,
+                it will be bind to f"npu:{local_rank}".
+            library_path: the path to the HCCL library. If None, it will
+                use the default library path.
+        It is the caller's responsibility to make sure each communicator
+        is bind to a unique device.
+        """
+
+        if not isinstance(group, StatelessProcessGroup):
+            assert dist.is_initialized()
+            assert dist.get_backend(group) != dist.Backend.HCCL, (
+                "PyHcclCommunicator should be attached to a non-HCCL group.")
+            # note: this rank is the rank in the group
+            self.rank = dist.get_rank(group)
+            self.world_size = dist.get_world_size(group)
+        else:
+            self.rank = group.rank
+            self.world_size = group.world_size
+
+        self.group = group
+
+        # if world_size == 1, no need to create communicator
+        if self.world_size == 1:
+            self.available = False
+            self.disabled = True
+            return
+
+        try:
+            self.hccl = HCCLLibrary(library_path)
+        except Exception:
+            # disable because of missing HCCL library
+            # e.g. in a non-NPU environment
+            self.available = False
+            self.disabled = True
+            return
+
+        self.available = True
+        self.disabled = False
+
+        logger.info("vLLM is using pyhccl")
+
+        if isinstance(device, int):
+            device = torch.device(f"npu:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        # now `device` is a `torch.device` object
+        assert isinstance(device, torch.device)
+        self.device = device
+
+        if self.rank == 0:
+            # get the unique id from HCCL
+            with torch.npu.device(device):
+                self.unique_id = self.hccl.hcclGetUniqueId()
+        else:
+            # construct an empty unique id
+            self.unique_id = hcclUniqueId()
+
+        if not isinstance(group, StatelessProcessGroup):
+            tensor = torch.ByteTensor(list(self.unique_id.internal))
+            ranks = dist.get_process_group_ranks(group)
+            # arg `src` in `broadcast` is the global rank
+            dist.broadcast(tensor, src=ranks[0], group=group)
+            byte_list = tensor.tolist()
+            for i, byte in enumerate(byte_list):
+                self.unique_id.internal[i] = byte
+        else:
+            self.unique_id = group.broadcast_obj(self.unique_id, src=0)
+
+        # hccl communicator and stream will use this device
+        # `torch.npu.device` is a context manager that changes the
+        # current npu device to the specified one
+        with torch.npu.device(device):
+            self.comm: hcclComm_t = self.hccl.hcclCommInitRank(
+                self.world_size, self.unique_id, self.rank)
+
+            stream = current_stream()
+            # A small all_reduce for warmup.
+            data = torch.zeros(1, device=device)
+            self.all_reduce(data)
+            stream.synchronize()
+            del data
+
+    def all_reduce(self,
+                   in_tensor: torch.Tensor,
+                   op: ReduceOp = ReduceOp.SUM,
+                   stream=None) -> torch.Tensor:
+        if self.disabled:
+            return None
+        # hccl communicator created on a specific device
+        # will only work on tensors on the same device
+        # otherwise it will cause "illegal memory access"
+        assert in_tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {in_tensor.device}")
+
+        out_tensor = torch.empty_like(in_tensor)
+
+        if stream is None:
+            stream = current_stream()
+        self.hccl.hcclAllReduce(buffer_type(in_tensor.data_ptr()),
+                                buffer_type(out_tensor.data_ptr()),
+                                in_tensor.numel(),
+                                hcclDataTypeEnum.from_torch(in_tensor.dtype),
+                                hcclRedOpTypeEnum.from_torch(op), self.comm,
+                                aclrtStream_t(stream.npu_stream))
+        return out_tensor
+
+    def broadcast(self, tensor: torch.Tensor, src: int, stream=None):
+        if self.disabled:
+            return
+        assert tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {tensor.device}")
+        if stream is None:
+            stream = current_stream()
+        if src == self.rank:
+            buffer = buffer_type(tensor.data_ptr())
+        else:
+            buffer = buffer_type(tensor.data_ptr())
+        self.hccl.hcclBroadcast(buffer, tensor.numel(),
+                                hcclDataTypeEnum.from_torch(tensor.dtype), src,
+                                self.comm, aclrtStream_t(stream.npu_stream))
+    
+    def all_gather(self, out_tensor: torch.Tensor, in_tensor: torch.Tensor, stream=None):
+        if self.disabled:
+            return
+        assert in_tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {in_tensor.device}")
+
+        assert out_tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {out_tensor.device}")
+
+        if stream is None:
+            stream = current_stream()
+               
+        self.hccl.hcclAllGather(
+                buffer_type(in_tensor.data_ptr()),
+                buffer_type(out_tensor.data_ptr()),
+                in_tensor.numel(),
+                hcclDataTypeEnum.from_torch(in_tensor.dtype),
+                self.comm,
+                aclrtStream_t(stream.npu_stream),
+            )
+
+    def reduce_scatter(self, in_tensor: torch.Tensor, out_tensor: torch.Tensor, 
+                       op: ReduceOp = ReduceOp.SUM, stream=None):
+        if self.disabled:
+            return
+        assert in_tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {in_tensor.device}")
+
+        assert out_tensor.device == self.device, (
+            f"this hccl communicator is created to work on {self.device}, "
+            f"but the input tensor is on {out_tensor.device}")
+
+        if stream is None:
+            stream = current_stream()
+               
+        self.hccl.hcclReduceScatter(
+                buffer_type(in_tensor.data_ptr()),
+                buffer_type(out_tensor.data_ptr()),
+                out_tensor.numel(),
+                hcclDataTypeEnum.from_torch(in_tensor.dtype),
+                hcclRedOpTypeEnum.from_torch(op),
+                self.comm,
+                aclrtStream_t(stream.npu_stream),
+            )
+
+    def barrier(self, stream=None):
+        if self.disabled:
+            return
+        if stream is None:
+            stream = current_stream()
+               
+        self.hccl.hcclBarrier(
+                self.comm,
+                aclrtStream_t(stream.npu_stream),
+            )

--- a/python/sglang/srt/distributed/device_communicators/pyhccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pyhccl.py
@@ -74,7 +74,7 @@ class PyHcclCommunicator:
         self.available = True
         self.disabled = False
 
-        logger.info("vLLM is using pyhccl")
+        logger.info("sglang is using pyhccl")
 
         if isinstance(device, int):
             device = torch.device(f"npu:{device}")
@@ -155,10 +155,7 @@ class PyHcclCommunicator:
         )
         if stream is None:
             stream = current_stream()
-        if src == self.rank:
-            buffer = buffer_type(tensor.data_ptr())
-        else:
-            buffer = buffer_type(tensor.data_ptr())
+        buffer = buffer_type(tensor.data_ptr())
         self.hccl.hcclBroadcast(
             buffer,
             tensor.numel(),

--- a/python/sglang/srt/distributed/device_communicators/pyhccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pyhccl.py
@@ -1,19 +1,26 @@
-
 # Adapted from https://github.com/vllm-project/vllm-ascend/blob/v0.11.0-dev/vllm_ascend/distributed/device_communicators/pyhccl.py
 
-from typing import Optional, Union
 import logging
+from typing import Optional, Union
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup, ReduceOp
 
+from sglang.srt.distributed.device_communicators.pyhccl_wrapper import (
+    HCCLLibrary,
+    aclrtStream_t,
+    buffer_type,
+    current_stream,
+    hcclComm_t,
+    hcclDataTypeEnum,
+    hcclRedOpTypeEnum,
+    hcclUniqueId,
+)
 from sglang.srt.distributed.utils import StatelessProcessGroup
 
-from sglang.srt.distributed.device_communicators.pyhccl_wrapper import (
-    HCCLLibrary, aclrtStream_t, buffer_type, hcclComm_t, hcclDataTypeEnum,
-    hcclRedOpTypeEnum, hcclUniqueId, current_stream)
-
 logger = logging.getLogger(__name__)
+
 
 class PyHcclCommunicator:
 
@@ -37,8 +44,9 @@ class PyHcclCommunicator:
 
         if not isinstance(group, StatelessProcessGroup):
             assert dist.is_initialized()
-            assert dist.get_backend(group) != dist.Backend.HCCL, (
-                "PyHcclCommunicator should be attached to a non-HCCL group.")
+            assert (
+                dist.get_backend(group) != dist.Backend.HCCL
+            ), "PyHcclCommunicator should be attached to a non-HCCL group."
             # note: this rank is the rank in the group
             self.rank = dist.get_rank(group)
             self.world_size = dist.get_world_size(group)
@@ -100,7 +108,8 @@ class PyHcclCommunicator:
         # current npu device to the specified one
         with torch.npu.device(device):
             self.comm: hcclComm_t = self.hccl.hcclCommInitRank(
-                self.world_size, self.unique_id, self.rank)
+                self.world_size, self.unique_id, self.rank
+            )
 
             stream = current_stream()
             # A small all_reduce for warmup.
@@ -109,10 +118,9 @@ class PyHcclCommunicator:
             stream.synchronize()
             del data
 
-    def all_reduce(self,
-                   in_tensor: torch.Tensor,
-                   op: ReduceOp = ReduceOp.SUM,
-                   stream=None) -> torch.Tensor:
+    def all_reduce(
+        self, in_tensor: torch.Tensor, op: ReduceOp = ReduceOp.SUM, stream=None
+    ) -> torch.Tensor:
         if self.disabled:
             return None
         # hccl communicator created on a specific device
@@ -120,18 +128,22 @@ class PyHcclCommunicator:
         # otherwise it will cause "illegal memory access"
         assert in_tensor.device == self.device, (
             f"this hccl communicator is created to work on {self.device}, "
-            f"but the input tensor is on {in_tensor.device}")
+            f"but the input tensor is on {in_tensor.device}"
+        )
 
         out_tensor = torch.empty_like(in_tensor)
 
         if stream is None:
             stream = current_stream()
-        self.hccl.hcclAllReduce(buffer_type(in_tensor.data_ptr()),
-                                buffer_type(out_tensor.data_ptr()),
-                                in_tensor.numel(),
-                                hcclDataTypeEnum.from_torch(in_tensor.dtype),
-                                hcclRedOpTypeEnum.from_torch(op), self.comm,
-                                aclrtStream_t(stream.npu_stream))
+        self.hccl.hcclAllReduce(
+            buffer_type(in_tensor.data_ptr()),
+            buffer_type(out_tensor.data_ptr()),
+            in_tensor.numel(),
+            hcclDataTypeEnum.from_torch(in_tensor.dtype),
+            hcclRedOpTypeEnum.from_torch(op),
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
         return out_tensor
 
     def broadcast(self, tensor: torch.Tensor, src: int, stream=None):
@@ -139,72 +151,89 @@ class PyHcclCommunicator:
             return
         assert tensor.device == self.device, (
             f"this hccl communicator is created to work on {self.device}, "
-            f"but the input tensor is on {tensor.device}")
+            f"but the input tensor is on {tensor.device}"
+        )
         if stream is None:
             stream = current_stream()
         if src == self.rank:
             buffer = buffer_type(tensor.data_ptr())
         else:
             buffer = buffer_type(tensor.data_ptr())
-        self.hccl.hcclBroadcast(buffer, tensor.numel(),
-                                hcclDataTypeEnum.from_torch(tensor.dtype), src,
-                                self.comm, aclrtStream_t(stream.npu_stream))
-    
-    def all_gather(self, out_tensor: torch.Tensor, in_tensor: torch.Tensor, stream=None):
+        self.hccl.hcclBroadcast(
+            buffer,
+            tensor.numel(),
+            hcclDataTypeEnum.from_torch(tensor.dtype),
+            src,
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
+
+    def all_gather(
+        self, out_tensor: torch.Tensor, in_tensor: torch.Tensor, stream=None
+    ):
         if self.disabled:
             return
         assert in_tensor.device == self.device, (
             f"this hccl communicator is created to work on {self.device}, "
-            f"but the input tensor is on {in_tensor.device}")
+            f"but the input tensor is on {in_tensor.device}"
+        )
 
         assert out_tensor.device == self.device, (
             f"this hccl communicator is created to work on {self.device}, "
-            f"but the input tensor is on {out_tensor.device}")
+            f"but the input tensor is on {out_tensor.device}"
+        )
 
         if stream is None:
             stream = current_stream()
-               
+
         self.hccl.hcclAllGather(
-                buffer_type(in_tensor.data_ptr()),
-                buffer_type(out_tensor.data_ptr()),
-                in_tensor.numel(),
-                hcclDataTypeEnum.from_torch(in_tensor.dtype),
-                self.comm,
-                aclrtStream_t(stream.npu_stream),
-            )
+            buffer_type(in_tensor.data_ptr()),
+            buffer_type(out_tensor.data_ptr()),
+            in_tensor.numel(),
+            hcclDataTypeEnum.from_torch(in_tensor.dtype),
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
 
-    def reduce_scatter(self, in_tensor: torch.Tensor, out_tensor: torch.Tensor, 
-                       op: ReduceOp = ReduceOp.SUM, stream=None):
+    def reduce_scatter(
+        self,
+        in_tensor: torch.Tensor,
+        out_tensor: torch.Tensor,
+        op: ReduceOp = ReduceOp.SUM,
+        stream=None,
+    ):
         if self.disabled:
             return
         assert in_tensor.device == self.device, (
             f"this hccl communicator is created to work on {self.device}, "
-            f"but the input tensor is on {in_tensor.device}")
+            f"but the input tensor is on {in_tensor.device}"
+        )
 
         assert out_tensor.device == self.device, (
             f"this hccl communicator is created to work on {self.device}, "
-            f"but the input tensor is on {out_tensor.device}")
+            f"but the input tensor is on {out_tensor.device}"
+        )
 
         if stream is None:
             stream = current_stream()
-               
+
         self.hccl.hcclReduceScatter(
-                buffer_type(in_tensor.data_ptr()),
-                buffer_type(out_tensor.data_ptr()),
-                out_tensor.numel(),
-                hcclDataTypeEnum.from_torch(in_tensor.dtype),
-                hcclRedOpTypeEnum.from_torch(op),
-                self.comm,
-                aclrtStream_t(stream.npu_stream),
-            )
+            buffer_type(in_tensor.data_ptr()),
+            buffer_type(out_tensor.data_ptr()),
+            out_tensor.numel(),
+            hcclDataTypeEnum.from_torch(in_tensor.dtype),
+            hcclRedOpTypeEnum.from_torch(op),
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )
 
     def barrier(self, stream=None):
         if self.disabled:
             return
         if stream is None:
             stream = current_stream()
-               
+
         self.hccl.hcclBarrier(
-                self.comm,
-                aclrtStream_t(stream.npu_stream),
-            )
+            self.comm,
+            aclrtStream_t(stream.npu_stream),
+        )

--- a/python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py
@@ -141,10 +141,8 @@ class HCCLLibrary:
     exported_functions = [
         # const char* HcclGetErrorString(HcclResult code);
         Function("HcclGetErrorString", ctypes.c_char_p, [hcclResult_t]),
-
         # HcclResult HcclGetRootInfo(HcclRootInfo *rootInfo);
         Function("HcclGetRootInfo", hcclResult_t, [ctypes.POINTER(hcclUniqueId)]),
-
         # HcclResult HcclCommInitRootInfo(
         #   uint32_t nRanks, const HcclRootInfo *rootInfo, uint32_t rank, HcclComm *comm);
         # note that HcclComm is a pointer type, so the last argument is a pointer to a pointer
@@ -336,7 +334,7 @@ class HCCLLibrary:
         stream: aclrtStream_t,
     ) -> None:
         self.HCCL_CHECK(
-            self._funcs["HcclBroadcast"](buf, count, datatype,root, comm, stream)
+            self._funcs["HcclBroadcast"](buf, count, datatype, root, comm, stream)
         )
 
     def hcclAllGather(

--- a/python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py
@@ -1,0 +1,329 @@
+# Adapted from https://github.com/vllm-project/vllm-ascend/blob/v0.11.0-dev/vllm_ascend/distributed/device_communicators/pyhccl_wrapper.py
+
+import os
+import logging
+import ctypes
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.distributed import ReduceOp
+
+
+# export types and functions from hccl to Python ===
+# for the original hccl definition, please check
+# https://github.com/EternalLied/cann-hccl-new/blob/64ec6ce2923319caa5df8c3c531e06bdc148ce9c/inc/hccl/hccl.h#L90
+# https://github.com/EternalLied/cann-hccl-new/blob/64ec6ce2923319caa5df8c3c531e06bdc148ce9c/inc/hccl/hccl_types.h#L48
+
+hcclResult_t = ctypes.c_int
+hcclComm_t = ctypes.c_void_p
+
+
+logger = logging.getLogger(__name__)
+
+class hcclUniqueId(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * 4108)]
+
+
+aclrtStream_t = ctypes.c_void_p
+buffer_type = ctypes.c_void_p
+
+hcclDataType_t = ctypes.c_int
+
+_CURRENT_STREAM = None
+
+def find_hccl_library() -> str:
+    """
+    We either use the library file specified by the `HCCL_SO_PATH`
+    environment variable, or we find the library file brought by PyTorch.
+    After importing `torch`, `libhccl.so` can be
+    found by `ctypes` automatically.
+    """
+    so_file = os.environ.get("HCCL_SO_PATH", None)
+
+    # manually load the hccl library
+    if so_file:
+        logger.info("Found hccl from environment variable HCCL_SO_PATH=%s",
+                    so_file)
+    else:
+        if torch.version.cann is not None:
+            so_file = "libhccl.so"
+        else:
+            raise ValueError("HCCL only supports Ascend NPU backends.")
+        logger.info("Found hccl from library %s", so_file)
+    return so_file
+
+def current_stream() -> torch.npu.Stream:
+    """
+    replace `torch.npu.current_stream()` with `vllm.utils.current_stream()`.
+    it turns out that `torch.npu.current_stream()` is quite expensive,
+    as it will construct a new stream object at each call.
+    here we patch `torch.npu.set_stream` to keep track of the current stream
+    directly, so that we can avoid calling `torch.npu.current_stream()`.
+
+    """
+    global _CURRENT_STREAM
+    if _CURRENT_STREAM is None:
+        # when this function is called before any stream is set,
+        # we return the default stream.
+        _CURRENT_STREAM = torch.npu.current_stream()
+    return _CURRENT_STREAM
+
+class hcclDataTypeEnum:
+    hcclInt8 = 0
+    hcclInt16 = 1
+    hcclInt32 = 2
+    hcclFloat16 = 3
+    hcclFloat32 = 4
+    hcclInt64 = 5
+    hcclUint64 = 6
+    hcclUint8 = 7
+    hcclUint16 = 8
+    hcclUint32 = 9
+    hcclFloat64 = 10
+    hcclBfloat16 = 11
+    hcclInt128 = 12
+
+    @classmethod
+    def from_torch(cls, dtype: torch.dtype) -> int:
+        if dtype == torch.int8:
+            return cls.hcclInt8
+        if dtype == torch.uint8:
+            return cls.hcclUint8
+        if dtype == torch.int32:
+            return cls.hcclInt32
+        if dtype == torch.int64:
+            return cls.hcclInt64
+        if dtype == torch.float16:
+            return cls.hcclFloat16
+        if dtype == torch.float32:
+            return cls.hcclFloat32
+        if dtype == torch.float64:
+            return cls.hcclFloat64
+        if dtype == torch.bfloat16:
+            return cls.hcclBfloat16
+        raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+hcclRedOp_t = ctypes.c_int
+
+
+class hcclRedOpTypeEnum:
+    hcclSum = 0
+    hcclProd = 1
+    hcclMax = 2
+    hcclMin = 3
+
+    @classmethod
+    def from_torch(cls, op: ReduceOp) -> int:
+        if op == ReduceOp.SUM:
+            return cls.hcclSum
+        if op == ReduceOp.PRODUCT:
+            return cls.hcclProd
+        if op == ReduceOp.MAX:
+            return cls.hcclMax
+        if op == ReduceOp.MIN:
+            return cls.hcclMin
+        raise ValueError(f"Unsupported op: {op}")
+
+
+@dataclass
+class Function:
+    name: str
+    restype: Any
+    argtypes: List[Any]
+
+
+class HCCLLibrary:
+    exported_functions = [
+        # const char* HcclGetErrorString(HcclResult code);
+        Function("HcclGetErrorString", ctypes.c_char_p, [hcclResult_t]),
+
+        # HcclResult HcclGetRootInfo(HcclRootInfo *rootInfo);
+        Function("HcclGetRootInfo", hcclResult_t,
+                 [ctypes.POINTER(hcclUniqueId)]),
+
+        # HcclResult HcclCommInitRootInfo(
+        #   uint32_t nRanks, const HcclRootInfo *rootInfo, uint32_t rank, HcclComm *comm);
+        # note that HcclComm is a pointer type, so the last argument is a pointer to a pointer
+        Function("HcclCommInitRootInfo", hcclResult_t, [
+            ctypes.c_int,
+            ctypes.POINTER(hcclUniqueId),
+            ctypes.c_int,
+            ctypes.POINTER(hcclComm_t),
+        ]),
+
+        # HcclResult HcclAllReduce(
+        #   void *sendBuf, void *recvBuf, uint64_t count,
+        #   HcclDataType dataType, HcclReduceOp op, HcclComm comm,
+        #   aclrtStream stream);
+        Function("HcclAllReduce", hcclResult_t, [
+            buffer_type,
+            buffer_type,
+            ctypes.c_size_t,
+            hcclDataType_t,
+            hcclRedOp_t,
+            hcclComm_t,
+            aclrtStream_t,
+        ]),
+
+        # HcclResult HcclBroadcast(
+        #   void *buf, uint64_t count,
+        #   HcclDataType dataType, uint32_t root,
+        #   HcclComm comm, aclrtStream stream);
+        Function("HcclBroadcast", hcclResult_t, [
+            buffer_type,
+            ctypes.c_size_t,
+            hcclDataType_t,
+            ctypes.c_int,
+            hcclComm_t,
+            aclrtStream_t,
+        ]),
+        
+        # HcclResult HcclAllGather(
+        #   void *sendBuf, void *recvBuf, 
+        #   uint64_t sendCount, HcclDataType dataType, 
+        #   HcclComm comm, aclrtStream stream);
+        Function("HcclAllGather", hcclResult_t, [
+            buffer_type,
+            buffer_type,
+            ctypes.c_size_t,
+            hcclDataType_t,
+            hcclComm_t,
+            aclrtStream_t,
+        ]),
+        
+        # HcclResult HcclReduceScatter(
+        #   void *sendBuf, void *recvBuf, 
+        #   uint64_t recvCount, HcclDataType dataType, 
+        #   HcclReduceOp op, HcclComm comm, 
+        #   aclrtStream stream);
+        Function("HcclReduceScatter", hcclResult_t, [
+            buffer_type,
+            buffer_type,
+            ctypes.c_size_t,
+            hcclDataType_t,
+            hcclRedOp_t,
+            hcclComm_t,
+            aclrtStream_t,
+        ]),
+
+        # HcclResult HcclBarrier(
+        #   HcclComm comm, aclrtStream stream);
+        Function("HcclBarrier", hcclResult_t, [
+            hcclComm_t,
+            aclrtStream_t,
+        ]),
+
+        # HcclResult HcclCommDestroy(HcclComm comm);
+        Function("HcclCommDestroy", hcclResult_t, [hcclComm_t]),
+    ]
+
+    # class attribute to store the mapping from the path to the library
+    # to avoid loading the same library multiple times
+    path_to_library_cache: Dict[str, Any] = {}
+
+    # class attribute to store the mapping from library path
+    # to the correspongding directory
+    path_to_dict_mapping: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(self, so_file: Optional[str] = None):
+
+        so_file = so_file or find_hccl_library()
+
+        try:
+            if so_file not in HCCLLibrary.path_to_dict_mapping:
+                
+                lib = ctypes.CDLL(so_file)
+                HCCLLibrary.path_to_library_cache[so_file] = lib
+            self.lib = HCCLLibrary.path_to_library_cache[so_file]
+        except Exception as e:
+            logger.error(
+                "Failed to load HCCL library from %s. "
+                "It is expected if you are not running on Ascend NPUs."
+                "Otherwise, the hccl library might not exist, be corrupted "
+                "or it does not support the current platform %s. "
+                "If you already have the library, please set the "
+                "environment variable HCCL_SO_PATH"
+                " to point to the correct hccl library path.", so_file,
+                platform.platform())
+            raise e
+
+        if so_file not in HCCLLibrary.path_to_dict_mapping:
+            _funcs: Dict[str, Any] = {}
+            for func in HCCLLibrary.exported_functions:
+                f = getattr(self.lib, func.name)
+                f.restype = func.restype
+                f.argtypes = func.argtypes
+                _funcs[func.name] = f
+            HCCLLibrary.path_to_dict_mapping[so_file] = _funcs
+        self._funcs = HCCLLibrary.path_to_dict_mapping[so_file]
+
+    def hcclGetErrorString(self, result: hcclResult_t) -> str:
+        return self._funcs["HcclGetErrorString"](result).decode("utf-8")
+
+    def HCCL_CHECK(self, result: hcclResult_t) -> None:
+        if result != 0:
+            error_str = self.hcclGetErrorString(result)
+            raise RuntimeError(f"HCCL error: {error_str}")
+
+    def hcclGetUniqueId(self) -> hcclUniqueId:
+        unique_id = hcclUniqueId()
+        self.HCCL_CHECK(self._funcs["HcclGetRootInfo"](
+            ctypes.byref(unique_id)))
+        return unique_id
+
+    def hcclCommInitRank(self, world_size: int, unique_id: hcclUniqueId,
+                         rank: int) -> hcclComm_t:
+        comm = hcclComm_t()
+        self.HCCL_CHECK(self._funcs["HcclCommInitRootInfo"](
+            world_size, ctypes.byref(unique_id), rank, ctypes.byref(comm)))
+        return comm
+
+    def hcclAllReduce(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, op: int, comm: hcclComm_t,
+                      stream: aclrtStream_t) -> None:
+        # `datatype` actually should be `hcclDataType_t`
+        # and `op` should be `hcclRedOp_t`
+        # both are aliases of `ctypes.c_int`
+        # when we pass int to a function, it will be converted to `ctypes.c_int`
+        # by ctypes automatically
+        self.HCCL_CHECK(self._funcs["HcclAllReduce"](sendbuff, recvbuff, count,
+                                                     datatype, op, comm,
+                                                     stream))
+
+    def hcclBroadcast(self, buf: buffer_type, count: int, datatype: int,
+                      root: int, comm: hcclComm_t,
+                      stream: aclrtStream_t) -> None:
+        self.HCCL_CHECK(self._funcs["HcclBroadcast"](buf, count, datatype,
+                                                   root, comm, stream))
+  
+    def hcclAllGather(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                      count: int, datatype: int, comm: hcclComm_t,
+                      stream: aclrtStream_t) -> None:
+        self.HCCL_CHECK(self._funcs["HcclAllGather"](sendbuff, recvbuff, count,
+                                                     datatype, comm, stream))
+        
+    def hcclReduceScatter(self, sendbuff: buffer_type, recvbuff: buffer_type,
+                          count: int, datatype: int, op: int, comm: hcclComm_t,
+                          stream: aclrtStream_t) -> None:
+        self.HCCL_CHECK(self._funcs["HcclReduceScatter"](sendbuff, recvbuff, count,
+                                                     datatype, op, comm, stream))
+    
+    def hcclBarrier(self, comm: hcclComm_t, stream: aclrtStream_t) -> None:
+        self.HCCL_CHECK(self._funcs["HcclBarrier"](comm, stream))
+    
+    def hcclCommDestroy(self, comm: hcclComm_t) -> None:
+        self.HCCL_CHECK(self._funcs["HcclCommDestroy"](comm))
+
+
+__all__ = [
+    "HCCLLibrary",
+    "hcclDataTypeEnum",
+    "hcclRedOpTypeEnum",
+    "hcclUniqueId",
+    "hcclComm_t",
+    "aclrtStream_t",
+    "buffer_type",
+]

--- a/python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py
@@ -57,7 +57,7 @@ def find_hccl_library() -> str:
 
 def current_stream() -> torch.npu.Stream:
     """
-    replace `torch.npu.current_stream()` with `vllm.utils.current_stream()`.
+    replace `torch.npu.current_stream()` with `pyhccl_wrapper.current_stream()`.
     it turns out that `torch.npu.current_stream()` is quite expensive,
     as it will construct a new stream object at each call.
     here we patch `torch.npu.set_stream` to keep track of the current stream

--- a/test/srt/ascend/test_ascend_pyhccl.py
+++ b/test/srt/ascend/test_ascend_pyhccl.py
@@ -1,0 +1,220 @@
+import multiprocessing
+import os
+import unittest
+
+import pytest
+import torch
+
+from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+    update_environment_variables,
+)
+from sglang.srt.distributed.device_communicators.pyhccl import PyHcclCommunicator
+from sglang.srt.distributed.parallel_state import (
+    get_world_group,
+    init_distributed_environment,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def distributed_run(fn, world_size):
+    number_of_processes = world_size
+    processes: list[multiprocessing.Process] = []
+    for i in range(number_of_processes):
+        env: dict[str, str] = {}
+        env["RANK"] = str(i)
+        env["LOCAL_RANK"] = str(i)
+        env["WORLD_SIZE"] = str(number_of_processes)
+        env["LOCAL_WORLD_SIZE"] = str(number_of_processes)
+        env["MASTER_ADDR"] = "127.0.0.1"
+        env["MASTER_PORT"] = "12345"
+        p = multiprocessing.Process(target=fn, args=(env,))
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    for p in processes:
+        assert p.exitcode == 0
+
+
+def worker_fn_wrapper(fn):
+    # `multiprocessing.Process` cannot accept environment variables directly
+    # so we need to pass the environment variables as arguments
+    # and update the environment variables in the function
+
+    def wrapped_fn(env):
+        update_environment_variables(env)
+        rank = int(os.environ["RANK"])
+        world_size = int(os.environ["WORLD_SIZE"])
+        local_rank = os.environ["LOCAL_RANK"]
+        ip = env["MASTER_ADDR"]
+        port = env["MASTER_PORT"]
+
+        device = torch.device(f"npu:{local_rank}")
+        torch.npu.set_device(device)
+        init_distributed_environment(
+            world_size=world_size,
+            rank=rank,
+            distributed_init_method=f"tcp://{ip}:{port}",
+            backend="hccl",
+        )
+        fn()
+
+    return wrapped_fn
+
+
+@worker_fn_wrapper
+def worker_fn():
+    pyhccl_comm = PyHcclCommunicator(
+        get_world_group().cpu_group, device=get_world_group().device
+    )
+    tensor = torch.ones(16, 1024, 1024, dtype=torch.float32).npu(pyhccl_comm.rank)
+    tensor = pyhccl_comm.all_reduce(tensor)
+    torch.npu.synchronize()
+
+    assert torch.all(tensor == pyhccl_comm.world_size).cpu().item()
+
+
+@worker_fn_wrapper
+def multiple_allreduce_worker_fn():
+    device = torch.device(f"npu:{torch.distributed.get_rank()}")
+    groups = [
+        torch.distributed.new_group(ranks=[0, 1], backend="gloo"),
+        torch.distributed.new_group(ranks=[2, 3], backend="gloo"),
+    ]
+    group = groups[0] if torch.distributed.get_rank() in [0, 1] else groups[1]
+    pyhccl_comm = PyHcclCommunicator(group=group, device=device)
+    tensor = torch.ones(16, 1024, 1024, dtype=torch.float32, device=device)
+    # two groups can communicate independently
+    if torch.distributed.get_rank() in [0, 1]:
+        tensor = pyhccl_comm.all_reduce(tensor)
+        tensor = pyhccl_comm.all_reduce(tensor)
+        torch.npu.synchronize()
+        assert torch.all(tensor == 4).cpu().item()
+    else:
+        tensor = pyhccl_comm.all_reduce(tensor)
+        torch.npu.synchronize()
+        assert torch.all(tensor == 2).cpu().item()
+
+
+@worker_fn_wrapper
+def broadcast_worker_fn():
+    # Test broadcast for every root rank.
+    # Essentially this is an all-gather operation.
+    pyhccl_comm = PyHcclCommunicator(
+        get_world_group().cpu_group, device=get_world_group().device
+    )
+    recv_tensors = [
+        torch.empty(16, 1024, 1024, dtype=torch.float32, device=pyhccl_comm.device)
+        for i in range(pyhccl_comm.world_size)
+    ]
+    recv_tensors[pyhccl_comm.rank] = (
+        torch.ones(16, 1024, 1024, dtype=torch.float32, device=pyhccl_comm.device)
+        * pyhccl_comm.rank
+    )
+
+    for i in range(pyhccl_comm.world_size):
+        pyhccl_comm.broadcast(recv_tensors[i], src=i)
+        # the broadcast op might be launched in a different stream
+        # need to synchronize to make sure the tensor is ready
+        torch.npu.synchronize()
+        assert torch.all(recv_tensors[i] == i).cpu().item()
+
+
+@worker_fn_wrapper
+def all_gather_worker_fn():
+    pyhccl_comm = PyHcclCommunicator(
+        get_world_group().cpu_group, device=get_world_group().device
+    )
+
+    rank = pyhccl_comm.rank
+    world_size = pyhccl_comm.world_size
+    device = f"npu:{pyhccl_comm.rank}"
+
+    num_elems = 1000
+    tensor = (
+        torch.arange(num_elems, dtype=torch.float32, device=device) + rank * num_elems
+    )
+    result = torch.zeros(num_elems * world_size, dtype=torch.float32, device=device)
+
+    expected = torch.cat(
+        [
+            torch.arange(num_elems, dtype=torch.float32) + r * num_elems
+            for r in range(world_size)
+        ]
+    ).to(device)
+
+    pyhccl_comm.all_gather(result, tensor)
+    torch.npu.synchronize()
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-8)
+
+
+@worker_fn_wrapper
+def reduce_scatter_worker_fn():
+    pyhccl_comm = PyHcclCommunicator(
+        get_world_group().cpu_group, device=get_world_group().device
+    )
+
+    rank = pyhccl_comm.rank
+    world_size = pyhccl_comm.world_size
+    device = f"npu:{pyhccl_comm.rank}"
+
+    num_elems = 1000
+    tensor = (
+        torch.arange(num_elems, dtype=torch.float32, device=device) + rank * num_elems
+    )
+    assert num_elems % world_size == 0
+    result = torch.zeros(num_elems // world_size, dtype=torch.float32, device=device)
+
+    # Calculate expected result for this rank's chunk
+    scattered_size = num_elems // world_size
+    all_tensors = [
+        torch.arange(num_elems, dtype=torch.float32) + r * num_elems
+        for r in range(world_size)
+    ]
+    expected = sum(
+        tensor[rank * scattered_size : (rank + 1) * scattered_size]
+        for tensor in all_tensors
+    ).to(device)
+
+    pyhccl_comm.reduce_scatter(tensor, result)
+
+    torch.npu.synchronize()
+    torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-8)
+
+
+class TestAscendPyhccl(CustomTestCase):
+    @pytest.mark.skipif(
+        torch.npu.device_count() < 2, reason="Need at least 2 GPUs to run the test."
+    )
+    def test_pyhccl(self):
+        distributed_run(worker_fn, 2)
+
+    @pytest.mark.skipif(
+        torch.npu.device_count() < 4, reason="Need at least 4 GPUs to run the test."
+    )
+    def test_pyhccl_multiple_allreduce(self):
+        distributed_run(multiple_allreduce_worker_fn, 4)
+
+    @pytest.mark.skipif(
+        torch.npu.device_count() < 4, reason="Need at least 4 GPUs to run the test."
+    )
+    def test_pyhccl_broadcast(self):
+        distributed_run(broadcast_worker_fn, 4)
+
+    @pytest.mark.skipif(
+        torch.npu.device_count() < 2, reason="Need at least 2 GPUs to run the test."
+    )
+    def test_pyhccl_all_gather(self):
+        distributed_run(all_gather_worker_fn, 2)
+
+    @pytest.mark.skipif(
+        torch.npu.device_count() < 2, reason="Need at least 2 GPUs to run the test."
+    )
+    def test_pyhccl_reduce_scatter(self):
+        distributed_run(reduce_scatter_worker_fn, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

In RL async mode, multiple communication groups are often required for coordination between actors and rollout workers. However, Ray's collective communication interfaces currently do not support the HCCL backend. To address this, pynccl (and its counterpart pyhccl) are used to support the creation of new communication groups. Furthermore, pyhccl will be utilized for KV Cache communication, ensuring efficient data exchange across NPUs. While vLLM already supports both([[Core] Add pyhccl](https://github.com/vllm-project/vllm-ascend/pull/503)), sglang currently only supports pynccl. This PR aims to bridge that gap by supporting pyhccl to sglang.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

add two files:
python/sglang/srt/distributed/device_communicators/pyhccl.py
python/sglang/srt/distributed/device_communicators/pyhccl_wrapper.py

Within these two files, we wrap collective communication algorithms—including All-Reduce, Broadcast, All-Gather, Reduce-Scatter, and Barrier using `hccl_library`.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

We have verified the correctness of the provided collective communication library:
```
[CI Test Method] TestAscendPyhccl.test_pyhccl
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-01-05 20:50:41] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:41] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:41] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:50:41] INFO pyhccl.py:77: sglang is using pyhccl
.[CI Test Method] TestAscendPyhccl.test_pyhccl_all_gather
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-01-05 20:50:45] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:45] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:45] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:50:45] INFO pyhccl.py:77: sglang is using pyhccl
.[CI Test Method] TestAscendPyhccl.test_pyhccl_broadcast
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[2026-01-05 20:50:56] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:56] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:50:56] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:56] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:50:56] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:56] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:50:56] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:50:56] INFO pyhccl.py:77: sglang is using pyhccl
.[CI Test Method] TestAscendPyhccl.test_pyhccl_multiple_allreduce
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-01-05 20:51:00] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:51:00] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:51:00] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:51:00] INFO pyhccl.py:77: sglang is using pyhccl
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-01-05 20:51:00] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:51:00] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:51:00] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:51:00] INFO pyhccl.py:77: sglang is using pyhccl
.[CI Test Method] TestAscendPyhccl.test_pyhccl_reduce_scatter
[Gloo] Rank 0 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[Gloo] Rank 1 is connected to 1 peer ranks. Expected number of connected peer ranks is : 1
[2026-01-05 20:51:04] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:51:04] INFO pyhccl_wrapper.py:54: Found hccl from library libhccl.so
[2026-01-05 20:51:04] INFO pyhccl.py:77: sglang is using pyhccl
[2026-01-05 20:51:04] INFO pyhccl.py:77: sglang is using pyhccl
.
----------------------------------------------------------------------
Ran 5 tests in 34.045s

OK
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
