### PR TITLE
[WIP] add AMD flashinfer for diffusion tests

### DIFF
--- a/scripts/ci/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd_ci_install_dependency.sh
@@ -91,7 +91,10 @@ docker cp ./dummy-grok ci_sglang:/
 
 docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache huggingface_hub[hf_xet]
 docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache pytest
-
+if [[ "$OPTIONAL_DEPS" == *"diffusion"* ]]; then
+    echo "Installing ROCm flashinfer for diffusion tests..."
+    docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache flashinfer --extra-index-url=https://pypi.amd.com/simple
+fi
 # Detect AITER version
 #############################################
 # Detect correct AITER_COMMIT for this runner


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
It seems that qwen-image has been dependent on flashinfer since the [51dbdb2](https://github.com/sgl-project/sglang/commit/51dbdb22026d2d13b1957a9bc0b8660be1561576#diff-a1d4f7adbfc068b3af9b02dbca9fda29b80c734364bc03d6e251600dafbdf6b4) while the AMD test environment does not have flashinfer installed. Below is the error message:
```
  0%|          | 0/5 [00:00<?, ?it/s][12-26 22:39:36] [denoising_step_0] Error during execution after 346.3030 ms: flashinfer is required
Traceback (most recent call last):
  File "/sglang-checkout/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1001, in forward
    noise_pred = self._predict_noise_with_cfg(
  File "/sglang-checkout/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1252, in _predict_noise_with_cfg
    noise_pred_cond = self._predict_noise(
  File "/sglang-checkout/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py", line 1198, in _predict_noise
    return current_model(
  File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
  File "/sglang-checkout/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py", line 976, in forward
    encoder_hidden_states, hidden_states = block(
  File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
  File "/sglang-checkout/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py", line 778, in forward
    attn_output = self.attn(
  File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
  File "/sglang-checkout/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py", line 565, in forward
    raise RuntimeError("flashinfer is required")
RuntimeError: flashinfer is required
```
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
