### PR TITLE
fix(lora): add divisibility check for gate_up_lora_b in chunked backend

### DIFF
--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -112,6 +112,11 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
         # gate_up_lora_a: (num_lora, 2 * r, input_dim)
         # gate_up_lora_b: (num_lora, 2 * output_dim, r)
         assert isinstance(gate_up_lora_b, torch.Tensor)
+        if gate_up_lora_b.shape[-2] % 2 != 0:
+            raise ValueError(
+                f"gate_up_lora_b dimension must be divisible by 2, "
+                f"got {gate_up_lora_b.shape[-2]}"
+            )
         output_dim = gate_up_lora_b.shape[-2] // 2
 
         # lora_a_output: (s, 2 * r)


### PR DESCRIPTION
## Summary
- Add validation that `gate_up_lora_b` dimension is divisible by 2 before division in `run_gate_up_lora`
- Prevents incorrect dimension calculation if tensor has unexpected shape

## Test plan
- Existing LoRA tests should pass
- The validation will raise a clear `ValueError` if the dimension is not divisible by 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)