### PR TITLE
fix(function_call): consistent unknown tool handling in streaming mode

### DIFF
--- a/test/registered/function_call/test_unknown_tool_name.py
+++ b/test/registered/function_call/test_unknown_tool_name.py
@@ -7,6 +7,7 @@ from sglang.srt.entrypoints.openai.protocol import Function, Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult
+from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(1.0, "default")
@@ -24,6 +25,17 @@ class DummyDetector(BaseFormatDetector):
 
     def structure_info(self):
         pass
+
+
+def get_test_tools():
+    """Helper to create test tools list."""
+    return [
+        Tool(
+            function=Function(
+                name="get_weather", parameters={"type": "object", "properties": {}}
+            )
+        )
+    ]
 
 
 def test_unknown_tool_name_dropped_default(caplog):
@@ -75,6 +87,113 @@ def test_unknown_tool_name_forwarded(caplog):
         assert result.calls[0].name == "unknown_tool"
         assert result.calls[0].tool_index == -1
         assert json.loads(result.calls[0].parameters)["city"] == "Paris"
+
+
+def test_streaming_unknown_tool_dropped_default(caplog):
+    """Test that unknown tools are dropped in streaming mode by default."""
+    with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(False):
+        tools = get_test_tools()
+        detector = MistralDetector()
+        # Mistral format: [TOOL_CALLS] [{"name": "...", "arguments": {...}}]
+        text = '[TOOL_CALLS] [{"name": "unknown_tool", "arguments": {"city": "Paris"}}]'
+
+        with caplog.at_level(
+            logging.WARNING, logger="sglang.srt.function_call.base_format_detector"
+        ):
+            result = detector.parse_streaming_increment(text, tools)
+
+        # Should log warning about unknown tool
+        assert any(
+            "Model attempted to call undefined function: unknown_tool" in m
+            for m in caplog.messages
+        )
+        # Should not return any tool calls (dropped)
+        assert len(result.calls) == 0
+
+
+def test_streaming_unknown_tool_forwarded(caplog):
+    """Test that unknown tools are forwarded in streaming mode when env var is True."""
+    with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+        tools = get_test_tools()
+        detector = MistralDetector()
+        # Mistral format: [TOOL_CALLS] [{"name": "...", "arguments": {...}}]
+        text = '[TOOL_CALLS] [{"name": "unknown_tool", "arguments": {"city": "Paris"}}]'
+
+        with caplog.at_level(
+            logging.WARNING, logger="sglang.srt.function_call.base_format_detector"
+        ):
+            result = detector.parse_streaming_increment(text, tools)
+
+        # Should log warning about unknown tool
+        assert any(
+            "Model attempted to call undefined function: unknown_tool" in m
+            for m in caplog.messages
+        )
+        # Should return the tool call with tool_index=-1
+        assert len(result.calls) == 1
+        assert result.calls[0].name == "unknown_tool"
+        assert result.calls[0].tool_index == -1
+
+
+def test_streaming_unknown_tool_with_arguments(caplog):
+    """Test that unknown tool arguments are correctly streamed when forwarding is enabled."""
+    with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+        tools = get_test_tools()
+        detector = MistralDetector()
+
+        # Simulate streaming in chunks
+        chunks = [
+            '[TOOL_CALLS] [{"name": "unknown_tool"',
+            ', "arguments": {"city": "Paris"}}]',
+        ]
+
+        all_calls = []
+        with caplog.at_level(
+            logging.WARNING, logger="sglang.srt.function_call.base_format_detector"
+        ):
+            for chunk in chunks:
+                result = detector.parse_streaming_increment(chunk, tools)
+                all_calls.extend(result.calls)
+
+        # Should have received tool name and arguments
+        assert len(all_calls) >= 1
+        # First call should have the tool name
+        assert all_calls[0].name == "unknown_tool"
+        assert all_calls[0].tool_index == -1
+
+
+def test_streaming_mixed_known_and_unknown_tools(caplog):
+    """Test streaming with both known and unknown tools."""
+    with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(True):
+        tools = get_test_tools()  # Only has "get_weather"
+        detector = MistralDetector()
+
+        # First call known tool
+        text1 = '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "NYC"}}]'
+        result1 = detector.parse_streaming_increment(text1, tools)
+
+        # Known tool should have proper index (0)
+        assert len(result1.calls) >= 1
+        # Find the call with the name (first one)
+        name_call = next((c for c in result1.calls if c.name == "get_weather"), None)
+        assert name_call is not None
+        assert name_call.tool_index == 0
+
+        # Reset detector for second call
+        detector = MistralDetector()
+
+        # Now call unknown tool
+        text2 = '[TOOL_CALLS] [{"name": "unknown_func", "arguments": {"x": 1}}]'
+        with caplog.at_level(
+            logging.WARNING, logger="sglang.srt.function_call.base_format_detector"
+        ):
+            result2 = detector.parse_streaming_increment(text2, tools)
+
+        # Unknown tool should have index -1
+        assert len(result2.calls) >= 1
+        name_call = next((c for c in result2.calls if c.name == "unknown_func"), None)
+        assert name_call is not None
+        assert name_call.tool_index == -1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix inconsistent `SGLANG_FORWARD_UNKNOWN_TOOLS` handling between streaming and non-streaming modes
- Add streaming test coverage for unknown tool forwarding

## Problem

The `SGLANG_FORWARD_UNKNOWN_TOOLS` environment variable was only respected in non-streaming mode (`parse_base_json`). In streaming mode (`parse_streaming_increment`), unknown tools were always dropped silently, regardless of the env var setting.

This caused inconsistent behavior:
- Non-streaming: Unknown tools could be forwarded with `tool_index=-1` when `SGLANG_FORWARD_UNKNOWN_TOOLS=true`
- Streaming: Unknown tools were always dropped

## Solution

Modified `base_format_detector.py` to:
1. Check `SGLANG_FORWARD_UNKNOWN_TOOLS` in the streaming path
2. Log warning for unknown tools (consistent with non-streaming)
3. Track unknown tool state across streaming chunks
4. Return `tool_index=-1` for unknown tools in streaming responses

## Test plan

- [x] Added 4 new streaming tests for unknown tool forwarding
- [x] All 6 tests in `test_unknown_tool_name.py` pass
- [x] 88 tests in `test_function_call_parser.py` pass (7 failures unrelated - missing `transformers` dep)

```
test_streaming_unknown_tool_dropped_default PASSED
test_streaming_unknown_tool_forwarded PASSED
test_streaming_unknown_tool_with_arguments PASSED
test_streaming_mixed_known_and_unknown_tools PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)