### PR TITLE
[WIP][diffusion] new model: support Wan Animate with Data preprocessing

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/wanvideo.py
@@ -16,6 +16,7 @@ class WanVideoArchConfig(DiTArchConfig):
 
     param_names_mapping: dict = field(
         default_factory=lambda: {
+            r"^pose_patch_embedding\.(.*)$": r"pose_patch_embedding.proj.\1",
             r"^patch_embedding\.(.*)$": r"patch_embedding.proj.\1",
             r"^condition_embedder\.text_embedder\.linear_1\.(.*)$": r"condition_embedder.text_embedder.fc_in.\1",
             r"^condition_embedder\.text_embedder\.linear_2\.(.*)$": r"condition_embedder.text_embedder.fc_out.\1",

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -269,11 +269,21 @@ class PipelineConfig:
         image_latents = torch.concat([mask_lat_size, latent_condition], dim=1)
         return image_latents
 
+    def postprocess_decoded_frames(self, batch, frames):
+        return frames, None
+
     def slice_noise_pred(self, noise, latents):
         return noise
 
     def adjust_num_frames(self, num_frames):
         return num_frames
+
+    def get_latent_video_length(self, num_frames: int) -> int:
+        return num_frames
+
+    # for wan animate ref image latent(1 frame)
+    def get_latent_extra_frames(self) -> int:
+        return 0
 
     # tokenize the prompt
     def tokenize_prompt(self, prompt: list[str], tokenizer, tok_kwargs) -> dict:

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -204,9 +204,40 @@ class Wan2_2_I2V_A14B_Config(WanI2V480PConfig):
 class Wan2_2_Animate_14B_Config(WanI2V480PConfig):
     flow_shift: float | None = 5.0
     boundary_ratio: float | None = 0.900
+    refert_num: int = 1
+    clip_len: int = 77
+
+    def get_latent_video_length(self, num_frames: int) -> int:
+        return self.clip_len
+
+    def get_latent_extra_frames(self) -> int:
+        return 1
 
     def post_denoising_loop(self, latents, batch):
-        return latents[:, :, 1:]
+        return latents[:, :, self.refert_num :]
+
+    def postprocess_decoded_frames(self, batch, frames):
+        print("Decoding stage: handling WanAnimate segment stitching.")
+        if batch.extra.get("all_frames") is None:
+            batch.extra["all_frames"] = frames
+        else:
+            batch.extra["all_frames"] = torch.cat(
+                (
+                    batch.extra.get("all_frames"),
+                    frames[:, :, self.refert_num :],
+                ),
+                dim=2,
+            )
+
+        if batch.extra.get("cur_segment") != batch.extra.get("num_segments") - 1:
+            batch.extra["cur_segment"] = batch.extra.get("cur_segment") + 1
+            batch.timesteps = None
+            batch.latents = None
+            return frames, batch
+
+        frames = batch.extra.get("all_frames")
+        frames = frames[:, :, : batch.extra["real_frame_len"]]
+        return frames, None
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -201,6 +201,17 @@ class Wan2_2_I2V_A14B_Config(WanI2V480PConfig):
         self.dit_config.boundary_ratio = self.boundary_ratio
 
 
+class Wan2_2_Animate_14B_Config(WanI2V480PConfig):
+    flow_shift: float | None = 5.0
+    boundary_ratio: float | None = 0.900
+
+    def post_denoising_loop(self, latents, batch):
+        return latents[:, :, 1:]
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+
 # =============================================
 # ============= Causal Self-Forcing =============
 # =============================================

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -342,12 +342,12 @@ class SamplingParams:
 
     @staticmethod
     def from_user_sampling_params_args(model_path: str, server_args, *args, **kwargs):
-        sampling_params = SamplingParams.from_pretrained(model_path)
+        sampling_params = SamplingParams.from_pretrained(model_path, **kwargs)
 
-        user_sampling_params = SamplingParams(*args, **kwargs)
+        # user_sampling_params = SamplingParams(*args, **kwargs)
         # TODO: refactor
-        sampling_params._merge_with_user_params(user_sampling_params)
-        sampling_params._adjust(server_args)
+        # sampling_params._merge_with_user_params(user_sampling_params)
+        # sampling_params._adjust(server_args)
 
         sampling_params._validate_with_pipeline_config(server_args.pipeline_config)
 

--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -89,6 +89,11 @@ class SamplingParams:
     # Image inputs
     image_path: str | list[str] | None = None
 
+    # Video inputs
+    pose_video_path: str | None = None
+    face_video_path: str | None = None
+    video_path: str | None = None
+
     # Text inputs
     prompt: str | list[str] | None = None
     negative_prompt: str = (
@@ -342,12 +347,12 @@ class SamplingParams:
 
     @staticmethod
     def from_user_sampling_params_args(model_path: str, server_args, *args, **kwargs):
-        sampling_params = SamplingParams.from_pretrained(model_path, **kwargs)
+        sampling_params = SamplingParams.from_pretrained(model_path)
 
-        # user_sampling_params = SamplingParams(*args, **kwargs)
+        user_sampling_params = SamplingParams(*args, **kwargs)
         # TODO: refactor
-        # sampling_params._merge_with_user_params(user_sampling_params)
-        # sampling_params._adjust(server_args)
+        sampling_params._merge_with_user_params(user_sampling_params)
+        sampling_params._adjust(server_args)
 
         sampling_params._validate_with_pipeline_config(server_args.pipeline_config)
 
@@ -561,6 +566,24 @@ class SamplingParams:
                 "values, e.g.: "
                 '--image-path "img1.png" "img2.png"'
             ),
+        )
+        parser.add_argument(
+            "--video-path",
+            type=str,
+            default=SamplingParams.video_path,
+            help="Path to input video for wan animate generation",
+        )
+        parser.add_argument(
+            "--pose-video-path",
+            type=str,
+            default=SamplingParams.pose_video_path,
+            help="Path to input pose video for wan animate generation",
+        )
+        parser.add_argument(
+            "--face-video-path",
+            type=str,
+            default=SamplingParams.face_video_path,
+            help="Path to input face video for wan animate generation",
         )
         parser.add_argument(
             "--moba-config-path",

--- a/python/sglang/multimodal_gen/configs/sample/wan.py
+++ b/python/sglang/multimodal_gen/configs/sample/wan.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass, field
 
+from typing import Any
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.configs.sample.teacache import WanTeaCacheParams
 
@@ -271,6 +272,15 @@ class Wan2_2_I2V_A14B_SamplingParam(Wan2_2_Base_SamplingParams):
             (480, 832),  # 9:16
         ]
     )
+
+
+@dataclass
+class Wan2_2_Animate_14B_SamplingParam(Wan2_2_Base_SamplingParams):
+    guidance_scale: float = 1
+    num_inference_steps: int = 20
+    fps: int = 16
+
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 # =============================================

--- a/python/sglang/multimodal_gen/configs/sample/wan.py
+++ b/python/sglang/multimodal_gen/configs/sample/wan.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass, field
 
-from typing import Any
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.configs.sample.teacache import WanTeaCacheParams
 
@@ -276,11 +275,11 @@ class Wan2_2_I2V_A14B_SamplingParam(Wan2_2_Base_SamplingParams):
 
 @dataclass
 class Wan2_2_Animate_14B_SamplingParam(Wan2_2_Base_SamplingParams):
-    guidance_scale: float = 1
+    guidance_scale: float = 1.0
     num_inference_steps: int = 20
-    fps: int = 16
-
-    extra: dict[str, Any] = field(default_factory=dict)
+    fps: int = 24
+    retarget_flag: bool = False
+    use_flux: bool = False
 
 
 # =============================================

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -59,8 +59,8 @@ from sglang.multimodal_gen.configs.sample.wan import (
     Wan2_2_TI2V_5B_SamplingParam,
     WanI2V_14B_480P_SamplingParam,
     WanI2V_14B_720P_SamplingParam,
-    WanT2V_14B_SamplingParams,
     WanT2V_1_3B_SamplingParams,
+    WanT2V_14B_SamplingParams,
 )
 from sglang.multimodal_gen.configs.sample.zimage import ZImageSamplingParams
 from sglang.multimodal_gen.runtime.pipelines_core.composed_pipeline_base import (

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -35,6 +35,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
 from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     FastWan2_1_T2V_480P_Config,
     FastWan2_2_TI2V_5B_Config,
+    Wan2_2_Animate_14B_Config,
     Wan2_2_I2V_A14B_Config,
     Wan2_2_T2V_A14B_Config,
     Wan2_2_TI2V_5B_Config,
@@ -52,13 +53,14 @@ from sglang.multimodal_gen.configs.sample.qwenimage import (
 from sglang.multimodal_gen.configs.sample.wan import (
     FastWanT2V480PConfig,
     Wan2_1_Fun_1_3B_InP_SamplingParams,
+    Wan2_2_Animate_14B_SamplingParam,
     Wan2_2_I2V_A14B_SamplingParam,
     Wan2_2_T2V_A14B_SamplingParam,
     Wan2_2_TI2V_5B_SamplingParam,
     WanI2V_14B_480P_SamplingParam,
     WanI2V_14B_720P_SamplingParam,
-    WanT2V_1_3B_SamplingParams,
     WanT2V_14B_SamplingParams,
+    WanT2V_1_3B_SamplingParams,
 )
 from sglang.multimodal_gen.configs.sample.zimage import ZImageSamplingParams
 from sglang.multimodal_gen.runtime.pipelines_core.composed_pipeline_base import (
@@ -339,6 +341,13 @@ def _register_configs():
         pipeline_config_cls=WanI2V720PConfig,
         hf_model_paths=[
             "Wan-AI/Wan2.1-I2V-14B-720P-Diffusers",
+        ],
+    )
+    register_configs(
+        sampling_param_cls=Wan2_2_Animate_14B_SamplingParam,
+        pipeline_config_cls=Wan2_2_Animate_14B_Config,
+        hf_model_paths=[
+            "Wan-AI/Wan2.2-Animate-14B-Diffusers",
         ],
     )
     register_configs(

--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -211,6 +211,16 @@ class DiffGenerator:
 
         # 2. send requests to scheduler, one at a time
         # TODO: send batch when supported
+        # import debugpy
+        # print("正在启动 Debugger 监听，端口 5678...")
+        # debugpy.listen(("0.0.0.0", 5678))
+
+        # # 2. (可选) 暂停程序，直到 VS Code 连接上来
+        # # 如果你想调试程序启动阶段的逻辑，这行是必须的
+        # print("等待 VS Code 调试器连接...")
+        # debugpy.wait_for_client()
+
+        # print("调试器已连接，程序继续运行！")
         for request_idx, req in enumerate(requests):
             try:
                 with log_generation_timer(

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -295,7 +295,10 @@ def load_model_from_full_model_state_dict(
         logger.warning("Found unloaded parameters in meta state dict: %s", unused_keys)
 
     # List of allowed parameter name patterns
-    ALLOWED_NEW_PARAM_PATTERNS = ["gate_compress"]  # Can be extended as needed
+    ALLOWED_NEW_PARAM_PATTERNS = [
+        "gate_compress",
+        "norm_added_q",
+    ]  # Can be extended as needed
     for new_param_name in unused_keys:
         if not any(pattern in new_param_name for pattern in ALLOWED_NEW_PARAM_PATTERNS):
             logger.error(

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -139,10 +139,7 @@ class GPUWorker:
                     OutputBatch,
                 )
 
-                output_batch = OutputBatch()
-            output_batch.error = f"Error executing request {req.request_id}: {e}"
-        finally:
-            return output_batch
+        return output_batch
 
     def get_can_stay_resident_components(
         self, remaining_gpu_mem_gb: float

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -135,9 +135,7 @@ class GPUWorker:
                 f"Error executing request {req.request_id}: {e}", exc_info=True
             )
             if output_batch is None:
-                from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
-                    OutputBatch,
-                )
+                pass
 
         return output_batch
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/wan_animate_video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wan_animate_video.py
@@ -1,0 +1,843 @@
+# Adapted from diffusers transformer_wan_animate.py for SGLang
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from sglang.multimodal_gen.configs.models.dits import WanVideoConfig
+from sglang.multimodal_gen.runtime.distributed.parallel_state import get_sp_world_size
+from sglang.multimodal_gen.runtime.layers.attention import USPAttention
+from sglang.multimodal_gen.runtime.layers.layernorm import (
+    FP32LayerNorm,
+    LayerNormScaleShift,
+    RMSNorm,
+    ScaleResidual,
+    ScaleResidualLayerNormScaleShift,
+)
+from sglang.multimodal_gen.runtime.layers.linear import ReplicatedLinear
+from sglang.multimodal_gen.runtime.layers.mlp import MLP
+from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
+    _apply_rotary_emb,
+    NDRotaryEmbedding,
+)
+from sglang.multimodal_gen.runtime.layers.visual_embedding import (
+    ModulateProjection,
+    PatchEmbed,
+    TimestepEmbedder,
+)
+from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT, CachableDiT
+from sglang.multimodal_gen.runtime.models.dits.wanvideo import (
+    WanImageEmbedding,
+    WanT2VCrossAttention,
+    WanTimeTextImageEmbedding,
+    WanTransformerBlock,
+)
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+# Default channel sizes for the motion encoder at different resolutions
+WAN_ANIMATE_MOTION_ENCODER_CHANNEL_SIZES = {
+    "4": 512,
+    "8": 512,
+    "16": 512,
+    "32": 512,
+    "64": 256,
+    "128": 128,
+    "256": 64,
+    "512": 32,
+    "1024": 16,
+}
+
+
+class FusedLeakyReLU(nn.Module):
+    """
+    Fused LeakyRelu with scale factor and channel-wise bias.
+    """
+
+    def __init__(
+        self,
+        negative_slope: float = 0.2,
+        scale: float = 2**0.5,
+        bias_channels: int | None = None,
+    ):
+        super().__init__()
+        self.negative_slope = negative_slope
+        self.scale = scale
+        self.channels = bias_channels
+
+        if self.channels is not None:
+            self.bias = nn.Parameter(torch.zeros(self.channels))
+        else:
+            self.bias = None
+
+    def forward(self, x: torch.Tensor, channel_dim: int = 1) -> torch.Tensor:
+        if self.bias is not None:
+            # Expand self.bias to have all singleton dims except at channel_dim
+            expanded_shape = [1] * x.ndim
+            expanded_shape[channel_dim] = self.bias.shape[0]
+            bias = self.bias.reshape(*expanded_shape)
+            x = x + bias
+        return F.leaky_relu(x, self.negative_slope) * self.scale
+
+
+class MotionConv2d(nn.Module):
+    """
+    Conv2d layer with optional blur and fused activation for motion encoding.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+        bias: bool = True,
+        blur_kernel: tuple[int, ...] | None = None,
+        blur_upsample_factor: int = 1,
+        use_activation: bool = True,
+    ):
+        super().__init__()
+        self.use_activation = use_activation
+        self.in_channels = in_channels
+
+        # Handle blurring (applying a FIR filter with the given kernel) if available
+        self.blur = False
+        if blur_kernel is not None:
+            p = (len(blur_kernel) - stride) + (kernel_size - 1)
+            self.blur_padding = ((p + 1) // 2, p // 2)
+
+            kernel = torch.tensor(blur_kernel, dtype=torch.float32, device="cuda")
+            # Convert kernel to 2D if necessary
+            if kernel.ndim == 1:
+                kernel = kernel[None, :] * kernel[:, None]
+            # Normalize kernel
+            kernel = kernel / kernel.sum()
+            if blur_upsample_factor > 1:
+                kernel = kernel * (blur_upsample_factor**2)
+            self.register_buffer("blur_kernel", kernel, persistent=False)
+            self.blur = True
+
+        # Main Conv2d parameters (with scale factor)
+        self.weight = nn.Parameter(
+            torch.randn(out_channels, in_channels, kernel_size, kernel_size)
+        )
+        self.scale = 1 / math.sqrt(in_channels * kernel_size**2)
+
+        self.stride = stride
+        self.padding = padding
+
+        # If using an activation function, the bias will be fused into the activation
+        if bias and not self.use_activation:
+            self.conv_bias = nn.Parameter(torch.zeros(out_channels))
+        else:
+            self.conv_bias = None
+
+        if self.use_activation:
+            self.act_fn = FusedLeakyReLU(bias_channels=out_channels)
+        else:
+            self.act_fn = None
+
+    def forward(self, x: torch.Tensor, channel_dim: int = 1) -> torch.Tensor:
+        # Apply blur if using
+        if self.blur:
+            expanded_kernel = self.blur_kernel[None, None, :, :].expand(
+                self.in_channels, 1, -1, -1
+            )
+            x = F.conv2d(
+                x, expanded_kernel, padding=self.blur_padding, groups=self.in_channels
+            )
+
+        # Main Conv2D with scaling
+        x = F.conv2d(
+            x,
+            self.weight * self.scale,
+            bias=self.conv_bias,
+            stride=self.stride,
+            padding=self.padding,
+        )
+
+        # Activation with fused bias, if using
+        if self.use_activation:
+            x = self.act_fn(x, channel_dim=channel_dim)
+        return x
+
+
+class MotionLinear(nn.Module):
+    """
+    Linear layer with optional fused activation for motion encoding.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        bias: bool = True,
+        use_activation: bool = False,
+    ):
+        super().__init__()
+        self.use_activation = use_activation
+
+        # Linear weight with scale factor
+        self.weight = nn.Parameter(torch.randn(out_dim, in_dim))
+        self.scale = 1 / math.sqrt(in_dim)
+
+        # If an activation is present, the bias will be fused to it
+        if bias and not self.use_activation:
+            self.bias = nn.Parameter(torch.zeros(out_dim))
+        else:
+            self.bias = None
+
+        if self.use_activation:
+            self.act_fn = FusedLeakyReLU(bias_channels=out_dim)
+        else:
+            self.act_fn = None
+
+    def forward(self, input: torch.Tensor, channel_dim: int = 1) -> torch.Tensor:
+        out = F.linear(input, self.weight * self.scale, bias=self.bias)
+        if self.use_activation:
+            out = self.act_fn(out, channel_dim=channel_dim)
+        return out
+
+
+class MotionEncoderResBlock(nn.Module):
+    """
+    Residual block for motion encoder with downsampling.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        kernel_size_skip: int = 1,
+        blur_kernel: tuple[int, ...] = (1, 3, 3, 1),
+        downsample_factor: int = 2,
+    ):
+        super().__init__()
+        self.downsample_factor = downsample_factor
+
+        # 3 x 3 Conv + fused leaky ReLU
+        self.conv1 = MotionConv2d(
+            in_channels,
+            in_channels,
+            kernel_size,
+            stride=1,
+            padding=kernel_size // 2,
+            use_activation=True,
+        )
+
+        # 3 x 3 Conv that downsamples 2x + fused leaky ReLU
+        self.conv2 = MotionConv2d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=self.downsample_factor,
+            padding=0,
+            blur_kernel=blur_kernel,
+            use_activation=True,
+        )
+
+        # 1 x 1 Conv that downsamples 2x in skip connection
+        self.conv_skip = MotionConv2d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size_skip,
+            stride=self.downsample_factor,
+            padding=0,
+            bias=False,
+            blur_kernel=blur_kernel,
+            use_activation=False,
+        )
+
+    def forward(self, x: torch.Tensor, channel_dim: int = 1) -> torch.Tensor:
+        x_out = self.conv1(x, channel_dim)
+        x_out = self.conv2(x_out, channel_dim)
+
+        x_skip = self.conv_skip(x, channel_dim)
+
+        x_out = (x_out + x_skip) / math.sqrt(2)
+        return x_out
+
+
+class WanAnimateMotionEncoder(nn.Module):
+    """
+    Motion encoder that extracts motion features from face video frames.
+    Uses a convolutional appearance encoder followed by linear motion encoding
+    with QR-based Linear Motion Decomposition.
+    """
+
+    def __init__(
+        self,
+        size: int = 512,
+        style_dim: int = 512,
+        motion_dim: int = 20,
+        out_dim: int = 512,
+        motion_blocks: int = 5,
+        channels: dict[str, int] | None = None,
+    ):
+        super().__init__()
+        self.size = size
+
+        # Appearance encoder: conv layers
+        if channels is None:
+            channels = WAN_ANIMATE_MOTION_ENCODER_CHANNEL_SIZES
+
+        self.conv_in = MotionConv2d(3, channels[str(size)], 1, use_activation=True)
+
+        self.res_blocks = nn.ModuleList()
+        in_channels = channels[str(size)]
+        log_size = int(math.log(size, 2))
+        for i in range(log_size, 2, -1):
+            out_channels = channels[str(2 ** (i - 1))]
+            self.res_blocks.append(MotionEncoderResBlock(in_channels, out_channels))
+            in_channels = out_channels
+
+        self.conv_out = MotionConv2d(
+            in_channels, style_dim, 4, padding=0, bias=False, use_activation=False
+        )
+
+        # Motion encoder: linear layers
+        linears = [MotionLinear(style_dim, style_dim) for _ in range(motion_blocks - 1)]
+        linears.append(MotionLinear(style_dim, motion_dim))
+        self.motion_network = nn.ModuleList(linears)
+
+        self.motion_synthesis_weight = nn.Parameter(torch.randn(out_dim, motion_dim))
+
+    def forward(self, face_image: torch.Tensor, channel_dim: int = 1) -> torch.Tensor:
+        if (face_image.shape[-2] != self.size) or (face_image.shape[-1] != self.size):
+            raise ValueError(
+                f"Face pixel values has resolution ({face_image.shape[-1]}, {face_image.shape[-2]}) but is expected"
+                f" to have resolution ({self.size}, {self.size})"
+            )
+
+        # Appearance encoding through convs
+        face_image = self.conv_in(face_image, channel_dim)
+        for block in self.res_blocks:
+            face_image = block(face_image, channel_dim)
+        face_image = self.conv_out(face_image, channel_dim)
+        motion_feat = face_image.squeeze(-1).squeeze(-1)
+
+        # Motion feature extraction
+        for linear_layer in self.motion_network:
+            motion_feat = linear_layer(motion_feat, channel_dim=channel_dim)
+
+        # Motion synthesis via Linear Motion Decomposition
+        weight = self.motion_synthesis_weight + 1e-8
+        # Upcast the QR orthogonalization operation to FP32
+        original_motion_dtype = motion_feat.dtype
+        motion_feat = motion_feat.to(torch.float32)
+        weight = weight.to(torch.float32)
+
+        Q = torch.linalg.qr(weight)[0].to(device=motion_feat.device)
+
+        motion_feat_diag = torch.diag_embed(motion_feat)  # Alpha, diagonal matrix
+        motion_decomposition = torch.matmul(motion_feat_diag, Q.T)
+        motion_vec = torch.sum(motion_decomposition, dim=1)
+
+        motion_vec = motion_vec.to(dtype=original_motion_dtype)
+
+        return motion_vec
+
+
+class WanAnimateFaceEncoder(nn.Module):
+    """
+    Face encoder that processes motion features through temporal 1D convolutions.
+    Produces temporally-aligned features for cross-attention with video latents.
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        hidden_dim: int = 1024,
+        num_heads: int = 4,
+        kernel_size: int = 3,
+        eps: float = 1e-6,
+        pad_mode: str = "replicate",
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.time_causal_padding = (kernel_size - 1, 0)
+        self.pad_mode = pad_mode
+
+        self.act = nn.SiLU()
+
+        self.conv1_local = nn.Conv1d(
+            in_dim, hidden_dim * num_heads, kernel_size=kernel_size, stride=1
+        )
+        self.conv2 = nn.Conv1d(hidden_dim, hidden_dim, kernel_size, stride=2)
+        self.conv3 = nn.Conv1d(hidden_dim, hidden_dim, kernel_size, stride=2)
+
+        self.norm1 = nn.LayerNorm(hidden_dim, eps, elementwise_affine=False)
+        self.norm2 = nn.LayerNorm(hidden_dim, eps, elementwise_affine=False)
+        self.norm3 = nn.LayerNorm(hidden_dim, eps, elementwise_affine=False)
+
+        self.out_proj = nn.Linear(hidden_dim, out_dim)
+
+        self.padding_tokens = nn.Parameter(torch.zeros(1, 1, 1, out_dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.shape[0]
+
+        # Reshape to channels-first to apply causal Conv1d over frame dim
+        x = x.permute(0, 2, 1)
+        x = F.pad(x, self.time_causal_padding, mode=self.pad_mode)
+        x = self.conv1_local(x)  # [B, C, T_padded] --> [B, N * C, T]
+        x = x.unflatten(1, (self.num_heads, -1)).flatten(0, 1)  # [B * N, C, T]
+        # Reshape back to channels-last to apply LayerNorm over channel dim
+        x = x.permute(0, 2, 1)
+        x = self.norm1(x)
+        x = self.act(x)
+
+        x = x.permute(0, 2, 1)
+        x = F.pad(x, self.time_causal_padding, mode=self.pad_mode)
+        x = self.conv2(x)
+        x = x.permute(0, 2, 1)
+        x = self.norm2(x)
+        x = self.act(x)
+
+        x = x.permute(0, 2, 1)
+        x = F.pad(x, self.time_causal_padding, mode=self.pad_mode)
+        x = self.conv3(x)
+        x = x.permute(0, 2, 1)
+        x = self.norm3(x)
+        x = self.act(x)
+
+        x = self.out_proj(x)
+        x = x.unflatten(0, (batch_size, -1)).permute(
+            0, 2, 1, 3
+        )  # [B * N, T, C_out] --> [B, T, N, C_out]
+
+        padding = self.padding_tokens.repeat(batch_size, x.shape[1], 1, 1).to(
+            device=x.device, dtype=x.dtype
+        )
+        x = torch.cat([x, padding], dim=-2)  # [B, T, N, C_out] --> [B, T, N + 1, C_out]
+
+        return x
+
+
+class WanAnimateFaceBlockCrossAttention(nn.Module):
+    """
+    Temporally-aligned cross attention with the face motion signal in the Wan Animate Face Blocks.
+    Uses pre-normalization and reshapes Q to align temporally with motion K/V.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int = 8,
+        dim_head: int = 64,
+        eps: float = 1e-6,
+        cross_attention_dim_head: int | None = None,
+        supported_attention_backends: set[AttentionBackendEnum] | None = None,
+    ):
+        super().__init__()
+        self.inner_dim = dim_head * num_heads
+        self.num_heads = num_heads
+        self.cross_attention_head_dim = cross_attention_dim_head
+        self.kv_inner_dim = (
+            self.inner_dim
+            if cross_attention_dim_head is None
+            else cross_attention_dim_head * num_heads
+        )
+
+        # 1. Pre-Attention Norms for the hidden_states (video latents) and encoder_hidden_states (motion vector)
+        self.pre_norm_q = nn.LayerNorm(dim, eps, elementwise_affine=False)
+        self.pre_norm_kv = nn.LayerNorm(dim, eps, elementwise_affine=False)
+
+        # 2. QKV and Output Projections
+        self.to_q = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.to_k = ReplicatedLinear(dim, self.kv_inner_dim, bias=True)
+        self.to_v = ReplicatedLinear(dim, self.kv_inner_dim, bias=True)
+        self.to_out = ReplicatedLinear(self.inner_dim, dim, bias=True)
+
+        # 3. QK Norm (applied after the reshape, so only over dim_head rather than dim_head * heads)
+        self.norm_q = RMSNorm(dim_head, eps=eps)
+        self.norm_k = RMSNorm(dim_head, eps=eps)
+
+        # 4. Attention layer
+        self.attn = USPAttention(
+            num_heads=num_heads,
+            head_size=dim_head,
+            causal=False,
+            supported_attention_backends=supported_attention_backends,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            hidden_states: Video latent features [B, S, C] where S is sequence length
+            encoder_hidden_states: Motion features [B, T, N, C] where T is temporal length,
+                                   N is num_heads + 1
+            attention_mask: Optional mask for attention
+        """
+        # Pre-normalize
+        hidden_states = self.pre_norm_q(hidden_states)
+        encoder_hidden_states = self.pre_norm_kv(encoder_hidden_states)
+
+        B, T, N, C = encoder_hidden_states.shape
+
+        # Compute query, key, value
+        query, _ = self.to_q(hidden_states)
+        key, _ = self.to_k(encoder_hidden_states)
+        value, _ = self.to_v(encoder_hidden_states)
+
+        query = query.unflatten(2, (self.num_heads, -1))  # [B, S, H, D]
+        key = key.view(B, T, N, self.num_heads, -1)  # [B, T, N, H, D_kv]
+        value = value.view(B, T, N, self.num_heads, -1)
+
+        # Apply QK norm
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        # Reshape for temporal alignment:
+        # Q: [B, S, H, D] -> [B * T, S / T, H, D]
+        # K, V: [B, T, N, H, D_kv] -> [B * T, N, H, D_kv]
+        query = query.unflatten(1, (T, -1)).flatten(0, 1)  # [B * T, S / T, H, D]
+        key = key.flatten(0, 1)  # [B * T, N, H, D_kv]
+        value = value.flatten(0, 1)
+
+        # Compute attention
+        hidden_states = self.attn(query, key, value)
+
+        hidden_states = hidden_states.flatten(2, 3)
+        hidden_states = hidden_states.unflatten(0, (B, T)).flatten(1, 2)
+
+        hidden_states, _ = self.to_out(hidden_states)
+
+        if attention_mask is not None:
+            # attention_mask is assumed to be a multiplicative mask
+            attention_mask = attention_mask.flatten(start_dim=1)
+            hidden_states = hidden_states * attention_mask
+
+        return hidden_states
+
+
+class WanAnimateTransformer3DModel(BaseDiT):
+    """
+    Transformer model for Wan2.2-Animate video generation.
+    Extends WanTransformer3DModel with motion encoder, face encoder, and face adapter blocks.
+    """
+
+    _fsdp_shard_conditions = WanVideoConfig()._fsdp_shard_conditions
+    _compile_conditions = WanVideoConfig()._compile_conditions
+    _supported_attention_backends = WanVideoConfig()._supported_attention_backends
+    param_names_mapping = WanVideoConfig().param_names_mapping
+    reverse_param_names_mapping = WanVideoConfig().reverse_param_names_mapping
+    lora_param_names_mapping = WanVideoConfig().lora_param_names_mapping
+
+    def __init__(self, config: WanVideoConfig, hf_config: dict[str, Any]) -> None:
+        super().__init__(config=config, hf_config=hf_config)
+
+        inner_dim = config.num_attention_heads * config.attention_head_dim
+        self.hidden_size = config.hidden_size
+        self.num_attention_heads = config.num_attention_heads
+        self.num_channels_latents = config.num_channels_latents
+        self.patch_size = config.patch_size
+
+        # Wan Animate specific config with defaults
+        self.latent_channels = getattr(config, "latent_channels", 16)
+        self.in_channels = getattr(
+            config, "in_channels", 2 * self.latent_channels + 4
+        )  # 36 for Animate
+        self.out_channels = getattr(config, "out_channels", self.latent_channels)
+        self.motion_encoder_size = getattr(config, "motion_encoder_size", 512)
+        self.motion_style_dim = getattr(config, "motion_style_dim", 512)
+        self.motion_dim = getattr(config, "motion_dim", 20)
+        self.motion_encoder_dim = getattr(config, "motion_encoder_dim", 512)
+        self.face_encoder_hidden_dim = getattr(config, "face_encoder_hidden_dim", 1024)
+        self.face_encoder_num_heads = getattr(config, "face_encoder_num_heads", 4)
+        self.inject_face_latents_blocks = getattr(
+            config, "inject_face_latents_blocks", 5
+        )
+        self.motion_encoder_batch_size = getattr(config, "motion_encoder_batch_size", 8)
+
+        # 1. Patch & position embedding
+        self.patch_embedding = PatchEmbed(
+            in_chans=self.in_channels,
+            embed_dim=inner_dim,
+            patch_size=config.patch_size,
+            flatten=False,
+        )
+        self.pose_patch_embedding = PatchEmbed(
+            in_chans=self.latent_channels,
+            embed_dim=inner_dim,
+            patch_size=config.patch_size,
+            flatten=False,
+        )
+
+        # 2. Condition embeddings
+        self.condition_embedder = WanTimeTextImageEmbedding(
+            dim=inner_dim,
+            time_freq_dim=config.freq_dim,
+            text_embed_dim=config.text_dim,
+            image_embed_dim=config.image_dim,
+        )
+
+        # 3. Motion encoder
+        self.motion_encoder = WanAnimateMotionEncoder(
+            size=self.motion_encoder_size,
+            style_dim=self.motion_style_dim,
+            motion_dim=self.motion_dim,
+            out_dim=self.motion_encoder_dim,
+        )
+
+        # 4. Face encoder
+        self.face_encoder = WanAnimateFaceEncoder(
+            in_dim=self.motion_encoder_dim,
+            out_dim=inner_dim,
+            hidden_dim=self.face_encoder_hidden_dim,
+            num_heads=self.face_encoder_num_heads,
+        )
+
+        # 5. Transformer blocks
+        self.blocks = nn.ModuleList(
+            [
+                WanTransformerBlock(
+                    inner_dim,
+                    config.ffn_dim,
+                    config.num_attention_heads,
+                    config.qk_norm,
+                    config.cross_attn_norm,
+                    config.eps,
+                    config.added_kv_proj_dim,
+                    self._supported_attention_backends,
+                    prefix=f"{config.prefix}.blocks.{i}",
+                )
+                for i in range(config.num_layers)
+            ]
+        )
+
+        # 6. Face adapter blocks (applied every inject_face_latents_blocks)
+        num_face_adapters = config.num_layers // self.inject_face_latents_blocks
+        self.face_adapter = nn.ModuleList(
+            [
+                WanAnimateFaceBlockCrossAttention(
+                    dim=inner_dim,
+                    num_heads=config.num_attention_heads,
+                    dim_head=inner_dim // config.num_attention_heads,
+                    eps=config.eps,
+                    cross_attention_dim_head=inner_dim // config.num_attention_heads,
+                    supported_attention_backends=self._supported_attention_backends,
+                )
+                for _ in range(num_face_adapters)
+            ]
+        )
+
+        # 7. Output norm & projection
+        self.norm_out = LayerNormScaleShift(
+            inner_dim,
+            norm_type="layer",
+            eps=config.eps,
+            elementwise_affine=False,
+            dtype=torch.float32,
+            compute_dtype=torch.float32,
+        )
+        self.proj_out = nn.Linear(
+            inner_dim, self.out_channels * math.prod(config.patch_size)
+        )
+        self.scale_shift_table = nn.Parameter(
+            torch.randn(1, 2, inner_dim) / inner_dim**0.5
+        )
+
+        self.__post_init__()
+
+        # misc
+        self.sp_size = get_sp_world_size()
+
+        # Get rotary embeddings
+        d = self.hidden_size // self.num_attention_heads
+        self.rope_dim_list = [d - 4 * (d // 6), 2 * (d // 6), 2 * (d // 6)]
+
+        self.rotary_emb = NDRotaryEmbedding(
+            rope_dim_list=self.rope_dim_list,
+            rope_theta=10000,
+            dtype=torch.float32 if current_platform.is_mps() else torch.float64,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor | list[torch.Tensor],
+        timestep: torch.LongTensor,
+        encoder_hidden_states_image: torch.Tensor | list[torch.Tensor] | None = None,
+        pose_hidden_states: torch.Tensor | None = None,
+        face_pixel_values: torch.Tensor | None = None,
+        motion_encode_batch_size: int | None = None,
+        guidance: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Forward pass of Wan2.2-Animate transformer model.
+
+        Args:
+            hidden_states: Input noisy video latents [B, 2C + 4, T + 1, H, W]
+            encoder_hidden_states: Text embeddings from text encoder
+            timestep: Current timestep in the denoising loop
+            encoder_hidden_states_image: CLIP visual features of the reference image
+            pose_hidden_states: Pose video latents [B, C, T, H, W]
+            face_pixel_values: Face video in pixel space [B, C', S, H', W']
+            motion_encode_batch_size: Batch size for motion encoding
+        """
+        orig_dtype = hidden_states.dtype
+
+        if not isinstance(encoder_hidden_states, torch.Tensor):
+            encoder_hidden_states = encoder_hidden_states[0]
+        if (
+            isinstance(encoder_hidden_states_image, list)
+            and len(encoder_hidden_states_image) > 0
+        ):
+            encoder_hidden_states_image = encoder_hidden_states_image[0]
+        else:
+            encoder_hidden_states_image = None
+
+        # Validate shapes
+        if pose_hidden_states is not None:
+            if pose_hidden_states.shape[2] + 1 != hidden_states.shape[2]:
+                raise ValueError(
+                    f"pose_hidden_states frame dim is {pose_hidden_states.shape[2]} but must be one less than "
+                    f"hidden_states frame dim: {hidden_states.shape[2]}"
+                )
+
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.patch_size
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        # 1. Rotary position embedding
+        freqs_cos, freqs_sin = self.rotary_emb.forward_from_grid(
+            (
+                post_patch_num_frames * self.sp_size,
+                post_patch_height,
+                post_patch_width,
+            ),
+            shard_dim=0,
+            start_frame=0,
+            device=hidden_states.device,
+        )
+        assert freqs_cos.dtype == torch.float32
+        freqs_cis = (freqs_cos.float(), freqs_sin.float())
+
+        # 2. Patch embedding
+        hidden_states = self.patch_embedding(hidden_states)
+        pose_hidden_states = self.pose_patch_embedding(pose_hidden_states)
+
+        # Add pose embeddings to frames 1+ (skip first frame which is the reference)
+        hidden_states[:, :, 1:] = hidden_states[:, :, 1:] + pose_hidden_states
+
+        # Flatten for transformer
+        hidden_states = hidden_states.flatten(2).transpose(1, 2).contiguous()
+
+        # 3. Condition embeddings (time, text, image)
+        temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = (
+            self.condition_embedder(
+                timestep, encoder_hidden_states, encoder_hidden_states_image
+            )
+        )
+        # batch_size, 6, inner_dim
+        timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+        if encoder_hidden_states_image is not None:
+            encoder_hidden_states = torch.concat(
+                [encoder_hidden_states_image, encoder_hidden_states], dim=1
+            )
+
+        encoder_hidden_states = (
+            encoder_hidden_states.to(orig_dtype)
+            if current_platform.is_mps()
+            else encoder_hidden_states
+        )
+
+        # 4. Get motion features from the face video
+        if face_pixel_values is not None:
+            batch_size_face, channels, num_face_frames, face_height, face_width = (
+                face_pixel_values.shape
+            )
+            # Rearrange from (B, C, T, H, W) to (B*T, C, H, W)
+            face_pixel_values = face_pixel_values.permute(0, 2, 1, 3, 4).reshape(
+                -1, channels, face_height, face_width
+            )
+
+            # Extract motion features using motion encoder (batched for memory efficiency)
+            motion_encode_batch_size = (
+                motion_encode_batch_size or self.motion_encoder_batch_size
+            )
+            face_batches = torch.split(face_pixel_values, motion_encode_batch_size)
+            motion_vec_batches = []
+            for face_batch in face_batches:
+                motion_vec_batch = self.motion_encoder(face_batch)
+                motion_vec_batches.append(motion_vec_batch)
+            motion_vec = torch.cat(motion_vec_batches)
+            motion_vec = motion_vec.view(batch_size_face, num_face_frames, -1)
+
+            # Get face features from the motion vector
+            motion_vec = self.face_encoder(motion_vec)
+
+            # Add padding at the beginning (prepend zeros for first frame)
+            pad_face = torch.zeros_like(motion_vec[:, :1])
+            motion_vec = torch.cat([pad_face, motion_vec], dim=1)
+        else:
+            motion_vec = None
+
+        # 5. Transformer blocks with face adapter integration
+        for block_idx, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states, encoder_hidden_states, timestep_proj, freqs_cis
+            )
+
+            # Face adapter integration: apply after every inject_face_latents_blocks blocks
+            if (
+                motion_vec is not None
+                and block_idx % self.inject_face_latents_blocks == 0
+            ):
+                face_adapter_block_idx = block_idx // self.inject_face_latents_blocks
+                face_adapter_output = self.face_adapter[face_adapter_block_idx](
+                    hidden_states, motion_vec
+                )
+                # Handle potential device mismatch with model parallelism
+                face_adapter_output = face_adapter_output.to(
+                    device=hidden_states.device
+                )
+                hidden_states = face_adapter_output + hidden_states
+
+        # 6. Output norm, projection & unpatchify
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+
+        hidden_states = self.norm_out(hidden_states, shift, scale)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            batch_size,
+            post_patch_num_frames,
+            post_patch_height,
+            post_patch_width,
+            p_t,
+            p_h,
+            p_w,
+            -1,
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        return output
+
+
+EntryClass = WanAnimateTransformer3DModel

--- a/python/sglang/multimodal_gen/runtime/models/dits/wan_animate_video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wan_animate_video.py
@@ -12,28 +12,12 @@ import torch.nn.functional as F
 from sglang.multimodal_gen.configs.models.dits import WanVideoConfig
 from sglang.multimodal_gen.runtime.distributed.parallel_state import get_sp_world_size
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
-from sglang.multimodal_gen.runtime.layers.layernorm import (
-    FP32LayerNorm,
-    LayerNormScaleShift,
-    RMSNorm,
-    ScaleResidual,
-    ScaleResidualLayerNormScaleShift,
-)
+from sglang.multimodal_gen.runtime.layers.layernorm import LayerNormScaleShift, RMSNorm
 from sglang.multimodal_gen.runtime.layers.linear import ReplicatedLinear
-from sglang.multimodal_gen.runtime.layers.mlp import MLP
-from sglang.multimodal_gen.runtime.layers.rotary_embedding import (
-    _apply_rotary_emb,
-    NDRotaryEmbedding,
-)
-from sglang.multimodal_gen.runtime.layers.visual_embedding import (
-    ModulateProjection,
-    PatchEmbed,
-    TimestepEmbedder,
-)
-from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT, CachableDiT
+from sglang.multimodal_gen.runtime.layers.rotary_embedding import NDRotaryEmbedding
+from sglang.multimodal_gen.runtime.layers.visual_embedding import PatchEmbed
+from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT
 from sglang.multimodal_gen.runtime.models.dits.wanvideo import (
-    WanImageEmbedding,
-    WanT2VCrossAttention,
     WanTimeTextImageEmbedding,
     WanTransformerBlock,
 )

--- a/python/sglang/multimodal_gen/runtime/pipelines/wan_animate_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/wan_animate_pipeline.py
@@ -1,0 +1,125 @@
+from os import sched_yield
+
+from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_unipc_multistep import (
+    FlowUniPCMultistepScheduler,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.composed_pipeline_base import (
+    ComposedPipelineBase,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages import (
+    ImageEncodingStage,
+    InputValidationStage,
+    TextEncodingStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.conditioning import (
+    ConditioningStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding import DecodingStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import DenoisingStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.image_encoding import (
+    ImageVAEEncodingStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.latent_preparation import (
+    LatentPreparationStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.timestep_preparation import (
+    TimestepPreparationStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.wan_animate_conditioning import (
+    WanAnimateConditioningStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.wan_video_processing import (
+    VideoProcessingStage,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class WanAnimatePipeline(ComposedPipelineBase):
+    pipeline_name = "WanAnimatePipeline"
+
+    _required_config_modules = [
+        "text_encoder",
+        "tokenizer",
+        "image_encoder",
+        "image_processor",
+        "vae",
+        "transformer",
+    ]
+
+    def initialize_pipeline(self, server_args: ServerArgs) -> None:
+        self.modules["scheduler"] = FlowUniPCMultistepScheduler(
+            shift=server_args.pipeline_config.flow_shift
+        )
+
+    def create_pipeline_stages(self, server_args: ServerArgs) -> None:
+        self.add_stage(
+            stage_name="input_validation_stage", stage=InputValidationStage()
+        )
+
+        self.add_stage(
+            stage_name="prompt_encoding_stage",
+            stage=TextEncodingStage(
+                text_encoders=[self.get_module("text_encoder")],
+                tokenizers=[self.get_module("tokenizer")],
+            ),
+        )
+
+        self.add_stage(
+            stage_name="image_encoding_stage",
+            stage=ImageEncodingStage(
+                image_encoder=self.get_module("image_encoder"),
+                image_processor=self.get_module("image_processor"),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="image_latent_preparation_stage",
+            stage=ImageVAEEncodingStage(vae=self.get_module("vae")),
+        )
+
+        self.add_stage(
+            stage_name="video_processing_stage",
+            stage=VideoProcessingStage(),
+        )
+
+        self.add_stage(stage_name="conditioning_stage", stage=ConditioningStage())
+
+        for _ in range(2):
+            self.add_stage(
+                stage_name="wan_animate_conditioning_stage",
+                stage=WanAnimateConditioningStage(vae=self.get_module("vae")),
+            )
+
+            self.add_stage(
+                stage_name="timestep_preparation_stage",
+                stage=TimestepPreparationStage(scheduler=self.get_module("scheduler")),
+            )
+
+            self.add_stage(
+                stage_name="latent_preparation_stage",
+                stage=LatentPreparationStage(
+                    scheduler=self.get_module("scheduler"),
+                    transformer=self.get_module("transformer"),
+                ),
+            )
+
+            self.add_stage(
+                stage_name="denoising_stage",
+                stage=DenoisingStage(
+                    transformer=self.get_module("transformer"),
+                    transformer_2=self.get_module("transformer_2"),
+                    scheduler=self.get_module("scheduler"),
+                    vae=self.get_module("vae"),
+                ),
+            )
+
+            self.add_stage(
+                stage_name="deconding_stage",
+                stage=DecodingStage(vae=self.get_module("vae")),
+            )
+
+
+EntryClass = WanAnimatePipeline

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -53,6 +53,14 @@ class Req:
 
     # Image inputs
     image_path: str | list[str] | None = None
+    # Video input paths (pose / face) used by animate pipelines
+    pose_video_path: str | None = None
+    face_video_path: str | None = None
+    video_path: str | None = None
+    # For preprocessed video inputs (e.g., WanAnimate)
+    retarget_flag: bool = False
+    use_flux: bool = False
+
     # Image encoder hidden states
     image_embeds: list[torch.Tensor] = field(default_factory=list)
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/__init__.py
@@ -37,6 +37,15 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.text_encoding import (
 from sglang.multimodal_gen.runtime.pipelines_core.stages.timestep_preparation import (
     TimestepPreparationStage,
 )
+from sglang.multimodal_gen.runtime.pipelines_core.stages.wan_animate_conditioning import (
+    WanAnimateConditioningStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.wan_animate_segment_loop import (
+    SegmentLoopStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.wan_video_processing import (
+    VideoProcessingStage,
+)
 
 __all__ = [
     "PipelineStage",
@@ -52,4 +61,7 @@ __all__ = [
     "ImageEncodingStage",
     "ImageVAEEncodingStage",
     "TextEncodingStage",
+    "VideoProcessingStage",
+    "SegmentLoopStage",
+    "WanAnimateConditioningStage",
 ]

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/data_preprocessing.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/data_preprocessing.py
@@ -1,0 +1,717 @@
+import os
+from typing import List, Union
+
+import cv2
+import numpy as np
+import onnxruntime
+import torch
+from decord import VideoReader
+from PIL import Image
+
+from sglang.multimodal_gen.configs.utils import resolve_wan_preprocess_model_paths
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.human_visualization import (
+    draw_aapose_by_meta_new,
+)
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.pose2d import (
+    AAPoseMeta,
+    bbox_from_detector,
+    box_convert_simple,
+    crop,
+    get_face_bboxes,
+    get_frame_indices,
+    keypoints_from_heatmaps,
+    load_pose_metas_from_kp2ds_seq,
+    padding_resize,
+    read_img,
+    resize_by_area,
+)
+from sglang.multimodal_gen.runtime.utils.retarget_pose import get_retarget_pose
+
+logger = init_logger(__name__)
+
+
+class SimpleOnnxInference(object):
+    def __init__(self, checkpoint, device="cuda", reverse_input=False, **kwargs):
+        if isinstance(device, str):
+            device = torch.device(device)
+        if device.type == "cuda":
+            device = "{}:{}".format(device.type, device.index)
+            providers = [
+                (
+                    "CUDAExecutionProvider",
+                    {
+                        "device_id": (
+                            device[-1:]
+                            if device[-1] in [str(_i) for _i in range(10)]
+                            else "0"
+                        )
+                    },
+                ),
+                "CPUExecutionProvider",
+            ]
+        else:
+            providers = ["CPUExecutionProvider"]
+        self.device = device
+        if not os.path.exists(checkpoint):
+            raise RuntimeError("{} is not existed!".format(checkpoint))
+
+        if os.path.isdir(checkpoint):
+            checkpoint = os.path.join(checkpoint, "end2end.onnx")
+
+        self.session = onnxruntime.InferenceSession(checkpoint, providers=providers)
+        self.input_name = self.session.get_inputs()[0].name
+        self.output_name = self.session.get_outputs()[0].name
+        self.input_resolution = (
+            self.session.get_inputs()[0].shape[2:]
+            if not reverse_input
+            else self.session.get_inputs()[0].shape[2:][::-1]
+        )
+        self.input_resolution = np.array(self.input_resolution)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+    # def get_output_names(self):
+    #     output_names = []
+    #     for node in self.session.get_outputs():
+    #         output_names.append(node.name)
+    #     return output_names
+
+
+class Yolo(SimpleOnnxInference):
+    def __init__(
+        self,
+        checkpoint,
+        device="cuda",
+        threshold_conf=0.05,
+        threshold_multi_persons=0.1,
+        input_resolution=(640, 640),
+        threshold_iou=0.5,
+        threshold_bbox_shape_ratio=0.4,
+        cat_id=[1],
+        select_type="max",
+        strict=True,
+        sorted_func=None,
+        **kwargs,
+    ):
+        super(Yolo, self).__init__(checkpoint, device=device, **kwargs)
+
+        model_inputs = self.session.get_inputs()
+        input_shape = model_inputs[0].shape
+
+        self.input_width = 640
+        self.input_height = 640
+
+        self.threshold_multi_persons = threshold_multi_persons
+        self.threshold_conf = threshold_conf
+        self.threshold_iou = threshold_iou
+        self.threshold_bbox_shape_ratio = threshold_bbox_shape_ratio
+        self.input_resolution = input_resolution
+        self.cat_id = cat_id
+        self.select_type = select_type
+        self.strict = strict
+        self.sorted_func = sorted_func
+
+    def preprocess(self, input_image):
+        """
+        Preprocesses the input image before performing inference.
+
+        Returns:
+            image_data: Preprocessed image data ready for inference.
+        """
+        img = read_img(input_image)
+        # Get the height and width of the input image
+        img_height, img_width = img.shape[:2]
+        # Resize the image to match the input shape
+        img = cv2.resize(img, (self.input_resolution[1], self.input_resolution[0]))
+        # Normalize the image data by dividing it by 255.0
+        image_data = np.array(img) / 255.0
+        # Transpose the image to have the channel dimension as the first dimension
+        image_data = np.transpose(image_data, (2, 0, 1))  # Channel first
+        # Expand the dimensions of the image data to match the expected input shape
+        # image_data = np.expand_dims(image_data, axis=0).astype(np.float32)
+        image_data = image_data.astype(np.float32)
+        # Return the preprocessed image data
+        return image_data, np.array([img_height, img_width])
+
+    def postprocess(self, output, shape_raw, cat_id=[1]):
+        """
+        Performs post-processing on the model's output to extract bounding boxes, scores, and class IDs.
+
+        Args:
+            input_image (numpy.ndarray): The input image.
+            output (numpy.ndarray): The output of the model.
+
+        Returns:
+            numpy.ndarray: The input image with detections drawn on it.
+        """
+        # Transpose and squeeze the output to match the expected shape
+
+        outputs = np.squeeze(output)
+        if len(outputs.shape) == 1:
+            outputs = outputs[None]
+        if output.shape[-1] != 6 and output.shape[1] == 84:
+            outputs = np.transpose(outputs)
+
+        # Get the number of rows in the outputs array
+        rows = outputs.shape[0]
+
+        # Calculate the scaling factors for the bounding box coordinates
+        x_factor = shape_raw[1] / self.input_width
+        y_factor = shape_raw[0] / self.input_height
+
+        # Lists to store the bounding boxes, scores, and class IDs of the detections
+        boxes = []
+        scores = []
+        class_ids = []
+
+        if outputs.shape[-1] == 6:
+            max_scores = outputs[:, 4]
+            classid = outputs[:, -1]
+
+            threshold_conf_masks = max_scores >= self.threshold_conf
+            classid_masks = classid[threshold_conf_masks] != 3.14159
+
+            max_scores = max_scores[threshold_conf_masks][classid_masks]
+            classid = classid[threshold_conf_masks][classid_masks]
+
+            boxes = outputs[:, :4][threshold_conf_masks][classid_masks]
+            boxes[:, [0, 2]] *= x_factor
+            boxes[:, [1, 3]] *= y_factor
+            boxes[:, 2] = boxes[:, 2] - boxes[:, 0]
+            boxes[:, 3] = boxes[:, 3] - boxes[:, 1]
+            boxes = boxes.astype(np.int32)
+
+        else:
+            classes_scores = outputs[:, 4:]
+            max_scores = np.amax(classes_scores, -1)
+            threshold_conf_masks = max_scores >= self.threshold_conf
+
+            classid = np.argmax(classes_scores[threshold_conf_masks], -1)
+
+            classid_masks = classid != 3.14159
+
+            classes_scores = classes_scores[threshold_conf_masks][classid_masks]
+            max_scores = max_scores[threshold_conf_masks][classid_masks]
+            classid = classid[classid_masks]
+
+            xywh = outputs[:, :4][threshold_conf_masks][classid_masks]
+
+            x = xywh[:, 0:1]
+            y = xywh[:, 1:2]
+            w = xywh[:, 2:3]
+            h = xywh[:, 3:4]
+
+            left = (x - w / 2) * x_factor
+            top = (y - h / 2) * y_factor
+            width = w * x_factor
+            height = h * y_factor
+            boxes = np.concatenate([left, top, width, height], axis=-1).astype(np.int32)
+
+        boxes = boxes.tolist()
+        scores = max_scores.tolist()
+        class_ids = classid.tolist()
+
+        # Apply non-maximum suppression to filter out overlapping bounding boxes
+        indices = cv2.dnn.NMSBoxes(
+            boxes, scores, self.threshold_conf, self.threshold_iou
+        )
+        # Iterate over the selected indices after non-maximum suppression
+
+        results = []
+        for i in indices:
+            # Get the box, score, and class ID corresponding to the index
+            box = box_convert_simple(boxes[i], "xywh2xyxy")
+            score = scores[i]
+            class_id = class_ids[i]
+            results.append(box + [score] + [class_id])
+            # # Draw the detection on the input image
+
+        # Return the modified input image
+        return np.array(results)
+
+    def process_results(self, results, shape_raw, cat_id=[1], single_person=True):
+        if isinstance(results, tuple):
+            det_results = results[0]
+        else:
+            det_results = results
+
+        person_results = []
+        person_count = 0
+        if len(results):
+            max_idx = -1
+            max_bbox_size = shape_raw[0] * shape_raw[1] * -10
+            max_bbox_shape = -1
+
+            bboxes = []
+            idx_list = []
+            for i in range(results.shape[0]):
+                bbox = results[i]
+                if (bbox[-1] + 1 in cat_id) and (bbox[-2] > self.threshold_conf):
+                    idx_list.append(i)
+                    bbox_shape = max((bbox[2] - bbox[0]), ((bbox[3] - bbox[1])))
+                    if bbox_shape > max_bbox_shape:
+                        max_bbox_shape = bbox_shape
+
+            results = results[idx_list]
+
+            for i in range(results.shape[0]):
+                bbox = results[i]
+                bboxes.append(bbox)
+                if self.select_type == "max":
+                    bbox_size = (bbox[2] - bbox[0]) * ((bbox[3] - bbox[1]))
+                elif self.select_type == "center":
+                    bbox_size = (abs((bbox[2] + bbox[0]) / 2 - shape_raw[1] / 2)) * -1
+                bbox_shape = max((bbox[2] - bbox[0]), ((bbox[3] - bbox[1])))
+                if bbox_size > max_bbox_size:
+                    if (
+                        (self.strict or max_idx != -1)
+                        and bbox_shape
+                        < max_bbox_shape * self.threshold_bbox_shape_ratio
+                    ):
+                        continue
+                    max_bbox_size = bbox_size
+                    max_bbox_shape = bbox_shape
+                    max_idx = i
+
+            if self.sorted_func is not None and len(bboxes) > 0:
+                max_idx = self.sorted_func(bboxes, shape_raw)
+                bbox = bboxes[max_idx]
+                if self.select_type == "max":
+                    max_bbox_size = (bbox[2] - bbox[0]) * ((bbox[3] - bbox[1]))
+                elif self.select_type == "center":
+                    max_bbox_size = (
+                        abs((bbox[2] + bbox[0]) / 2 - shape_raw[1] / 2)
+                    ) * -1
+
+            if max_idx != -1:
+                person_count = 1
+
+            if max_idx != -1:
+                person = {}
+                person["bbox"] = results[max_idx, :5]
+                person["track_id"] = int(0)
+                person_results.append(person)
+
+            for i in range(results.shape[0]):
+                bbox = results[i]
+                if (bbox[-1] + 1 in cat_id) and (bbox[-2] > self.threshold_conf):
+                    if self.select_type == "max":
+                        bbox_size = (bbox[2] - bbox[0]) * ((bbox[3] - bbox[1]))
+                    elif self.select_type == "center":
+                        bbox_size = (
+                            abs((bbox[2] + bbox[0]) / 2 - shape_raw[1] / 2)
+                        ) * -1
+                    if (
+                        i != max_idx
+                        and bbox_size > max_bbox_size * self.threshold_multi_persons
+                        and bbox_size < max_bbox_size
+                    ):
+                        person_count += 1
+                        if not single_person:
+                            person = {}
+                            person["bbox"] = results[i, :5]
+                            person["track_id"] = int(person_count - 1)
+                            person_results.append(person)
+            return person_results
+        else:
+            return None
+
+    def postprocess_threading(
+        self, outputs, shape_raw, person_results, i, single_person=True, **kwargs
+    ):
+        result = self.postprocess(outputs[i], shape_raw[i], cat_id=self.cat_id)
+        result = self.process_results(
+            result, shape_raw[i], cat_id=self.cat_id, single_person=single_person
+        )
+        if result is not None and len(result) != 0:
+            person_results[i] = result
+
+    def forward(self, img, shape_raw, **kwargs):
+        """
+        Performs inference using an ONNX model and returns the output image with drawn detections.
+
+        Returns:
+            output_img: The output image with drawn detections.
+        """
+        if isinstance(img, torch.Tensor):
+            img = img.cpu().numpy()
+            shape_raw = shape_raw.cpu().numpy()
+
+        outputs = self.session.run(None, {self.session.get_inputs()[0].name: img})[0]
+        person_results = [
+            [
+                {
+                    "bbox": np.array(
+                        [0.0, 0.0, 1.0 * shape_raw[i][1], 1.0 * shape_raw[i][0], -1]
+                    ),
+                    "track_id": -1,
+                }
+            ]
+            for i in range(len(outputs))
+        ]
+
+        for i in range(len(outputs)):
+            self.postprocess_threading(outputs, shape_raw, person_results, i, **kwargs)
+        return person_results
+
+
+class ViTPose(SimpleOnnxInference):
+    def __init__(self, checkpoint, device="cuda", **kwargs):
+        super(ViTPose, self).__init__(checkpoint, device=device)
+
+    def forward(self, img, center, scale, **kwargs):
+        heatmaps = self.session.run([], {self.session.get_inputs()[0].name: img})[0]
+        points, prob = keypoints_from_heatmaps(
+            heatmaps=heatmaps,
+            center=center,
+            scale=scale * 200,
+            unbiased=True,
+            use_udp=False,
+        )
+        return np.concatenate([points, prob], axis=2)
+
+    @staticmethod
+    def preprocess(
+        img, bbox=None, input_resolution=(256, 192), rescale=1.25, mask=None, **kwargs
+    ):
+        if (
+            bbox is None
+            or bbox[-1] <= 0
+            or (bbox[2] - bbox[0]) < 10
+            or (bbox[3] - bbox[1]) < 10
+        ):
+            bbox = np.array([0, 0, img.shape[1], img.shape[0]])
+
+        bbox_xywh = bbox
+        if mask is not None:
+            img = np.where(mask > 128, img, mask)
+
+        if isinstance(input_resolution, int):
+            center, scale = bbox_from_detector(
+                bbox_xywh, (input_resolution, input_resolution), rescale=rescale
+            )
+            img, new_shape, old_xy, new_xy = crop(
+                img, center, scale, (input_resolution, input_resolution)
+            )
+        else:
+            center, scale = bbox_from_detector(
+                bbox_xywh, input_resolution, rescale=rescale
+            )
+            img, new_shape, old_xy, new_xy = crop(
+                img, center, scale, (input_resolution[0], input_resolution[1])
+            )
+
+        IMG_NORM_MEAN = np.array([0.485, 0.456, 0.406])
+        IMG_NORM_STD = np.array([0.229, 0.224, 0.225])
+        img_norm = (img / 255.0 - IMG_NORM_MEAN) / IMG_NORM_STD
+        img_norm = img_norm.transpose(2, 0, 1).astype(np.float32)
+        return img_norm, np.array(center), np.array(scale)
+
+
+class Pose2d:
+    def __init__(self, checkpoint, detector_checkpoint=None, device="cpu", **kwargs):
+
+        if detector_checkpoint is not None:
+            self.detector = Yolo(detector_checkpoint, device=device)
+        else:
+            self.detector = None
+
+        self.model = ViTPose(checkpoint, device=device)
+
+    def load_images(self, inputs):
+        """
+        Load images from various input types.
+
+        Args:
+            inputs (Union[str, np.ndarray, List[np.ndarray]]): Input can be file path,
+                     single image array, or list of image arrays
+
+        Returns:
+            List[np.ndarray]: List of RGB image arrays
+
+        Raises:
+            ValueError: If file format is unsupported or image cannot be read
+        """
+        if isinstance(inputs, str):
+            if inputs.lower().endswith((".mp4", ".avi", ".mov", ".mkv")):
+                cap = cv2.VideoCapture(inputs)
+                frames = []
+                while True:
+                    ret, frame = cap.read()
+                    if not ret:
+                        break
+                    frames.append(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+                cap.release()
+                images = frames
+            elif inputs.lower().endswith((".jpg", ".jpeg", ".png", ".bmp")):
+                img = cv2.cvtColor(cv2.imread(inputs), cv2.COLOR_BGR2RGB)
+                if img is None:
+                    raise ValueError(f"Cannot read image: {inputs}")
+                images = [img]
+            else:
+                raise ValueError(f"Unsupported file format: {inputs}")
+
+        elif isinstance(inputs, np.ndarray):
+            images = [cv2.cvtColor(image, cv2.COLOR_BGR2RGB) for image in inputs]
+        elif isinstance(inputs, list):
+            images = [cv2.cvtColor(image, cv2.COLOR_BGR2RGB) for image in inputs]
+        return images
+
+    def __call__(
+        self,
+        inputs: Union[str, np.ndarray, List[np.ndarray]],
+        return_image: bool = False,
+        **kwargs,
+    ):
+        """
+        Process input and estimate 2D keypoints.
+
+        Args:
+            inputs (Union[str, np.ndarray, List[np.ndarray]]): Input can be file path,
+                     single image array, or list of image arrays
+            **kwargs: Additional arguments for processing
+
+        Returns:
+            np.ndarray: Array of detected 2D keypoints for all input images
+        """
+        images = self.load_images(inputs)
+        H, W = images[0].shape[:2]
+        if self.detector is not None:
+            bboxes = []
+            for _image in images:
+                img, shape = self.detector.preprocess(_image)
+                bboxes.append(self.detector(img[None], shape[None])[0][0]["bbox"])
+        else:
+            bboxes = [None] * len(images)
+
+        kp2ds = []
+        for _image, _bbox in zip(images, bboxes):
+            img, center, scale = self.model.preprocess(_image, _bbox)
+            kp2ds.append(self.model(img[None], center[None], scale[None]))
+        kp2ds = np.concatenate(kp2ds, 0)
+        metas = load_pose_metas_from_kp2ds_seq(kp2ds, width=W, height=H)
+        return metas
+
+
+class WanDataPreprocessingStage(PipelineStage):
+    """
+    Preprocessing Stage for Wan-Animate.
+    Handles video reading, pose extraction, face cropping, and optional Flux-based retargeting.
+    Outputs normalized tensors to batch.extra for downstream diffusion stages.
+    """
+
+    def __init__(
+        self,
+        preprocess_model_path: str | None = None,
+    ):
+        super().__init__()
+        self.pose2d = None
+        if preprocess_model_path is not None:
+            det_path, pose_path = resolve_wan_preprocess_model_paths(
+                preprocess_model_path
+            )
+            resolved_det = det_path
+            resolved_pose = pose_path
+            self._init_pose2d(resolved_pose, resolved_det)
+
+    def _init_pose2d(
+        self, pose2d_checkpoint_path: str, det_checkpoint_path: str
+    ) -> None:
+        self.pose2d = Pose2d(
+            checkpoint=pose2d_checkpoint_path,
+            detector_checkpoint=det_checkpoint_path,
+            device=self.device,
+        )
+
+    def forward(self, batch: Req, server_args: ServerArgs) -> Req:
+        if self.pose2d is None:
+            return batch
+        assert batch.video_path is not None
+        assert batch.image_path is not None
+        # --- 1. Extract Parameters from Batch ---
+        video_path = batch.video_path
+        image_path = batch.image_path
+        if isinstance(image_path, list):
+            if len(image_path) == 0:
+                raise ValueError("image_path list is empty")
+            if len(image_path) > 1:
+                logger.warning(
+                    "WanAnimate preprocessing expects a single reference image; using the first of %d.",
+                    len(image_path),
+                )
+            image_path = image_path[0]
+            image_path = os.fspath(image_path)
+        output_path = batch.output_path  # For debug dumps
+
+        # Configs with defaults
+        default_height = 1280 if batch.height is None else batch.height
+        default_width = 740 if batch.width is None else batch.width
+
+        fps = batch.fps
+        retarget_flag = (
+            batch.retarget_flag if hasattr(batch, "retarget_flag") else False
+        )
+        use_flux = batch.use_flux if hasattr(batch, "use_flux") else False
+
+        # --- 2. Process Reference Image ---
+        logger.info(f"Processing reference image: {image_path}")
+        refer_img = cv2.imread(image_path)
+        refer_img = refer_img[..., ::-1]  # BGR -> RGB
+
+        # Resize logic
+        refer_img = resize_by_area(
+            refer_img, default_height * default_width, divisor=16
+        )
+
+        # Extract Reference Pose
+        refer_pose_meta = self.pose2d([refer_img])[0]
+
+        # --- 3. Process Input Video ---
+        logger.info(f"Processing template video: {video_path}")
+        video_reader = VideoReader(video_path)
+        frame_num = len(video_reader)
+        video_fps = video_reader.get_avg_fps()
+
+        if fps == -1:
+            fps = video_fps
+
+        # Frame Sampling Logic
+        target_num = int(frame_num / video_fps * fps)
+        idxs = get_frame_indices(frame_num, video_fps, target_num, fps)
+        frames = video_reader.get_batch(idxs).asnumpy()  # [T, H, W, C]
+
+        # Initial Resize of Frames
+        # Note: frames here are resized to match resolution area logic
+        # You might want to resize them to match refer_img dimensions exactly if needed
+        frames = [
+            resize_by_area(frame, default_height * default_width, divisor=16)
+            for frame in frames
+        ]
+
+        # --- 4. Extract Poses & Faces from Video ---
+        logger.info("Extracting video poses")
+
+        # Optim: Process first frame separately if needed, or all at once
+        tpl_pose_metas = self.pose2d(frames)
+        tpl_pose_meta0 = tpl_pose_metas[0]
+
+        face_images = []
+        for idx, meta in enumerate(tpl_pose_metas):
+            # Face Cropping
+            face_bbox = get_face_bboxes(
+                meta["keypoints_face"][:, :2],
+                scale=1.3,
+                image_shape=(default_height, default_width),
+            )
+            x1, x2, y1, y2 = face_bbox
+            face_image = frames[idx][y1:y2, x1:x2]
+            face_image = cv2.resize(face_image, (512, 512))
+            face_images.append(face_image)
+
+        # TODO(LZY): Retargeting Logic
+        if retarget_flag:
+            logger.info("Performing pose retargeting...")
+            if use_flux:
+                raise NotImplementedError("Flux is not supported now")
+            else:
+                # Standard Retarget (No Flux)
+                tpl_retarget_pose_metas = get_retarget_pose(
+                    tpl_pose_meta0, refer_pose_meta, tpl_pose_metas, None, None
+                )
+        else:
+            # No Retargeting, just format conversion
+            tpl_retarget_pose_metas = [
+                AAPoseMeta.from_humanapi_meta(meta) for meta in tpl_pose_metas
+            ]
+
+        # --- 6. Draw Condition Images (Skeleton) ---
+        cond_images = []
+
+        for idx, meta in enumerate(tpl_retarget_pose_metas):
+            if retarget_flag:
+                # If retargeted, we draw on a canvas matching reference image size
+                # (usually refer_img shape)
+                canvas = np.zeros_like(refer_img)
+                conditioning_image = draw_aapose_by_meta_new(canvas, meta)
+            else:
+                # If not retargeted, draw on canvas matching video frame size
+                # and then pad/resize to match reference
+                canvas = np.zeros_like(frames[0])
+                conditioning_image = draw_aapose_by_meta_new(canvas, meta)
+                conditioning_image = padding_resize(
+                    conditioning_image, refer_img.shape[0], refer_img.shape[1]
+                )
+
+            cond_images.append(conditioning_image)
+
+        # --- 7. Tensor Conversion & Batch Update ---
+        # Convert Lists of Numpy Arrays to PyTorch Tensors [B, C, T, H, W]
+        # Range: [-1, 1] for pixels
+
+        batch.extra["pose_video"] = cond_images
+        batch.extra["face_video"] = face_images
+
+        # Also store raw reference image for VAE encoding later if needed
+        # [B, C, 1, H, W]
+        # batch.extra["refer_image"] = self._to_tensor([refer_img])
+
+        # Optional: Save debug video to disk if output_path is provided
+        if batch.debug and output_path is not None:
+            self._save_debug_videos(output_path, fps, face_images, cond_images)
+
+        return batch
+
+    def _run_flux_edit(self, image_np, prompt, target_h, target_w):
+        """Helper to run Flux Kontext editing."""
+        input_pil = Image.fromarray(image_np)
+
+        with torch.no_grad():
+            output_pil = self.flux_kontext(
+                image=input_pil,
+                height=image_np.shape[0],
+                width=image_np.shape[1],
+                prompt=prompt,
+                guidance_scale=2.5,
+                num_inference_steps=28,
+            ).images[0]
+
+        # Resize back to target
+        return padding_resize(np.array(output_pil), target_h, target_w)
+
+    def get_editing_prompts(self, tpl_pose_metas, refer_pose_meta):
+        """Analyzes pose meta to generate prompts for Flux."""
+        # [Keep the exact logic from your provided code here]
+        # For brevity, I am summarizing, but you should copy the exact
+        # 'arm_visible', 'leg_visible', logic block here.
+
+        # ... (Insert your logic for detecting arm/leg visibility) ...
+        # ...
+
+        # Placeholder return for the example:
+        tpl_prompt = "Change the person to a standard T-pose..."
+        refer_prompt = "Change the person to a standard T-pose..."
+        return tpl_prompt, refer_prompt
+
+    def _save_debug_videos(self, output_path, fps, face_images, cond_images):
+        """Optional: Write intermediate MP4s for debugging."""
+        try:
+            import moviepy as mpy
+
+            face_path = os.path.join(output_path, "debug_src_face.mp4")
+            mpy.ImageSequenceClip(face_images, fps=fps).write_videofile(
+                face_path, logger=None
+            )
+
+            pose_path = os.path.join(output_path, "debug_src_pose.mp4")
+            mpy.ImageSequenceClip(cond_images, fps=fps).write_videofile(
+                pose_path, logger=None
+            )
+
+            logger.info(f"Debug videos saved to {output_path}")
+        except Exception as e:
+            logger.warning(f"Failed to save debug videos: {e}")

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -8,7 +8,6 @@ Decoding stage for diffusion pipelines.
 import weakref
 
 import torch
-from sglang.multimodal_gen.configs.pipeline_configs.wan import Wan2_2_Animate_14B_Config
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.loader.component_loader import VAELoader
@@ -22,7 +21,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
-from sglang.multimodal_gen.runtime.server_args import get_global_server_args, ServerArgs
+from sglang.multimodal_gen.runtime.server_args import ServerArgs, get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
@@ -240,25 +239,11 @@ class DecodingStage(PipelineStage):
         else:
             trajectory_decoded = None
 
-        if isinstance(server_args.pipeline_config, Wan2_2_Animate_14B_Config):
-            if batch.extra.get("all_frames") is None:
-                batch.extra["all_frames"] = frames
-            else:
-                batch.extra["all_frames"] = torch.cat(
-                    (
-                        batch.extra.get("all_frames"),
-                        frames[:, :, batch.extra.get("refert_num") :],
-                    ),
-                    dim=2,
-                )
-            if batch.extra.get("cur_segment") != batch.extra.get("num_segments") - 1:
-                batch.extra["cur_segment"] = batch.extra.get("cur_segment") + 1
-                batch.timesteps = None
-                batch.latents = None
-                return batch
-            else:
-                frames = batch.extra.get("all_frames")
-                frames = frames[:, :, : batch.extra["real_frame_len"]]
+        frames, early_batch = server_args.pipeline_config.postprocess_decoded_frames(
+            batch, frames
+        )
+        if early_batch is not None:
+            return early_batch
 
         # Convert to CPU float32 for compatibility
         frames = frames.cpu().float()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -16,13 +16,12 @@ from typing import Any
 
 import torch
 from einops import rearrange
-from tqdm.auto import tqdm
 
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
 from sglang.multimodal_gen.configs.pipeline_configs.wan import (
+    Wan2_2_Animate_14B_Config,
     Wan2_2_TI2V_5B_Config,
-    WanI2V480PConfig,
 )
 from sglang.multimodal_gen.runtime.distributed import (
     cfg_model_parallel_all_reduce,
@@ -52,8 +51,6 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     StageValidators as V,
-)
-from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
 from sglang.multimodal_gen.runtime.platforms import (
@@ -600,6 +597,8 @@ class DenoisingStage(PipelineStage):
             {
                 "encoder_hidden_states_2": batch.clip_embedding_pos,
                 "encoder_attention_mask": batch.prompt_attention_mask,
+                "pose_hidden_states": batch.extra["pose_hidden_states"],
+                "face_pixel_values": batch.extra["face_pixel_values"],
             }
             | server_args.pipeline_config.prepare_pos_cond_kwargs(
                 batch,
@@ -982,8 +981,20 @@ class DenoisingStage(PipelineStage):
                                 not server_args.pipeline_config.task_type
                                 == ModelTaskType.TI2V
                             ), "image latents should not be provided for TI2V task"
+
+                            if isinstance(
+                                server_args.pipeline_config, Wan2_2_Animate_14B_Config
+                            ):
+                                prev_segment_latent = batch.extra.get(
+                                    "prev_segment_cond_latents"
+                                )
+                                cond_latent = torch.cat(
+                                    [batch.image_latent, prev_segment_latent], dim=2
+                                ).to(target_dtype)
+                            else:
+                                cond_latent = batch.image_latent
                             latent_model_input = torch.cat(
-                                [latent_model_input, batch.image_latent], dim=1
+                                [latent_model_input, cond_latent], dim=1
                             ).to(target_dtype)
 
                         timestep = self.expand_timestep_before_forward(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -16,12 +16,14 @@ from typing import Any
 
 import torch
 from einops import rearrange
+from tqdm.auto import tqdm
 
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
 from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     Wan2_2_Animate_14B_Config,
     Wan2_2_TI2V_5B_Config,
+    WanI2V480PConfig,
 )
 from sglang.multimodal_gen.runtime.distributed import (
     cfg_model_parallel_all_reduce,
@@ -51,6 +53,8 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     StageValidators as V,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
 from sglang.multimodal_gen.runtime.platforms import (

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/latent_preparation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/latent_preparation.py
@@ -11,8 +11,6 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
 from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     StageValidators as V,
-)
-from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
@@ -105,6 +103,7 @@ class LatentPreparationStage(PipelineStage):
         # Update batch with prepared latents
         batch.latents = latents
         batch.raw_latent_shape = latents.shape
+
         return batch
 
     def adjust_video_length(self, batch: Req, server_args: ServerArgs) -> int:
@@ -120,6 +119,8 @@ class LatentPreparationStage(PipelineStage):
         """
 
         video_length = batch.num_frames
+        if batch.extra.get("clip_len") is not None:
+            video_length = batch.extra.get("clip_len")
         use_temporal_scaling_frames = (
             server_args.pipeline_config.vae_config.use_temporal_scaling_frames
         )
@@ -128,6 +129,8 @@ class LatentPreparationStage(PipelineStage):
                 server_args.pipeline_config.vae_config.arch_config.temporal_compression_ratio
             )
             latent_num_frames = (video_length - 1) // temporal_scale_factor + 1
+        if batch.extra.get("clip_len") is not None:
+            return int(latent_num_frames) + 1
         return int(latent_num_frames)
 
     def verify_input(self, batch: Req, server_args: ServerArgs) -> VerificationResult:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/wan_animate_conditioning.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/wan_animate_conditioning.py
@@ -1,0 +1,253 @@
+from typing import Any, List, Union
+
+import numpy as np
+
+import PIL
+import torch
+from diffusers.models.autoencoders.vae import DiagonalGaussianDistribution
+from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+
+logger = init_logger(__name__)
+
+
+class WanAnimateConditioningStage(PipelineStage):
+    def __init__(self, vae: Any):
+        super().__init__()
+        self.vae = vae
+
+    def encode(
+        self,
+        video_condition: torch.Tensor,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> torch.Tensor:
+        # Setup VAE precision
+        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_autocast_enabled = (
+            vae_dtype != torch.float32
+        ) and not server_args.disable_autocast
+
+        # Encode Image
+        with torch.autocast(
+            device_type="cuda", dtype=vae_dtype, enabled=vae_autocast_enabled
+        ):
+            if server_args.pipeline_config.vae_tiling:
+                self.vae.enable_tiling()
+            if not vae_autocast_enabled:
+                video_condition = video_condition.to(vae_dtype)
+            encoder_output: DiagonalGaussianDistribution = self.vae.encode(
+                video_condition
+            )
+
+        generator = batch.generator
+
+        sample_mode = server_args.pipeline_config.vae_config.encode_sample_mode()
+
+        latent_condition = self.retrieve_latents(
+            encoder_output, generator, sample_mode=sample_mode
+        )
+        latent_condition = server_args.pipeline_config.postprocess_vae_encode(
+            latent_condition, self.vae
+        )
+
+        scaling_factor, shift_factor = (
+            server_args.pipeline_config.get_decode_scale_and_shift(
+                device=latent_condition.device,
+                dtype=latent_condition.dtype,
+                vae=self.vae,
+            )
+        )
+
+        # apply shift & scale if needed
+        if isinstance(shift_factor, torch.Tensor):
+            shift_factor = shift_factor.to(latent_condition.device)
+
+        if isinstance(scaling_factor, torch.Tensor):
+            scaling_factor = scaling_factor.to(latent_condition.device)
+
+        latent_condition -= shift_factor
+        latent_condition = latent_condition * scaling_factor
+
+        # output = server_args.pipeline_config.postprocess_image_latent(
+        #     latent_condition, batch
+        # )
+        return latent_condition
+
+    def retrieve_latents(
+        self,
+        encoder_output: DiagonalGaussianDistribution,
+        generator: torch.Generator | None = None,
+        sample_mode: str = "sample",
+    ):
+        if sample_mode == "sample":
+            return encoder_output.sample(generator)
+        elif sample_mode == "argmax":
+            return encoder_output.mode()
+        else:
+            raise AttributeError("Could not access latents of provided encoder_output")
+
+    def get_i2v_mask(
+        self,
+        batch_size: int,
+        latent_t: int,
+        latent_h: int,
+        latent_w: int,
+        mask_len: int = 1,
+        dtype: torch.dtype = None,
+        device: Union[str, torch.device] = "cuda",
+    ) -> torch.Tensor:
+        # mask_pixel_values shape (if supplied): [B, C = 1, T, latent_h, latent_w]
+        mask_lat_size = torch.zeros(
+            batch_size,
+            1,
+            (latent_t - 1) * 4 + 1,
+            latent_h,
+            latent_w,
+            dtype=dtype,
+            device=device,
+        )
+        mask_lat_size[:, :, :mask_len] = 1
+        first_frame_mask = mask_lat_size[:, :, 0:1]
+        first_frame_mask = torch.repeat_interleave(first_frame_mask, dim=2, repeats=4)
+        mask_lat_size = torch.concat([first_frame_mask, mask_lat_size[:, :, 1:]], dim=2)
+        mask_lat_size = mask_lat_size.view(
+            batch_size, -1, 4, latent_h, latent_w
+        ).transpose(
+            1, 2
+        )  # [B, C = 1, 4 * T_lat, H_lat, W_lat] --> [B, C = 4, T_lat, H_lat, W_lat]
+
+        return mask_lat_size
+
+    def prepare_prev_segment_cond_latents(
+        self,
+        batch,
+        server_args,
+        prev_segment_cond_video,
+        batch_size: int = 1,
+        segment_frame_length: int = 77,
+        height: int = 720,
+        width: int = 1280,
+        prev_segment_cond_frames: int = 1,
+        interpolation_mode: str = "bicubic",
+        dtype=torch.float32,
+        device="cuda",
+    ) -> torch.Tensor:
+        # prev_segment_cond_video shape: (B, C, T, H, W) in pixel space if supplied
+        # background_video shape: (B, C, T, H, W) (same as prev_segment_cond_video shape)
+        # mask_video shape: (B, 1, T, H, W) (same as prev_segment_cond_video, but with only 1 channel)
+        first_frame = prev_segment_cond_video is None
+        cond_frames_shape = (
+            batch_size,
+            3,
+            prev_segment_cond_frames,
+            height,
+            width,
+        )  # In pixel space
+        if prev_segment_cond_video is None:
+            prev_segment_cond_video = torch.zeros(
+                cond_frames_shape, dtype=dtype, device=device
+            )
+        else:
+            assert prev_segment_cond_video.shape == cond_frames_shape
+
+        data_batch_size, channels, _, segment_height, segment_width = (
+            prev_segment_cond_video.shape
+        )
+        num_latent_frames = (segment_frame_length - 1) // 4 + 1
+        latent_height = height // 8
+        latent_width = width // 8
+        if segment_height != height or segment_width != width:
+            print(
+                f"Interpolating prev segment cond video from ({segment_width}, {segment_height}) to ({width}, {height})"
+            )
+            # Perform a 4D (spatial) rather than a 5D (spatiotemporal) reshape, following the original code
+            prev_segment_cond_video = prev_segment_cond_video.transpose(1, 2).flatten(
+                0, 1
+            )  # [B * T, C, H, W]
+            prev_segment_cond_video = F.interpolate(
+                prev_segment_cond_video, size=(height, width), mode=interpolation_mode
+            )
+            prev_segment_cond_video = prev_segment_cond_video.unflatten(
+                0, (batch_size, -1)
+            ).transpose(1, 2)
+
+        remaining_segment_frames = segment_frame_length - prev_segment_cond_frames
+        remaining_segment = torch.zeros(
+            batch_size,
+            channels,
+            remaining_segment_frames,
+            height,
+            width,
+            dtype=dtype,
+            device=device,
+        )
+
+        # Prepend the conditioning frames from the previous segment to the remaining segment video in the frame dim
+        prev_segment_cond_video = prev_segment_cond_video.to(dtype=dtype)
+        full_segment_cond_video = torch.cat(
+            [prev_segment_cond_video, remaining_segment], dim=2
+        )
+
+        prev_segment_cond_latents = self.encode(
+            full_segment_cond_video, batch, server_args
+        )
+
+        # Prepare I2V mask
+        prev_segment_cond_mask = self.get_i2v_mask(
+            batch_size,
+            num_latent_frames,
+            latent_height,
+            latent_width,
+            mask_len=prev_segment_cond_frames if not first_frame else 0,
+            dtype=dtype,
+            device=device,
+        )
+
+        # Prepend cond I2V mask to prev segment cond latents along channel dimension
+        prev_segment_cond_latents = torch.cat(
+            [prev_segment_cond_mask, prev_segment_cond_latents], dim=1
+        )
+        return prev_segment_cond_latents
+
+    def forward(self, batch: Req, server_args: ServerArgs) -> Req:
+        self.vae = self.vae.to(get_local_torch_device())
+
+        clip_len = batch.extra.get("clip_len")
+        refert_num = batch.extra.get("refert_num")
+        cur_segment = batch.extra.get("cur_segment")
+        start_frame = cur_segment * (clip_len - refert_num)
+        end_frame = start_frame + clip_len
+
+        pose_video_tensor = batch.extra.get("pose_video")[
+            :, :, start_frame:end_frame, :, :
+        ]
+        face_video_tensor = batch.extra.get("face_video")[
+            :, :, start_frame:end_frame, :, :
+        ]
+        if cur_segment == 0:
+            prev_segment_cond_video = None
+        else:
+            prev_segment_cond_video = (
+                batch.extra.get("all_frames")[:, :, -refert_num:].clone().detach()
+            )
+            prev_segment_cond_video = prev_segment_cond_video * 2 - 1
+
+        pose_latents_no_ref = self.encode(pose_video_tensor, batch, server_args)
+
+        batch.extra["pose_hidden_states"] = pose_latents_no_ref
+        batch.extra["face_pixel_values"] = face_video_tensor
+
+        batch.extra["prev_segment_cond_latents"] = (
+            self.prepare_prev_segment_cond_latents(
+                batch, server_args, prev_segment_cond_video
+            )
+        )
+
+        self.maybe_free_model_hooks()
+
+        return batch

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/wan_animate_segment_loop.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/wan_animate_segment_loop.py
@@ -1,0 +1,80 @@
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch, Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding import DecodingStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import DenoisingStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.latent_preparation import (
+    LatentPreparationStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.timestep_preparation import (
+    TimestepPreparationStage,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.wan_animate_conditioning import (
+    WanAnimateConditioningStage,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class SegmentLoopStage(PipelineStage):
+    def __init__(self, vae, scheduler, transformer, transformer_2) -> None:
+        super().__init__()
+        self.animate_cond_stage = WanAnimateConditioningStage(vae=vae)
+        self.timestep_prep_stage = TimestepPreparationStage(scheduler=scheduler)
+        self.latent_stage = LatentPreparationStage(
+            scheduler=scheduler, transformer=transformer
+        )
+        self.denoising_stage = DenoisingStage(
+            transformer=transformer,
+            transformer_2=transformer_2,
+            scheduler=scheduler,
+            vae=vae,
+        )
+        self.decoding_stage = DecodingStage(vae=vae)
+
+    def forward(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> OutputBatch:
+
+        num_segments = batch.extra["num_segments"]
+        refert_num = server_args.pipeline_config.refert_num
+        final_video_segments = []
+
+        # Clear any previous generated context
+        batch.extra["all_frames"] = None
+        output = None
+        for segment_idx in range(num_segments):
+            logger.debug(f"--> Processing segment {segment_idx + 1}/{num_segments}")
+
+            # Update segment index in batch for downstream stages to read
+            batch.extra["cur_segment"] = segment_idx
+            # --- Pipeline Chain ---
+            # 1. Conditioning (Encodes the specific segment of pose/face/image)
+            batch = self.animate_cond_stage.forward(batch, server_args)
+
+            # 2. Timestep Prep (Sets up noise schedule for this run)
+            batch = self.timestep_prep_stage.forward(batch, server_args)
+
+            # 3. Latent Prep (Prepares initial noise or input latents)
+            batch = self.latent_stage.forward(batch, server_args)
+
+            # 4. Denoising (Runs the Transformer/UNet loop)
+            batch = self.denoising_stage.forward(batch, server_args)
+
+            # 5. Decoding (VAE Decode for this segment)
+            output = self.decoding_stage.forward(batch, server_args)
+            # If decoding returned an OutputBatch, it's the final assembled output —
+            # propagate it upward immediately instead of treating it as a Req.
+            if isinstance(output, OutputBatch):
+                break
+
+        # 5. Final Concatenation
+        # Concatenate all valid non-overlapping segments
+        assert isinstance(output, OutputBatch)
+
+        logger.info("WanAnimate generation complete.")
+
+        return output

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/wan_video_processing.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/wan_video_processing.py
@@ -1,0 +1,93 @@
+# Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+Image encoding stages for I2V diffusion pipelines.
+
+This module contains implementations of image encoding stages for diffusion pipelines.
+"""
+
+from typing import List
+
+import numpy as np
+import PIL
+import torch
+from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
+from sglang.multimodal_gen.runtime.models.vaes.common import ParallelTiledVAE
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
+from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
+    StageValidators as V,
+    VerificationResult,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class WanVideoProcessor:
+    def __init__(self, vae_scale_factor=8):
+        self.vae_scale_factor = vae_scale_factor
+
+    def preprocess_video(self, video: List[PIL.Image.Image]) -> torch.Tensor:
+        if not isinstance(video, list):
+            video = [video]
+
+        frames = []
+        for img in video:
+            arr = np.array(img)
+            tensor = torch.from_numpy(arr).float() / 255.0
+            tensor = tensor.permute(2, 0, 1)  # CHW
+            frames.append(tensor)
+
+        video_tensor = torch.stack(frames, dim=1)
+        video_tensor = 2.0 * video_tensor - 1.0
+
+        # (1, C, T, H, W)
+        video_tensor = video_tensor.unsqueeze(0)
+
+        return video_tensor
+
+
+class VideoProcessingStage(PipelineStage):
+    def __init__(self, vae_scale_factor: int = 8) -> None:
+        super().__init__()
+        self.video_processor = WanVideoProcessor(vae_scale_factor)
+
+    def forward(
+        self,
+        batch: Req,
+        server_args: ServerArgs,
+    ) -> Req:
+        pose_video = batch.extra.get("pose_video")
+        pose_video_tensor = self.video_processor.preprocess_video(pose_video).to(
+            get_local_torch_device(), dtype=torch.float32
+        )
+        batch.extra["pose_video"] = pose_video_tensor
+
+        face_video = batch.extra.get("face_video")
+        face_video_tensor = self.video_processor.preprocess_video(face_video).to(
+            get_local_torch_device(), dtype=torch.float32
+        )
+        batch.extra["face_video"] = face_video_tensor
+
+        return batch
+
+    def verify_input(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
+        """Verify encoding stage inputs."""
+        result = VerificationResult()
+        result.add_check("pose", batch.extra.get("pose_video"), V.list_not_empty)
+        result.add_check("face", batch.extra.get("face_video"), V.list_not_empty)
+        return result
+
+    def verify_output(self, batch: Req, server_args: ServerArgs) -> VerificationResult:
+        """Verify encoding stage outputs."""
+        result = VerificationResult()
+        result.add_check(
+            "pose", batch.extra.get("pose_video"), [V.is_tensor, V.with_dims(5)]
+        )
+        result.add_check(
+            "face", batch.extra.get("face_video"), [V.is_tensor, V.with_dims(5)]
+        )
+        return result

--- a/python/sglang/multimodal_gen/runtime/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args.py
@@ -186,6 +186,9 @@ class ServerArgs:
 
     # VAE parameters
     vae_path: str | None = None  # Custom VAE path (e.g., for distilled autoencoder)
+    # Wan Animate preprocessing paths
+    preprocess_model_path: str | None = None
+
     # can restrict layers to adapt, e.g. ["q_proj"]
     # Will adapt only q, k, v, o by default.
     lora_target_modules: list[str] | None = None
@@ -330,6 +333,27 @@ class ServerArgs:
             default=ServerArgs.vae_path,
             help="Custom path to VAE model (e.g., for distilled autoencoder). If not specified, VAE will be loaded from the main model path.",
         )
+        parser.add_argument(
+            "--preprocess-model-path",
+            type=str,
+            default=ServerArgs.preprocess_model_path,
+            help=(
+                "Base directory for Wan animate preprocess models. Used to auto-resolve "
+                "det/pose2d model paths at server startup."
+            ),
+        )
+        # parser.add_argument(
+        #     "--det-model-path",
+        #     type=str,
+        #     default=ServerArgs.det_model_path,
+        #     help="Path to Wan animate detection model.",
+        # )
+        # parser.add_argument(
+        #     "--pose2d-model-path",
+        #     type=str,
+        #     default=ServerArgs.pose2d_model_path,
+        #     help="Path to Wan animate 2D pose model.",
+        # )
 
         # attention
         parser.add_argument(

--- a/python/sglang/multimodal_gen/runtime/utils/human_visualization.py
+++ b/python/sglang/multimodal_gen/runtime/utils/human_visualization.py
@@ -1,0 +1,1475 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import math
+import random
+from typing import Dict, List
+
+import cv2
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sglang.multimodal_gen.runtime.utils.pose2d import AAPoseMeta
+
+
+def draw_handpose(canvas, keypoints, hand_score_th=0.6):
+    """
+    Draw keypoints and connections representing hand pose on a given canvas.
+
+    Args:
+        canvas (np.ndarray): A 3D numpy array representing the canvas (image) on which to draw the hand pose.
+        keypoints (List[Keypoint]| None): A list of Keypoint objects representing the hand keypoints to be drawn
+                                          or None if no keypoints are present.
+
+    Returns:
+        np.ndarray: A 3D numpy array representing the modified canvas with the drawn hand pose.
+
+    Note:
+        The function expects the x and y coordinates of the keypoints to be normalized between 0 and 1.
+    """
+    eps = 0.01
+
+    H, W, C = canvas.shape
+    stickwidth = max(int(min(H, W) / 200), 1)
+
+    edges = [
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [0, 5],
+        [5, 6],
+        [6, 7],
+        [7, 8],
+        [0, 9],
+        [9, 10],
+        [10, 11],
+        [11, 12],
+        [0, 13],
+        [13, 14],
+        [14, 15],
+        [15, 16],
+        [0, 17],
+        [17, 18],
+        [18, 19],
+        [19, 20],
+    ]
+
+    for ie, (e1, e2) in enumerate(edges):
+        k1 = keypoints[e1]
+        k2 = keypoints[e2]
+        if k1 is None or k2 is None:
+            continue
+        if k1[2] < hand_score_th or k2[2] < hand_score_th:
+            continue
+
+        x1 = int(k1[0])
+        y1 = int(k1[1])
+        x2 = int(k2[0])
+        y2 = int(k2[1])
+        if x1 > eps and y1 > eps and x2 > eps and y2 > eps:
+            cv2.line(
+                canvas,
+                (x1, y1),
+                (x2, y2),
+                matplotlib.colors.hsv_to_rgb([ie / float(len(edges)), 1.0, 1.0]) * 255,
+                thickness=stickwidth,
+            )
+
+    for keypoint in keypoints:
+
+        if keypoint is None:
+            continue
+        if keypoint[2] < hand_score_th:
+            continue
+
+        x, y = keypoint[0], keypoint[1]
+        x = int(x)
+        y = int(y)
+        if x > eps and y > eps:
+            cv2.circle(canvas, (x, y), stickwidth, (0, 0, 255), thickness=-1)
+    return canvas
+
+
+def draw_handpose_new(canvas, keypoints, stickwidth_type="v2", hand_score_th=0.6):
+    """
+    Draw keypoints and connections representing hand pose on a given canvas.
+
+    Args:
+        canvas (np.ndarray): A 3D numpy array representing the canvas (image) on which to draw the hand pose.
+        keypoints (List[Keypoint]| None): A list of Keypoint objects representing the hand keypoints to be drawn
+                                          or None if no keypoints are present.
+
+    Returns:
+        np.ndarray: A 3D numpy array representing the modified canvas with the drawn hand pose.
+
+    Note:
+        The function expects the x and y coordinates of the keypoints to be normalized between 0 and 1.
+    """
+    eps = 0.01
+
+    H, W, C = canvas.shape
+    if stickwidth_type == "v1":
+        stickwidth = max(int(min(H, W) / 200), 1)
+    elif stickwidth_type == "v2":
+        stickwidth = max(max(int(min(H, W) / 200) - 1, 1) // 2, 1)
+
+    edges = [
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [0, 5],
+        [5, 6],
+        [6, 7],
+        [7, 8],
+        [0, 9],
+        [9, 10],
+        [10, 11],
+        [11, 12],
+        [0, 13],
+        [13, 14],
+        [14, 15],
+        [15, 16],
+        [0, 17],
+        [17, 18],
+        [18, 19],
+        [19, 20],
+    ]
+
+    for ie, (e1, e2) in enumerate(edges):
+        k1 = keypoints[e1]
+        k2 = keypoints[e2]
+        if k1 is None or k2 is None:
+            continue
+        if k1[2] < hand_score_th or k2[2] < hand_score_th:
+            continue
+
+        x1 = int(k1[0])
+        y1 = int(k1[1])
+        x2 = int(k2[0])
+        y2 = int(k2[1])
+        if x1 > eps and y1 > eps and x2 > eps and y2 > eps:
+            cv2.line(
+                canvas,
+                (x1, y1),
+                (x2, y2),
+                matplotlib.colors.hsv_to_rgb([ie / float(len(edges)), 1.0, 1.0]) * 255,
+                thickness=stickwidth,
+            )
+
+    for keypoint in keypoints:
+
+        if keypoint is None:
+            continue
+        if keypoint[2] < hand_score_th:
+            continue
+
+        x, y = keypoint[0], keypoint[1]
+        x = int(x)
+        y = int(y)
+        if x > eps and y > eps:
+            cv2.circle(canvas, (x, y), stickwidth, (0, 0, 255), thickness=-1)
+    return canvas
+
+
+def draw_ellipse_by_2kp(img, keypoint1, keypoint2, color, threshold=0.6):
+    H, W, C = img.shape
+    stickwidth = max(int(min(H, W) / 200), 1)
+
+    if keypoint1[-1] < threshold or keypoint2[-1] < threshold:
+        return img
+
+    Y = np.array([keypoint1[0], keypoint2[0]])
+    X = np.array([keypoint1[1], keypoint2[1]])
+    mX = np.mean(X)
+    mY = np.mean(Y)
+    length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+    angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+    polygon = cv2.ellipse2Poly(
+        (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+    )
+    cv2.fillConvexPoly(img, polygon, [int(float(c) * 0.6) for c in color])
+    return img
+
+
+def split_pose2d_kps_to_aa(kp2ds: np.ndarray) -> List[np.ndarray]:
+    """Convert the 133 keypoints from pose2d to body and hands keypoints.
+
+    Args:
+        kp2ds (np.ndarray): [133, 2]
+
+    Returns:
+        List[np.ndarray]: _description_
+    """
+    kp2ds_body = (
+        kp2ds[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]]
+        + kp2ds[[0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]]
+    ) / 2
+    kp2ds_lhand = kp2ds[91:112]
+    kp2ds_rhand = kp2ds[112:133]
+    return kp2ds_body.copy(), kp2ds_lhand.copy(), kp2ds_rhand.copy()
+
+
+def draw_aapose_by_meta(
+    img,
+    meta: AAPoseMeta,
+    threshold=0.5,
+    stick_width_norm=200,
+    draw_hand=True,
+    draw_head=True,
+):
+    kp2ds = np.concatenate([meta.kps_body, meta.kps_body_p[:, None]], axis=1)
+    kp2ds_lhand = np.concatenate([meta.kps_lhand, meta.kps_lhand_p[:, None]], axis=1)
+    kp2ds_rhand = np.concatenate([meta.kps_rhand, meta.kps_rhand_p[:, None]], axis=1)
+    pose_img = draw_aapose(
+        img,
+        kp2ds,
+        threshold,
+        kp2ds_lhand=kp2ds_lhand,
+        kp2ds_rhand=kp2ds_rhand,
+        stick_width_norm=stick_width_norm,
+        draw_hand=draw_hand,
+        draw_head=draw_head,
+    )
+    return pose_img
+
+
+def draw_aapose_by_meta_new(
+    img,
+    meta: AAPoseMeta,
+    threshold=0.5,
+    stickwidth_type="v2",
+    draw_hand=True,
+    draw_head=True,
+):
+    kp2ds = np.concatenate([meta.kps_body, meta.kps_body_p[:, None]], axis=1)
+    kp2ds_lhand = np.concatenate([meta.kps_lhand, meta.kps_lhand_p[:, None]], axis=1)
+    kp2ds_rhand = np.concatenate([meta.kps_rhand, meta.kps_rhand_p[:, None]], axis=1)
+    pose_img = draw_aapose_new(
+        img,
+        kp2ds,
+        threshold,
+        kp2ds_lhand=kp2ds_lhand,
+        kp2ds_rhand=kp2ds_rhand,
+        stickwidth_type=stickwidth_type,
+        draw_hand=draw_hand,
+        draw_head=draw_head,
+    )
+    return pose_img
+
+
+def draw_hand_by_meta(img, meta: AAPoseMeta, threshold=0.5, stick_width_norm=200):
+    kp2ds = np.concatenate([meta.kps_body, meta.kps_body_p[:, None] * 0], axis=1)
+    kp2ds_lhand = np.concatenate([meta.kps_lhand, meta.kps_lhand_p[:, None]], axis=1)
+    kp2ds_rhand = np.concatenate([meta.kps_rhand, meta.kps_rhand_p[:, None]], axis=1)
+    pose_img = draw_aapose(
+        img,
+        kp2ds,
+        threshold,
+        kp2ds_lhand=kp2ds_lhand,
+        kp2ds_rhand=kp2ds_rhand,
+        stick_width_norm=stick_width_norm,
+        draw_hand=True,
+        draw_head=False,
+    )
+    return pose_img
+
+
+def draw_aaface_by_meta(
+    img,
+    meta: AAPoseMeta,
+    threshold=0.5,
+    stick_width_norm=200,
+    draw_hand=False,
+    draw_head=True,
+):
+    kp2ds = np.concatenate([meta.kps_body, meta.kps_body_p[:, None]], axis=1)
+    # kp2ds_lhand = np.concatenate([meta.kps_lhand, meta.kps_lhand_p[:, None]], axis=1)
+    # kp2ds_rhand = np.concatenate([meta.kps_rhand, meta.kps_rhand_p[:, None]], axis=1)
+    pose_img = draw_M(
+        img,
+        kp2ds,
+        threshold,
+        kp2ds_lhand=None,
+        kp2ds_rhand=None,
+        stick_width_norm=stick_width_norm,
+        draw_hand=draw_hand,
+        draw_head=draw_head,
+    )
+    return pose_img
+
+
+def draw_aanose_by_meta(
+    img, meta: AAPoseMeta, threshold=0.5, stick_width_norm=100, draw_hand=False
+):
+    kp2ds = np.concatenate([meta.kps_body, meta.kps_body_p[:, None]], axis=1)
+    # kp2ds_lhand = np.concatenate([meta.kps_lhand, meta.kps_lhand_p[:, None]], axis=1)
+    # kp2ds_rhand = np.concatenate([meta.kps_rhand, meta.kps_rhand_p[:, None]], axis=1)
+    pose_img = draw_nose(
+        img,
+        kp2ds,
+        threshold,
+        kp2ds_lhand=None,
+        kp2ds_rhand=None,
+        stick_width_norm=stick_width_norm,
+        draw_hand=draw_hand,
+    )
+    return pose_img
+
+
+def gen_face_motion_seq(
+    img, metas: List[AAPoseMeta], threshold=0.5, stick_width_norm=200
+):
+
+    return
+
+
+def draw_M(
+    img,
+    kp2ds,
+    threshold=0.6,
+    data_to_json=None,
+    idx=-1,
+    kp2ds_lhand=None,
+    kp2ds_rhand=None,
+    draw_hand=False,
+    stick_width_norm=200,
+    draw_head=True,
+):
+    """
+    Draw keypoints and connections representing hand pose on a given canvas.
+
+    Args:
+        canvas (np.ndarray): A 3D numpy array representing the canvas (image) on which to draw the hand pose.
+        keypoints (List[Keypoint]| None): A list of Keypoint objects representing the hand keypoints to be drawn
+                                          or None if no keypoints are present.
+
+    Returns:
+        np.ndarray: A 3D numpy array representing the modified canvas with the drawn hand pose.
+
+    Note:
+        The function expects the x and y coordinates of the keypoints to be normalized between 0 and 1.
+    """
+
+    new_kep_list = [
+        "Nose",
+        "Neck",
+        "RShoulder",
+        "RElbow",
+        "RWrist",  # No.4
+        "LShoulder",
+        "LElbow",
+        "LWrist",  # No.7
+        "RHip",
+        "RKnee",
+        "RAnkle",  # No.10
+        "LHip",
+        "LKnee",
+        "LAnkle",  # No.13
+        "REye",
+        "LEye",
+        "REar",
+        "LEar",
+        "LToe",
+        "RToe",
+    ]
+    # kp2ds_body = (kp2ds.copy()[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]] + \
+    #              kp2ds.copy()[[0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]]) / 2
+    kp2ds = kp2ds.copy()
+    # import ipdb; ipdb.set_trace()
+    kp2ds[[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 18, 19], 2] = 0
+    if not draw_head:
+        kp2ds[[0, 14, 15, 16, 17], 2] = 0
+    kp2ds_body = kp2ds
+    # kp2ds_body = kp2ds_body[:18]
+
+    # kp2ds_lhand = kp2ds.copy()[91:112]
+    # kp2ds_rhand = kp2ds.copy()[112:133]
+
+    limbSeq = [
+        # [2, 3],
+        # [2, 6],  # shoulders
+        # [3, 4],
+        # [4, 5],  # left arm
+        # [6, 7],
+        # [7, 8],  # right arm
+        # [2, 9],
+        # [9, 10],
+        # [10, 11],  # right leg
+        # [2, 12],
+        # [12, 13],
+        # [13, 14],  # left leg
+        # [2, 1],
+        [1, 15],
+        [15, 17],
+        [1, 16],
+        [16, 18],  # face (nose, eyes, ears)
+        # [14, 19],
+        # [11, 20],  # foot
+    ]
+
+    colors = [
+        # [255, 0, 0],
+        # [255, 85, 0],
+        # [255, 170, 0],
+        # [255, 255, 0],
+        # [170, 255, 0],
+        # [85, 255, 0],
+        # [0, 255, 0],
+        # [0, 255, 85],
+        # [0, 255, 170],
+        # [0, 255, 255],
+        # [0, 170, 255],
+        # [0, 85, 255],
+        # [0, 0, 255],
+        # [85, 0, 255],
+        [170, 0, 255],
+        [255, 0, 255],
+        [255, 0, 170],
+        [255, 0, 85],
+        # foot
+        # [200, 200, 0],
+        # [100, 100, 0],
+    ]
+
+    H, W, C = img.shape
+    stickwidth = max(int(min(H, W) / stick_width_norm), 1)
+
+    for _idx, ((k1_index, k2_index), color) in enumerate(zip(limbSeq, colors)):
+        keypoint1 = kp2ds_body[k1_index - 1]
+        keypoint2 = kp2ds_body[k2_index - 1]
+
+        if keypoint1[-1] < threshold or keypoint2[-1] < threshold:
+            continue
+
+        Y = np.array([keypoint1[0], keypoint2[0]])
+        X = np.array([keypoint1[1], keypoint2[1]])
+        mX = np.mean(X)
+        mY = np.mean(Y)
+        length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+        angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+        polygon = cv2.ellipse2Poly(
+            (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+        )
+        cv2.fillConvexPoly(img, polygon, [int(float(c) * 0.6) for c in color])
+
+    for _idx, (keypoint, color) in enumerate(zip(kp2ds_body, colors)):
+        if keypoint[-1] < threshold:
+            continue
+        x, y = keypoint[0], keypoint[1]
+        # cv2.circle(canvas, (int(x), int(y)), 4, color, thickness=-1)
+        cv2.circle(img, (int(x), int(y)), stickwidth, color, thickness=-1)
+
+    if draw_hand:
+        img = draw_handpose(img, kp2ds_lhand, hand_score_th=threshold)
+        img = draw_handpose(img, kp2ds_rhand, hand_score_th=threshold)
+
+    kp2ds_body[:, 0] /= W
+    kp2ds_body[:, 1] /= H
+
+    if data_to_json is not None:
+        if idx == -1:
+            data_to_json.append(
+                {
+                    "image_id": "frame_{:05d}.jpg".format(len(data_to_json) + 1),
+                    "height": H,
+                    "width": W,
+                    "category_id": 1,
+                    "keypoints_body": kp2ds_body.tolist(),
+                    "keypoints_left_hand": kp2ds_lhand.tolist(),
+                    "keypoints_right_hand": kp2ds_rhand.tolist(),
+                }
+            )
+        else:
+            data_to_json[idx] = {
+                "image_id": "frame_{:05d}.jpg".format(idx + 1),
+                "height": H,
+                "width": W,
+                "category_id": 1,
+                "keypoints_body": kp2ds_body.tolist(),
+                "keypoints_left_hand": kp2ds_lhand.tolist(),
+                "keypoints_right_hand": kp2ds_rhand.tolist(),
+            }
+    return img
+
+
+def draw_nose(
+    img,
+    kp2ds,
+    threshold=0.6,
+    data_to_json=None,
+    idx=-1,
+    kp2ds_lhand=None,
+    kp2ds_rhand=None,
+    draw_hand=False,
+    stick_width_norm=200,
+):
+    """
+    Draw keypoints and connections representing hand pose on a given canvas.
+
+    Args:
+        canvas (np.ndarray): A 3D numpy array representing the canvas (image) on which to draw the hand pose.
+        keypoints (List[Keypoint]| None): A list of Keypoint objects representing the hand keypoints to be drawn
+                                          or None if no keypoints are present.
+
+    Returns:
+        np.ndarray: A 3D numpy array representing the modified canvas with the drawn hand pose.
+
+    Note:
+        The function expects the x and y coordinates of the keypoints to be normalized between 0 and 1.
+    """
+
+    new_kep_list = [
+        "Nose",
+        "Neck",
+        "RShoulder",
+        "RElbow",
+        "RWrist",  # No.4
+        "LShoulder",
+        "LElbow",
+        "LWrist",  # No.7
+        "RHip",
+        "RKnee",
+        "RAnkle",  # No.10
+        "LHip",
+        "LKnee",
+        "LAnkle",  # No.13
+        "REye",
+        "LEye",
+        "REar",
+        "LEar",
+        "LToe",
+        "RToe",
+    ]
+    # kp2ds_body = (kp2ds.copy()[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]] + \
+    #              kp2ds.copy()[[0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]]) / 2
+    kp2ds = kp2ds.copy()
+    kp2ds[1:, 2] = 0
+    # kp2ds[0, 2] = 1
+    kp2ds_body = kp2ds
+    # kp2ds_body = kp2ds_body[:18]
+
+    # kp2ds_lhand = kp2ds.copy()[91:112]
+    # kp2ds_rhand = kp2ds.copy()[112:133]
+
+    limbSeq = [
+        # [2, 3],
+        # [2, 6],  # shoulders
+        # [3, 4],
+        # [4, 5],  # left arm
+        # [6, 7],
+        # [7, 8],  # right arm
+        # [2, 9],
+        # [9, 10],
+        # [10, 11],  # right leg
+        # [2, 12],
+        # [12, 13],
+        # [13, 14],  # left leg
+        # [2, 1],
+        [1, 15],
+        [15, 17],
+        [1, 16],
+        [16, 18],  # face (nose, eyes, ears)
+        # [14, 19],
+        # [11, 20],  # foot
+    ]
+
+    colors = [
+        # [255, 0, 0],
+        # [255, 85, 0],
+        # [255, 170, 0],
+        # [255, 255, 0],
+        # [170, 255, 0],
+        # [85, 255, 0],
+        # [0, 255, 0],
+        # [0, 255, 85],
+        # [0, 255, 170],
+        # [0, 255, 255],
+        # [0, 170, 255],
+        # [0, 85, 255],
+        # [0, 0, 255],
+        # [85, 0, 255],
+        [170, 0, 255],
+        # [255, 0, 255],
+        # [255, 0, 170],
+        # [255, 0, 85],
+        # foot
+        # [200, 200, 0],
+        # [100, 100, 0],
+    ]
+
+    H, W, C = img.shape
+    stickwidth = max(int(min(H, W) / stick_width_norm), 1)
+
+    # for _idx, ((k1_index, k2_index), color) in enumerate(zip(limbSeq, colors)):
+    #     keypoint1 = kp2ds_body[k1_index - 1]
+    #     keypoint2 = kp2ds_body[k2_index - 1]
+
+    #     if keypoint1[-1] < threshold or keypoint2[-1] < threshold:
+    #         continue
+
+    #     Y = np.array([keypoint1[0], keypoint2[0]])
+    #     X = np.array([keypoint1[1], keypoint2[1]])
+    #     mX = np.mean(X)
+    #     mY = np.mean(Y)
+    #     length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+    #     angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+    #     polygon = cv2.ellipse2Poly((int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1)
+    #     cv2.fillConvexPoly(img, polygon, [int(float(c) * 0.6) for c in color])
+
+    for _idx, (keypoint, color) in enumerate(zip(kp2ds_body, colors)):
+        if keypoint[-1] < threshold:
+            continue
+        x, y = keypoint[0], keypoint[1]
+        # cv2.circle(canvas, (int(x), int(y)), 4, color, thickness=-1)
+        cv2.circle(img, (int(x), int(y)), stickwidth, color, thickness=-1)
+
+    if draw_hand:
+        img = draw_handpose(img, kp2ds_lhand, hand_score_th=threshold)
+        img = draw_handpose(img, kp2ds_rhand, hand_score_th=threshold)
+
+    kp2ds_body[:, 0] /= W
+    kp2ds_body[:, 1] /= H
+
+    if data_to_json is not None:
+        if idx == -1:
+            data_to_json.append(
+                {
+                    "image_id": "frame_{:05d}.jpg".format(len(data_to_json) + 1),
+                    "height": H,
+                    "width": W,
+                    "category_id": 1,
+                    "keypoints_body": kp2ds_body.tolist(),
+                    "keypoints_left_hand": kp2ds_lhand.tolist(),
+                    "keypoints_right_hand": kp2ds_rhand.tolist(),
+                }
+            )
+        else:
+            data_to_json[idx] = {
+                "image_id": "frame_{:05d}.jpg".format(idx + 1),
+                "height": H,
+                "width": W,
+                "category_id": 1,
+                "keypoints_body": kp2ds_body.tolist(),
+                "keypoints_left_hand": kp2ds_lhand.tolist(),
+                "keypoints_right_hand": kp2ds_rhand.tolist(),
+            }
+    return img
+
+
+def draw_aapose(
+    img,
+    kp2ds,
+    threshold=0.6,
+    data_to_json=None,
+    idx=-1,
+    kp2ds_lhand=None,
+    kp2ds_rhand=None,
+    draw_hand=False,
+    stick_width_norm=200,
+    draw_head=True,
+):
+    """
+    Draw keypoints and connections representing hand pose on a given canvas.
+
+    Args:
+        canvas (np.ndarray): A 3D numpy array representing the canvas (image) on which to draw the hand pose.
+        keypoints (List[Keypoint]| None): A list of Keypoint objects representing the hand keypoints to be drawn
+                                          or None if no keypoints are present.
+
+    Returns:
+        np.ndarray: A 3D numpy array representing the modified canvas with the drawn hand pose.
+
+    Note:
+        The function expects the x and y coordinates of the keypoints to be normalized between 0 and 1.
+    """
+
+    new_kep_list = [
+        "Nose",
+        "Neck",
+        "RShoulder",
+        "RElbow",
+        "RWrist",  # No.4
+        "LShoulder",
+        "LElbow",
+        "LWrist",  # No.7
+        "RHip",
+        "RKnee",
+        "RAnkle",  # No.10
+        "LHip",
+        "LKnee",
+        "LAnkle",  # No.13
+        "REye",
+        "LEye",
+        "REar",
+        "LEar",
+        "LToe",
+        "RToe",
+    ]
+    # kp2ds_body = (kp2ds.copy()[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]] + \
+    #              kp2ds.copy()[[0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]]) / 2
+    kp2ds = kp2ds.copy()
+    if not draw_head:
+        kp2ds[[0, 14, 15, 16, 17], 2] = 0
+    kp2ds_body = kp2ds
+
+    # kp2ds_lhand = kp2ds.copy()[91:112]
+    # kp2ds_rhand = kp2ds.copy()[112:133]
+
+    limbSeq = [
+        [2, 3],
+        [2, 6],  # shoulders
+        [3, 4],
+        [4, 5],  # left arm
+        [6, 7],
+        [7, 8],  # right arm
+        [2, 9],
+        [9, 10],
+        [10, 11],  # right leg
+        [2, 12],
+        [12, 13],
+        [13, 14],  # left leg
+        [2, 1],
+        [1, 15],
+        [15, 17],
+        [1, 16],
+        [16, 18],  # face (nose, eyes, ears)
+        [14, 19],
+        [11, 20],  # foot
+    ]
+
+    colors = [
+        [255, 0, 0],
+        [255, 85, 0],
+        [255, 170, 0],
+        [255, 255, 0],
+        [170, 255, 0],
+        [85, 255, 0],
+        [0, 255, 0],
+        [0, 255, 85],
+        [0, 255, 170],
+        [0, 255, 255],
+        [0, 170, 255],
+        [0, 85, 255],
+        [0, 0, 255],
+        [85, 0, 255],
+        [170, 0, 255],
+        [255, 0, 255],
+        [255, 0, 170],
+        [255, 0, 85],
+        # foot
+        [200, 200, 0],
+        [100, 100, 0],
+    ]
+
+    H, W, C = img.shape
+    stickwidth = max(int(min(H, W) / stick_width_norm), 1)
+
+    for _idx, ((k1_index, k2_index), color) in enumerate(zip(limbSeq, colors)):
+        keypoint1 = kp2ds_body[k1_index - 1]
+        keypoint2 = kp2ds_body[k2_index - 1]
+
+        if keypoint1[-1] < threshold or keypoint2[-1] < threshold:
+            continue
+
+        Y = np.array([keypoint1[0], keypoint2[0]])
+        X = np.array([keypoint1[1], keypoint2[1]])
+        mX = np.mean(X)
+        mY = np.mean(Y)
+        length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+        angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+        polygon = cv2.ellipse2Poly(
+            (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+        )
+        cv2.fillConvexPoly(img, polygon, [int(float(c) * 0.6) for c in color])
+
+    for _idx, (keypoint, color) in enumerate(zip(kp2ds_body, colors)):
+        if keypoint[-1] < threshold:
+            continue
+        x, y = keypoint[0], keypoint[1]
+        # cv2.circle(canvas, (int(x), int(y)), 4, color, thickness=-1)
+        cv2.circle(img, (int(x), int(y)), stickwidth, color, thickness=-1)
+
+    if draw_hand:
+        img = draw_handpose(img, kp2ds_lhand, hand_score_th=threshold)
+        img = draw_handpose(img, kp2ds_rhand, hand_score_th=threshold)
+
+    kp2ds_body[:, 0] /= W
+    kp2ds_body[:, 1] /= H
+
+    if data_to_json is not None:
+        if idx == -1:
+            data_to_json.append(
+                {
+                    "image_id": "frame_{:05d}.jpg".format(len(data_to_json) + 1),
+                    "height": H,
+                    "width": W,
+                    "category_id": 1,
+                    "keypoints_body": kp2ds_body.tolist(),
+                    "keypoints_left_hand": kp2ds_lhand.tolist(),
+                    "keypoints_right_hand": kp2ds_rhand.tolist(),
+                }
+            )
+        else:
+            data_to_json[idx] = {
+                "image_id": "frame_{:05d}.jpg".format(idx + 1),
+                "height": H,
+                "width": W,
+                "category_id": 1,
+                "keypoints_body": kp2ds_body.tolist(),
+                "keypoints_left_hand": kp2ds_lhand.tolist(),
+                "keypoints_right_hand": kp2ds_rhand.tolist(),
+            }
+    return img
+
+
+def draw_aapose_new(
+    img,
+    kp2ds,
+    threshold=0.6,
+    data_to_json=None,
+    idx=-1,
+    kp2ds_lhand=None,
+    kp2ds_rhand=None,
+    draw_hand=False,
+    stickwidth_type="v2",
+    draw_head=True,
+):
+    """
+    Draw keypoints and connections representing hand pose on a given canvas.
+
+    Args:
+        canvas (np.ndarray): A 3D numpy array representing the canvas (image) on which to draw the hand pose.
+        keypoints (List[Keypoint]| None): A list of Keypoint objects representing the hand keypoints to be drawn
+                                          or None if no keypoints are present.
+
+    Returns:
+        np.ndarray: A 3D numpy array representing the modified canvas with the drawn hand pose.
+
+    Note:
+        The function expects the x and y coordinates of the keypoints to be normalized between 0 and 1.
+    """
+
+    new_kep_list = [
+        "Nose",
+        "Neck",
+        "RShoulder",
+        "RElbow",
+        "RWrist",  # No.4
+        "LShoulder",
+        "LElbow",
+        "LWrist",  # No.7
+        "RHip",
+        "RKnee",
+        "RAnkle",  # No.10
+        "LHip",
+        "LKnee",
+        "LAnkle",  # No.13
+        "REye",
+        "LEye",
+        "REar",
+        "LEar",
+        "LToe",
+        "RToe",
+    ]
+    # kp2ds_body = (kp2ds.copy()[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]] + \
+    #              kp2ds.copy()[[0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]]) / 2
+    kp2ds = kp2ds.copy()
+    if not draw_head:
+        kp2ds[[0, 14, 15, 16, 17], 2] = 0
+    kp2ds_body = kp2ds
+
+    # kp2ds_lhand = kp2ds.copy()[91:112]
+    # kp2ds_rhand = kp2ds.copy()[112:133]
+
+    limbSeq = [
+        [2, 3],
+        [2, 6],  # shoulders
+        [3, 4],
+        [4, 5],  # left arm
+        [6, 7],
+        [7, 8],  # right arm
+        [2, 9],
+        [9, 10],
+        [10, 11],  # right leg
+        [2, 12],
+        [12, 13],
+        [13, 14],  # left leg
+        [2, 1],
+        [1, 15],
+        [15, 17],
+        [1, 16],
+        [16, 18],  # face (nose, eyes, ears)
+        [14, 19],
+        [11, 20],  # foot
+    ]
+
+    colors = [
+        [255, 0, 0],
+        [255, 85, 0],
+        [255, 170, 0],
+        [255, 255, 0],
+        [170, 255, 0],
+        [85, 255, 0],
+        [0, 255, 0],
+        [0, 255, 85],
+        [0, 255, 170],
+        [0, 255, 255],
+        [0, 170, 255],
+        [0, 85, 255],
+        [0, 0, 255],
+        [85, 0, 255],
+        [170, 0, 255],
+        [255, 0, 255],
+        [255, 0, 170],
+        [255, 0, 85],
+        # foot
+        [200, 200, 0],
+        [100, 100, 0],
+    ]
+
+    H, W, C = img.shape
+    H, W, C = img.shape
+
+    if stickwidth_type == "v1":
+        stickwidth = max(int(min(H, W) / 200), 1)
+    elif stickwidth_type == "v2":
+        stickwidth = max(int(min(H, W) / 200) - 1, 1)
+    else:
+        raise
+
+    for _idx, ((k1_index, k2_index), color) in enumerate(zip(limbSeq, colors)):
+        keypoint1 = kp2ds_body[k1_index - 1]
+        keypoint2 = kp2ds_body[k2_index - 1]
+
+        if keypoint1[-1] < threshold or keypoint2[-1] < threshold:
+            continue
+
+        Y = np.array([keypoint1[0], keypoint2[0]])
+        X = np.array([keypoint1[1], keypoint2[1]])
+        mX = np.mean(X)
+        mY = np.mean(Y)
+        length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+        angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+        polygon = cv2.ellipse2Poly(
+            (int(mY), int(mX)), (int(length / 2), stickwidth), int(angle), 0, 360, 1
+        )
+        cv2.fillConvexPoly(img, polygon, [int(float(c) * 0.6) for c in color])
+
+    for _idx, (keypoint, color) in enumerate(zip(kp2ds_body, colors)):
+        if keypoint[-1] < threshold:
+            continue
+        x, y = keypoint[0], keypoint[1]
+        # cv2.circle(canvas, (int(x), int(y)), 4, color, thickness=-1)
+        cv2.circle(img, (int(x), int(y)), stickwidth, color, thickness=-1)
+
+    if draw_hand:
+        img = draw_handpose_new(
+            img, kp2ds_lhand, stickwidth_type=stickwidth_type, hand_score_th=threshold
+        )
+        img = draw_handpose_new(
+            img, kp2ds_rhand, stickwidth_type=stickwidth_type, hand_score_th=threshold
+        )
+
+    kp2ds_body[:, 0] /= W
+    kp2ds_body[:, 1] /= H
+
+    if data_to_json is not None:
+        if idx == -1:
+            data_to_json.append(
+                {
+                    "image_id": "frame_{:05d}.jpg".format(len(data_to_json) + 1),
+                    "height": H,
+                    "width": W,
+                    "category_id": 1,
+                    "keypoints_body": kp2ds_body.tolist(),
+                    "keypoints_left_hand": kp2ds_lhand.tolist(),
+                    "keypoints_right_hand": kp2ds_rhand.tolist(),
+                }
+            )
+        else:
+            data_to_json[idx] = {
+                "image_id": "frame_{:05d}.jpg".format(idx + 1),
+                "height": H,
+                "width": W,
+                "category_id": 1,
+                "keypoints_body": kp2ds_body.tolist(),
+                "keypoints_left_hand": kp2ds_lhand.tolist(),
+                "keypoints_right_hand": kp2ds_rhand.tolist(),
+            }
+    return img
+
+
+def draw_bbox(img, bbox, color=(255, 0, 0)):
+    img = load_image(img)
+    bbox = [int(bbox_tmp) for bbox_tmp in bbox]
+    cv2.rectangle(img, (bbox[0], bbox[1]), (bbox[2], bbox[3]), color, 2)
+    return img
+
+
+def draw_kp2ds(
+    img, kp2ds, threshold=0, color=(255, 0, 0), skeleton=None, reverse=False
+):
+    img = load_image(img, reverse)
+
+    if skeleton is not None:
+        if skeleton == "coco17":
+            skeleton_list = [
+                [6, 8],
+                [8, 10],
+                [5, 7],
+                [7, 9],
+                [11, 13],
+                [13, 15],
+                [12, 14],
+                [14, 16],
+                [5, 6],
+                [6, 12],
+                [12, 11],
+                [11, 5],
+            ]
+            color_list = [
+                (255, 0, 0),
+                (0, 255, 0),
+                (0, 0, 255),
+                (255, 255, 0),
+                (255, 0, 255),
+                (0, 255, 255),
+            ]
+        elif skeleton == "cocowholebody":
+            skeleton_list = [
+                [6, 8],
+                [8, 10],
+                [5, 7],
+                [7, 9],
+                [11, 13],
+                [13, 15],
+                [12, 14],
+                [14, 16],
+                [5, 6],
+                [6, 12],
+                [12, 11],
+                [11, 5],
+                [15, 17],
+                [15, 18],
+                [15, 19],
+                [16, 20],
+                [16, 21],
+                [16, 22],
+                [91, 92, 93, 94, 95],
+                [91, 96, 97, 98, 99],
+                [91, 100, 101, 102, 103],
+                [91, 104, 105, 106, 107],
+                [91, 108, 109, 110, 111],
+                [112, 113, 114, 115, 116],
+                [112, 117, 118, 119, 120],
+                [112, 121, 122, 123, 124],
+                [112, 125, 126, 127, 128],
+                [112, 129, 130, 131, 132],
+            ]
+            color_list = [
+                (255, 0, 0),
+                (0, 255, 0),
+                (0, 0, 255),
+                (255, 255, 0),
+                (255, 0, 255),
+                (0, 255, 255),
+            ]
+        else:
+            color_list = [color]
+        for _idx, _skeleton in enumerate(skeleton_list):
+            for i in range(len(_skeleton) - 1):
+                cv2.line(
+                    img,
+                    (int(kp2ds[_skeleton[i], 0]), int(kp2ds[_skeleton[i], 1])),
+                    (int(kp2ds[_skeleton[i + 1], 0]), int(kp2ds[_skeleton[i + 1], 1])),
+                    color_list[_idx % len(color_list)],
+                    3,
+                )
+
+    for _idx, kp2d in enumerate(kp2ds):
+        if kp2d[2] > threshold:
+            cv2.circle(img, (int(kp2d[0]), int(kp2d[1])), 3, color, -1)
+            # cv2.putText(img,
+            #         str(_idx),
+            #         (int(kp2d[0, i, 0])*1,
+            #             int(kp2d[0, i, 1])*1),
+            #         cv2.FONT_HERSHEY_SIMPLEX,
+            #         0.75,
+            #         color,
+            #         2
+            #         )
+
+    return img
+
+
+def draw_pcd(pcd_list, save_path=None):
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="3d")
+
+    color_list = ["r", "g", "b", "y", "p"]
+
+    for _idx, _pcd in enumerate(pcd_list):
+        ax.scatter(_pcd[:, 0], _pcd[:, 1], _pcd[:, 2], c=color_list[_idx], marker="o")
+
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_zlabel("Z")
+
+    if save_path is not None:
+        plt.savefig(save_path)
+    else:
+        plt.savefig("tmp.png")
+
+
+def load_image(img, reverse=False):
+    if type(img) == str:
+        img = cv2.imread(img)
+    if reverse:
+        img = img.astype(np.float32)
+        img = img[:, :, ::-1]
+        img = img.astype(np.uint8)
+    return img
+
+
+def draw_skeleten(meta):
+    kps = []
+    for i, kp in enumerate(meta["keypoints_body"]):
+        if kp is None:
+            # if kp is None:
+            kps.append([0, 0, 0])
+        else:
+            kps.append([*kp, 1])
+    kps = np.array(kps)
+
+    kps[:, 0] *= meta["width"]
+    kps[:, 1] *= meta["height"]
+    pose_img = np.zeros([meta["height"], meta["width"], 3], dtype=np.uint8)
+
+    pose_img = draw_aapose(
+        pose_img,
+        kps,
+        draw_hand=True,
+        kp2ds_lhand=meta["keypoints_left_hand"],
+        kp2ds_rhand=meta["keypoints_right_hand"],
+    )
+    return pose_img
+
+
+def draw_skeleten_with_pncc(pncc: np.ndarray, meta: Dict) -> np.ndarray:
+    """
+    Args:
+        pncc: [H,W,3]
+        meta: required keys: keypoints_body: [N, 3] keypoints_left_hand, keypoints_right_hand
+    Return:
+        np.ndarray [H, W, 3]
+    """
+    # preprocess keypoints
+    kps = []
+    for i, kp in enumerate(meta["keypoints_body"]):
+        if kp is None:
+            # if kp is None:
+            kps.append([0, 0, 0])
+        elif i in [14, 15, 16, 17]:
+            kps.append([0, 0, 0])
+        else:
+            kps.append([*kp])
+    kps = np.stack(kps)
+
+    kps[:, 0] *= pncc.shape[1]
+    kps[:, 1] *= pncc.shape[0]
+
+    # draw neck
+    canvas = np.zeros_like(pncc)
+    if kps[0][2] > 0.6 and kps[1][2] > 0.6:
+        canvas = draw_ellipse_by_2kp(canvas, kps[0], kps[1], [0, 0, 255])
+
+    # draw pncc
+    mask = (pncc > 0).max(axis=2)
+    canvas[mask] = pncc[mask]
+    pncc = canvas
+
+    # draw other skeleten
+    kps[0] = 0
+
+    meta["keypoints_left_hand"][:, 0] *= meta["width"]
+    meta["keypoints_left_hand"][:, 1] *= meta["height"]
+
+    meta["keypoints_right_hand"][:, 0] *= meta["width"]
+    meta["keypoints_right_hand"][:, 1] *= meta["height"]
+    pose_img = draw_aapose(
+        pncc,
+        kps,
+        draw_hand=True,
+        kp2ds_lhand=meta["keypoints_left_hand"],
+        kp2ds_rhand=meta["keypoints_right_hand"],
+    )
+    return pose_img
+
+
+FACE_CUSTOM_STYLE = {
+    "eyeball": {"indices": [68, 69], "color": [255, 255, 255], "connect": False},
+    "left_eyebrow": {"indices": [17, 18, 19, 20, 21], "color": [0, 255, 0]},
+    "right_eyebrow": {"indices": [22, 23, 24, 25, 26], "color": [0, 0, 255]},
+    "left_eye": {
+        "indices": [36, 37, 38, 39, 40, 41],
+        "color": [255, 255, 0],
+        "close": True,
+    },
+    "right_eye": {
+        "indices": [42, 43, 44, 45, 46, 47],
+        "color": [255, 0, 255],
+        "close": True,
+    },
+    "mouth_outside": {
+        "indices": list(range(48, 60)),
+        "color": [100, 255, 50],
+        "close": True,
+    },
+    "mouth_inside": {
+        "indices": [60, 61, 62, 63, 64, 65, 66, 67],
+        "color": [255, 100, 50],
+        "close": True,
+    },
+}
+
+
+def draw_face_kp(img, kps, thickness=2, style=FACE_CUSTOM_STYLE):
+    """
+    Args:
+        img: [H, W, 3]
+        kps: [70, 2]
+    """
+    img = img.copy()
+    for key, item in style.items():
+        pts = np.array(kps[item["indices"]]).astype(np.int32)
+        connect = item.get("connect", True)
+        color = item["color"]
+        close = item.get("close", False)
+        if connect:
+            cv2.polylines(img, [pts], close, color, thickness=thickness)
+        else:
+            for kp in pts:
+                kp = np.array(kp).astype(np.int32)
+                cv2.circle(img, kp, thickness * 2, color=color, thickness=-1)
+    return img
+
+
+def draw_traj(metas: List[AAPoseMeta], threshold=0.6):
+
+    colors = [
+        [255, 0, 0],
+        [255, 85, 0],
+        [255, 170, 0],
+        [255, 255, 0],
+        [170, 255, 0],
+        [85, 255, 0],
+        [0, 255, 0],
+        [0, 255, 85],
+        [0, 255, 170],
+        [0, 255, 255],
+        [0, 170, 255],
+        [0, 85, 255],
+        [0, 0, 255],
+        [85, 0, 255],
+        [170, 0, 255],
+        [255, 0, 255],
+        [255, 0, 170],
+        [255, 0, 85],
+        [100, 255, 50],
+        [255, 100, 50],
+        # foot
+        [200, 200, 0],
+        [100, 100, 0],
+    ]
+    limbSeq = [
+        [1, 2],
+        [1, 5],  # shoulders
+        [2, 3],
+        [3, 4],  # left arm
+        [5, 6],
+        [6, 7],  # right arm
+        [1, 8],
+        [8, 9],
+        [9, 10],  # right leg
+        [1, 11],
+        [11, 12],
+        [12, 13],  # left leg
+        # face (nose, eyes, ears)
+        [13, 18],
+        [10, 19],  # foot
+    ]
+
+    face_seq = [[1, 0], [0, 14], [14, 16], [0, 15], [15, 17]]
+    kp_body = np.array([meta.kps_body for meta in metas])
+    kp_body_p = np.array([meta.kps_body_p for meta in metas])
+
+    face_seq = random.sample(face_seq, 2)
+
+    kp_lh = np.array([meta.kps_lhand for meta in metas])
+    kp_rh = np.array([meta.kps_rhand for meta in metas])
+
+    kp_lh_p = np.array([meta.kps_lhand_p for meta in metas])
+    kp_rh_p = np.array([meta.kps_rhand_p for meta in metas])
+
+    # kp_lh = np.concatenate([kp_lh, kp_lh_p], axis=-1)
+    # kp_rh = np.concatenate([kp_rh, kp_rh_p], axis=-1)
+
+    new_limbSeq = []
+    key_point_list = []
+    for _idx, ((k1_index, k2_index)) in enumerate(limbSeq):
+
+        vis = (
+            (kp_body_p[:, k1_index] > threshold)
+            * (kp_body_p[:, k2_index] > threshold)
+            * 1
+        )
+        if vis.sum() * 1.0 / vis.shape[0] > 0.4:
+            new_limbSeq.append([k1_index, k2_index])
+
+    for _idx, ((k1_index, k2_index)) in enumerate(limbSeq):
+
+        keypoint1 = kp_body[:, k1_index - 1]
+        keypoint2 = kp_body[:, k2_index - 1]
+        interleave = random.randint(4, 7)
+        randind = random.randint(0, interleave - 1)
+        # randind = random.rand(range(interleave), sampling_num)
+
+        Y = np.array([keypoint1[:, 0], keypoint2[:, 0]])
+        X = np.array([keypoint1[:, 1], keypoint2[:, 1]])
+
+        vis = (keypoint1[:, -1] > threshold) * (keypoint2[:, -1] > threshold) * 1
+
+        # for randidx in randind:
+        t = randind / interleave
+        x = (1 - t) * Y[0, :] + t * Y[1, :]
+        y = (1 - t) * X[0, :] + t * X[1, :]
+
+        # np.array([1])
+        x = x.astype(int)
+        y = y.astype(int)
+
+        new_array = np.array([x, y, vis]).T
+
+        key_point_list.append(new_array)
+
+    indx_lh = random.randint(0, kp_lh.shape[1] - 1)
+    lh = kp_lh[:, indx_lh, :]
+    lh_p = kp_lh_p[:, indx_lh : indx_lh + 1]
+    lh = np.concatenate([lh, lh_p], axis=-1)
+
+    indx_rh = random.randint(0, kp_rh.shape[1] - 1)
+    rh = kp_rh[:, random.randint(0, kp_rh.shape[1] - 1), :]
+    rh_p = kp_rh_p[:, indx_rh : indx_rh + 1]
+    rh = np.concatenate([rh, rh_p], axis=-1)
+
+    lh[-1, :] = (lh[-1, :] > threshold) * 1
+    rh[-1, :] = (rh[-1, :] > threshold) * 1
+
+    # print(rh.shape, new_array.shape)
+    # exit()
+    key_point_list.append(lh.astype(int))
+    key_point_list.append(rh.astype(int))
+
+    key_points_list = np.stack(key_point_list)
+    num_points = len(key_points_list)
+    sample_colors = random.sample(colors, num_points)
+
+    stickwidth = max(int(min(metas[0].width, metas[0].height) / 150), 2)
+
+    image_list_ori = []
+    for i in range(key_points_list.shape[-2]):
+        _image_vis = np.zeros((metas[0].width, metas[0].height, 3))
+        points = key_points_list[:, i, :]
+        for idx, point in enumerate(points):
+            x, y, vis = point
+            if vis == 1:
+                cv2.circle(
+                    _image_vis, (x, y), stickwidth, sample_colors[idx], thickness=-1
+                )
+
+        image_list_ori.append(_image_vis)
+
+    return image_list_ori
+
+    return [np.zeros([meta.width, meta.height, 3], dtype=np.uint8) for meta in metas]
+
+
+if __name__ == "__main__":
+    meta = {
+        "image_id": "00472.jpg",
+        "height": 540,
+        "width": 414,
+        "category_id": 1,
+        "keypoints_body": [
+            [0.5084776947463768, 0.11350188078703703],
+            [0.504467655495169, 0.20419560185185184],
+            [0.3982016153381642, 0.198046875],
+            [0.3841664779589372, 0.34869068287037036],
+            [0.3901815368357488, 0.4670536747685185],
+            [0.610733695652174, 0.2103443287037037],
+            [0.6167487545289855, 0.3517650462962963],
+            [0.6448190292874396, 0.4762767650462963],
+            [0.4523371452294686, 0.47320240162037036],
+            [0.4503321256038647, 0.6776475694444445],
+            [0.47639738073671495, 0.8544234664351852],
+            [0.5766483620169082, 0.47320240162037036],
+            [0.5666232638888888, 0.6761103877314815],
+            [0.534542949879227, 0.863646556712963],
+            [0.4864224788647343, 0.09505570023148148],
+            [0.5285278910024155, 0.09351851851851851],
+            [0.46236224335748793, 0.10581597222222222],
+            [0.5586031853864735, 0.10274160879629629],
+            [0.4994551064311594, 0.9405056423611111],
+            [0.4152442821557971, 0.9312825520833333],
+        ],
+        "keypoints_left_hand": [
+            [267.78515625, 263.830078125, 1.2840936183929443],
+            [265.294921875, 269.640625, 1.2546794414520264],
+            [263.634765625, 277.111328125, 1.2863062620162964],
+            [262.8046875, 285.412109375, 1.267038345336914],
+            [261.14453125, 292.8828125, 1.280144453048706],
+            [273.595703125, 281.26171875, 1.2592815160751343],
+            [271.10546875, 291.22265625, 1.3256099224090576],
+            [265.294921875, 294.54296875, 1.2368024587631226],
+            [261.14453125, 294.54296875, 0.9771889448165894],
+            [274.42578125, 282.091796875, 1.250044584274292],
+            [269.4453125, 291.22265625, 1.2571144104003906],
+            [264.46484375, 292.8828125, 1.177802324295044],
+            [260.314453125, 292.052734375, 0.9283463358879089],
+            [273.595703125, 282.091796875, 1.1834490299224854],
+            [269.4453125, 290.392578125, 1.188171625137329],
+            [265.294921875, 290.392578125, 1.192609429359436],
+            [261.974609375, 289.5625, 0.9366656541824341],
+            [271.935546875, 281.26171875, 1.0946396589279175],
+            [268.615234375, 287.072265625, 0.9906131029129028],
+            [265.294921875, 287.90234375, 1.0219476222991943],
+            [262.8046875, 287.072265625, 0.9240120053291321],
+        ],
+        "keypoints_right_hand": [
+            [161.53515625, 258.849609375, 1.2069408893585205],
+            [168.17578125, 263.0, 1.1846840381622314],
+            [173.986328125, 269.640625, 1.1435924768447876],
+            [173.986328125, 277.94140625, 1.1802611351013184],
+            [173.986328125, 286.2421875, 1.2599592208862305],
+            [165.685546875, 275.451171875, 1.0633569955825806],
+            [167.345703125, 286.2421875, 1.1693341732025146],
+            [169.8359375, 291.22265625, 1.2698509693145752],
+            [170.666015625, 294.54296875, 1.0619274377822876],
+            [160.705078125, 276.28125, 1.0995020866394043],
+            [163.1953125, 287.90234375, 1.2735884189605713],
+            [166.515625, 291.22265625, 1.339503526687622],
+            [169.005859375, 294.54296875, 1.0835273265838623],
+            [157.384765625, 277.111328125, 1.0866981744766235],
+            [161.53515625, 287.072265625, 1.2468621730804443],
+            [164.025390625, 289.5625, 1.2817761898040771],
+            [166.515625, 292.052734375, 1.099466323852539],
+            [155.724609375, 277.111328125, 1.1065717935562134],
+            [159.044921875, 285.412109375, 1.1924479007720947],
+            [160.705078125, 287.072265625, 1.1304771900177002],
+            [162.365234375, 287.90234375, 1.0040509700775146],
+        ],
+    }
+    demo_meta = AAPoseMeta(meta)
+    res = draw_traj([demo_meta] * 5)
+    cv2.imwrite("traj.png", res[0][..., ::-1])

--- a/python/sglang/multimodal_gen/runtime/utils/pose2d.py
+++ b/python/sglang/multimodal_gen/runtime/utils/pose2d.py
@@ -1,0 +1,1075 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import math
+import os
+import random
+import warnings
+from typing import List
+
+import cv2
+import numpy as np
+from PIL import Image
+
+
+def get_mask_boxes(mask):
+    """
+
+    Args:
+        mask: [h, w]
+    Returns:
+
+    """
+    y_coords, x_coords = np.nonzero(mask)
+    x_min = x_coords.min()
+    x_max = x_coords.max()
+    y_min = y_coords.min()
+    y_max = y_coords.max()
+    bbox = np.array([x_min, y_min, x_max, y_max]).astype(np.int32)
+    return bbox
+
+
+def get_aug_mask(body_mask, w_len=10, h_len=20):
+    body_bbox = get_mask_boxes(body_mask)
+
+    bbox_wh = body_bbox[2:4] - body_bbox[0:2]
+    w_slice = np.int32(bbox_wh[0] / w_len)
+    h_slice = np.int32(bbox_wh[1] / h_len)
+
+    for each_w in range(body_bbox[0], body_bbox[2], w_slice):
+        w_start = min(each_w, body_bbox[2])
+        w_end = min((each_w + w_slice), body_bbox[2])
+        # print(w_start, w_end)
+        for each_h in range(body_bbox[1], body_bbox[3], h_slice):
+            h_start = min(each_h, body_bbox[3])
+            h_end = min((each_h + h_slice), body_bbox[3])
+            if body_mask[h_start:h_end, w_start:w_end].sum() > 0:
+                body_mask[h_start:h_end, w_start:w_end] = 1
+
+    return body_mask
+
+
+def get_mask_body_img(img_copy, hand_mask, k=7, iterations=1):
+    kernel = np.ones((k, k), np.uint8)
+    dilation = cv2.dilate(hand_mask, kernel, iterations=iterations)
+    mask_hand_img = img_copy * (1 - dilation[:, :, None])
+
+    return mask_hand_img, dilation
+
+
+def get_face_bboxes(kp2ds, scale, image_shape, ratio_aug):
+    h, w = image_shape
+    kp2ds_face = kp2ds.copy()[23:91, :2]
+
+    min_x, min_y = np.min(kp2ds_face, axis=0)
+    max_x, max_y = np.max(kp2ds_face, axis=0)
+
+    initial_width = max_x - min_x
+    initial_height = max_y - min_y
+
+    initial_area = initial_width * initial_height
+
+    expanded_area = initial_area * scale
+
+    new_width = np.sqrt(expanded_area * (initial_width / initial_height))
+    new_height = np.sqrt(expanded_area * (initial_height / initial_width))
+
+    delta_width = (new_width - initial_width) / 2
+    delta_height = (new_height - initial_height) / 4
+
+    if ratio_aug:
+        if random.random() > 0.5:
+            delta_width += random.uniform(0, initial_width // 10)
+        else:
+            delta_height += random.uniform(0, initial_height // 10)
+
+    expanded_min_x = max(min_x - delta_width, 0)
+    expanded_max_x = min(max_x + delta_width, w)
+    expanded_min_y = max(min_y - 3 * delta_height, 0)
+    expanded_max_y = min(max_y + delta_height, h)
+
+    return [
+        int(expanded_min_x),
+        int(expanded_max_x),
+        int(expanded_min_y),
+        int(expanded_max_y),
+    ]
+
+
+def calculate_new_size(orig_w, orig_h, target_area, divisor=64):
+
+    target_ratio = orig_w / orig_h
+
+    def check_valid(w, h):
+
+        if w <= 0 or h <= 0:
+            return False
+        return w * h <= target_area and w % divisor == 0 and h % divisor == 0
+
+    def get_ratio_diff(w, h):
+
+        return abs(w / h - target_ratio)
+
+    def round_to_64(value, round_up=False, divisor=64):
+
+        if round_up:
+            return divisor * ((value + (divisor - 1)) // divisor)
+        return divisor * (value // divisor)
+
+    possible_sizes = []
+
+    max_area_h = int(np.sqrt(target_area / target_ratio))
+    max_area_w = int(max_area_h * target_ratio)
+
+    max_h = round_to_64(max_area_h, round_up=True, divisor=divisor)
+    max_w = round_to_64(max_area_w, round_up=True, divisor=divisor)
+
+    for h in range(divisor, max_h + divisor, divisor):
+        ideal_w = h * target_ratio
+
+        w_down = round_to_64(ideal_w)
+        w_up = round_to_64(ideal_w, round_up=True)
+
+        for w in [w_down, w_up]:
+            if check_valid(w, h, divisor):
+                possible_sizes.append((w, h, get_ratio_diff(w, h)))
+
+    if not possible_sizes:
+        raise ValueError("Can not find suitable size")
+
+    possible_sizes.sort(key=lambda x: (-x[0] * x[1], x[2]))
+
+    best_w, best_h, _ = possible_sizes[0]
+    return int(best_w), int(best_h)
+
+
+def resize_by_area(
+    image, target_area, keep_aspect_ratio=True, divisor=64, padding_color=(0, 0, 0)
+):
+    h, w = image.shape[:2]
+    try:
+        new_w, new_h = calculate_new_size(w, h, target_area, divisor)
+    except:
+        aspect_ratio = w / h
+
+        if keep_aspect_ratio:
+            new_h = math.sqrt(target_area / aspect_ratio)
+            new_w = target_area / new_h
+        else:
+            new_w = new_h = math.sqrt(target_area)
+
+        new_w, new_h = int((new_w // divisor) * divisor), int(
+            (new_h // divisor) * divisor
+        )
+
+    interpolation = cv2.INTER_AREA if (new_w * new_h < w * h) else cv2.INTER_LINEAR
+
+    resized_image = padding_resize(
+        image,
+        height=new_h,
+        width=new_w,
+        padding_color=padding_color,
+        interpolation=interpolation,
+    )
+    return resized_image
+
+
+def padding_resize(
+    img_ori,
+    height=512,
+    width=512,
+    padding_color=(0, 0, 0),
+    interpolation=cv2.INTER_LINEAR,
+):
+    ori_height = img_ori.shape[0]
+    ori_width = img_ori.shape[1]
+    channel = img_ori.shape[2]
+
+    img_pad = np.zeros((height, width, channel))
+    if channel == 1:
+        img_pad[:, :, 0] = padding_color[0]
+    else:
+        img_pad[:, :, 0] = padding_color[0]
+        img_pad[:, :, 1] = padding_color[1]
+        img_pad[:, :, 2] = padding_color[2]
+
+    if (ori_height / ori_width) > (height / width):
+        new_width = int(height / ori_height * ori_width)
+        img = cv2.resize(img_ori, (new_width, height), interpolation=interpolation)
+        padding = int((width - new_width) / 2)
+        if len(img.shape) == 2:
+            img = img[:, :, np.newaxis]
+        img_pad[:, padding : padding + new_width, :] = img
+    else:
+        new_height = int(width / ori_width * ori_height)
+        img = cv2.resize(img_ori, (width, new_height), interpolation=interpolation)
+        padding = int((height - new_height) / 2)
+        if len(img.shape) == 2:
+            img = img[:, :, np.newaxis]
+        img_pad[padding : padding + new_height, :, :] = img
+
+    img_pad = np.uint8(img_pad)
+
+    return img_pad
+
+
+def get_frame_indices(frame_num, video_fps, clip_length, train_fps):
+
+    start_frame = 0
+    times = np.arange(0, clip_length) / train_fps
+    frame_indices = start_frame + np.round(times * video_fps).astype(int)
+    frame_indices = np.clip(frame_indices, 0, frame_num - 1)
+
+    return frame_indices.tolist()
+
+
+def get_face_bboxes(kp2ds, scale, image_shape):
+    h, w = image_shape
+    kp2ds_face = kp2ds.copy()[1:] * (w, h)
+
+    min_x, min_y = np.min(kp2ds_face, axis=0)
+    max_x, max_y = np.max(kp2ds_face, axis=0)
+
+    initial_width = max_x - min_x
+    initial_height = max_y - min_y
+
+    initial_area = initial_width * initial_height
+
+    expanded_area = initial_area * scale
+
+    new_width = np.sqrt(expanded_area * (initial_width / initial_height))
+    new_height = np.sqrt(expanded_area * (initial_height / initial_width))
+
+    delta_width = (new_width - initial_width) / 2
+    delta_height = (new_height - initial_height) / 4
+
+    expanded_min_x = max(min_x - delta_width, 0)
+    expanded_max_x = min(max_x + delta_width, w)
+    expanded_min_y = max(min_y - 3 * delta_height, 0)
+    expanded_max_y = min(max_y + delta_height, h)
+
+    return [
+        int(expanded_min_x),
+        int(expanded_max_x),
+        int(expanded_min_y),
+        int(expanded_max_y),
+    ]
+
+
+def box_convert_simple(box, convert_type="xyxy2xywh"):
+    if convert_type == "xyxy2xywh":
+        return [box[0], box[1], box[2] - box[0], box[3] - box[1]]
+    elif convert_type == "xywh2xyxy":
+        return [box[0], box[1], box[2] + box[0], box[3] + box[1]]
+    elif convert_type == "xyxy2ctwh":
+        return [
+            (box[0] + box[2]) / 2,
+            (box[1] + box[3]) / 2,
+            box[2] - box[0],
+            box[3] - box[1],
+        ]
+    elif convert_type == "ctwh2xyxy":
+        return [
+            box[0] - box[2] // 2,
+            box[1] - box[3] // 2,
+            box[0] + (box[2] - box[2] // 2),
+            box[1] + (box[3] - box[3] // 2),
+        ]
+
+
+def read_img(image, convert="RGB", check_exist=False):
+    if isinstance(image, str):
+        if check_exist and not os.exists(image):
+            return None
+        try:
+            img = Image.open(image)
+            if convert:
+                img = img.convert(convert)
+        except:
+            raise IOError("File error: ", image)
+        return np.asarray(img)
+    else:
+        if isinstance(image, np.ndarray):
+            if convert:
+                return image[..., ::-1]
+        else:
+            if convert:
+                img = img.convert(convert)
+            return np.asarray(img)
+
+
+class AAPoseMeta:
+    def __init__(self, meta=None, kp2ds=None):
+        self.image_id = ""
+        self.height = 0
+        self.width = 0
+
+        self.kps_body: np.ndarray = None
+        self.kps_lhand: np.ndarray = None
+        self.kps_rhand: np.ndarray = None
+        self.kps_face: np.ndarray = None
+        self.kps_body_p: np.ndarray = None
+        self.kps_lhand_p: np.ndarray = None
+        self.kps_rhand_p: np.ndarray = None
+        self.kps_face_p: np.ndarray = None
+
+        if meta is not None:
+            self.load_from_meta(meta)
+        elif kp2ds is not None:
+            self.load_from_kp2ds(kp2ds)
+
+    def is_valid(self, kp, p, threshold):
+        x, y = kp
+        if x < 0 or y < 0 or x > self.width or y > self.height or p < threshold:
+            return False
+        else:
+            return True
+
+    def get_bbox(self, kp, kp_p, threshold=0.5):
+        kps = kp[kp_p > threshold]
+        if kps.size == 0:
+            return 0, 0, 0, 0
+        x0, y0 = kps.min(axis=0)
+        x1, y1 = kps.max(axis=0)
+        return x0, y0, x1, y1
+
+    def crop(self, x0, y0, x1, y1):
+        all_kps = [self.kps_body, self.kps_lhand, self.kps_rhand, self.kps_face]
+        for kps in all_kps:
+            if kps is not None:
+                kps[:, 0] -= x0
+                kps[:, 1] -= y0
+        self.width = x1 - x0
+        self.height = y1 - y0
+        return self
+
+    def resize(self, width, height):
+        scale_x = width / self.width
+        scale_y = height / self.height
+        all_kps = [self.kps_body, self.kps_lhand, self.kps_rhand, self.kps_face]
+        for kps in all_kps:
+            if kps is not None:
+                kps[:, 0] *= scale_x
+                kps[:, 1] *= scale_y
+        self.width = width
+        self.height = height
+        return self
+
+    def get_kps_body_with_p(self, normalize=False):
+        kps_body = self.kps_body.copy()
+        if normalize:
+            kps_body = kps_body / np.array([self.width, self.height])
+
+        return np.concatenate([kps_body, self.kps_body_p[:, None]])
+
+    @staticmethod
+    def from_kps_face(kps_face: np.ndarray, height: int, width: int):
+
+        pose_meta = AAPoseMeta()
+        pose_meta.kps_face = kps_face[:, :2]
+        if kps_face.shape[1] == 3:
+            pose_meta.kps_face_p = kps_face[:, 2]
+        else:
+            pose_meta.kps_face_p = kps_face[:, 0] * 0 + 1
+        pose_meta.height = height
+        pose_meta.width = width
+        return pose_meta
+
+    @staticmethod
+    def from_kps_body(kps_body: np.ndarray, height: int, width: int):
+
+        pose_meta = AAPoseMeta()
+        pose_meta.kps_body = kps_body[:, :2]
+        pose_meta.kps_body_p = kps_body[:, 2]
+        pose_meta.height = height
+        pose_meta.width = width
+        return pose_meta
+
+    @staticmethod
+    def from_humanapi_meta(meta):
+        pose_meta = AAPoseMeta()
+        width, height = meta["width"], meta["height"]
+        pose_meta.width = width
+        pose_meta.height = height
+        pose_meta.kps_body = meta["keypoints_body"][:, :2] * (width, height)
+        pose_meta.kps_body_p = meta["keypoints_body"][:, 2]
+        pose_meta.kps_lhand = meta["keypoints_left_hand"][:, :2] * (width, height)
+        pose_meta.kps_lhand_p = meta["keypoints_left_hand"][:, 2]
+        pose_meta.kps_rhand = meta["keypoints_right_hand"][:, :2] * (width, height)
+        pose_meta.kps_rhand_p = meta["keypoints_right_hand"][:, 2]
+        if "keypoints_face" in meta:
+            pose_meta.kps_face = meta["keypoints_face"][:, :2] * (width, height)
+            pose_meta.kps_face_p = meta["keypoints_face"][:, 2]
+        return pose_meta
+
+    def load_from_meta(self, meta, norm_body=True, norm_hand=False):
+
+        self.image_id = meta.get("image_id", "00000.png")
+        self.height = meta["height"]
+        self.width = meta["width"]
+        kps_body_p = []
+        kps_body = []
+        for kp in meta["keypoints_body"]:
+            if kp is None:
+                kps_body.append([0, 0])
+                kps_body_p.append(0)
+            else:
+                kps_body.append(kp)
+                kps_body_p.append(1)
+
+        self.kps_body = np.array(kps_body)
+        self.kps_body[:, 0] *= self.width
+        self.kps_body[:, 1] *= self.height
+        self.kps_body_p = np.array(kps_body_p)
+
+        self.kps_lhand = np.array(meta["keypoints_left_hand"])[:, :2]
+        self.kps_lhand_p = np.array(meta["keypoints_left_hand"])[:, 2]
+        self.kps_rhand = np.array(meta["keypoints_right_hand"])[:, :2]
+        self.kps_rhand_p = np.array(meta["keypoints_right_hand"])[:, 2]
+
+    @staticmethod
+    def load_from_kp2ds(kp2ds: List[np.ndarray], width: int, height: int):
+        """input 133x3 numpy keypoints and output AAPoseMeta
+
+        Args:
+            kp2ds (List[np.ndarray]): _description_
+            width (int): _description_
+            height (int): _description_
+
+        Returns:
+            _type_: _description_
+        """
+        pose_meta = AAPoseMeta()
+        pose_meta.width = width
+        pose_meta.height = height
+        kps_body = (
+            kp2ds[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]]
+            + kp2ds[
+                [0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]
+            ]
+        ) / 2
+        kps_lhand = kp2ds[91:112]
+        kps_rhand = kp2ds[112:133]
+        kps_face = np.concatenate([kp2ds[23 : 23 + 68], kp2ds[1:3]], axis=0)
+        pose_meta.kps_body = kps_body[:, :2]
+        pose_meta.kps_body_p = kps_body[:, 2]
+        pose_meta.kps_lhand = kps_lhand[:, :2]
+        pose_meta.kps_lhand_p = kps_lhand[:, 2]
+        pose_meta.kps_rhand = kps_rhand[:, :2]
+        pose_meta.kps_rhand_p = kps_rhand[:, 2]
+        pose_meta.kps_face = kps_face[:, :2]
+        pose_meta.kps_face_p = kps_face[:, 2]
+        return pose_meta
+
+    @staticmethod
+    def from_dwpose(dwpose_det_res, height, width):
+        pose_meta = AAPoseMeta()
+        pose_meta.kps_body = dwpose_det_res["bodies"]["candidate"]
+        pose_meta.kps_body_p = dwpose_det_res["bodies"]["score"]
+        pose_meta.kps_body[:, 0] *= width
+        pose_meta.kps_body[:, 1] *= height
+
+        pose_meta.kps_lhand, pose_meta.kps_rhand = dwpose_det_res["hands"]
+        pose_meta.kps_lhand[:, 0] *= width
+        pose_meta.kps_lhand[:, 1] *= height
+        pose_meta.kps_rhand[:, 0] *= width
+        pose_meta.kps_rhand[:, 1] *= height
+        pose_meta.kps_lhand_p, pose_meta.kps_rhand_p = dwpose_det_res["hands_score"]
+
+        pose_meta.kps_face = dwpose_det_res["faces"][0]
+        pose_meta.kps_face[:, 0] *= width
+        pose_meta.kps_face[:, 1] *= height
+        pose_meta.kps_face_p = dwpose_det_res["faces_score"][0]
+        return pose_meta
+
+    def save_json(self):
+        pass
+
+    def draw_aapose(
+        self, img, threshold=0.5, stick_width_norm=200, draw_hand=True, draw_head=True
+    ):
+        from .human_visualization import draw_aapose_by_meta
+
+        return draw_aapose_by_meta(
+            img, self, threshold, stick_width_norm, draw_hand, draw_head
+        )
+
+    def translate(self, x0, y0):
+        all_kps = [self.kps_body, self.kps_lhand, self.kps_rhand, self.kps_face]
+        for kps in all_kps:
+            if kps is not None:
+                kps[:, 0] -= x0
+                kps[:, 1] -= y0
+
+    def scale(self, sx, sy):
+        all_kps = [self.kps_body, self.kps_lhand, self.kps_rhand, self.kps_face]
+        for kps in all_kps:
+            if kps is not None:
+                kps[:, 0] *= sx
+                kps[:, 1] *= sy
+
+    def padding_resize2(self, height=512, width=512):
+        """kps will be changed inplace"""
+
+        all_kps = [self.kps_body, self.kps_lhand, self.kps_rhand, self.kps_face]
+
+        ori_height, ori_width = self.height, self.width
+
+        if (ori_height / ori_width) > (height / width):
+            new_width = int(height / ori_height * ori_width)
+            padding = int((width - new_width) / 2)
+            padding_width = padding
+            padding_height = 0
+            scale = height / ori_height
+
+            for kps in all_kps:
+                if kps is not None:
+                    kps[:, 0] = kps[:, 0] * scale + padding
+                    kps[:, 1] = kps[:, 1] * scale
+
+        else:
+            new_height = int(width / ori_width * ori_height)
+            padding = int((height - new_height) / 2)
+            padding_width = 0
+            padding_height = padding
+            scale = width / ori_width
+            for kps in all_kps:
+                if kps is not None:
+                    kps[:, 1] = kps[:, 1] * scale + padding
+                    kps[:, 0] = kps[:, 0] * scale
+
+        self.width = width
+        self.height = height
+        return self
+
+
+def transform_preds(coords, center, scale, output_size, use_udp=False):
+    """Get final keypoint predictions from heatmaps and apply scaling and
+    translation to map them back to the image.
+
+    Note:
+        num_keypoints: K
+
+    Args:
+        coords (np.ndarray[K, ndims]):
+
+            * If ndims=2, corrds are predicted keypoint location.
+            * If ndims=4, corrds are composed of (x, y, scores, tags)
+            * If ndims=5, corrds are composed of (x, y, scores, tags,
+              flipped_tags)
+
+        center (np.ndarray[2, ]): Center of the bounding box (x, y).
+        scale (np.ndarray[2, ]): Scale of the bounding box
+            wrt [width, height].
+        output_size (np.ndarray[2, ] | list(2,)): Size of the
+            destination heatmaps.
+        use_udp (bool): Use unbiased data processing
+
+    Returns:
+        np.ndarray: Predicted coordinates in the images.
+    """
+    assert coords.shape[1] in (2, 4, 5)
+    assert len(center) == 2
+    assert len(scale) == 2
+    assert len(output_size) == 2
+
+    # Recover the scale which is normalized by a factor of 200.
+    # scale = scale * 200.0
+
+    if use_udp:
+        scale_x = scale[0] / (output_size[0] - 1.0)
+        scale_y = scale[1] / (output_size[1] - 1.0)
+    else:
+        scale_x = scale[0] / output_size[0]
+        scale_y = scale[1] / output_size[1]
+
+    target_coords = np.ones_like(coords)
+    target_coords[:, 0] = coords[:, 0] * scale_x + center[0] - scale[0] * 0.5
+    target_coords[:, 1] = coords[:, 1] * scale_y + center[1] - scale[1] * 0.5
+
+    return target_coords
+
+
+def _get_max_preds(heatmaps):
+    """Get keypoint predictions from score maps.
+
+    Note:
+        batch_size: N
+        num_keypoints: K
+        heatmap height: H
+        heatmap width: W
+
+    Args:
+        heatmaps (np.ndarray[N, K, H, W]): model predicted heatmaps.
+
+    Returns:
+        tuple: A tuple containing aggregated results.
+
+        - preds (np.ndarray[N, K, 2]): Predicted keypoint location.
+        - maxvals (np.ndarray[N, K, 1]): Scores (confidence) of the keypoints.
+    """
+    assert isinstance(heatmaps, np.ndarray), "heatmaps should be numpy.ndarray"
+    assert heatmaps.ndim == 4, "batch_images should be 4-ndim"
+
+    N, K, _, W = heatmaps.shape
+    heatmaps_reshaped = heatmaps.reshape((N, K, -1))
+    idx = np.argmax(heatmaps_reshaped, 2).reshape((N, K, 1))
+    maxvals = np.amax(heatmaps_reshaped, 2).reshape((N, K, 1))
+
+    preds = np.tile(idx, (1, 1, 2)).astype(np.float32)
+    preds[:, :, 0] = preds[:, :, 0] % W
+    preds[:, :, 1] = preds[:, :, 1] // W
+
+    preds = np.where(np.tile(maxvals, (1, 1, 2)) > 0.0, preds, -1)
+    return preds, maxvals
+
+
+def _taylor(heatmap, coord):
+    """Distribution aware coordinate decoding method.
+
+    Note:
+        - heatmap height: H
+        - heatmap width: W
+
+    Args:
+        heatmap (np.ndarray[H, W]): Heatmap of a particular joint type.
+        coord (np.ndarray[2,]): Coordinates of the predicted keypoints.
+
+    Returns:
+        np.ndarray[2,]: Updated coordinates.
+    """
+    H, W = heatmap.shape[:2]
+    px, py = int(coord[0]), int(coord[1])
+    if 1 < px < W - 2 and 1 < py < H - 2:
+        dx = 0.5 * (heatmap[py][px + 1] - heatmap[py][px - 1])
+        dy = 0.5 * (heatmap[py + 1][px] - heatmap[py - 1][px])
+        dxx = 0.25 * (heatmap[py][px + 2] - 2 * heatmap[py][px] + heatmap[py][px - 2])
+        dxy = 0.25 * (
+            heatmap[py + 1][px + 1]
+            - heatmap[py - 1][px + 1]
+            - heatmap[py + 1][px - 1]
+            + heatmap[py - 1][px - 1]
+        )
+        dyy = 0.25 * (
+            heatmap[py + 2 * 1][px] - 2 * heatmap[py][px] + heatmap[py - 2 * 1][px]
+        )
+        derivative = np.array([[dx], [dy]])
+        hessian = np.array([[dxx, dxy], [dxy, dyy]])
+        if dxx * dyy - dxy**2 != 0:
+            hessianinv = np.linalg.inv(hessian)
+            offset = -hessianinv @ derivative
+            offset = np.squeeze(np.array(offset.T), axis=0)
+            coord += offset
+    return coord
+
+
+def post_dark_udp(coords, batch_heatmaps, kernel=3):
+    """DARK post-pocessing. Implemented by udp. Paper ref: Huang et al. The
+    Devil is in the Details: Delving into Unbiased Data Processing for Human
+    Pose Estimation (CVPR 2020). Zhang et al. Distribution-Aware Coordinate
+    Representation for Human Pose Estimation (CVPR 2020).
+
+    Note:
+        - batch size: B
+        - num keypoints: K
+        - num persons: N
+        - height of heatmaps: H
+        - width of heatmaps: W
+
+        B=1 for bottom_up paradigm where all persons share the same heatmap.
+        B=N for top_down paradigm where each person has its own heatmaps.
+
+    Args:
+        coords (np.ndarray[N, K, 2]): Initial coordinates of human pose.
+        batch_heatmaps (np.ndarray[B, K, H, W]): batch_heatmaps
+        kernel (int): Gaussian kernel size (K) for modulation.
+
+    Returns:
+        np.ndarray([N, K, 2]): Refined coordinates.
+    """
+    if not isinstance(batch_heatmaps, np.ndarray):
+        batch_heatmaps = batch_heatmaps.cpu().numpy()
+    B, K, H, W = batch_heatmaps.shape
+    N = coords.shape[0]
+    assert B == 1 or B == N
+    for heatmaps in batch_heatmaps:
+        for heatmap in heatmaps:
+            cv2.GaussianBlur(heatmap, (kernel, kernel), 0, heatmap)
+    np.clip(batch_heatmaps, 0.001, 50, batch_heatmaps)
+    np.log(batch_heatmaps, batch_heatmaps)
+
+    batch_heatmaps_pad = np.pad(
+        batch_heatmaps, ((0, 0), (0, 0), (1, 1), (1, 1)), mode="edge"
+    ).flatten()
+
+    index = coords[..., 0] + 1 + (coords[..., 1] + 1) * (W + 2)
+    index += (W + 2) * (H + 2) * np.arange(0, B * K).reshape(-1, K)
+    index = index.astype(int).reshape(-1, 1)
+    i_ = batch_heatmaps_pad[index]
+    ix1 = batch_heatmaps_pad[index + 1]
+    iy1 = batch_heatmaps_pad[index + W + 2]
+    ix1y1 = batch_heatmaps_pad[index + W + 3]
+    ix1_y1_ = batch_heatmaps_pad[index - W - 3]
+    ix1_ = batch_heatmaps_pad[index - 1]
+    iy1_ = batch_heatmaps_pad[index - 2 - W]
+
+    dx = 0.5 * (ix1 - ix1_)
+    dy = 0.5 * (iy1 - iy1_)
+    derivative = np.concatenate([dx, dy], axis=1)
+    derivative = derivative.reshape(N, K, 2, 1)
+    dxx = ix1 - 2 * i_ + ix1_
+    dyy = iy1 - 2 * i_ + iy1_
+    dxy = 0.5 * (ix1y1 - ix1 - iy1 + i_ + i_ - ix1_ - iy1_ + ix1_y1_)
+    hessian = np.concatenate([dxx, dxy, dxy, dyy], axis=1)
+    hessian = hessian.reshape(N, K, 2, 2)
+    hessian = np.linalg.inv(hessian + np.finfo(np.float32).eps * np.eye(2))
+    coords -= np.einsum("ijmn,ijnk->ijmk", hessian, derivative).squeeze()
+    return coords
+
+
+def _gaussian_blur(heatmaps, kernel=11):
+    """Modulate heatmap distribution with Gaussian.
+     sigma = 0.3*((kernel_size-1)*0.5-1)+0.8
+     sigma~=3 if k=17
+     sigma=2 if k=11;
+     sigma~=1.5 if k=7;
+     sigma~=1 if k=3;
+
+    Note:
+        - batch_size: N
+        - num_keypoints: K
+        - heatmap height: H
+        - heatmap width: W
+
+    Args:
+        heatmaps (np.ndarray[N, K, H, W]): model predicted heatmaps.
+        kernel (int): Gaussian kernel size (K) for modulation, which should
+            match the heatmap gaussian sigma when training.
+            K=17 for sigma=3 and k=11 for sigma=2.
+
+    Returns:
+        np.ndarray ([N, K, H, W]): Modulated heatmap distribution.
+    """
+    assert kernel % 2 == 1
+
+    border = (kernel - 1) // 2
+    batch_size = heatmaps.shape[0]
+    num_joints = heatmaps.shape[1]
+    height = heatmaps.shape[2]
+    width = heatmaps.shape[3]
+    for i in range(batch_size):
+        for j in range(num_joints):
+            origin_max = np.max(heatmaps[i, j])
+            dr = np.zeros((height + 2 * border, width + 2 * border), dtype=np.float32)
+            dr[border:-border, border:-border] = heatmaps[i, j].copy()
+            dr = cv2.GaussianBlur(dr, (kernel, kernel), 0)
+            heatmaps[i, j] = dr[border:-border, border:-border].copy()
+            heatmaps[i, j] *= origin_max / np.max(heatmaps[i, j])
+    return heatmaps
+
+
+def keypoints_from_heatmaps(
+    heatmaps,
+    center,
+    scale,
+    unbiased=False,
+    post_process="default",
+    kernel=11,
+    valid_radius_factor=0.0546875,
+    use_udp=False,
+    target_type="GaussianHeatmap",
+):
+    """Get final keypoint predictions from heatmaps and transform them back to
+    the image.
+
+    Note:
+        - batch size: N
+        - num keypoints: K
+        - heatmap height: H
+        - heatmap width: W
+
+    Args:
+        heatmaps (np.ndarray[N, K, H, W]): model predicted heatmaps.
+        center (np.ndarray[N, 2]): Center of the bounding box (x, y).
+        scale (np.ndarray[N, 2]): Scale of the bounding box
+            wrt height/width.
+        post_process (str/None): Choice of methods to post-process
+            heatmaps. Currently supported: None, 'default', 'unbiased',
+            'megvii'.
+        unbiased (bool): Option to use unbiased decoding. Mutually
+            exclusive with megvii.
+            Note: this arg is deprecated and unbiased=True can be replaced
+            by post_process='unbiased'
+            Paper ref: Zhang et al. Distribution-Aware Coordinate
+            Representation for Human Pose Estimation (CVPR 2020).
+        kernel (int): Gaussian kernel size (K) for modulation, which should
+            match the heatmap gaussian sigma when training.
+            K=17 for sigma=3 and k=11 for sigma=2.
+        valid_radius_factor (float): The radius factor of the positive area
+            in classification heatmap for UDP.
+        use_udp (bool): Use unbiased data processing.
+        target_type (str): 'GaussianHeatmap' or 'CombinedTarget'.
+            GaussianHeatmap: Classification target with gaussian distribution.
+            CombinedTarget: The combination of classification target
+            (response map) and regression target (offset map).
+            Paper ref: Huang et al. The Devil is in the Details: Delving into
+            Unbiased Data Processing for Human Pose Estimation (CVPR 2020).
+
+    Returns:
+        tuple: A tuple containing keypoint predictions and scores.
+
+        - preds (np.ndarray[N, K, 2]): Predicted keypoint location in images.
+        - maxvals (np.ndarray[N, K, 1]): Scores (confidence) of the keypoints.
+    """
+    # Avoid being affected
+    heatmaps = heatmaps.copy()
+
+    # detect conflicts
+    if unbiased:
+        assert post_process not in [False, None, "megvii"]
+    if post_process in ["megvii", "unbiased"]:
+        assert kernel > 0
+    if use_udp:
+        assert not post_process == "megvii"
+
+    # normalize configs
+    if post_process is False:
+        warnings.warn(
+            "post_process=False is deprecated, " "please use post_process=None instead",
+            DeprecationWarning,
+        )
+        post_process = None
+    elif post_process is True:
+        if unbiased is True:
+            warnings.warn(
+                "post_process=True, unbiased=True is deprecated,"
+                " please use post_process='unbiased' instead",
+                DeprecationWarning,
+            )
+            post_process = "unbiased"
+        else:
+            warnings.warn(
+                "post_process=True, unbiased=False is deprecated, "
+                "please use post_process='default' instead",
+                DeprecationWarning,
+            )
+            post_process = "default"
+    elif post_process == "default":
+        if unbiased is True:
+            warnings.warn(
+                "unbiased=True is deprecated, please use "
+                "post_process='unbiased' instead",
+                DeprecationWarning,
+            )
+            post_process = "unbiased"
+
+    # start processing
+    if post_process == "megvii":
+        heatmaps = _gaussian_blur(heatmaps, kernel=kernel)
+
+    N, K, H, W = heatmaps.shape
+    if use_udp:
+        if target_type.lower() == "GaussianHeatMap".lower():
+            preds, maxvals = _get_max_preds(heatmaps)
+            preds = post_dark_udp(preds, heatmaps, kernel=kernel)
+        elif target_type.lower() == "CombinedTarget".lower():
+            for person_heatmaps in heatmaps:
+                for i, heatmap in enumerate(person_heatmaps):
+                    kt = 2 * kernel + 1 if i % 3 == 0 else kernel
+                    cv2.GaussianBlur(heatmap, (kt, kt), 0, heatmap)
+            # valid radius is in direct proportion to the height of heatmap.
+            valid_radius = valid_radius_factor * H
+            offset_x = heatmaps[:, 1::3, :].flatten() * valid_radius
+            offset_y = heatmaps[:, 2::3, :].flatten() * valid_radius
+            heatmaps = heatmaps[:, ::3, :]
+            preds, maxvals = _get_max_preds(heatmaps)
+            index = preds[..., 0] + preds[..., 1] * W
+            index += W * H * np.arange(0, N * K / 3)
+            index = index.astype(int).reshape(N, K // 3, 1)
+            preds += np.concatenate((offset_x[index], offset_y[index]), axis=2)
+        else:
+            raise ValueError(
+                "target_type should be either " "'GaussianHeatmap' or 'CombinedTarget'"
+            )
+    else:
+        preds, maxvals = _get_max_preds(heatmaps)
+        if post_process == "unbiased":  # alleviate biased coordinate
+            # apply Gaussian distribution modulation.
+            heatmaps = np.log(np.maximum(_gaussian_blur(heatmaps, kernel), 1e-10))
+            for n in range(N):
+                for k in range(K):
+                    preds[n][k] = _taylor(heatmaps[n][k], preds[n][k])
+        elif post_process is not None:
+            # add +/-0.25 shift to the predicted locations for higher acc.
+            for n in range(N):
+                for k in range(K):
+                    heatmap = heatmaps[n][k]
+                    px = int(preds[n][k][0])
+                    py = int(preds[n][k][1])
+                    if 1 < px < W - 1 and 1 < py < H - 1:
+                        diff = np.array(
+                            [
+                                heatmap[py][px + 1] - heatmap[py][px - 1],
+                                heatmap[py + 1][px] - heatmap[py - 1][px],
+                            ]
+                        )
+                        preds[n][k] += np.sign(diff) * 0.25
+                        if post_process == "megvii":
+                            preds[n][k] += 0.5
+
+    # Transform back to the image
+    for i in range(N):
+        preds[i] = transform_preds(
+            preds[i], center[i], scale[i], [W, H], use_udp=use_udp
+        )
+
+    if post_process == "megvii":
+        maxvals = maxvals / 255.0 + 0.5
+
+    return preds, maxvals
+
+
+def get_transform(center, scale, res, rot=0):
+    """Generate transformation matrix."""
+    # res: (height, width), (rows, cols)
+    crop_aspect_ratio = res[0] / float(res[1])
+    h = 200 * scale
+    w = h / crop_aspect_ratio
+    t = np.zeros((3, 3))
+    t[0, 0] = float(res[1]) / w
+    t[1, 1] = float(res[0]) / h
+    t[0, 2] = res[1] * (-float(center[0]) / w + 0.5)
+    t[1, 2] = res[0] * (-float(center[1]) / h + 0.5)
+    t[2, 2] = 1
+    if not rot == 0:
+        rot = -rot  # To match direction of rotation from cropping
+        rot_mat = np.zeros((3, 3))
+        rot_rad = rot * np.pi / 180
+        sn, cs = np.sin(rot_rad), np.cos(rot_rad)
+        rot_mat[0, :2] = [cs, -sn]
+        rot_mat[1, :2] = [sn, cs]
+        rot_mat[2, 2] = 1
+        # Need to rotate around center
+        t_mat = np.eye(3)
+        t_mat[0, 2] = -res[1] / 2
+        t_mat[1, 2] = -res[0] / 2
+        t_inv = t_mat.copy()
+        t_inv[:2, 2] *= -1
+        t = np.dot(t_inv, np.dot(rot_mat, np.dot(t_mat, t)))
+    return t
+
+
+def transform(pt, center, scale, res, invert=0, rot=0):
+    """Transform pixel location to different reference."""
+    t = get_transform(center, scale, res, rot=rot)
+    if invert:
+        t = np.linalg.inv(t)
+    new_pt = np.array([pt[0] - 1, pt[1] - 1, 1.0]).T
+    new_pt = np.dot(t, new_pt)
+    return np.array([round(new_pt[0]), round(new_pt[1])], dtype=int) + 1
+
+
+def bbox_from_detector(bbox, input_resolution=(224, 224), rescale=1.25):
+    """
+    Get center and scale of bounding box from bounding box.
+    The expected format is [min_x, min_y, max_x, max_y].
+    """
+    CROP_IMG_HEIGHT, CROP_IMG_WIDTH = input_resolution
+    CROP_ASPECT_RATIO = CROP_IMG_HEIGHT / float(CROP_IMG_WIDTH)
+
+    # center
+    center_x = (bbox[0] + bbox[2]) / 2.0
+    center_y = (bbox[1] + bbox[3]) / 2.0
+    center = np.array([center_x, center_y])
+
+    # scale
+    bbox_w = bbox[2] - bbox[0]
+    bbox_h = bbox[3] - bbox[1]
+    bbox_size = max(bbox_w * CROP_ASPECT_RATIO, bbox_h)
+
+    scale = np.array([bbox_size / CROP_ASPECT_RATIO, bbox_size]) / 200.0
+    # scale = bbox_size / 200.0
+    # adjust bounding box tightness
+    scale *= rescale
+    return center, scale
+
+
+def crop(img, center, scale, res):
+    """
+    Crop image according to the supplied bounding box.
+    res: [rows, cols]
+    """
+    # Upper left point
+    ul = np.array(transform([1, 1], center, max(scale), res, invert=1)) - 1
+    # Bottom right point
+    br = (
+        np.array(transform([res[1] + 1, res[0] + 1], center, max(scale), res, invert=1))
+        - 1
+    )
+
+    # Padding so that when rotated proper amount of context is included
+    pad = int(np.linalg.norm(br - ul) / 2 - float(br[1] - ul[1]) / 2)
+
+    new_shape = [br[1] - ul[1], br[0] - ul[0]]
+    if len(img.shape) > 2:
+        new_shape += [img.shape[2]]
+    new_img = np.zeros(new_shape, dtype=np.float32)
+
+    # Range to fill new array
+    new_x = max(0, -ul[0]), min(br[0], len(img[0])) - ul[0]
+    new_y = max(0, -ul[1]), min(br[1], len(img)) - ul[1]
+    # Range to sample from original image
+    old_x = max(0, ul[0]), min(len(img[0]), br[0])
+    old_y = max(0, ul[1]), min(len(img), br[1])
+    try:
+        new_img[new_y[0] : new_y[1], new_x[0] : new_x[1]] = img[
+            old_y[0] : old_y[1], old_x[0] : old_x[1]
+        ]
+    except Exception as e:
+        print(e)
+
+    new_img = cv2.resize(new_img, (res[1], res[0]))  # (cols, rows)
+    return new_img, new_shape, (old_x, old_y), (new_x, new_y)  # , ul, br
+
+
+def split_kp2ds_for_aa(kp2ds, ret_face=False):
+    kp2ds_body = (
+        kp2ds[[0, 6, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 17, 20]]
+        + kp2ds[[0, 5, 6, 8, 10, 5, 7, 9, 12, 14, 16, 11, 13, 15, 2, 1, 4, 3, 18, 21]]
+    ) / 2
+    kp2ds_lhand = kp2ds[91:112]
+    kp2ds_rhand = kp2ds[112:133]
+    kp2ds_face = kp2ds[22:91]
+    if ret_face:
+        return (
+            kp2ds_body.copy(),
+            kp2ds_lhand.copy(),
+            kp2ds_rhand.copy(),
+            kp2ds_face.copy(),
+        )
+    return kp2ds_body.copy(), kp2ds_lhand.copy(), kp2ds_rhand.copy()
+
+
+def load_pose_metas_from_kp2ds_seq(kp2ds_seq, width, height):
+    metas = []
+    last_kp2ds_body = None
+    for kps in kp2ds_seq:
+        kps = kps.copy()
+        kps[:, 0] /= width
+        kps[:, 1] /= height
+        kp2ds_body, kp2ds_lhand, kp2ds_rhand, kp2ds_face = split_kp2ds_for_aa(
+            kps, ret_face=True
+        )
+
+        if kp2ds_body[:, :2].min(axis=1).max() < 0:
+            kp2ds_body = last_kp2ds_body
+        last_kp2ds_body = kp2ds_body
+
+        meta = {
+            "width": width,
+            "height": height,
+            "keypoints_body": kp2ds_body,
+            "keypoints_left_hand": kp2ds_lhand,
+            "keypoints_right_hand": kp2ds_rhand,
+            "keypoints_face": kp2ds_face,
+        }
+        metas.append(meta)
+    return metas

--- a/python/sglang/multimodal_gen/runtime/utils/retarget_pose.py
+++ b/python/sglang/multimodal_gen/runtime/utils/retarget_pose.py
@@ -1,0 +1,1164 @@
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import copy
+import math
+from typing import NamedTuple
+
+import numpy as np
+from tqdm import tqdm
+
+from sglang.multimodal_gen.runtime.utils.pose2d import AAPoseMeta
+
+# load skeleton name and bone lines
+keypoint_list = [
+    "Nose",
+    "Neck",
+    "RShoulder",
+    "RElbow",
+    "RWrist",  # No.4
+    "LShoulder",
+    "LElbow",
+    "LWrist",  # No.7
+    "RHip",
+    "RKnee",
+    "RAnkle",  # No.10
+    "LHip",
+    "LKnee",
+    "LAnkle",  # No.13
+    "REye",
+    "LEye",
+    "REar",
+    "LEar",
+    "LToe",
+    "RToe",
+]
+
+
+limbSeq = [
+    [2, 3],
+    [2, 6],  # shoulders
+    [3, 4],
+    [4, 5],  # left arm
+    [6, 7],
+    [7, 8],  # right arm
+    [2, 9],
+    [9, 10],
+    [10, 11],  # right leg
+    [2, 12],
+    [12, 13],
+    [13, 14],  # left leg
+    [2, 1],
+    [1, 15],
+    [15, 17],
+    [1, 16],
+    [16, 18],  # face (nose, eyes, ears)
+    [14, 19],  # left foot
+    [11, 20],  #  right foot
+]
+
+eps = 0.01
+
+
+class Keypoint(NamedTuple):
+    x: float
+    y: float
+    score: float = 1.0
+    id: int = -1
+
+
+# for each limb, calculate src & dst bone's length
+# and calculate their ratios
+def get_length(skeleton, limb):
+
+    k1_index, k2_index = limb
+
+    H, W = skeleton["height"], skeleton["width"]
+    keypoints = skeleton["keypoints_body"]
+    keypoint1 = keypoints[k1_index - 1]
+    keypoint2 = keypoints[k2_index - 1]
+
+    if keypoint1 is None or keypoint2 is None:
+        return None, None, None
+
+    X = np.array([keypoint1[0], keypoint2[0]]) * float(W)
+    Y = np.array([keypoint1[1], keypoint2[1]]) * float(H)
+    length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+
+    return X, Y, length
+
+
+def get_handpose_meta(keypoints, delta, src_H, src_W):
+
+    new_keypoints = []
+
+    for idx, keypoint in enumerate(keypoints):
+        if keypoint is None:
+            new_keypoints.append(None)
+            continue
+        if keypoint.score == 0:
+            new_keypoints.append(None)
+            continue
+
+        x, y = keypoint.x, keypoint.y
+        x = int(x * src_W + delta[0])
+        y = int(y * src_H + delta[1])
+
+        new_keypoints.append(
+            Keypoint(
+                x=x,
+                y=y,
+                score=keypoint.score,
+            )
+        )
+
+    return new_keypoints
+
+
+def deal_hand_keypoints(hand_res, r_ratio, l_ratio, hand_score_th=0.5):
+
+    left_hand = []
+    right_hand = []
+
+    left_delta_x = hand_res["left"][0][0] * (l_ratio - 1)
+    left_delta_y = hand_res["left"][0][1] * (l_ratio - 1)
+
+    right_delta_x = hand_res["right"][0][0] * (r_ratio - 1)
+    right_delta_y = hand_res["right"][0][1] * (r_ratio - 1)
+
+    length = len(hand_res["left"])
+
+    for i in range(length):
+        # left hand
+        if hand_res["left"][i][2] < hand_score_th:
+            left_hand.append(
+                Keypoint(
+                    x=-1,
+                    y=-1,
+                    score=0,
+                )
+            )
+        else:
+            left_hand.append(
+                Keypoint(
+                    x=hand_res["left"][i][0] * l_ratio - left_delta_x,
+                    y=hand_res["left"][i][1] * l_ratio - left_delta_y,
+                    score=hand_res["left"][i][2],
+                )
+            )
+
+        # right hand
+        if hand_res["right"][i][2] < hand_score_th:
+            right_hand.append(
+                Keypoint(
+                    x=-1,
+                    y=-1,
+                    score=0,
+                )
+            )
+        else:
+            right_hand.append(
+                Keypoint(
+                    x=hand_res["right"][i][0] * r_ratio - right_delta_x,
+                    y=hand_res["right"][i][1] * r_ratio - right_delta_y,
+                    score=hand_res["right"][i][2],
+                )
+            )
+
+    return right_hand, left_hand
+
+
+def get_scaled_pose(
+    canvas,
+    src_canvas,
+    keypoints,
+    keypoints_hand,
+    bone_ratio_list,
+    delta_ground_x,
+    delta_ground_y,
+    rescaled_src_ground_x,
+    body_flag,
+    id,
+    scale_min,
+    threshold=0.4,
+):
+
+    H, W = canvas
+    src_H, src_W = src_canvas
+
+    new_length_list = []
+    angle_list = []
+
+    # keypoints from 0-1 to H/W range
+    for idx in range(len(keypoints)):
+        if keypoints[idx] is None or len(keypoints[idx]) == 0:
+            continue
+
+        keypoints[idx] = [
+            keypoints[idx][0] * src_W,
+            keypoints[idx][1] * src_H,
+            keypoints[idx][2],
+        ]
+
+    # first traverse, get new_length_list and angle_list
+    for idx, (k1_index, k2_index) in enumerate(limbSeq):
+        keypoint1 = keypoints[k1_index - 1]
+        keypoint2 = keypoints[k2_index - 1]
+
+        if (
+            keypoint1 is None
+            or keypoint2 is None
+            or len(keypoint1) == 0
+            or len(keypoint2) == 0
+        ):
+            new_length_list.append(None)
+            angle_list.append(None)
+            continue
+
+        Y = np.array([keypoint1[0], keypoint2[0]])  # * float(W)
+        X = np.array([keypoint1[1], keypoint2[1]])  # * float(H)
+
+        length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+
+        new_length = length * bone_ratio_list[idx]
+        angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+
+        new_length_list.append(new_length)
+        angle_list.append(angle)
+
+    # Keep foot length within 0.5x calf length
+    foot_lower_leg_ratio = 0.5
+    if new_length_list[8] != None and new_length_list[18] != None:
+        if new_length_list[18] > new_length_list[8] * foot_lower_leg_ratio:
+            new_length_list[18] = new_length_list[8] * foot_lower_leg_ratio
+
+    if new_length_list[11] != None and new_length_list[17] != None:
+        if new_length_list[17] > new_length_list[11] * foot_lower_leg_ratio:
+            new_length_list[17] = new_length_list[11] * foot_lower_leg_ratio
+
+    # second traverse, calculate new keypoints
+    rescale_keypoints = keypoints.copy()
+
+    for idx, (k1_index, k2_index) in enumerate(limbSeq):
+        # update dst_keypoints
+        start_keypoint = rescale_keypoints[k1_index - 1]
+        new_length = new_length_list[idx]
+        angle = angle_list[idx]
+
+        if (
+            rescale_keypoints[k1_index - 1] is None
+            or rescale_keypoints[k2_index - 1] is None
+            or len(rescale_keypoints[k1_index - 1]) == 0
+            or len(rescale_keypoints[k2_index - 1]) == 0
+        ):
+            continue
+
+        # calculate end_keypoint
+        delta_x = new_length * math.cos(math.radians(angle))
+        delta_y = new_length * math.sin(math.radians(angle))
+
+        end_keypoint_x = start_keypoint[0] - delta_x
+        end_keypoint_y = start_keypoint[1] - delta_y
+
+        # update keypoints
+        rescale_keypoints[k2_index - 1] = [
+            end_keypoint_x,
+            end_keypoint_y,
+            rescale_keypoints[k2_index - 1][2],
+        ]
+
+    if id == 0:
+        if (
+            body_flag == "full_body"
+            and rescale_keypoints[8] != None
+            and rescale_keypoints[11] != None
+        ):
+            delta_ground_x_offset_first_frame = (
+                rescale_keypoints[8][0] + rescale_keypoints[11][0]
+            ) / 2 - rescaled_src_ground_x
+            delta_ground_x += delta_ground_x_offset_first_frame
+        elif body_flag == "half_body" and rescale_keypoints[1] != None:
+            delta_ground_x_offset_first_frame = (
+                rescale_keypoints[1][0] - rescaled_src_ground_x
+            )
+            delta_ground_x += delta_ground_x_offset_first_frame
+
+    # offset all keypoints
+    for idx in range(len(rescale_keypoints)):
+        if rescale_keypoints[idx] is None or len(rescale_keypoints[idx]) == 0:
+            continue
+        rescale_keypoints[idx][0] -= delta_ground_x
+        rescale_keypoints[idx][1] -= delta_ground_y
+
+        # rescale keypoints to original size
+        rescale_keypoints[idx][0] /= scale_min
+        rescale_keypoints[idx][1] /= scale_min
+
+    # Scale hand proportions based on body skeletal ratios
+    r_ratio = max(bone_ratio_list[0], bone_ratio_list[1]) / scale_min
+    l_ratio = max(bone_ratio_list[0], bone_ratio_list[1]) / scale_min
+    left_hand, right_hand = deal_hand_keypoints(
+        keypoints_hand, r_ratio, l_ratio, hand_score_th=threshold
+    )
+
+    left_hand_new = left_hand.copy()
+    right_hand_new = right_hand.copy()
+
+    if rescale_keypoints[4] == None and rescale_keypoints[7] == None:
+        pass
+
+    elif rescale_keypoints[4] == None and rescale_keypoints[7] != None:
+        right_hand_delta = np.array(rescale_keypoints[7][:2]) - np.array(
+            keypoints[7][:2]
+        )
+        right_hand_new = get_handpose_meta(right_hand, right_hand_delta, src_H, src_W)
+
+    elif rescale_keypoints[4] != None and rescale_keypoints[7] == None:
+        left_hand_delta = np.array(rescale_keypoints[4][:2]) - np.array(
+            keypoints[4][:2]
+        )
+        left_hand_new = get_handpose_meta(left_hand, left_hand_delta, src_H, src_W)
+
+    else:
+        # get left_hand and right_hand offset
+        left_hand_delta = np.array(rescale_keypoints[4][:2]) - np.array(
+            keypoints[4][:2]
+        )
+        right_hand_delta = np.array(rescale_keypoints[7][:2]) - np.array(
+            keypoints[7][:2]
+        )
+
+        if keypoints[4][0] != None and left_hand[0].x != -1:
+            left_hand_root_offset = np.array(
+                (
+                    keypoints[4][0] - left_hand[0].x * src_W,
+                    keypoints[4][1] - left_hand[0].y * src_H,
+                )
+            )
+            left_hand_delta += left_hand_root_offset
+
+        if keypoints[7][0] != None and right_hand[0].x != -1:
+            right_hand_root_offset = np.array(
+                (
+                    keypoints[7][0] - right_hand[0].x * src_W,
+                    keypoints[7][1] - right_hand[0].y * src_H,
+                )
+            )
+            right_hand_delta += right_hand_root_offset
+
+        dis_left_hand = (
+            (keypoints[4][0] - left_hand[0].x * src_W) ** 2
+            + (keypoints[4][1] - left_hand[0].y * src_H) ** 2
+        ) ** 0.5
+        dis_right_hand = (
+            (keypoints[7][0] - left_hand[0].x * src_W) ** 2
+            + (keypoints[7][1] - left_hand[0].y * src_H) ** 2
+        ) ** 0.5
+
+        if dis_left_hand > dis_right_hand:
+            right_hand_new = get_handpose_meta(
+                left_hand, right_hand_delta, src_H, src_W
+            )
+            left_hand_new = get_handpose_meta(right_hand, left_hand_delta, src_H, src_W)
+        else:
+            left_hand_new = get_handpose_meta(left_hand, left_hand_delta, src_H, src_W)
+            right_hand_new = get_handpose_meta(
+                right_hand, right_hand_delta, src_H, src_W
+            )
+
+    # get normalized keypoints_body
+    norm_body_keypoints = []
+    for body_keypoint in rescale_keypoints:
+        if body_keypoint != None:
+            norm_body_keypoints.append(
+                [body_keypoint[0] / W, body_keypoint[1] / H, body_keypoint[2]]
+            )
+        else:
+            norm_body_keypoints.append(None)
+
+    frame_info = {
+        "height": H,
+        "width": W,
+        "keypoints_body": norm_body_keypoints,
+        "keypoints_left_hand": left_hand_new,
+        "keypoints_right_hand": right_hand_new,
+    }
+
+    return frame_info
+
+
+def rescale_skeleton(H, W, keypoints, bone_ratio_list):
+
+    rescale_keypoints = keypoints.copy()
+
+    new_length_list = []
+    angle_list = []
+
+    # keypoints from 0-1 to H/W range
+    for idx in range(len(rescale_keypoints)):
+        if rescale_keypoints[idx] is None or len(rescale_keypoints[idx]) == 0:
+            continue
+
+        rescale_keypoints[idx] = [
+            rescale_keypoints[idx][0] * W,
+            rescale_keypoints[idx][1] * H,
+        ]
+
+    # first traverse, get new_length_list and angle_list
+    for idx, (k1_index, k2_index) in enumerate(limbSeq):
+        keypoint1 = rescale_keypoints[k1_index - 1]
+        keypoint2 = rescale_keypoints[k2_index - 1]
+
+        if (
+            keypoint1 is None
+            or keypoint2 is None
+            or len(keypoint1) == 0
+            or len(keypoint2) == 0
+        ):
+            new_length_list.append(None)
+            angle_list.append(None)
+            continue
+
+        Y = np.array([keypoint1[0], keypoint2[0]])  # * float(W)
+        X = np.array([keypoint1[1], keypoint2[1]])  # * float(H)
+
+        length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+
+        new_length = length * bone_ratio_list[idx]
+        angle = math.degrees(math.atan2(X[0] - X[1], Y[0] - Y[1]))
+
+        new_length_list.append(new_length)
+        angle_list.append(angle)
+
+    # # second traverse, calculate new keypoints
+    for idx, (k1_index, k2_index) in enumerate(limbSeq):
+        # update dst_keypoints
+        start_keypoint = rescale_keypoints[k1_index - 1]
+        new_length = new_length_list[idx]
+        angle = angle_list[idx]
+
+        if (
+            rescale_keypoints[k1_index - 1] is None
+            or rescale_keypoints[k2_index - 1] is None
+            or len(rescale_keypoints[k1_index - 1]) == 0
+            or len(rescale_keypoints[k2_index - 1]) == 0
+        ):
+            continue
+
+        # calculate end_keypoint
+        delta_x = new_length * math.cos(math.radians(angle))
+        delta_y = new_length * math.sin(math.radians(angle))
+
+        end_keypoint_x = start_keypoint[0] - delta_x
+        end_keypoint_y = start_keypoint[1] - delta_y
+
+        # update keypoints
+        rescale_keypoints[k2_index - 1] = [end_keypoint_x, end_keypoint_y]
+
+    return rescale_keypoints
+
+
+def fix_lack_keypoints_use_sym(skeleton):
+
+    keypoints = skeleton["keypoints_body"]
+    H, W = skeleton["height"], skeleton["width"]
+
+    limb_points_list = [
+        [3, 4, 5],
+        [6, 7, 8],
+        [12, 13, 14, 19],
+        [9, 10, 11, 20],
+    ]
+
+    for limb_points in limb_points_list:
+        miss_flag = False
+        for point in limb_points:
+            if keypoints[point - 1] is None:
+                miss_flag = True
+                continue
+            if miss_flag:
+                skeleton["keypoints_body"][point - 1] = None
+
+    repair_limb_seq_left = [
+        [3, 4],
+        [4, 5],  # left arm
+        [12, 13],
+        [13, 14],  # left leg
+        [14, 19],  # left foot
+    ]
+
+    repair_limb_seq_right = [
+        [6, 7],
+        [7, 8],  # right arm
+        [9, 10],
+        [10, 11],  # right leg
+        [11, 20],  # right foot
+    ]
+
+    repair_limb_seq = [repair_limb_seq_left, repair_limb_seq_right]
+
+    for idx_part, part in enumerate(repair_limb_seq):
+        for idx, limb in enumerate(part):
+
+            k1_index, k2_index = limb
+            keypoint1 = keypoints[k1_index - 1]
+            keypoint2 = keypoints[k2_index - 1]
+
+            if keypoint1 != None and keypoint2 is None:
+                # reference to symmetric limb
+                sym_limb = repair_limb_seq[1 - idx_part][idx]
+                k1_index_sym, k2_index_sym = sym_limb
+                keypoint1_sym = keypoints[k1_index_sym - 1]
+                keypoint2_sym = keypoints[k2_index_sym - 1]
+                ref_length = 0
+
+                if keypoint1_sym != None and keypoint2_sym != None:
+                    X = np.array([keypoint1_sym[0], keypoint2_sym[0]]) * float(W)
+                    Y = np.array([keypoint1_sym[1], keypoint2_sym[1]]) * float(H)
+                    ref_length = ((X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2) ** 0.5
+                else:
+                    ref_length_left, ref_length_right = 0, 0
+                    if keypoints[1] != None and keypoints[8] != None:
+                        X = np.array([keypoints[1][0], keypoints[8][0]]) * float(W)
+                        Y = np.array([keypoints[1][1], keypoints[8][1]]) * float(H)
+                        ref_length_left = (
+                            (X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2
+                        ) ** 0.5
+                        if idx <= 1:  # arms
+                            ref_length_left /= 2
+
+                    if keypoints[1] != None and keypoints[11] != None:
+                        X = np.array([keypoints[1][0], keypoints[11][0]]) * float(W)
+                        Y = np.array([keypoints[1][1], keypoints[11][1]]) * float(H)
+                        ref_length_right = (
+                            (X[0] - X[1]) ** 2 + (Y[0] - Y[1]) ** 2
+                        ) ** 0.5
+                        if idx <= 1:  # arms
+                            ref_length_right /= 2
+                        elif idx == 4:  # foot
+                            ref_length_right /= 5
+
+                    ref_length = max(ref_length_left, ref_length_right)
+
+                if ref_length != 0:
+                    skeleton["keypoints_body"][k2_index - 1] = [0, 0]  # init
+                    skeleton["keypoints_body"][k2_index - 1][0] = skeleton[
+                        "keypoints_body"
+                    ][k1_index - 1][0]
+                    skeleton["keypoints_body"][k2_index - 1][1] = (
+                        skeleton["keypoints_body"][k1_index - 1][1] + ref_length / H
+                    )
+    return skeleton
+
+
+def rescale_shorten_skeleton(ratio_list, src_length_list, dst_length_list):
+
+    modify_bone_list = [[0, 1], [2, 4], [3, 5], [6, 9], [7, 10], [8, 11], [17, 18]]
+
+    for modify_bone in modify_bone_list:
+        new_ratio = max(ratio_list[modify_bone[0]], ratio_list[modify_bone[1]])
+        ratio_list[modify_bone[0]] = new_ratio
+        ratio_list[modify_bone[1]] = new_ratio
+
+    if ratio_list[13] != None and ratio_list[15] != None:
+        ratio_eye_avg = (ratio_list[13] + ratio_list[15]) / 2
+        ratio_list[13] = ratio_eye_avg
+        ratio_list[15] = ratio_eye_avg
+
+    if ratio_list[14] != None and ratio_list[16] != None:
+        ratio_eye_avg = (ratio_list[14] + ratio_list[16]) / 2
+        ratio_list[14] = ratio_eye_avg
+        ratio_list[16] = ratio_eye_avg
+
+    return ratio_list, src_length_list, dst_length_list
+
+
+def check_full_body(keypoints, threshold=0.4):
+
+    body_flag = "half_body"
+
+    # 1. If ankle points exist, confidence is greater than the threshold, and points do not exceed the frame, return full_body
+    if (
+        keypoints[10] != None
+        and keypoints[13] != None
+        and keypoints[8] != None
+        and keypoints[11] != None
+    ):
+        if (
+            (keypoints[10][1] <= 1 and keypoints[13][1] <= 1)
+            and (keypoints[10][2] >= threshold and keypoints[13][2] >= threshold)
+            and (keypoints[8][1] <= 1 and keypoints[11][1] <= 1)
+            and (keypoints[8][2] >= threshold and keypoints[11][2] >= threshold)
+        ):
+            body_flag = "full_body"
+            return body_flag
+
+    # 2. If hip points exist, return three_quarter_body
+    if keypoints[8] != None and keypoints[11] != None:
+        if (keypoints[8][1] <= 1 and keypoints[11][1] <= 1) and (
+            keypoints[8][2] >= threshold and keypoints[11][2] >= threshold
+        ):
+            body_flag = "three_quarter_body"
+            return body_flag
+
+    return body_flag
+
+
+def check_full_body_both(flag1, flag2):
+    body_flag_dict = {"full_body": 2, "three_quarter_body": 1, "half_body": 0}
+
+    body_flag_dict_reverse = {2: "full_body", 1: "three_quarter_body", 0: "half_body"}
+
+    flag1_num = body_flag_dict[flag1]
+    flag2_num = body_flag_dict[flag2]
+    flag_both_num = min(flag1_num, flag2_num)
+    return body_flag_dict_reverse[flag_both_num]
+
+
+def write_to_poses(
+    data_to_json,
+    none_idx,
+    dst_shape,
+    bone_ratio_list,
+    delta_ground_x,
+    delta_ground_y,
+    rescaled_src_ground_x,
+    body_flag,
+    scale_min,
+):
+    outputs = []
+    length = len(data_to_json)
+    for id in tqdm(range(length)):
+
+        src_height, src_width = data_to_json[id]["height"], data_to_json[id]["width"]
+        width, height = dst_shape
+        keypoints = data_to_json[id]["keypoints_body"]
+        for idx in range(len(keypoints)):
+            if idx in none_idx:
+                keypoints[idx] = None
+        new_keypoints = keypoints.copy()
+
+        # get hand keypoints
+        keypoints_hand = {
+            "left": data_to_json[id]["keypoints_left_hand"],
+            "right": data_to_json[id]["keypoints_right_hand"],
+        }
+        # Normalize hand coordinates to 0-1 range
+        for hand_idx in range(len(data_to_json[id]["keypoints_left_hand"])):
+            data_to_json[id]["keypoints_left_hand"][hand_idx][0] = (
+                data_to_json[id]["keypoints_left_hand"][hand_idx][0] / src_width
+            )
+            data_to_json[id]["keypoints_left_hand"][hand_idx][1] = (
+                data_to_json[id]["keypoints_left_hand"][hand_idx][1] / src_height
+            )
+
+        for hand_idx in range(len(data_to_json[id]["keypoints_right_hand"])):
+            data_to_json[id]["keypoints_right_hand"][hand_idx][0] = (
+                data_to_json[id]["keypoints_right_hand"][hand_idx][0] / src_width
+            )
+            data_to_json[id]["keypoints_right_hand"][hand_idx][1] = (
+                data_to_json[id]["keypoints_right_hand"][hand_idx][1] / src_height
+            )
+
+        frame_info = get_scaled_pose(
+            (height, width),
+            (src_height, src_width),
+            new_keypoints,
+            keypoints_hand,
+            bone_ratio_list,
+            delta_ground_x,
+            delta_ground_y,
+            rescaled_src_ground_x,
+            body_flag,
+            id,
+            scale_min,
+        )
+        outputs.append(frame_info)
+
+    return outputs
+
+
+def calculate_scale_ratio(skeleton, skeleton_edit, scale_ratio_flag):
+    if scale_ratio_flag:
+
+        headw = max(
+            skeleton["keypoints_body"][0][0],
+            skeleton["keypoints_body"][14][0],
+            skeleton["keypoints_body"][15][0],
+            skeleton["keypoints_body"][16][0],
+            skeleton["keypoints_body"][17][0],
+        ) - min(
+            skeleton["keypoints_body"][0][0],
+            skeleton["keypoints_body"][14][0],
+            skeleton["keypoints_body"][15][0],
+            skeleton["keypoints_body"][16][0],
+            skeleton["keypoints_body"][17][0],
+        )
+        headw_edit = max(
+            skeleton_edit["keypoints_body"][0][0],
+            skeleton_edit["keypoints_body"][14][0],
+            skeleton_edit["keypoints_body"][15][0],
+            skeleton_edit["keypoints_body"][16][0],
+            skeleton_edit["keypoints_body"][17][0],
+        ) - min(
+            skeleton_edit["keypoints_body"][0][0],
+            skeleton_edit["keypoints_body"][14][0],
+            skeleton_edit["keypoints_body"][15][0],
+            skeleton_edit["keypoints_body"][16][0],
+            skeleton_edit["keypoints_body"][17][0],
+        )
+        headw_ratio = headw / headw_edit
+
+        _, _, shoulder = get_length(skeleton, [6, 3])
+        _, _, shoulder_edit = get_length(skeleton_edit, [6, 3])
+        shoulder_ratio = shoulder / shoulder_edit
+
+        return max(headw_ratio, shoulder_ratio)
+
+    else:
+        return 1
+
+
+def retarget_pose(
+    src_skeleton,
+    dst_skeleton,
+    all_src_skeleton,
+    src_skeleton_edit,
+    dst_skeleton_edit,
+    threshold=0.4,
+):
+
+    if src_skeleton_edit is not None and dst_skeleton_edit is not None:
+        use_edit_for_base = True
+    else:
+        use_edit_for_base = False
+
+    src_skeleton_ori = copy.deepcopy(src_skeleton)
+
+    dst_skeleton_ori_h, dst_skeleton_ori_w = (
+        dst_skeleton["height"],
+        dst_skeleton["width"],
+    )
+    if (
+        src_skeleton["keypoints_body"][0] != None
+        and src_skeleton["keypoints_body"][10] != None
+        and src_skeleton["keypoints_body"][13] != None
+        and dst_skeleton["keypoints_body"][0] != None
+        and dst_skeleton["keypoints_body"][10] != None
+        and dst_skeleton["keypoints_body"][13] != None
+        and src_skeleton["keypoints_body"][0][2] > 0.5
+        and src_skeleton["keypoints_body"][10][2] > 0.5
+        and src_skeleton["keypoints_body"][13][2] > 0.5
+        and dst_skeleton["keypoints_body"][0][2] > 0.5
+        and dst_skeleton["keypoints_body"][10][2] > 0.5
+        and dst_skeleton["keypoints_body"][13][2] > 0.5
+    ):
+
+        src_height = src_skeleton["height"] * abs(
+            (
+                src_skeleton["keypoints_body"][10][1]
+                + src_skeleton["keypoints_body"][13][1]
+            )
+            / 2
+            - src_skeleton["keypoints_body"][0][1]
+        )
+        dst_height = dst_skeleton["height"] * abs(
+            (
+                dst_skeleton["keypoints_body"][10][1]
+                + dst_skeleton["keypoints_body"][13][1]
+            )
+            / 2
+            - dst_skeleton["keypoints_body"][0][1]
+        )
+        scale_min = 1.0 * src_height / dst_height
+    elif (
+        src_skeleton["keypoints_body"][0] != None
+        and src_skeleton["keypoints_body"][8] != None
+        and src_skeleton["keypoints_body"][11] != None
+        and dst_skeleton["keypoints_body"][0] != None
+        and dst_skeleton["keypoints_body"][8] != None
+        and dst_skeleton["keypoints_body"][11] != None
+        and src_skeleton["keypoints_body"][0][2] > 0.5
+        and src_skeleton["keypoints_body"][8][2] > 0.5
+        and src_skeleton["keypoints_body"][11][2] > 0.5
+        and dst_skeleton["keypoints_body"][0][2] > 0.5
+        and dst_skeleton["keypoints_body"][8][2] > 0.5
+        and dst_skeleton["keypoints_body"][11][2] > 0.5
+    ):
+
+        src_height = src_skeleton["height"] * abs(
+            (
+                src_skeleton["keypoints_body"][8][1]
+                + src_skeleton["keypoints_body"][11][1]
+            )
+            / 2
+            - src_skeleton["keypoints_body"][0][1]
+        )
+        dst_height = dst_skeleton["height"] * abs(
+            (
+                dst_skeleton["keypoints_body"][8][1]
+                + dst_skeleton["keypoints_body"][11][1]
+            )
+            / 2
+            - dst_skeleton["keypoints_body"][0][1]
+        )
+        scale_min = 1.0 * src_height / dst_height
+    else:
+        scale_min = np.sqrt(src_skeleton["height"] * src_skeleton["width"]) / np.sqrt(
+            dst_skeleton["height"] * dst_skeleton["width"]
+        )
+
+    if use_edit_for_base:
+        scale_ratio_flag = False
+        if (
+            src_skeleton_edit["keypoints_body"][0] != None
+            and src_skeleton_edit["keypoints_body"][10] != None
+            and src_skeleton_edit["keypoints_body"][13] != None
+            and dst_skeleton_edit["keypoints_body"][0] != None
+            and dst_skeleton_edit["keypoints_body"][10] != None
+            and dst_skeleton_edit["keypoints_body"][13] != None
+            and src_skeleton_edit["keypoints_body"][0][2] > 0.5
+            and src_skeleton_edit["keypoints_body"][10][2] > 0.5
+            and src_skeleton_edit["keypoints_body"][13][2] > 0.5
+            and dst_skeleton_edit["keypoints_body"][0][2] > 0.5
+            and dst_skeleton_edit["keypoints_body"][10][2] > 0.5
+            and dst_skeleton_edit["keypoints_body"][13][2] > 0.5
+        ):
+
+            src_height_edit = src_skeleton_edit["height"] * abs(
+                (
+                    src_skeleton_edit["keypoints_body"][10][1]
+                    + src_skeleton_edit["keypoints_body"][13][1]
+                )
+                / 2
+                - src_skeleton_edit["keypoints_body"][0][1]
+            )
+            dst_height_edit = dst_skeleton_edit["height"] * abs(
+                (
+                    dst_skeleton_edit["keypoints_body"][10][1]
+                    + dst_skeleton_edit["keypoints_body"][13][1]
+                )
+                / 2
+                - dst_skeleton_edit["keypoints_body"][0][1]
+            )
+            scale_min_edit = 1.0 * src_height_edit / dst_height_edit
+        elif (
+            src_skeleton_edit["keypoints_body"][0] != None
+            and src_skeleton_edit["keypoints_body"][8] != None
+            and src_skeleton_edit["keypoints_body"][11] != None
+            and dst_skeleton_edit["keypoints_body"][0] != None
+            and dst_skeleton_edit["keypoints_body"][8] != None
+            and dst_skeleton_edit["keypoints_body"][11] != None
+            and src_skeleton_edit["keypoints_body"][0][2] > 0.5
+            and src_skeleton_edit["keypoints_body"][8][2] > 0.5
+            and src_skeleton_edit["keypoints_body"][11][2] > 0.5
+            and dst_skeleton_edit["keypoints_body"][0][2] > 0.5
+            and dst_skeleton_edit["keypoints_body"][8][2] > 0.5
+            and dst_skeleton_edit["keypoints_body"][11][2] > 0.5
+        ):
+
+            src_height_edit = src_skeleton_edit["height"] * abs(
+                (
+                    src_skeleton_edit["keypoints_body"][8][1]
+                    + src_skeleton_edit["keypoints_body"][11][1]
+                )
+                / 2
+                - src_skeleton_edit["keypoints_body"][0][1]
+            )
+            dst_height_edit = dst_skeleton_edit["height"] * abs(
+                (
+                    dst_skeleton_edit["keypoints_body"][8][1]
+                    + dst_skeleton_edit["keypoints_body"][11][1]
+                )
+                / 2
+                - dst_skeleton_edit["keypoints_body"][0][1]
+            )
+            scale_min_edit = 1.0 * src_height_edit / dst_height_edit
+        else:
+            scale_min_edit = np.sqrt(
+                src_skeleton_edit["height"] * src_skeleton_edit["width"]
+            ) / np.sqrt(dst_skeleton_edit["height"] * dst_skeleton_edit["width"])
+            scale_ratio_flag = True
+
+        # Flux may change the scale, compensate for it here
+        ratio_src = calculate_scale_ratio(
+            src_skeleton, src_skeleton_edit, scale_ratio_flag
+        )
+        ratio_dst = calculate_scale_ratio(
+            dst_skeleton, dst_skeleton_edit, scale_ratio_flag
+        )
+
+        dst_skeleton_edit["height"] = int(dst_skeleton_edit["height"] * scale_min_edit)
+        dst_skeleton_edit["width"] = int(dst_skeleton_edit["width"] * scale_min_edit)
+        for idx in range(len(dst_skeleton_edit["keypoints_left_hand"])):
+            dst_skeleton_edit["keypoints_left_hand"][idx][0] *= scale_min_edit
+            dst_skeleton_edit["keypoints_left_hand"][idx][1] *= scale_min_edit
+        for idx in range(len(dst_skeleton_edit["keypoints_right_hand"])):
+            dst_skeleton_edit["keypoints_right_hand"][idx][0] *= scale_min_edit
+            dst_skeleton_edit["keypoints_right_hand"][idx][1] *= scale_min_edit
+
+    dst_skeleton["height"] = int(dst_skeleton["height"] * scale_min)
+    dst_skeleton["width"] = int(dst_skeleton["width"] * scale_min)
+    for idx in range(len(dst_skeleton["keypoints_left_hand"])):
+        dst_skeleton["keypoints_left_hand"][idx][0] *= scale_min
+        dst_skeleton["keypoints_left_hand"][idx][1] *= scale_min
+    for idx in range(len(dst_skeleton["keypoints_right_hand"])):
+        dst_skeleton["keypoints_right_hand"][idx][0] *= scale_min
+        dst_skeleton["keypoints_right_hand"][idx][1] *= scale_min
+
+    dst_body_flag = check_full_body(dst_skeleton["keypoints_body"], threshold)
+    src_body_flag = check_full_body(src_skeleton_ori["keypoints_body"], threshold)
+    body_flag = check_full_body_both(dst_body_flag, src_body_flag)
+    # print('body_flag: ', body_flag)
+
+    if use_edit_for_base:
+        src_skeleton_edit = fix_lack_keypoints_use_sym(src_skeleton_edit)
+        dst_skeleton_edit = fix_lack_keypoints_use_sym(dst_skeleton_edit)
+    else:
+        src_skeleton = fix_lack_keypoints_use_sym(src_skeleton)
+        dst_skeleton = fix_lack_keypoints_use_sym(dst_skeleton)
+
+    none_idx = []
+    for idx in range(len(dst_skeleton["keypoints_body"])):
+        if (
+            dst_skeleton["keypoints_body"][idx] == None
+            or src_skeleton["keypoints_body"][idx] == None
+        ):
+            src_skeleton["keypoints_body"][idx] = None
+            dst_skeleton["keypoints_body"][idx] = None
+            none_idx.append(idx)
+
+    # get bone ratio list
+    ratio_list, src_length_list, dst_length_list = [], [], []
+    for idx, limb in enumerate(limbSeq):
+        if use_edit_for_base:
+            src_X, src_Y, src_length = get_length(src_skeleton_edit, limb)
+            dst_X, dst_Y, dst_length = get_length(dst_skeleton_edit, limb)
+
+            if src_X is None or src_Y is None or dst_X is None or dst_Y is None:
+                ratio = -1
+            else:
+                ratio = 1.0 * dst_length * ratio_dst / src_length / ratio_src
+
+        else:
+            src_X, src_Y, src_length = get_length(src_skeleton, limb)
+            dst_X, dst_Y, dst_length = get_length(dst_skeleton, limb)
+
+            if src_X is None or src_Y is None or dst_X is None or dst_Y is None:
+                ratio = -1
+            else:
+                ratio = 1.0 * dst_length / src_length
+
+        ratio_list.append(ratio)
+        src_length_list.append(src_length)
+        dst_length_list.append(dst_length)
+
+    for idx, ratio in enumerate(ratio_list):
+        if ratio == -1:
+            if ratio_list[0] != -1 and ratio_list[1] != -1:
+                ratio_list[idx] = (ratio_list[0] + ratio_list[1]) / 2
+
+    # Consider adding constraints when Flux fails to correct head pose, causing neck issues.
+    # if ratio_list[12] > (ratio_list[0]+ratio_list[1])/2*1.25:
+    #     ratio_list[12] = (ratio_list[0]+ratio_list[1])/2*1.25
+
+    ratio_list, src_length_list, dst_length_list = rescale_shorten_skeleton(
+        ratio_list, src_length_list, dst_length_list
+    )
+
+    rescaled_src_skeleton_ori = rescale_skeleton(
+        src_skeleton_ori["height"],
+        src_skeleton_ori["width"],
+        src_skeleton_ori["keypoints_body"],
+        ratio_list,
+    )
+
+    # get global translation offset_x and offset_y
+    if body_flag == "full_body":
+        # print('use foot mark.')
+        dst_ground_y = (
+            max(
+                dst_skeleton["keypoints_body"][10][1],
+                dst_skeleton["keypoints_body"][13][1],
+            )
+            * dst_skeleton["height"]
+        )
+        # The midpoint between toe and ankle
+        if (
+            dst_skeleton["keypoints_body"][18] != None
+            and dst_skeleton["keypoints_body"][19] != None
+        ):
+            right_foot_mid = (
+                dst_skeleton["keypoints_body"][10][1]
+                + dst_skeleton["keypoints_body"][19][1]
+            ) / 2
+            left_foot_mid = (
+                dst_skeleton["keypoints_body"][13][1]
+                + dst_skeleton["keypoints_body"][18][1]
+            ) / 2
+            dst_ground_y = max(left_foot_mid, right_foot_mid) * dst_skeleton["height"]
+
+        rescaled_src_ground_y = max(
+            rescaled_src_skeleton_ori[10][1], rescaled_src_skeleton_ori[13][1]
+        )
+        delta_ground_y = rescaled_src_ground_y - dst_ground_y
+
+        dst_ground_x = (
+            (
+                dst_skeleton["keypoints_body"][8][0]
+                + dst_skeleton["keypoints_body"][11][0]
+            )
+            * dst_skeleton["width"]
+            / 2
+        )
+        rescaled_src_ground_x = (
+            rescaled_src_skeleton_ori[8][0] + rescaled_src_skeleton_ori[11][0]
+        ) / 2
+        delta_ground_x = rescaled_src_ground_x - dst_ground_x
+        delta_x, delta_y = delta_ground_x, delta_ground_y
+
+    else:
+        # print('use neck mark.')
+        # use neck keypoint as mark
+        src_neck_y = rescaled_src_skeleton_ori[1][1]
+        dst_neck_y = dst_skeleton["keypoints_body"][1][1]
+        delta_neck_y = src_neck_y - dst_neck_y * dst_skeleton["height"]
+
+        src_neck_x = rescaled_src_skeleton_ori[1][0]
+        dst_neck_x = dst_skeleton["keypoints_body"][1][0]
+        delta_neck_x = src_neck_x - dst_neck_x * dst_skeleton["width"]
+        delta_x, delta_y = delta_neck_x, delta_neck_y
+        rescaled_src_ground_x = src_neck_x
+
+    dst_shape = (dst_skeleton_ori_w, dst_skeleton_ori_h)
+    output = write_to_poses(
+        all_src_skeleton,
+        none_idx,
+        dst_shape,
+        ratio_list,
+        delta_x,
+        delta_y,
+        rescaled_src_ground_x,
+        body_flag,
+        scale_min,
+    )
+    return output
+
+
+def get_retarget_pose(
+    tpl_pose_meta0,
+    refer_pose_meta,
+    tpl_pose_metas,
+    tql_edit_pose_meta0,
+    refer_edit_pose_meta,
+):
+
+    for key, value in tpl_pose_meta0.items():
+        if type(value) is np.ndarray:
+            if key in ["keypoints_left_hand", "keypoints_right_hand"]:
+                value = value * np.array(
+                    [[tpl_pose_meta0["width"], tpl_pose_meta0["height"], 1.0]]
+                )
+            if not isinstance(value, list):
+                value = value.tolist()
+        tpl_pose_meta0[key] = value
+
+    for key, value in refer_pose_meta.items():
+        if type(value) is np.ndarray:
+            if key in ["keypoints_left_hand", "keypoints_right_hand"]:
+                value = value * np.array(
+                    [[refer_pose_meta["width"], refer_pose_meta["height"], 1.0]]
+                )
+            if not isinstance(value, list):
+                value = value.tolist()
+        refer_pose_meta[key] = value
+
+    tpl_pose_metas_new = []
+    for meta in tpl_pose_metas:
+        for key, value in meta.items():
+            if type(value) is np.ndarray:
+                if key in ["keypoints_left_hand", "keypoints_right_hand"]:
+                    value = value * np.array([[meta["width"], meta["height"], 1.0]])
+                if not isinstance(value, list):
+                    value = value.tolist()
+            meta[key] = value
+        tpl_pose_metas_new.append(meta)
+
+    if tql_edit_pose_meta0 is not None:
+        for key, value in tql_edit_pose_meta0.items():
+            if type(value) is np.ndarray:
+                if key in ["keypoints_left_hand", "keypoints_right_hand"]:
+                    value = value * np.array(
+                        [
+                            [
+                                tql_edit_pose_meta0["width"],
+                                tql_edit_pose_meta0["height"],
+                                1.0,
+                            ]
+                        ]
+                    )
+                if not isinstance(value, list):
+                    value = value.tolist()
+            tql_edit_pose_meta0[key] = value
+
+    if refer_edit_pose_meta is not None:
+        for key, value in refer_edit_pose_meta.items():
+            if type(value) is np.ndarray:
+                if key in ["keypoints_left_hand", "keypoints_right_hand"]:
+                    value = value * np.array(
+                        [
+                            [
+                                refer_edit_pose_meta["width"],
+                                refer_edit_pose_meta["height"],
+                                1.0,
+                            ]
+                        ]
+                    )
+                if not isinstance(value, list):
+                    value = value.tolist()
+            refer_edit_pose_meta[key] = value
+
+    retarget_tpl_pose_metas = retarget_pose(
+        tpl_pose_meta0,
+        refer_pose_meta,
+        tpl_pose_metas_new,
+        tql_edit_pose_meta0,
+        refer_edit_pose_meta,
+    )
+
+    pose_metas = []
+    for meta in retarget_tpl_pose_metas:
+        pose_meta = AAPoseMeta()
+        width, height = meta["width"], meta["height"]
+        pose_meta.width = width
+        pose_meta.height = height
+        pose_meta.kps_body = np.array(meta["keypoints_body"])[:, :2] * (width, height)
+        pose_meta.kps_body_p = np.array(meta["keypoints_body"])[:, 2]
+
+        kps_lhand = []
+        kps_lhand_p = []
+        for each_kps_lhand in meta["keypoints_left_hand"]:
+            if each_kps_lhand is not None:
+                kps_lhand.append([each_kps_lhand.x, each_kps_lhand.y])
+                kps_lhand_p.append(each_kps_lhand.score)
+            else:
+                kps_lhand.append([None, None])
+                kps_lhand_p.append(0.0)
+
+        pose_meta.kps_lhand = np.array(kps_lhand)
+        pose_meta.kps_lhand_p = np.array(kps_lhand_p)
+
+        kps_rhand = []
+        kps_rhand_p = []
+        for each_kps_rhand in meta["keypoints_right_hand"]:
+            if each_kps_rhand is not None:
+                kps_rhand.append([each_kps_rhand.x, each_kps_rhand.y])
+                kps_rhand_p.append(each_kps_rhand.score)
+            else:
+                kps_rhand.append([None, None])
+                kps_rhand_p.append(0.0)
+
+        pose_meta.kps_rhand = np.array(kps_rhand)
+        pose_meta.kps_rhand_p = np.array(kps_rhand_p)
+
+        pose_metas.append(pose_meta)
+
+    return pose_metas


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Supporting Wan Animate (https://huggingface.co/Wan-AI/Wan2.2-Animate-14B-Diffusers)

See issue https://github.com/sgl-project/sglang/issues/13867

Based on PR https://github.com/sgl-project/sglang/pull/15419

## Modifications

This PR introduces a customized orchestration pipeline for the Wan Animate model. By implementing a Segment Loop mechanism, it overcomes VRAM limitations for long video generation. Additionally, it integrates a Data Preprocessing stage that supports direct extraction of pose and face features from raw videos, significantly lowering the barrier to entry for end-users.

### Pipeline Design
#### `WanAnimatePipeline`:
```shell
Preprocessing -> Validation -> Text/Image Encoding -> VAE Encoding -> Video Processing -> Condition Construction -> Segment Loop
```
#### SegmentLoopStage
- The SegmentLoopStage manages the cur_segment index and orchestrates a sub-pipeline consisting of five stages: Conditioning → Timestep → Latent → Denoising → Decoding
- The WanAnimateConditioningStage dynamically slices the Pose/Face conditions for the current segment.
- The DecodingStage triggers postprocess_decoded_frames for incremental frame stitching and returns a Req object to drive the next iteration or returns OutputBatch to terminate.


<img width="500" height="625" alt="image" src="https://github.com/user-attachments/assets/8b8a09c6-e4e8-42d6-a23b-a1482dbbdada" />

#### Data Preprocessing Stage
We provide a Data Preprocessing Stage, if users provide the onnx model path of the preprocess model, we can directly process the original video passed in by the user instead of the user passing in the preprocessed pose video and face video.

With `preprocess_model_path`:
```shell
sglang generate --model-path Wan-AI/Wan2.2-Animate-14B-Diffusers \
 --prompt='People in the video are doing actions.' --image-path [ref image path] --video-path [video path] --preprocess-model-path [process model path] --width  1280 --height 720 --save-output 
```

Without `preprocess_model_path`:
```shell
sglang generate --model-path Wan-AI/Wan2.2-Animate-14B-Diffusers\\n --prompt='People in the video are doing actions.'  --image-path [ref image path] --pose-video-path [processed pose video path] --face-video-path [processed face video path] --width  1280 --height 720 --save-output 
```
## TODO
- replace mode for wan animate
- retarget and use flux for data preprocess

## Accuracy Tests
Replicate.com wan animate animation:

https://github.com/user-attachments/assets/f02381bf-6d8a-44bf-a026-492a6e0764e9


Our results:

https://github.com/user-attachments/assets/891e7f4b-cbab-4e38-ab98-558c22ff3c9e


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
