### PR TITLE
[Diffusion] Qwen image edit support qknorm optimization

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/layernorm.py
+++ b/python/sglang/multimodal_gen/runtime/layers/layernorm.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from sgl_kernel import fused_add_rmsnorm, rmsnorm
 
+from sglang.jit_kernel.norm import can_use_fused_inplace_qknorm, fused_inplace_qknorm
 from sglang.multimodal_gen.runtime.layers.custom_op import CustomOp
 from sglang.multimodal_gen.runtime.layers.triton_ops import (
     fuse_scale_shift_kernel,
@@ -421,3 +422,43 @@ class LayerNormScaleShift(nn.Module):
             output = output.to(x.dtype)
 
         return output
+
+
+def apply_qk_norm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_norm: "RMSNorm",
+    k_norm: "RMSNorm",
+    head_dim: int,
+    allow_inplace: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply QK normalization for query and key tensors.
+
+    Minimal multimodal_gen-only implementation: only the JIT fused inplace
+    QK-norm kernel path is supported (no fallback).
+    """
+
+    batch_size = q.size(0)
+    q_eps = q_norm.variance_epsilon
+    k_eps = k_norm.variance_epsilon
+    # Only try fused path on CUDA and when it won't introduce implicit copies.
+    if (
+        q.is_cuda
+        and allow_inplace
+        and (q_eps == k_eps)
+        and can_use_fused_inplace_qknorm(head_dim)
+    ):
+        fused_inplace_qknorm(
+            q=q.view(batch_size, -1, head_dim),
+            k=k.view(batch_size, -1, head_dim),
+            q_weight=q_norm.weight,
+            k_weight=k_norm.weight,
+            head_dim=head_dim,
+            eps=q_eps,
+        )
+        return q, k
+
+    raise RuntimeError(
+        "apply_qk_norm: fused inplace QK-norm is not applicable "
+        "(expected CUDA, contiguous q/k, matching eps, and supported head_dim)"
+    )

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -17,7 +17,11 @@ from diffusers.models.normalization import AdaLayerNormContinuous
 
 from sglang.multimodal_gen.configs.models.dits.qwenimage import QwenImageDitConfig
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
-from sglang.multimodal_gen.runtime.layers.layernorm import LayerNorm, RMSNorm
+from sglang.multimodal_gen.runtime.layers.layernorm import (
+    LayerNorm,
+    RMSNorm,
+    apply_qk_norm,
+)
 from sglang.multimodal_gen.runtime.layers.linear import ReplicatedLinear
 from sglang.multimodal_gen.runtime.layers.triton_ops import (
     fuse_scale_shift_gate_select01_kernel,
@@ -34,8 +38,6 @@ try:
     from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
 except Exception:
     apply_rope_with_cos_sin_cache_inplace = None
-
-from sglang.srt.models.utils import apply_qk_norm
 
 
 def _get_qkv_projections(

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -554,16 +554,16 @@ class QwenImageCrossAttention(nn.Module):
         # Apply QK normalization
         if self.qk_norm:
             img_query, img_key = apply_qk_norm(
-                q=img_query.contiguous(),
-                k=img_key.contiguous(),
+                q=img_query,
+                k=img_key,
                 q_norm=self.norm_q,
                 k_norm=self.norm_k,
                 head_dim=img_query.shape[-1],
                 allow_inplace=True,
             )
             txt_query, txt_key = apply_qk_norm(
-                q=txt_query.contiguous(),
-                k=txt_key.contiguous(),
+                q=txt_query,
+                k=txt_key,
                 q_norm=self.norm_added_q,
                 k_norm=self.norm_added_k,
                 head_dim=txt_query.shape[-1],


### PR DESCRIPTION
5% performace gain, 0.633 s/step -> 0.6 s/step

LightX2V 0.632s/step

## main

sglang generate --model-path Qwen/Qwen-Image-Edit-2511 --prompt "Change the person to a standing position, bending over to hold the dog's front paws."  --image-path "/home/lmsys/bbuf/LightX2V/examples/qwen_image/1.png"

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 40/40 [00:25<00:00,  1.58it/s]
[12-29 07:50:24] [DenoisingStage] average time per step: 0.6332 seconds
[12-29 07:50:24] [DenoisingStage] finished in 25.3352 seconds

<img width="1069" height="586" alt="图片" src="https://github.com/user-attachments/assets/aa2f67c7-e4e8-4254-a0fa-25575edd0af8" />


## pr

sglang generate --model-path Qwen/Qwen-Image-Edit-2511 --prompt "Change the person to a standing position, bending over to hold the dog's front paws."  --image-path "/home/lmsys/bbuf/LightX2V/examples/qwen_image/1.png"

100%|█████████████████████████████████████████████████████████████████| 40/40 [00:24<00:00,  1.65it/s]
[12-29 08:43:18] [DenoisingStage] average time per step: 0.6048 seconds
[12-29 08:43:18] [DenoisingStage] finished in 24.1986 seconds

<img width="735" height="692" alt="图片" src="https://github.com/user-attachments/assets/68bda5ce-f600-4d8c-8871-d45dfc7ddf4d" />


500us->69us.

<img width="1472" height="918" alt="图片" src="https://github.com/user-attachments/assets/3c811133-3904-49a8-a95b-5f1b9de3b6a8" />



