### PR TITLE
fix(multimodal): filter None values before torch.cat in mm_utils

### DIFF
--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -647,5 +647,10 @@ def run_dp_sharded_mrope_vision_model(
                 ]
                 embed_start += img_patches
             current_idx += count
-    out_embeddings = torch.cat(original_order_embeddings, dim=0)
+
+    # Filter out any None values that weren't filled
+    valid_embeddings = [e for e in original_order_embeddings if e is not None]
+    if not valid_embeddings:
+        raise ValueError("No valid embeddings found after gathering")
+    out_embeddings = torch.cat(valid_embeddings, dim=0)
     return out_embeddings


### PR DESCRIPTION
## Summary
- Filter None values from embeddings list before calling `torch.cat()` to prevent TypeError

## Problem
`original_order_embeddings` is initialized with None values and some indices may not get filled if certain ranks have zero images assigned. Calling `torch.cat()` on a list containing None raises TypeError.

## Solution
Filter out None values before concatenation:
```python
valid_embeddings = [e for e in original_order_embeddings if e is not None]
if not valid_embeddings:
    raise ValueError("No valid embeddings found after gathering")
out_embeddings = torch.cat(valid_embeddings, dim=0)
```