### PR TITLE
fix(lora): use safe dictionary access in mem_pool eviction

### DIFF
--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -332,8 +332,10 @@ class LoRAMemoryPool:
             victim_uid = self.eviction_policy.select_victim(candidates)
 
             # Evict the selected victim
-            victim_buffer_id = self.uid_to_buffer_id[victim_uid]
-            self.uid_to_buffer_id.pop(victim_uid)
+            victim_buffer_id = self.uid_to_buffer_id.get(victim_uid)
+            if victim_buffer_id is None:
+                raise ValueError(f"Victim UID {victim_uid} not found in buffer mapping")
+            self.uid_to_buffer_id.pop(victim_uid, None)
             self.eviction_policy.remove(victim_uid)
             self.buffer_id_to_uid[victim_buffer_id] = EMPTY_SLOT
             logger.debug(


### PR DESCRIPTION
## Summary
- Replace direct dictionary access `self.uid_to_buffer_id[victim_uid]` with `.get()` and explicit error handling
- Use `.pop(victim_uid, None)` with default to prevent potential KeyError during eviction
- Provides clearer error message if victim UID is not found

## Test plan
- Existing LoRA tests should pass
- The change improves error handling without changing normal behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)