### PR TITLE
Fix race condition in /tag-and-rerun-ci command

### DIFF
--- a/scripts/ci/slash_command_handler.py
+++ b/scripts/ci/slash_command_handler.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import time
 
 import requests
 from github import Auth, Github
@@ -301,6 +302,12 @@ def main():
         tagged = handle_tag_run_ci(
             repo, pr, comment, user_perms, react_on_success=False
         )
+
+        # Wait for the label to propagate before triggering rerun
+        if tagged:
+            print("Waiting 5 seconds for label to propagate...")
+            time.sleep(5)
+
         rerun = handle_rerun_failed_ci(
             repo, pr, comment, user_perms, react_on_success=False
         )


### PR DESCRIPTION
## Summary
- Add 5-second delay between adding the `run-ci` label and triggering the CI rerun
- Fixes issue where rerun could be triggered before the label had propagated

## Test plan
- [x] Code review passed
- [ ] Test `/tag-and-rerun-ci` command on a PR to verify the label is applied before rerun triggers