### PR TITLE
[VLM][Tiny] Refactor DP ViT parallel framework

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -602,9 +602,8 @@ class VisionAttention(nn.Module):
                 total_num_kv_heads=num_dummy_heads + num_heads,
                 bias=qkv_bias,
                 quant_config=quant_config,
-                tp_rank=self.tp_rank,
-                tp_size=self.tp_size,
                 prefix=add_prefix("qkv_proj", prefix),
+                disable_tp=use_data_parallel,
             )
         else:
             self.qkv_proj = ColumnParallelLinear(
@@ -612,18 +611,16 @@ class VisionAttention(nn.Module):
                 output_size=3 * self.dummy_dim,
                 bias=qkv_bias,
                 quant_config=quant_config,
-                tp_rank=self.tp_rank,
-                tp_size=self.tp_size,
                 prefix=add_prefix("qkv_proj", prefix),
+                disable_tp=use_data_parallel,
             )
         self.proj = RowParallelLinear(
             input_size=self.dummy_dim,
             output_size=embed_dim,
             bias=proj_bias,
             quant_config=quant_config,
-            tp_rank=self.tp_rank,
-            tp_size=self.tp_size,
             prefix=add_prefix("proj", prefix),
+            disable_tp=use_data_parallel,
         )
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -142,6 +142,7 @@ class LinearBase(torch.nn.Module):
         skip_bias_add: If true, skip adding bias but instead return it.
         params_dtype: Data type for the parameters.
         quant_config: Quantization configure.
+        disable_tp: If true, tensor parallelism will be disabled for this layer.
     """
 
     def __init__(
@@ -152,6 +153,8 @@ class LinearBase(torch.nn.Module):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        *,
+        disable_tp: bool = False,
     ):
         super().__init__()
 
@@ -167,6 +170,9 @@ class LinearBase(torch.nn.Module):
             self.quant_method: Optional[QuantizeMethodBase] = UnquantizedLinearMethod()
         else:
             self.quant_method = quant_config.get_quant_method(self, prefix=prefix)
+        self.disable_tp = disable_tp
+        self.tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        self.tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError
@@ -184,6 +190,7 @@ class ReplicatedLinear(LinearBase):
         quant_config: Quantization configure.
         prefix: The name of the layer in the state dict, including all parents
                         (e.g. model.layers.0.qkv_proj)
+        disable_tp: Take no effect for replicated linear layers.
     """
 
     def __init__(
@@ -195,6 +202,8 @@ class ReplicatedLinear(LinearBase):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        *,
+        disable_tp: bool = False,
     ):
         super().__init__(
             input_size,
@@ -203,6 +212,7 @@ class ReplicatedLinear(LinearBase):
             params_dtype,
             quant_config,
             prefix=prefix,
+            disable_tp=disable_tp,
         )
 
         # All the linear layer supports quant method.
@@ -289,6 +299,7 @@ class ColumnParallelLinear(LinearBase):
                        the list would be size 3.
         prefix: The name of the layer in the state dict, including all parents
                         (e.g. model.layers.0.qkv_proj)
+        disable_tp: If true, weights matrix won't be sharded through tp rank.
     """
 
     def __init__(
@@ -302,26 +313,29 @@ class ColumnParallelLinear(LinearBase):
         quant_config: Optional[QuantizationConfig] = None,
         output_sizes: Optional[List[int]] = None,
         prefix: str = "",
-        tp_rank: Optional[int] = None,
-        tp_size: Optional[int] = None,
+        disable_tp: bool = False,
         use_presharded_weights: bool = False,
         skip_block_quant_check: bool = False,
     ):
         super().__init__(
-            input_size, output_size, skip_bias_add, params_dtype, quant_config, prefix
+            input_size,
+            output_size,
+            skip_bias_add,
+            params_dtype,
+            quant_config,
+            prefix,
+            disable_tp=disable_tp,
         )
 
         self.gather_output = gather_output
         self.use_presharded_weights = use_presharded_weights
 
         # Divide the weight matrix along the last dimension.
-        if tp_rank is None:
-            tp_rank = get_tensor_model_parallel_rank()
-        if tp_size is None:
-            tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank, self.tp_size = tp_rank, tp_size
         assert self.quant_method is not None
-        self.output_size_per_partition = divide(self.output_size, tp_size)
+        self.output_size_per_partition = divide(output_size, self.tp_size)
         self.output_partition_sizes = [self.output_size_per_partition]
         # If QKV or MergedColumn, use output size of each partition.
         if hasattr(self, "output_sizes"):
@@ -481,6 +495,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         quant_config: Quantization configure.
         prefix: The name of the layer in the state dict, including all parents
                         (e.g. model.layers.0.qkv_proj)
+        disable_tp: If true, all weights matrix won't be sharded, this layer
+                    will be treated as a "Replicated" MergedLinear.
     """
 
     def __init__(
@@ -493,15 +509,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         params_dtype: Optional[torch.dtype] = None,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        tp_rank: Optional[int] = None,
-        tp_size: Optional[int] = None,
         use_presharded_weights: bool = False,
+        *,
+        disable_tp: bool = False,
     ):
         self.output_sizes = output_sizes
-        if tp_rank is None:
-            tp_rank = get_tensor_model_parallel_rank()
-        if tp_size is None:
-            tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
+        tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank, self.tp_size = tp_rank, tp_size
         assert all(output_size % tp_size == 0 for output_size in output_sizes)
         self.use_presharded_weights = use_presharded_weights
@@ -514,9 +528,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             params_dtype=params_dtype,
             quant_config=quant_config,
             prefix=prefix,
-            tp_rank=tp_rank,
-            tp_size=tp_size,
             use_presharded_weights=use_presharded_weights,
+            disable_tp=disable_tp,
         )
         self.prefix = prefix
 
@@ -801,6 +814,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         quant_config: Quantization configure.
         prefix: The name of the layer in the state dict, including all parents
                         (e.g. model.layers.0.qkv_proj)
+        disable_tp: If true, weights matrix won't be sharded through tp rank.
     """
 
     def __init__(
@@ -819,6 +833,8 @@ class QKVParallelLinear(ColumnParallelLinear):
         load_presharded_attn: bool = False,
         v_head_size: Optional[int] = None,
         skip_block_quant_check: bool = False,
+        *,
+        disable_tp: bool = False,
     ):
         self.hidden_size = hidden_size
         self.head_size = head_size
@@ -831,7 +847,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         if tp_rank is None:
             tp_rank = get_tensor_model_parallel_rank()
         if tp_size is None:
-            tp_size = get_tensor_model_parallel_world_size()
+            tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank, self.tp_size = tp_rank, tp_size
         self.num_heads = divide(self.total_num_heads, tp_size)
         if tp_size >= self.total_num_kv_heads:
@@ -866,10 +882,9 @@ class QKVParallelLinear(ColumnParallelLinear):
             params_dtype=params_dtype,
             quant_config=quant_config,
             prefix=prefix,
-            tp_rank=tp_rank,
-            tp_size=tp_size,
             use_presharded_weights=self.use_presharded_weights,
             skip_block_quant_check=skip_block_quant_check,
+            disable_tp=disable_tp,
         )
 
     def _get_shard_offset_mapping(self, loaded_shard_id: str):
@@ -1245,6 +1260,7 @@ class RowParallelLinear(LinearBase):
                        We skip adding bias but instead return it.
         params_dtype: Data type for the parameters.
         quant_config: Quantization configure.
+        disable_tp: If true, weights matrix won't be sharded through tp rank.
     """
 
     def __init__(
@@ -1261,10 +1277,18 @@ class RowParallelLinear(LinearBase):
         tp_rank: Optional[int] = None,
         tp_size: Optional[int] = None,
         use_presharded_weights: bool = False,
+        *,
+        disable_tp: bool = False,
     ):
         quant_config = None if _disable_hip_linear_quant else quant_config
         super().__init__(
-            input_size, output_size, skip_bias_add, params_dtype, quant_config, prefix
+            input_size,
+            output_size,
+            skip_bias_add,
+            params_dtype,
+            quant_config,
+            prefix,
+            disable_tp=disable_tp,
         )
 
         self.input_is_parallel = input_is_parallel
@@ -1272,9 +1296,9 @@ class RowParallelLinear(LinearBase):
 
         # Divide the weight matrix along the last dimension.
         if tp_rank is None:
-            tp_rank = get_tensor_model_parallel_rank()
+            tp_rank = get_tensor_model_parallel_rank() if not disable_tp else 0
         if tp_size is None:
-            tp_size = get_tensor_model_parallel_world_size()
+            tp_size = get_tensor_model_parallel_world_size() if not disable_tp else 1
         self.tp_rank, self.tp_size = tp_rank, tp_size
         self.input_size_per_partition = divide(input_size, self.tp_size)
         assert self.quant_method is not None

--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -194,16 +194,14 @@ class InternMLP(nn.Module):
             config.intermediate_size,
             bias=True,
             quant_config=None,
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
         self.fc2 = RowParallelLinear(
             config.intermediate_size,
             config.hidden_size,
             bias=True,
             quant_config=None,
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/models/qwen2_5_vl.py
+++ b/python/sglang/srt/models/qwen2_5_vl.py
@@ -41,10 +41,6 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2_5_VisionRotaryEmbedding,
 )
 
-from sglang.srt.distributed import (
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
-)
 from sglang.srt.distributed.parallel_state import get_pp_group
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.vision import VisionAttention
@@ -92,18 +88,13 @@ class Qwen2_5_VLMLP(nn.Module):
         use_data_parallel: bool = False,
     ):
         super().__init__()
-        self.tp_size = (
-            1 if use_data_parallel else get_tensor_model_parallel_world_size()
-        )
-        self.tp_rank = 0 if use_data_parallel else get_tensor_model_parallel_rank()
         self.gate_up_proj = MergedColumnParallelLinear(
             input_size=in_features,
             output_sizes=[hidden_features] * 2,  # [gate_proj, up_proj]
             bias=bias,
             quant_config=quant_config,
             prefix=add_prefix("gate_up_proj", prefix),
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
         self.down_proj = RowParallelLinear(
             hidden_features,
@@ -111,8 +102,7 @@ class Qwen2_5_VLMLP(nn.Module):
             bias=bias,
             quant_config=quant_config,
             prefix=add_prefix("down_proj", prefix),
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
         self.act = ACT2FN[hidden_act]
 
@@ -212,8 +202,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
         super().__init__()
         self.hidden_size = context_dim * (spatial_merge_size**2)
         self.ln_q = RMSNorm(context_dim, eps=1e-6)
-        tp_size = 1 if use_data_parallel else get_tensor_model_parallel_world_size()
-        tp_rank = 0 if use_data_parallel else get_tensor_model_parallel_rank()
+
         self.mlp = nn.ModuleList(
             [
                 ColumnParallelLinear(
@@ -222,8 +211,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
                     bias=True,
                     quant_config=quant_config,
                     prefix=add_prefix("mlp.0", prefix),
-                    tp_size=tp_size,
-                    tp_rank=tp_rank,
+                    disable_tp=use_data_parallel,
                 ),
                 nn.GELU(),
                 RowParallelLinear(
@@ -232,8 +220,7 @@ class Qwen2_5_VisionPatchMerger(nn.Module):
                     bias=True,
                     quant_config=quant_config,
                     prefix=add_prefix("mlp.2", prefix),
-                    tp_size=tp_size,
-                    tp_rank=tp_rank,
+                    disable_tp=use_data_parallel,
                 ),
             ]
         )
@@ -314,9 +301,6 @@ class Qwen2_5_VisionTransformer(nn.Module, RotaryPosMixin):
         )
 
         # Resource prepared for vit cuda graph
-        self.tp_size = (
-            1 if use_data_parallel else get_tensor_model_parallel_world_size()
-        )
         self.max_context_len = max_context_len
         self.cuda_graph_runner: Optional[ViTCudaGraphRunner] = ViTCudaGraphRunner(self)
 

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -26,10 +26,6 @@ from einops import rearrange
 from transformers.activations import ACT2FN
 
 from sglang.srt.configs.qwen3_vl import Qwen3VLConfig, Qwen3VLVisionConfig
-from sglang.srt.distributed import (
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
-)
 from sglang.srt.distributed.parallel_state import get_pp_group
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.vision import VisionAttention
@@ -82,18 +78,13 @@ class Qwen3_VisionMLP(nn.Module):
         use_data_parallel: bool = False,
     ):
         super().__init__()
-        self.tp_size = (
-            1 if use_data_parallel else get_tensor_model_parallel_world_size()
-        )
-        self.tp_rank = 0 if use_data_parallel else get_tensor_model_parallel_rank()
         self.linear_fc1 = ColumnParallelLinear(
             in_features,
             hidden_features,
             bias=bias,
             quant_config=quant_config,
             prefix=add_prefix("linear_fc1", prefix),
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
         self.linear_fc2 = RowParallelLinear(
             hidden_features,
@@ -101,8 +92,7 @@ class Qwen3_VisionMLP(nn.Module):
             bias=bias,
             quant_config=quant_config,
             prefix=add_prefix("linear_fc2", prefix),
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
         self.act = ACT2FN[hidden_act]
 
@@ -232,18 +222,13 @@ class Qwen3VLMoeVisionPatchMerger(nn.Module):
         self.norm = norm_layer(
             self.hidden_size if use_postshuffle_norm else context_dim
         )
-        self.tp_size = (
-            1 if use_data_parallel else get_tensor_model_parallel_world_size()
-        )
-        self.tp_rank = 0 if use_data_parallel else get_tensor_model_parallel_rank()
         self.linear_fc1 = ColumnParallelLinear(
             self.hidden_size,
             self.hidden_size,
             bias=True,
             quant_config=quant_config,
             prefix=add_prefix("linear_fc1", prefix),
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
         self.act_fn = nn.GELU()
         self.linear_fc2 = RowParallelLinear(
@@ -252,8 +237,7 @@ class Qwen3VLMoeVisionPatchMerger(nn.Module):
             bias=True,
             quant_config=quant_config,
             prefix=add_prefix("linear_fc2", prefix),
-            tp_size=self.tp_size,
-            tp_rank=self.tp_rank,
+            disable_tp=use_data_parallel,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -345,9 +329,6 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
             ]
         )
 
-        self.tp_size = (
-            1 if use_data_parallel else get_tensor_model_parallel_world_size()
-        )
         self.cuda_graph_runner: Optional[ViTCudaGraphRunner] = ViTCudaGraphRunner(self)
 
     @property

--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -566,7 +566,7 @@ def run_dp_sharded_mrope_vision_model(
                 image_embeds_local = torch.cat(image_embeds_local, dim=0)
         else:
             out_dim = getattr(vision_model.config, "hidden_size", None)
-            image_embeds_local = torch.empty(
+            image_embeds_local = torch.zeros(
                 (0, embed_dim_reduction_factor, out_dim),
                 device=pixel_values.device,
                 dtype=pixel_values.dtype,
@@ -579,7 +579,7 @@ def run_dp_sharded_mrope_vision_model(
             )
         else:
             # Handle empty case
-            image_embeds_local = torch.empty(
+            image_embeds_local = torch.zeros(
                 (0, vision_model.out_hidden_size),
                 device=pixel_values.device,
                 dtype=pixel_values.dtype,
@@ -591,7 +591,7 @@ def run_dp_sharded_mrope_vision_model(
     if current_len < max_len_per_rank:
         padding_size = max_len_per_rank - current_len
         if rope_type == "rope_2d":
-            padding = torch.empty(
+            padding = torch.zeros(
                 (
                     padding_size,
                     image_embeds_local.shape[1],
@@ -601,7 +601,7 @@ def run_dp_sharded_mrope_vision_model(
                 device=image_embeds_local.device,
             )
         else:
-            padding = torch.empty(
+            padding = torch.zeros(
                 (padding_size, image_embeds_local.shape[1]),
                 dtype=image_embeds_local.dtype,
                 device=image_embeds_local.device,
@@ -610,6 +610,7 @@ def run_dp_sharded_mrope_vision_model(
     else:
         image_embeds_local_padded = image_embeds_local
 
+    image_embeds_local_padded = image_embeds_local_padded.contiguous()
     # Do all_gather to collect embeddings from all ranks
     gathered_embeds = tensor_model_parallel_all_gather(image_embeds_local_padded, dim=0)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The principle is to hide tp_rank and tp_size from VLM models. Model just needs to care about feature such as ViT DP, Attention TP etc.
This is a pre-requisite PR for the on-going ViT Sequence Parallel implementation to make the change neat. 

It also involves changes in non-VLM models such as DeepSeek and Qwen_MoE which are non-trivial. Setting draft for now.
```
            self.mlp = DeepseekV2MLP(
                hidden_size=config.hidden_size,
                intermediate_size=config.intermediate_size,
                hidden_act=config.hidden_act,
                quant_config=quant_config,
                prefix=add_prefix("mlp", prefix),
                tp_rank=mlp_tp_rank,
                tp_size=mlp_tp_size,
            )
...

        self.gate_up_proj = MergedColumnParallelLinear(
            hidden_size,
            [intermediate_size] * 2,
            bias=False,
            quant_config=quant_config,
            prefix=add_prefix("gate_up_proj", prefix),
            tp_rank=tp_rank,
            tp_size=tp_size,
        )
```

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Maunally tested ViT DP passed.  VLM CI will cover the acc and correctness.

```
root@6996fb46042d:/sgl-workspace/sglang_dev2/python# SGLANG_MM_FEATURE_CACHE_MB=4096 SGLANG_USE_CUDA_IPC_TRANSPORT=1 SGLANG_VLM_CACHE_SIZE_MB=0 python -m sglang.launch_server --host 0.0.0.0 --port 30000 --model-path Qwen/Qwen2.5-VL-7B-Instruct --served-model-name test --trust-remote-code --disable-radix-cache --tp 4 --mem-fraction-static 0.85  --mm-attention-backend fa3 --attention-backend flashinfer --mm-enable-dp-encoder
```

```
root@6996fb46042d:/sgl-workspace/bench_script# bash bench_n_image.sh 
{"id":"6ddc10a85ba0472cba86fbf76cc86c25","object":"chat.completion","created":1766912707,"model":"auto","choices":[{"index":0,"message":{"role":"assistant","content":"图中植物是飞廉（学名：Cirsium vulgare），也被称为野飞廉、飞廉草。这是一种常见的野草，广泛分布于欧洲、亚洲和北美洲的温带地区。飞廉的茎直立，叶片宽大，边缘有锯齿，花朵呈紫色或白色，果实为倒三角形的飞廉果。","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":"stop","matched_stop":151645}],"usage":{"prompt_tokens":970,"total_tokens":1049,"completion_tokens":79,"prompt_tokens_details":null,"reasoning_tokens":0},"metadata":{"weight_version":"default"}}
real    0m0.360s
user    0m0.002s
sys     0m0.003s
```

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
