### PR TITLE
fix(mem_cache): add empty token_ids check in get_child_key

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -179,7 +179,9 @@ def _key_match_paged(key0: RadixKey, key1: RadixKey, page_size: int):
 
 
 def get_child_key(key: RadixKey, page_size: int = 1):
-    if page_size == 1:
+    if not key.token_ids:
+        plain_key = ()
+    elif page_size == 1:
         plain_key = key.token_ids[0]
     else:
         plain_key = tuple(key.token_ids[:page_size])


### PR DESCRIPTION
## Summary
- Add empty token_ids check before accessing `token_ids[0]` to prevent IndexError

## Problem
When `page_size == 1`, the function accesses `key.token_ids[0]` without checking if the list is empty:
```python
if page_size == 1:
    plain_key = key.token_ids[0]  # IndexError if empty
```

## Solution
Add early check for empty token_ids:
```python
if not key.token_ids:
    plain_key = ()
elif page_size == 1:
    plain_key = key.token_ids[0]
else:
    plain_key = tuple(key.token_ids[:page_size])
```