### PR TITLE
fix(constrained): add empty bytes check in test_main

### DIFF
--- a/python/sglang/srt/constrained/outlines_jump_forward.py
+++ b/python/sglang/srt/constrained/outlines_jump_forward.py
@@ -185,7 +185,8 @@ def test_main(regex_string):
             jump_forward_str, next_state = jump_forward_map.jump_forward_symbol(state)
             print(f"{state} -> {next_state}", jump_forward_str)
         bytes_ = jump_forward_map.jump_forward_byte(state)
-        print(f"{state} -> {bytes_[-1][1]}", [hex(b) for b, _ in bytes_])
+        if bytes_:
+            print(f"{state} -> {bytes_[-1][1]}", [hex(b) for b, _ in bytes_])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add empty list check before accessing `bytes_[-1]` to prevent IndexError

## Problem
In `test_main()`, `bytes_[-1][1]` is accessed without checking if `bytes_` is empty:
```python
bytes_ = jump_forward_map.jump_forward_byte(state)
print(f"{state} -> {bytes_[-1][1]}", ...)  # IndexError if empty
```

## Solution
Add guard for empty list:
```python
bytes_ = jump_forward_map.jump_forward_byte(state)
if bytes_:
    print(f"{state} -> {bytes_[-1][1]}", ...)
```