### PR TITLE
[model-gateway] Generate UUID-based request IDs for embedding/classify

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
+use uuid::Uuid;
 
 use crate::routers::{
     error,
@@ -70,13 +71,12 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
                 error::internal_error("client_missing", "Client not selected")
             })?;
 
-        // Extract request ID
-        let request_id = ctx
-            .state
-            .dispatch
-            .as_ref()
-            .map(|d| d.request_id.clone())
-            .unwrap_or_else(|| "unknown".to_string());
+        // Generate request ID with appropriate prefix based on request type
+        let request_id = match &ctx.input.request_type {
+            RequestType::Embedding(_) => format!("embed-{}", Uuid::new_v4()),
+            RequestType::Classify(_) => format!("classify-{}", Uuid::new_v4()),
+            _ => format!("embed-{}", Uuid::new_v4()), // fallback
+        };
 
         // Extract original text
         let original_text = prep_output.original_text.clone();


### PR DESCRIPTION
Fix request ID generation in EmbeddingRequestBuildingStage to generate proper UUID-based IDs like other endpoints (chat uses "chatcmpl-{uuid}").

- Embedding requests: "embed-{uuid}"
- Classify requests: "classify-{uuid}"

Previously fell back to "unknown" because dispatch metadata wasn't available yet at request building stage.



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
