### PR TITLE
fix(conversation): handle None case in append_image/video/audio methods

### DIFF
--- a/python/sglang/srt/parser/conversation.py
+++ b/python/sglang/srt/parser/conversation.py
@@ -407,14 +407,20 @@ class Conversation:
 
     def append_image(self, image: str, detail: Literal["auto", "low", "high"]):
         """Append a new image."""
+        if self.image_data is None:
+            self.image_data = []
         self.image_data.append(ImageData(url=image, detail=detail))
 
     def append_video(self, video: str):
         """Append a new video."""
+        if self.video_data is None:
+            self.video_data = []
         self.video_data.append(video)
 
     def append_audio(self, audio: str):
         """Append a new audio."""
+        if self.audio_data is None:
+            self.audio_data = []
         self.audio_data.append(audio)
 
     def update_last_message(self, message: str):


### PR DESCRIPTION
## Summary
- Add None checks before calling `.append()` on `image_data`, `video_data`, and `audio_data` fields
- Prevents `AttributeError` when these methods are called on a Conversation where these fields are `None`

## Motivation
The `Conversation` dataclass defines these fields as `Optional[List[...]]` with default `None`:
```python
image_data: Optional[List[ImageData]] = None
video_data: Optional[List[str]] = None
audio_data: Optional[List[str]] = None
```

However, the `append_image()`, `append_video()`, and `append_audio()` methods directly call `.append()` without checking for `None`, causing `AttributeError: 'NoneType' object has no attribute 'append'`.

## Changes
Added defensive None checks to initialize the lists if needed:
```python
def append_image(self, image: str, detail: Literal["auto", "low", "high"]):
    if self.image_data is None:
        self.image_data = []
    self.image_data.append(ImageData(url=image, detail=detail))
```

Same pattern applied to `append_video()` and `append_audio()`.

## Test plan
- No functional changes for normal usage
- Fixes edge case where fields are `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)