### PR TITLE
perf(vision): avoid GPU→CPU sync on attention mask cache hits

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -195,7 +195,7 @@ class VisionSdpaAttention(nn.Module):
         # Fast path: check pointer-based cache (no GPU→CPU sync)
         ptr = cu_seqlens.data_ptr()
         numel = cu_seqlens.numel()
-        fast_key = (s, flatten_batch, ptr, numel)
+        fast_key = (s, flatten_batch, id(cu_seqlens), cu_seqlens._version, ptr, numel)
 
         if not hasattr(self, "_ptr_mask_cache"):
             self._ptr_mask_cache = {}
@@ -209,7 +209,7 @@ class VisionSdpaAttention(nn.Module):
 
         # Store in fast cache (bounded size)
         if len(self._ptr_mask_cache) >= 256:
-            self._ptr_mask_cache.clear()
+            self._ptr_mask_cache.pop(next(iter(self._ptr_mask_cache)))
         self._ptr_mask_cache[fast_key] = mask
 
         return mask


### PR DESCRIPTION
## Summary

The `generate_patch_attention_mask()` method was calling `cu_seqlens.cpu().tolist()` on every forward pass to compute the cache key, even when the mask was already cached. This GPU→CPU synchronization blocks the prefill pipeline and significantly impacts VLM throughput.

## Changes

Add a pointer-based fast cache that uses tensor metadata (`data_ptr`, `numel`) as the cache key:
- Cache hits: O(1) dict lookup, NO CPU sync
- Cache misses: CPU sync (unavoidable), then cached
- Memory bounded by 256-entry limit

## Test plan

- [ ] Run existing VLM tests
- [ ] Benchmark prefill throughput with/without the fix

Fixes #7518

🤖 Generated with [Claude Code](https://claude.com/claude-code)