### PR TITLE
fix(distributed): add None assertions for subscribe ports in shm_broadcast

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
+++ b/python/sglang/srt/distributed/device_communicators/shm_broadcast.py
@@ -268,6 +268,7 @@ class MessageQueue:
 
         if rank in handle.local_reader_ranks:
             assert handle.buffer is not None
+            assert handle.local_subscribe_port is not None
             self.buffer = handle.buffer
             self.current_idx = 0
             self.local_reader_rank = handle.local_reader_ranks.index(rank)
@@ -290,6 +291,7 @@ class MessageQueue:
 
             self.local_socket = None
 
+            assert handle.remote_subscribe_port is not None
             self.remote_socket = context.socket(SUB)
             self.remote_socket.setsockopt_string(SUBSCRIBE, "")
             if is_valid_ipv6_address(handle.connect_ip):


### PR DESCRIPTION
## Summary
- Add None assertions for `local_subscribe_port` and `remote_subscribe_port` before use

## Problem
In `MessageQueue.create_from_handle()`, `handle.local_subscribe_port` and `handle.remote_subscribe_port` are typed as `Optional[int]` but used directly without None checks:
- Line 280: `f"tcp://127.0.0.1:{handle.local_subscribe_port}"` 
- Line 299: `format_tcp_address(handle.connect_ip, handle.remote_subscribe_port)`

If these are None, the code will produce invalid socket addresses or raise TypeError.

## Solution
Add assertions before use, consistent with existing pattern (line 270 asserts `handle.buffer is not None`):
```python
assert handle.local_subscribe_port is not None
# ... use local_subscribe_port

assert handle.remote_subscribe_port is not None
# ... use remote_subscribe_port
```