### PR TITLE
[diffusion] lora: Fix/qkv fuse lora breakage

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
@@ -1,6 +1,11 @@
+# =========================
+# File 2: LoRAFormatAdapter (e.g. sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py)
+# =========================
+
 from __future__ import annotations
 
 import logging
+import re
 from enum import Enum
 from typing import Dict, Iterable, Mapping, Optional
 
@@ -19,6 +24,428 @@ class LoRAFormat(str, Enum):
     XLABS_FLUX = "xlabs-ai"
     KOHYA_FLUX = "kohya-flux"
     WAN = "wan"
+
+
+# ---------------------------------------------------------------------------
+# Qwen-Image specific: fuse split Q/K/V LoRA into fused to_qkv/to_added_qkv
+# ---------------------------------------------------------------------------
+
+
+def apply_lora_alpha_scaling_inplace(
+    sd: Dict[str, torch.Tensor],
+    log: logging.Logger,
+    *,
+    remove_alpha: bool = True,
+    atol: float = 1e-8,
+) -> int:
+    """
+    Bake LoRA scaling (alpha / rank) into lora_B.weight in-place.
+
+    This makes the pipeline correct even if runtime ignores `.alpha`.
+    Returns: number of modules scaled.
+    """
+    scaled = 0
+    keys = list(sd.keys())
+
+    for kA in keys:
+        if not kA.endswith(".lora_A.weight"):
+            continue
+        prefix = kA[: -len(".lora_A.weight")]
+        kB = prefix + ".lora_B.weight"
+        kAlpha = prefix + ".alpha"
+        if kB not in sd or kAlpha not in sd:
+            continue
+
+        A = sd[kA]
+        B = sd[kB]
+        alpha_t = sd[kAlpha]
+
+        # alpha may be scalar tensor or something similar
+        try:
+            alpha_val = float(alpha_t.reshape(-1)[0].item())
+        except Exception:
+            log.warning("[LoRAFormatAdapter] cannot parse alpha for %s", prefix)
+            continue
+
+        layout = _infer_lora_layout(A, B)
+        if layout is None:
+            log.warning("[LoRAFormatAdapter] cannot infer layout for %s", prefix)
+            continue
+
+        if layout == "BA":
+            # A: (r, in), B: (out, r)
+            r = int(A.shape[0])
+        else:
+            # "AB": A: (in, r), B: (r, out)
+            r = int(B.shape[0])
+
+        if r <= 0:
+            continue
+        scale = alpha_val / float(r)
+
+        # If alpha is 0 or extremely small, skip (or keep)
+        if abs(scale) <= atol:
+            # still can zero out if desired; keep conservative
+            continue
+
+        # keep dtype/device consistent (avoid fp32 upcast surprises)
+        scale_t = torch.tensor(scale, device=B.device, dtype=B.dtype)
+        sd[kB] = B * scale_t
+
+        if remove_alpha:
+            sd.pop(kAlpha, None)
+
+        scaled += 1
+
+    if scaled > 0:
+        log.info(
+            "[LoRAFormatAdapter] baked alpha/rank into lora_B for %d modules", scaled
+        )
+    return scaled
+
+
+def _infer_lora_layout(A: torch.Tensor, B: torch.Tensor) -> str | None:
+    """
+    Infer LoRA matmul layout from A/B shapes.
+
+    Return:
+      - "BA" if ΔW = B @ A is valid with (B: out×r, A: r×in)
+      - "AB" if ΔW = A @ B is valid with (A: in×r, B: r×out)
+      - None if neither works / unknown
+    """
+    if A.ndim != 2 or B.ndim != 2:
+        return None
+
+    ba_ok = B.shape[1] == A.shape[0]  # B(out,r) @ A(r,in)
+    ab_ok = A.shape[1] == B.shape[0]  # A(in,r) @ B(r,out)
+
+    if ba_ok and not ab_ok:
+        return "BA"
+    if ab_ok and not ba_ok:
+        return "AB"
+    if ba_ok and ab_ok:
+        # Ambiguous (rare but possible if square-ish). Prefer the one that treats
+        # the smaller dimension as rank.
+        r_ba = int(A.shape[0])
+        r_ab = int(A.shape[1])
+        return "BA" if r_ba <= r_ab else "AB"
+    return None
+
+
+def _block_diag(mats: list[torch.Tensor]) -> torch.Tensor:
+    """Dense block-diagonal concatenation for 2D tensors."""
+    if not mats:
+        raise ValueError("mats must be non-empty")
+    if any(m.ndim != 2 for m in mats):
+        raise ValueError("all mats must be 2D tensors")
+
+    dtype = mats[0].dtype
+    device = mats[0].device
+    rows = sum(int(m.shape[0]) for m in mats)
+    cols = sum(int(m.shape[1]) for m in mats)
+
+    out = torch.zeros((rows, cols), dtype=dtype, device=device)
+    r0 = 0
+    c0 = 0
+    for m in mats:
+        r, c = int(m.shape[0]), int(m.shape[1])
+        out[r0 : r0 + r, c0 : c0 + c] = m
+        r0 += r
+        c0 += c
+    return out
+
+
+def _max_abs_diff(a: torch.Tensor, b: torch.Tensor) -> float:
+    if a.shape != b.shape:
+        return float("inf")
+    try:
+        return (a - b).abs().max().item()
+    except Exception:
+        return float("inf")
+
+
+def _fuse_one_qkv_triplet(
+    sd: Dict[str, torch.Tensor],
+    prefix: str,
+    q: str,
+    k: str,
+    v: str,
+    fused: str,
+    log: logging.Logger,
+    *,
+    atol: float = 1e-5,
+    rtol: float = 1e-3,
+) -> tuple[bool, bool]:
+    """
+    Fuse one (q,k,v) triplet under a shared prefix into a fused projection.
+
+    Returns:
+      (fused_ok, used_blockdiag)
+    """
+    Aq_k = f"{prefix}.{q}.lora_A.weight"
+    Ak_k = f"{prefix}.{k}.lora_A.weight"
+    Av_k = f"{prefix}.{v}.lora_A.weight"
+    Bq_k = f"{prefix}.{q}.lora_B.weight"
+    Bk_k = f"{prefix}.{k}.lora_B.weight"
+    Bv_k = f"{prefix}.{v}.lora_B.weight"
+
+    need = (Aq_k, Ak_k, Av_k, Bq_k, Bk_k, Bv_k)
+    if not all(x in sd for x in need):
+        return False, False
+
+    Aq, Ak, Av = sd[Aq_k], sd[Ak_k], sd[Av_k]
+    Bq, Bk, Bv = sd[Bq_k], sd[Bk_k], sd[Bv_k]
+
+    if any(t.ndim != 2 for t in (Aq, Ak, Av, Bq, Bk, Bv)):
+        return False, False
+
+    # Ensure all tensors are on the same device (avoid block_diag device mismatch).
+    # Prefer Q's device/dtype.
+    dev = Aq.device
+    dtype = Aq.dtype
+    if Ak.device != dev:
+        Ak = Ak.to(dev)
+    if Av.device != dev:
+        Av = Av.to(dev)
+    if Bq.device != dev:
+        Bq = Bq.to(dev)
+    if Bk.device != dev:
+        Bk = Bk.to(dev)
+    if Bv.device != dev:
+        Bv = Bv.to(dev)
+
+    # Keep consistent dtype where reasonable (avoid accidental fp32 expansion).
+    if Ak.dtype != dtype:
+        Ak = Ak.to(dtype)
+    if Av.dtype != dtype:
+        Av = Av.to(dtype)
+    if Bq.dtype != dtype:
+        Bq = Bq.to(dtype)
+    if Bk.dtype != dtype:
+        Bk = Bk.to(dtype)
+    if Bv.dtype != dtype:
+        Bv = Bv.to(dtype)
+
+    layout = _infer_lora_layout(Aq, Bq)
+    if layout is None:
+        return False, False
+    if _infer_lora_layout(Ak, Bk) != layout or _infer_lora_layout(Av, Bv) != layout:
+        return False, False
+
+    # Validate in/out feature dims are compatible
+    if layout == "BA":
+        # A: (r, in), B: (out, r)
+        in_dim = int(Aq.shape[1])
+        out_dim = int(Bq.shape[0])
+
+        if int(Ak.shape[1]) != in_dim or int(Av.shape[1]) != in_dim:
+            return False, False
+        if int(Bk.shape[0]) != out_dim or int(Bv.shape[0]) != out_dim:
+            return False, False
+
+        shared_a = (
+            Aq.shape == Ak.shape
+            and Aq.shape == Av.shape
+            and torch.allclose(Aq, Ak, atol=atol, rtol=rtol)
+            and torch.allclose(Aq, Av, atol=atol, rtol=rtol)
+        )
+
+        if shared_a:
+            # Exact fusion with shared A: concat B on out-dim (rows)
+            A_fused = Aq
+            B_fused = torch.cat([Bq, Bk, Bv], dim=0)  # (3*out, r)
+            used_blockdiag = False
+            log.info(
+                "[LoRAFormatAdapter] QKV A shared at %s.%s, using shared-A fusion (layout=%s).",
+                prefix,
+                fused,
+                layout,
+            )
+        else:
+            # Exact fusion with mismatched A: block-diagonal B and stacked A (rank expands)
+            A_fused = torch.cat([Aq, Ak, Av], dim=0)  # (r_sum, in)
+            B_fused = _block_diag([Bq, Bk, Bv])  # (3*out, r_sum)
+            used_blockdiag = True
+            diff1 = _max_abs_diff(Aq, Ak)
+            diff2 = _max_abs_diff(Aq, Av)
+            log.warning(
+                "[LoRAFormatAdapter] QKV LoRA A mismatch at %s.%s: max|Aq-Ak|=%s max|Aq-Av|=%s. "
+                "Using block-diagonal exact fusion (layout=%s, rank expands).",
+                prefix,
+                fused,
+                diff1,
+                diff2,
+                layout,
+            )
+
+    else:
+        # layout == "AB"
+        # A: (in, r), B: (r, out)
+        in_dim = int(Aq.shape[0])
+        out_dim = int(Bq.shape[1])
+
+        if int(Ak.shape[0]) != in_dim or int(Av.shape[0]) != in_dim:
+            return False, False
+        if int(Bk.shape[1]) != out_dim or int(Bv.shape[1]) != out_dim:
+            return False, False
+
+        shared_a = (
+            Aq.shape == Ak.shape
+            and Aq.shape == Av.shape
+            and torch.allclose(Aq, Ak, atol=atol, rtol=rtol)
+            and torch.allclose(Aq, Av, atol=atol, rtol=rtol)
+        )
+
+        if shared_a:
+            # Exact fusion with shared A: concat B on out-dim (cols)
+            A_fused = Aq
+            B_fused = torch.cat([Bq, Bk, Bv], dim=1)  # (r, 3*out)
+            used_blockdiag = False
+            log.info(
+                "[LoRAFormatAdapter] QKV A shared at %s.%s, using shared-A fusion (layout=%s).",
+                prefix,
+                fused,
+                layout,
+            )
+        else:
+            # Exact fusion with mismatched A: block-diagonal B and concatenated A on rank-dim
+            A_fused = torch.cat([Aq, Ak, Av], dim=1)  # (in, r_sum)
+            B_fused = _block_diag([Bq, Bk, Bv])  # (r_sum, 3*out)
+            used_blockdiag = True
+            diff1 = _max_abs_diff(Aq, Ak)
+            diff2 = _max_abs_diff(Aq, Av)
+            log.warning(
+                "[LoRAFormatAdapter] QKV LoRA A mismatch at %s.%s: max|Aq-Ak|=%s max|Aq-Av|=%s. "
+                "Using block-diagonal exact fusion (layout=%s, rank expands).",
+                prefix,
+                fused,
+                diff1,
+                diff2,
+                layout,
+            )
+
+    fused_A_k = f"{prefix}.{fused}.lora_A.weight"
+    fused_B_k = f"{prefix}.{fused}.lora_B.weight"
+    sd[fused_A_k] = A_fused
+    sd[fused_B_k] = B_fused
+
+    # Copy alpha from Q-proj if present (pipeline currently ignores alpha, but keep for completeness)
+    alpha_q = f"{prefix}.{q}.alpha"
+    if alpha_q in sd:
+        sd[f"{prefix}.{fused}.alpha"] = sd[alpha_q]
+
+    # Remove old split keys (avoid downstream collisions / confusion)
+    for p in (q, k, v):
+        sd.pop(f"{prefix}.{p}.lora_A.weight", None)
+        sd.pop(f"{prefix}.{p}.lora_B.weight", None)
+        sd.pop(f"{prefix}.{p}.alpha", None)
+
+    return True, used_blockdiag
+
+
+def fuse_qkv_like_keys_inplace(
+    sd: Dict[str, torch.Tensor], log: logging.Logger
+) -> dict[str, int]:
+    """
+    In-place fuse split q/k/v (and add_q/k/v) LoRA weights into fused projections.
+
+    This is *exact*:
+      - If Aq==Ak==Av (shared A), we keep A and concat B (standard fused-QKV constraint).
+      - If A differs, we perform block-diagonal exact fusion (rank expands, typically 3r).
+
+    Returns a small stats dict for logging/diagnostics.
+    """
+    patterns = [
+        ("to_q", "to_k", "to_v", "to_qkv"),
+        ("add_q_proj", "add_k_proj", "add_v_proj", "to_added_qkv"),
+    ]
+
+    fused = 0
+    skipped = 0
+    a_mismatch = 0
+    for q, k, v, fused_name in patterns:
+        pat = re.compile(rf"^(?P<prefix>.+\.attn)\.{re.escape(q)}\.lora_A\.weight$")
+        prefixes = sorted(
+            {
+                m.group("prefix")
+                for key in sd.keys()
+                for m in [pat.match(key)]
+                if m is not None
+            }
+        )
+
+        for prefix in prefixes:
+            # If already fused keys exist, skip
+            if (
+                f"{prefix}.{fused_name}.lora_A.weight" in sd
+                or f"{prefix}.{fused_name}.lora_B.weight" in sd
+            ):
+                continue
+
+            ok, used_blockdiag = _fuse_one_qkv_triplet(
+                sd, prefix, q, k, v, fused_name, log
+            )
+            if ok:
+                fused += 1
+                if used_blockdiag:
+                    a_mismatch += 1
+            else:
+                skipped += 1
+
+    return {"fused": fused, "skipped": skipped, "A_mismatch": a_mismatch}
+
+
+def maybe_fuse_qwen_image_qkv_lora_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, torch.Tensor]:
+    """
+    Fuse split Q/K/V LoRA weights into fused to_qkv / to_added_qkv for Qwen-Image style models.
+
+    Expected split keys (after normalize_lora_state_dict):
+      ...attn.to_q.lora_A.weight / ...attn.to_k... / ...attn.to_v...
+      ...attn.add_q_proj.lora_A.weight / ...add_k_proj... / ...add_v_proj...
+
+    Output fused keys:
+      ...attn.to_qkv.lora_A.weight / ...attn.to_qkv.lora_B.weight
+      ...attn.to_added_qkv.lora_A.weight / ...attn.to_added_qkv.lora_B.weight
+
+    Fusion rule (EXACT, preserves Lightning LoRA semantics):
+      - If Aq/Ak/Av are equal (shared-A), keep A and concatenate B on output dim.
+      - If Aq/Ak/Av differ, perform block-diagonal exact fusion, expanding effective rank
+        (typically from r to 3r).
+
+    Notes:
+      - We strip an optional "diffusion_model." prefix for robustness.
+      - We remove the original split keys after fusing to avoid collisions downstream.
+      - We copy alpha from Q-proj to fused proj if present (pipeline currently ignores alpha).
+    """
+    log = logger or globals()["logger"]
+    if not state_dict:
+        return dict(state_dict)
+
+    # Canonicalize keys: strip optional "diffusion_model." prefix
+    sd: Dict[str, torch.Tensor] = {}
+    for k, v in state_dict.items():
+        if k.startswith("diffusion_model."):
+            k = k[len("diffusion_model.") :]
+        sd[k] = v
+
+    stats = fuse_qkv_like_keys_inplace(sd, log)
+
+    if stats["fused"] > 0:
+        sample = [k for k in sd.keys() if (".to_qkv." in k or ".to_added_qkv." in k)][
+            :20
+        ]
+        log.info(
+            "[LoRAFormatAdapter] fused qkv/add_qkv LoRA: fused=%d skipped=%d A_mismatch=%d, sample fused keys (<=20): %s",
+            stats["fused"],
+            stats["skipped"],
+            stats["A_mismatch"],
+            ", ".join(sample) if sample else "(none)",
+        )
+
+    return sd
 
 
 # ---------------------------------------------------------------------------
@@ -175,7 +602,7 @@ def _convert_qwen_image_standard(
 
         out[new_name] = tensor
 
-    sample = _sample_keys(out.keys(), 20)
+    _ = _sample_keys(out.keys(), 20)
     return out
 
 
@@ -407,6 +834,7 @@ def normalize_lora_state_dict(
     log.info("[LoRAFormatAdapter] detected format: %s", fmt)
 
     normalized = convert_lora_state_dict_by_format(state_dict, fmt, log)
+    apply_lora_alpha_scaling_inplace(normalized, log, remove_alpha=True)
 
     norm_keys = list(normalized.keys())
     if norm_keys:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py
@@ -1,13 +1,10 @@
-# =========================
-# File 2: LoRAFormatAdapter (e.g. sglang/multimodal_gen/runtime/pipelines_core/lora_format_adapter.py)
-# =========================
-
 from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterable, Mapping, Optional
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Sequence
 
 import torch
 from diffusers.loaders import lora_conversion_utils as lcu
@@ -26,113 +23,106 @@ class LoRAFormat(str, Enum):
     WAN = "wan"
 
 
-# ---------------------------------------------------------------------------
-# Qwen-Image specific: fuse split Q/K/V LoRA into fused to_qkv/to_added_qkv
-# ---------------------------------------------------------------------------
-
-
-def apply_lora_alpha_scaling_inplace(
-    sd: Dict[str, torch.Tensor],
-    log: logging.Logger,
+def set_lora_weights_dynamic_rank(
+    layer: Any,
+    lora_A: torch.Tensor,
+    lora_B: torch.Tensor,
     *,
-    remove_alpha: bool = True,
-    atol: float = 1e-8,
-) -> int:
+    lora_path: str | None,
+    strength: float,
+    rank: int = 0,
+    layer_name: str = "",
+    logger: Optional[logging.Logger] = None,
+) -> None:
     """
-    Bake LoRA scaling (alpha / rank) into lora_B.weight in-place.
+    Set LoRA weights on a layer.
 
-    This makes the pipeline correct even if runtime ignores `.alpha`.
-    Returns: number of modules scaled.
+    Prefer layer.set_lora_weights(). If it fails due to rank/shape mismatch,
+    fall back to replacing layer.lora_A/lora_B parameters (inference-oriented).
     """
-    scaled = 0
-    keys = list(sd.keys())
+    log = logger or globals()["logger"]
 
-    for kA in keys:
-        if not kA.endswith(".lora_A.weight"):
-            continue
-        prefix = kA[: -len(".lora_A.weight")]
-        kB = prefix + ".lora_B.weight"
-        kAlpha = prefix + ".alpha"
-        if kB not in sd or kAlpha not in sd:
-            continue
-
-        A = sd[kA]
-        B = sd[kB]
-        alpha_t = sd[kAlpha]
-
-        # alpha may be scalar tensor or something similar
-        try:
-            alpha_val = float(alpha_t.reshape(-1)[0].item())
-        except Exception:
-            log.warning("[LoRAFormatAdapter] cannot parse alpha for %s", prefix)
-            continue
-
-        layout = _infer_lora_layout(A, B)
-        if layout is None:
-            log.warning("[LoRAFormatAdapter] cannot infer layout for %s", prefix)
-            continue
-
-        if layout == "BA":
-            # A: (r, in), B: (out, r)
-            r = int(A.shape[0])
-        else:
-            # "AB": A: (in, r), B: (r, out)
-            r = int(B.shape[0])
-
-        if r <= 0:
-            continue
-        scale = alpha_val / float(r)
-
-        # If alpha is 0 or extremely small, skip (or keep)
-        if abs(scale) <= atol:
-            # still can zero out if desired; keep conservative
-            continue
-
-        # keep dtype/device consistent (avoid fp32 upcast surprises)
-        scale_t = torch.tensor(scale, device=B.device, dtype=B.dtype)
-        sd[kB] = B * scale_t
-
-        if remove_alpha:
-            sd.pop(kAlpha, None)
-
-        scaled += 1
-
-    if scaled > 0:
-        log.info(
-            "[LoRAFormatAdapter] baked alpha/rank into lora_B for %d modules", scaled
+    try:
+        layer.set_lora_weights(lora_A, lora_B, lora_path=lora_path, strength=strength)
+        return
+    except Exception as exc:
+        msg = str(exc).lower()
+        looks_like_shape_issue = isinstance(exc, AssertionError) or any(
+            s in msg for s in ("shape", "size", "rank", "mismatch", "dim")
         )
-    return scaled
+        if not looks_like_shape_issue:
+            raise
+
+        if rank == 0:
+            log.warning(
+                "Layer '%s': set_lora_weights failed (%s). "
+                "Falling back to dynamic parameter replacement (inference-safe).",
+                layer_name,
+                exc,
+            )
+
+        try:
+            if (
+                not hasattr(layer, "lora_A")
+                or getattr(layer, "lora_A") is None
+                or layer.lora_A.shape != lora_A.shape
+            ):
+                layer.lora_A = torch.nn.Parameter(lora_A, requires_grad=False)
+            else:
+                layer.lora_A.data.copy_(lora_A)
+
+            if (
+                not hasattr(layer, "lora_B")
+                or getattr(layer, "lora_B") is None
+                or layer.lora_B.shape != lora_B.shape
+            ):
+                layer.lora_B = torch.nn.Parameter(lora_B, requires_grad=False)
+            else:
+                layer.lora_B.data.copy_(lora_B)
+
+            for attr, val in (
+                ("disable_lora", False),
+                ("merged", False),
+                ("lora_strength", strength),
+                ("lora_path", lora_path),
+            ):
+                if hasattr(layer, attr):
+                    setattr(layer, attr, val)
+        except Exception as exc2:
+            raise RuntimeError(
+                f"Layer '{layer_name}': dynamic-rank fallback failed ({exc2})"
+            ) from exc2
 
 
+# ----------------------------
+# Common tensor helpers
+# ----------------------------
 def _infer_lora_layout(A: torch.Tensor, B: torch.Tensor) -> str | None:
     """
     Infer LoRA matmul layout from A/B shapes.
 
-    Return:
-      - "BA" if ΔW = B @ A is valid with (B: out×r, A: r×in)
-      - "AB" if ΔW = A @ B is valid with (A: in×r, B: r×out)
-      - None if neither works / unknown
+    Returns:
+      - "BA" if ΔW = B @ A (B: out×r, A: r×in)
+      - "AB" if ΔW = A @ B (A: in×r, B: r×out)
     """
     if A.ndim != 2 or B.ndim != 2:
         return None
 
-    ba_ok = B.shape[1] == A.shape[0]  # B(out,r) @ A(r,in)
-    ab_ok = A.shape[1] == B.shape[0]  # A(in,r) @ B(r,out)
+    ba_ok = B.shape[1] == A.shape[0]
+    ab_ok = A.shape[1] == B.shape[0]
 
     if ba_ok and not ab_ok:
         return "BA"
     if ab_ok and not ba_ok:
         return "AB"
     if ba_ok and ab_ok:
-        # Ambiguous (rare but possible if square-ish). Prefer the one that treats
-        # the smaller dimension as rank.
         r_ba = int(A.shape[0])
         r_ab = int(A.shape[1])
         return "BA" if r_ba <= r_ab else "AB"
     return None
 
 
-def _block_diag(mats: list[torch.Tensor]) -> torch.Tensor:
+def _block_diag(mats: Sequence[torch.Tensor]) -> torch.Tensor:
     """Dense block-diagonal concatenation for 2D tensors."""
     if not mats:
         raise ValueError("mats must be non-empty")
@@ -145,8 +135,7 @@ def _block_diag(mats: list[torch.Tensor]) -> torch.Tensor:
     cols = sum(int(m.shape[1]) for m in mats)
 
     out = torch.zeros((rows, cols), dtype=dtype, device=device)
-    r0 = 0
-    c0 = 0
+    r0 = c0 = 0
     for m in mats:
         r, c = int(m.shape[0]), int(m.shape[1])
         out[r0 : r0 + r, c0 : c0 + c] = m
@@ -164,178 +153,141 @@ def _max_abs_diff(a: torch.Tensor, b: torch.Tensor) -> float:
         return float("inf")
 
 
-def _fuse_one_qkv_triplet(
+def _sample_keys(keys: Iterable[str], k: int = 20) -> list[str]:
+    out: list[str] = []
+    for i, key in enumerate(keys):
+        if i >= k:
+            break
+        out.append(key)
+    return out
+
+
+def _strip_diffusion_model_prefix(
+    state_dict: Mapping[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
+    """Return a dict with optional 'diffusion_model.' prefix stripped from keys."""
+    out: Dict[str, torch.Tensor] = {}
+    for k, v in state_dict.items():
+        if k.startswith("diffusion_model."):
+            k = k[len("diffusion_model.") :]
+        out[k] = v
+    return out
+
+
+# ----------------------------
+# Fuse split projections (data-driven)
+# ----------------------------
+@dataclass(frozen=True)
+class _FuseSpec:
+    block_pat: str  # regex alternatives, e.g. "attn|attention"
+    parts: tuple[str, ...]  # e.g. ("to_q","to_k","to_v")
+    fused: str  # e.g. "to_qkv"
+
+
+_QKV_SPECS: tuple[_FuseSpec, ...] = (
+    _FuseSpec("attn|attention", ("to_q", "to_k", "to_v"), "to_qkv"),
+    _FuseSpec(
+        "attn|attention", ("add_q_proj", "add_k_proj", "add_v_proj"), "to_added_qkv"
+    ),
+)
+
+_W13_SPECS: tuple[_FuseSpec, ...] = (
+    _FuseSpec("feed_forward|ffn|mlp", ("w1", "w3"), "w13"),
+)
+
+
+def _fuse_parts(
     sd: Dict[str, torch.Tensor],
     prefix: str,
-    q: str,
-    k: str,
-    v: str,
-    fused: str,
+    parts: Sequence[str],
+    fused_name: str,
     log: logging.Logger,
     *,
     atol: float = 1e-5,
     rtol: float = 1e-3,
 ) -> tuple[bool, bool]:
     """
-    Fuse one (q,k,v) triplet under a shared prefix into a fused projection.
+    Fuse N split projections into a single fused projection.
 
     Returns:
-      (fused_ok, used_blockdiag)
+      (ok, used_blockdiag)
     """
-    Aq_k = f"{prefix}.{q}.lora_A.weight"
-    Ak_k = f"{prefix}.{k}.lora_A.weight"
-    Av_k = f"{prefix}.{v}.lora_A.weight"
-    Bq_k = f"{prefix}.{q}.lora_B.weight"
-    Bk_k = f"{prefix}.{k}.lora_B.weight"
-    Bv_k = f"{prefix}.{v}.lora_B.weight"
-
-    need = (Aq_k, Ak_k, Av_k, Bq_k, Bk_k, Bv_k)
-    if not all(x in sd for x in need):
+    A_keys = [f"{prefix}.{p}.lora_A.weight" for p in parts]
+    B_keys = [f"{prefix}.{p}.lora_B.weight" for p in parts]
+    if not all(k in sd for k in (*A_keys, *B_keys)):
         return False, False
 
-    Aq, Ak, Av = sd[Aq_k], sd[Ak_k], sd[Av_k]
-    Bq, Bk, Bv = sd[Bq_k], sd[Bk_k], sd[Bv_k]
-
-    if any(t.ndim != 2 for t in (Aq, Ak, Av, Bq, Bk, Bv)):
+    As = [sd[k] for k in A_keys]
+    Bs = [sd[k] for k in B_keys]
+    if any(t.ndim != 2 for t in (*As, *Bs)):
         return False, False
 
-    # Ensure all tensors are on the same device (avoid block_diag device mismatch).
-    # Prefer Q's device/dtype.
-    dev = Aq.device
-    dtype = Aq.dtype
-    if Ak.device != dev:
-        Ak = Ak.to(dev)
-    if Av.device != dev:
-        Av = Av.to(dev)
-    if Bq.device != dev:
-        Bq = Bq.to(dev)
-    if Bk.device != dev:
-        Bk = Bk.to(dev)
-    if Bv.device != dev:
-        Bv = Bv.to(dev)
+    ref = As[0]
+    dev, dtype = ref.device, ref.dtype
+    As = [
+        t.to(device=dev, dtype=dtype) if (t.device != dev or t.dtype != dtype) else t
+        for t in As
+    ]
+    Bs = [
+        t.to(device=dev, dtype=dtype) if (t.device != dev or t.dtype != dtype) else t
+        for t in Bs
+    ]
 
-    # Keep consistent dtype where reasonable (avoid accidental fp32 expansion).
-    if Ak.dtype != dtype:
-        Ak = Ak.to(dtype)
-    if Av.dtype != dtype:
-        Av = Av.to(dtype)
-    if Bq.dtype != dtype:
-        Bq = Bq.to(dtype)
-    if Bk.dtype != dtype:
-        Bk = Bk.to(dtype)
-    if Bv.dtype != dtype:
-        Bv = Bv.to(dtype)
-
-    layout = _infer_lora_layout(Aq, Bq)
+    layout = _infer_lora_layout(As[0], Bs[0])
     if layout is None:
         return False, False
-    if _infer_lora_layout(Ak, Bk) != layout or _infer_lora_layout(Av, Bv) != layout:
+    if any(_infer_lora_layout(a, b) != layout for a, b in zip(As, Bs)):
         return False, False
 
-    # Validate in/out feature dims are compatible
+    # Require consistent "in_dim" only; allow ranks/out_dims to differ.
     if layout == "BA":
-        # A: (r, in), B: (out, r)
-        in_dim = int(Aq.shape[1])
-        out_dim = int(Bq.shape[0])
-
-        if int(Ak.shape[1]) != in_dim or int(Av.shape[1]) != in_dim:
+        in_dim = int(As[0].shape[1])
+        if any(int(a.shape[1]) != in_dim for a in As):
             return False, False
-        if int(Bk.shape[0]) != out_dim or int(Bv.shape[0]) != out_dim:
-            return False, False
-
-        shared_a = (
-            Aq.shape == Ak.shape
-            and Aq.shape == Av.shape
-            and torch.allclose(Aq, Ak, atol=atol, rtol=rtol)
-            and torch.allclose(Aq, Av, atol=atol, rtol=rtol)
-        )
-
-        if shared_a:
-            # Exact fusion with shared A: concat B on out-dim (rows)
-            A_fused = Aq
-            B_fused = torch.cat([Bq, Bk, Bv], dim=0)  # (3*out, r)
-            used_blockdiag = False
-            log.info(
-                "[LoRAFormatAdapter] QKV A shared at %s.%s, using shared-A fusion (layout=%s).",
-                prefix,
-                fused,
-                layout,
-            )
-        else:
-            # Exact fusion with mismatched A: block-diagonal B and stacked A (rank expands)
-            A_fused = torch.cat([Aq, Ak, Av], dim=0)  # (r_sum, in)
-            B_fused = _block_diag([Bq, Bk, Bv])  # (3*out, r_sum)
-            used_blockdiag = True
-            diff1 = _max_abs_diff(Aq, Ak)
-            diff2 = _max_abs_diff(Aq, Av)
-            log.warning(
-                "[LoRAFormatAdapter] QKV LoRA A mismatch at %s.%s: max|Aq-Ak|=%s max|Aq-Av|=%s. "
-                "Using block-diagonal exact fusion (layout=%s, rank expands).",
-                prefix,
-                fused,
-                diff1,
-                diff2,
-                layout,
-            )
-
     else:
-        # layout == "AB"
-        # A: (in, r), B: (r, out)
-        in_dim = int(Aq.shape[0])
-        out_dim = int(Bq.shape[1])
-
-        if int(Ak.shape[0]) != in_dim or int(Av.shape[0]) != in_dim:
-            return False, False
-        if int(Bk.shape[1]) != out_dim or int(Bv.shape[1]) != out_dim:
+        in_dim = int(As[0].shape[0])
+        if any(int(a.shape[0]) != in_dim for a in As):
             return False, False
 
-        shared_a = (
-            Aq.shape == Ak.shape
-            and Aq.shape == Av.shape
-            and torch.allclose(Aq, Ak, atol=atol, rtol=rtol)
-            and torch.allclose(Aq, Av, atol=atol, rtol=rtol)
+    shared_a = all(
+        As[0].shape == a.shape and torch.allclose(As[0], a, atol=atol, rtol=rtol)
+        for a in As[1:]
+    )
+
+    used_blockdiag = not shared_a
+    if shared_a:
+        A_fused = As[0]
+        B_fused = torch.cat(Bs, dim=0 if layout == "BA" else 1)
+        log.info(
+            "[LoRAFormatAdapter] fuse %s: shared-A fusion at %s.%s (layout=%s, parts=%s)",
+            fused_name,
+            prefix,
+            fused_name,
+            layout,
+            ",".join(parts),
+        )
+    else:
+        A_fused = torch.cat(As, dim=0 if layout == "BA" else 1)
+        B_fused = _block_diag(Bs)
+        diffs = [_max_abs_diff(As[0], a) for a in As[1:]]
+        log.warning(
+            "[LoRAFormatAdapter] fuse %s: A mismatch at %s.%s (max|A0-Ai|=%s). "
+            "Using block-diagonal exact fusion (layout=%s, rank expands).",
+            fused_name,
+            prefix,
+            fused_name,
+            max(diffs) if diffs else 0.0,
+            layout,
         )
 
-        if shared_a:
-            # Exact fusion with shared A: concat B on out-dim (cols)
-            A_fused = Aq
-            B_fused = torch.cat([Bq, Bk, Bv], dim=1)  # (r, 3*out)
-            used_blockdiag = False
-            log.info(
-                "[LoRAFormatAdapter] QKV A shared at %s.%s, using shared-A fusion (layout=%s).",
-                prefix,
-                fused,
-                layout,
-            )
-        else:
-            # Exact fusion with mismatched A: block-diagonal B and concatenated A on rank-dim
-            A_fused = torch.cat([Aq, Ak, Av], dim=1)  # (in, r_sum)
-            B_fused = _block_diag([Bq, Bk, Bv])  # (r_sum, 3*out)
-            used_blockdiag = True
-            diff1 = _max_abs_diff(Aq, Ak)
-            diff2 = _max_abs_diff(Aq, Av)
-            log.warning(
-                "[LoRAFormatAdapter] QKV LoRA A mismatch at %s.%s: max|Aq-Ak|=%s max|Aq-Av|=%s. "
-                "Using block-diagonal exact fusion (layout=%s, rank expands).",
-                prefix,
-                fused,
-                diff1,
-                diff2,
-                layout,
-            )
+    sd[f"{prefix}.{fused_name}.lora_A.weight"] = A_fused
+    sd[f"{prefix}.{fused_name}.lora_B.weight"] = B_fused
 
-    fused_A_k = f"{prefix}.{fused}.lora_A.weight"
-    fused_B_k = f"{prefix}.{fused}.lora_B.weight"
-    sd[fused_A_k] = A_fused
-    sd[fused_B_k] = B_fused
+    alpha0 = f"{prefix}.{parts[0]}.alpha"
+    if alpha0 in sd:
+        sd[f"{prefix}.{fused_name}.alpha"] = sd[alpha0]
 
-    # Copy alpha from Q-proj if present (pipeline currently ignores alpha, but keep for completeness)
-    alpha_q = f"{prefix}.{q}.alpha"
-    if alpha_q in sd:
-        sd[f"{prefix}.{fused}.alpha"] = sd[alpha_q]
-
-    # Remove old split keys (avoid downstream collisions / confusion)
-    for p in (q, k, v):
+    for p in parts:
         sd.pop(f"{prefix}.{p}.lora_A.weight", None)
         sd.pop(f"{prefix}.{p}.lora_B.weight", None)
         sd.pop(f"{prefix}.{p}.alpha", None)
@@ -343,32 +295,17 @@ def _fuse_one_qkv_triplet(
     return True, used_blockdiag
 
 
-def fuse_qkv_like_keys_inplace(
-    sd: Dict[str, torch.Tensor], log: logging.Logger
+def _fuse_specs_inplace(
+    sd: Dict[str, torch.Tensor], specs: Sequence[_FuseSpec], log: logging.Logger
 ) -> dict[str, int]:
-    """
-    In-place fuse split q/k/v (and add_q/k/v) LoRA weights into fused projections.
+    """Apply fuse specs in-place. Returns stats dict."""
+    fused = skipped = a_mismatch = 0
 
-    This is *exact*:
-      - If Aq==Ak==Av (shared A), we keep A and concat B (standard fused-QKV constraint).
-      - If A differs, we perform block-diagonal exact fusion (rank expands, typically 3r).
-
-    Returns a small stats dict for logging/diagnostics.
-    """
-    patterns = [
-        ("to_q", "to_k", "to_v", "to_qkv"),
-        ("add_q_proj", "add_k_proj", "add_v_proj", "to_added_qkv"),
-    ]
-
-    fused = 0
-    skipped = 0
-    a_mismatch = 0
-    for q, k, v, fused_name in patterns:
-        # Support both "...attn.*" and "...attention.*"
+    for spec in specs:
+        p0 = re.escape(spec.parts[0])
         pat = re.compile(
-            rf"^(?P<prefix>.+\.(?:attn|attention))\.{re.escape(q)}\.lora_A\.weight$"
+            rf"^(?P<prefix>.+\.(?:{spec.block_pat}))\.{p0}\.lora_A\.weight$"
         )
-
         prefixes = sorted(
             {
                 m.group("prefix")
@@ -379,16 +316,13 @@ def fuse_qkv_like_keys_inplace(
         )
 
         for prefix in prefixes:
-            # If already fused keys exist, skip
             if (
-                f"{prefix}.{fused_name}.lora_A.weight" in sd
-                or f"{prefix}.{fused_name}.lora_B.weight" in sd
+                f"{prefix}.{spec.fused}.lora_A.weight" in sd
+                or f"{prefix}.{spec.fused}.lora_B.weight" in sd
             ):
                 continue
 
-            ok, used_blockdiag = _fuse_one_qkv_triplet(
-                sd, prefix, q, k, v, fused_name, log
-            )
+            ok, used_blockdiag = _fuse_parts(sd, prefix, spec.parts, spec.fused, log)
             if ok:
                 fused += 1
                 if used_blockdiag:
@@ -399,313 +333,226 @@ def fuse_qkv_like_keys_inplace(
     return {"fused": fused, "skipped": skipped, "A_mismatch": a_mismatch}
 
 
-def maybe_fuse_qwen_image_qkv_lora_state_dict(
-    state_dict: Mapping[str, torch.Tensor],
-    logger: Optional[logging.Logger] = None,
-) -> Dict[str, torch.Tensor]:
-    """
-    Fuse split Q/K/V LoRA weights into fused to_qkv / to_added_qkv for Qwen-Image style models.
-
-    Expected split keys (after normalize_lora_state_dict):
-      ...attn.to_q.lora_A.weight / ...attn.to_k... / ...attn.to_v...
-      ...attn.add_q_proj.lora_A.weight / ...add_k_proj... / ...add_v_proj...
-
-    Output fused keys:
-      ...attn.to_qkv.lora_A.weight / ...attn.to_qkv.lora_B.weight
-      ...attn.to_added_qkv.lora_A.weight / ...attn.to_added_qkv.lora_B.weight
-
-    Fusion rule (EXACT, preserves Lightning LoRA semantics):
-      - If Aq/Ak/Av are equal (shared-A), keep A and concatenate B on output dim.
-      - If Aq/Ak/Av differ, perform block-diagonal exact fusion, expanding effective rank
-        (typically from r to 3r).
-
-    Notes:
-      - We strip an optional "diffusion_model." prefix for robustness.
-      - We remove the original split keys after fusing to avoid collisions downstream.
-      - We copy alpha from Q-proj to fused proj if present (pipeline currently ignores alpha).
-    """
-    log = logger or globals()["logger"]
-    if not state_dict:
-        return dict(state_dict)
-
-    # Canonicalize keys: strip optional "diffusion_model." prefix
-    sd: Dict[str, torch.Tensor] = {}
-    for k, v in state_dict.items():
-        if k.startswith("diffusion_model."):
-            k = k[len("diffusion_model.") :]
-        sd[k] = v
-
-    stats = fuse_qkv_like_keys_inplace(sd, log)
-
-    if stats["fused"] > 0:
-        sample = [k for k in sd.keys() if (".to_qkv." in k or ".to_added_qkv." in k)][
-            :20
-        ]
-        log.info(
-            "[LoRAFormatAdapter] fused qkv/add_qkv LoRA: fused=%d skipped=%d A_mismatch=%d, sample fused keys (<=20): %s",
-            stats["fused"],
-            stats["skipped"],
-            stats["A_mismatch"],
-            ", ".join(sample) if sample else "(none)",
-        )
-
-    return sd
-
-
-# ---------------------------------------------------------------------------
-# Fuse split FFN w1/w3 LoRA into fused w13 (SwiGLU gate+up projection)
-# ---------------------------------------------------------------------------
-
-
-def _fuse_one_w13_pair(
-    sd: Dict[str, torch.Tensor],
-    prefix: str,
-    w1: str,
-    w3: str,
-    fused: str,
-    log: logging.Logger,
-    *,
-    atol: float = 1e-5,
-    rtol: float = 1e-3,
-) -> tuple[bool, bool]:
-    """
-    Fuse one (w1, w3) pair under a shared FFN prefix into fused projection (w13).
-
-    Returns:
-      (fused_ok, used_blockdiag)
-
-    Exact fusion:
-      - If A1 == A3: keep A, concat B along output dim.
-      - Else: block-diagonal exact fusion (rank expands).
-    """
-    A1_k = f"{prefix}.{w1}.lora_A.weight"
-    A3_k = f"{prefix}.{w3}.lora_A.weight"
-    B1_k = f"{prefix}.{w1}.lora_B.weight"
-    B3_k = f"{prefix}.{w3}.lora_B.weight"
-
-    need = (A1_k, A3_k, B1_k, B3_k)
-    if not all(k in sd for k in need):
-        return False, False
-
-    A1, A3 = sd[A1_k], sd[A3_k]
-    B1, B3 = sd[B1_k], sd[B3_k]
-
-    if any(t.ndim != 2 for t in (A1, A3, B1, B3)):
-        return False, False
-
-    # Align device/dtype (avoid block_diag mismatch / fp32 surprises)
-    dev = A1.device
-    dtype = A1.dtype
-    if A3.device != dev:
-        A3 = A3.to(dev)
-    if B1.device != dev:
-        B1 = B1.to(dev)
-    if B3.device != dev:
-        B3 = B3.to(dev)
-
-    if A3.dtype != dtype:
-        A3 = A3.to(dtype)
-    if B1.dtype != dtype:
-        B1 = B1.to(dtype)
-    if B3.dtype != dtype:
-        B3 = B3.to(dtype)
-
-    layout = _infer_lora_layout(A1, B1)
-    if layout is None:
-        return False, False
-    if _infer_lora_layout(A3, B3) != layout:
-        return False, False
-
-    # Validate in_dim matches
-    if layout == "BA":
-        # A: (r, in), B: (out, r)
-        in_dim = int(A1.shape[1])
-        if int(A3.shape[1]) != in_dim:
-            return False, False
-        # out dims can differ; w13 out = out1 + out3, so no strict equality required.
-
-        shared_a = A1.shape == A3.shape and torch.allclose(A1, A3, atol=atol, rtol=rtol)
-
-        if shared_a:
-            A_fused = A1
-            B_fused = torch.cat([B1, B3], dim=0)  # (out1+out3, r)
-            used_blockdiag = False
-            log.info(
-                "[LoRAFormatAdapter] FFN w1/w3 A shared at %s.%s, using shared-A fusion (layout=%s).",
-                prefix,
-                fused,
-                layout,
-            )
-        else:
-            # Exact block-diag fusion: (B1@A1 ; B3@A3)
-            A_fused = torch.cat([A1, A3], dim=0)  # (r1+r3, in)
-            B_fused = _block_diag([B1, B3])  # (out1+out3, r1+r3)
-            used_blockdiag = True
-            diff = _max_abs_diff(A1, A3)
-            log.warning(
-                "[LoRAFormatAdapter] FFN w1/w3 LoRA A mismatch at %s.%s: max|A1-A3|=%s. "
-                "Using block-diagonal exact fusion (layout=%s, rank expands).",
-                prefix,
-                fused,
-                diff,
-                layout,
-            )
-
-    else:
-        # layout == "AB"
-        # A: (in, r), B: (r, out)
-        in_dim = int(A1.shape[0])
-        if int(A3.shape[0]) != in_dim:
-            return False, False
-
-        shared_a = A1.shape == A3.shape and torch.allclose(A1, A3, atol=atol, rtol=rtol)
-
-        if shared_a:
-            A_fused = A1
-            B_fused = torch.cat([B1, B3], dim=1)  # (r, out1+out3)
-            used_blockdiag = False
-            log.info(
-                "[LoRAFormatAdapter] FFN w1/w3 A shared at %s.%s, using shared-A fusion (layout=%s).",
-                prefix,
-                fused,
-                layout,
-            )
-        else:
-            A_fused = torch.cat([A1, A3], dim=1)  # (in, r1+r3)
-            B_fused = _block_diag([B1, B3])  # (r1+r3, out1+out3)
-            used_blockdiag = True
-            diff = _max_abs_diff(A1, A3)
-            log.warning(
-                "[LoRAFormatAdapter] FFN w1/w3 LoRA A mismatch at %s.%s: max|A1-A3|=%s. "
-                "Using block-diagonal exact fusion (layout=%s, rank expands).",
-                prefix,
-                fused,
-                diff,
-                layout,
-            )
-
-    fused_A_k = f"{prefix}.{fused}.lora_A.weight"
-    fused_B_k = f"{prefix}.{fused}.lora_B.weight"
-    sd[fused_A_k] = A_fused
-    sd[fused_B_k] = B_fused
-
-    # Copy alpha if still present (often already baked & removed)
-    alpha_1 = f"{prefix}.{w1}.alpha"
-    if alpha_1 in sd:
-        sd[f"{prefix}.{fused}.alpha"] = sd[alpha_1]
-
-    # Remove old split keys
-    for p in (w1, w3):
-        sd.pop(f"{prefix}.{p}.lora_A.weight", None)
-        sd.pop(f"{prefix}.{p}.lora_B.weight", None)
-        sd.pop(f"{prefix}.{p}.alpha", None)
-
-    return True, used_blockdiag
+# Back-compat wrappers — keep these names in case other code imports them.
+def fuse_qkv_like_keys_inplace(
+    sd: Dict[str, torch.Tensor], log: logging.Logger
+) -> dict[str, int]:
+    return _fuse_specs_inplace(sd, _QKV_SPECS, log)
 
 
 def fuse_w13_like_keys_inplace(
     sd: Dict[str, torch.Tensor], log: logging.Logger
 ) -> dict[str, int]:
-    """
-    In-place fuse split FFN w1/w3 LoRA into fused w13.
+    return _fuse_specs_inplace(sd, _W13_SPECS, log)
 
-    Supports prefixes like:
-      ...feed_forward.w1 / ...feed_forward.w3
-      ...ffn.w1 / ...ffn.w3
-      ...mlp.w1 / ...mlp.w3
 
-    Returns stats for logging/diagnostics.
-    """
-    fused = 0
-    skipped = 0
-    a_mismatch = 0
+def _maybe_fuse_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    *,
+    specs: Sequence[_FuseSpec],
+    sample_pred: Callable[[str], bool],
+    log_prefix: str,
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, torch.Tensor]:
+    log = logger or globals()["logger"]
+    if not state_dict:
+        return dict(state_dict)
 
-    # Match both Z-Image naming ("feed_forward") and possible variants ("ffn"/"mlp")
-    pat = re.compile(r"^(?P<prefix>.+\.(?:feed_forward|ffn|mlp))\.w1\.lora_A\.weight$")
+    sd = _strip_diffusion_model_prefix(state_dict)
+    stats = _fuse_specs_inplace(sd, specs, log)
 
-    prefixes = sorted(
-        {
-            m.group("prefix")
-            for key in sd.keys()
-            for m in [pat.match(key)]
-            if m is not None
-        }
+    if stats["fused"] > 0:
+        sample = [k for k in sd.keys() if sample_pred(k)][:20]
+        log.info(
+            "[LoRAFormatAdapter] fused %s LoRA: fused=%d skipped=%d A_mismatch=%d, sample keys (<=20): %s",
+            log_prefix,
+            stats["fused"],
+            stats["skipped"],
+            stats["A_mismatch"],
+            ", ".join(sample) if sample else "(none)",
+        )
+    return sd
+
+
+def maybe_fuse_qwen_image_qkv_lora_state_dict(
+    state_dict: Mapping[str, torch.Tensor],
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, torch.Tensor]:
+    return _maybe_fuse_state_dict(
+        state_dict,
+        specs=_QKV_SPECS,
+        sample_pred=lambda k: (".to_qkv." in k or ".to_added_qkv." in k),
+        log_prefix="qkv/add_qkv",
+        logger=logger,
     )
-
-    for prefix in prefixes:
-        # If already fused exists, skip
-        if f"{prefix}.w13.lora_A.weight" in sd or f"{prefix}.w13.lora_B.weight" in sd:
-            continue
-
-        ok, used_blockdiag = _fuse_one_w13_pair(sd, prefix, "w1", "w3", "w13", log)
-        if ok:
-            fused += 1
-            if used_blockdiag:
-                a_mismatch += 1
-        else:
-            skipped += 1
-
-    return {"fused": fused, "skipped": skipped, "A_mismatch": a_mismatch}
 
 
 def maybe_fuse_w13_lora_state_dict(
     state_dict: Mapping[str, torch.Tensor],
     logger: Optional[logging.Logger] = None,
 ) -> Dict[str, torch.Tensor]:
+    return _maybe_fuse_state_dict(
+        state_dict,
+        specs=_W13_SPECS,
+        sample_pred=lambda k: ".w13." in k,
+        log_prefix="w1/w3->w13",
+        logger=logger,
+    )
+
+
+# ----------------------------
+# Alpha bake
+# ----------------------------
+def apply_lora_alpha_scaling_inplace(
+    sd: Dict[str, torch.Tensor],
+    log: logging.Logger,
+    *,
+    remove_alpha: bool = True,
+    atol: float = 1e-8,
+) -> int:
+    """Bake (alpha / rank) scaling into lora_B.weight. Returns #modules scaled."""
+    scaled = 0
+    for kA in list(sd.keys()):
+        if not kA.endswith(".lora_A.weight"):
+            continue
+        prefix = kA[: -len(".lora_A.weight")]
+        kB = prefix + ".lora_B.weight"
+        kAlpha = prefix + ".alpha"
+        if kB not in sd or kAlpha not in sd:
+            continue
+
+        A, B, alpha_t = sd[kA], sd[kB], sd[kAlpha]
+        try:
+            alpha_val = float(alpha_t.reshape(-1)[0].item())
+        except Exception:
+            log.warning("[LoRAFormatAdapter] cannot parse alpha for %s", prefix)
+            continue
+
+        layout = _infer_lora_layout(A, B)
+        if layout is None:
+            log.warning("[LoRAFormatAdapter] cannot infer layout for %s", prefix)
+            continue
+
+        r = int(A.shape[0]) if layout == "BA" else int(B.shape[0])
+        if r <= 0:
+            continue
+
+        scale = alpha_val / float(r)
+        if abs(scale) <= atol:
+            continue
+
+        sd[kB] = B * torch.tensor(scale, device=B.device, dtype=B.dtype)
+        if remove_alpha:
+            sd.pop(kAlpha, None)
+        scaled += 1
+
+    if scaled:
+        log.info(
+            "[LoRAFormatAdapter] baked alpha/rank into lora_B for %d modules", scaled
+        )
+    return scaled
+
+
+# ----------------------------
+# Target-aware fuse decisions
+# ----------------------------
+def _inspect_target_fused(target_layer_names: Iterable[str]) -> dict[str, bool]:
+    """Inspect target module names for fused projections we may need to adapt to."""
+    names = list(target_layer_names)
+
+    def has_suffix(*suffixes: str) -> bool:
+        return any(n.endswith(suffixes) for n in names)
+
+    return {
+        "to_qkv": has_suffix("attn.to_qkv", "attention.to_qkv"),
+        "to_added_qkv": has_suffix("attn.to_added_qkv", "attention.to_added_qkv"),
+        "w13": has_suffix("feed_forward.w13", "ffn.w13", "mlp.w13"),
+    }
+
+
+def _inspect_sd_split(sd: Mapping[str, torch.Tensor]) -> dict[str, bool]:
+    keys = sd.keys()
+
+    def any_contains(*subs: str) -> bool:
+        return any(any(s in k for s in subs) for k in keys)
+
+    return {
+        "split_qkv": any_contains(
+            ".attn.to_q.lora_A.weight", ".attention.to_q.lora_A.weight"
+        ),
+        "split_added_qkv": any_contains(
+            ".attn.add_q_proj.lora_A.weight", ".attention.add_q_proj.lora_A.weight"
+        ),
+        "split_w1": any_contains(
+            ".feed_forward.w1.lora_A.weight",
+            ".ffn.w1.lora_A.weight",
+            ".mlp.w1.lora_A.weight",
+        ),
+        "split_w3": any_contains(
+            ".feed_forward.w3.lora_A.weight",
+            ".ffn.w3.lora_A.weight",
+            ".mlp.w3.lora_A.weight",
+        ),
+    }
+
+
+def prepare_lora_state_dict_for_target(
+    raw_state_dict: Mapping[str, torch.Tensor],
+    target_lora_layer_names: Optional[Iterable[str]] = None,
+    logger: Optional[logging.Logger] = None,
+    *,
+    rank: int | None = None,
+    fuse_qkv: bool = True,
+    fuse_w13: bool = True,
+) -> Dict[str, torch.Tensor]:
     """
-    Fuse split FFN w1/w3 LoRA into fused w13 when target model uses fused w13.
-
-    Input keys (after normalize_lora_state_dict):
-      ...feed_forward.w1.lora_A.weight / ...w1.lora_B.weight
-      ...feed_forward.w3.lora_A.weight / ...w3.lora_B.weight
-
-    Output:
-      ...feed_forward.w13.lora_A.weight / ...w13.lora_B.weight
-
-    Notes:
-      - Strips optional "diffusion_model." prefix.
-      - Removes original split keys after fusing.
+    Normalize an external LoRA state_dict and (optionally) fuse keys to match
+    target fused projections (to_qkv/to_added_qkv, w13).
     """
     log = logger or globals()["logger"]
-    if not state_dict:
-        return dict(state_dict)
+    is_rank0 = (rank is None) or (rank == 0)
 
-    # Canonicalize keys: strip optional "diffusion_model." prefix
-    sd: Dict[str, torch.Tensor] = {}
-    for k, v in state_dict.items():
-        if k.startswith("diffusion_model."):
-            k = k[len("diffusion_model.") :]
-        sd[k] = v
+    sd = normalize_lora_state_dict(raw_state_dict, logger=log)
 
-    stats = fuse_w13_like_keys_inplace(sd, log)
+    if not target_lora_layer_names:
+        return sd
+    target_names = list(target_lora_layer_names)
+    if not target_names:
+        return sd
 
-    if stats["fused"] > 0:
-        sample = [k for k in sd.keys() if ".w13." in k][:20]
+    tgt = _inspect_target_fused(target_names)
+    src = _inspect_sd_split(sd)
+
+    if is_rank0:
         log.info(
-            "[LoRAFormatAdapter] fused w1/w3->w13 LoRA: fused=%d skipped=%d A_mismatch=%d, sample fused keys (<=20): %s",
-            stats["fused"],
-            stats["skipped"],
-            stats["A_mismatch"],
-            ", ".join(sample) if sample else "(none)",
+            "[LoRAFormatAdapter] target-aware fuse check: "
+            "target_to_qkv=%s sd_split_qkv=%s "
+            "target_to_added_qkv=%s sd_split_added=%s "
+            "target_w13=%s sd_split_w1=%s sd_split_w3=%s",
+            tgt["to_qkv"],
+            src["split_qkv"],
+            tgt["to_added_qkv"],
+            src["split_added_qkv"],
+            tgt["w13"],
+            src["split_w1"],
+            src["split_w3"],
         )
+
+    if fuse_qkv and (
+        (tgt["to_qkv"] and src["split_qkv"])
+        or (tgt["to_added_qkv"] and src["split_added_qkv"])
+    ):
+        sd = maybe_fuse_qwen_image_qkv_lora_state_dict(sd, logger=log)
+
+    if fuse_w13 and tgt["w13"] and src["split_w1"] and src["split_w3"]:
+        sd = maybe_fuse_w13_lora_state_dict(sd, logger=log)
 
     return sd
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _sample_keys(keys: Iterable[str], k: int = 20) -> list[str]:
-    out = []
-    for i, key in enumerate(keys):
-        if i >= k:
-            break
-        out.append(key)
-    return out
-
-
+# ----------------------------
+# Format detection & conversion
+# ----------------------------
 def _has_substring_key(keys: Iterable[str], substr: str) -> bool:
     return any(substr in k for k in keys)
 
@@ -714,16 +561,10 @@ def _has_prefix_key(keys: Iterable[str], prefix: str) -> bool:
     return any(k.startswith(prefix) for k in keys)
 
 
-# ---------------------------------------------------------------------------
-# Format-specific heuristics
-# ---------------------------------------------------------------------------
-
-
 def _looks_like_xlabs_flux_key(k: str) -> bool:
     """XLabs FLUX-style keys under double_blocks/single_blocks with lora down/up."""
     if not (k.endswith(".down.weight") or k.endswith(".up.weight")):
         return False
-
     if not k.startswith(
         (
             "double_blocks.",
@@ -733,65 +574,124 @@ def _looks_like_xlabs_flux_key(k: str) -> bool:
         )
     ):
         return False
-
-    return ".processor." in k or ".proj_lora" in k or ".qkv_lora" in k
+    return (".processor." in k) or (".proj_lora" in k) or (".qkv_lora" in k)
 
 
 def _looks_like_kohya_flux(state_dict: Mapping[str, torch.Tensor]) -> bool:
-    """Kohya FLUX LoRA (flux_lora.py) under lora_unet_double/single_blocks_ prefixes."""
-    if not state_dict:
-        return False
-    keys = state_dict.keys()
+    """Kohya FLUX LoRA (flux_lora.py) prefixes."""
     return any(
         k.startswith("lora_unet_double_blocks_")
         or k.startswith("lora_unet_single_blocks_")
-        for k in keys
+        for k in state_dict.keys()
     )
 
 
 def _looks_like_non_diffusers_sd(state_dict: Mapping[str, torch.Tensor]) -> bool:
     """Classic non-diffusers SD LoRA (Kohya/A1111/sd-scripts)."""
-    if not state_dict:
-        return False
-    keys = state_dict.keys()
-    return all(
+    keys = list(state_dict.keys())
+    return bool(keys) and all(
         k.startswith(("lora_unet_", "lora_te_", "lora_te1_", "lora_te2_")) for k in keys
     )
 
 
+def _looks_like_non_diffusers_qwen_unet(state_dict: Mapping[str, torch.Tensor]) -> bool:
+    """A1111/kohya SD-LoRA keys that target Qwen-Image transformer blocks."""
+    return any(
+        k.startswith("lora_unet_transformer_blocks_")
+        or k.startswith("diffusion_model.lora_unet_transformer_blocks_")
+        for k in state_dict.keys()
+    )
+
+
+# --- Clean Qwen rewrite: single regex + token map ---
+_QWEN_UNET_PREFIX_RE = re.compile(r"^lora_unet_transformer_blocks_(\d+)_([^.]+)\.")
+
+_QWEN_UNET_TOKEN_MAP: dict[str, str] = {
+    f"attn_to_{x}": f"attn.to_{x}" for x in ("q", "k", "v")
+}
+_QWEN_UNET_TOKEN_MAP.update(
+    {
+        "attn_to_out_0": "attn.to_out.0",
+        "attn_add_q_proj": "attn.add_q_proj",
+        "attn_add_k_proj": "attn.add_k_proj",
+        "attn_add_v_proj": "attn.add_v_proj",
+        "attn_to_add_out": "attn.to_add_out",
+        "img_mlp_net_0_proj": "img_mlp.net.0.proj",
+        "img_mlp_net_2": "img_mlp.net.2",
+        "txt_mlp_net_0_proj": "txt_mlp.net.0.proj",
+        "txt_mlp_net_2": "txt_mlp.net.2",
+        "img_mod_1": "img_mod.1",
+        "txt_mod_1": "txt_mod.1",
+    }
+)
+
+
+def _rewrite_non_diffusers_qwen_key(key: str) -> str:
+    """
+    Rewrite:
+      lora_unet_transformer_blocks_{i}_{token}.<rest>
+    into:
+      transformer_blocks.{i}.{mapped_token}.<rest>
+
+    Keeps an optional leading 'diffusion_model.' prefix (if present).
+    """
+    dm_prefix = "diffusion_model."
+    has_dm = key.startswith(dm_prefix)
+    k = key[len(dm_prefix) :] if has_dm else key
+
+    m = _QWEN_UNET_PREFIX_RE.match(k)
+    if m is None:
+        return key
+
+    idx, token = m.group(1), m.group(2)
+    mapped = _QWEN_UNET_TOKEN_MAP.get(token)
+    if not mapped:
+        return key
+
+    rewritten = f"transformer_blocks.{idx}.{mapped}." + k[m.end() :]
+    return (dm_prefix + rewritten) if has_dm else rewritten
+
+
+def _convert_non_diffusers_qwen_lora_to_diffusers(
+    state_dict: Mapping[str, torch.Tensor], log: logging.Logger
+) -> Dict[str, torch.Tensor]:
+    """Rewrite NON_DIFFUSERS_SD keys (Qwen-Image transformer blocks) into dot-notation."""
+    out: Dict[str, torch.Tensor] = {
+        _rewrite_non_diffusers_qwen_key(k): v for k, v in state_dict.items()
+    }
+    log.info(
+        "[LoRAFormatAdapter] after NON_DIFFUSERS_QWEN rewrite, sample keys (<=20): %s",
+        ", ".join(_sample_keys(out.keys(), 20)),
+    )
+    return out
+
+
 def _looks_like_wan_lora(state_dict: Mapping[str, torch.Tensor]) -> bool:
     """Wan2.2 distill LoRAs (Wan-AI / Wan2.2-Distill-Loras style)."""
-    if not state_dict:
-        return False
-
     for k in state_dict.keys():
         if not k.startswith("diffusion_model.blocks."):
             continue
         if ".lora_down" not in k and ".lora_up" not in k:
             continue
-        if ".cross_attn." in k or ".self_attn." in k or ".ffn." in k or ".norm3." in k:
+        if any(s in k for s in (".cross_attn.", ".self_attn.", ".ffn.", ".norm3.")):
             return True
-
     return False
 
 
 def _looks_like_qwen_image(state_dict: Mapping[str, torch.Tensor]) -> bool:
     keys = list(state_dict.keys())
-    if not keys:
-        return False
-    return _has_prefix_key(keys, "transformer.transformer_blocks.") and (
-        _has_substring_key(keys, ".lora.down.weight")
-        or _has_substring_key(keys, ".lora.up.weight")
+    return (
+        bool(keys)
+        and _has_prefix_key(keys, "transformer.transformer_blocks.")
+        and (
+            _has_substring_key(keys, ".lora.down.weight")
+            or _has_substring_key(keys, ".lora.up.weight")
+        )
     )
 
 
-# ---------------------------------------------------------------------------
-# Format detection
-# ---------------------------------------------------------------------------
-
-
 def detect_lora_format_from_state_dict(
-    state_dict: Mapping[str, torch.Tensor],
+    state_dict: Mapping[str, torch.Tensor]
 ) -> LoRAFormat:
     """Classify LoRA format by key patterns only."""
     keys = list(state_dict.keys())
@@ -805,10 +705,10 @@ def detect_lora_format_from_state_dict(
         return LoRAFormat.XLABS_FLUX
     if _looks_like_kohya_flux(state_dict):
         return LoRAFormat.KOHYA_FLUX
-
     if _looks_like_wan_lora(state_dict):
         return LoRAFormat.WAN
 
+    # Qwen-Image "standard" still goes through STANDARD branch (then rewrite down/up -> A/B)
     if _looks_like_qwen_image(state_dict):
         return LoRAFormat.STANDARD
 
@@ -821,61 +721,41 @@ def detect_lora_format_from_state_dict(
     return LoRAFormat.STANDARD
 
 
-# ---------------------------------------------------------------------------
-# Converters
-# ---------------------------------------------------------------------------
-
-
 def _convert_qwen_image_standard(
-    state_dict: Mapping[str, torch.Tensor],
-    log: logging.Logger,
+    state_dict: Mapping[str, torch.Tensor], log: logging.Logger
 ) -> Dict[str, torch.Tensor]:
     """Qwen-Image: transformer.*.lora.down/up -> transformer_blocks.*.lora_A/B."""
     out: Dict[str, torch.Tensor] = {}
-
     for name, tensor in state_dict.items():
-        new_name = name
-
-        if new_name.startswith("transformer."):
-            new_name = new_name[len("transformer.") :]
-
+        new_name = (
+            name[len("transformer.") :] if name.startswith("transformer.") else name
+        )
         if new_name.endswith(".lora.down.weight"):
             new_name = new_name.replace(".lora.down.weight", ".lora_A.weight")
         elif new_name.endswith(".lora.up.weight"):
             new_name = new_name.replace(".lora.up.weight", ".lora_B.weight")
-
         out[new_name] = tensor
-
-    _ = _sample_keys(out.keys(), 20)
     return out
 
 
 def _convert_non_diffusers_sd_simple(
-    state_dict: Mapping[str, torch.Tensor],
-    log: logging.Logger,
+    state_dict: Mapping[str, torch.Tensor], log: logging.Logger
 ) -> Dict[str, torch.Tensor]:
     """Generic down/up -> A/B conversion for non-diffusers SD-like formats."""
     out: Dict[str, torch.Tensor] = {}
-
     for name, tensor in state_dict.items():
-        new_name = name
-
-        if "lora_down.weight" in new_name:
-            new_name = new_name.replace("lora_down.weight", "lora_A.weight")
-        elif "lora_up.weight" in new_name:
-            new_name = new_name.replace("lora_up.weight", "lora_B.weight")
-        elif new_name.endswith(".lora_down"):
-            new_name = new_name.replace(".lora_down", ".lora_A")
+        new_name = name.replace("lora_down.weight", "lora_A.weight").replace(
+            "lora_up.weight", "lora_B.weight"
+        )
+        if new_name.endswith(".lora_down"):
+            new_name = new_name[: -len(".lora_down")] + ".lora_A"
         elif new_name.endswith(".lora_up"):
-            new_name = new_name.replace(".lora_up", ".lora_B")
-
+            new_name = new_name[: -len(".lora_up")] + ".lora_B"
         out[new_name] = tensor
 
-    sample = _sample_keys(out.keys(), 20)
     log.info(
-        "[LoRAFormatAdapter] after NON_DIFFUSERS_SD simple conversion, "
-        "sample keys (<=20): %s",
-        ", ".join(sample),
+        "[LoRAFormatAdapter] after NON_DIFFUSERS_SD simple conversion, sample keys (<=20): %s",
+        ", ".join(_sample_keys(out.keys(), 20)),
     )
     return out
 
@@ -886,27 +766,21 @@ def _convert_with_diffusers_utils_if_available(
 ) -> Optional[Dict[str, torch.Tensor]]:
     """Use diffusers.lora_conversion_utils if available."""
     try:
-        if hasattr(lcu, "maybe_convert_state_dict"):
-            converted = lcu.maybe_convert_state_dict(  # type: ignore[attr-defined]
-                state_dict
-            )
-        else:
-            converted = dict(state_dict)
-
+        maybe_convert = getattr(lcu, "maybe_convert_state_dict", None)
+        converted = (
+            maybe_convert(state_dict) if callable(maybe_convert) else dict(state_dict)
+        )
         if not isinstance(converted, dict):
             converted = dict(converted)
 
-        sample = _sample_keys(converted.keys(), 20)
         log.info(
-            "[LoRAFormatAdapter] diffusers.lora_conversion_utils converted keys, "
-            "sample keys (<=20): %s",
-            ", ".join(sample),
+            "[LoRAFormatAdapter] diffusers.lora_conversion_utils converted keys, sample keys (<=20): %s",
+            ", ".join(_sample_keys(converted.keys(), 20)),
         )
         return converted
     except Exception as exc:  # pragma: no cover
         log.warning(
-            "[LoRAFormatAdapter] diffusers lora_conversion_utils failed, "
-            "falling back to internal converters. Error: %s",
+            "[LoRAFormatAdapter] diffusers lora_conversion_utils failed, falling back. Error: %s",
             exc,
         )
         return None
@@ -916,93 +790,35 @@ def _convert_via_diffusers_candidates(
     state_dict: Mapping[str, torch.Tensor],
     candidate_names: tuple[str, ...],
     log: logging.Logger,
-    unavailable_warning: str,
-    no_converter_warning: str,
-    success_info: str,
-    all_failed_warning: str,
+    *,
+    kind: str,
 ) -> Dict[str, torch.Tensor]:
     """Try multiple named converters in lora_conversion_utils, use the first that works."""
     converters = [
         (n, getattr(lcu, n)) for n in candidate_names if callable(getattr(lcu, n, None))
     ]
     if not converters:
-        log.warning(no_converter_warning)
+        log.warning("[LoRAFormatAdapter] No %s converter found in diffusers.", kind)
         return dict(state_dict)
 
     last_err: Optional[Exception] = None
-
     for name, fn in converters:
         try:
             sd_copy = dict(state_dict)
             out = fn(sd_copy)
-            if isinstance(out, tuple) and isinstance(out[0], dict):
+            if isinstance(out, tuple) and out and isinstance(out[0], dict):
                 out = out[0]
             if not isinstance(out, dict):
                 raise TypeError(f"Converter {name} returned {type(out)}")
-            log.info(success_info.format(name=name))
+            log.info("[LoRAFormatAdapter] Converted %s LoRA using %s", kind, name)
             return out
         except Exception as exc:
             last_err = exc
 
-    log.warning(all_failed_warning.format(last_err=last_err))
+    log.warning(
+        "[LoRAFormatAdapter] All %s converters failed; last error: %s", kind, last_err
+    )
     return dict(state_dict)
-
-
-def _convert_xlabs_ai_via_diffusers(
-    state_dict: Mapping[str, torch.Tensor],
-    log: logging.Logger,
-) -> Dict[str, torch.Tensor]:
-    """Convert XLabs FLUX LoRA via diffusers helpers."""
-    return _convert_via_diffusers_candidates(
-        state_dict,
-        (
-            "_convert_xlabs_flux_lora_to_diffusers",
-            "convert_xlabs_lora_state_dict_to_diffusers",
-            "convert_xlabs_lora_to_diffusers",
-            "convert_xlabs_flux_lora_to_diffusers",
-        ),
-        log=log,
-        unavailable_warning=(
-            "[LoRAFormatAdapter] XLabs FLUX detected but diffusers is unavailable."
-        ),
-        no_converter_warning=(
-            "[LoRAFormatAdapter] No XLabs FLUX converter found in diffusers."
-        ),
-        success_info="[LoRAFormatAdapter] Converted XLabs FLUX LoRA using {name}",
-        all_failed_warning=(
-            "[LoRAFormatAdapter] All XLabs FLUX converters failed; "
-            "last error: {last_err}"
-        ),
-    )
-
-
-def _convert_kohya_flux_via_diffusers(
-    state_dict: Mapping[str, torch.Tensor],
-    log: logging.Logger,
-) -> Dict[str, torch.Tensor]:
-    """Convert Kohya FLUX LoRA via diffusers helpers."""
-    return _convert_via_diffusers_candidates(
-        state_dict,
-        (
-            "_convert_kohya_flux_lora_to_diffusers",
-            "convert_kohya_flux_lora_to_diffusers",
-        ),
-        log=log,
-        unavailable_warning=(
-            "[LoRAFormatAdapter] Kohya FLUX detected but diffusers is unavailable."
-        ),
-        no_converter_warning="[LoRAFormatAdapter] No Kohya FLUX converter found.",
-        success_info="[LoRAFormatAdapter] Converted Kohya FLUX LoRA using {name}",
-        all_failed_warning=(
-            "[LoRAFormatAdapter] Kohya FLUX conversion failed; "
-            "last error: {last_err}"
-        ),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Conversion dispatcher
-# ---------------------------------------------------------------------------
 
 
 def convert_lora_state_dict_by_format(
@@ -1015,58 +831,71 @@ def convert_lora_state_dict_by_format(
         return _convert_qwen_image_standard(state_dict, log)
 
     if fmt == LoRAFormat.XLABS_FLUX:
-        converted = _convert_xlabs_ai_via_diffusers(state_dict, log)
+        converted = _convert_via_diffusers_candidates(
+            state_dict,
+            (
+                "_convert_xlabs_flux_lora_to_diffusers",
+                "convert_xlabs_lora_state_dict_to_diffusers",
+                "convert_xlabs_lora_to_diffusers",
+                "convert_xlabs_flux_lora_to_diffusers",
+            ),
+            log,
+            kind="XLabs FLUX",
+        )
         return _convert_non_diffusers_sd_simple(converted, log)
 
     if fmt == LoRAFormat.KOHYA_FLUX:
-        converted = _convert_kohya_flux_via_diffusers(state_dict, log)
+        converted = _convert_via_diffusers_candidates(
+            state_dict,
+            (
+                "_convert_kohya_flux_lora_to_diffusers",
+                "convert_kohya_flux_lora_to_diffusers",
+            ),
+            log,
+            kind="Kohya FLUX",
+        )
         return _convert_non_diffusers_sd_simple(converted, log)
 
     if fmt == LoRAFormat.WAN:
-        maybe = _convert_with_diffusers_utils_if_available(state_dict, log)
-        if maybe is None:
-            maybe = dict(state_dict)
+        maybe = _convert_with_diffusers_utils_if_available(state_dict, log) or dict(
+            state_dict
+        )
         return _convert_non_diffusers_sd_simple(maybe, log)
 
     if fmt == LoRAFormat.STANDARD:
-        maybe = _convert_with_diffusers_utils_if_available(state_dict, log)
-        if maybe is None:
-            maybe = dict(state_dict)
-
-        if _looks_like_qwen_image(maybe):
-            return _convert_qwen_image_standard(maybe, log)
-
-        return maybe
+        maybe = _convert_with_diffusers_utils_if_available(state_dict, log) or dict(
+            state_dict
+        )
+        return (
+            _convert_qwen_image_standard(maybe, log)
+            if _looks_like_qwen_image(maybe)
+            else maybe
+        )
 
     if fmt == LoRAFormat.NON_DIFFUSERS_SD:
-        maybe = _convert_with_diffusers_utils_if_available(state_dict, log)
-        if maybe is None:
-            maybe = dict(state_dict)
+        maybe = _convert_with_diffusers_utils_if_available(state_dict, log) or dict(
+            state_dict
+        )
+        if _looks_like_non_diffusers_qwen_unet(maybe):
+            maybe = _convert_non_diffusers_qwen_lora_to_diffusers(maybe, log)
         return _convert_non_diffusers_sd_simple(maybe, log)
 
     log.info(
-        "[LoRAFormatAdapter] format %s not handled specially, returning as-is",
-        fmt,
+        "[LoRAFormatAdapter] format %s not handled specially, returning as-is", fmt
     )
     return dict(state_dict)
-
-
-# ---------------------------------------------------------------------------
-# Public entry point
-# ---------------------------------------------------------------------------
 
 
 def normalize_lora_state_dict(
     state_dict: Mapping[str, torch.Tensor],
     logger: Optional[logging.Logger] = None,
 ) -> Dict[str, torch.Tensor]:
-    """Normalize any supported LoRA format into a single canonical layout."""
+    """Normalize any supported LoRA format into a canonical layout."""
     log = logger or globals()["logger"]
 
     keys = list(state_dict.keys())
     log.info(
-        "[LoRAFormatAdapter] normalize_lora_state_dict called, #keys=%d",
-        len(keys),
+        "[LoRAFormatAdapter] normalize_lora_state_dict called, #keys=%d", len(keys)
     )
     if keys:
         log.info(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Some diffusion pipelines/models use **fused projections** (e.g., `attn.to_qkv` / `attn.to_added_qkv`, and fused SwiGLU `ffn.w13`). However, many public LoRAs (including Qwen-Image / Z-Image / Lightning-style LoRAs) are authored for **split projections** (e.g., `to_q/to_k/to_v`, `add_q_proj/add_k_proj/add_v_proj`, `w1/w3`).

When the target model expects fused modules but the LoRA provides split keys, plain name-format normalization is not enough: LoRA keys may not match the target layers (becoming ineffective), or weight injection can fail with **rank/shape mismatches** (especially when exact fusions expand effective rank).

This PR adds **target-aware LoRA preparation + exact fusing** and a **dynamic-rank injection fallback** so split-projection LoRAs can be reliably applied to fused targets without breaking inference.

## Modifications

### 1) `lora_format_adapter.py`
- **Target-aware LoRA preparation** via `prepare_lora_state_dict_for_target(...)`:
  - Normalize external LoRA formats into canonical `.lora_A/.lora_B`.
  - Detect fused targets (QKV/add_qkv, SwiGLU) from target layer names.
  - Perform **exact fusion** when the target is fused but the LoRA is split:
    - QKV/add_qkv: `q/k/v → to_qkv / to_added_qkv`
    - FFN: `w1/w3 → w13`
    - Shared `A`: concatenate `B`; different `A`: block-diagonal exact fusion.
- **Robust injection** via `set_lora_weights_dynamic_rank(...)`:
  - Try `set_lora_weights(...)` first; on rank/shape mismatch, dynamically replace `lora_A/B` (inference-safe).
- **Correct scaling**:
  - Bake `(alpha / rank)` into `lora_B` and drop `.alpha`.

### 2) `lora_pipeline.py`
- **Load-time preparation**:
  - Collect target LoRA layers across components and call `prepare_lora_state_dict_for_target(...)`.
- **Application path**:
  - Use `set_lora_weights_dynamic_rank(...)` instead of direct setting to handle fused targets and rank mismatches.

## Compatibility notes

- If the target does not use fused modules (or the LoRA already matches fused keys), no fusing is performed and behavior remains unchanged.
- If the canonical `layer.set_lora_weights(...)` accepts the provided shapes, the dynamic-rank fallback is not triggered.

## Accuracy Tests

This PR affects LoRA weight mapping/injection logic. I ran local functional tests focusing on:
- no crashes / no shape assertion failures
- LoRA effectively applied (qualitative output changes as expected)
- logs indicate target-aware fuse behavior where applicable

### ✅ Local tests executed

1. **Qwen-Image + `lightx2v/Qwen-Image-Lightning-4` & `8steps-V2.0-bf16`**
2. **Z-Image + `Z-Image-Turbo-DeJPEG-Lora/dejpeg_v3`**
3. **Qwen-Edit + `lightx2v/Qwen-Image-Edit-2511-Lightning/Qwen-Image-Edit-2511-Lightning-4steps-V1.0-fp32`**

## Benchmarking and Profiling

This PR does not affect runtime inference performance. Normalization occurs only once at LoRA load time and has negligible overhead.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Work with maintainers to merge your PR. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)
