### PR TITLE
fix(io_struct): handle None case in regenerate_rids()

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -57,7 +57,10 @@ class BaseBatchReq(ABC):
 
     def regenerate_rids(self):
         """Generate new request IDs and return them."""
-        self.rids = [uuid.uuid4().hex for _ in range(len(self.rids))]
+        if self.rids is None:
+            self.rids = [uuid.uuid4().hex]
+        else:
+            self.rids = [uuid.uuid4().hex for _ in range(len(self.rids))]
         return self.rids
 
 


### PR DESCRIPTION
## Summary
- Add None check before accessing `self.rids` in `regenerate_rids()` method
- Prevents `TypeError` when `rids` attribute is `None`

## Motivation
The `rids` attribute in `BaseBatchReq` is typed as `Optional[List[str]]`, meaning it can be `None`. However, `regenerate_rids()` called `len(self.rids)` without checking for `None` first, which would raise a `TypeError` at runtime.

## Changes
Added a None check following the same pattern used in the similar `regenerate_rid()` method in `BaseReq`:

```python
def regenerate_rids(self):
    """Generate new request IDs and return them."""
    if self.rids is None:
        self.rids = [uuid.uuid4().hex]
    else:
        self.rids = [uuid.uuid4().hex for _ in range(len(self.rids))]
    return self.rids
```

## Test plan
- No functional changes for normal usage (when `rids` is not `None`)
- Fixes edge case where `rids` could be `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)