### PR TITLE
fix(eplb): add empty deque check in mean() to prevent ZeroDivisionError

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -744,7 +744,7 @@ class _DequeCollection:
             d.clear()
 
     def mean(self) -> Dict[int, float]:
-        return {d.maxlen: sum(d) / len(d) for d in self._dequeues}
+        return {d.maxlen: sum(d) / len(d) for d in self._dequeues if len(d) > 0}
 
 
 class _DetailAccumulator(_UtilizationRateAccumulatorMixin):


### PR DESCRIPTION
## Summary
- Add empty deque guard in `_MultiWindowHistory.mean()` method to prevent `ZeroDivisionError`

## Problem
The `mean()` method computes averages by dividing `sum(d)` by `len(d)` for each deque:
```python
def mean(self) -> Dict[int, float]:
    return {d.maxlen: sum(d) / len(d) for d in self._dequeues}
```

If a deque is empty (which can happen early in server lifecycle before enough forward passes have occurred), this raises `ZeroDivisionError`.

## Solution
Add a guard to skip empty deques in the dictionary comprehension:
```python
return {d.maxlen: sum(d) / len(d) for d in self._dequeues if len(d) > 0}
```

This ensures empty deques are excluded from the result rather than causing a crash.