### PR TITLE
fix(speculative): handle empty parents_list in organize_draft_results

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -31,9 +31,13 @@ def organize_draft_results(
 
     if len(parents_list) > 1:
         parent_list = torch.cat(parents_list[:-1], dim=1)
-    else:
+    elif len(parents_list) == 1:
         batch_size = parents_list[0].shape[0]
         parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
+    else:
+        # Empty parents_list - derive batch_size from token_list
+        batch_size = ss_token_list.shape[0]
+        parent_list = torch.empty(batch_size, 0, device=ss_token_list.device)
 
     return parent_list, top_scores_index, draft_tokens
 


### PR DESCRIPTION
## Summary
- Add empty list check in `organize_draft_results()` to prevent IndexError

## Problem
When `parents_list` is empty, the code at line 35-36 accesses `parents_list[0]` which raises `IndexError: list index out of range`.

```python
if len(parents_list) > 1:
    parent_list = torch.cat(parents_list[:-1], dim=1)
else:
    batch_size = parents_list[0].shape[0]  # IndexError if empty
```

## Solution
Add explicit check for empty list case:
```python
if len(parents_list) > 1:
    parent_list = torch.cat(parents_list[:-1], dim=1)
elif len(parents_list) == 1:
    batch_size = parents_list[0].shape[0]
    parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
else:
    # Empty parents_list - derive batch_size from token_list
    batch_size = ss_token_list.shape[0]
    parent_list = torch.empty(batch_size, 0, device=ss_token_list.device)
```