### PR TITLE
fix(entrypoints): add empty messages check in tool get_result methods

### DIFF
--- a/python/sglang/srt/entrypoints/tool.py
+++ b/python/sglang/srt/entrypoints/tool.py
@@ -46,6 +46,8 @@ class HarmonyBrowserTool(Tool):
         from sglang.srt.entrypoints.context import HarmonyContext
 
         assert isinstance(context, HarmonyContext)
+        if not context.messages:
+            return []
         last_msg = context.messages[-1]
         tool_output_msgs = []
         async for msg in self.browser_tool.process(last_msg):
@@ -76,6 +78,8 @@ class HarmonyPythonTool(Tool):
         from sglang.srt.entrypoints.context import HarmonyContext
 
         assert isinstance(context, HarmonyContext)
+        if not context.messages:
+            return []
         last_msg = context.messages[-1]
         tool_output_msgs = []
         async for msg in self.python_tool.process(last_msg):


### PR DESCRIPTION
## Summary
- Add empty messages check in `HarmonyBrowserTool.get_result()` and `HarmonyPythonTool.get_result()`

## Problem
Both methods access `context.messages[-1]` without checking if the messages list is empty, which raises `IndexError: list index out of range`.

## Solution
Add early return when `context.messages` is empty:
```python
if not context.messages:
    return []
last_msg = context.messages[-1]
```