### PR TITLE
[model-gateway] Optimize radix tree timestamp updates for multi-tenant scaling

### DIFF
--- a/sgl-model-gateway/benches/tree_benchmark.rs
+++ b/sgl-model-gateway/benches/tree_benchmark.rs
@@ -788,13 +788,12 @@ fn bench_summary(c: &mut Criterion) {
     // Configuration constants
     const TREE_SIZE: usize = 10_000; // Realistic cache size
     const INSERT_POOL_SIZE: usize = 10_000; // Unique requests for insert tests
-    const NUM_THREADS: usize = 8;
-    const OPS_PER_THREAD: usize = 100;
+    const NUM_THREADS: usize = 64; // Match GPU runner's 64 CPU cores
+    const OPS_PER_THREAD: usize = 200;
 
     // Worker scaling configurations to test
-    // Using 2 representative counts (low/high) to keep CI runtime reasonable
-    // while still demonstrating scaling behavior
-    const WORKER_COUNTS: [usize; 2] = [10, 100];
+    // Full range to demonstrate scaling behavior on GPU runner
+    const WORKER_COUNTS: [usize; 4] = [10, 50, 100, 500];
 
     // Pre-generate requests for tree population and queries
     let requests = generate_realistic_requests(TREE_SIZE);


### PR DESCRIPTION
Replace O(depth) ancestor timestamp propagation with O(1) matched-node-only
updates. The ancestor propagation was unnecessary - eviction only uses leaf
timestamps, so updating ancestors had no effect on LRU behavior.

Changes:
- Remove ancestor timestamp propagation entirely
- Update only the matched node's timestamp (O(1) per match)
- Replace SystemTime::now() syscalls with atomic epoch counter
- Reduce timestamp size from 16 bytes (u128) to 8 bytes (u64)

Performance improvement:
- MATCH latency now flat across worker counts (15-19µs for 10-500 workers)
- Previously saw 2x degradation at 500 workers (20µs → 64µs)
- Eliminates DashMap contention from ancestor updates
- Zero syscall overhead with epoch counter


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
