### PR TITLE
Use soxr for audio resampling

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   "python-multipart",
   "pyzmq>=25.1.2",
   "requests",
-  "scipy",
+  "soxr",
   "sentencepiece",
   "setproctitle",
   "sgl-kernel==0.3.20",
@@ -95,7 +95,8 @@ diffusion = [
   "vsa==0.0.4",
   "yunchang==0.6.3.post1",
   "runai_model_streamer",
-  "cache-dit==1.1.8"
+  "cache-dit==1.1.8",
+  "scipy",
 ]
 
 tracing = [

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -51,7 +51,7 @@ dependencies = [
   "python-multipart",
   "pyzmq>=25.1.2",
   "requests",
-  "scipy",
+  "soxr",
   "sentencepiece",
   "setproctitle",
   "soundfile==0.13.1",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -51,7 +51,7 @@ runtime_common = [
   "python-multipart",
   "pyzmq>=25.1.2",
   "requests",
-  "scipy",
+  "soxr",
   "sentencepiece",
   "setproctitle",
   "soundfile==0.13.1",
@@ -116,6 +116,7 @@ diffusion = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
   "runai_model_streamer",
+  "scipy",
 ]
 all_hip = ["sglang[srt_hip]"]
 all_npu = ["sglang[srt_npu]"]

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -55,7 +55,7 @@ dependencies = [
   "python-multipart",
   "pyzmq>=25.1.2",
   "requests",
-  "scipy",
+  "soxr",
   "sentencepiece",
   "setproctitle",
   "soundfile==0.13.1",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -824,7 +824,6 @@ def load_audio(
 
     # Resample audio if the original sample rate is different from the desired sample rate
     if original_sr != sr:
-        num_samples = int(len(audio) * float(sr) / original_sr)
         audio = soxr.resample(audio, original_sr, sr)
 
     # Convert to mono if requested and audio is stereo

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -798,7 +798,7 @@ def load_audio(
     # Use soundfile here, since librosa use it under the hood,
     # and librosa will not support audio loading in the future
     import soundfile as sf
-    from scipy.signal import resample
+    import soxr
 
     if sr is None:
         sr = 16000
@@ -825,7 +825,7 @@ def load_audio(
     # Resample audio if the original sample rate is different from the desired sample rate
     if original_sr != sr:
         num_samples = int(len(audio) * float(sr) / original_sr)
-        audio = resample(audio, num_samples)
+        audio = soxr.resample(audio, original_sr, sr)
 
     # Convert to mono if requested and audio is stereo
     if mono and len(audio.shape) > 1:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

```
import time
from openai import OpenAI

client = OpenAI(api_key="sk-123456", base_url="http://localhost:30000/v1")
audio_file_path = "https://raw.githubusercontent.com/yhyang201/tools/main/test_files/audio_file.mp3"

start_time = time.perf_counter()

response = client.chat.completions.create(
    model="default",
    messages=[{
        "role": "user",
        "content": [
            {"type": "audio_url", "audio_url": {"url": audio_file_path}},
            {"type": "text", "text": "Please transcribe this audio into text"},
        ],
    }],
    temperature=0,
    max_tokens=1024,
    stream=True, 
)

first_token_time = 0
token_count = 0
content = ""

for chunk in response:
    delta = chunk.choices[0].delta.content
    if delta:
        if first_token_time == 0:
            first_token_time = time.perf_counter()
        token_count += 1
        content += delta

end_time = time.perf_counter()

print(content)
print("-" * 20)

if first_token_time > 0:
    ttft = (first_token_time - start_time) * 1000
    decode_time = end_time - first_token_time
    tpot = (decode_time / (token_count - 1)) * 1000 if token_count > 1 else 0
    
    print(f"TTFT: {ttft:.2f} ms")
    print(f"TPOT: {tpot:.2f} ms")
else:
    print("No tokens generated.")
```

launch command
```
python -m sglang.launch_server --model-path zai-org/GLM-ASR-Nano-2512 --disable-radix-cache
```

main: 
```
((sglang) ) root@atlascloud-h100:/sgl-workspace# python test_audio_openai.py
My administration is committed to giving every American the opportunity to find a great job and have a rewarding career. There is nothing like it. Whether you are a high school student or a late career worker, there has never been a better time to learn a trade, hone a skill, and pursue your dreams. Last quarter, the United States economy grew by four point one percent. We've created three point seven million new jobs since the election. Unemployment reached its lowest rate in almost fifty years. Unemployment for Americans with disabilities has reached the lowest level ever recorded. In the month of June alone, six hundred thousand workers entered or reentered the workforce. Pretty good numbers. To continue this incredible momentum, we launched the Pledge to America's Workers. More than one hundred companies, associations, and others have pledged to train or retrain over four million American students. We're encouraging companies across the country to join our historic initiative and pledge to invest in training Americans for the jobs of today and the careers of tomorrow. In the last two weeks, I established the National Council for the American Worker, which will develop a national workforce strategy and sign the Modernized and Long-Awaited Perkins Career and Technical Education Act, which will deliver jobs and training to more than eleven million students and workers. We're very proud of that. When we invest in our workers, we are investing in our people. We are investing in our communities, and we are investing in the American Dream. And every single day, we are making new American dreams come true. Thank you, and God bless America.
--------------------
TTFT: 5353.10 ms
TPOT: 2.23 ms
```
pr:
```
((sglang) ) root@atlascloud-h100:/sgl-workspace# python test_audio_openai.py
My administration is committed to giving every American the opportunity to find a great job and have a rewarding career. There is nothing like it. Whether you are a high school student or a late career worker, there has never been a better time to learn a trade, hone a skill, and pursue your dreams. Last quarter, the United States economy grew by four point one percent. We've created three point seven million new jobs since the election. Unemployment reached its lowest rate in almost fifty years. Unemployment for Americans with disabilities has reached the lowest level ever recorded. In the month of June alone, six hundred thousand workers entered or reentered the workforce. Pretty good numbers. To continue this incredible momentum, we launched the Pledge to America's Workers. More than one hundred companies, associations, and others have pledged to train or retrain over four million American students. We're encouraging companies across the country to join our historic initiative and pledge to invest in training Americans for the jobs of today and the careers of tomorrow. In the last two weeks, I established the National Council for the American Worker, which will develop a national workforce strategy and sign the Modernized and Long-Awaited Perkins Career and Technical Education Act, which will deliver jobs and training to more than eleven million students and workers. We're very proud of that. When we invest in our workers, we are investing in our people. We are investing in our communities, and we are investing in the American Dream. And every single day, we are making new American dreams come true. Thank you, and God bless America.
--------------------
TTFT: 961.81 ms
TPOT: 2.23 ms
```


env: 
H100

```
((sglang) ) root@atlascloud-h100:/sgl-workspace/sglang# lscpu
Architecture:                x86_64
  CPU op-mode(s):            32-bit, 64-bit
  Address sizes:             46 bits physical, 57 bits virtual
  Byte Order:                Little Endian
CPU(s):                      128
  On-line CPU(s) list:       0-127
Vendor ID:                   GenuineIntel
  Model name:                INTEL(R) XEON(R) GOLD 6548Y+
    CPU family:              6
    Model:                   207
    Thread(s) per core:      2
    Core(s) per socket:      32
    Socket(s):               2
    Stepping:                2
    Frequency boost:         enabled
    CPU max MHz:             2501.0000
    CPU min MHz:             800.0000
    BogoMIPS:                5000.00
    Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm
                             constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx sm
                             x est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowpref
                             etch cpuid_fault epb cat_l3 cat_l2 cdp_l3 invpcid_single intel_ppin cdp_l2 ssbd mba ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vp
                             id ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb intel_pt avx512c
                             d sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local split_lock_detect avx_vnni avx512_bf16 wb
                             noinvd dtherm ida arat pln pts avx512vbmi umip pku ospke waitpkg avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg tme avx512_vpopcntdq la5
                             7 rdpid bus_lock_detect cldemote movdiri movdir64b enqcmd fsrm md_clear serialize tsxldtrk pconfig arch_lbr amx_bf16 avx512_fp16 amx_tile amx_int8 fl
                             ush_l1d arch_capabilities ibpb_exit_to_user
Virtualization features:
  Virtualization:            VT-x
Caches (sum of all):
  L1d:                       3 MiB (64 instances)
  L1i:                       2 MiB (64 instances)
  L2:                        128 MiB (64 instances)
  L3:                        120 MiB (2 instances)
NUMA:
  NUMA node(s):              2
  NUMA node0 CPU(s):         0-31,64-95
  NUMA node1 CPU(s):         32-63,96-127
Vulnerabilities:
  Gather data sampling:      Not affected
  Indirect target selection: Not affected
  Itlb multihit:             Not affected
  L1tf:                      Not affected
  Mds:                       Not affected
  Meltdown:                  Not affected
  Mmio stale data:           Not affected
  Reg file data sampling:    Not affected
  Retbleed:                  Not affected
  Spec rstack overflow:      Not affected
  Spec store bypass:         Mitigation; Speculative Store Bypass disabled via prctl and seccomp
  Spectre v1:                Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:                Mitigation; Enhanced / Automatic IBRS; IBPB conditional; PBRSB-eIBRS SW sequence; BHI BHI_DIS_S
  Srbds:                     Not affected
  Tsa:                       Not affected
  Tsx async abort:           Not affected
  Vmscape:                   Mitigation; IBPB before exit to userspace
```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
