### PR TITLE
fix(speculative): handle empty parents_list in eagle_worker_v2

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -418,9 +418,13 @@ class EagleDraftWorker(BaseDraftWorker):
 
         if len(parents_list) > 1:
             parent_list = torch.cat(parents_list[:-1], dim=1)
-        else:
+        elif len(parents_list) == 1:
             batch_size = parents_list[0].shape[0]
             parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
+        else:
+            # Empty parents_list - derive batch_size from token_list
+            batch_size = ss_token_list.shape[0]
+            parent_list = torch.empty(batch_size, 0, device=ss_token_list.device)
 
         return parent_list, top_scores_index, draft_tokens
 


### PR DESCRIPTION
## Summary
- Add empty list check in `_draft_extend_for_decode()` to prevent IndexError

## Problem
Same pattern as #15968. When `parents_list` is empty, the code accesses `parents_list[0]` which raises `IndexError`:
```python
if len(parents_list) > 1:
    parent_list = torch.cat(parents_list[:-1], dim=1)
else:
    batch_size = parents_list[0].shape[0]  # IndexError if empty
```

## Solution
Add explicit check for empty list case:
```python
if len(parents_list) > 1:
    parent_list = torch.cat(parents_list[:-1], dim=1)
elif len(parents_list) == 1:
    batch_size = parents_list[0].shape[0]
    parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
else:
    # Empty parents_list - derive batch_size from token_list
    batch_size = ss_token_list.shape[0]
    parent_list = torch.empty(batch_size, 0, device=ss_token_list.device)
```