### PR TITLE
fix(sampling): add None check in DisallowedTokensLogitsProcessor

### DIFF
--- a/python/sglang/srt/sampling/custom_logit_processor.py
+++ b/python/sglang/srt/sampling/custom_logit_processor.py
@@ -49,6 +49,8 @@ class DisallowedTokensLogitsProcessor(CustomLogitProcessor):
         logits: torch.Tensor,
         custom_param_list: Optional[List[Dict[str, Any]]] = None,
     ) -> torch.Tensor:
+        if not custom_param_list:
+            return logits
         disallowed_token_ids = custom_param_list[0]["token_ids"]
         assert all(
             disallowed_token_ids == c["token_ids"] for c in custom_param_list


### PR DESCRIPTION
## Summary
- Add None/empty check in `DisallowedTokensLogitsProcessor.__call__()` to prevent TypeError

## Problem
The `__call__` method accepts an `Optional[List[Dict[str, Any]]]` parameter but accesses it directly without checking for None:

```python
def __call__(
    self,
    logits: torch.Tensor,
    custom_param_list: Optional[List[Dict[str, Any]]] = None,  # Can be None
) -> torch.Tensor:
    disallowed_token_ids = custom_param_list[0]["token_ids"]  # TypeError if None
```

This raises `TypeError: 'NoneType' object is not subscriptable` when called with `None`.

## Solution
Add early return when `custom_param_list` is None or empty:

```python
if not custom_param_list:
    return logits
```

This is consistent with other processors in the same file:
- `ThinkingBudgetLogitProcessor` (line 68): `if custom_param_list is None or not custom_param_list:`
- `DeepseekOCRNoRepeatNGramLogitProcessor` (line 148): `if not custom_param_list:`