### PR TITLE
fix(tokenizer): validate negative token IDs in _validate_input_ids_in_vocab

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -742,9 +742,10 @@ class TokenizerManager(TokenizerCommunicatorMixin, TokenizerManagerMultiItemMixi
     def _validate_input_ids_in_vocab(
         self, input_ids: List[int], vocab_size: int
     ) -> None:
-        if any(id >= vocab_size for id in input_ids):
+        if any(id < 0 or id >= vocab_size for id in input_ids):
             raise ValueError(
-                f"The input_ids {input_ids} contains values greater than the vocab size ({vocab_size})."
+                f"The input_ids contains invalid token IDs. "
+                f"Token IDs must be in the range [0, {vocab_size})."
             )
 
     def _get_sampling_params(self, sampling_kwargs: Dict) -> SamplingParams:


### PR DESCRIPTION
## Summary
- Add validation for negative token IDs in `_validate_input_ids_in_vocab()`
- Token IDs must be in the range `[0, vocab_size)`, not just `< vocab_size`

## Motivation
The existing validation only checked the upper bound:
```python
if any(id >= vocab_size for id in input_ids):
```

This missed negative token IDs, which are invalid but would pass validation and cause cryptic errors downstream in the model executor.

## Changes
Added lower bound check:
```python
if any(id < 0 or id >= vocab_size for id in input_ids):
```

Also improved the error message to clearly state the valid range.

## Test plan
- No functional changes for valid input
- Invalid negative token IDs now raise clear `ValueError` with the valid range

🤖 Generated with [Claude Code](https://claude.com/claude-code)