### PR TITLE
[model-gateway] perf: optimize observability logging for minimal CPU/memory overhead

### DIFF
--- a/sgl-model-gateway/src/observability/logging.rs
+++ b/sgl-model-gateway/src/observability/logging.rs
@@ -1,3 +1,5 @@
+//! Logging infrastructure with non-blocking file I/O.
+
 use std::path::PathBuf;
 
 use tracing::Level;
@@ -13,6 +15,9 @@ use tracing_subscriber::{
 use super::otel_trace::get_otel_layer;
 use crate::config::TraceConfig;
 
+const TIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
+const DEFAULT_LOG_TARGET: &str = "sgl_model_gateway";
+
 #[derive(Debug, Clone)]
 pub struct LoggingConfig {
     pub level: Level,
@@ -24,6 +29,7 @@ pub struct LoggingConfig {
 }
 
 impl Default for LoggingConfig {
+    #[inline]
     fn default() -> Self {
         Self {
             level: Level::INFO,
@@ -31,56 +37,76 @@ impl Default for LoggingConfig {
             log_dir: None,
             colorize: true,
             log_file_name: "sgl-model-gateway".to_string(),
-            log_targets: Some(vec!["sgl_model_gateway".to_string()]),
+            log_targets: Some(vec![DEFAULT_LOG_TARGET.to_string()]),
         }
     }
 }
 
+/// Guard that keeps the file appender thread alive.
 #[allow(dead_code)]
 pub struct LogGuard {
     _file_guard: Option<WorkerGuard>,
 }
 
-pub fn init_logging(config: LoggingConfig, otel_layer_config: Option<TraceConfig>) -> LogGuard {
-    let _ = LogTracer::init();
-
-    let level_filter = match config.level {
+#[inline]
+const fn level_to_str(level: Level) -> &'static str {
+    match level {
         Level::TRACE => "trace",
         Level::DEBUG => "debug",
         Level::INFO => "info",
         Level::WARN => "warn",
         Level::ERROR => "error",
-    };
+    }
+}
+
+#[inline]
+fn build_filter_string(targets: &[String], level_filter: &str) -> String {
+    // Exact capacity: sum of target lengths + "=" and level per target + commas between
+    let capacity = targets.iter().map(String::len).sum::<usize>()
+        + targets.len() * (1 + level_filter.len())
+        + targets.len().saturating_sub(1);
+    let mut filter_string = String::with_capacity(capacity);
+
+    for (i, target) in targets.iter().enumerate() {
+        if i > 0 {
+            filter_string.push(',');
+        }
+        filter_string.push_str(target);
+        filter_string.push('=');
+        filter_string.push_str(level_filter);
+    }
+
+    filter_string
+}
+
+pub fn init_logging(config: LoggingConfig, otel_layer_config: Option<TraceConfig>) -> LogGuard {
+    let _ = LogTracer::init();
+
+    let level_filter = level_to_str(config.level);
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        let filter_string = if let Some(targets) = &config.log_targets {
-            targets
-                .iter()
-                .enumerate()
-                .map(|(i, target)| {
-                    if i > 0 {
-                        format!(",{}={}", target, level_filter)
-                    } else {
-                        format!("{}={}", target, level_filter)
-                    }
-                })
-                .collect::<String>()
-        } else {
-            format!("sgl_model_gateway={}", level_filter)
+        let filter_string = match &config.log_targets {
+            Some(targets) if !targets.is_empty() => build_filter_string(targets, level_filter),
+            _ => {
+                let mut s =
+                    String::with_capacity(DEFAULT_LOG_TARGET.len() + 1 + level_filter.len());
+                s.push_str(DEFAULT_LOG_TARGET);
+                s.push('=');
+                s.push_str(level_filter);
+                s
+            }
         };
 
         EnvFilter::new(filter_string)
     });
 
-    let mut layers = Vec::new();
-
-    let time_format = "%Y-%m-%d %H:%M:%S".to_string();
+    let mut layers = Vec::with_capacity(3);
 
     let stdout_layer = tracing_subscriber::fmt::layer()
         .with_ansi(config.colorize)
         .with_file(true)
         .with_line_number(true)
-        .with_timer(ChronoUtc::new(time_format.clone()));
+        .with_timer(ChronoUtc::new(TIME_FORMAT.to_string()));
 
     let stdout_layer = if config.json_format {
         stdout_layer.json().flatten_event(true).boxed()
@@ -93,7 +119,6 @@ pub fn init_logging(config: LoggingConfig, otel_layer_config: Option<TraceConfig
     let mut file_guard = None;
 
     if let Some(log_dir) = &config.log_dir {
-        let file_name = config.log_file_name.clone();
         let log_dir = PathBuf::from(log_dir);
 
         if !log_dir.exists() {
@@ -103,7 +128,8 @@ pub fn init_logging(config: LoggingConfig, otel_layer_config: Option<TraceConfig
             }
         }
 
-        let file_appender = RollingFileAppender::new(Rotation::DAILY, log_dir, file_name);
+        let file_appender =
+            RollingFileAppender::new(Rotation::DAILY, log_dir, &config.log_file_name);
 
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
         file_guard = Some(guard);
@@ -112,7 +138,7 @@ pub fn init_logging(config: LoggingConfig, otel_layer_config: Option<TraceConfig
             .with_ansi(false)
             .with_file(true)
             .with_line_number(true)
-            .with_timer(ChronoUtc::new(time_format))
+            .with_timer(ChronoUtc::new(TIME_FORMAT.to_string()))
             .with_writer(non_blocking);
 
         let file_layer = if config.json_format {

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -565,9 +565,10 @@ impl PDRouter {
         );
 
         // Send both requests concurrently and wait for both
+        // Note: Using borrowed references avoids heap allocation
         events::RequestPDSentEvent {
-            prefill_url: prefill.url().to_string(),
-            decode_url: decode.url().to_string(),
+            prefill_url: prefill.url(),
+            decode_url: decode.url(),
         }
         .emit();
 

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -303,10 +303,8 @@ impl Router {
         let load_guard =
             (policy.name() == "cache_aware").then(|| WorkerLoadGuard::new(worker.clone()));
 
-        events::RequestSentEvent {
-            url: worker.url().to_string(),
-        }
-        .emit();
+        // Note: Using borrowed reference avoids heap allocation
+        events::RequestSentEvent { url: worker.url() }.emit();
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);


### PR DESCRIPTION
- Use borrowed string slices (&str) instead of owned Strings in event structs to eliminate heap allocations on the hot path
- Add const TIME_FORMAT and DEFAULT_LOG_TARGET for static string usage
- Pre-calculate filter string capacity to minimize reallocations
- Add #[inline] hints on all hot path functions
- Make CustomOtelFilter a zero-sized Copy type
- Remove to_lowercase() allocation in gRPC context injection

Performance improvements:
- Zero heap allocations per event emit (was 1-2 String allocations)
- RequestReceivedEvent is now a ZST (0 bytes vs 16+ bytes)
- RequestSentEvent reduced from 24 bytes to 16 bytes (stack only)
- RequestPDSentEvent reduced from 48 bytes to 32 bytes (stack only)
- Single atomic load (~1 CPU cycle) for OTEL enabled check

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
