### PR TITLE
Enable testing slash command handler changes on non-fork PRs

### DIFF
--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -22,8 +22,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # SECURITY: This workflow runs on issue_comment trigger with elevated permissions
+      # (pull-requests: write, actions: write). For non-fork PRs, we can safely checkout
+      # the PR branch to allow testing changes to this handler. For fork PRs, we MUST
+      # stay on main to prevent untrusted code execution with these elevated permissions.
+      - name: Get PR details
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName,headRepositoryOwner) || {
+            echo "::error::Failed to fetch PR data"
+            exit 1
+          }
+          # Use 'empty' filter to handle null/missing values (e.g., deleted forks)
+          HEAD_OWNER=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login // empty')
+          REPO_OWNER="${{ github.repository_owner }}"
+          # Treat missing/null owner as fork for security (fail-safe)
+          if [[ -z "$HEAD_OWNER" || "$HEAD_OWNER" != "$REPO_OWNER" ]]; then
+            IS_FORK="true"
+          else
+            IS_FORK="false"
+          fi
+          echo "is_fork=$IS_FORK" >> $GITHUB_OUTPUT
+          echo "ref=$(echo "$PR_DATA" | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+          echo "PR owner: $HEAD_OWNER, Repo owner: $REPO_OWNER, Is fork: $IS_FORK"
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For non-fork PRs, checkout PR branch to allow testing handler changes
+          # For fork PRs, stay on main for security (don't run untrusted code with elevated permissions)
+          ref: ${{ steps.pr.outputs.is_fork == 'false' && steps.pr.outputs.ref || '' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
Add conditional checkout logic to the slash command handler workflow to enable testing handler changes before merging.

**Problem**: Currently, the slash command handler workflow always checks out `main`, meaning any changes to the handler can only be tested *after* merging - a chicken-and-egg problem.

**Solution**: 
- For **non-fork PRs**: checkout the PR branch, allowing changes to be tested
- For **fork PRs**: stay on `main` for security (don't run untrusted code with elevated permissions)

## Security Considerations
The workflow runs with elevated permissions (`pull-requests: write`, `actions: write`). Running fork code with these permissions would be a security risk, so we only enable PR branch checkout for non-fork PRs (trusted contributors).

The implementation includes:
- Fail-safe behavior: treat null/missing owner as fork
- Error handling for GitHub CLI failures
- Clear security comments explaining the model

## Test Plan
- [x] Tested bash logic locally - correctly detects fork vs non-fork PRs
- [ ] CI passes (validates YAML syntax and no breaking changes)
- [ ] After merge: verify non-fork PRs checkout PR branch via workflow logs