### PR TITLE
Add EAGLE3 test with MMLU dataset.

### DIFF
--- a/test/registered/attention/test_fa3.py
+++ b/test/registered/attention/test_fa3.py
@@ -115,8 +115,8 @@ class BaseFlashAttentionTest(CustomTestCase):
         self.assertGreater(metrics[metric_key], self.accuracy_threshold)
 
         if self.speculative_decode:
-            server_info = requests.get(self.base_url + "/get_server_info")
-            avg_spec_accept_length = server_info.json()["internal_states"][0][
+            server_info = requests.get(self.base_url + "/server_info").json()
+            avg_spec_accept_length = server_info["internal_states"][0][
                 "avg_spec_accept_length"
             ]
             print(f"{avg_spec_accept_length=}")

--- a/test/registered/mla/test_flashmla.py
+++ b/test/registered/mla/test_flashmla.py
@@ -125,9 +125,8 @@ class TestFlashMLAMTP(CustomTestCase):
 
         self.assertGreater(metrics["accuracy"], 0.60)
 
-        server_info = requests.get(self.base_url + "/get_server_info")
-        print(f"{server_info=}")
-        avg_spec_accept_length = server_info.json()["internal_states"][0][
+        server_info = requests.get(self.base_url + "/server_info").json()
+        avg_spec_accept_length = server_info["internal_states"][0][
             "avg_spec_accept_length"
         ]
         print(f"{avg_spec_accept_length=}")

--- a/test/registered/mla/test_mla_flashinfer.py
+++ b/test/registered/mla/test_mla_flashinfer.py
@@ -115,8 +115,7 @@ class TestFlashinferMLAMTP(CustomTestCase):
 
         self.assertGreater(metrics["accuracy"], 0.60)
 
-        server_info = requests.get(self.base_url + "/get_server_info")
-        print(f"{server_info=}")
+        server_info = requests.get(self.base_url + "/get_server_info").json()
         avg_spec_accept_length = server_info.json()["internal_states"][0][
             "avg_spec_accept_length"
         ]

--- a/test/registered/mla/test_mla_flashinfer.py
+++ b/test/registered/mla/test_mla_flashinfer.py
@@ -116,7 +116,7 @@ class TestFlashinferMLAMTP(CustomTestCase):
         self.assertGreater(metrics["accuracy"], 0.60)
 
         server_info = requests.get(self.base_url + "/get_server_info").json()
-        avg_spec_accept_length = server_info.json()["internal_states"][0][
+        avg_spec_accept_length = server_info["internal_states"][0][
             "avg_spec_accept_length"
         ]
         print(f"{avg_spec_accept_length=}")

--- a/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_stage_b.py
+++ b/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_stage_b.py
@@ -79,8 +79,8 @@ class TestDeepseekV3FP4MTP(CustomTestCase):
         metrics = run_eval_few_shot_gsm8k(args)
         print(f"{metrics=}")
 
-        server_info = requests.get(self.base_url + "/get_server_info")
-        avg_spec_accept_length = server_info.json()["internal_states"][0][
+        server_info = requests.get(self.base_url + "/server_info").json()
+        avg_spec_accept_length = server_info["internal_states"][0][
             "avg_spec_accept_length"
         ]
         print(f"{avg_spec_accept_length=}")

--- a/test/registered/spec/eagle/test_eagle3_basic.py
+++ b/test/registered/spec/eagle/test_eagle3_basic.py
@@ -34,9 +34,8 @@ class TestEagle3Basic(EagleServerBase):
         metrics = run_eval(args)
         self.assertGreaterEqual(metrics["score"], 0.72)
 
-        server_info = requests.get(self.base_url + "/server_info")
-        print(f"{server_info=}")
-        avg_spec_accept_length = server_info.json()["internal_states"][0][
+        server_info = requests.get(self.base_url + "/server_info").json()
+        avg_spec_accept_length = server_info["internal_states"][0][
             "avg_spec_accept_length"
         ]
         print(f"{avg_spec_accept_length=}")

--- a/test/registered/spec/eagle/test_eagle3_basic.py
+++ b/test/registered/spec/eagle/test_eagle3_basic.py
@@ -1,0 +1,48 @@
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.test.run_eval import run_eval
+from sglang.test.server_fixtures.eagle_fixture import EagleServerBase
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE3,
+    DEFAULT_TARGET_MODEL_EAGLE3,
+)
+
+
+class TestEagle3Basic(EagleServerBase):
+    target_model = DEFAULT_TARGET_MODEL_EAGLE3
+    draft_model = DEFAULT_DRAFT_MODEL_EAGLE3
+
+    spec_algo = "EAGLE3"
+    spec_steps = 2
+    spec_topk = 1
+    spec_tokens = 3
+    extra_args = ["--dtype=float16", "--chunked-prefill-size", 1024]
+
+    def test_mmlu(self):
+        """Override to add EAGLE-specific assertions"""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.target_model,
+            eval_name="mmlu",
+            num_examples=64,
+            num_threads=32,
+        )
+
+        metrics = run_eval(args)
+        self.assertGreaterEqual(metrics["score"], 0.72)
+
+        server_info = requests.get(self.base_url + "/server_info")
+        print(f"{server_info=}")
+        avg_spec_accept_length = server_info.json()["internal_states"][0][
+            "avg_spec_accept_length"
+        ]
+        print(f"{avg_spec_accept_length=}")
+        self.assertGreater(avg_spec_accept_length, 2.26)
+
+
+if __name__ == "__main__":
+
+    unittest.main()

--- a/test/registered/spec/eagle/test_eagle3_basic.py
+++ b/test/registered/spec/eagle/test_eagle3_basic.py
@@ -3,12 +3,15 @@ from types import SimpleNamespace
 
 import requests
 
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.server_fixtures.eagle_fixture import EagleServerBase
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE3,
     DEFAULT_TARGET_MODEL_EAGLE3,
 )
+
+register_cuda_ci(est_time=50, suite="stage-b-test-small-1-gpu")
 
 
 class TestEagle3Basic(EagleServerBase):

--- a/test/registered/spec/eagle/test_eagle_infer_b.py
+++ b/test/registered/spec/eagle/test_eagle_infer_b.py
@@ -75,7 +75,7 @@ class TestEAGLEServerBasic(EagleServerBase):
         print(f"{metrics=}")
         self.assertGreater(metrics["accuracy"], 0.20)
 
-        server_info = requests.get(self.base_url + "/get_server_info").json()
+        server_info = requests.get(self.base_url + "/server_info").json()
         avg_spec_accept_length = server_info["internal_states"][0][
             "avg_spec_accept_length"
         ]

--- a/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py
+++ b/test/registered/spec/eagle/test_eagle_infer_beta_dp_attention_large.py
@@ -34,10 +34,8 @@ def test_gsm8k(base_url: str):
         port=int(base_url.split(":")[-1]),
     )
     metrics = run_eval_few_shot_gsm8k(args)
-    server_info = requests.get(base_url + "/get_server_info")
-    avg_spec_accept_length = server_info.json()["internal_states"][0][
-        "avg_spec_accept_length"
-    ]
+    server_info = requests.get(base_url + "/server_info").json()
+    avg_spec_accept_length = server_info["internal_states"][0]["avg_spec_accept_length"]
 
     print(f"{metrics=}")
     print(f"{avg_spec_accept_length=}")

--- a/test/srt/hicache/test_hicache_variants.py
+++ b/test/srt/hicache/test_hicache_variants.py
@@ -152,9 +152,8 @@ class TestHiCacheEagle(HiCacheBaseServer, HiCacheEvalMixin):
         self.assertGreaterEqual(metrics["score"], self.expected_mmlu_score)
 
         # EAGLE-specific check
-        server_info = requests.get(self.base_url + "/get_server_info")
-        print(f"{server_info=}")
-        avg_spec_accept_length = server_info.json()["internal_states"][0][
+        server_info = requests.get(self.base_url + "/get_server_info").json()
+        avg_spec_accept_length = server_info["internal_states"][0][
             "avg_spec_accept_length"
         ]
         print(f"{avg_spec_accept_length=}")


### PR DESCRIPTION
This #15952 will skip some of the hicache tests, and inside the tests, the hicache + eagle test fails recently due to unknown reasons, probably non-deterministic batching inference and environment settings.

And according to @DarkSharpness and @hzh0425, `TestHiCacheEagle` did not hit the offloading to CPU. So adding this PR to do ablation also makes EAGLE3 testcases more robust.