### PR TITLE
fix(function_call): add empty body check in pythonic_detector

### DIFF
--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -73,6 +73,8 @@ class PythonicDetector(BaseFormatDetector):
 
         try:
             module = ast.parse(tool_call_text)
+            if not module.body:
+                return StreamingParseResult(normal_text=normal_text, calls=[])
             parsed = getattr(module.body[0], "value", None)
             if not (
                 isinstance(parsed, ast.List)


### PR DESCRIPTION
## Summary
- Add empty body check before accessing `module.body[0]` to prevent IndexError

## Problem
When `ast.parse(tool_call_text)` returns a module with an empty body (e.g., when parsing empty string or whitespace-only text), accessing `module.body[0]` raises `IndexError: list index out of range`.

## Solution
Add early return when `module.body` is empty:
```python
module = ast.parse(tool_call_text)
if not module.body:
    return StreamingParseResult(normal_text=normal_text, calls=[])
parsed = getattr(module.body[0], "value", None)
```