### PR TITLE
[test] Skip test_hicache_variants in CI due to intermittent failures

### DIFF
--- a/test/registered/hicache/test_hicache_variants.py
+++ b/test/registered/hicache/test_hicache_variants.py
@@ -10,6 +10,7 @@ import requests
 
 from sglang.bench_serving import get_tokenizer
 from sglang.srt.utils import is_hip, kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
     DEFAULT_DRAFT_MODEL_EAGLE3,
@@ -20,6 +21,15 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+)
+
+# HiCache variant tests - temporarily disabled due to intermittent CI failures
+# that cannot be reproduced locally. Use test_hicache_storage for accuracy testing.
+# Example failure: https://github.com/sgl-project/sglang/actions/runs/20527003659/job/58972707514
+register_cuda_ci(
+    est_time=368,
+    suite="stage-b-test-small-1-gpu",
+    disabled="Intermittent CI failures not reproducible locally, see PR #15952",
 )
 
 _is_hip = is_hip()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -9,7 +9,6 @@ suites = {
     "per-commit-1-gpu": [
         TestFile("debug_utils/test_tensor_dump_forward_hook.py", 9),
         TestFile("hicache/test_hicache_storage.py", 96),
-        TestFile("hicache/test_hicache_variants.py", 368),
         TestFile("layers/attention/mamba/test_causal_conv1d.py", 25),
         TestFile("layers/attention/mamba/test_mamba_ssm.py", 7),
         TestFile("layers/attention/mamba/test_mamba_ssm_ssd.py", 13),


### PR DESCRIPTION
## Summary
- Move `test_hicache_variants.py` to `test/registered/hicache/` with CI registry decorator
- Add `disabled` flag to `register_cuda_ci` due to intermittent CI failures not reproducible locally
- Remove test from legacy `test/srt/run_suite.py` per-commit-1-gpu suite
- Delete original test file from `test/srt/hicache/`

The tests remain runnable locally for debugging. Use `test_hicache_storage` tests for hicache accuracy and logic testing in the meantime.

## Example Failure
https://github.com/sgl-project/sglang/actions/runs/20527003659/job/58972707514

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes (tests are disabled so won't run)