### PR TITLE
Add warmup iterations to fix flaky speed tests in CI

### DIFF
--- a/test/srt/test_deepseek_v32_basic.py
+++ b/test/srt/test_deepseek_v32_basic.py
@@ -64,15 +64,15 @@ class TestDeepseekV32Basic(CustomTestCase):
     def test_bs_1_speed(self):
         # Additional warmup for single-request long-sequence generation
         # GSM8K's parallel batch warmup may not be sufficient for bs=1 long-sequence scenarios
-        warmup_args = BenchArgs(
+        args = BenchArgs(
             port=int(self.base_url.split(":")[-1]), max_new_tokens=2048
         )
-        for i in range(3):
-            print(f"Warmup iteration {i+1}/3...")
-            send_one_prompt(warmup_args)
+        num_warmup_iterations = 3
+        for i in range(num_warmup_iterations):
+            print(f"Warmup iteration {i+1}/{num_warmup_iterations}...")
+            send_one_prompt(args)
 
         # Actual test
-        args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=2048)
         acc_length, speed = send_one_prompt(args)
 
         print(f"{speed=:.2f}")

--- a/test/srt/test_deepseek_v32_basic.py
+++ b/test/srt/test_deepseek_v32_basic.py
@@ -62,6 +62,16 @@ class TestDeepseekV32Basic(CustomTestCase):
             self.assertGreater(metrics["accuracy"], 0.935)
 
     def test_bs_1_speed(self):
+        # Additional warmup for single-request long-sequence generation
+        # GSM8K's parallel batch warmup may not be sufficient for bs=1 long-sequence scenarios
+        warmup_args = BenchArgs(
+            port=int(self.base_url.split(":")[-1]), max_new_tokens=2048
+        )
+        for i in range(3):
+            print(f"Warmup iteration {i+1}/3...")
+            send_one_prompt(warmup_args)
+
+        # Actual test
         args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=2048)
         acc_length, speed = send_one_prompt(args)
 

--- a/test/srt/test_deepseek_v3_basic.py
+++ b/test/srt/test_deepseek_v3_basic.py
@@ -56,6 +56,16 @@ class TestDeepseekV3Basic(CustomTestCase):
             self.assertGreater(metrics["accuracy"], 0.935)
 
     def test_bs_1_speed(self):
+        # Additional warmup for single-request long-sequence generation
+        # GSM8K's parallel batch warmup may not be sufficient for bs=1 long-sequence scenarios
+        warmup_args = BenchArgs(
+            port=int(self.base_url.split(":")[-1]), max_new_tokens=2048
+        )
+        for i in range(3):
+            print(f"Warmup iteration {i+1}/3...")
+            send_one_prompt(warmup_args)
+
+        # Actual test
         args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=2048)
         acc_length, speed = send_one_prompt(args)
 

--- a/test/srt/test_deepseek_v3_basic.py
+++ b/test/srt/test_deepseek_v3_basic.py
@@ -58,15 +58,15 @@ class TestDeepseekV3Basic(CustomTestCase):
     def test_bs_1_speed(self):
         # Additional warmup for single-request long-sequence generation
         # GSM8K's parallel batch warmup may not be sufficient for bs=1 long-sequence scenarios
-        warmup_args = BenchArgs(
+        args = BenchArgs(
             port=int(self.base_url.split(":")[-1]), max_new_tokens=2048
         )
-        for i in range(3):
-            print(f"Warmup iteration {i+1}/3...")
-            send_one_prompt(warmup_args)
+        num_warmup_iterations = 3
+        for i in range(num_warmup_iterations):
+            print(f"Warmup iteration {i+1}/{num_warmup_iterations}...")
+            send_one_prompt(args)
 
         # Actual test
-        args = BenchArgs(port=int(self.base_url.split(":")[-1]), max_new_tokens=2048)
         acc_length, speed = send_one_prompt(args)
 
         print(f"{speed=:.2f}")


### PR DESCRIPTION
The DeepSeek V3/V32 speed tests were experiencing flaky behavior in CI (14 tok/s vs 107 tok/s locally). The GSM8K test's parallel batch warmup is insufficient for single-request long-sequence scenarios in test_bs_1_speed.

Added 3 warmup iterations with identical parameters (max_new_tokens=2048) before the actual speed test to ensure GPU kernels are properly warmed up.

Fixes intermittent test failures on 8-GPU H200 CI environment.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
