### PR TITLE
[bugfix]: add check, stream_options could only be set when stream=true

### DIFF
--- a/benchmark/hicache/bench_serving.py
+++ b/benchmark/hicache/bench_serving.py
@@ -78,15 +78,18 @@ async def async_request_openai_completions(
     ), "OpenAI Completions API URL must end with 'completions'."
 
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        stream = not args.disable_stream
         payload = {
             "model": request_func_input.model,
             "temperature": 0.0,
             "best_of": 1,
-            "stream": not args.disable_stream,
-            "stream_options": {"include_usage": True},
+            "stream": stream,
             "ignore_eos": not args.disable_ignore_eos,
             **request_func_input.extra_request_body,
         }
+        # stream_options is only allowed when stream is True
+        if stream:
+            payload["stream_options"] = {"include_usage": True}
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -144,6 +144,9 @@ class OpenAIServingChat(OpenAIServingBase):
             if schema is None:
                 return "schema_ is required for json_schema response format request."
 
+        # Validate stream_options dependency
+        if request.stream_options is not None and not request.stream:
+            return "The 'stream_options' parameter is only allowed when 'stream' is enabled."
         return None
 
     def _convert_to_internal_request(

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -54,6 +54,10 @@ class OpenAIServingCompletion(OpenAIServingBase):
         if not prompt or (isinstance(prompt, list) and all(not p for p in prompt)):
             return "Prompt cannot be empty"
 
+        # Validate stream_options dependency
+        if request.stream_options is not None and not request.stream:
+            return "The 'stream_options' parameter is only allowed when 'stream' is enabled."
+
         return None
 
     def _convert_to_internal_request(


### PR DESCRIPTION
## Motivation

I meet a bad req, that includes stream_options but it's stream=false. And we find model-gateway returns a 400 response, but sglang engine could just handle this req. I read [openai api doc](https://platform.openai.com/docs/api-reference/chat/create#chat_create-stream_options), and it seems that 400 is an expected response. So I fix this bug.

## Modifications

just add a check that stream_options could only be set when stream=true.
and fix one related bench script.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
