### PR TITLE
fix(mem_cache): add empty status_codes check in eic_storage

### DIFF
--- a/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
+++ b/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
@@ -592,6 +592,10 @@ class EICStorage(HiCacheStorage):
             for item in items:
                 self.kv_cache_write_mem_pool.free_to_mempool(item.data_ptr())
 
+        if not set_outcome.status_codes:
+            logger.error(f"set data key {len(eic_keys)} failed, empty status_codes")
+            return [False] * len(keys)
+
         err_code = set_outcome.status_codes[0]
         if err_code != eic.StatusCode.SUCCESS:
             logger.error(f"set data key {len(eic_keys)} failed, err_code {err_code}")


### PR DESCRIPTION
## Summary
- Add empty status_codes check before accessing `status_codes[0]` to prevent IndexError

## Problem
`set_outcome.status_codes[0]` is accessed without checking if `status_codes` is empty:
```python
err_code = set_outcome.status_codes[0]  # IndexError if empty
```

## Solution
Add guard for empty status_codes:
```python
if not set_outcome.status_codes:
    logger.error(f"set data key {len(eic_keys)} failed, empty status_codes")
    return [False] * len(keys)

err_code = set_outcome.status_codes[0]
```