### PR TITLE
[model-gateway]: optimize prefix_match with zero-copy tenant and deferred char count

### DIFF
--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -302,7 +302,7 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
             };
 
             let selected_url = if match_rate > self.config.cache_threshold {
-                result.tenant
+                result.tenant.to_string()
             } else {
                 let min_load_idx = *healthy_indices
                     .iter()


### PR DESCRIPTION
Reduce MATCH operation latency from ~64µs to ~22µs (3x improvement):

- Change tenant from String to TenantId (Arc<str>) for zero-copy return
- Remove matched_text from PrefixMatchResult (legacy API computes separately)
- Defer input_char_count computation: matched_chars + remaining.chars().count()
- Eliminates upfront O(n) chars().count() call on input text

Benchmarks (500 workers):
- Before: MATCH ~64µs (degraded with worker count)
- After:  MATCH ~22µs (flat scaling)



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
