### PR TITLE
[model-gateway] Fix duplicate classify prefix in response ID

### DIFF
--- a/sgl-model-gateway/src/policies/tree.rs
+++ b/sgl-model-gateway/src/policies/tree.rs
@@ -398,12 +398,17 @@ impl Tree {
 
                         // Attach tenant to the new split node (intermediate - no timestamp update)
                         // The cloned DashMap already has the tenant; just ensure char count is correct
-                        if !new_node.tenant_last_access_time.contains_key(tenant_id.as_ref()) {
+                        if !new_node
+                            .tenant_last_access_time
+                            .contains_key(tenant_id.as_ref())
+                        {
                             self.tenant_char_count
                                 .entry(Arc::clone(&tenant_id))
                                 .and_modify(|count| *count += matched_text_count)
                                 .or_insert(matched_text_count);
-                            new_node.tenant_last_access_time.insert(Arc::clone(&tenant_id), 0);
+                            new_node
+                                .tenant_last_access_time
+                                .insert(Arc::clone(&tenant_id), 0);
                         }
 
                         InsertStep::Continue {
@@ -415,12 +420,17 @@ impl Tree {
                         drop(matched_node_text);
 
                         // Ensure tenant exists at this intermediate node
-                        if !matched_node.tenant_last_access_time.contains_key(tenant_id.as_ref()) {
+                        if !matched_node
+                            .tenant_last_access_time
+                            .contains_key(tenant_id.as_ref())
+                        {
                             self.tenant_char_count
                                 .entry(Arc::clone(&tenant_id))
                                 .and_modify(|count| *count += matched_node_text_count)
                                 .or_insert(matched_node_text_count);
-                            matched_node.tenant_last_access_time.insert(Arc::clone(&tenant_id), 0);
+                            matched_node
+                                .tenant_last_access_time
+                                .insert(Arc::clone(&tenant_id), 0);
                         }
 
                         InsertStep::Continue {
@@ -447,7 +457,8 @@ impl Tree {
         // Loop exited normally (remaining empty) - prev is the leaf node
         // Update its timestamp for LRU ordering
         let epoch = get_epoch();
-        prev.tenant_last_access_time.insert(Arc::clone(&tenant_id), epoch);
+        prev.tenant_last_access_time
+            .insert(Arc::clone(&tenant_id), epoch);
     }
 
     /// Performs prefix matching and returns detailed result with char counts.

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
@@ -198,7 +198,7 @@ impl PipelineStage for ClassifyResponseProcessingStage {
 
         // Build response
         let response = ClassifyResponse::new(
-            format!("classify-{}", dispatch.request_id),
+            dispatch.request_id.clone(),
             dispatch.model.clone(),
             dispatch.created,
             vec![classify_data],


### PR DESCRIPTION
Remove redundant "classify-" prefix in ClassifyResponseProcessingStage since request_id already includes the prefix from request building stage.

Before: "classify-classify-{uuid}"
After: "classify-{uuid}"


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
