### PR TITLE
Tiny print launch command with `shlex`

### DIFF
--- a/examples/profiler/nsys_profile_tools/gputrc2graph.py
+++ b/examples/profiler/nsys_profile_tools/gputrc2graph.py
@@ -1,12 +1,13 @@
 """
-    This generates gpu kernel analysis output from nsys rep. Will call nsys
-    stats  -r cuda_gpu_kern_trace, get non-overlapped gpu cycles, then generate
-    csv and html output for analysis
+This generates gpu kernel analysis output from nsys rep. Will call nsys
+stats  -r cuda_gpu_kern_trace, get non-overlapped gpu cycles, then generate
+csv and html output for analysis
 """
 
 import argparse
 import logging
 import os
+import shlex
 
 import regex as re
 
@@ -223,7 +224,7 @@ class GPUTrace2Graph:
                 "-o",
                 f"{file_dir}/{file_name}",
             ]
-            cmd_str = " ".join(cmd)
+            cmd_str = shlex.join(cmd)
             logger.info("+ %s", cmd_str)
             # estimate time based on calibrated 240M/min
             file_size_mb = os.path.getsize(file) / 1e6

--- a/python/sglang/multimodal_gen/runtime/entrypoints/cli/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/cli/utils.py
@@ -4,6 +4,7 @@
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 
@@ -53,7 +54,7 @@ def launch_distributed(
     cmd.extend(args)
 
     logger.info("Running inference with %d GPU(s)", num_gpus)
-    logger.info("Launching command: %s", " ".join(cmd))
+    logger.info("Launching command: %s", shlex.join(cmd))
 
     current_env["PYTHONIOENCODING"] = "utf-8"
     process = subprocess.Popen(

--- a/python/sglang/test/server_fixtures/disaggregation_fixture.py
+++ b/python/sglang/test/server_fixtures/disaggregation_fixture.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shlex
 import time
 import warnings
 from urllib.parse import urlparse
@@ -69,7 +70,7 @@ class PDDisaggregationServerBase(CustomTestCase):
             "--port",
             cls.lb_port,
         ]
-        print("Starting load balancer:", " ".join(lb_command))
+        print("Starting load balancer:", shlex.join(lb_command))
         cls.process_lb = popen_with_error_check(lb_command)
         cls.wait_server_ready(cls.lb_url + "/health")
 

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import random
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -632,7 +633,7 @@ def popen_launch_server(
     if api_key:
         command += ["--api-key", api_key]
 
-    print(f"command={' '.join(command)}")
+    print(f"command={shlex.join(command)}")
 
     if return_stdout_stderr:
         process = subprocess.Popen(


### PR DESCRIPTION
With simply `" ".join(cmd)`, the result may like this:

```bash
--json-model-override-args {"vocab_size": 131072} 
```

which cannot be executed by the shell.

Use `shlex.join` to fix it:

```bash
--json-model-override-args '{"vocab_size": 131072}'
```
