### PR TITLE
fix(input_buffers): add None check before copying positions tensor

### DIFF
--- a/python/sglang/srt/model_executor/input_buffers.py
+++ b/python/sglang/srt/model_executor/input_buffers.py
@@ -140,7 +140,8 @@ class GraphInputBuffers:
         self.req_pool_indices[:raw_bs].copy_(forward_batch.req_pool_indices)
         self.seq_lens[:raw_bs].copy_(forward_batch.seq_lens)
         self.out_cache_loc[:raw_num_token].copy_(forward_batch.out_cache_loc)
-        self.positions[:raw_num_token].copy_(forward_batch.positions)
+        if forward_batch.positions is not None:
+            self.positions[:raw_num_token].copy_(forward_batch.positions)
 
         seq_lens_cpu: Optional[torch.Tensor] = None
         if forward_batch.seq_lens_cpu is not None:


### PR DESCRIPTION
## Summary
- Add defensive None check before calling `.copy_()` on `forward_batch.positions`
- Prevents `AttributeError` when `positions` is None

## Motivation
In `ForwardBatch`, the `positions` field is declared as:
```python
positions: torch.Tensor = None
```

The field can remain `None` in certain code paths during initialization. However, `populate_from_forward_batch()` unconditionally called `.copy_()` without checking for None first.

Other optional tensors in the same function have proper None checks:
- `seq_lens_cpu` (line 147)
- `encoder_lens` (line 152)
- `mrope_positions` (line 155)

But `positions` was missing this check.

## Changes
Added None check following the same pattern:
```python
if forward_batch.positions is not None:
    self.positions[:raw_num_token].copy_(forward_batch.positions)
```

## Test plan
- No functional changes for normal usage
- Gracefully handles edge cases where `positions` is None

🤖 Generated with [Claude Code](https://claude.com/claude-code)