### PR TITLE
[Diffusion] Refactor diffusion Flash Attention backend

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -86,6 +86,7 @@ diffusion = [
   "PyYAML==6.0.1",
   "cloudpickle",
   "diffusers==0.36.0",
+  "flash-attn",
   "imageio==2.36.0",
   "imageio-ffmpeg==0.5.1",
   "moviepy>=2.0.0",

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -141,7 +141,7 @@ class FlashAttentionImpl(AttentionImpl):
             seqlen_k,
             softmax_scale=self.softmax_scale,
             causal=self.causal,
-            return_softmax_lse=return_softmax_lse,
+            return_attn_probs=return_softmax_lse,
         )
 
         if return_softmax_lse:

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -7,25 +7,15 @@ from typing import Any
 
 import torch
 
-from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 
 try:
-    from sgl_kernel.flash_attn import flash_attn_varlen_func
-
-    # flash_attn 3 no longer have a different API, see following commit:
-    # https://github.com/Dao-AILab/flash-attention/commit/ed209409acedbb2379f870bbd03abce31a7a51b7
-    flash_attn_func = flash_attn_varlen_func
+    from flash_attn_interface import flash_attn_varlen_func
 except ImportError as e:
-    raise e
-
-
-try:
-    from flash_attn_interface import (
-        flash_attn_varlen_func as flash_attn_varlen_func_upstream,
-    )
-except Exception:
-    flash_attn_varlen_func_upstream = None
+    raise ImportError(
+        "flash-attention library is required. Please install it with: "
+        "pip install flash-attn --no-build-isolation"
+    ) from e
 
 from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
     AttentionBackend,
@@ -37,8 +27,6 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
-fa_ver = 3
-
 
 @lru_cache(maxsize=128)
 def _get_cu_seqlens(device_index: int, bsz: int, seqlen: int) -> torch.Tensor:
@@ -49,45 +37,6 @@ def _get_cu_seqlens(device_index: int, bsz: int, seqlen: int) -> torch.Tensor:
         device=torch.device("cuda", device_index),
         dtype=torch.int32,
     )
-
-
-@lru_cache(maxsize=256)
-def _should_use_upstream_flash_attention(
-    upstream_available: bool,
-    upstream_heads_ok: bool,
-    q_shape: tuple[int, ...],
-    k_shape: tuple[int, ...],
-    v_shape: tuple[int, ...],
-) -> bool:
-    if not upstream_available or not upstream_heads_ok:
-        return False
-
-    if len(q_shape) != 4 or len(k_shape) != 4 or len(v_shape) != 4:
-        return False
-
-    bsz, seqlen, nheads_q, d = q_shape
-    bsz_k, seqlen_k, nheads_k, d_k = k_shape
-    bsz_v, seqlen_v, nheads_v, d_v = v_shape
-
-    if (
-        bsz != bsz_k
-        or bsz != bsz_v
-        or seqlen != seqlen_k
-        or seqlen != seqlen_v
-        or d != d_k
-        or d != d_v
-    ):
-        return False
-    if nheads_k != nheads_v:
-        return False
-    if nheads_k == 0 or (nheads_q % nheads_k) != 0:
-        return False
-    return True
-
-
-def set_fa_ver(ver: int):
-    global fa_ver
-    fa_ver = ver
 
 
 @dataclass
@@ -162,13 +111,6 @@ class FlashAttentionImpl(AttentionImpl):
         self.causal = causal
         self.softmax_scale = softmax_scale
         self.attention_metadata = FlashAttentionMetadata()
-        if self.num_kv_heads is None:
-            self._upstream_heads_ok = True
-        else:
-            # For gqa, the num_heads must be a multiple of num_kv_heads
-            self._upstream_heads_ok = (
-                self.num_kv_heads > 0 and (self.num_heads % self.num_kv_heads) == 0
-            )
 
     def forward(
         self,
@@ -179,58 +121,30 @@ class FlashAttentionImpl(AttentionImpl):
         *,
         return_softmax_lse: bool = False,
     ):
-        attn_metadata: FlashAttentionMetadata = get_forward_context().attn_metadata
-        if attn_metadata is not None and attn_metadata.max_seqlen_q is None:
-            attn_metadata.max_seqlen_q = query.shape[1]
-            attn_metadata.max_seqlen_k = key.shape[1]
-            max_seqlen_q = attn_metadata.max_seqlen_q
-            max_seqlen_k = attn_metadata.max_seqlen_k
-        else:
-            max_seqlen_q = query.shape[1]
-            max_seqlen_k = key.shape[1]
-        q_shape = tuple(query.shape)
-        k_shape = tuple(key.shape)
-        v_shape = tuple(value.shape)
-        use_upstream = _should_use_upstream_flash_attention(
-            flash_attn_varlen_func_upstream is not None,
-            self._upstream_heads_ok,
-            q_shape,
-            k_shape,
-            v_shape,
-        )
+        bsz, seqlen, nheads_q, d = query.shape
+        bsz_k, seqlen_k, nheads_k, d_k = key.shape
 
-        if use_upstream:
-            bsz, seqlen, nheads_q, d = q_shape
-            bsz_k, seqlen_k, nheads_k, d_k = k_shape
-            bsz_v, seqlen_v, nheads_v, d_v = v_shape
-            q_ = query.contiguous().reshape(bsz * seqlen, nheads_q, d)
-            k_ = key.contiguous().reshape(bsz * seqlen, nheads_k, d)
-            v_ = value.contiguous().reshape(bsz * seqlen, nheads_v, d)
-            cu = _get_cu_seqlens(q_.device.index, bsz, seqlen)
-            out = flash_attn_varlen_func_upstream(
-                q_,
-                k_,
-                v_,
-                cu,
-                cu,
-                seqlen,
-                seqlen,
-                softmax_scale=self.softmax_scale,
-                causal=self.causal,
-            )
-            return out.reshape(bsz, seqlen, nheads_q, d)
+        q_ = query.contiguous().reshape(bsz * seqlen, nheads_q, d)
+        k_ = key.contiguous().reshape(bsz * seqlen_k, nheads_k, d_k)
+        v_ = value.contiguous().reshape(bsz * seqlen_k, nheads_k, value.shape[-1])
 
-        output = flash_attn_func(
-            q=query,  # type: ignore[no-untyped-call]
-            k=key,
-            v=value,
-            cu_seqlens_q=None,
-            cu_seqlens_k=None,
-            max_seqlen_q=max_seqlen_q,
-            max_seqlen_k=max_seqlen_k,
+        cu_seqlens_q = _get_cu_seqlens(q_.device.index, bsz, seqlen)
+        cu_seqlens_k = _get_cu_seqlens(k_.device.index, bsz, seqlen_k)
+
+        out = flash_attn_varlen_func(
+            q_,
+            k_,
+            v_,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqlen,
+            seqlen_k,
             softmax_scale=self.softmax_scale,
             causal=self.causal,
             return_softmax_lse=return_softmax_lse,
-            ver=fa_ver,
         )
-        return output
+
+        if return_softmax_lse:
+            out, softmax_lse = out
+            return out.reshape(bsz, seqlen, nheads_q, -1), softmax_lse
+        return out.reshape(bsz, seqlen, nheads_q, -1)

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn_2.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn_2.py
@@ -72,6 +72,8 @@ class FlashAttention2Impl(AttentionImpl):
         key: torch.Tensor,
         value: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        *,
+        return_softmax_lse: bool = False,
     ):
         bsz, seqlen, nheads_q, d = query.shape
         bsz_k, seqlen_k, nheads_k, d_k = key.shape
@@ -93,6 +95,10 @@ class FlashAttention2Impl(AttentionImpl):
             seqlen_k,
             softmax_scale=self.softmax_scale,
             causal=self.causal,
+            return_attn_probs=return_softmax_lse,
         )
 
+        if return_softmax_lse:
+            out, softmax_lse = out
+            return out.reshape(bsz, seqlen, nheads_q, -1), softmax_lse
         return out.reshape(bsz, seqlen, nheads_q, -1)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Refer to : https://github.com/sgl-project/sglang/pull/15812

This PR refactors the flash attention implementation in the diffusion module to use only the official `flash-attention` library instead of `sgl-kernel`, simplifying the codebase and improving performance.

## H100 single gpu Performance Benchmarks
Tested on single GPU with various diffusion models:
| Model | Steps | Main (s) | PR (s) | Speedup | Improvement |
|-------|-------|----------|--------|---------|-------------|
| FLUX.1-dev | 50 | 8.26 | 7.96 | **1.04x** | 3.6% faster |
| FLUX.2-dev | 50 | 26.49 | 23.45 | **1.13x** | 11.5% faster |
| Qwen-Image | 50 | 14.16 | 13.55 | **1.04x** | 4.3% faster |
| Qwen-Image-Edit-2511 | 40 | 27.74 | 25.58 | **1.08x** | 7.8% faster |
| **Average** | - | - | - | **1.07x** | **6.8% faster** |
### Per-Step Performance
| Model | Main (s/step) | PR (s/step) | Improvement |
|-------|---------------|-------------|-------------|
| FLUX.1-dev | 0.1649 | 0.1591 | 3.5% faster |
| FLUX.2-dev | 0.5209 | 0.4614 | 11.4% faster |
| Qwen-Image | 0.2831 | 0.2709 | 4.3% faster |
| Qwen-Image-Edit-2511 | 0.6934 | 0.6395 | 7.8% faster |
| **Average** | - | - | **6.8% faster** |

## main

```shell
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/flash_attn.py
@@ -59,6 +59,7 @@ def _should_use_upstream_flash_attention(
     k_shape: tuple[int, ...],
     v_shape: tuple[int, ...],
 ) -> bool:
+    return False
     if not upstream_available or not upstream_heads_ok:
         return False
 
```

CUDA_VISIBLE_DEVICES=7 sglang generate --prompt='A curious raccoon' --save-output --log-level=debug --output-path=outputs --model-path=black-forest-labs/FLUX.1-dev  --output-file-name=FLUX.1.dev

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:08<00:00,  6.06it/s]
[12-27 15:00:40] [DenoisingStage] average time per step: 0.1649 seconds
[12-27 15:00:40] [DenoisingStage] finished in 8.2553 seconds

CUDA_VISIBLE_DEVICES=7 sglang generate --prompt='A curious raccoon' --save-output --log-level=debug --output-path=outputs --model-path=black-forest-labs/FLUX.2-dev  --output-file-name=FLUX.2.dev

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:26<00:00,  1.92it/s]
[12-27 14:59:45] [DenoisingStage] average time per step: 0.5209 seconds
[12-27 14:59:46] [DenoisingStage] finished in 26.4943 seconds

CUDA_VISIBLE_DEVICES=7 sglang generate --prompt='A curious raccoon' --save-output --log-level=debug --output-path=outputs --model-path=Qwen/Qwen-Image --output-file-name=Qwen-Image

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:14<00:00,  3.53it/s]
[12-27 15:03:20] [DenoisingStage] average time per step: 0.2831 seconds
[12-27 15:03:20] [DenoisingStage] finished in 14.1618 seconds

CUDA_VISIBLE_DEVICES=7 sglang generate --model-path Qwen/Qwen-Image-Edit-2511 --prompt "Change the person to a standing position, bending over to hold the dog's front paws."  --image-path "/home/lmsys/bbuf/LightX2V/examples/qwen_image/1.png"

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 40/40 [00:27<00:00,  1.44it/s]
[12-27 15:07:31] [DenoisingStage] average time per step: 0.6934 seconds
[12-27 15:07:31] [DenoisingStage] finished in 27.7448 seconds


## pr


CUDA_VISIBLE_DEVICES=7 sglang generate --prompt='A curious raccoon' --save-output --log-level=debug --output-path=outputs --model-path=black-forest-labs/FLUX.1-dev  --output-file-name=FLUX.1.dev

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:07<00:00,  6.29it/s]
[12-28 06:09:44] [DenoisingStage] average time per step: 0.1591 seconds
[12-28 06:09:44] [DenoisingStage] finished in 7.9619 seconds

CUDA_VISIBLE_DEVICES=7 sglang generate --prompt='A curious raccoon' --save-output --log-level=debug --output-path=outputs --model-path=black-forest-labs/FLUX.2-dev  --output-file-name=FLUX.2.dev

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:23<00:00,  2.17it/s]
[12-28 06:12:50] [DenoisingStage] average time per step: 0.4614 seconds
[12-28 06:12:51] [DenoisingStage] finished in 23.4544 seconds

CUDA_VISIBLE_DEVICES=7 sglang generate --prompt='A curious raccoon' --save-output --log-level=debug --output-path=outputs --model-path=Qwen/Qwen-Image --output-file-name=Qwen-Image

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 50/50 [00:13<00:00,  3.69it/s]
[12-28 06:14:14] [DenoisingStage] average time per step: 0.2709 seconds
[12-28 06:14:14] [DenoisingStage] finished in 13.5527 seconds

CUDA_VISIBLE_DEVICES=7 sglang generate --model-path Qwen/Qwen-Image-Edit-2511 --prompt "Change the person to a standing position, bending over to hold the dog's front paws."  --image-path "/home/lmsys/bbuf/LightX2V/examples/qwen_image/1.png"

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 40/40 [00:25<00:00,  1.56it/s]
[12-28 06:54:22] [DenoisingStage] average time per step: 0.6395 seconds
[12-28 06:54:22] [DenoisingStage] finished in 25.5836 seconds





## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
