### PR TITLE
fix(metrics): add None check for FUNC_LATENCY in time_func_latency

### DIFF
--- a/python/sglang/srt/metrics/func_timer.py
+++ b/python/sglang/srt/metrics/func_timer.py
@@ -75,7 +75,8 @@ def time_func_latency(
                 try:
                     ret = await ret
                 finally:
-                    metric.labels(name=name).observe(time.monotonic() - start)
+                    if metric is not None:
+                        metric.labels(name=name).observe(time.monotonic() - start)
             return ret
 
         @wraps(func)
@@ -88,7 +89,8 @@ def time_func_latency(
             try:
                 ret = func(*args, **kwargs)
             finally:
-                metric.labels(name=name).observe(time.monotonic() - start)
+                if metric is not None:
+                    metric.labels(name=name).observe(time.monotonic() - start)
             return ret
 
         if asyncio.iscoroutinefunction(func):


### PR DESCRIPTION
## Summary
- Add defensive None checks before accessing `metric.labels()` in `time_func_latency` decorator
- Prevents `AttributeError` when `FUNC_LATENCY` is None

## Motivation
`FUNC_LATENCY` is initialized as `None` (line 44) and only set when `enable_func_timer()` is called. If the `@time_func_latency` decorator is used before `enable_func_timer()` is called, the code would crash with:
```
AttributeError: 'NoneType' object has no attribute 'labels'
```

## Changes
Added None checks in both `async_wrapper` and `sync_wrapper`:
```python
finally:
    if metric is not None:
        metric.labels(name=name).observe(time.monotonic() - start)
```

## Test plan
- No functional changes when metrics are properly initialized
- Gracefully handles the case where `FUNC_LATENCY` is None

🤖 Generated with [Claude Code](https://claude.com/claude-code)