### PR TITLE
[model-gateway]  add --connection-mode for {http/grpc} URLs

### DIFF
--- a/docs/advanced_features/sgl_model_gateway.md
+++ b/docs/advanced_features/sgl_model_gateway.md
@@ -166,6 +166,18 @@ python -m sglang_router.launch_router \
   --host 0.0.0.0 --port 8080
 ```
 
+If you have many gRPC workers and want to avoid repeating the `grpc://` prefix, you can force gRPC mode and provide bare `host:port` entries:
+
+```bash
+python -m sglang_router.launch_router \
+  --connection-mode grpc \
+  --worker-urls 127.0.0.1:20000 \
+  --model-path meta-llama/Llama-3.1-8B-Instruct \
+  --reasoning-parser deepseek-r1 \
+  --tool-call-parser json \
+  --host 0.0.0.0 --port 8080
+```
+
 ---
 
 ## Deployment Modes
@@ -237,6 +249,10 @@ python -m sglang_router.launch_router \
 ```
 
 The gRPC router supports both regular HTTP-equivalent serving and PD (prefill/decode) serving. Provide `--tokenizer-path` or `--model-path` (HuggingFace ID or local directory) whenever connection mode resolves to gRPC.
+
+Tip: you may also use `--connection-mode grpc` and pass bare `host:port` URLs (the router will prefix them as `grpc://...`).
+
+Similarly, `--connection-mode http` allows bare `host:port` entries and prefixes them as `http://...`.
 
 ### Prefill/Decode Disaggregation
 
@@ -1570,7 +1586,8 @@ groups:
 |-----------|------|---------|-------------|
 | `--host` | str | 127.0.0.1 | Router host |
 | `--port` | int | 30000 | Router port |
-| `--worker-urls` | list | [] | Worker URLs (HTTP or gRPC) |
+| `--worker-urls` | list | [] | Worker URLs (HTTP or gRPC). By default, each URL must include a scheme (e.g. `http://...` or `grpc://...`). If you set `--connection-mode`, bare `host:port` entries are accepted and will be auto-prefixed. |
+| `--connection-mode` | enum | None | Force worker connection mode (`http` or `grpc`). When set, bare `host:port` entries in `--worker-urls` / `--prefill` / `--decode` are auto-prefixed accordingly. |
 | `--policy` | str | cache_aware | Routing policy |
 | `--max-concurrent-requests` | int | -1 | Concurrency limit (-1 disables) |
 | `--request-timeout-secs` | int | 600 | Request timeout |

--- a/sgl-model-gateway/README.md
+++ b/sgl-model-gateway/README.md
@@ -217,6 +217,18 @@ Add more workers with the same API; include optional `labels` (for per-model pol
     --reasoning-parser deepseek-r1 \
     --tool-call-parser json
   ```
+
+  If you want to avoid repeating `grpc://` across many workers, you can force gRPC mode and provide bare `host:port` entries:
+
+  ```bash
+  ./target/release/sgl-model-gateway \
+    --connection-mode grpc \
+    --worker-urls worker-grpc-0:31001 worker-grpc-1:31002 \
+    --tokenizer-path /path/to/tokenizer.json \
+    --reasoning-parser deepseek-r1 \
+    --tool-call-parser json
+  ```
+  Likewise, `--connection-mode http` allows bare `host:port` entries and prefixes them as `http://...`.
 - **Python router**
   ```bash
   python3 -m sglang_router.launch_router \

--- a/sgl-model-gateway/bindings/python/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/sglang_router/router_args.py
@@ -15,6 +15,9 @@ class RouterArgs:
     worker_urls: List[str] = dataclasses.field(default_factory=list)
     host: str = "0.0.0.0"
     port: int = 30000
+    # Force worker connection mode (and auto-prefix URLs that don't include a scheme)
+    # Valid values: "http", "grpc"
+    connection_mode: Optional[str] = None
 
     # PD-specific configuration
     mini_lb: bool = False
@@ -173,6 +176,13 @@ class RouterArgs:
             nargs="*",
             default=[],
             help="List of worker URLs. Supports IPv4 and IPv6 addresses (use brackets for IPv6, e.g., http://[::1]:8000 http://192.168.1.1:8000)",
+        )
+        parser.add_argument(
+            "--connection-mode",
+            type=str,
+            choices=["http", "grpc"],
+            default=None,
+            help="Force worker connection mode. When set, bare `host:port` entries in --worker-urls/--prefill/--decode are accepted and auto-prefixed.",
         )
 
         # Routing policy configuration

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -393,21 +393,6 @@ impl Router {
         core::ConnectionMode::Http
     }
 
-    fn normalize_url_for_mode(url: &str, mode: &core::ConnectionMode) -> String {
-        if url.starts_with("http://")
-            || url.starts_with("https://")
-            || url.starts_with("grpc://")
-            || url.starts_with("grpcs://")
-        {
-            url.to_string()
-        } else {
-            match mode {
-                core::ConnectionMode::Http => format!("http://{}", url),
-                core::ConnectionMode::Grpc { .. } => format!("grpc://{}", url),
-            }
-        }
-    }
-
     fn parse_connection_mode_str(mode: &str) -> PyResult<core::ConnectionMode> {
         match mode.to_lowercase().as_str() {
             "http" => Ok(core::ConnectionMode::Http),
@@ -795,7 +780,7 @@ impl Router {
         let worker_urls = if normalize {
             worker_urls
                 .into_iter()
-                .map(|u| Self::normalize_url_for_mode(&u, &connection_mode))
+                .map(|u| connection_mode.normalize_url(&u))
                 .collect()
         } else {
             worker_urls
@@ -803,7 +788,7 @@ impl Router {
         let prefill_urls = if normalize {
             prefill_urls.map(|v| {
                 v.into_iter()
-                    .map(|(u, p)| (Self::normalize_url_for_mode(&u, &connection_mode), p))
+                    .map(|(u, p)| (connection_mode.normalize_url(&u), p))
                     .collect()
             })
         } else {
@@ -812,7 +797,7 @@ impl Router {
         let decode_urls = if normalize {
             decode_urls.map(|v| {
                 v.into_iter()
-                    .map(|u| Self::normalize_url_for_mode(&u, &connection_mode))
+                    .map(|u| connection_mode.normalize_url(&u))
                     .collect()
             })
         } else {

--- a/sgl-model-gateway/src/config/validation.rs
+++ b/sgl-model-gateway/src/config/validation.rs
@@ -603,11 +603,12 @@ impl ConfigValidator {
             if !url.starts_with("http://")
                 && !url.starts_with("https://")
                 && !url.starts_with("grpc://")
+                && !url.starts_with("grpcs://")
             {
                 return Err(ConfigError::InvalidValue {
                     field: "worker_url".to_string(),
                     value: url.clone(),
-                    reason: "URL must start with http://, https://, or grpc://".to_string(),
+                    reason: "URL must start with http://, https://, grpc://, or grpcs://".to_string(),
                 });
             }
 

--- a/sgl-model-gateway/src/core/worker.rs
+++ b/sgl-model-gateway/src/core/worker.rs
@@ -320,6 +320,25 @@ impl ConnectionMode {
             ConnectionMode::Grpc { .. } => metrics_labels::CONNECTION_GRPC,
         }
     }
+
+    /// Normalize a potentially scheme-less endpoint URL according to this connection mode.
+    ///
+    /// - If the URL already has a supported scheme (http/https/grpc/grpcs), it is returned as-is.
+    /// - Otherwise, the URL is prefixed with `http://` for HTTP mode or `grpc://` for gRPC mode.
+    pub fn normalize_url(&self, url: &str) -> String {
+        if url.starts_with("http://")
+            || url.starts_with("https://")
+            || url.starts_with("grpc://")
+            || url.starts_with("grpcs://")
+        {
+            url.to_string()
+        } else {
+            match self {
+                ConnectionMode::Http => format!("http://{}", url),
+                ConnectionMode::Grpc { .. } => format!("grpc://{}", url),
+            }
+        }
+    }
 }
 
 impl fmt::Display for ConnectionMode {

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -26,57 +26,6 @@ enum ConnectionModeCli {
     Grpc,
 }
 
-fn normalize_cli_url(url: &str, connection_mode: &ConnectionMode) -> String {
-    if url.starts_with("http://")
-        || url.starts_with("https://")
-        || url.starts_with("grpc://")
-        || url.starts_with("grpcs://")
-    {
-        url.to_string()
-    } else {
-        match connection_mode {
-            ConnectionMode::Http => format!("http://{}", url),
-            ConnectionMode::Grpc { .. } => format!("grpc://{}", url),
-        }
-    }
-}
-
-fn normalize_cli_urls_if_requested(
-    mode: RoutingMode,
-    connection_mode: &ConnectionMode,
-    normalize: bool,
-) -> RoutingMode {
-    if !normalize {
-        return mode;
-    }
-
-    match mode {
-        RoutingMode::Regular { worker_urls } => RoutingMode::Regular {
-            worker_urls: worker_urls
-                .into_iter()
-                .map(|u| normalize_cli_url(&u, connection_mode))
-                .collect(),
-        },
-        RoutingMode::PrefillDecode {
-            prefill_urls,
-            decode_urls,
-            prefill_policy,
-            decode_policy,
-        } => RoutingMode::PrefillDecode {
-            prefill_urls: prefill_urls
-                .into_iter()
-                .map(|(u, p)| (normalize_cli_url(&u, connection_mode), p))
-                .collect(),
-            decode_urls: decode_urls
-                .into_iter()
-                .map(|u| normalize_cli_url(&u, connection_mode))
-                .collect(),
-            prefill_policy,
-            decode_policy,
-        },
-        RoutingMode::OpenAI { worker_urls } => RoutingMode::OpenAI { worker_urls },
-    }
-}
 fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
     let args: Vec<String> = std::env::args().collect();
     let mut prefill_entries = Vec::new();
@@ -808,7 +757,7 @@ impl CliArgs {
 
         // Only auto-prefix URLs when user explicitly requests a connection mode.
         // This preserves existing strict behavior by default.
-        let mode = normalize_cli_urls_if_requested(mode, &connection_mode, self.connection_mode.is_some());
+        let mode = mode.normalize_urls_if_requested(&connection_mode, self.connection_mode.is_some());
 
         let history_backend = match self.history_backend.as_str() {
             "none" => HistoryBackend::None,


### PR DESCRIPTION
## Motivation
to https://github.com/sgl-project/sglang/issues/14342
This patch introduces a `--connection-mode {http,grpc}` argument.
When `--connection-mode` is explicitly set, the router will treat bare `host:port` entries in `--worker-urls`, `--prefill`, and `--decode` as valid and automatically prefix them with the corresponding scheme (`http://` or `grpc://`). 
The default behavior remains unchanged: URLs must include a scheme unless `--connection-mode` is provided.

URL validation is also extended to accept `grpcs://`. Documentation examples and the configuration reference have been updated accordingly.


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
