### PR TITLE
fix(function_call): ensure streamed_args_for_tool bounds in base_format_detector

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -247,6 +247,9 @@ class BaseFormatDetector(ABC):
                 res = StreamingParseResult()
 
                 if cur_arguments:
+                    # Ensure streamed_args_for_tool is large enough
+                    while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                        self.streamed_args_for_tool.append("")
                     # Calculate how much of the arguments we've already streamed
                     sent = len(self.streamed_args_for_tool[self.current_tool_id])
                     cur_args_json = json.dumps(cur_arguments)


### PR DESCRIPTION
## Summary
- Add bounds check before accessing `streamed_args_for_tool[current_tool_id]` to prevent IndexError

## Problem
In Case 2 (streaming arguments), `self.streamed_args_for_tool[self.current_tool_id]` is accessed without ensuring the list is large enough:
```python
sent = len(self.streamed_args_for_tool[self.current_tool_id])  # IndexError possible
```

While Case 1 has similar extension logic (lines 225-227), Case 2 doesn't, which can lead to IndexError if the control flow doesn't pass through Case 1 first.

## Solution
Add the same bounds check pattern used in Case 1:
```python
while len(self.streamed_args_for_tool) <= self.current_tool_id:
    self.streamed_args_for_tool.append("")
sent = len(self.streamed_args_for_tool[self.current_tool_id])
```