### PR TITLE
[PD][FIX] main thread busy loop cause pop bootstrap stuck

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -77,6 +77,9 @@ class CommonKVManager(BaseKVManager):
             context, zmq.PULL, host=zmq_bind_host
         )
         logger.debug(f"kv manager bind to {zmq_bind_host}:{self.rank_port}")
+        self.server_socket_poller = zmq.Poller()
+        self.server_socket_poller.register(self.server_socket, zmq.POLLIN)
+        self.kv_status_lock = threading.Lock()
 
         self.request_status: Dict[int, KVPoll] = {}
 
@@ -176,6 +179,8 @@ class CommonKVManager(BaseKVManager):
         sliced_dst_kv_ptrs = dst_kv_ptrs[start_layer:end_layer]
         layers_current_pp_stage = len(src_kv_ptrs)
         return src_kv_ptrs, sliced_dst_kv_ptrs, layers_current_pp_stage
+
+    def consume_bootstrap(self): ...
 
 
 class CommonKVSender(BaseKVSender):

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, List, Optional, Type
 import torch
 
 from sglang.srt.disaggregation.base import BaseKVManager, KVPoll
+from sglang.srt.disaggregation.common import CommonKVManager
 from sglang.srt.disaggregation.utils import (
     FAKE_BOOTSTRAP_HOST,
     DisaggregationMode,
@@ -108,7 +109,7 @@ class PrefillBootstrapQueue:
         self.max_total_num_tokens = max_total_num_tokens
         self.scheduler = scheduler
         self.transfer_backend = transfer_backend
-        self.kv_manager = self._init_kv_manager()
+        self.kv_manager: BaseKVManager | CommonKVManager = self._init_kv_manager()
 
     def _init_kv_manager(self) -> BaseKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
@@ -242,6 +243,8 @@ class PrefillBootstrapQueue:
                 return []
             else:
                 return [], []
+
+        self.kv_manager.consume_bootstrap()
 
         polls = poll_and_all_reduce(
             [req.disagg_kv_sender for req in self.queue], self.gloo_group


### PR DESCRIPTION
## Motivation

when pop bootstrap: main thread busy loop at `poll_and_allreduce`, but another Thread `bootstrap_thread` can not be execute by python, then main thread would never pop a req because all reqs still in zmq, waiting for `recv_multipart`

## Modifications

Implement CommonKVManager and integrate bootstrap consumption in various KV managers

- Added CommonKVManager to handle common functionalities for KV management.
- Introduced consume_bootstrap method in CommonKVManager, NixlKVManager, and MooncakeKVManager to manage bootstrap notifications.
- Updated PrefillBootstrapQueue to utilize CommonKVManager for kv_manager initialization.
- Enhanced threading for bootstrap consumption in Nixl and Mooncake KV managers.

## Benchmarking and Profiling

before: Prefill node `pre_alloc_queue` increase rapidly, waiting queue stuck at ZERO, meanwhile Decode node `trasfer_queue` increase.

after: Prefill node `pre_alloc_queue` and `waiting_queue` not increase, most time zero.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
