### PR TITLE
[diffusion] pipeline: free DiT GPU memory after denoising

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -733,10 +733,8 @@ class DenoisingStage(PipelineStage):
         for model in (self.transformer, self.transformer_2):
             if model is None:
                 continue
-            model_param = next(model.parameters(), None)
-            if model_param is None:
-                continue
-            if model_param.device.type == "cuda":
+            first_tensor = next(model.parameters(), next(model.buffers(), None))
+            if first_tensor is not None and first_tensor.is_cuda:
                 model.to("cpu")
                 did_offload = True
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -724,7 +724,7 @@ class DenoisingStage(PipelineStage):
             )
 
     def _offload_transformers_after_denoising(self, server_args: ServerArgs) -> None:
-        if not (server_args.dit_cpu_offload or server_args.dit_layerwise_offload):
+        if not server_args.dit_cpu_offload:
             return
         if current_platform.device_type != "cuda":
             return


### PR DESCRIPTION
## Motivation
Fix a CUDA OOM that occurs after DiT denoising when VAE decoding begins in multi-GPU runs. In Wan TI2V with multi-GPU (SP/Ring) enabled, DiT weights remain resident on GPU, leaving insufficient headroom for VAE decode/output transfer and causing the run to abort.

## Modifications
- Offload `transformer`/`transformer_2` to CPU after the denoising loop when CPU/layerwise offload is enabled.
- Clear CUDA cache after offload to free memory before VAE decode.

## Minimal Repro (multi-GPU)
```
sglang generate \
  --model-path /path/to/Wan2.2-TI2V-5B-Diffusers \
  --generator-device cuda \
  --dit-precision bf16 \
  --vae-cpu-offload \
  --pin-cpu-memory \
  --text-encoder-cpu-offload \
  --num-gpus 2 \
  --sp-degree 2 \
  --ring-degree 2 \
  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
  --image-path /path/to/Wan2.2-TI2V-5B-Diffusers/examples/i2v_input.JPG \
  --num-frames 61 \
  --num-inference-steps 10 \
  --save-output \
  --output-path /path/to/output_dir \
  --output-file-name wan_ti2v.mp4
```

```bash
[12-29 19:25:18] Failed to generate output for prompt 1: CUDA out of memory. Tried to allocate 608.00 MiB. GPU 0 has a total capacity of 39.49 GiB of which 107.38 MiB is free. Including non-PyTorch memory, this process has 416.00 MiB memory in use. Process 205729 has 38.43 GiB memory in use. Process 205730 has 416.00 MiB memory in use. Of the allocated memory 0 bytes is allocated by PyTorch, and 0 bytes is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
Traceback (most recent call last):
  File "/path/to/sglang/python/sglang/multimodal_gen/runtime/utils/logging_utils.py", line 466, in log_generation_timer
    yield timer
  File "/path/to/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 219, in generate
    output_batch = self._send_to_scheduler_and_wait_for_response([req])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/sglang/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py", line 289, in _send_to_scheduler_and_wait_for_response
    return sync_scheduler_client.forward(batch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/sglang/python/sglang/multimodal_gen/runtime/scheduler_client.py", line 83, in forward
    output_batch = self.scheduler_socket.recv_pyobj()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/zmq/sugar/socket.py", line 990, in recv_pyobj
    return self._deserialize(msg, pickle.loads)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/zmq/sugar/socket.py", line 828, in _deserialize
    return load(recvd)
           ^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/storage.py", line 534, in _load_from_bytes
    return torch.load(io.BytesIO(b), weights_only=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/serialization.py", line 1554, in load
    return _legacy_load(
           ^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/serialization.py", line 1812, in _legacy_load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/serialization.py", line 1747, in persistent_load
    obj = restore_location(obj, location)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/serialization.py", line 698, in default_restore_location
    result = fn(storage, location)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/serialization.py", line 637, in _deserialize
    return obj.to(device=device)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/storage.py", line 291, in to
    return _to(self, device, non_blocking)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/conda/env/lib/python3.11/site-packages/torch/_utils.py", line 101, in _to
    untyped_storage = torch.UntypedStorage(self.size(), device=device)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 608.00 MiB. GPU 0 has a total capacity of 39.49 GiB of which 107.38 MiB is free. Including non-PyTorch memory, this process has 416.00 MiB memory in use. Process 205729 has 38.43 GiB memory in use. Process 205730 has 416.00 MiB memory in use. Of the allocated memory 0 bytes is allocated by PyTorch, and 0 bytes is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```

## Accuracy Tests
Not run (no change to model math/output expected; memory management only).

## Benchmarking and Profiling
- Baseline perf dump could not be generated because the baseline run aborted with CUDA OOM.
- New run succeeded and generated perf dump: /path/to/new.json (see /path/to/run_new.log).

## Checklist
- [x] Format your code according to the pre-commit guide.
- [ ] Update documentation.
- [x] Provide accuracy and speed benchmark results (baseline unavailable due to OOM; new run available).
- [x] Follow the SGLang code style guidance.
- [ ] Work with maintainers to merge your PR.
