### PR TITLE
feat: Add validation for n and top_logprobs in OpenAI protocol

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -279,6 +279,20 @@ class CompletionRequest(BaseModel):
             raise ValueError("max_tokens must be positive")
         return v
 
+    @field_validator("n")
+    @classmethod
+    def validate_n_positive(cls, v):
+        if v is not None and v < 1:
+            raise ValueError("n must be at least 1")
+        return v
+
+    @field_validator("logprobs")
+    @classmethod
+    def validate_logprobs_range(cls, v):
+        if v is not None and (v < 0 or v > 5):
+            raise ValueError("logprobs must be between 0 and 5")
+        return v
+
 
 class CompletionResponseChoice(BaseModel):
     index: int
@@ -545,6 +559,20 @@ class ChatCompletionRequest(BaseModel):
         "min_p": 0.0,
         "repetition_penalty": 1.0,
     }
+
+    @field_validator("n")
+    @classmethod
+    def validate_n_positive(cls, v):
+        if v is not None and v < 1:
+            raise ValueError("n must be at least 1")
+        return v
+
+    @field_validator("top_logprobs")
+    @classmethod
+    def validate_top_logprobs_range(cls, v):
+        if v is not None and (v < 0 or v > 20):
+            raise ValueError("top_logprobs must be between 0 and 20")
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/test/srt/openai_server/basic/test_protocol.py
+++ b/test/srt/openai_server/basic/test_protocol.py
@@ -325,6 +325,56 @@ class TestValidationEdgeCases(unittest.TestCase):
         with self.assertRaises(ValidationError):
             CompletionRequest(model="test-model", prompt="Hello", max_tokens=-1)
 
+    def test_completion_n_validation(self):
+        """Test CompletionRequest n must be >= 1"""
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", n=0)
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", n=-1)
+        # Valid values
+        req = CompletionRequest(model="test-model", prompt="Hello", n=1)
+        self.assertEqual(req.n, 1)
+        req = CompletionRequest(model="test-model", prompt="Hello", n=5)
+        self.assertEqual(req.n, 5)
+
+    def test_completion_logprobs_validation(self):
+        """Test CompletionRequest logprobs must be between 0 and 5"""
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", logprobs=-1)
+        with self.assertRaises(ValidationError):
+            CompletionRequest(model="test-model", prompt="Hello", logprobs=6)
+        # Valid values
+        req = CompletionRequest(model="test-model", prompt="Hello", logprobs=0)
+        self.assertEqual(req.logprobs, 0)
+        req = CompletionRequest(model="test-model", prompt="Hello", logprobs=5)
+        self.assertEqual(req.logprobs, 5)
+
+    def test_chat_completion_n_validation(self):
+        """Test ChatCompletionRequest n must be >= 1"""
+        messages = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(model="test-model", messages=messages, n=0)
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(model="test-model", messages=messages, n=-1)
+        # Valid values
+        req = ChatCompletionRequest(model="test-model", messages=messages, n=1)
+        self.assertEqual(req.n, 1)
+        req = ChatCompletionRequest(model="test-model", messages=messages, n=3)
+        self.assertEqual(req.n, 3)
+
+    def test_chat_completion_top_logprobs_validation(self):
+        """Test ChatCompletionRequest top_logprobs must be between 0 and 20"""
+        messages = [{"role": "user", "content": "Hello"}]
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(model="test-model", messages=messages, top_logprobs=-1)
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest(model="test-model", messages=messages, top_logprobs=21)
+        # Valid values
+        req = ChatCompletionRequest(model="test-model", messages=messages, top_logprobs=0)
+        self.assertEqual(req.top_logprobs, 0)
+        req = ChatCompletionRequest(model="test-model", messages=messages, top_logprobs=20)
+        self.assertEqual(req.top_logprobs, 20)
+
     def test_model_serialization_roundtrip(self):
         """Test that models can be serialized and deserialized"""
         original_request = ChatCompletionRequest(


### PR DESCRIPTION
## Summary

Add field validators to ensure OpenAI API request parameters match the official specifications:

- **CompletionRequest.n**: must be >= 1 (number of completions to generate)
- **CompletionRequest.logprobs**: must be between 0 and 5 (per OpenAI docs)
- **ChatCompletionRequest.n**: must be >= 1 (number of completions to generate)
- **ChatCompletionRequest.top_logprobs**: must be between 0 and 20 (per OpenAI docs)

These validations provide early, clear error messages for invalid requests instead of silent failures or undefined behavior downstream.

## Changes

- Added `validate_n_positive` and `validate_logprobs_range` validators to `CompletionRequest`
- Added `validate_n_positive` and `validate_top_logprobs_range` validators to `ChatCompletionRequest`
- Added comprehensive unit tests for all new validators

## Test plan

- [x] Added unit tests for all validation scenarios
- [x] Tested invalid values are rejected with clear error messages
- [x] Tested boundary values (e.g., n=1, logprobs=0, logprobs=5, top_logprobs=20)
- [x] All 21 protocol tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)