### PR TITLE
fix(lora): add bounds check for output_offset_cpu in torch backend

### DIFF
--- a/python/sglang/srt/lora/backend/torch_backend.py
+++ b/python/sglang/srt/lora/backend/torch_backend.py
@@ -87,6 +87,11 @@ class TorchNativeLoRABackend(BaseLoRABackend):
     ) -> torch.Tensor:
         num_slices = 3
         assert isinstance(qkv_lora_b, torch.Tensor)
+        if len(output_offset_cpu) < num_slices + 1:
+            raise ValueError(
+                f"output_offset_cpu must have at least {num_slices + 1} elements, "
+                f"got {len(output_offset_cpu)}"
+            )
 
         total_seq_len, _ = x.shape
         _, weight_intermediate_dim, _ = qkv_lora_a.shape


### PR DESCRIPTION
## Summary
- Add validation that `output_offset_cpu` has at least `num_slices + 1` elements before accessing it in `run_qkv_lora`
- Prevents potential `IndexError` when `output_offset_cpu[slice_id + 1]` is accessed in the loop

## Test plan
- Existing LoRA tests should pass
- The validation will raise a clear `ValueError` if the array is too short

🤖 Generated with [Claude Code](https://claude.com/claude-code)